### PR TITLE
Makes pain lethal again

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -69,7 +69,9 @@
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE
 			return
-	if(pulse && oxy <= BLOOD_VOLUME_SURVIVE && !owner.chem_effects[CE_STABLE])	//I SAID MOAR OXYGEN
+
+	var/fibrillation = oxy <= BLOOD_VOLUME_SURVIVE || (prob(30) && owner.shock_stage > 120)
+	if(pulse && fibrillation && !owner.chem_effects[CE_STABLE])	//I SAID MOAR OXYGEN
 		pulse = PULSE_THREADY
 		return
 

--- a/html/changelogs/chinsky - paain.yml
+++ b/html/changelogs/chinsky - paain.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - soundadd: "Pain has a low chance of heartstop again. High shock levels ('You feel like you can die any moment now!' level) can sometimes cause thready pulse. Countered by giving poor sod some painkillers to prevent shock, or some inapro to stabilize the pulse."


### PR DESCRIPTION
I've heard some skreeching that making pain not stop heart was worst thing since vegemite, and that it made our powergaming doctors just not bother with painkillers ever now.

So I think it'd be ok to stick it back in vastly dilluted form (since I still think pain shouldn't be sole killing factor).

Now if you're past 120 shock stage ("You feel you could die any minute now" one), sometimes heart will enter thready pulse state, which in turn can cause heartstop. All in all pretty low chance, but it CAN happen, so don't ignore severe shock.
