### PR TITLE
Fixes some small stuff from gunpocalypse

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -457,7 +457,7 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	category = "Arms and Ammunition"
 
 /datum/autolathe/recipe/speedloader
-	name = "speed loader (speedloader)"
+	name = "ammunition (speedloader)"
 	path = /obj/item/ammo_magazine/speedloader
 	hidden = 1
 	category = "Arms and Ammunition"
@@ -477,6 +477,24 @@ var/const/EXTRA_COST_FACTOR = 1.25
 /datum/autolathe/recipe/magazine_pistol
 	name = "ammunition (pistol)"
 	path = /obj/item/ammo_magazine/pistol
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_pistol_rubber
+	name = "ammunition (pistol, rubber)"
+	path = /obj/item/ammo_magazine/pistol/rubber
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_pistol_double
+	name = "ammunition (pistol, doublestack)"
+	path = /obj/item/ammo_magazine/pistol/double
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_pistol_double_rubber
+	name = "ammunition (pistol, doublestack. rubber)"
+	path = /obj/item/ammo_magazine/pistol/double/rubber
 	hidden = 1
 	category = "Arms and Ammunition"
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -77,6 +77,7 @@
 /obj/item/weapon/gun/projectile/pistol/throwback/Initialize()
 	. = ..()
 	base_icon = "pistol[rand(1,4)]"
+	update_icon()
 
 /obj/item/weapon/gun/projectile/pistol/throwback/on_update_icon()
 	..()


### PR DESCRIPTION
Re-adds some missing recipies, renames speedloader "speedloader" (speedloader) a bit, makes throwback guns update their icons right away instead of morphing when someoen takes them.
