### PR TITLE
Add SPECIES_IPC to command RIGs

### DIFF
--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -25,22 +25,22 @@
 	icon = 'maps/torch/icons/obj/obj_head_solgov.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/onmob_head_solgov.dmi')
 	camera = /obj/machinery/camera/network/command
-	species_restricted = list(SPECIES_HUMAN) //no available icons for aliens
+	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC) //no available icons for aliens
 
 /obj/item/clothing/suit/space/rig/command
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
-	species_restricted = list(SPECIES_HUMAN)
+	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
 
 /obj/item/clothing/shoes/magboots/rig/command
 	icon = 'maps/torch/icons/obj/obj_feet_solgov.dmi'
 	item_icons = list(slot_shoes_str = 'maps/torch/icons/mob/onmob_feet_solgov.dmi')
-	species_restricted = list(SPECIES_HUMAN)
+	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
 
 /obj/item/clothing/gloves/rig/command
 	icon = 'maps/torch/icons/obj/obj_hands_solgov.dmi'
 	item_icons = list(slot_gloves_str = 'maps/torch/icons/mob/onmob_hands_solgov.dmi')
-	species_restricted = list(SPECIES_HUMAN)
+	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
 
 
 /obj/item/weapon/rig/command/equipped


### PR DESCRIPTION
🆑 lorwp
tweak: IPCs can now use the Command Hardsuits
/🆑

So human-shaped IPCs can use Human-shaped RIGs.

~~Assumed to be intended due to the cooling unit installed in the suits. Doesn't give them anymore access mechanically to use anything other than the Command RIG unless they're a traitor~~

Fixes #22353

![metal boi wearing that command rig](https://user-images.githubusercontent.com/8052896/50436130-62af8780-0938-11e9-9b90-bf4e277d43c4.png)

