### PR TITLE
Fixed /material/glass/phoron melting temperature to be consistent with pre-material overhaul

### DIFF
--- a/code/modules/materials/definitions/materials_glass.dm
+++ b/code/modules/materials/definitions/materials_glass.dm
@@ -37,7 +37,7 @@
 	integrity = 70
 	brute_armor = 2
 	burn_armor = 5
-	melting_point = T0C + 2000
+	melting_point = T0C + 4000
 	icon_colour = GLASS_COLOR_PHORON
 	stack_origin_tech = list(TECH_MATERIAL = 4)
 	wire_product = null


### PR DESCRIPTION
Now the engine should stop breaching in stupid ways.

Why didn't the whole core breach you ask and only one tile? Here's why. It's because temperature doesn't matter, nor does pressure. Not by themselves anyways.

Here's the code for windows breaking:

```
/obj/structure/window/fire_act(datum/gas_mixture/air,` exposed_temperature, exposed_volume)
    var/melting_point = material.melting_point
    if(reinf_material)
        melting_point += 0.25*reinf_material.melting_point
    if(exposed_temperature > melting_point)
        hit(damage_per_fire_tick, 0)
    ..()
```

Fires are what call this fire_act proc, and they only do so on their own tile, and adjacent ones. 

As the engine got fired up hotter and hotter, it would offgas o2 and phoron. When the mix got high enough, a tile in that core would ignite, and immediately lower the o2 and phoron mix too low for the fire to spread. There's enough o2 and phoron being released from the crystal to keep one tile of fire going though!

So the reason the core would breach is because it satisfied all of the following:
- A fire started
- It was next to glass
- The temperature of the core exceeded T0C + 2000 + (1800  * .25), or 2723 kelvin.

T0C is 273.

Break any of these conditions, and the core wouldn't breach. Sometimes fires started only the tile with the crystal, and that's why the core wouldn't breach at all on those rounds.

**How did this happen?**

There was a material overhaul recently. Melting points are now set by the materials in which the structure is composed of.

Prior to the material overhaul, phoron glass windows and phoron reinforced glass windows were two separate things. They had their own melting points and it differed by a huge amount. Someone probably copied the regular melting point of phoron glass windows for phoron glass sheets. As such, reinforced phoron glass lost significant strength.

Now that said, this change does inadvertently buff regular, un-reinforced phoron windows. There's no getting around this without changing fire_act. If I do that, it would change regular reinforced glass as a result, which means further tweaking of values to match the old values, which would change walls too... On top of that, it would mean I now would have to create an override specifically for phoron reinforced glass, and inconsistencies like this should just be avoided.

We're just going to have to accept that phoron glass is strong, and reinforcing only makes it marginally stronger against temperature. That said, unreinforced phoron glass is still relatively weak to **physical** attacks, so there's that.

Fixes https://github.com/Baystation12/Baystation12/issues/24330

Melting temp of phoron glass: 4273
Melting temperature of reinforced phoron glass: 4723

Credit to @MistakeNot4892 for some initial direction.

:cl:
bugfix: Fixed phoron glass sheet's melting temperature so that reinforced phoron glass is consistent with the pre-material overhaul melting temperature. This should stop the random window breakage in the engine core until close to delamination temperatures.
tweak: Due to the nature of the material overhaul and this change, regular un-reinforced phoron glass also gets its temperature significantly buffed. It's still weak to physical attack by comparison to reinforced phoron glass.
/:cl: