### PR TITLE
Removes roundstart AI

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -32,7 +32,7 @@ Possible to do for anyone motivated enough:
 var/const/HOLOPAD_MODE = RANGE_BASED
 
 /obj/machinery/hologram/holopad
-	name = "\improper AI holopad"
+	name = "\improper holopad"
 	desc = "It's a floor-mounted device for projecting holographic images."
 	icon_state = "holopad-B0"
 
@@ -190,7 +190,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(M)
 		for(var/mob/living/silicon/ai/master in masters)
 			var/ai_text = text
-			if(!master.say_understands(M, speaking))//The AI will be able to understand most mobs talking through the holopad.			
+			if(!master.say_understands(M, speaking))//The AI will be able to understand most mobs talking through the holopad.
 				if(speaking)
 					ai_text = speaking.scramble(text)
 				else

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -26,7 +26,7 @@
 						/datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor, /datum/job/mining,
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
 						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant,
-						/datum/job/ai, /datum/job/cyborg,
+						/datum/job/cyborg,
 						/datum/job/crew, /datum/job/assistant,
 						/datum/job/merchant, /datum/job/stowaway
 						)

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -5405,9 +5405,6 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "ml" = (
-/obj/effect/landmark/start{
-	name = "AI"
-	},
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;


### PR DESCRIPTION
🆑 Cakey
rscdel: Removed the ability to join the round as AI. AI cores can still be constructed and installed into the empty AI chamber.
/🆑

https://forums.baystation12.net/threads/remove-roundstart-ai.7382/unread

PR Opened on request.
Map untouched for the time being and will probably be looked at in another PR.
See #24268 for better functionality replacement.

