### PR TITLE
AI Traitor Removal Take Two

### DIFF
--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -3,6 +3,7 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 /datum/antagonist/renegade
 	role_text = "Renegade"
 	role_text_plural = "Renegades"
+	blacklisted_jobs = list(/datum/job/ai)
 	restricted_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/hos, /datum/job/captain)
 	welcome_text = "Something's going to go wrong today, you can just feel it. You're paranoid, you've got a gun, and you're going to survive."
 	antag_text = "You are a <b>minor</b> antagonist! Within the rules, \

--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -15,7 +15,7 @@
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 
 /datum/antagonist/traitor
-	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop)
+	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai)
 
 /datum/antagonist/ert
 	var/sic //Second-In-Command


### PR DESCRIPTION
PR to prevent AI from getting the traitor role by adding it to the Torch-specific blacklist for traitor jobs. Now with actual testing beforehand. 

Renegade has also been blacklisted for the AI as per the last staff meeting as it promotes antagonist-hunting behavior that we'd prefer not to see. There doesn't appear to be a Torch-specific job blacklist for renegades so AI was simply added to the blacklist in the base renegade datum. 