### PR TITLE
Enforce nutrition requirements for Unathi and Diona regeneration

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -11,11 +11,13 @@
 
 /obj/aura/regenerating/human
 	var/nutrition_damage_mult = 1 //How much nutrition it takes to heal regular damage
+	var/external_nutrition_mult = 50 // How much nutrition it takes to regrow a limb
 	var/organ_mult = 2
 	var/regen_message = "<span class='warning'>Your body throbs as you feel your ORGAN regenerate.</span>"
 	var/grow_chance = 0
 	var/grow_threshold = 0
 	var/ignore_tag//organ tag to ignore
+	var/last_nutrition_warning = 0
 
 
 /obj/aura/regenerating/human/proc/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
@@ -27,6 +29,9 @@
 		CRASH("Someone gave [user.type] a [src.type] aura. This is invalid.")
 		return 0
 	if(!H.innate_heal || H.InStasis() || H.stat == DEAD)
+		return 0
+	if(H.nutrition < nutrition_damage_mult)
+		low_nut_warning()
 		return 0
 
 	if(brute_mult && H.getBruteLoss())
@@ -43,8 +48,11 @@
 		if(prob(10) && H.nutrition >= 150 && !H.getBruteLoss() && !H.getFireLoss())
 			var/obj/item/organ/external/head/D = H.organs_by_name["head"]
 			if (D.status & ORGAN_DISFIGURED)
-				D.status &= ~ORGAN_DISFIGURED
-				H.nutrition -= 20
+				if (H.nutrition >= 20)
+					D.status &= ~ORGAN_DISFIGURED
+					H.nutrition -= 20
+				else
+					low_nut_warning("head")
 
 		for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
 			var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
@@ -52,18 +60,23 @@
 				continue
 			if(istype(regen_organ))
 				if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
-					regen_organ.damage = max(regen_organ.damage - organ_mult, 0)
-					H.nutrition -= organ_mult
-					if(prob(5))
-						to_chat(H, replacetext(regen_message,"ORGAN", regen_organ.name))
+					if (H.nutrition >= organ_mult)
+						regen_organ.damage = max(regen_organ.damage - organ_mult, 0)
+						H.nutrition -= organ_mult
+						if(prob(5))
+							to_chat(H, replacetext(regen_message,"ORGAN", regen_organ.name))
+					else
+						low_nut_warning(regen_organ.name)
 
-	if(prob(grow_chance) && H.nutrition > grow_threshold)
+	if(prob(grow_chance))
 		for(var/limb_type in H.species.has_limbs)
 			var/obj/item/organ/external/E = H.organs_by_name[limb_type]
-			if(E && E.organ_tag != BP_HEAD && !E.vital && !E.is_usable())	//Skips heads and vital bits...
+			if(H.nutrition > grow_threshold && E && E.organ_tag != BP_HEAD && !E.vital && !E.is_usable())	//Skips heads and vital bits...
 				E.removed()			//...because no one wants their head to explode to make way for a new one.
 				qdel(E)
 				E= null
+			else
+				low_nut_warning(E.name)
 			if(!E)
 				var/list/organ_data = H.species.has_limbs[limb_type]
 				var/limb_path = organ_data["path"]
@@ -78,6 +91,14 @@
 						E.wounds -= W
 	return 1
 
+/obj/aura/regenerating/human/proc/low_nut_warning(var/wound_type)
+	if (last_nutrition_warning + 1 MINUTE < world.time)
+		to_chat(user, "<span class='warning'>You need more energy to regenerate your [wound_type || "wounds"].</span>")
+		last_nutrition_warning = world.time
+		return 1
+	return 0
+
+
 /obj/aura/regenerating/human/unathi
 	brute_mult = 2
 	organ_mult = 4
@@ -89,7 +110,7 @@
 /obj/aura/regenerating/human/unathi/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	to_chat(H, "<span class='danger'>With a shower of fresh blood, a new [O.name] forms.</span>")
 	H.visible_message("<span class='danger'>With a shower of fresh blood, a length of biomass shoots from [H]'s [O.amputation_point], forming a new [O.name]!</span>")
-	H.nutrition -= 50
+	H.nutrition -= external_nutrition_mult
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in H.vessel.reagent_list
 	blood_splatter(H,B,1)
 	O.set_dna(H.dna)
@@ -104,10 +125,11 @@
 	regen_message = "<span class='warning'>You sense your nymphs shifting internally to regenerate your ORGAN..</span>"
 	grow_chance = 5
 	grow_threshold = 100
+	external_nutrition_mult = 60
 
 /obj/aura/regenerating/human/diona/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	to_chat(H, "<span class='warning'>Some of your nymphs split and hurry to reform your [O.name].</span>")
-	H.nutrition -= 60
+	H.nutrition -= external_nutrition_mult
 
 /obj/aura/regenerating/human/unathi/yeosa
 	brute_mult = 1.5


### PR DESCRIPTION
Enforces the existing nutrition requirement for Unathi and Diona regeneration. If they run out of nut, they can't heal.

Informs the user when regeneration fails but prevents spamming them by limiting messages to one per minute.

This doesn't seem to ruin Unathi's combat dominance. They can heal for multiple minutes just as well as they could before, and hitting a chug jug protein shake will give them enough nut to go for several more minutes.

Tested and working on latest version.

🆑 Persona E
balance: Unathi and Dionaea can no longer regenerate without nutrition.
/🆑