### PR TITLE
Reagent containers 'set transfer amount' verb range increased to one tile + refactor + fixes

### DIFF
--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -9,11 +9,17 @@
 	var/list/transfer_amounts = list(REM, 1, 2)
 	var/transfer_amount = 1
 
-/obj/structure/iv_drip/verb/set_APTFT()
+/obj/structure/iv_drip/verb/set_amount_per_transfer_from_this()
 	set name = "Set IV transfer amount"
 	set category = "Object"
 	set src in range(1)
+	if(!CanPhysicallyInteract(usr))
+		to_chat(usr, "<span class='notice'>You're in no condition to do that!'</span>")
+		return
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in transfer_amounts
+	if(!CanPhysicallyInteract(usr)) // because input takes time and the situation can change
+		to_chat(usr, "<span class='notice'>You're in no condition to do that!'</span>")
+		return
 	if(N)
 		transfer_amount = N
 
@@ -154,14 +160,9 @@
 	set category = "Object"
 	set name = "Toggle IV Mode"
 	set src in view(1)
-
-	if(!istype(usr, /mob/living))
-		to_chat(usr, "<span class='warning'>You can't do that.</span>")
+	if(!CanPhysicallyInteract(usr))
+		to_chat(usr, "<span class='notice'>You're in no condition to do that!'</span>")
 		return
-
-	if(usr.incapacitated())
-		return
-
 	mode = !mode
 	to_chat(usr, "The IV drip is now [mode ? "injecting" : "taking blood"].")
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -9,11 +9,24 @@
 	var/volume = 30
 	var/label_text
 
-/obj/item/weapon/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
+/obj/item/weapon/reagent_containers/proc/cannot_interact(mob/user)
+	if(!CanPhysicallyInteract(user))
+		to_chat(usr, "<span class='notice'>You're in no condition to do that!'</span>")
+		return TRUE
+	if(ismob(loc) && loc != user)
+		to_chat(usr, "<span class='notice'>You can't set transfer amounts while [src] is being held by someone else.</span>")
+		return TRUE
+	return FALSE
+
+/obj/item/weapon/reagent_containers/verb/set_amount_per_transfer_from_this()
 	set name = "Set transfer amount"
 	set category = "Object"
-	set src in range(0)
+	set src in range(1)
+	if (cannot_interact(usr))
+		return
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in cached_number_list_decode(possible_transfer_amounts)
+	if (cannot_interact(usr)) // because input takes time and the situation can change
+		return
 	if(N)
 		amount_per_transfer_from_this = N
 
@@ -21,7 +34,7 @@
 	create_reagents(volume)
 	..()
 	if(!possible_transfer_amounts)
-		src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
+		src.verbs -= /obj/item/weapon/reagent_containers/verb/set_amount_per_transfer_from_this
 
 /obj/item/weapon/reagent_containers/attack_self(mob/user as mob)
 	return
@@ -191,8 +204,7 @@
 
 /obj/item/weapon/reagent_containers/AltClick(var/mob/user)
 	if(possible_transfer_amounts)
-		if(CanPhysicallyInteract(user))
-			set_APTFT()
+		set_amount_per_transfer_from_this()
 	else
 		return ..()
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -21,7 +21,7 @@
 
 /obj/item/weapon/reagent_containers/spray/New()
 	..()
-	src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
+	src.verbs -= /obj/item/weapon/reagent_containers/verb/set_amount_per_transfer_from_this
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
 	if(istype(A, /obj/item/weapon/storage) || istype(A, /obj/structure/table) || istype(A, /obj/structure/closet) || istype(A, /obj/item/weapon/reagent_containers) || istype(A, /obj/structure/hygiene/sink) || istype(A, /obj/structure/janitorialcart))

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -19,7 +19,7 @@
 	create_reagents(initial_capacity)
 
 	if (!possible_transfer_amounts)
-		src.verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT
+		src.verbs -= /obj/structure/reagent_dispensers/verb/set_amount_per_transfer_from_this
 
 	for(var/reagent_type in initial_reagent_types)
 		var/reagent_ratio = initial_reagent_types[reagent_type]
@@ -37,11 +37,17 @@
 	else
 		to_chat(user, "<span class='notice'>Nothing.</span>")
 
-/obj/structure/reagent_dispensers/verb/set_APTFT() //set amount_per_transfer_from_this
+/obj/structure/reagent_dispensers/verb/set_amount_per_transfer_from_this()
 	set name = "Set transfer amount"
 	set category = "Object"
 	set src in view(1)
+	if(!CanPhysicallyInteract(usr))
+		to_chat(usr, "<span class='notice'>You're in no condition to do that!'</span>")
+		return
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in cached_number_list_decode(possible_transfer_amounts)
+	if(!CanPhysicallyInteract(usr))  // because input takes time and the situation can change
+		to_chat(usr, "<span class='notice'>You're in no condition to do that!'</span>")
+		return
 	if (N)
 		amount_per_transfer_from_this = N
 
@@ -65,8 +71,7 @@
 
 /obj/structure/reagent_dispensers/AltClick(var/mob/user)
 	if(possible_transfer_amounts)
-		if(CanPhysicallyInteract(user))
-			set_APTFT()
+		set_amount_per_transfer_from_this()
 	else
 		return ..()
 


### PR DESCRIPTION
Title.

This is an extremely small QoL change, but the biggest effect is for chemists, cooks, and bartenders. It means you can now set transfer amounts on reagent containers without having to have it in your hands (or stand on them). So when you're laying all those containers out and prepping them, this streamlines the process just a little.

Huge credit to afterthought and lohikar for helping me learn and create the additional checks.

Edit: During testing, some exploit-y things were found. Ghosts could interact with containers, and even IVs. This is no longer the case.

🆑 
tweak: The "Set transfer amount" verb's range is now one tile, so now you don't have to be carrying them to set it anymore.
bugfix: ghosts and unconscious can no longer invoke the set transfer amount verb on containers and IVs.
/:cl: