### PR TITLE
Improvements for sleep button

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -205,11 +205,12 @@
 			var/show_ssd
 			var/mob/living/carbon/human/H = src
 			if(istype(H)) show_ssd = H.species.show_ssd
-			if(show_ssd && !client && !teleop)
+			if(show_ssd && ssd_check())
 				M.visible_message("<span class='notice'>[M] shakes [src] trying to wake [t_him] up!</span>", \
 				"<span class='notice'>You shake [src], but they do not respond... Maybe they have S.S.D?</span>")
-			else if(lying || src.sleeping)
-				src.sleeping = max(0,src.sleeping-5)
+			else if(lying || src.sleeping || player_triggered_sleeping)
+				src.player_triggered_sleeping = 0
+				src.sleeping = max(0,src.sleeping - 5)
 				if(src.sleeping == 0)
 					src.resting = 0
 				M.visible_message("<span class='notice'>[M] shakes [src] trying to wake [t_him] up!</span>", \
@@ -366,11 +367,8 @@
 	set name = "Sleep"
 	set category = "IC"
 
-	if(usr.sleeping)
-		to_chat(usr, "<span class='warning'>You are already sleeping</span>")
-		return
-	if(alert(src,"You sure you want to sleep for a while?","Sleep","Yes","No") == "Yes")
-		usr.sleeping = 20 //Short nap
+	if(alert(src,"You sure you want to [src.player_triggered_sleeping ? "wake up" : "sleep for a while"]?", "Sleep", "Yes", "No") == "Yes")
+		src.player_triggered_sleeping = !src.player_triggered_sleeping
 
 /mob/living/carbon/Bump(var/atom/movable/AM, yes)
 	if(now_pushing || !yes)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -40,3 +40,5 @@
 
 	var/list/stasis_sources = list()
 	var/stasis_value
+
+	var/player_triggered_sleeping = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -556,7 +556,7 @@
 	if(status_flags & GODMODE)	return 0
 
 	//SSD check, if a logged player is awake put them back to sleep!
-	if(ssd_check() && species.get_ssd(src))
+	if(ssd_check() && species.get_ssd(src) || player_triggered_sleeping)
 		Sleeping(2)
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		blinded = 1


### PR DESCRIPTION
This PR changes sleep button slightly:
* Now you can control your sleep time! Not like a "Wait how long?" feature in the Skyrim, but now you don't need press sleep button every time when you need sleep more than 40 seconds. Press the button to go to eternal sleep... Or press again to wake up. You still can't wake up if you affected with something sleepy like poison or whatever what can make you sleep.