### PR TITLE
You can show the contents of supply products

### DIFF
--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -1,7 +1,7 @@
 {{##def.common_supply_header:
   <th style="width:65%">Item
   <th style="width:20%">Cost
-  <th style="width:15%">Order
+  <th style="width:15%">Options
 #}}
 {{##def.common_request_header:
   <th style="width:5%">ID
@@ -63,7 +63,20 @@
 				<tr class="candystripe">
 				<td>{{:value.name}}
 				<td>{{:value.cost}} {{:data.currency}}
-				<td>{{:helper.link('Order', null, {'order' : value.ref})}}
+				<td>
+				{{:helper.link('Order', null, {'order' : value.ref})}}
+				{{if data.showing_contents_of && data.showing_contents_of == value.ref}}
+					{{:helper.link('Close', null, {'hide_contents' : 1})}}
+					<tr class="candystripe"><th colspan="3">Contents
+					{{for data.contents_of_order :content :content_index}}
+						<tr class="candystripe">
+						<td colspan="3">{{:content.name}} × {{:content.amount}}
+					{{/for}}
+          			<hr>
+					<tr>{{#def.common_supply_header}}
+				{{else}}
+					{{:helper.link('Contents', null, {'show_contents' : value.ref})}}
+				{{/if}}
 			{{/for}}
 		</table>
 	{{/if}}


### PR DESCRIPTION
**Depends on #24019**
Made a new PR to figure out the problems that were originally in #24019 but moved here. **This has been fixed!**
![image](https://user-images.githubusercontent.com/3196371/50319780-0f9c8700-0497-11e9-9bcf-27410ea3b49c.png)
~~**Feature is showing odd behavior and causes crashes.** Not sure why but it works enough to get a picture out of it. It _should_ list the contents of the order then use the defined header so everything reads nicely, but sometimes it deletes the next entry, or all of them for no particular reason.~~
**It's been fixed!** Turns out this was a variable collision when having a for loop inside a for loop, and changing the variable names of the inner for loop fixed everything.
:cl:
rscadd: You can show the contents of supply products.
/:cl: