### PR TITLE
Spider tweaks (1st Pass)

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -98,7 +98,7 @@
 /obj/effect/spider/eggcluster/Process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
-		var/num = rand(6,24)
+		var/num = rand(3,12)
 		var/obj/item/organ/external/O = null
 		if(istype(loc, /obj/item/organ/external))
 			O = loc

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -7,7 +7,7 @@
 
 /datum/event/spider_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 60)
-	spawncount = rand(4 * severity, 6 * severity)	//spiderlings only have a 50% chance to grow big and strong
+	spawncount = rand(3 * severity, 5 * severity)	//spiderlings only have a 50% chance to grow big and strong
 	sent_spiders_to_station = 0
 
 /datum/event/spider_infestation/announce()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -22,8 +22,8 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "pokes"
 	stop_automated_movement_when_pulled = 0
-	maxHealth = 200
-	health = 200
+	maxHealth = 175
+	health = 175
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	heat_damage_per_tick = 20
@@ -69,8 +69,8 @@
 	icon_state = "black"
 	icon_living = "black"
 	icon_dead = "black_dead"
-	maxHealth = 150
-	health = 150
+	maxHealth = 100
+	health = 100
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	poison_per_bite = 15


### PR DESCRIPTION
First pass in what may be a number of tweaks to spider balance while I try to find the right balance. Doing it this way because while I can test 1v1 on a test build, I can't account for how a full spider event affects a round of players, or the effects server/tick lag may have on the event (Alot of people say all spiders are too fast for example, while in local testing only black spiders are fast enough to outpace you if you run).

This first pass does the following:
 - Black and brown spiders have had their health slightly reduced.
 - Eggsacs will produce half the number of spiderlings they used to.
 - Spider events will produce slightly less spiders at event start.

:cl: SierraKomodo
experiment: Experimental spider balance tweak: Brown and beige spiders have reduced health, and spider events/eggsacs spawn less spiders (Based on feedback from discord). Further changes may come depending on how these changes effect spider events in round.
/:cl: