### PR TITLE
Further machines optimization.

### DIFF
--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -47,15 +47,12 @@ SUBSYSTEM_DEF(machines)
 	var/cost_power_objects = 0
 
 	var/list/pipenets      = list()
-	var/list/machinery     = list()
+	var/list/machinery     = list() // These are all machines.
 	var/list/powernets     = list()
 	var/list/power_objects = list()
 
-	var/list/processing
+	var/list/processing  = list() // These are the machines which are processing.
 	var/list/current_run = list()
-
-/datum/controller/subsystem/machines/PreInit()
-	 processing = machinery
 
 /datum/controller/subsystem/machines/Initialize(timeofday)
 	makepowernets()
@@ -131,10 +128,10 @@ datum/controller/subsystem/machines/proc/setup_atmos_machinery(list/machines)
 	msg += "PO:[round(cost_power_objects,1)]"
 	msg += "} "
 	msg += "PI:[pipenets.len]|"
-	msg += "MC:[machinery.len]|"
+	msg += "MC:[processing.len]|"
 	msg += "PN:[powernets.len]|"
 	msg += "PO:[power_objects.len]|"
-	msg += "MC/MS:[round((cost ? machinery.len/cost : 0),0.1)]"
+	msg += "MC/MS:[round((cost ? processing.len/cost : 0),0.1)]"
 	..(jointext(msg, null))
 
 /datum/controller/subsystem/machines/proc/process_pipenets(resumed = 0)
@@ -155,14 +152,14 @@ datum/controller/subsystem/machines/proc/setup_atmos_machinery(list/machines)
 
 /datum/controller/subsystem/machines/proc/process_machinery(resumed = 0)
 	if (!resumed)
-		src.current_run = machinery.Copy()
+		src.current_run = processing.Copy()
 
 	var/list/current_run = src.current_run
 	while(current_run.len)
 		var/obj/machinery/M = current_run[current_run.len]
 		current_run.len--
 		if(!QDELETED(M) && (M.Process(wait) == PROCESS_KILL))
-			machinery.Remove(M)
+			processing.Remove(M)
 			M.is_processing = null
 		if(MC_TICK_CHECK)
 			return
@@ -202,6 +199,8 @@ datum/controller/subsystem/machines/proc/setup_atmos_machinery(list/machines)
 		pipenets = SSmachines.pipenets
 	if (istype(SSmachines.machinery))
 		machinery = SSmachines.machinery
+	if (istype(SSmachines.processing))
+		processing = SSmachines.processing
 	if (istype(SSmachines.powernets))
 		powernets = SSmachines.powernets
 	if (istype(SSmachines.power_objects))

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -27,12 +27,14 @@
 	. = ..()
 
 /obj/machinery/portable_atmospherics/Initialize()
-	. = ..()
-	spawn()
-		var/obj/machinery/atmospherics/portables_connector/port = locate() in loc
-		if(port)
-			connect(port)
-			update_icon()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/portable_atmospherics/LateInitialize()
+	var/obj/machinery/atmospherics/portables_connector/port = locate() in loc
+	if(port)
+		connect(port)
+		update_icon()
 
 /obj/machinery/portable_atmospherics/Process()
 	if(!connected_port) //only react when pipe_network will ont it do it for you

--- a/code/game/machinery/bluespacerelay.dm
+++ b/code/game/machinery/bluespacerelay.dm
@@ -3,24 +3,15 @@
 	desc = "This sends messages through bluespace! Wow!"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "bspacerelay"
-
 	anchored = 1
 	density = 1
-	var/on = 1
-
 	idle_power_usage = 15000
-	active_power_usage = 15000
-
-/obj/machinery/bluespacerelay/Process()
-	update_power()
-	update_icon()
-
 
 /obj/machinery/bluespacerelay/on_update_icon()
-	if(on)
-		icon_state = initial(icon_state)
-	else
+	if(stat & (BROKEN|NOPOWER))
 		icon_state = "[initial(icon_state)]_off"
+	else
+		icon_state = initial(icon_state)
 
 /obj/machinery/bluespacerelay/New()
 	..()
@@ -31,12 +22,6 @@
 	component_parts += new /obj/item/weapon/stock_parts/subspace/filter(src)
 	component_parts += new /obj/item/weapon/stock_parts/subspace/crystal(src)
 	component_parts += new /obj/item/stack/cable_coil(src, 30)
-/obj/machinery/bluespacerelay/proc/update_power()
-
-	if(stat & (BROKEN|NOPOWER|EMPED))
-		on = 0
-	else
-		on = 1
 
 /obj/machinery/bluespacerelay/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(default_deconstruction_screwdriver(user, O))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -270,11 +270,11 @@
 
 //Used when someone breaks a camera
 /obj/machinery/camera/proc/destroy()
-	stat |= BROKEN
+	set_broken(TRUE)
 	wires.RandomCutAll()
 
 	triggerCameraAlarm()
-	update_icon()
+	queue_icon_update()
 	update_coverage()
 
 	//sparks
@@ -470,9 +470,7 @@
 /obj/machinery/camera/proc/reset_wires()
 	if(!wires)
 		return
-	if (stat & BROKEN) // Fix the camera
-		stat &= ~BROKEN
+	set_broken(FALSE) // Fixes the camera and updates the icon.
 	wires.CutAll()
 	wires.MendAll()
-	update_icon()
 	update_coverage()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -59,5 +59,5 @@
 	onclose(user, "op")
 
 /obj/machinery/computer/operating/Process()
-	if(..())
-		src.updateDialog()
+	if(!inoperable())
+		updateDialog()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -27,15 +27,9 @@
 	power_change()
 	update_icon()
 
-/obj/machinery/computer/Process()
-	if(stat & (NOPOWER|BROKEN))
-		return 0
-	return 1
-
 /obj/machinery/computer/emp_act(severity)
-	if(prob(20/severity)) set_broken()
+	if(prob(20/severity)) set_broken(TRUE)
 	..()
-
 
 /obj/machinery/computer/ex_act(severity)
 	switch(severity)
@@ -49,18 +43,16 @@
 			if (prob(50))
 				for(var/x in verbs)
 					verbs -= x
-				set_broken()
+				set_broken(TRUE)
 		if(3.0)
 			if (prob(25))
 				for(var/x in verbs)
 					verbs -= x
-				set_broken()
-		else
-	return
+				set_broken(TRUE)
 
 /obj/machinery/computer/bullet_act(var/obj/item/projectile/Proj)
 	if(prob(Proj.get_structure_damage()))
-		set_broken()
+		set_broken(TRUE)
 	..()
 
 /obj/machinery/computer/on_update_icon()
@@ -80,10 +72,6 @@
 
 	if(icon_keyboard)
 		overlays += image(icon, icon_keyboard, overlay_layer)
-
-/obj/machinery/computer/proc/set_broken()
-	stat |= BROKEN
-	update_icon()
 
 /obj/machinery/computer/proc/decode(text)
 	// Adds line breaks

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -143,7 +143,7 @@
 
 
 /obj/machinery/computer/pod/Process()
-	if(!..())
+	if(inoperable())
 		return
 	if(timing)
 		if(time > 0)
@@ -153,8 +153,6 @@
 			time = 0
 			timing = 0
 		updateDialog()
-	return
-
 
 /obj/machinery/computer/pod/OnTopic(user, href_list)
 	if(href_list["power"])

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1104,8 +1104,8 @@ About the new airlock wires panel:
 		if (F.wielded)
 			playsound(src, 'sound/weapons/smash.ogg', 100, 1)
 			user.visible_message("<span class='danger'>[user] smashes \the [C] into the airlock's control panel! It explodes in a shower of sparks!</span>", "<span class='danger'>You smash \the [C] into the airlock's control panel! It explodes in a shower of sparks!</span>")
-			src.health = 0
-			src.set_broken()
+			health = 0
+			set_broken(TRUE)
 		else
 			..()
 			return
@@ -1171,21 +1171,16 @@ About the new airlock wires panel:
 		ignite(is_hot(C))
 	..()
 
-/obj/machinery/door/airlock/set_broken()
-	src.p_open = 1
-	stat |= BROKEN
-	if (secured_wires)
-		lock()
-	for (var/mob/O in viewers(src, null))
-		if ((O.client && !( O.blinded )))
-			O.show_message("[src.name]'s control panel bursts open, sparks spewing out!")
-
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
-
-	update_icon()
-	return
+/obj/machinery/door/airlock/set_broken(new_state)
+	. = ..()
+	if(. && new_state)
+		p_open = 1
+		if (secured_wires)
+			lock()
+		visible_message("\The [src]'s control panel bursts open, sparks spewing out!")
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(5, 1, src)
+		s.start()
 
 /obj/machinery/door/airlock/open(var/forced=0)
 	if(!can_open(forced))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -194,10 +194,8 @@
 // Description: Fully repairs the blast door.
 /obj/machinery/door/blast/proc/repair()
 	health = maxhealth
