### PR TITLE
Waste tank fix

### DIFF
--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -1700,6 +1700,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/tech)
+"dL" = (
+/obj/structure/sign/warning/hot_exhaust,
+/turf/simulated/wall/ocp_wall,
+/area/engineering/wastetank)
 "dM" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -3025,7 +3029,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_room)
 "gB" = (
 /obj/machinery/power/sensor{
@@ -4662,20 +4666,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "kb" = (
-/obj/machinery/button/remote/blast_door{
-	desc = "A control switch to open and close the waste gate.";
-	id = "WasteGate";
-	name = "Waste Gate Control";
-	pixel_x = 0;
-	pixel_y = 25;
-	req_access = list(24)
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
 	pixel_y = 0;
 	req_one_access = list(24,11)
 	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Waste Tank"
+	},
+/obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/wastetank)
 "kc" = (
@@ -9570,10 +9580,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos/storage)
-"vL" = (
-/obj/structure/sign/warning/hot_exhaust,
-/turf/simulated/wall/r_wall/hull,
-/area/engineering/wastetank)
 "vN" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -11172,9 +11178,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/seconddeck/aftport)
-"Au" = (
-/turf/simulated/wall/ocp_wall,
-/area/engineering/engine_room)
 "Aw" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -12425,32 +12428,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/research)
 "DB" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Waste Tank"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A control switch to open and close the waste gate.";
+	id = "WasteGate";
+	name = "Waste Gate Control";
+	pixel_x = 0;
+	pixel_y = 25;
+	req_access = list(24)
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/wastetank)
 "DC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/wastetank)
 "DD" = (
@@ -12614,10 +12612,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/wastetank)
 "Eb" = (
-/obj/machinery/atmospherics/portables_connector,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/wastetank)
@@ -13967,7 +13967,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
 	},
-/turf/simulated/wall/ocp_wall,
+/turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_room)
 "HY" = (
 /obj/structure/lattice,
@@ -40153,7 +40153,7 @@ QN
 Ff
 NC
 Qw
-vL
+Vq
 aa
 aa
 aa
@@ -40354,8 +40354,8 @@ tE
 Ek
 Et
 NC
-uT
-OG
+Qw
+Vq
 aa
 aa
 aa
@@ -40557,7 +40557,7 @@ Hs
 Eu
 DF
 Qw
-vL
+Vq
 aa
 aa
 aa
@@ -40756,9 +40756,9 @@ Fl
 Fl
 Fl
 JY
-JY
-JY
-JY
+Qw
+uT
+Qw
 Vq
 aa
 aa
@@ -40958,9 +40958,9 @@ Fl
 Fr
 Fx
 FE
-JF
-JF
-JF
+Qw
+DF
+dL
 aa
 aa
 aa
@@ -41160,9 +41160,9 @@ Gl
 Fq
 Fw
 FD
-JF
-JF
-JF
+Qw
+DF
+OG
 aa
 aa
 aa
@@ -41362,9 +41362,9 @@ Fo
 OW
 Fz
 FF
-JF
-JF
-JF
+Qw
+Qw
+dL
 aa
 aa
 aa
@@ -44185,7 +44185,7 @@ At
 Bc
 Bc
 Bc
-wU
+Bc
 wU
 wU
 wU
@@ -44384,9 +44384,9 @@ Un
 Zn
 dp
 gA
-Au
-Au
-Zs
+dp
+dp
+dp
 wU
 wU
 wU
@@ -44586,8 +44586,8 @@ Vn
 bo
 mp
 HW
-Au
-Zs
+dp
+dp
 Zs
 wU
 wU
@@ -44787,8 +44787,8 @@ xa
 Wn
 yR
 yR
-Au
-Zs
+dp
+dp
 Zs
 Zs
 Zs
@@ -44989,7 +44989,7 @@ xb
 xT
 mS
 yR
-Zs
+dp
 Zs
 Zs
 Zs


### PR DESCRIPTION
I made a couple small mapping errors with the waste tank.

There were a few OCP walls left in engineering, they have been changed back to rwalls.

There's the other issue:

![image](https://user-images.githubusercontent.com/521038/50918985-b1b4ec80-140f-11e9-9965-971deb5e08bc.png)

Shields. Again.

It's not the prettiest way of resolving, but it should work. This routs the port to the edge of shields. Also added a pump.

![image](https://user-images.githubusercontent.com/521038/50922260-12e0be00-1418-11e9-8db6-6a9576320172.png)


:cl:
tweak: Adjusted waste tank dump port so it goes to the edge of shields, rather than dumping onto the top of D3 pod.
tweak: Added a pump to the waste tank canister port.
/:cl:
