### PR TITLE
Maps monitoring alarms into Xenobio and Anomaly

### DIFF
--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -12521,10 +12521,9 @@
 	icon_state = "bulb1";
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor/isolation{
 	alarm_id = "petrov2";
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/reinforced,
@@ -14037,10 +14036,9 @@
 	icon_state = "bulb1";
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor/isolation{
 	alarm_id = "petrov3";
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/reinforced,
@@ -14264,10 +14262,9 @@
 	icon_state = "map_scrubber_off";
 	dir = 1
 	},
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor/isolation{
 	alarm_id = "petrov1";
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24
 	},
 /turf/simulated/floor/reinforced,

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -14266,11 +14266,8 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "aVf" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor{
 	alarm_id = "xenobio1_alarm";
-	dir = 2;
-	icon_state = "alarm0";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/reinforced,
@@ -14336,11 +14333,8 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
 "aVq" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/monitor{
 	alarm_id = "xenobio4_alarm";
-	dir = 2;
-	icon_state = "alarm0";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/reinforced,
@@ -30530,16 +30524,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/xenobiology)
 "ttb" = (
-/obj/machinery/alarm{
-	alarm_id = "xenobio2_alarm";
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/alarm/monitor{
+	alarm_id = "xenobio2_alarm";
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "tub" = (
@@ -30584,16 +30577,15 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "tyb" = (
-/obj/machinery/alarm{
-	alarm_id = "xenobio3_alarm";
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/alarm/monitor{
+	alarm_id = "xenobio3_alarm";
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "tzb" = (


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Anomaly isolation and Xenobiology air alarms will no longer cause atmos alarms.
/:cl:

Yes it's a bug, we have specific subtypes of air alarms intended to be used for these rooms that are not actually mapped in.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->