-	if(stat & BROKEN)
-		stat &= ~BROKEN
-	update_icon()
-
+	set_broken(FALSE)
+	queue_icon_update()
 
 /obj/machinery/door/blast/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group) return 1

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -49,8 +49,8 @@
 			targets += C
 
 	if(targets.len==0)
-		stat |= BROKEN
-	update_icon()
+		set_broken(TRUE)
+	queue_icon_update()
 
 //Main door timer loop, if it's timing and time is >0 reduce time by 1.
 // if it's less than 0, open door, reset timer

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -333,11 +333,10 @@
 		to_chat(user, "\The [src] shows signs of damage!")
 
 
-/obj/machinery/door/proc/set_broken()
-	stat |= BROKEN
-	visible_message("<span class = 'warning'>\The [src.name] breaks!</span>")
-	update_icon()
-
+/obj/machinery/door/set_broken(new_state)
+	. = ..()
+	if(. && new_state)
+		visible_message("<span class = 'warning'>\The [src.name] breaks!</span>")
 
 /obj/machinery/door/ex_act(severity)
 	switch(severity)

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -39,7 +39,7 @@ var/list/floor_light_cache = list()
 		if(!src || !WT.isOn())
 			return
 		visible_message("<span class='notice'>\The [user] has repaired \the [src].</span>")
-		stat &= ~BROKEN
+		set_broken(FALSE)
 		damaged = null
 		update_brightness()
 	else if(W.force && user.a_intent == "hurt")
@@ -52,7 +52,7 @@ var/list/floor_light_cache = list()
 		if(!isnull(damaged) && !(stat & BROKEN))
 			visible_message("<span class='danger'>\The [user] smashes \the [src]!</span>")
 			playsound(src, "shatter", 70, 1)
-			stat |= BROKEN
+			set_broken(TRUE)
 		else
 			visible_message("<span class='danger'>\The [user] attacks \the [src]!</span>")
 			playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
@@ -140,7 +140,7 @@ var/list/floor_light_cache = list()
 			if (prob(50))
 				qdel(src)
 			else if(prob(20))
-				stat |= BROKEN
+				set_broken(TRUE)
 			else
 				if(isnull(damaged))
 					damaged = 0

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -11,10 +11,6 @@
 	var/_wifi_id
 	var/datum/wifi/receiver/button/igniter/wifi_receiver
 
-/obj/machinery/igniter/New()
-	..()
-	update_icon()
-
 /obj/machinery/igniter/Initialize()
 	. = ..()
 	update_icon()
@@ -38,8 +34,8 @@
 		return
 	ignite()
 
-/obj/machinery/igniter/Process()	//ugh why is this even in process()?
-	if (on && powered() )
+/obj/machinery/igniter/Process()
+	if(powered())
 		var/turf/location = src.loc
 		if (isturf(location))
 			location.hotspot_expose(1000,500,1)
@@ -48,8 +44,11 @@
 /obj/machinery/igniter/proc/ignite()
 	use_power_oneoff(50)
 	on = !on
+	if(on)
+		START_PROCESSING(SSmachines, src)
+	else
+		STOP_PROCESSING(SSmachines, src)
 	update_icon()
-
 
 // Wall mounted remote-control igniter.
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -95,6 +95,7 @@ Class Procs:
 	var/idle_power_usage = 0
 	var/active_power_usage = 0
 	var/power_channel = EQUIP //EQUIP, ENVIRON or LIGHT
+	var/power_init_complete = FALSE // Helps with bookkeeping when initializing atoms. Don't modify.
 	var/list/component_parts = null //list of all the parts used to build it, if made from certain kinds of frames.
 	var/uid
 	var/panel_open = 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -109,9 +109,11 @@ Class Procs:
 	. = ..()
 	if(d)
 		set_dir(d)
-	START_PROCESSING(SSmachines, src)
+	START_PROCESSING(SSmachines, src) // It's safe to remove machines from here.
+	SSmachines.machinery += src // All machines should remain in this list, always.
 
 /obj/machinery/Destroy()
