### PR TITLE
Adds AI to list of restricted traitor jobs

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -3,6 +3,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 // Inherits most of its vars from the base datum.
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
+	blacklisted_jobs = list(/datum/job/ai)
 	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	skill_setter = /datum/antag_skill_setter/station


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: 
rscdel: Removes ability for ship AI to be traitors
/:cl:

This is something that has been brought up in past staff meetings to general agreement. Reasoning is as follows:

1. AI traitors immediately draw focus from pretty much anything else happening in a round.
2. Their easy access to atmospherics, computer, and engineering systems puts too much power in the hands of one antagonist.
3. Rounds with traitor AIs generally end up following one of two paths: either there are enough experienced security and engineering personnel around that the core is breached and the AI is destroyed/carded within 15 minutes or a long intractable siege of the AI core ensues while more and more of the ship is vented/doors are shocked/SM is delamed. It's a stale process that is more headache  than engaging. 