### PR TITLE
Reduces Travis spam.

### DIFF
--- a/scripts/dm.sh
+++ b/scripts/dm.sh
@@ -46,7 +46,7 @@ if [[ $DM == "" ]]; then
     exit 3
 fi
 
-"$DM" -verbose $dmepath.mdme | tee build_log.txt
+"$DM" $dmepath.mdme | tee build_log.txt
 retval=$?
 
 [[ -e $dmepath.mdme.dmb ]] && mv $dmepath.mdme.dmb $dmepath.dmb


### PR DESCRIPTION
The `-verbose` compile option has the following effect only: it shows which .dm files were included when compiling. This is annoying on Travis, and is not useful on the server to diagnose anything.

There is also a (very useful) `-verbose` dreamseeker option which this does not affect.