### PR TITLE
Fixes Drop-Item verb for robot/drone grippers

### DIFF
--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -8,8 +8,8 @@
 	if(camera)
 		camera.status = 0
 	if(module)
-		var/obj/item/weapon/gripper/G = locate(/obj/item/weapon/gripper) in module
-		if(G) G.drop_item()
+		for(var/obj/item/weapon/gripper/G in module.modules)
+			G.drop_gripped_item()
 	locked = 0
 	remove_robot_verbs()
 	..(gibbed,"shudders violently for a moment, then becomes motionless, its eyes slowly darkening.", "You have suffered a critical system failure, and are dead.")

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -146,12 +146,11 @@
 		return wrapped.attack_self(user)
 	return ..()
 
-/obj/item/weapon/gripper/verb/drop_item()
+/obj/item/weapon/gripper/verb/drop_gripped_item()
 
-	set name = "Drop Item"
+	set name = "Drop Gripped Item"
 	set desc = "Release an item from your magnetic gripper."
 	set category = "Silicon Commands"
-
 	if(!wrapped)
 		//There's some weirdness with items being lost inside the arm. Trying to fix all cases. ~Z
 		for(var/obj/item/thing in src.contents)


### PR DESCRIPTION
🆑
bugfix: Robots and drones should once again be able to drop items from their grippers from the Silicon Commands tab (the verb has been renamed "Drop Gripped Item").
bugfix: Robots and drones now drop all gripped items on death.
/🆑