### PR TITLE
Update to vegan MRE to no longer have honey. Slight code cleaning in the random dessert section.

### DIFF
--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -80,7 +80,7 @@ MRE Stuff
 	startswith = list(
 	/obj/item/weapon/storage/mrebag/dessert/menu9,
 	/obj/item/weapon/storage/fancy/crackers,
-	/obj/random/mre/spread,
+	/obj/random/mre/spread/vegan,
 	/obj/random/mre/drink,
 	/obj/random/mre/sauce/vegan,
 	/obj/item/weapon/material/kitchen/utensil/spoon/plastic

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1307,4 +1307,4 @@ var/list/random_useful_
 				/obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/blue,
 				/obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/purple,
 				/obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/grey,
-				/obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/brown,)
+				/obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/brown)

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1228,9 +1228,15 @@ var/list/random_useful_
 				/obj/item/weapon/reagent_containers/food/snacks/poppypretzel,
 				/obj/item/clothing/mask/chewable/candy/gum)
 
+/obj/random/mre/dessert/vegan
+	name = "random vegan MRE dessert"
+	desc = "This is a random vegan dessert for MREs."
+	icon_state = "pouch"
+
 /obj/random/mre/dessert/vegan/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/snacks/candy,
 				/obj/item/weapon/reagent_containers/food/snacks/chocolatebar,
+				/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
 				/obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit)
 
 /obj/random/mre/drink

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1231,7 +1231,6 @@ var/list/random_useful_
 /obj/random/mre/dessert/vegan
 	name = "random vegan MRE dessert"
 	desc = "This is a random vegan dessert for MREs."
-	icon_state = "pouch"
 
 /obj/random/mre/dessert/vegan/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/snacks/candy,
@@ -1265,7 +1264,6 @@ var/list/random_useful_
 /obj/random/mre/spread/vegan
 	name = "random vegan MRE spread"
 	desc = "This is a random vegan spread packet for MREs"
-	icon_state = "packet"
 
 /obj/random/mre/spread/vegan/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/jelly)

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1256,6 +1256,14 @@ var/list/random_useful_
 	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/jelly,
 				/obj/item/weapon/reagent_containers/food/condiment/small/packet/honey)
 
+/obj/random/mre/spread/vegan
+	name = "random vegan MRE spread"
+	desc = "This is a random vegan spread packet for MREs"
+	icon_state = "packet"
+
+/obj/random/mre/spread/vegan/spawn_choices()
+	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/jelly)
+
 /obj/random/mre/sauce
 	name = "random MRE sauce"
 	desc = "This is a random sauce packet for MREs."


### PR DESCRIPTION
So this is a fairly simple PR.

Removed the chance for honey to spawn in the vegan MRE as honey is not vegan.

Updated the dessert random spawning for the vegan MRE so it no longer implicitly defines /obj/random/mre/dessert/vegan as a identical child of /obj/random/mre/dessert as this is generally harder to read.

Also added the jelly dessert to the vegan dessert spawn list.