+	SSmachines.machinery -= src
 	STOP_PROCESSING(SSmachines, src)
 	if(component_parts)
 		for(var/atom/A in component_parts)
@@ -121,9 +123,8 @@ Class Procs:
 				component_parts -= A
 	. = ..()
 
-/obj/machinery/Process()//If you dont use process or power why are you here
-	if(!(use_power || idle_power_usage || active_power_usage))
-		return PROCESS_KILL
+/obj/machinery/Process()
+	return PROCESS_KILL // Only process if you need to.
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)
@@ -155,6 +156,16 @@ Class Procs:
 				return
 		else
 	return
+
+/obj/machinery/proc/set_broken(new_state)
+	if(new_state && !(stat & BROKEN))
+		stat |= BROKEN
+		. = TRUE
+	else if(!new_state && (stat & BROKEN))
+		stat &= ~BROKEN
+		. = TRUE
+	if(.)
+		queue_icon_update()
 
 /proc/is_operable(var/obj/machinery/M, var/mob/user)
 	return istype(M) && M.operable()

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -713,7 +713,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				if(hitstaken==3)
 					for (var/mob/O in hearers(5, src.loc))
 						O.show_message("[user.name] smashes the [src.name]!" )
-					stat |= BROKEN
+					set_broken(TRUE)
 					playsound(src.loc, 'sound/effects/Glassbr3.ogg', 100, 1)
 				else
 					for (var/mob/O in hearers(5, src.loc))
@@ -721,7 +721,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					playsound(src.loc, 'sound/effects/Glasshit.ogg', 100, 1)
 		else
 			to_chat(user, "<span class='notice'>This does nothing.</span>")
-	update_icon()
+	queue_icon_update()
 
 /obj/machinery/newscaster/attack_ai(mob/user as mob)
 	return src.attack_hand(user) //or maybe it'll have some special functions? No idea.

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -434,9 +434,8 @@ var/list/turret_icons
 
 /obj/machinery/porta_turret/proc/die()	//called when the turret dies, ie, health <= 0
 	health = 0
-	stat |= BROKEN	//enables the BROKEN bit
+	set_broken(TRUE)
 	spark_system.start()	//creates some sparks because they look cool
-	update_icon()
 	atom_flags |= ATOM_FLAG_CLIMBABLE // they're now climbable
 
 /obj/machinery/porta_turret/Process()

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -60,14 +60,14 @@
 				construct_op ++
 				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( user.loc )
 				A.amount = 5
-				stat |= BROKEN // the machine's been borked!
+				set_broken(TRUE, TRUE) // the machine's been borked!
 		if(3)
 			if(isCoil(P))
 				var/obj/item/stack/cable_coil/A = P
 				if (A.use(5))
 					to_chat(user, "<span class='notice'>You insert the cables.</span>")
 					construct_op--
-					stat &= ~BROKEN // the machine's not borked anymore!
+					set_broken(FALSE, TRUE) // the machine's not borked anymore!
 				else
 					to_chat(user, "<span class='warning'>You need five coils of wire for this.</span>")
 			if(isCrowbar(P))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -559,10 +559,7 @@
 		while(R.get_amount()>0)
 			R.get_product(loc)
 		break
-
-	stat |= BROKEN
-	src.icon_state = "[initial(icon_state)]-broken"
-	return
+	set_broken(TRUE)
 
 //Somebody cut an important wire and now we're following a new definition of "pitch."
 /obj/machinery/vending/proc/throw_item()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -640,14 +640,14 @@
 				"<span class='notice'>[user.name] has replaced the damaged APC frame with new one.</span>",\
 				"You replace the damaged APC frame with new one.")
 			qdel(W)
-			stat &= ~BROKEN
+			set_broken(FALSE)
 			// Malf AI, removes the APC from AI's hacked APCs list.
 			if(hacker && hacker.hacked_apcs && (src in hacker.hacked_apcs))
 				hacker.hacked_apcs -= src
 				hacker = null
 			if (opened==2)
 				opened = 1
