### PR TITLE
GetConnectedZlevels to get_connected_z_levels

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -69,7 +69,7 @@
 /proc/pick_area_turf_in_connected_z_levels(var/list/area_predicates, var/list/turf_predicates, var/z_level)
 	area_predicates = area_predicates.Copy()
 
-	var/z_levels = GetConnectedZlevels(z_level)
+	var/z_levels = get_connected_z_levels(z_level)
 	area_predicates[/proc/area_belongs_to_zlevels] = z_levels
 	return pick_area_and_turf(area_predicates, turf_predicates)
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -91,7 +91,7 @@
 		overlays += image(icon,"pin_here")
 		return
 
-	if(!(there.z in GetConnectedZlevels(here.z)))
+	if(!(there.z in get_connected_z_levels(here.z)))
 		overlays += image(icon,"pin_invalid")
 		return
 	if(here.z > there.z)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -97,7 +97,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
 				last_request = world.time
 				var/list/holopadlist = list()
-				var/zlevels = GetConnectedZlevels(z)
+				var/zlevels = get_connected_z_levels(z)
 				if(GLOB.using_map.use_overmap && map_range >= 0)
 					var/obj/effect/overmap/O = map_sectors["[z]"]
 					for(var/obj/effect/overmap/OO in range(O,map_range))
@@ -190,7 +190,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(M)
 		for(var/mob/living/silicon/ai/master in masters)
 			var/ai_text = text
-			if(!master.say_understands(M, speaking))//The AI will be able to understand most mobs talking through the holopad.			
+			if(!master.say_understands(M, speaking))//The AI will be able to understand most mobs talking through the holopad.
 				if(speaking)
 					ai_text = speaking.scramble(text)
 				else

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -198,7 +198,7 @@
 
 	// Toggle on/off getting signals from the station or the current Z level
 	if(src.listening_levels == GLOB.using_map.contact_levels) // equals the station
-		src.listening_levels = GetConnectedZlevels(position.z)
+		src.listening_levels = get_connected_z_levels(position.z)
 		return 1
 	else
 		src.listening_levels = GLOB.using_map.contact_levels

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -125,7 +125,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	if(!listening_levels)
 		//Defaults to our Z level!
 		var/turf/position = get_turf(src)
-		listening_levels = GetConnectedZlevels(position.z)
+		listening_levels = get_connected_z_levels(position.z)
 
 	if(autolinkers.len)
 		// Links nearby machines
@@ -356,7 +356,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 /obj/machinery/telecomms/relay/forceMove(var/newloc)
 	. = ..(newloc)
-	listening_levels = GetConnectedZlevels(z)
+	listening_levels = get_connected_z_levels(z)
 	update_power()
 
 // Relays on ship's Z levels use less power as they don't have to transmit over such large distances.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -464,7 +464,7 @@
 	if(!connection)	return 0	//~Carn
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
-					  filter_type, signal.data["compression"], GetConnectedZlevels(position.z), connection.frequency, verb, speaking,
+					  filter_type, signal.data["compression"], get_connected_z_levels(position.z), connection.frequency, verb, speaking,
 					  "#unkn", channel_color_presets["Menacing Maroon"])
 
 

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -53,7 +53,7 @@
 /datum/alarm_handler/proc/alarms(var/z_level)
 	if(z_level)
 		. = list()
-		for(var/z in GetConnectedZlevels(z_level))
+		for(var/z in get_connected_z_levels(z_level))
 			. += alarms_by_z["[z]"] || list()
 	else
 		return alarms

--- a/code/modules/bsa/bsa_fire.dm
+++ b/code/modules/bsa/bsa_fire.dm
@@ -30,7 +30,7 @@
 				else
 					A.ex_act(1)
 
-	var/list/relevant_z = GetConnectedZlevels(start.z)
+	var/list/relevant_z = get_connected_z_levels(start.z)
 	for(var/mob/M in GLOB.player_list)
 		var/turf/T = get_turf(M)
 		if(!T || !(T.z in relevant_z))

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -48,7 +48,7 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Initialize()
 	. = ..()
-	connected_zlevels = GetConnectedZlevels(z)
+	connected_zlevels = get_connected_z_levels(z)
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Process()
 	if(z in GLOB.using_map.station_levels) //plants on station always tick

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -64,7 +64,7 @@
 	//Null rod stuff
 	var/supernatural = 0
 	var/purge = 0
-	
+
 	var/bleed_ticks = 0
 	var/bleed_colour = COLOR_BLOOD_HUMAN
 	var/can_bleed = TRUE
@@ -76,7 +76,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!living_observers_present(GetConnectedZlevels(z)))
+	if(!living_observers_present(get_connected_z_levels(z)))
 		return
 	//Health
 	if(stat == DEAD)
@@ -102,7 +102,7 @@
 	handle_confused()
 	handle_supernatural()
 	handle_impaired_vision()
-	
+
 	if(can_bleed && bleed_ticks > 0)
 		handle_bleeding()
 
@@ -417,13 +417,13 @@
 		bleed_ticks = max(bleed_ticks, amount)
 	else
 		bleed_ticks = max(bleed_ticks + amount, 0)
-		
+
 	bleed_ticks = round(bleed_ticks)
-	
+
 /mob/living/simple_animal/proc/handle_bleeding()
 	bleed_ticks--
 	adjustBruteLoss(1)
-	
+
 	var/obj/effect/decal/cleanable/blood/drip/drip = new(get_turf(src))
 	drip.basecolor = bleed_colour
 	drip.update_icon()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -417,7 +417,7 @@ proc/is_blind(A)
 	var/turf/sourceturf = get_turf(broadcast_source)
 	for(var/mob/M in targets)
 		var/turf/targetturf = get_turf(M)
-		if(!sourceturf || (targetturf.z in GetConnectedZlevels(sourceturf.z)))
+		if(!sourceturf || (targetturf.z in get_connected_z_levels(sourceturf.z)))
 			M.show_message("<span class='info'>\icon[icon] [message]</span>", 1)
 
 /proc/mobs_in_area(var/area/A)

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -105,13 +105,13 @@
 		executed = 1
 		target.dos_sources.Add(src)
 		operator_skill = usr.get_skill_value(SKILL_COMPUTER)
-	
+
 		var/list/sources_to_show = list(computer.network_card.get_network_tag())
 		var/extra_to_show = 2 * max(operator_skill - SKILL_ADEPT, 0)
 		if(extra_to_show)
 			var/list/candidates = list()
 			for(var/obj/item/modular_computer/C in SSobj.processing) // Apparently the only place these are stored.
-				if(C.network_card && (C.z in GetConnectedZlevels(computer.z)))
+				if(C.network_card && (C.z in get_connected_z_levels(computer.z)))
 					candidates += C
 			for(var/i = 1, i <= extra_to_show, i++)
 				var/obj/item/modular_computer/C = pick_n_take(candidates)

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -145,7 +145,7 @@
 				var/affected_zlevels = GLOB.using_map.contact_levels
 				var/atom/A = host
 				if(istype(A))
-					affected_zlevels = GetConnectedZlevels(A.z)
+					affected_zlevels = get_connected_z_levels(A.z)
 				crew_announcement.Announce(input, zlevels = affected_zlevels)
 				announcment_cooldown = 1
 				spawn(600)//One minute cooldown

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -88,7 +88,7 @@
 	var/turf/T = get_turf(nano_host())
 	if(!T) // Safety check
 		return
-	var/connected_z_levels = GetConnectedZlevels(T.z)
+	var/connected_z_levels = get_connected_z_levels(T.z)
 	for(var/obj/machinery/power/sensor/S in SSmachines.machinery)
 		if((S.long_range) || (S.loc.z in connected_z_levels)) // Consoles have range on their Z-Level. Sensors with long_range var will work between Z levels.
 			if(S.name_tag == "#UNKN#") // Default name. Shouldn't happen!

--- a/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
@@ -25,7 +25,7 @@
 		return list()
 
 	var/list/shields = list()
-	var/connected_z_levels = GetConnectedZlevels(T.z)
+	var/connected_z_levels = get_connected_z_levels(T.z)
 	for(var/obj/machinery/power/shield_generator/S in SSmachines.machinery)
 		if(!(S.z in connected_z_levels))
 			continue

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -44,7 +44,7 @@
 	var/turf/T = get_turf(nano_host())
 	if(!T)
 		return
-	var/valid_z_levels = (GetConnectedZlevels(T.z) & GLOB.using_map.station_levels)
+	var/valid_z_levels = (get_connected_z_levels(T.z) & GLOB.using_map.station_levels)
 	for(var/obj/machinery/power/supermatter/S in SSmachines.machinery)
 		// Delaminating, not within coverage, not on a tile.
 		if(S.grav_pulling || S.exploded || !(S.z in valid_z_levels) || !istype(S.loc, /turf/))

--- a/code/modules/modular_computers/file_system/programs/generic/docks.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/docks.dm
@@ -27,7 +27,7 @@
 	if(!istype(AM))
 		return
 	docking_controllers.Cut()
-	var/list/zlevels = GetConnectedZlevels(AM.z)
+	var/list/zlevels = get_connected_z_levels(AM.z)
 	for(var/obj/machinery/embedded_controller/radio/airlock/docking_port/D in SSmachines.machinery)
 		if(D.z in zlevels)
 			var/shuttleside = 0

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -164,7 +164,7 @@
 
 	..()
 
-	if(channel && !(channel.source_z in GetConnectedZlevels(computer.z)))
+	if(channel && !(channel.source_z in get_connected_z_levels(computer.z)))
 		channel.remove_client(src)
 		channel = null
 
