### PR TITLE
Adds Adherent Maintenance Area

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -74,7 +74,7 @@
 #define COLOR_BRASS            "#b99d71"
 #define COLOR_INDIGO           "#4b0082"
 #define COLOR_ALUMINIUM        "#c9c9c9"
-#define COLOR_CRYSTAL          "#00C8A5"
+#define COLOR_CRYSTAL          "#00c8a5"
 
 #define	PIPE_COLOR_GREY        "#ffffff"	//yes white is grey
 #define	PIPE_COLOR_RED         "#ff0000"

--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -74,6 +74,7 @@
 #define COLOR_BRASS            "#b99d71"
 #define COLOR_INDIGO           "#4b0082"
 #define COLOR_ALUMINIUM        "#c9c9c9"
+#define COLOR_CRYSTAL          "#00C8A5"
 
 #define	PIPE_COLOR_GREY        "#ffffff"	//yes white is grey
 #define	PIPE_COLOR_RED         "#ff0000"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -273,6 +273,11 @@ var/list/airlock_overlays = list()
 	door_color = COLOR_SUN
 	mineral = MATERIAL_GOLD
 
+/obj/machinery/door/airlock/crystal
+	name = "Crystal Airlock"
+	door_color = COLOR_CRYSTAL
+	mineral = MATERIAL_CRYSTAL
+
 /obj/machinery/door/airlock/silver
 	name = "Silver Airlock"
 	door_color = COLOR_SILVER

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -107,9 +107,12 @@
 
 	if(target && !target.fully_charged())
 		var/diff = min(target.maxcharge - target.charge, charging_power * CELLRATE) // Capped by charging_power / tick
+		if(ishuman(occupant))
+			var/mob/living/carbon/human/H = occupant
+			if(H.species.name == SPECIES_ADHERENT)
+				diff /= 2 //Adherents charge at half the normal rate.
 		var/charge_used = cell.use(diff)
 		target.give(charge_used)
-
 
 /obj/machinery/recharge_station/examine(mob/user)
 	. = ..(user)
@@ -227,7 +230,7 @@
 		var/mob/living/silicon/robot/R = M
 		return (R.cell)
 	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
+		var/mob/living/carbon/human/H = M		
 		if(H.isSynthetic()) // FBPs and IPCs
 			return 1
 		return H.internal_organs_by_name["cell"]

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1060,6 +1060,27 @@
 	contraband = list(/obj/item/weapon/weldingtool/hugetank = 2,/obj/item/clothing/gloves/insulated/cheap = 2)
 	premium = list(/obj/item/clothing/gloves/insulated = 1)
 
+/obj/machinery/vending/tool/adherent
+	name = "Adherent Tool Dispenser"
+	desc = "This looks like a heavily modified vending machine. It contains technology that doesn't appear to be human in origin."
+	product_ads = "\[C#\]\[Cb\]\[Db\]. \[Ab\]\[A#\]\[Bb\]. \[E\]\[C\]\[Gb\]\[B#\]. \[C#\].;\[Cb\]\[A\]\[F\]\[Cb\]\[C\]\[E\]\[Cb\]\[E\]\[Fb\]. \[G#\]\[C\]\[Ab\]\[A\]\[C#\]\[B\]. \[Eb\]\[choral\]. \[E#\]\[C#\]\[Ab\]\[E\]\[C#\]\[Fb\]\[Cb\]\[F#\]\[C#\]\[Gb\]."
+	icon_state = "tool"
+	icon_deny = "tool-deny"
+	icon_vend = "tool_vend"
+	vend_delay = 5
+	products = list(/obj/item/weapon/weldingtool/crystal = 5,
+					/obj/item/weapon/wirecutters/crystal = 5,
+					/obj/item/weapon/screwdriver/crystal = 5,
+					/obj/item/weapon/crowbar/crystal = 5,
+					/obj/item/weapon/wrench/crystal = 5,
+					/obj/item/device/multitool/crystal = 5,
+					/obj/item/weapon/storage/belt/utility/vigil = 5)
+/obj/machinery/vending/tool/adherent/vend(var/datum/stored_items/vending_products/R, var/mob/living/carbon/user)
+	if((istype(user) && user.species.name == SPECIES_ADHERENT) || emagged)
+		. = ..()
+	else
+		to_chat(user, "<span class='notice'>The vending machine emits a discordant note, and a small hole blinks several times. It looks like it wants something inserted.</span>")
+
 /obj/machinery/vending/engivend
 	name = "Engi-Vend"
 	desc = "Spare tool vending. What? Did you expect some witty description?"

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -12,6 +12,9 @@
 		attack_hand(user)
 
 /obj/structure/adherent_pylon/attack_hand(var/mob/living/user)
+	charge_user(user)
+
+/obj/structure/adherent_pylon/proc/charge_user(var/mob/living/user)
 	var/mob/living/carbon/human/H = user
 	var/obj/item/weapon/cell/power_cell
 	if(ishuman(user))
@@ -20,13 +23,25 @@
 			power_cell = cell.cell
 	else if(isrobot(user))
 		var/mob/living/silicon/robot/robot = user
-		power_cell = robot.cell
+		power_cell = robot.get_cell()
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(power_cell)
-		user.visible_message("<span class='notice'>There is a loud crack and the smell of ozone as \the [user] caresses \the [src].</span>")
+		user.visible_message("<span class='notice'>There is a loud crack and the smell of ozone as \the [user] touches \the [src].</span>")
 		power_cell.charge = power_cell.maxcharge
 		to_chat(user, "<span class='notice'><b>Your [power_cell] has been charged to capacity.</b></span>")
+		if(istype(H) & H.species.name == SPECIES_ADHERENT)
+			return
+	if(isrobot(user))		
+		user.apply_damage(150, BURN, def_zone = BP_CHEST)
+		visible_message("<span class='danger'>Electricity arcs off [user] as it touches \the [src]!</span>")
+		to_chat(user, "<span class='danger'><b>You detect damage to your components!</b></span>")
+	else
+		user.electrocute_act(100, src, def_zone = BP_CHEST)
+		visible_message("<span class='danger'>\The [user] has been shocked by \the [src]!</span>")
+
+/obj/structure/adherent_pylon/attackby(obj/item/grab/normal/G, mob/user)
+	if(!istype(G))		
 		return
-	visible_message("<span class='danger'>\The [user] has been shocked by \the [src]!</span>")
-	user.electrocute_act(50, src, def_zone = BP_CHEST)
+	var/mob/M = G.affecting	
+	charge_user(M)

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -81,7 +81,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "au" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/wall,
+/turf/simulated/floor,
 /area/crew_quarters/adherent)
 "av" = (
 /obj/effect/floor_decal/industrial/warning,

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -20,6 +20,9 @@
 /obj/effect/shuttle_landmark/merc/deck4,
 /turf/space,
 /area/space)
+"af" = (
+/turf/simulated/wall,
+/area/crew_quarters/adherent)
 "ag" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -57,12 +60,29 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/maintenance/fourthdeck/forestarboard)
+"ao" = (
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/adherent)
+"ap" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/primary/fourthdeck/aft)
 "aq" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/starboard)
 "ar" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod6/station)
+"as" = (
+/turf/simulated/wall,
+/area/hallway/primary/fourthdeck/aft)
+"at" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall,
+/area/hallway/primary/fourthdeck/aft)
+"au" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/wall,
+/area/crew_quarters/adherent)
 "av" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -70,6 +90,16 @@
 "aw" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod7/station)
+"ax" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
+/area/hallway/primary/fourthdeck/aft)
+"ay" = (
+/obj/structure/sign/warning/fire{
+	name = "\improper DANGER: BOILING LIQUID"
+	},
+/turf/simulated/wall,
+/area/hallway/primary/fourthdeck/aft)
 "az" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/fourthdeck)
@@ -849,9 +879,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod6/station)
-"da" = (
-/turf/simulated/floor/plating,
-/area/quartermaster/unused)
 "dd" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -2661,10 +2688,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "iA" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/unused)
+/obj/machinery/vending/tool/adherent,
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "iC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -2676,13 +2702,20 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "iD" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
+"iE" = (
+/obj/structure/adherent_bath,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "iM" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -2912,9 +2945,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "jz" = (
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/unused)
+/obj/structure/flora/pottedplant/crystal,
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "jB" = (
 /obj/item/modular_computer/console/preset/civilian/professional,
 /obj/structure/noticeboard{
@@ -3106,9 +3139,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
-"kz" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/quartermaster/unused)
 "kA" = (
 /obj/random/junk,
 /obj/structure/cable{
@@ -3367,14 +3397,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor/aux)
 "ly" = (
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/unused)
-"lz" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/adherent_bath,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
+"lz" = (
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "lB" = (
 /obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
@@ -3824,8 +3855,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/quartermaster/unused)
+/obj/structure/adherent_pylon,
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "mQ" = (
 /obj/effect/floor_decal/corner/green/half{
 	icon_state = "bordercolorhalf";
@@ -4209,8 +4241,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "oa" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4221,14 +4253,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/quartermaster/unused)
-"ob" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "oc" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Emergency Storage";
@@ -4523,14 +4549,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor/aux)
-"pl" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/unused)
-"pm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/quartermaster/unused)
 "po" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4539,8 +4557,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "pp" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -4852,10 +4870,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fourthdeck/aft)
 "qy" = (
-/obj/machinery/door/airlock/civilian{
-	locked = 1;
-	name = "Ready Room"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -4863,8 +4877,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/crystal{
+	name = "Adherent Maintenence"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/crew_quarters/adherent)
 "qB" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
@@ -8676,6 +8693,10 @@
 "Dc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/foreport)
+"Df" = (
+/obj/structure/table/glass,
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "Dq" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -13341,8 +13362,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "RV" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_coffee/full{
@@ -14876,8 +14897,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/quartermaster/unused)
+/turf/simulated/floor/crystal,
+/area/crew_quarters/adherent)
 "VR" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -15582,9 +15603,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
-"XJ" = (
-/turf/simulated/floor/tiled,
-/area/quartermaster/unused)
 "XL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16472,9 +16490,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
-"ZM" = (
-/turf/simulated/wall/prepainted,
-/area/quartermaster/unused)
 "ZN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -38703,13 +38718,13 @@ fJ
 Zw
 Zw
 iy
-ZM
-ZM
-ZM
-ZM
-ZM
-ZM
-Xn
+af
+af
+af
+af
+af
+af
+as
 RK
 tb
 uH
@@ -38905,13 +38920,13 @@ eb
 eb
 hB
 eb
-ZM
+au
 jz
 ly
-da
-da
-pl
-Xn
+Df
+Df
+ly
+ax
 TH
 tc
 KG
@@ -39107,13 +39122,13 @@ ec
 ec
 eP
 ec
-ZM
+au
 iA
 lz
-XJ
+lz
 VQ
-pm
-Xn
+lz
+ax
 TH
 MI
 Vi
@@ -39309,13 +39324,13 @@ XT
 XT
 XT
 XT
-kz
-kz
-da
+ao
+ao
+lz
 mP
 nZ
-XJ
-Xn
+lz
+at
 TH
 MI
 ql
@@ -39512,7 +39527,7 @@ ar
 ar
 ar
 ar
-kz
+ao
 iC
 RU
 oa
@@ -39714,12 +39729,12 @@ fr
 gi
 hj
 ib
-kz
-jz
-ly
-ob
-jz
-Xn
+ao
+iE
+Df
+Df
+iE
+ay
 TH
 MI
 ql
@@ -39916,12 +39931,12 @@ fs
 gj
 hj
 ib
-wa
-Xn
-Xn
-Xn
-Xn
-Xn
+ap
+as
+as
+as
+as
+as
 Rr
 UM
 sR

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -14389,7 +14389,10 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/adherent_bath,
+/obj/structure/closet/secure_closet/crew,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/cryolocker)
 "FW" = (

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -23395,7 +23395,7 @@
 /area/crew_quarters/safe_room/firstdeck)
 "kAb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/adherent_bath,
+/obj/machinery/cryopod/robot,
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/chargebay)
 "kBb" = (

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -829,10 +829,6 @@
 	name = "\improper Flight Control Tower"
 	icon_state = "hangar"
 
-/area/quartermaster/unused
-	name = "\improper Ready Room"
-	icon_state = "auxstorage"
-
 // Research
 /area/rnd/canister
 	name = "\improper Canister Storage"
@@ -921,6 +917,10 @@
 	name = "\improper Diplomatic Quarters"
 	icon_state = "Sleep"
 	sound_env = SMALL_SOFTFLOOR
+
+/area/crew_quarters/adherent
+	name = "\improper Adherent Maintenence"
+	icon_state = "robotics"
 
 /area/holocontrol
 	name = "\improper Holodeck Control"


### PR DESCRIPTION
:cl: Textor
maptweak: Replaces ready room with adherent maintenance. Ding.
tweak: Adherents now recharge at cyborg rechargers at half the rate.
maptweak: Removes mineral baths from all other map locations.
tweak: Adherent pylon will now damage robots.
rscadd: Adds adherent tool vendor and crystal material airlock.
/:cl:

![image](https://user-images.githubusercontent.com/12721324/51220162-fdbcd100-18e8-11e9-80ea-5cbad176a78a.png)
