### PR TITLE
Add Science encryption key to XO key box

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -69,7 +69,8 @@
 	desc = "A box full of assorted encryption keys."
 	startswith = list(/obj/item/device/encryptionkey/headset_sec = 3,
 					  /obj/item/device/encryptionkey/headset_med = 3,
-					  /obj/item/device/encryptionkey/headset_cargo = 3)
+					  /obj/item/device/encryptionkey/headset_cargo = 3,
+					  /obj/item/device/encryptionkey/headset_sci = 3)
 
 /obj/item/weapon/storage/box/radiokeys/Initialize()
 	. = ..()


### PR DESCRIPTION
🆑 
tweak: The XO now has science keys in their locker.
/:cl:

(NB: this is the approach @EcklesFire requested, as the alternative to just giving SEA this channel.)