### PR TITLE
Ship speed display tweaks

### DIFF
--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -121,7 +121,7 @@
 		. = round(. * 0.5)
 	if(victim.is_still()) //Standing still means less shit flies your way
 		. = round(. * 0.25)
-	if(victim.get_speed() < 0.3) //Slow and steady
+	if(victim.get_speed() < victim.min_speed * 5) //Slow and steady
 		. = round(. * 0.6)
-	if(victim.get_speed() > 3) //Sanic stahp
+	if(victim.get_speed() > victim.max_speed * 0.75) //Sanic stahp
 		. *= 2

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -101,9 +101,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		data["dest"] = dy && dx
 		data["d_x"] = dx
 		data["d_y"] = dy
-		data["speedlimit"] = speedlimit ? speedlimit : "None"
-		data["speed"] = linked.get_speed()
-		data["accel"] = linked.get_acceleration()
+		data["speedlimit"] = speedlimit ? speedlimit*1000 : "None"
+		data["speed"] = round(linked.get_speed()*1000, 0.01)
+		data["accel"] = round(linked.get_acceleration()*1000, 0.01)
 		data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
 		data["autopilot"] = autopilot
 		data["manual_control"] = manual_control
@@ -195,9 +195,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		dy = 0
 
 	if (href_list["speedlimit"])
-		var/newlimit = input("Input new speed limit for autopilot (0 to disable)", "Autopilot speed limit", speedlimit) as num|null
+		var/newlimit = input("Input new speed limit for autopilot (0 to disable)", "Autopilot speed limit", speedlimit*1000) as num|null
 		if(newlimit)
-			speedlimit = Clamp(newlimit, 0, 100)
+			speedlimit = Clamp(newlimit/1000, 0, 100)
 
 	if (href_list["move"])
 		var/ndir = text2num(href_list["move"])
@@ -240,8 +240,8 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	data["sector_info"] = current_sector ? current_sector.desc : "Not Available"
 	data["s_x"] = linked.x
 	data["s_y"] = linked.y
-	data["speed"] = linked.get_speed()
-	data["accel"] = linked.get_acceleration()
+	data["speed"] = round(linked.get_speed()*1000, 0.01)
+	data["accel"] = round(linked.get_acceleration()*1000, 0.01)
 	data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
 	data["viewing"] = viewing
 


### PR DESCRIPTION
All displayed values are 1000 higher now because tiny decimals look not as pretty. Actual values are same, just displayed in 1000s.
In effect that means 1/1000th of tile per second

Fixes meteor overmap event expecting unreasonable speeds. Now it will give you smol waves if you go 3x the lowest ship speed possible, and bigger wavs if you go more than 3/4th of max speed

:cl:
tweak: All speed/acceleration values are now displayed multiplied by 1000. Actual mechanics are still same.
/:cl: