### PR TITLE
Null out non-rank name_shorts

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -644,18 +644,15 @@
  *  Civilians
  *  =========
  */
-
+ 
 /datum/mil_rank/civ/civ
 	name = "Civilian"
-	name_short = "Civ"
 
 /datum/mil_rank/civ/contractor
 	name = "Contractor"
-	name_short = "Con"
 
 /datum/mil_rank/civ/synthetic
 	name = "Synthetic"
-	name_short = "Syn"
 
 /*
  *  SolGov Employees


### PR DESCRIPTION
Doing this displays people in manifest as just their name (Jon Smith) instead of Con Jon Smith