### PR TITLE
Toned radiation planets radiation WAY down.

### DIFF
--- a/code/modules/overmap/exoplanets/garbage.dm
+++ b/code/modules/overmap/exoplanets/garbage.dm
@@ -47,7 +47,7 @@
 
 /datum/random_map/noise/exoplanet/garbage/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0)
 	if(prob(60))
-		fallout = rand(5, 60)
+		fallout = rand(10, 50)
 	..()
 
 /datum/random_map/noise/exoplanet/garbage/get_additional_spawns(var/value, var/turf/T)

--- a/code/modules/overmap/exoplanets/garbage.dm
+++ b/code/modules/overmap/exoplanets/garbage.dm
@@ -47,7 +47,7 @@
 
 /datum/random_map/noise/exoplanet/garbage/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0)
 	if(prob(60))
-		fallout = rand(20, 100)
+		fallout = rand(5, 60)
 	..()
 
 /datum/random_map/noise/exoplanet/garbage/get_additional_spawns(var/value, var/turf/T)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

Radiation planets were pretty crazy. 20-100 Bq.

Now it's 10-50. This tweak may be adjusted again in the future, I would like to see how this holds up for now. Radiation planets should be dangerous, but not a death sentence soon as you step out of the Charon.

:cl:
tweak: Radiation planets hotspots can now be between 10 and 50 Bq, down from 20-100.
/:cl: