### PR TITLE
You can run diagnostics on RFID card readers

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -308,7 +308,7 @@
 		hard_drive.store_file(autorun)
 
 /obj/item/modular_computer/GetIdCard()
-	if(card_slot && card_slot.can_broadcast && istype(card_slot.stored_card))
+	if(card_slot && card_slot.can_broadcast && istype(card_slot.stored_card) && card_slot.check_functionality())
 		return card_slot.stored_card
 
 /obj/item/modular_computer/proc/update_name()

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -12,6 +12,44 @@
 
 	var/obj/item/weapon/card/id/stored_card = null
 
+/obj/item/weapon/computer_hardware/card_slot/diagnostics(var/mob/user)
+	..()
+	var/to_send = list()
+	to_send += "[name] status: [stored_card ? "Card Inserted" : "Card Not Present"]\n"
+	if(stored_card)
+		to_send += "Testing card read...\n"
+		if( damage >= damage_failure )
+			to_send += "...FAILURE!\n"
+		else
+			var/read_string_stability
+			if(check_functionality())
+				read_string_stability = 100
+			else
+				read_string_stability = 100 - malfunction_probability
+			to_send += "Registered Name: [stars(stored_card.registered_name, read_string_stability)]\n"
+			to_send += "Registered Assignment: [stars(stored_card.assignment, read_string_stability)]\n"
+			to_send += "Registered Rank: [stars(stored_card.rank, read_string_stability)]\n"
+			to_send += "Access Addresses Enabled: \n"
+			var/list/access_list = stored_card.GetAccess()
+			if(!access_list) // "NONE" for empty list
+				to_send += "NONE"
+			else
+				var/list_of_accesses = list()
+				for(var/access_id in access_list)
+					if(check_functionality()) // Read the access, or show "RD_ERR"
+						var/datum/access/access_information = get_access_by_id(access_id)
+						var/access_type = access_information.access_type
+						if(access_type == ACCESS_TYPE_NONE || access_type == ACCESS_TYPE_SYNDICATE || access_type == ACCESS_TYPE_CENTCOM) // Don't elaborate on these access types.
+							list_of_accesses += "UNKNOWN" // "UNKNOWN"
+						else
+							list_of_accesses += uppertext(access_information.desc)
+					else
+						list_of_accesses += "RD_ERR"
+				to_send += jointext(list_of_accesses, ", ") + "\n" // Should append a proper, comma separated list.
+	
+	to_chat(user, JOINTEXT(to_send))
+		
+
 /obj/item/weapon/computer_hardware/card_slot/broadcaster // read only
 	name = "RFID card broadcaster"
 	desc = "Reads and broadcasts the RFID signal of an inserted card."


### PR DESCRIPTION
Working
![image](https://user-images.githubusercontent.com/3196371/50399523-11dc3b00-074e-11e9-98c1-1d23d4e5315a.png)
Malfunctioning
![image](https://user-images.githubusercontent.com/3196371/50399527-17398580-074e-11e9-9ba5-6be3e3766b81.png)
Also malfunctioning RFID broadcasters will occasionally fail to read the ID and thus prevent you from accessing doors/items randomly.
:cl:
rscadd: RFID card readers firmware has been updated to allow verbose diagnostics checks.
/:cl: