### PR TITLE
Radiation resistance calculation change

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -55,7 +55,7 @@
 		if(PAIN)
 			adjustHalLoss(effect * blocked_mult(blocked))
 		if(IRRADIATE)
-			radiation += max(effect - blocked, 0) * blocked_mult(blocked)
+			radiation += max(effect - blocked, 0) * blocked_mult(blocked) // set a floor threshold where radiation is completely blocked, and a percentage reduction to exposure after that.
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter - TODO CANSTUTTER flag?
 				stuttering = max(stuttering, effect * blocked_mult(blocked))

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -55,7 +55,7 @@
 		if(PAIN)
 			adjustHalLoss(effect * blocked_mult(blocked))
 		if(IRRADIATE)
-			radiation += effect * blocked_mult(blocked)
+			radiation += max(effect - blocked, 0) * blocked_mult(blocked)
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter - TODO CANSTUTTER flag?
 				stuttering = max(stuttering, effect * blocked_mult(blocked))


### PR DESCRIPTION
After feedback and brainstorming regarding PR https://github.com/Baystation12/Baystation12/pull/24108, afterthought provided a simple solution to create a lower irradiation bound. Basically, radiation resistance now fully blocks radiation levels below its resistance percentage, and thereafter some will leak through. Lower resistance suits leak much more readily, and to greater degrees, while high resistance suits will only leak a little bit after the threshold is reached.

Because @comma is evil though, expect him to be buffing the extreme hot zones on radiation planets. At least for now, the simple background radiation won't be lethal anymore to explorers, but the higher hotzones that exist still are.

:cl:
tweak: Radiation resistance now fully blocks radiation levels below its radiation resistance percentage, and thereafter will only allow some radiation leakthrough. Lower resistance suits leak much more readily once  past the threshold, while high resistance suits will only leak a little bit after the threshold is reached. Very highly irradiated environments are still extremely dangerous.
/:cl: