### PR TITLE
Nerfs xenoflora and xenoarch

### DIFF
--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -150,7 +150,7 @@
 		/obj/item/seeds/wheatseed = 30,
 		/obj/item/seeds/whitebeetseed = 30,
 		/obj/item/seeds/algaeseed = 30,
-		/obj/item/seeds/random = 10
+		/obj/item/seeds/random = 2
 	)
 
 /obj/machinery/seed_storage/attack_hand(mob/user as mob)

--- a/maps/torch/datums/supplypacks/science.dm
+++ b/maps/torch/datums/supplypacks/science.dm
@@ -77,3 +77,9 @@
 	containername = "exploration voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_explorer
+
+/decl/hierarchy/supply_pack/hydroponics/exoticseeds
+	contains = list(/obj/item/seeds/replicapod = 2,
+					/obj/item/seeds/libertymycelium = 2,
+					/obj/item/seeds/reishimycelium = 2,
+					/obj/item/seeds/kudzuseed = 2)

--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -13415,8 +13415,6 @@
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/maint)
 "Ji" = (
-/obj/machinery/artifact,
-/obj/structure/anomaly_container,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -13842,8 +13840,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
 "KN" = (
-/obj/machinery/artifact,
-/obj/structure/anomaly_container,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -12687,10 +12687,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/aftport)
-"DQ" = (
-/obj/machinery/seed_storage/random,
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
 "DR" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -34040,7 +34036,7 @@ BN
 lr
 pi
 pi
-DQ
+pi
 Wp
 Wp
 Wp


### PR DESCRIPTION
No more pre-spawned anomalies for xenoarch. Seemed like a good idea at the time, but now even if someone decides to xenoarch, there's no point for them to go on excavation ever.

No more orderable random xenoseeds from cargo. Seed storage now starts with only 1 alien seed sample
:cl:
tweak: Only 1 random alien seed in Xenoflora storage now, and can't order them from cargo. Go on expeditions nerds.
maptweak: No more pre-spawned anomalies on Petrov. Go on expeditions nerds.
/:cl: