### PR TITLE
Makes map voting work properly.

### DIFF
--- a/code/datums/vote/map.dm
+++ b/code/datums/vote/map.dm
@@ -4,7 +4,7 @@
 /datum/vote/map/can_run(mob/creator, automatic)
 	if(!config.allow_map_switching)
 		return FALSE
-	if(!automatic || !is_admin(creator))
+	if(!automatic && !is_admin(creator))
 		return FALSE // Must be an admin.
 	return ..()
 


### PR DESCRIPTION
Not 100% sure that it actually works, as changing maps requires recompiling and depends on server-side stuff that I can't (or am not willing to, at any rate) reproduce locally, but you can at least run the vote and have it save the result for future use.

If you plan on using it, there are two config options that are relevant: one for whether map votes are allowed, and another for whether the ticker holds an automatic map vote at the end of every round.