### PR TITLE
Changed radiation planets backround radiation to 20-75bq.

### DIFF
--- a/code/modules/overmap/exoplanets/garbage.dm
+++ b/code/modules/overmap/exoplanets/garbage.dm
@@ -47,7 +47,7 @@
 
 /datum/random_map/noise/exoplanet/garbage/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0)
 	if(prob(60))
-		fallout = rand(20, 100)
+		fallout = rand(20, 75)
 	..()
 
 /datum/random_map/noise/exoplanet/garbage/get_additional_spawns(var/value, var/turf/T)


### PR DESCRIPTION
Title. Originally was 20-100. With the new rad calculation, it makes sense that the background radiation wouldn't surpass the exploration suits (but hotspots can).

This is basically https://github.com/Baystation12/Baystation12/pull/24108 but with different values. Learned the hard way that you should reopen a PR before you force push the repo.

:cl:
tweak: Radiation planets background rads peak out at 75bq. Hotspots are still deadly though!
/:cl: