### PR TITLE
Supply Candystriped List

### DIFF
--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -22,7 +22,7 @@
 		<table style="width:100%">
 			<tr><th style="width:70%">Item<th style="width:20%">Cost<th style="width:10%">Order
 			{{for data.possible_purchases}}
-				<tr>
+				<tr class="candystripe">
 				<td>{{:value.name}}
 				<td>{{:value.cost}} {{:data.currency}}
 				<td>{{:helper.link('Order', null, {'order' : value.ref})}}


### PR DESCRIPTION
_Now 100% less broken commits because `git` is hard_

Before:
![2018-12-11_02-35-56](https://user-images.githubusercontent.com/3196371/49785337-454eac80-fcee-11e8-9235-e6da28639f36.png)
After:
![2018-12-11_02-33-26](https://user-images.githubusercontent.com/3196371/49785342-48e23380-fcee-11e8-87f8-02827319feb6.png)

Surprised no one did this earlier. Looking at the supply terminal was a pain to look at.
:cl: Carlen White
tweak: The supply terminal listing of supplies shade every so listing to help item selection.
/:cl: