### PR TITLE
Fixed syringe icon logic

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -92,7 +92,7 @@
 		icon_state = "broken"
 		return
 
-	var/rounded_vol = Clamp(round((reagents.total_volume / volume * 15),5), 1, 15)
+	var/rounded_vol = Clamp(round((reagents.total_volume / volume * 15),5), 5, 15)
 	if (reagents.total_volume == 0)
 		rounded_vol = 0
 	if(ismob(loc))


### PR DESCRIPTION
Fixes https://github.com/Baystation12/Baystation12/issues/24311

This is caused by clamping allowing a value less than 5. The syringe icon reference is constructed from the amount of reagents in a syringe, rather than explicitly defining each icon reference. Valid icons for syringes are 0, 5, 10, and 15, so when it allowed <5, it would result in an invalid icon state.

Thank you @Textor44 for giving us a lead, and @sabiram and @afterthought2 for some more learning assistance in how icons work.