### PR TITLE
Reimplements table and window slamming

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -49,7 +49,7 @@
 
 	if(light_max_bright && light_outer_range)
 		update_light()
-		
+
 	if(opacity)
 		updateVisibility(src)
 		var/turf/T = loc
@@ -431,6 +431,11 @@ its easier to just keep the beam vertical.
 		user.visible_message("<span class='warning'>[user.name] shakes \the [src].</span>", \
 					"<span class='notice'>You shake \the [src].</span>")
 		object_shaken()
+
+// Called when hitting the atom with a grab.
+// Will skip attackby() and afterattack() if returning TRUE.
+/atom/proc/grab_attack(var/obj/item/grab/G)
+	return FALSE
 
 /atom/proc/climb_on()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -277,6 +277,27 @@
 		..()
 	return
 
+/obj/structure/window/grab_attack(var/obj/item/grab/G)
+	if (G.assailant.a_intent != I_HURT)
+		return TRUE
+	if (!G.force_danger())
+		to_chat(G.assailant, "<span class='danger'>You need a better grip to do that!</span>")
+		return TRUE
+	var/def_zone = ran_zone(BP_HEAD, 20)
+	var/blocked = G.affecting.run_armor_check(def_zone, "melee")
+	if(G.damage_stage() < 2)
+		G.affecting.visible_message("<span class='danger'>[G.assailant] bashes [G.affecting] against \the [src]!</span>")
+		if (prob(50))
+			G.affecting.Weaken(1)
+		G.affecting.apply_damage(10, BRUTE, def_zone, blocked, used_weapon = src)
+		hit(25)
+	else
+		G.affecting.visible_message("<span class='danger'>[G.assailant] crushes [G.affecting] against \the [src]!</span>")
+		G.affecting.Weaken(5)
+		G.affecting.apply_damage(20, BRUTE, def_zone, blocked, used_weapon = src)
+		hit(50)
+	return TRUE
+
 /obj/structure/window/proc/hit(var/damage, var/sound_effect = 1)
 	if(reinf) damage *= 0.5
 	take_damage(damage)

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -15,6 +15,7 @@
 	var/can_absorb = 0							// Whether this grab state is strong enough to, as a changeling, absorb the person you're grabbing.
 	var/shield_assailant = 0					// Whether the person you're grabbing will shield you from bullets.,,
 	var/point_blank_mult = 1					// How much the grab increases point blank damage.
+	var/damage_stage = 1						// Affects how much damage is being dealt using certain actions.
 	var/same_tile = 0							// If the grabbed person and the grabbing person are on the same tile.
 	var/ladder_carry = 0						// If the grabber can carry the grabbed person up or down ladders.
 	var/can_throw = 0							// If the grabber can throw the person grabbed.

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -17,6 +17,7 @@
 	var/attacking = 0
 	var/target_zone
 
+	item_flags = ITEM_FLAG_NO_BLUDGEON
 	w_class = ITEM_SIZE_NO_CONTAINER
 /*
 	This section is for overrides of existing procs.
@@ -61,6 +62,15 @@
 
 /obj/item/grab/attack(mob/M, mob/living/user)
 	current_grab.hit_with_grab(src)
+
+/obj/item/grab/resolve_attackby(atom/A, mob/user, var/click_params)
+	assailant.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	if(!A.grab_attack(src))
+		return ..()
+	action_used()
+	if (current_grab.downgrade_on_action)
+		downgrade()
+	return TRUE
 
 /obj/item/grab/dropped()
 	..()
@@ -177,7 +187,7 @@
 		C.leave_evidence(assailant)
 		if(prob(50))
 			C.ironed_state = WRINKLES_WRINKLY
-	
+
 /obj/item/grab/proc/upgrade(var/bypass_cooldown = FALSE)
 	if(!check_upgrade_cooldown() && !bypass_cooldown)
 		to_chat(assailant, "<span class='danger'>It's too soon to upgrade.</span>")
@@ -255,6 +265,9 @@
 
 /obj/item/grab/proc/point_blank_mult()
 	return current_grab.point_blank_mult
+
+/obj/item/grab/proc/damage_stage()
+	return current_grab.damage_stage
 
 /obj/item/grab/proc/force_danger()
 	return current_grab.force_danger

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -12,6 +12,7 @@
 	can_absorb = 0
 	shield_assailant = 0
 	point_blank_mult = 1.5
+	damage_stage = 1
 	same_tile = 0
 	can_throw = 1
 	force_danger = 1

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -10,6 +10,7 @@
 	can_absorb = 1
 	shield_assailant = 0
 	point_blank_mult = 2
+	damage_stage = 3
 	same_tile = 1
 	force_danger = 1
 	restrains = 1

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -14,6 +14,7 @@
 	can_absorb = 1
 	shield_assailant = 1
 	point_blank_mult = 2
+	damage_stage = 2
 	same_tile = 1
 	can_throw = 1
 	force_danger = 1

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -76,26 +76,42 @@
 	return
 
 
+/obj/structure/table/grab_attack(var/obj/item/grab/G)
+	if (!G.force_danger())
+		to_chat(G.assailant, "<span class='danger'>You need a better grip to do that!</span>")
+		return TRUE
+	if (G.assailant.a_intent == I_HURT)
+		// Slam their face against the table.
+		var/blocked = G.affecting.run_armor_check(BP_HEAD, "melee")
+		if (prob(30 * blocked_mult(blocked)))
+			G.affecting.Weaken(5)
+		G.affecting.apply_damage(8, BRUTE, BP_HEAD, blocked)
+		visible_message("<span class='danger'>[G.assailant] slams [G.affecting]'s face against \the [src]!</span>")
+		if (material)
+			playsound(loc, material.tableslam_noise, 50, 1)
+		else
+			playsound(loc, 'sound/weapons/tablehit1.ogg', 50, 1)
+		var/list/L = take_damage(rand(1,5))
+		for(var/obj/item/weapon/material/shard/S in L)
+			if(S.sharp && prob(50))
+				G.affecting.visible_message("<span class='danger'>\The [S] slices into [G.affecting]'s face!</span>",
+				                  "<span class='danger'>\The [S] slices into your face!</span>")
+				G.affecting.standard_weapon_hit_effects(S, G.assailant, S.force*2, blocked, BP_HEAD)
+		qdel(G)
+	else
+		// Attempt to put them on the table instead.
+		var/obj/occupied = turf_is_crowded()
+		if (occupied)
+			to_chat(G.assailant, "<span class='danger'>There's \a [occupied] in the way.</span>")
+			return TRUE
+		G.affecting.forceMove(src.loc)
+		G.affecting.Weaken(rand(2,5))
+		visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
+		qdel(G)
+	return TRUE
+
 /obj/structure/table/attackby(obj/item/W, mob/user, var/click_params)
 	if (!W) return
-
-	// Handle harm intent grabbing/tabling.
-	if(istype(W, /obj/item/grab) && get_dist(src,user)<2)
-		var/obj/item/grab/G = W
-		if (istype(G.affecting, /mob/living/carbon/human))
-			var/obj/occupied = turf_is_crowded()
-			if(occupied)
-				to_chat(user, "<span class='danger'>There's \a [occupied] in the way.</span>")
-				return
-
-			if(G.force_danger())
-				G.affecting.forceMove(src.loc)
-				G.affecting.Weaken(rand(2,5))
-				visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
-				qdel(W)
-			else
-				to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
-			return
 
 	// Handle dismantling or placing things on the table from here on.
 	if(isrobot(user))


### PR DESCRIPTION
 - Adds `grab_attack()` for grab interactions on objects.
 - Adds `damage_stage` to the grab datum to determine action damage.
 - Reimplements table slamming.
 - Reimplements window slamming.

Reuses some of the old code, slightly adjusted so it fits with the grab rework.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->