### PR TITLE
[READY] Sets the nacelle sensor alert temperature back to 10,000 and removes the windows

### DIFF
--- a/code/game/machinery/status_light.dm
+++ b/code/game/machinery/status_light.dm
@@ -5,7 +5,7 @@
 	icon_state = "doortimer-p"
 	var/frequency = 1439
 	var/id_tag
-	var/alert_temperature = 4000
+	var/alert_temperature = 10000
 	var/alert = 1
 	var/datum/radio_frequency/radio_connection
 

--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -9034,45 +9034,20 @@
 /turf/simulated/wall/r_wall/hull,
 /area/ai_monitored/storage/eva)
 "td" = (
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 2
 	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d3starboardnacelle"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d3starboard)
 "te" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
+/obj/structure/sign/warning/fire{
 	dir = 1
 	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d3starboardnacelle"
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d3starboard)
 "tf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 4
-	},
-/obj/structure/grille,
+/obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "d3starboardnacelle";
@@ -17026,25 +17001,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
-"Mi" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d3portnacelle"
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/turf/simulated/floor/reinforced,
-/area/thruster/d3port)
 "Mj" = (
 /obj/machinery/door/airlock/sol{
 	name = "Diplomatic Quarters"
@@ -17373,21 +17329,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"Ni" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d3portnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d3port)
 "Nj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
@@ -17614,25 +17555,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics/storage)
-"Of" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d3starboardnacelle"
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/turf/simulated/floor/reinforced,
-/area/thruster/d3starboard)
 "Og" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin{
@@ -17664,22 +17586,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai_monitored/storage/eva)
-"Oi" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d3portnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d3port)
 "Oj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/steel,
@@ -17977,21 +17883,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
-"Pg" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d3starboardnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d3starboard)
 "Ph" = (
 /obj/machinery/light{
 	dir = 1
@@ -18299,20 +18190,10 @@
 /turf/space,
 /area/space)
 "Qi" = (
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d3portnacelle"
-	},
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d3port)
 "Qj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -18613,39 +18494,15 @@
 "Rf" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/gym)
-"Rg" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d3starboardnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d3starboard)
 "Rh" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "Ri" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
+/obj/structure/sign/warning/fire{
+	dir = 2
 	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d3portnacelle"
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d3port)
 "Rl" = (
 /obj/effect/floor_decal/industrial/hatch,
@@ -18910,19 +18767,11 @@
 /area/space)
 "Si" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced,
+/obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "d3portnacelle"
 	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/grille,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Sj" = (
@@ -50139,9 +49988,9 @@ Jh
 zf
 KO
 KP
-Of
-Pg
-Rg
+KP
+KP
+KP
 bd
 aa
 aa
@@ -50169,9 +50018,9 @@ aa
 aa
 aa
 pI
-Mi
-Ni
-Oi
+La
+La
+La
 La
 Lo
 Jj

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -14689,45 +14689,14 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "bbb" = (
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 2
 	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1starboardnacelle"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
-"bcb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1starboardnacelle"
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d1starboard)
 "bdb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 4
-	},
-/obj/structure/grille,
+/obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "d1starboardnacelle"
@@ -14745,56 +14714,6 @@
 "bdL" = (
 /obj/structure/lattice,
 /turf/simulated/floor/reinforced/hydrogen,
-/area/thruster/d1starboard)
-"beb" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d1starboardnacelle"
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
-"bfb" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d1starboardnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
-"bgb" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d1starboardnacelle"
-	},
-/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "bhb" = (
 /obj/machinery/door/blast/regular{
@@ -15118,40 +15037,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/security/detectives_office)
-"bub" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d1portnacelle"
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1port)
-"bvb" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d1portnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d1port)
 "bvI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -15170,22 +15055,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics/surgery)
-"bwb" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "d1portnacelle"
-	},
-/turf/simulated/floor/reinforced,
-/area/thruster/d1port)
 "bxz" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -15206,50 +15075,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics/surgery)
 "byb" = (
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1portnacelle"
-	},
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d1port)
 "bzb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1portnacelle"
-	},
-/turf/simulated/floor/reinforced,
+/obj/structure/sign/warning/fire,
+/turf/simulated/wall/ocp_wall,
 /area/thruster/d1port)
 "bAb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/window/phoronreinforced,
+/obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "d1portnacelle"
 	},
-/obj/structure/window/phoronreinforced{
-	icon_state = "phoronrwindow";
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/grille,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "bBb" = (
@@ -59998,7 +59839,7 @@ vci
 acn
 adb
 adF
-bcb
+aet
 afw
 agw
 aet
@@ -60403,9 +60244,9 @@ bqv
 kfG
 adH
 aet
-beb
-bfb
-bgb
+aet
+aet
+aet
 abN
 aaa
 aaa
@@ -60437,9 +60278,9 @@ aaa
 aaa
 aaa
 xPU
-bub
-bvb
-bwb
+aPq
+aPq
+aPq
 wEw
 aTn
 rYd


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
The reason I added these sensors is so you know when the walls of the combustion chambers are reaching their melting point, so you can vent the chamber. They aren't meant for the windows, and worrying about said windows makes these sensors pointless. I might remove the windows entirely when I get home.

Fixes the burn chambers filling at an uneven rate

Also removed the windows from the nacelles, replacing them with walls and a shuttered door for if you *really* want to get inside.