### PR TITLE
Adds the Toggle SSD verb, usable on beds

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -165,6 +165,35 @@
 	if(padding_material)
 		padding_material.place_sheet(get_turf(src))
 
+/obj/structure/bed/verb/toggle_ssd() // Going to sleep with the intent of AFKing; sets medical record to SSD
+	set src in range(1)
+	set name = "Toggle SSD"
+	set category = "IC"
+
+	var/mob/living/carbon/user = usr
+	var/datum/computer_file/report/crew_record/E = get_crewmember_record(user.name)
+	
+	if (!istype(user))
+		return
+	if (user.drowsyness > 0 || user.paralysis || user.status_flags & FAKEDEATH) // Against waking up from other sleep-induced sources
+		to_chat(user, "<span style='warning'>You cannot wake up right now!</span>")
+		return
+	if (user.ssd_sleeping) // They are asleep and waking up
+		to_chat(user, "<span class='notice'>You wake up.</span>")
+		user.ssd_sleeping = 0
+		user.sleeping = 0
+		E.set_status("Active")
+		return
+	if ((get_turf(user) != src.loc) || (!user.lying)) // They are awake but not being or lying on top of it
+		to_chat(user, "<span style='warning'>You must be lying on top of the [src] to fall asleep.</span>")
+		return
+
+	to_chat(user, "<span style='font-size: 150%;'>Your character has gone SSD. You can wake them up with the \"Toggle SSD\" verb if you are ready to return.</span>")
+	user.ssd_sleeping = 1
+	user.sleeping = 3 HOURS
+	E.set_status("SSD")
+	return
+
 /obj/structure/bed/psych
 	name = "psychiatrist's couch"
 	desc = "For prime comfort during psychiatric evaluations."

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -184,7 +184,7 @@
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
 			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span>\n"
-		else if(!client)
+		else if(!client || ssd_sleeping)
 			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>\n"
 
 	var/obj/item/organ/external/head/H = organs_by_name[BP_HEAD]

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -85,6 +85,7 @@
 	var/resting = 0			//Carbon
 	var/lying = 0
 	var/lying_prev = 0
+	var/ssd_sleeping = 0	// Went to SSD, set their own medical status to SSD
 
 	var/unacidable = 0
 	var/list/pinned = list()            // List of things pinning this creature to walls (see living_defense.dm)


### PR DESCRIPTION
:cl:
rscadd: Adds a new verb called "Toggle SSD". If you use it while you are on a bed, your character will go to sleep and on the crew manifest your status will be set to SSD.
/:cl:

- A new verb popping up near any `/obj/structure/bed/`.
- It puts the user to sleep for 3 hours (I couldn't properly set them to unconscious and didn't want to use paralyse to avoid people cheesing this verb).
- It sets the user's status to SSD on the crew manifest.
- It adds the regular SSD message upon examining.
- Once they wake up, their status will return to Active.
- A huge message informs the user about how to wake up to avoid getting people stuck in this state.
- There are checks to make sure people won't wake up from other KO states with this.
- This is purely a cosmetic change so other players would know if you went to the bunks/fell asleep elsewhere without having to track you down - they can just check the crew manifest with this.
- The reason why I didn't add this to all logged out characters is that this indicates you're in the bunks and/or planning to return.
- The other reason for this is that I wish to replace the "XYZ is AFK" habit on OOC with the active usage of bunks/sub-acute.

I thoroughly tested it and found no issues but I may have missed something.
I hope this will be welcomed.

![00](https://user-images.githubusercontent.com/33333517/49345184-a25cb980-f681-11e8-86ea-10235c7601a2.PNG)
![02](https://user-images.githubusercontent.com/33333517/49345186-a2f55000-f681-11e8-88fb-dc98fc8ba739.PNG)
