### PR TITLE
Tweak test, test messages, fix re-occuring build error

### DIFF
--- a/code/unit_tests/area_tests.dm
+++ b/code/unit_tests/area_tests.dm
@@ -12,16 +12,19 @@
 		for(var/turf/T in A)
 			area_turfs += T
 
-		var/actual_number_of_sub_areas = 0
-		var/expected_number_of_sub_areas = (A.type in GLOB.using_map.area_coherency_test_subarea_count) ? GLOB.using_map.area_coherency_test_subarea_count[A.type] : 1
+		var/list/sub_area_turfs = list()
+		var/expected_number_of_sub_areas = GLOB.using_map.area_coherency_test_subarea_count[A.type] || 1
 		do
-			actual_number_of_sub_areas++
-			area_turfs -= get_turfs_fill(area_turfs[1])
+			var/turf/T = area_turfs[1]
+			sub_area_turfs += T
+			area_turfs -= get_turfs_fill(T)
 		while(area_turfs.len)
 
-		if(actual_number_of_sub_areas != expected_number_of_sub_areas)
+		if(sub_area_turfs.len != expected_number_of_sub_areas)
 			incoherent_areas++
-			log_bad("[log_info_line(A)] is incoherent. Expected [expected_number_of_sub_areas] subarea\s, fill gave [actual_number_of_sub_areas].")
+			log_bad("[log_info_line(A)] is incoherent. Expected [expected_number_of_sub_areas] subarea\s, fill gave [sub_area_turfs.len]. Origin turfs:")
+			for(var/T in sub_area_turfs)
+				log_bad(log_info_line(T))
 
 	if(incoherent_areas)
 		fail("Found [incoherent_areas] incoherent area\s.")

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1553,7 +1553,6 @@
 /obj/item/clothing/suit/storage/toggle/brown_jacket,
 /obj/item/clothing/suit/storage/toggle/hoodie/nt,
 /obj/item/clothing/suit/storage/toggle/hoodie/smw,
-/obj/item/clothing/suit/storage/toggle/track/tcc,
 /obj/item/device/radio,
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/carpet,
@@ -2589,7 +2588,6 @@
 /obj/item/clothing/suit/storage/toggle/brown_jacket,
 /obj/item/clothing/suit/storage/toggle/hoodie/nt,
 /obj/item/clothing/suit/storage/toggle/hoodie/smw,
-/obj/item/clothing/suit/storage/toggle/track/tcc,
 /obj/item/device/radio,
 /obj/structure/closet/shipping_wall{
 	pixel_y = 34

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -251,7 +251,7 @@ function run_byond_tests {
     run_test_fail "check no runtimes 2" "grep 'runtime error:' log.txt"
     run_test_fail "check no scheduler failures" "grep 'Process scheduler caught exception processing' log.txt"
     run_test_fail "check no warnings" "grep 'WARNING:' log.txt"
-    run_test_fail "check no failures" "grep 'ERROR:' log.txt"
+    run_test_fail "check no errors" "grep 'ERROR:' log.txt"
 }
 
 function run_all_tests {


### PR DESCRIPTION
* Makes the area coherency test more helpful
* Makes the error-check claim it checked for errors, not failures.
* Remove invalid items, which caused reoccurring build failures, from the colony map.