### PR TITLE
Kills suit parry meme

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -676,6 +676,9 @@ BLIND     // can't see anything
 		ret.icon_state = icon_state
 	return ret
 
+/obj/item/clothing/suit/handle_shield()
+	return FALSE
+
 /obj/item/clothing/suit/proc/get_collar()
 	var/icon/C = new('icons/mob/collar.dmi')
 	if(icon_state in C.IconStates())


### PR DESCRIPTION
It was in handle_shields list just for laser/reactive armor.
Made all other suits just not do parrying.
