### PR TITLE
Fixes Science Uniforms

### DIFF
--- a/maps/torch/datums/uniforms_expedition.dm
+++ b/maps/torch/datums/uniforms_expedition.dm
@@ -212,8 +212,10 @@
 	name = "EC science"
 	departments = SCI
 
-	utility_extra = list(/obj/item/clothing/head/ushanka/solgov, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov)
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/research
+	utility_extra = list(/obj/item/clothing/head/ushanka/solgov, 
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov,
+						 /obj/item/clothing/suit/storage/toggle/labcoat/science/ec)
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/research
 
@@ -222,7 +224,10 @@
 	min_rank = 11
 
 	utility_under = /obj/item/clothing/under/solgov/utility/expeditionary/officer/research
-	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command, /obj/item/clothing/head/ushanka/solgov, /obj/item/clothing/suit/storage/hooded/wintercoat/solgov)
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command, 
+						 /obj/item/clothing/head/ushanka/solgov, 
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov,
+						 /obj/item/clothing/suit/storage/toggle/labcoat/science/ec)
 
 	service_under = /obj/item/clothing/under/solgov/service/expeditionary/command
 	service_skirt = /obj/item/clothing/under/solgov/service/expeditionary/command/skirt
@@ -234,3 +239,12 @@
 	dress_over = /obj/item/clothing/suit/dress/solgov/expedition/command
 	dress_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
+/decl/hierarchy/mil_uniform/ec/sci/officer/com //Can only be officers
+	name = "EC science command"
+	departments = SCI|COM
+
+	utility_extra = list(/obj/item/clothing/head/beret/solgov/expedition/command, 
+						 /obj/item/clothing/head/ushanka/solgov, 
+						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov,
+						 /obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
+						 /obj/item/clothing/suit/storage/toggle/labcoat/science/cso)

--- a/maps/torch/job/torch_outfits.dm
+++ b/maps/torch/job/torch_outfits.dm
@@ -821,5 +821,6 @@ TERRAN OUTFITS
 
 /decl/hierarchy/outfit/job/torch/crew/research/scientist
 	name = OUTFIT_JOB_NAME("Scientist - Expeditionary Corps")
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/research
 	id_type = /obj/item/weapon/card/id/torch/crew/research/scientist
  

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -17,16 +17,18 @@
 	allowed_roles = list(/datum/job/merchant)
 
 /datum/gear/suit/medical_poncho
-	allowed_roles = list(/datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/biomech, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/suit/engineering_poncho
 	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/suit/science_poncho
-	allowed_roles = list(/datum/job/scientist, /datum/job/scientist_assistant)
+	allowed_roles = list(/datum/job/scientist, /datum/job/senior_scientist, /datum/job/scientist_assistant)
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/nanotrasen_poncho
-	allowed_roles = list(/datum/job/scientist, /datum/job/scientist_assistant, /datum/job/merchant)
+	allowed_roles = list(/datum/job/scientist, /datum/job/scientist_assistant, /datum/job/senior_scientist, /datum/job/merchant)
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/cargo_poncho
 	allowed_roles = list(/datum/job/cargo_contractor, /datum/job/merchant)
@@ -49,11 +51,13 @@
 	allowed_roles = STERILE_ROLES
 
 /datum/gear/suit/labcoat_corp
-	allowed_roles = list(/datum/job/scientist, /datum/job/engineer_contractor, /datum/job/scientist, /datum/job/rd, /datum/job/biomech, /datum/job/roboticist)
+	allowed_roles = STERILE_ROLES
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/labcoat_ec
 	display_name = "labcoat, Expeditionary Corps"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/science/ec
+	allowed_roles = list(/datum/job/scientist_assistant, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/rd)
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
 
 /datum/gear/suit/labcoat_ec_cso
@@ -63,7 +67,8 @@
 
 /datum/gear/suit/wintercoat_dais
 	display_name = "winter coat, DAIS"
-	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/scientist, /datum/job/rd)
+	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/rd)
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/coat
 	allowed_branches = CIVILIAN_BRANCHES


### PR DESCRIPTION
:cl: Textor
bugfix: After paperwork being filled out in triplicate, lost, found, and buried in peat for two weeks, the CSO now has access to their uniform in the uniform vendor.
bugfix: You now need to be an EC scientist to select an EC labcoat in loadout. Senior Researchers and Assistants now have access to some of the same stuff as normal scientists that they lacked. Also adds some equipment the biomech should have access to.
bugfix: Non-senior researcher Ensigns in the science department are now properly considered officers and have an officer's uniform given to them when they wake up instead of an enlisted uniform.
rscadd: Labcoats can now be issued via the uniform vendor for EC science people.
/:cl:
Closes #24211 