### PR TITLE
You can now print pending, approved, and fulfilled orders [Ready]

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -1,3 +1,7 @@
+#define SUPPLY_LIST_ID_CART 1
+#define SUPPLY_LIST_ID_REQUEST 2
+#define SUPPLY_LIST_ID_DONE 3
+
 /datum/computer_file/program/supply
 	filename = "supply"
 	filedesc = "Supply Management"
@@ -32,7 +36,8 @@
 	var/selected_category
 	var/list/category_names
 	var/list/category_contents
-	var/emagged = FALSE	// TODO: Implement synchronisation with modular computer framework.
+	var/emagged = FALSE	// TODO: Implement synchronization with modular computer framework.
+	var/emagged_memory = FALSE // Keeps track if the program has to regenerate the catagories after an emag.
 	var/current_security_level
 	var/notifications_enabled = FALSE
 
@@ -40,9 +45,10 @@
 	var/list/data = host.initial_data()
 	var/is_admin = check_access(user, access_cargo)
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-	if(!category_names || !category_contents || current_security_level != security_state.current_security_level)
+	if(!category_names || !category_contents || current_security_level != security_state.current_security_level || emagged_memory != emagged )
 		generate_categories()
 		current_security_level = security_state.current_security_level
+		emagged_memory = emagged
 
 	data["is_admin"] = is_admin
 	if(is_admin)
@@ -81,20 +87,22 @@
 
 
 		if(4)// Order processing
-			var/list/cart[0]
-			var/list/requests[0]
-			var/list/done[0]
-			for(var/datum/supply_order/SO in SSsupply.shoppinglist)
-				cart.Add(order_to_nanoui(SO))
-			for(var/datum/supply_order/SO in SSsupply.requestlist)
-				requests.Add(order_to_nanoui(SO))
-			for(var/datum/supply_order/SO in SSsupply.donelist)
-				done.Add(order_to_nanoui(SO))
-			data["cart"] = cart
-			data["requests"] = requests
-			data["done"] = done
-			data["is_NTOS"] = istype(nano_host(), /obj/item/modular_computer) // Can we even use notifications?
-			data["notifications_enabled"] = notifications_enabled
+			if(is_admin) // No bother sending all of this if the user can't see it.
+				var/list/cart[0]
+				var/list/requests[0]
+				var/list/done[0]
+				for(var/datum/supply_order/SO in SSsupply.shoppinglist)
+					cart.Add(order_to_nanoui(SO, SUPPLY_LIST_ID_CART))
+				for(var/datum/supply_order/SO in SSsupply.requestlist)
+					requests.Add(order_to_nanoui(SO, SUPPLY_LIST_ID_REQUEST))
+				for(var/datum/supply_order/SO in SSsupply.donelist)
+					done.Add(order_to_nanoui(SO, SUPPLY_LIST_ID_DONE))
+				data["cart"] = cart
+				data["requests"] = requests
+				data["done"] = done
+				data["can_print"] = can_print()
+				data["is_NTOS"] = istype(nano_host(), /obj/item/modular_computer) // Can we even use notifications?
+				data["notifications_enabled"] = notifications_enabled
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -102,6 +110,12 @@
 		ui.set_auto_update(1)
 		ui.set_initial_data(data)
 		ui.open()
+
+// Supply the order ID and where to look. This is just to reduce copypaste code.
+/datum/nano_module/supply/proc/find_order_by_id(var/order_id, var/list/find_in)
+	for(var/datum/supply_order/SO in find_in)
+		if(SO.ordernum == order_id)
+			return SO
 
 /datum/nano_module/supply/Topic(href, href_list)
 	var/mob/user = usr
@@ -186,41 +200,76 @@
 
 	if(href_list["approve_order"])
 		var/id = text2num(href_list["approve_order"])
-		for(var/datum/supply_order/SO in SSsupply.requestlist)
-			if(SO.ordernum != id)
-				continue
-			if(SO.object.cost > SSsupply.points)
+		var/datum/supply_order/SO = find_order_by_id(id, SSsupply.requestlist)
+		if(SO)
+			if(SO.object.cost >= SSsupply.points)
 				to_chat(usr, "<span class='warning'>Not enough points to purchase \the [SO.object.name]!</span>")
-				return 1
-			SSsupply.requestlist -= SO
-			SSsupply.shoppinglist += SO
-			SSsupply.points -= SO.object.cost
-			break
+			else
+				SSsupply.requestlist -= SO
+				SSsupply.shoppinglist += SO
+				SSsupply.points -= SO.object.cost
+		
+		else
+			to_chat(user, "<span class='warning'>Could not find order number [id] to approve.</span>")
+		
 		return 1
 
 	if(href_list["deny_order"])
 		var/id = text2num(href_list["deny_order"])
-		for(var/datum/supply_order/SO in SSsupply.requestlist)
-			if(SO.ordernum == id)
-				SSsupply.requestlist -= SO
-				break
+		var/datum/supply_order/SO = find_order_by_id(id, SSsupply.requestlist)
+		if(SO)
+			SSsupply.requestlist -= SO
+		else
+			to_chat(user, "<span class='warning'>Could not find order number [id] to deny.</span>")
+		
 		return 1
 
 	if(href_list["cancel_order"])
 		var/id = text2num(href_list["cancel_order"])
-		for(var/datum/supply_order/SO in SSsupply.shoppinglist)
-			if(SO.ordernum == id)
-				SSsupply.shoppinglist -= SO
-				SSsupply.points += SO.object.cost
-				break
+		var/datum/supply_order/SO = find_order_by_id(id, SSsupply.shoppinglist)
+		if(SO)
+			SSsupply.shoppinglist -= SO
+			SSsupply.points += SO.object.cost
+		else
+			to_chat(user, "<span class='warning'>Could not find order number [id] to cancel.</span>")
+		
 		return 1
 
 	if(href_list["delete_order"])
 		var/id = text2num(href_list["delete_order"])
-		for(var/datum/supply_order/SO in SSsupply.donelist)
-			if(SO.ordernum == id)
-				SSsupply.donelist -= SO
-				break
+		var/datum/supply_order/SO = find_order_by_id(id, SSsupply.donelist)
+		if(SO)
+			SSsupply.donelist -= SO
+		else
+			to_chat(user, "<span class='warning'>Could not find order number [id] to delete.</span>")
+		
+		return 1
+	
+	if(href_list["print_receipt"])
+		if(!can_print())
+			to_chat(user, "<span class='warning'>No printer connected to print receipts.</span>")
+			return 1
+		
+		var/id = text2num(href_list["print_receipt"])
+		var/list_id = text2num(href_list["list_id"])
+		var/list/list_to_search
+		switch(list_id)
+			if(SUPPLY_LIST_ID_CART)
+				list_to_search = SSsupply.shoppinglist
+			if(SUPPLY_LIST_ID_REQUEST)
+				list_to_search = SSsupply.requestlist
+			if(SUPPLY_LIST_ID_DONE)
+				list_to_search = SSsupply.donelist
+			else
+				to_chat(user, "<span class='warning'>Invalid list ID for order number [id]. Receipt not printed.</span>")
+				return 1
+		
+		var/datum/supply_order/SO = find_order_by_id(id, list_to_search)
+		if(SO)
+			print_order(SO, user)
+		else
+			to_chat(user, "<span class='warning'>Could not find order number [id] to print receipt.</span>")
+		
 		return 1
 	
 	if(href_list["toggle_notifications"])
@@ -258,13 +307,14 @@
 		return "Docked"
 	return "Docking/Undocking"
 
-/datum/nano_module/supply/proc/order_to_nanoui(var/datum/supply_order/SO)
+/datum/nano_module/supply/proc/order_to_nanoui(var/datum/supply_order/SO, var/list_id)
 	return list(list(
 		"id" = SO.ordernum,
 		"object" = SO.object.name,
 		"orderer" = SO.orderedby,
 		"cost" = SO.object.cost,
-		"reason" = SO.reason
+		"reason" = SO.reason,
+		"list_id" = list_id
 		))
 
 /datum/nano_module/supply/proc/can_print()
@@ -296,3 +346,7 @@
 	for(var/source in SSsupply.point_source_descriptions)
 		t += "[SSsupply.point_source_descriptions[source]]: [SSsupply.point_sources[source] || 0]<br>"
 	print_text(t, user)
+
+#undef SUPPLY_LIST_ID_CART
+#undef SUPPLY_LIST_ID_REQUEST
+#undef SUPPLY_LIST_ID_DONE

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -1,3 +1,24 @@
+{{##def.common_supply_header:
+  <th style="width:65%">Item
+  <th style="width:20%">Cost
+  <th style="width:15%">Order
+#}}
+{{##def.common_request_header:
+  <th style="width:5%">ID
+  <th style="width:25%">Requested item
+  <th style="width:20%">Requested by
+  <th style="width:20%">Reason
+  <th style="width:10%">Cost
+  <th style="width:20%">Options
+#}}
+{{##def.supply_request_item:
+	<tr class="candystripe">
+	<td>{{:value.id}}
+	<td>{{:value.object}}
+	<td>{{:value.orderer}}
+	<td>{{:value.reason || '<i>No reason provided.</i>'}}
+	<td>{{:value.cost}} {{:data.currency_short}}
+#}}
 <div class='notice'>
 	{{if data.is_admin}}
 		You are authenticated. You may access all functions of this program.
@@ -37,7 +58,7 @@
 	{{/for}}
 	{{if data.category}}
 		<table style="width:100%">
-			<tr><th style="width:70%">Item<th style="width:20%">Cost<th style="width:10%">Order
+			<tr>{{#def.common_supply_header}}
 			{{for data.possible_purchases}}
 				<tr class="candystripe">
 				<td>{{:value.name}}
@@ -105,45 +126,37 @@
 		<div class="item">
 			<center><h3>Pending orders</h3></span>
 			<table style="width:100%">
-				<tr><th style="width:10%">ID<th style="width:25%">Requested item<th style="width:20%">Requested by<th style="width:20%">Reason<th style="width:10%">Cost<th style="width:15%">Options
+				<tr>{{#def.common_request_header}}
 				{{for data.requests}}
-					<tr class="candystripe">
-					<td>{{:value.id}}
-					<td>{{:value.object}}
-					<td>{{:value.orderer}}
-					<td>{{:value.reason}}
-					<td>{{:value.cost}} {{:data.currency_short}}
-					<td>{{:helper.link('Approve', 'check', {'approve_order' : value.id}, value.cost > data.credits ? 'disabled' : null )}}{{:helper.link('Deny', 'cancel', {'deny_order' : value.id})}}
+					{{#def.supply_request_item}}
+					<td>
+					{{:helper.link('Approve', 'check', {'approve_order' : value.id}, value.cost > data.credits ? 'disabled' : null )}}
+					{{:helper.link('Deny', 'cancel', {'deny_order' : value.id})}}
+					{{:helper.link('Print', 'print', {'print_receipt' : value.id, 'list_id' : value.list_id}, data.can_print ? null : 'disabled')}}
 				{{/for}}
 			</table>
 		</div>
 		<div class="item">
 			<center><h3>Approved orders</h3></span>
 			<table style="width:100%">
-				<tr><th style="width:10%">ID<th style="width:25%">Requested item<th style="width:20%">Requested by<th style="width:20%">Reason<th style="width:10%">Cost<th style="width:15%">Options
+				<tr>{{#def.common_request_header}}
 				{{for data.cart}}
-					<tr class="candystripe">
-					<td>{{:value.id}}
-					<td>{{:value.object}}
-					<td>{{:value.orderer}}
-					<td>{{:value.reason}}
-					<td>{{:value.cost}} {{:data.currency_short}}
-					<td>{{:helper.link('Cancel', 'cancel', {'cancel_order' : value.id})}}
+					{{#def.supply_request_item}}
+					<td>
+					{{:helper.link('Cancel', 'cancel', {'cancel_order' : value.id})}}
+					{{:helper.link('Print', 'print', {'print_receipt' : value.id, 'list_id' : value.list_id}, data.can_print ? null : 'disabled')}}
 				{{/for}}
 			</table>
 		</div>
 		<div class="item">
 			<center><h3>Filled orders</h3></span>
 			<table style="width:100%">
-				<tr><th style="width:10%">ID<th style="width:25%">Requested item<th style="width:20%">Requested by<th style="width:20%">Reason<th style="width:10%">Cost<th style="width:15%">Options
+				<tr>{{#def.common_request_header}}
 				{{for data.done}}
-					<tr class="candystripe">
-					<td>{{:value.id}}
-					<td>{{:value.object}}
-					<td>{{:value.orderer}}
-					<td>{{:value.reason}}
-					<td>{{:value.cost}} {{:data.currency_short}}
-					<td>{{:helper.link('Delete', 'cancel', {'delete_order' : value.id})}}
+					{{#def.supply_request_item}}
+					<td>
+					{{:helper.link('Delete', 'cancel', {'delete_order' : value.id})}}
+					{{:helper.link('Print', 'print', {'print_receipt' : value.id, 'list_id' : value.list_id}, data.can_print ? null : 'disabled')}}
 				{{/for}}
 			</table>
 		</div>


### PR DESCRIPTION
- [X] Can you print the receipts?
- [ ] ~~Did the bugfix actually fix an existing problem?~~
  - There's no hidden contraband supplypacks, yet, but at least this will make sure it'll regenerate if the emag state changes.
- [X] Is it stable?
  - ~~Something did break. For some reason after opening and closing a few contents it causes the browser to freeze and crash Byond with it. Variables seem sane and attempting to use the computer/program in that current state will crash the client again until it's closed (force restart of the computer). [See here.](https://puu.sh/CkTna.webm)~~ Feature removed. See bottom.

Todo:
- [X] Give more room for buttons
  - Decreased sized of other columns.
- [ ] ~~Maybe redesign the order view?~~
  - No longer needed.

![image](https://user-images.githubusercontent.com/3196371/50319662-7bcabb00-0496-11e9-93e6-b2b681ce69dc.png)
~~[Show Contents Feature](https://user-images.githubusercontent.com/3196371/50319780-0f9c8700-0497-11e9-9bcf-27410ea3b49c.png)
Added the ability to see contents. **This is broken and causes the browser to crash randomly. Unsure why.**~~
Feature removed and will be part of a different PR. The other feature of printing receipts works fine and there's no good reason to halt that for much longer because of it's own issue.
:cl:
rscadd: You can now print receipts on pending, approved, and archived orders.
/:cl: