### PR TITLE
Gives shuttle SMES' a capacitance coil

### DIFF
--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -187,6 +187,7 @@ var/const/NETWORK_NANOTRASEN  = "Petrov"
 // Shuttle SMES
 /obj/machinery/power/smes/buildable/preset/torch/shuttle/configure_and_install_coils()
 	component_parts += new /obj/item/weapon/smes_coil/super_io(src)
+	component_parts += new /obj/item/weapon/smes_coil/super_capacity(src)
 	_input_maxed = TRUE
 	_output_maxed = TRUE
 	_input_on = TRUE


### PR DESCRIPTION
🆑Roland410:
:tweak:Gives shuttle SMES' a capacitance coil upgrading maximum charge to 270kW.
/🆑
This was a very much needed addition in my opinion since we have proper overmap capabilities with sensors and everything draining a LOT of power, and at the same time this is a bandaid fix to atmos machinery using WAY more power than usually expected.