### PR TITLE
Adds remote door functionality to camera program

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -527,3 +527,9 @@
 
 /obj/machinery/door/CanFluidPass(var/coming_from)
 	return !density
+
+/obj/machinery/door/proc/toggle_open()
+	if(density)
+		open()
+	else
+		close()

--- a/nano/templates/sec_camera.tmpl
+++ b/nano/templates/sec_camera.tmpl
@@ -1,6 +1,7 @@
 <div class='item'>
     {{:helper.link('Show Map', 'pin-s', {'showMap' : 1})}}
     {{:helper.link('Reset', 'refresh', {'reset' : 1})}}
+	{{:helper.link(data.clicker_status ? 'Disable Camera Interaction' : 'Enable Camera Interaction', 'search', data.clicker_status ? {'disableClicker' : 1}: {'enableClicker' : 1}, null, data.clicker_status ? 'selected' : null)}}
 </div>
 
 <div class='item'>


### PR DESCRIPTION
🆑 Cakey
rscadd: The Camera program can now be used to remote control airlocks that you have access to, as well as accessing the airlock's settings panel if you have engineering access.
tweak: Fixed being able to view cameras non connected to your Z-level.
/🆑

![image](https://user-images.githubusercontent.com/17550641/51574172-9e406180-1ea4-11e9-9c35-d86a9715ad8f.png)

- [x] click_handler code
- [x] remote control
- [ ] cleanup related to disabling click_handler when moving away from console