### PR TITLE
Makes sleeper, bodyscanner, cryo and cryopod show more information on view

### DIFF
--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -21,6 +21,12 @@
 		new /obj/item/weapon/stock_parts/console_screen(src))
 	RefreshParts()
 
+
+/obj/machinery/bodyscanner/examine(mob/user)
+	. = ..()
+	if (. && occupant && user.Adjacent(src))
+		occupant.examine(user)
+
 /obj/machinery/bodyscanner/relaymove(mob/user as mob)
 	..()
 	src.go_out()
@@ -53,7 +59,7 @@
 /obj/machinery/bodyscanner/proc/go_out()
 	if ((!( src.occupant ) || src.locked))
 		return
-	drop_contents()	
+	drop_contents()
 	if (src.occupant.client)
 		src.occupant.client.eye = src.occupant.client.mob
 		src.occupant.client.perspective = MOB_PERSPECTIVE
@@ -61,6 +67,7 @@
 	src.occupant = null
 	update_use_power(POWER_USE_IDLE)
 	update_icon()
+	SetName(initial(name))
 
 /obj/machinery/bodyscanner/attackby(obj/item/grab/normal/G, user as mob)
 	if(!istype(G))
@@ -73,7 +80,7 @@
 			return
 	var/mob/M = G.affecting
 	if(!user_can_move_target_inside(M, user))
-		return	
+		return
 	qdel(G)
 
 /obj/machinery/bodyscanner/proc/user_can_move_target_inside(var/mob/target, var/mob/user)
@@ -95,6 +102,7 @@
 	update_use_power(POWER_USE_ACTIVE)
 	update_icon()
 	drop_contents()
+	SetName("[name] ([occupant])")
 
 	src.add_fingerprint(user)
 	return TRUE
@@ -106,7 +114,7 @@
 		src.icon_state = "body_scanner_1"
 
 //Like grap-put, but for mouse-drop.
-/obj/machinery/bodyscanner/MouseDrop_T(var/mob/target, var/mob/user)	
+/obj/machinery/bodyscanner/MouseDrop_T(var/mob/target, var/mob/user)
 	if(!CanMouseDrop(target, user) || !istype(target))
 		return FALSE
 	user.visible_message("<span class='notice'>\The [user] begins placing \the [target] into \the [src].</span>", "<span class='notice'>You start placing \the [target] into \the [src].</span>")
@@ -120,7 +128,7 @@
 		if(1.0)
 			for(var/atom/movable/A as mob|obj in src)
 				A.dropInto(loc)
-				A.ex_act(severity)				
+				A.ex_act(severity)
 			qdel(src)
 		if(2.0)
 			if (prob(50))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -57,6 +57,14 @@
 			node = target
 			break
 
+/obj/machinery/atmospherics/unary/cryo_cell/examine(mob/user)
+	. = ..()
+	if (. && user.Adjacent(src))
+		if (beaker)
+			to_chat(user, "It is loaded with a beaker.")
+		if (occupant)
+			occupant.examine(user)
+
 /obj/machinery/atmospherics/unary/cryo_cell/Process()
 	..()
 	if(!node)
@@ -285,7 +293,9 @@
 	current_heat_capacity = initial(current_heat_capacity)
 	update_use_power(POWER_USE_IDLE)
 	update_icon()
+	SetName(initial(name))
 	return
+
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M as mob)
 	if (stat & (NOPOWER|BROKEN))
 		to_chat(usr, "<span class='warning'>The cryo cell is not functioning.</span>")
@@ -315,6 +325,7 @@
 	update_use_power(POWER_USE_ACTIVE)
 	add_fingerprint(usr)
 	update_icon()
+	SetName("[name] ([occupant])")
 	return 1
 
 	//Like grab-putting, but for mouse-dropping.

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -294,6 +294,11 @@
 
 	return 1
 
+/obj/machinery/cryopod/examine(mob/user)
+	. = ..()
+	if (. && occupant && user.Adjacent(src))
+		occupant.examine(user)
+
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/machinery/cryopod/Process()
 	if(occupant)


### PR DESCRIPTION
Sleepers, bodyscanners, cryo cells and cryo pods will all be showing the name of the occupant.
Anyone standing adjacent to those machines will also be examining the occupant when examining the machine.

This would be a lot less copypaste if the code for putting and removing occupants in and out of a machine was abstracted, but that is unfortunately not the case and I have no plans for rewriting that.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->