### PR TITLE
Fixes missing ore name for diamonds.

### DIFF
--- a/code/modules/materials/definitions/materials_stone.dm
+++ b/code/modules/materials/definitions/materials_stone.dm
@@ -14,6 +14,7 @@
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	conductive = 0
 	construction_difficulty = 3
+	ore_name = "rough diamonds"
 	ore_compresses_to = MATERIAL_DIAMOND
 	ore_result_amount = 5
 	ore_spread_chance = 10


### PR DESCRIPTION
This will fix the ores being unclickable and nameless.

I swear I fixed this months ago.