### PR TITLE
Allows Skrell to be rank O-3

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -7,12 +7,12 @@
 		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway)
 	)
 
-#define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder
+#define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder
 	species_to_job_blacklist = list(
-		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden), //Other jobs unavailable via branch restrictions,
+		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/liaison, /datum/job/warden), //Other jobs unavailable via branch restrictions,
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
-		/datum/species/machine = list(HUMAN_ONLY_JOBS),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/guard, /datum/job/officer, /datum/job/rd, /datum/job/liaison, /datum/job/warden),	//Other jobs unavailable via branch restrictions,
+		/datum/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos),
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/guard, /datum/job/officer, /datum/job/rd, /datum/job/liaison, /datum/job/warden),	//Other jobs unavailable via branch restrictions,
 	)
 #undef HUMAN_ONLY_JOBS
 

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -50,7 +50,8 @@
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,
-				/datum/mil_rank/ec/o1
+				/datum/mil_rank/ec/o1,
+				/datum/mil_rank/ec/o3
 			)
 		),
 		/datum/species/unathi = list(


### PR DESCRIPTION
DNM until a consensus is reached on the [forums](https://forums.baystation12.net/threads/allow-skrell-to-be-lieutenants.7242) and @EcklesFire makes a final decision.

PR may also receive additional changes based on the final decision (I.e., what jobs will remain locked)

Remember to keep track of your LT, even if they Warble. Many a LT was lost to a failed land-nav course.

:cl: SierraKomodo
tweak: Skrell can now hold the EC rank of Lieutenant, and the titles Chief Medical Officer, Chief Engineer, and Chief of Security. Warble.
/:cl: