### PR TITLE
Re-adds explorer helmet cams

### DIFF
--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -394,6 +394,9 @@
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/onmob_head_solgov.dmi')
 	starting_accessories = null
 
+/obj/item/clothing/head/helmet/space/void/exploration
+	camera = /obj/machinery/camera/network/exploration
+	
 //SolGov Hardsuits
 
 /obj/item/clothing/head/helmet/space/void/engineering/alt/sol

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -201,6 +201,7 @@
 	req_access = list(access_pathfinder)
 
 /obj/item/clothing/head/helmet/space/rig/command/exploration
+	camera = /obj/machinery/camera/network/exploration
 	icon_state = "command_exp_rig"
 /obj/item/clothing/suit/space/rig/command/exploration
 	icon_state = "command_exp_rig"


### PR DESCRIPTION
🆑 Cakey
rscadd: Re-adds exploration helmet-cameras.
/🆑

Was removed because of ability to view away-cameras, which has since been patched.
Re-add for people on the Charon to be able to monitor their exploration team (gives the pilot something to do)