### PR TITLE
Removes fax access restriction and adds one to forensics office

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1417,6 +1417,9 @@ var/global/floorIsLava = 0
 		log_and_message_admins(msg)
 
 
+
+
+
 /datum/admins/proc/sendFax()
 	set category = "Special Verbs"
 	set name = "Send Fax"
@@ -1486,7 +1489,7 @@ datum/admins/var/obj/item/weapon/paper/admin/faxreply // var to hold fax replies
 
 
 
-	if(destination.recievefax(P))
+	if(destination.recievefax(P, P.origin))
 		to_chat(src.owner, "<span class='notice'>Message reply to transmitted successfully.</span>")
 		if(P.sender) // sent as a reply
 			log_admin("[key_name(src.owner)] replied to a fax message from [key_name(P.sender)]")

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -5344,10 +5344,16 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/camera/network/security{
 	c_tag = "Security Wing - Forensics";
 	dir = 8
+	},
+/obj/structure/table/steel,
+/obj/machinery/photocopier/faxmachine{
+	department = "Forensic's Office"
+	},
+/obj/structure/filingcabinet/wallcabinet{
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)


### PR DESCRIPTION
🆑 TheGreyWolf
maptweak: forensic office now has a fax machine.
tweak: fax machines are no longer access restricted.
/🆑
just doing a favor for a classmate. Anyway, codewise it works fine but I got no clue how mapmerge is supposed to function and the instructions didn't work. A little help would be appreciated if possible.
based on https://github.com/Baystation12/Baystation12/pull/23894 

until the map part is fixed at some point, this likely shouldn't be merged.

map change: https://i.imgur.com/PP5UHdI.png (two wall drawers and the fax machine)

EDIT: okay, changes as described below but in short: the description of printed-whatever will now add the name from whichever id is inserted into the fax machine. Impersonation, anyone?