### PR TITLE
You no longer keep dropping hardware onto the floor as a default

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -109,7 +109,9 @@
 	if(found)
 		if(user)
 			to_chat(user, "You remove \the [H] from \the [src].")
-		H.dropInto(loc)
+			user.put_in_hands(H)
+		else
+			H.dropInto(loc)
 		H.holder2 = null
 		update_verbs()
 	if(critical && enabled)


### PR DESCRIPTION
Because it's annoying to pick it up back up
:cl:
tweak: You no longer drop computer hardware onto the floor if possible.
/:cl: