### PR TITLE
Fixes certain cameras not being accessible

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -27,18 +27,6 @@
 					return TRUE
 	return FALSE
 
-/proc/get_x(O)
-	var/turf/loc = get_turf(O)
-	return loc ? loc.x : 0
-
-/proc/get_y(O)
-	var/turf/loc = get_turf(O)
-	return loc ? loc.y : 0
-
-/proc/get_z(O)
-	var/turf/loc = get_turf(O)
-	return loc ? loc.z : 0
-
 /proc/get_area(O)
 	var/turf/loc = get_turf(O)
 	if(loc)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -27,6 +27,14 @@
 					return TRUE
 	return FALSE
 
+/proc/get_x(O)
+	var/turf/loc = get_turf(O)
+	return loc ? loc.x : 0
+
+/proc/get_y(O)
+	var/turf/loc = get_turf(O)
+	return loc ? loc.y : 0
+
 /proc/get_z(O)
 	var/turf/loc = get_turf(O)
 	return loc ? loc.z : 0

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -5,6 +5,12 @@
 
 #define get_turf(A) get_step(A,0)
 
+#define get_x(A) (get_step(A, 0)?.x || 0)
+
+#define get_y(A) (get_step(A, 0)?.y || 0)
+
+#define get_z(A) (get_step(A, 0)?.z || 0)
+
 #define isAI(A) istype(A, /mob/living/silicon/ai)
 
 #define isalien(A) istype(A, /mob/living/carbon/alien)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -461,9 +461,9 @@
 	cam["name"] = sanitize(c_tag)
 	cam["deact"] = !can_use()
 	cam["camera"] = "\ref[src]"
-	cam["x"] = x
-	cam["y"] = y
-	cam["z"] = z
+	cam["x"] = get_x(src)
+	cam["y"] = get_y(src)
+	cam["z"] = get_z(src)
 	return cam
 
 // Resets the camera's wires to fully operational state. Used by one of Malfunction abilities.

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -93,6 +93,9 @@
 			return
 		if(!(current_network in C.network))
 			return
+		if(!AreConnectedZLevels(get_z(C), get_z(host)) && !(get_z(C) in GLOB.using_map.admin_levels))
+			to_chat(usr, "Unable to establish a connection.")
+			return
 
 		switch_to_camera(usr, C)
 		return 1

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -519,8 +519,6 @@ nanoui is used to open and update nano browser uis
 		if(map_z in GLOB.using_map.map_levels)
 			set_map_z_level(map_z)
 			map_update = 1
-		else
-			return
 
 	if ((src_object && src_object.Topic(href, href_list, state)) || map_update)
 		SSnano.update_uis(src_object) // update all UIs attached to src_object


### PR DESCRIPTION
🆑Hubblenaut
bugfix: Fixes cameras of robots, hardsuits, Thunderdome and similar not being accessable.
/:cl:

**Update:**
Cameras on admin z levels (i.e. Thunderdome) will now work again, trying to connect to cameras that are neither on an admin level nor connected to the z level of the camera console will show the user a warning that the console was unable to establish a connection with the camera.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->