### PR TITLE
Hypospray, syringe, and container quality of life improvements

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -182,7 +182,7 @@
 
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 	playsound(src, 'sound/effects/pour.ogg', 25, 1)
-	to_chat(user, "<span class='notice'>You transfer [trans] unit\s of the solution to \the [target].</span>")
+	to_chat(user, "<span class='notice'>You transfer [trans] unit\s of the solution to \the [target].  \The [src] now contains [src.reagents.total_volume] units.</span>")
 	return 1
 
 /obj/item/weapon/reagent_containers/do_surgery(mob/living/carbon/M, mob/living/user)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -27,7 +27,7 @@
 	attack(M, user)
 	return 1
 
-/obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M, mob/user)
 	if(!reagents.total_volume)
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
 		return
@@ -64,6 +64,8 @@
 	item_state = "autoinjector"
 	desc = "The DeForest Medical Corporation, a subsidiary of Zeng-Hu Pharmaceuticals, hypospray is a sterile, air-needle autoinjector for rapid administration of drugs to patients. Uses a replacable 30u vial."
 	var/obj/item/weapon/reagent_containers/glass/beaker/vial/loaded_vial
+	possible_transfer_amounts = "1;2;5;10;15;20;30"
+	amount_per_transfer_from_this = 5
 	volume = 0
 
 /obj/item/weapon/reagent_containers/hypospray/vial/New()
@@ -72,42 +74,56 @@
 	volume = loaded_vial.volume
 	reagents.maximum_volume = loaded_vial.reagents.maximum_volume
 
-/obj/item/weapon/reagent_containers/hypospray/vial/attack_hand(mob/user as mob)
-	if(user.get_inactive_hand() == src)
-		if(loaded_vial)
-			reagents.trans_to_holder(loaded_vial.reagents,volume)
-			reagents.maximum_volume = 0
-			loaded_vial.update_icon()
-			user.put_in_hands(loaded_vial)
-			loaded_vial = null
-			to_chat(user, "You remove the vial from the [src].")
-			update_icon()
-			playsound(src.loc, 'sound/weapons/flipblade.ogg', 50, 1)
-			return
-		..()
-	else
-		return ..()
+/obj/item/weapon/reagent_containers/hypospray/vial/proc/remove_vial(mob/user, swap_mode)
+	if(!loaded_vial)
+		return
+	reagents.trans_to_holder(loaded_vial.reagents,volume)
+	reagents.maximum_volume = 0
+	loaded_vial.update_icon()
+	user.put_in_hands(loaded_vial)
+	loaded_vial = null
+	if (swap_mode != "swap") // if swapping vials, we will print a different message in another proc
+		to_chat(user, "You remove the vial from the [src].")
 
-/obj/item/weapon/reagent_containers/hypospray/vial/attackby(obj/item/weapon/W, mob/user as mob)
-	if(istype(W, /obj/item/weapon/reagent_containers/glass/beaker/vial))
+/obj/item/weapon/reagent_containers/hypospray/vial/attack_hand(mob/user)
+	if(user.get_inactive_hand() == src)
 		if(!loaded_vial)
-			if(!do_after(user,10) || loaded_vial || !(W in user))
-				return 0
-			if(!user.unEquip(W, src))
-				return
-			if(W.is_open_container())
-				W.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
-				W.update_icon()
-			loaded_vial = W
-			reagents.maximum_volume = loaded_vial.reagents.maximum_volume
-			loaded_vial.reagents.trans_to_holder(reagents,volume)
-			user.visible_message("<span class='notice'>[user] has loaded [W] into \the [src].</span>","<span class='notice'>You load \the [W] into \the [src].</span>")
-			update_icon()
-			playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
+			to_chat(user, "<span class='notice'>There is no vial loaded in the [src].</span>")
+			return
+		remove_vial(user)
+		update_icon()
+		playsound(loc, 'sound/weapons/flipblade.ogg', 50, 1)
+		return
+	return ..()
+
+/obj/item/weapon/reagent_containers/hypospray/vial/attackby(obj/item/weapon/W, mob/user)
+	var/usermessage = ""
+	if(istype(W, /obj/item/weapon/reagent_containers/glass/beaker/vial))
+		if(!do_after(user,10) || !(W in user))
+			return 0
+		if(!user.unEquip(W, src))
+			return
+		if(loaded_vial)
+			remove_vial(user, "swap")
+			usermessage = "You load \the [W] into \the [src] as you remove the old one."
 		else
-			to_chat(user,"<span class='notice'>\The [src] already has a vial.</span>")
-	else
-		..()
+			usermessage = "You load \the [W] into \the [src]."
+		if(W.is_open_container())
+			W.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+			W.update_icon()
+		loaded_vial = W
+		reagents.maximum_volume = loaded_vial.reagents.maximum_volume
+		loaded_vial.reagents.trans_to_holder(reagents,volume)
+		user.visible_message("<span class='notice'>[user] has loaded [W] into \the [src].</span>","<span class='notice'>[usermessage]</span>")
+		update_icon()
+		playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
+		return
+	..()
+
+/obj/item/weapon/reagent_containers/hypospray/vial/afterattack(obj/target, mob/user, proximity) // hyposprays can be dumped into, why not out? uses standard_pour_into helper checks.
+	if(!proximity)
+		return
+	standard_pour_into(user, target)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector
 	name = "autoinjector"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -13,7 +13,7 @@
 	icon_state = "rg"
 	matter = list(MATERIAL_GLASS = 150)
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = null
+	possible_transfer_amounts = "1;2;5"
 	volume = 15
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS


### PR DESCRIPTION
Title. See changelog for what has changed.

credit to afterthought for his assistance with a good chunk of the logic.

:cl:
rscadd: CMOs rejoice! Your hypospray now has a quantity setting, you can administer in 1,2,5,10,15,20, or 30 units per injection!
rscadd: CMOs rejoice! You can now pour your hypospray contents into a container without removing the vial! (you can already put reagents in it too without swapping vials)
rscadd: CMOs rejoice! You are now coordinated enough to swap vials on the fly. No longer do you have to remove and put away the old vial before you can install a new one.
rscadd: Medical rejoice! The contractor producing your syringes have heard your cries and installed easier to read graduations on syringes. You now can set transfer amounts in 1, 2, and 5.
rscadd: Everyone rejoice! When pouring containers, you will now be able to see how many units are remaining.
/:cl: