### PR TITLE
Clarify developer responsibilites, codify discord dev bans

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
-In order to foster a more healthy, productive and friendly contributing environment, the following code is in effect.
+In order to foster a more healthy, productive and friendly contributing environment, the following code is in effect on this repository and all Development category channels on Discord/IRC.
 
 
 ## Rules
@@ -20,37 +20,46 @@ The following conduct may result in a warning being logged against your account:
 * Any other conduct deemed unhealthy or unhelpful as discussed on a case-by-case basis among the development team.
 
 The following conduct is unacceptable and will result in up to three strikes, depending on severity as determined by the Head Developer:
-* Derogatory, bigoted or prejudiced language based on race/ethnicity, sex/gender, sexuality, religion, disability, or nationality.
+* Derogatory, bigoted or prejudiced language based on race, ethnicity, sex, gender, sexuality, religion, disability, nationality or any other identifiable group.
 * Personal or political attacks.
 * Public or private harassment.
 
 
 ## Warnings and Punishments
-Accumulating three warnings will result in a repository ban.
+Accumulating three warnings will result in a repository ban. The Developer issuing the ban may optionally ban the violating contributor from development channels in Discord for the duration of their repository ban.
 Warnings expire in six months from the date of warning.
 **Severe violations of this code of conduct may result in community or game server bans.**
 
-* The first issued ban against your account will result in a **one week ban**, which cannot be appealed.
+* The first issued ban against your account will result in a **one week ban**, which may be appealed after four days.
 * The second issued ban against your account will result in a **one month ban**, which may be appealed after two weeks.
-* The third issued ban against your account will result in a **permanent ban** and removal of chat privlages in #coding, both of which may be appealed after one month.
+* The third issued ban against your account will result in a **permanent ban**, which may be appealed after one month.
 * Every subsequent ban will result in a permanent ban until appeal as described above.
-    * Fully serving or successfully appealing a ban will remove the oldest warning, resulting in two. 
+    * Fully serving or successfully appealing a ban will remove the oldest warning, resulting in two.
 
 
 ## Developer Responsibilities
-The Head Developer is responsible for clarifying the standards of acceptable behaviour and is expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour. The Head Developer has the right to to ban temporarily or permanently any contributor for behaviours that they deem inappropriate, threatening, offensive, or harmful, in accordance with the rules established above.
+The Head Developer has the responsiblity to:
+* Clarify the standards of acceptable behaviour
+* Handle the appeals process for all issued ban
 
-Developers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. 
+All Developers have the responsibility to:
+* Take appropriate and fair corrective action in response to any instances of unacceptable behaviour
+* Properly log all corrective action they take in the relevant thread
 
+All Developers have the right to: 
+* Remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct
+* Issue warnings in accordance with the Code of Conduct (except in the cases elaborated in the second section of the Rules category, which require conference with the Head Developer)
+* Temporarily ban any contributor from Discord development channels for behaviour not aligned to this Code of Conduct, for a period up to three days
+    * Any such ban issued will be accompanied by a warning, and should be logged
 
 ## Enforcement
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the Head Developer on Discord (@sabiram). The Head Developer will review and investigate all complaints, and will respond in a way that they deem appropriate to the circumstances. The Head Developer is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the Head Developer on Discord (@sabiram). The Head Developer will review and investigate all complaints, and will respond in a way that they deem appropriate to the circumstances. The Head Developer is obligated to maintain confidentiality with regard to the reporter of an incident.
 
 Developers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the Head Developer.
 
 
 ## Modifications
-Modifications to this code of conduct may be made by any contributor, by way of a pull request, and will be considered by the development staff. Any accepted modifications will be announced in the #news channel on Discord, and on the forums.
+Modifications to this code of conduct may be made by any contributor by way of a pull request, and will be considered by the development staff. Any accepted modifications will be announced in the #news channel on Discord, and on the forums.
 
 
 ## Attribution


### PR DESCRIPTION
Summary of changes:

Makes it clearer that this code applies on discord dev channels (#coding, #feedback, etc)
All developers are responsible for issuing warnings
All developers can ban bad eggs from dev channels