### PR TITLE
Remove TCC meme ushanka from loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -101,7 +101,6 @@
 	var/informalhats = list()
 	informalhats["cowboy hat"] = /obj/item/clothing/head/cowboy_hat
 	informalhats["ushanka"] = /obj/item/clothing/head/ushanka
-	informalhats["TCC ushanka"] = /obj/item/clothing/head/ushanka/tcc
 	gear_tweaks += new/datum/gear_tweak/path(informalhats)
 
 /datum/gear/head/hijab

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -167,9 +167,9 @@
 		icon_state = initial(icon_state)
 		to_chat(user, "You lower the ear flaps on the ushanka.")
 
-/obj/item/clothing/head/ushanka/tcc
-	name = "TCC ushanka"
-	desc = "Perfect for keeping ears warm during your courtmartial."
+/obj/item/clothing/head/ushanka/gcc
+	name = "GCC ushanka"
+	desc = "Perfect for keeping ears warm during your court-martial."
 	icon_state = "tccushankadown"
 	icon_state_up = "tccushankaup"
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -522,9 +522,9 @@
 	icon_open = "trackjacketwhite_open"
 	icon_closed = "trackjacketwhite"
 
-/obj/item/clothing/suit/storage/toggle/track/tcc
-	name = "TCC track jacket"
-	desc = "A Terran track jacket, for the truly cheeki breeki."
+/obj/item/clothing/suit/storage/toggle/track/gcc
+	name = "GCC track jacket"
+	desc = "An Independent track jacket, for the truly cheeki breeki."
 	icon_state = "trackjackettcc"
 	icon_open = "trackjackettcc_open"
 	icon_closed = "trackjackettcc"

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -175,7 +175,7 @@
 /obj/item/clothing/suit/storage/toggle/brown_jacket,
 /obj/item/clothing/suit/storage/toggle/hoodie/nt,
 /obj/item/clothing/suit/storage/toggle/hoodie/smw,
-/obj/item/clothing/suit/storage/toggle/track/tcc,
+/obj/item/clothing/suit/storage/toggle/track/gcc,
 /obj/item/device/radio,
 /obj/structure/closet/shipping_wall{
 	pixel_y = -28
@@ -3076,7 +3076,7 @@
 /obj/item/clothing/suit/storage/toggle/brown_jacket,
 /obj/item/clothing/suit/storage/toggle/hoodie/nt,
 /obj/item/clothing/suit/storage/toggle/hoodie/smw,
-/obj/item/clothing/suit/storage/toggle/track/tcc,
+/obj/item/clothing/suit/storage/toggle/track/gcc,
 /obj/item/device/radio,
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/carpet,


### PR DESCRIPTION
In the spirit of annihilating gopnik memes, this does the following:

- Removes the TCC ushanka from the loadout.
- Renames the TCC ushanka as the admin-spawnable GCC ushanka in case it's wanted.

🆑 Persona E
rscdel: Removed the TCC ushanka from the loadout.
/🆑