### PR TITLE
Brings species rank whitelists up to date.

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -32,6 +32,7 @@
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7,
 				/datum/mil_rank/ec/o1
 			),
 			/datum/mil_branch/fleet = list(
@@ -40,6 +41,8 @@
 				/datum/mil_rank/fleet/e3,
 				/datum/mil_rank/fleet/e4,
 				/datum/mil_rank/fleet/e5,
+				/datum/mil_rank/fleet/e6,
+				/datum/mil_rank/fleet/e7,
 				/datum/mil_rank/fleet/o1
 			),
 			/datum/mil_branch/solgov = list(
@@ -50,6 +53,7 @@
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7,
 				/datum/mil_rank/ec/o1
 			)
 		),


### PR DESCRIPTION
Previously they were broken (this includes prior to Zuh's update) and weren't enforced at all. Now they are enforced, so it turned out they were out of date.

Fixes #24306.