### PR TITLE
Fix simple_animal immortality

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -325,11 +325,6 @@
 
 	adjustBruteLoss(damage * blocked_mult(getarmor(null, "bomb")))
 
-/mob/living/simple_animal/updatehealth()
-	..()
-	if(health <= 0)
-		death()
-
 /mob/living/simple_animal/adjustBruteLoss(damage)
 	..()
 	updatehealth()


### PR DESCRIPTION
I apologise for not testing this thoroughly enough to realise this was happening.

simple_animal's update_icon sets their icon to the dead state before they actually die, so I didn't notice that they weren't actually dying, and I closed the window before I ever saw the mobs SS crashing.

This is not currently on the live server.