### PR TITLE
Adrenaline does heart damage on heart restart.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1574,6 +1574,7 @@
 			setOxyLoss(75)
 		heart.pulse = PULSE_NORM
 		heart.handle_pulse()
+		return TRUE
 
 /mob/living/carbon/human/proc/make_reagent(amount, reagent_type)
 	if(stat == CONSCIOUS)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -784,7 +784,9 @@
 		M.make_jittery(5)
 	if(volume >= 5 && M.is_asystole())
 		remove_self(5)
-		M.resuscitate()
+		if(M.resuscitate())
+			var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
+			heart.take_internal_damage(heart.max_damage * 0.15)
 
 /datum/reagent/lactate
 	name = "Lactate"


### PR DESCRIPTION
:cl:
tweak: Adrenaline now does some heart damage if used to restart the heart.
/:cl:

It wasn't meant to be an all-around improvement over the defib or cpr, as the defib is more interesting mechanically for all parties concerned. This leaves it still useful unless you're doing abusive things, as the heart damage is not that severe.