-			update_icon()
+			queue_icon_update()
 	else
 		if (((stat & BROKEN) || (hacker && !hacker.hacked_apcs_hidden)) \
 				&& !opened \
@@ -678,8 +678,8 @@
 						opened = 1
 					if(90 to 100)
 						to_chat(user, "<span class='warning'>There's a nasty sound and \the [src] goes cold...</span>")
-						stat |= BROKEN
-				update_icon()
+						set_broken(TRUE)
+				queue_icon_update()
 		playsound(get_turf(src), 'sound/weapons/smash.ogg', 75, 1)
 
 // attack with hand - remove cell (if cover open) or interact with the APC
@@ -1203,12 +1203,12 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 			return
 		if(2.0)
 			if (prob(50))
-				set_broken()
+				set_broken(TRUE)
 				if (cell && prob(50))
 					cell.ex_act(2.0)
 		if(3.0)
 			if (prob(25))
-				set_broken()
+				set_broken(TRUE)
 				if (cell && prob(25))
 					cell.ex_act(3.0)
 	return
@@ -1218,16 +1218,17 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 		terminal.master = null
 		terminal = null
 
-/obj/machinery/power/apc/proc/set_broken()
-	// Aesthetically much better!
-	src.visible_message("<span class='notice'>[src]'s screen flickers with warnings briefly!</span>")
+/obj/machinery/power/apc/set_broken(new_state)
+	if(!new_state || (stat & BROKEN))
+		return ..()
+	visible_message("<span class='notice'>[src]'s screen flickers with warnings briefly!</span>")
 	power_alarm.triggerAlarm(loc, src)
 	spawn(rand(2,5))
-		src.visible_message("<span class='notice'>[src]'s screen suddenly explodes in rain of sparks and small debris!</span>")
-		stat |= BROKEN
+		..()
+		visible_message("<span class='notice'>[src]'s screen suddenly explodes in rain of sparks and small debris!</span>")
 		operating = 0
-		update_icon()
 		update()
+	return TRUE
 
 /obj/machinery/power/apc/proc/reboot()
 	//reset various counters so that process() will start fresh

--- a/code/modules/power/power_usage.dm
+++ b/code/modules/power/power_usage.dm
@@ -65,6 +65,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 /obj/machinery/Initialize()
 	REPORT_POWER_CONSUMPTION_CHANGE(0, get_power_usage())
 	GLOB.moved_event.register(src, src, .proc/update_power_on_move)
+	power_init_complete = TRUE
 	. = ..()
 
 // Or in Destroy at all, but especially after the ..().
@@ -87,6 +88,9 @@ This is /obj/machinery level code to properly manage power usage from the area.
 
 // The three procs below are the only allowed ways of modifying the corresponding variables.
 /obj/machinery/proc/update_use_power(new_use_power)
+	if(!power_init_complete)
+		use_power = new_use_power
+		return // We'll be retallying anyway.
 	if(use_power == new_use_power)
 		return
 	var/old_power = get_power_usage()
@@ -95,6 +99,9 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power)
 
 /obj/machinery/proc/update_power_channel(new_channel)
+	if(!power_init_complete)
+		power_channel = new_channel
+		return
 	var/old_channel = power_channel
 	if(old_channel == old_channel)
 		return
@@ -114,7 +121,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 			active_power_usage = new_power_consumption
 		else
 			return
-	if(use_power_mode == use_power)
+	if(power_init_complete && (use_power_mode == use_power))
 		REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power_consumption)
 
 #undef REPORT_POWER_CONSUMPTION_CHANGE

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -76,7 +76,7 @@
 				term.master = src
 				term.connect_to_network()
 	if(!terminals.len)
-		stat |= BROKEN
+		set_broken(TRUE)
 		return
 	update_icon()
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -78,13 +78,10 @@ var/list/solars_list = list()
 		src.healthcheck()
 	..()
 
-
 /obj/machinery/power/solar/proc/healthcheck()
 	if (src.health <= 0)
 		if(!(stat & BROKEN))
-			broken()
-
-
+			set_broken(TRUE)
 
 /obj/machinery/power/solar/on_update_icon()
 	..()
@@ -130,16 +127,15 @@ var/list/solars_list = list()
 		else //if we're no longer on the same powernet, remove from control computer
 			unset_control()
 
-/obj/machinery/power/solar/proc/broken()
-	stat |= BROKEN
-	health = 0
-	new /obj/item/weapon/material/shard(src.loc)
-	new /obj/item/weapon/material/shard(src.loc)
-	var/obj/item/solar_assembly/S = locate() in src
-	S.glass_type = null
-	unset_control()
-	update_icon()
-
+/obj/machinery/power/solar/set_broken(new_state)
+	. = ..()
+	if(. && new_state)
+		health = 0
+		new /obj/item/weapon/material/shard(src.loc)
+		new /obj/item/weapon/material/shard(src.loc)
+		var/obj/item/solar_assembly/S = locate() in src
+		S.glass_type = null
+		unset_control()
 
 /obj/machinery/power/solar/ex_act(severity)
 	switch(severity)
@@ -156,11 +152,11 @@ var/list/solars_list = list()
 				return
 
 			if (prob(50))
-				broken()
+				set_broken(TRUE)
 
 		if(3.0)
 			if (prob(25))
-				broken()
+				set_broken(TRUE)
 	return
 
 
@@ -493,19 +489,11 @@ var/list/solars_list = list()
 
 //rotates the panel to the passed angle
 /obj/machinery/power/solar_control/proc/set_panels(var/cdir)
-
 	for(var/obj/machinery/power/solar/S in connected_panels)
 		S.adir = cdir //instantly rotates the panel
 		S.occlusion()//and
 		S.update_icon() //update it
-
 	update_icon()
-
-
-/obj/machinery/power/solar_control/proc/broken()
-	stat |= BROKEN
-	update_icon()
-
 
 /obj/machinery/power/solar_control/ex_act(severity)
 	switch(severity)
@@ -515,11 +503,10 @@ var/list/solars_list = list()
 			return
 		if(2.0)
 			if (prob(50))
-				broken()
+				set_broken(TRUE)
 		if(3.0)
 			if (prob(25))
-				broken()
-	return
+				set_broken(TRUE)
 
 // Used for mapping in solar array which automatically starts itself (telecomms, for example)
 /obj/machinery/power/solar_control/autostart

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -112,18 +112,16 @@
 
 // make the conveyor broken
 // also propagate inoperability to any connected conveyor with the same ID
-/obj/machinery/conveyor/proc/broken()
-	stat |= BROKEN
-	update_icon()
+/obj/machinery/conveyor/set_broken(new_state)
+	. = ..()
+	if(. && new_state)
+		var/obj/machinery/conveyor/C = locate() in get_step(src, dir)
+		if(C)
+			C.set_operable(dir, id, 0)
 
-	var/obj/machinery/conveyor/C = locate() in get_step(src, dir)
-	if(C)
-		C.set_operable(dir, id, 0)
-
-	C = locate() in get_step(src, turn(dir,180))
-	if(C)
-		C.set_operable(turn(dir,180), id, 0)
-
+		C = locate() in get_step(src, turn(dir,180))
+		if(C)
+			C.set_operable(turn(dir,180), id, 0)
 
 //set the operable var if ID matches, propagating in the given direction
 
@@ -138,15 +136,7 @@
 	if(C)
 		C.set_operable(stepdir, id, op)
 
-/*
-/obj/machinery/conveyor/verb/destroy()
-	set src in view()
-	src.broken()
-*/
-
 // the conveyor control switch
-//
-//
 
 /obj/machinery/conveyor_switch
 

--- a/code/modules/species/xenomorphs/alien_powers.dm
+++ b/code/modules/species/xenomorphs/alien_powers.dm
@@ -267,6 +267,6 @@ mob/living/carbon/human/proc/xeno_infest(mob/living/carbon/human/M as mob in ovi
 
 	A.do_animate("spark")
 	sleep(6)
-	A.stat |= BROKEN
+	A.set_broken(TRUE)
 	var/check = A.open(1)
 	src.visible_message("\The [src] slices \the [A]'s controls[check ? ", ripping it open!" : ", breaking it!"]")

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -236,7 +236,7 @@
 		if(!(S.z in affected_z))
 			continue
 		if(prob(DETONATION_SOLAR_BREAK_CHANCE))
-			S.broken()
+			S.set_broken(TRUE)
 
 
 


### PR DESCRIPTION
Separates the processing list from the all machines list. This makes it fine for machines to stop processing whenever, and also provides a truly accurate machines list as well. Makes setting the broken state go through a proc call to avoid having to process to constantly check for brokenness.

Removes about 20% of machine instances from processing constantly. Many more can be done, but this is the energy I had at the moment.

Slightly improves some init and deletion code.

Removed prior restriction that power vars cannot be modified prior to the machinery's Initialize completing. They can now be modified whenever.