### PR TITLE
Fixes for Riot Security Voidsuit Icons

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -218,12 +218,6 @@
 	icon_state = "rig0-secalt"
 	item_state = "secalt_helm"
 	armor = list(melee = 70, bullet = 20, laser = 30, energy = 5, bomb = 35, bio = 100, rad = 10)
-	sprite_sheets = list(
-		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_head_skrell.dmi',
-		)
-	sprite_sheets_obj = list(
-		SPECIES_SKRELL = 'icons/obj/clothing/species/skrell/obj_head_skrell.dmi',
-		)
 
 /obj/item/clothing/suit/space/void/security/alt
 	icon_state = "rig-secalt"
@@ -231,12 +225,6 @@
 	desc = "A heavily armored voidsuit, designed to intimidate people who find black intimidating. Surprisingly slimming."
 	armor = list(melee = 70, bullet = 20, laser = 30, energy = 5, bomb = 35, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
-	sprite_sheets = list(
-		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_head_skrell.dmi',
-		)
-	sprite_sheets_obj = list(
-		SPECIES_SKRELL = 'icons/obj/clothing/species/skrell/obj_head_skrell.dmi',
-		)
 
 /obj/item/clothing/suit/space/void/security/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/security/alt


### PR DESCRIPTION
Makes the Riot Security Voidsuit work properly for Unathi and Skrell. Sprite sheets on the items were overriding and making them not work. Now they do!

:cl: Eckles
bugfix: Fixes sprite and object issues with the riot security voidsuit for Unathi and Skrell
/:cl: