### PR TITLE
Removes wall icon runtime during init.

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -43,9 +43,17 @@
 	if(!damage_overlays[1]) //list hasn't been populated
 		generate_overlays()
 
-	overlays.Cut()
-	var/image/I
+	// This line apparently causes runtimes during initialization.
+	// As we don't know why, or how to resolve this, I'm blocking runtime recording until after init.
+	try
+		overlays.Cut()
+	catch(var/exception/e)
+		if(e && GAME_STATE < RUNLEVEL_GAME)
+			queue_icon_update()
+			return
+		throw e
 
+	var/image/I
 	var/base_color = paint_color ? paint_color : material.icon_colour
 	if(!density)
 		I = image('icons/turf/wall_masks.dmi', "[material.icon_base]fwall_open")


### PR DESCRIPTION
This probably fixes nothing, but may alleviate the travis failure rate. If they runtime during game, I'm less comfortable removing it.