@@ -223,7 +223,7 @@
 
 	else // Channel selection screen
 		var/list/all_channels[0]
-		var/list/connected_zs = GetConnectedZlevels(C.computer.z)
+		var/list/connected_zs = get_connected_z_levels(C.computer.z)
 		for(var/datum/ntnet_conversation/conv in ntnet_global.chat_channels)
 			if(conv && conv.title && (conv.source_z in connected_zs))
 				all_channels.Add(list(list(

--- a/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
+++ b/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
@@ -22,7 +22,7 @@
 	var/atom/movable/AM = nano_host()
 	if(!istype(AM))
 		return
-	var/list/zlevels = GetConnectedZlevels(AM.z)
+	var/list/zlevels = get_connected_z_levels(AM.z)
 	for(var/obj/item/weapon/gun/G in GLOB.registered_weapons)
 		if(G.standby)
 			continue

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -37,7 +37,7 @@ var/list/z_levels = list()// Each bit re... haha just kidding this is a list of 
 		return null
 	return HasBelow(turf.z) ? get_step(turf, DOWN) : null
 
-/proc/GetConnectedZlevels(z)
+/proc/get_connected_z_levels(z)
 	. = list(z)
 	for(var/level = z, HasBelow(level), level--)
 		. |= level-1
@@ -45,7 +45,7 @@ var/list/z_levels = list()// Each bit re... haha just kidding this is a list of 
 		. |= level+1
 
 /proc/AreConnectedZLevels(var/zA, var/zB)
-	return zA == zB || (zB in GetConnectedZlevels(zA))
+	return zA == zB || (zB in get_connected_z_levels(zA))
 
 /proc/get_zstep(ref, dir)
 	if(dir == UP)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -49,7 +49,7 @@
 /obj/effect/overmap/proc/get_areas()
 
 /obj/effect/overmap/proc/find_z_levels()
-	map_z = GetConnectedZlevels(z)
+	map_z = get_connected_z_levels(z)
 
 /obj/effect/overmap/proc/register_z_levels()
 	for(var/zlevel in map_z)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -83,7 +83,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	if (stamp)
 		authmsg += "[stamp]<br>"
 	. = FALSE
-	var/list/good_z = GetConnectedZlevels(z)
+	var/list/good_z = get_connected_z_levels(z)
 	for (var/obj/machinery/requests_console/Console in allConsoles)
 		if(!(Console.z in good_z))
 			continue

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -69,7 +69,7 @@
 
 	// Add the spawn points to the appropriate job list.
 	var/added_spawnpoint
-	for(var/check_z in GetConnectedZlevels(associated_z))
+	for(var/check_z in get_connected_z_levels(associated_z))
 		for(var/thing in block(locate(1, 1, check_z), locate(world.maxx, world.maxy, check_z)))
 			for(var/obj/effect/submap_landmark/spawnpoint/landmark in thing)
 				var/datum/job/submap/job = jobs[landmark.name]

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -192,7 +192,7 @@
 	if(!istype(TS))
 		return
 
-	var/list/affected_z = GetConnectedZlevels(TS.z)
+	var/list/affected_z = get_connected_z_levels(TS.z)
 
 	// Effect 1: Radiation, weakening to all mobs on Z level
 	for(var/z in affected_z)

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -247,7 +247,7 @@
 
 /obj/item/weapon/pinpointer/radio/acquire_target()
 	var/turf/T = get_turf(src)
-	var/zlevels = GetConnectedZlevels(T.z)
+	var/zlevels = get_connected_z_levels(T.z)
 	var/cur_dist = world.maxx+world.maxy
 	for(var/obj/item/device/radio/beacon/R in world)
 		if((R.z in zlevels) && R.frequency == tracking_freq)

--- a/code/procs/radio.dm
+++ b/code/procs/radio.dm
@@ -40,7 +40,7 @@
 	if(message_servers)
 		var/list/zlevels = GLOB.using_map.contact_levels
 		if(z)
-			zlevels = GetConnectedZlevels(z)
+			zlevels = get_connected_z_levels(z)
 		for (var/obj/machinery/message_server/MS in message_servers)
 			if(MS.active && (MS.z in zlevels))
 				return MS


### PR DESCRIPTION
Rundown of Discord discussion:

What's the issue?
`GetConnectedZlevels is not CamelCase.`
Why?
`level` should start with a capital.
What to do?
A) Nothing, because we may consider zlevel a single word. _In this case just close the PR._
B) Make it CamelCase, by capitalizing `level`. _If you prefer this instead, please request changes._
C) As per BYOND standard, and as enforced in our codebase at some cases, make it snake_case. _This is the currently pushed commit._

There are 36 edits in this diff, thus there are 35 times this proc is called. Better settle this issue before it grows further, as it surely will.

_In order to have the authentic code reviewing experience, imagine Lohikar echoing "It creates blame and commit noise!" in the background while reading this PR._