### PR TITLE
Improvements to random chems.

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -429,11 +429,6 @@
 		chems[/datum/reagent/nutriment] = list(rand(1,10),rand(10,20))
 
 	var/additional_chems = rand(0,5)
-	if(prob(50))
-		var/chem_type = SSchemistry.get_random_chem(TRUE)
-		if(chem_type)
-			additional_chems = 0
-			chems[chem_type] = list(rand(1,10),rand(10,20))
 
 	if(additional_chems)
 		var/list/banned_chems = list(

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -148,6 +148,13 @@
 	for(var/g in atmosphere.gas)
 		if(gas_data.flags[g] & XGM_GAS_CONTAMINANT)
 			S.set_trait(TRAIT_TOXINS_TOLERANCE, rand(10,15))
+	if(prob(50))
+		var/chem_type = SSchemistry.get_random_chem(TRUE, atmosphere.temperature)
+		if(chem_type)
+			var/nutriment = S.chems[/datum/reagent/nutriment]
+			S.chems.Cut()
+			S.chems[/datum/reagent/nutriment] = nutriment
+			S.chems[chem_type] = list(rand(1,10),rand(10,20))
 
 /obj/effect/overmap/sector/exoplanet/proc/adapt_animal(var/mob/living/simple_animal/A)
 	if(species[A.type])

--- a/code/modules/reagents/Chemistry-Reagents/Random/Chemistry-Reagents-Random.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Random/Chemistry-Reagents-Random.dm
@@ -10,7 +10,8 @@ GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	/datum/reagent/drink,
 	/datum/reagent/crayon_dust,
 	/datum/reagent/random,
-	/datum/reagent/toxin/phoron
+	/datum/reagent/toxin/phoron,
+	/datum/reagent/ethanol // Includes alcoholic beverages
 ))
 
 #define FOR_ALL_EFFECTS \
@@ -31,7 +32,7 @@ GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	return ..(holder)
 
 /datum/reagent/random/initialize_data(var/list/newdata)
-	var/datum/reagent/random/other = SSchemistry.get_prototype(src)
+	var/datum/reagent/random/other = SSchemistry.get_prototype(type)
 	if(istype(newdata))
 		data = newdata.Copy()
 	else
@@ -40,7 +41,7 @@ GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	heating_products = other.heating_products
 	recompute_properties()
 
-/datum/reagent/random/proc/randomize_data()
+/datum/reagent/random/proc/randomize_data(temperature)
 	data = list()
 	var/list/effects_to_get = subtypesof(/decl/random_chem_effect/random_properties)
 	if(length(effects_to_get) > max_effect_number)
@@ -51,7 +52,7 @@ GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	var/list/decls = decls_repository.get_decls_unassociated(effects_to_get)
 	for(var/item in decls)
 		var/decl/random_chem_effect/effect = item
-		effect.prototype_process(src)
+		effect.prototype_process(src, temperature)
 	
 	var/whitelist = subtypesof(/datum/reagent)
 	for(var/bad_type in GLOB.random_chem_interaction_blacklist)
@@ -66,6 +67,10 @@ GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	
 	for(var/decl/random_chem_effect/random_properties/effect in decls)
 		effect.set_caches(src, whitelist)
+
+/datum/reagent/random/proc/stable_at_temperature(temperature)
+	if(temperature > chilling_point && temperature < heating_point)
+		return TRUE
 
 /datum/reagent/random/mix_data(var/list/other_data, var/amount)
 	if(volume <= 0)

--- a/code/modules/reagents/Chemistry-Reagents/Random/random_effects.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Random/random_effects.dm
@@ -28,7 +28,7 @@
 		if(RANDOM_CHEM_EFFECT_FLOAT)
 			return first_value * first_ratio + second_value * (1 - first_ratio)
 
-/decl/random_chem_effect/proc/prototype_process(var/datum/reagent/random/prototype)
+/decl/random_chem_effect/proc/prototype_process(var/datum/reagent/random/prototype, temperature)
 	prototype.data[type] = get_random_value()
 
 /decl/random_chem_effect/proc/on_property_recompute(var/datum/reagent/random/reagent, var/value)
@@ -97,17 +97,35 @@
 	reagent.metabolism = value
 
 /decl/random_chem_effect/general_properties/chilling_point
-	minimum = T0C - 80
+	minimum = TCMB
+	var/generic_minimum = T0C - 80 // Will be used unless the temperature we're gunning for is too cold
 	maximum = T0C - 10
 	mode = RANDOM_CHEM_EFFECT_FLOAT
+
+/decl/random_chem_effect/general_properties/chilling_point/get_random_value(temperature)
+	var/max = max(min(maximum, temperature - 20), minimum) // Use given max unless that's above the given temp - margin
+	var/min = max(min(generic_minimum, max - 20), minimum) // Use the generic min as min unless that's above the max - margin
+	return rand() * (max - min) + min
+
+/decl/random_chem_effect/general_properties/chilling_point/prototype_process(var/datum/reagent/random/prototype, temperature = T20C)
+	prototype.data[type] = get_random_value(temperature)
 
 /decl/random_chem_effect/general_properties/chilling_point/on_property_recompute(var/datum/reagent/random/reagent, var/value)
 	reagent.chilling_point = value
 
 /decl/random_chem_effect/general_properties/heating_point
 	minimum = T0C + 60
-	maximum = T0C + 180
+	var/generic_maximum = T0C + 180
+	maximum = T0C + 500
 	mode = RANDOM_CHEM_EFFECT_FLOAT
+
+/decl/random_chem_effect/general_properties/heating_point/get_random_value(temperature)
+	var/min = min(max(minimum, temperature + 20), maximum)
+	var/max = min(max(generic_maximum, min + 20), maximum)
+	return rand() * (max - min) + min
+
+/decl/random_chem_effect/general_properties/heating_point/prototype_process(var/datum/reagent/random/prototype, temperature = T20C)
+	prototype.data[type] = get_random_value(temperature)
 
 /decl/random_chem_effect/general_properties/heating_point/on_property_recompute(var/datum/reagent/random/reagent, var/value)
 	reagent.heating_point = value


### PR DESCRIPTION
Blacklists alcoholic beverages for interaction. 
They no longer spawn on non-exoplanet seeds.
Makes them tailored to the exoplanet they spawn on in terms of temperature tolerance, at least within reason. Note that this will likely make it difficult to heat or cool them to improve the effects, but at least one of two should still be possible.