### PR TITLE
Gun Accuracy Changes

### DIFF
--- a/code/__defines/guns.dm
+++ b/code/__defines/guns.dm
@@ -22,3 +22,6 @@
 #define SINGLE_CASING 	1	//The gun only accepts ammo_casings. ammo_magazines should never have this as their mag_type.
 #define SPEEDLOADER 	2	//Transfers casings from the mag to the gun when used.
 #define MAGAZINE 		4	//The magazine item itself goes inside the gun
+
+
+#define GUN_BULK_RIFLE  5

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -785,6 +785,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(ID)
 		. += "  <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
 
+/obj/item/proc/on_active_hand()
+
 /obj/item/is_burnable()
 	return simulated
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -144,7 +144,7 @@
 	return
 
 /mob/living/carbon/swap_hand()
-	src.hand = !( src.hand )
+	hand = !hand
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)
 		if(hand)	//This being 1 means the left hand is in use
 			hud_used.l_hand_hud_object.icon_state = "l_hand_active"
@@ -152,7 +152,9 @@
 		else
 			hud_used.l_hand_hud_object.icon_state = "l_hand_inactive"
 			hud_used.r_hand_hud_object.icon_state = "r_hand_active"
-	return
+	var/obj/item/I = get_active_hand()
+	if(istype(I))
+		I.on_active_hand()
 
 /mob/living/carbon/proc/activate_hand(var/selhand) //0 or "r" or "right" for right hand; 1 or "l" or "left" for left hand.
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -176,7 +176,7 @@ var/list/global/organ_rel_size = list(
 		miss_chance = base_miss_chance[zone]
 	miss_chance = max(miss_chance + miss_chance_mod, 0)
 	if(prob(miss_chance))
-		if(prob(70))
+		if(ranged_attack || prob(70))
 			return null
 		return pick(base_miss_chance)
 	return zone

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -62,6 +62,7 @@
 	var/silenced = 0
 	var/accuracy = 0   //accuracy is measured in tiles. +1 accuracy means that everything is effectively one tile closer for the purpose of miss chance, -1 means the opposite. launchers are not supported, at the moment.
 	var/accuracy_power = 5  //increase of to-hit chance per 1 point of accuracy
+	var/bulk = 0			//how unwieldy this weapon for its size, affects accuracy when fired without aiming
 	var/last_handled		//time when hand gun's in became active, for purposes of aiming bonuses
 	var/scoped_accuracy = null  //accuracy used when zoomed in a scope
 	var/scope_zoom = 0
@@ -348,8 +349,9 @@
 	stood_still = max(0,round((world.time - stood_still)/10) - 1)
 	if(stood_still)
 		acc_mod += min(max(2, accuracy), stood_still)
-	else if(w_class > ITEM_SIZE_NORMAL)
-		acc_mod -= 2*w_class - ITEM_SIZE_NORMAL
+	else 
+		acc_mod -= w_class - ITEM_SIZE_NORMAL
+		acc_mod -= bulk
 
 	if(one_hand_penalty >= 4 && !held_twohanded)
 		acc_mod -= one_hand_penalty/2

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 	icon_state = "energy"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	fire_sound_text = "laser blast"
+	accuracy = 1
 
 	var/obj/item/weapon/cell/power_supply //What type of power cell this uses
 	var/charge_cost = 20 //How much energy is needed to fire.

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_LARGE
 	force = 10
 	one_hand_penalty = 2
-	accuracy = 2
+	bulk = GUN_BULK_RIFLE
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(MATERIAL_STEEL = 2000)
 	projectile_type = /obj/item/projectile/beam/midlaser

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -145,7 +145,7 @@ obj/item/weapon/gun/energy/retro
 	force = 10
 	w_class = ITEM_SIZE_HUGE
 	accuracy = -2 //shooting at the hip
-	scoped_accuracy = 0
+	scoped_accuracy = 9
 	scope_zoom = 2
 	wielded_item_state = "gun_wielded"
 

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -16,6 +16,7 @@
 	move_delay = 4
 	accuracy = -1
 	wielded_item_state = "gun_wielded"
+	bulk = GUN_BULK_RIFLE
 
 /obj/item/weapon/gun/energy/pulse_rifle/carbine
 	name = "pulse carbine"
@@ -30,6 +31,7 @@
 	one_hand_penalty= 3
 	burst_delay = 2
 	move_delay = 2
+	bulk = GUN_BULK_RIFLE - 3
 
 /obj/item/weapon/gun/energy/pulse_rifle/pistol
 	name = "pulse pistol"
@@ -45,6 +47,7 @@
 	burst_delay = 1
 	move_delay = 1
 	wielded_item_state = null
+	bulk = 0
 
 /obj/item/weapon/gun/energy/pulse_rifle/mounted
 	self_recharge = 1

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -8,6 +8,7 @@
 	fire_delay = 20
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_ILLEGAL = 2, TECH_MAGNET = 4)
 	w_class = ITEM_SIZE_LARGE
+	bulk = GUN_BULK_RIFLE
 	combustion = 1
 
 	var/obj/item/weapon/cell/cell                              // Currently installed powercell.

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -14,6 +14,7 @@
 	slot_flags = SLOT_BACK
 	loaded = /obj/item/weapon/rcd_ammo/large // ~30 shots
 	combustion = 1
+	bulk = GUN_BULK_RIFLE + 3
 
 	var/initial_cell_type = /obj/item/weapon/cell/hyper
 	var/initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv // 6-8 shots

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/guns/prototype_smg.dmi'
 	icon_state = "prototype"
 	w_class = ITEM_SIZE_NORMAL
+	bulk = -1
 	load_method = MAGAZINE
 	caliber = CALIBER_PISTOL_FLECHETTE
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 3)
@@ -42,6 +43,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	magazine_type = /obj/item/ammo_magazine/machine_pistol
 	allowed_magazines = /obj/item/ammo_magazine/machine_pistol //more damage compared to the wt550, smaller mag size
+	one_hand_penalty = 2
 
 	firemodes = list(
 		list(mode_name="semi auto",       burst=1, fire_delay=0,    move_delay=null, one_hand_penalty=0, burst_accuracy=null, dispersion=null),
@@ -73,7 +75,8 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	accuracy = 2
+	bulk = -1
+	accuracy = 1
 	one_hand_penalty = 4
 
 	//SMG
@@ -104,8 +107,10 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/rifle
 	allowed_magazines = /obj/item/ammo_magazine/rifle
-	accuracy = 0
 	one_hand_penalty = 8
+	accuracy_power = 7
+	accuracy = 2
+	bulk = GUN_BULK_RIFLE + 1
 	wielded_item_state = "arifle-wielded"
 	mag_insert_sound = 'sound/weapons/guns/interaction/ltrifle_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/ltrifle_magout.ogg'
@@ -141,6 +146,8 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/smg_top/rubber
 	allowed_magazines = /obj/item/ammo_magazine/smg_top
+	accuracy_power = 7
+	one_hand_penalty = 3
 
 	//machine pistol, like SMG but easier to one-hand with
 	firemodes = list(
@@ -173,9 +180,10 @@
 	allowed_magazines = /obj/item/ammo_magazine/mil_rifle
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	accuracy = 1
+	accuracy = 2
 	accuracy_power = 7
 	one_hand_penalty = 8
+	bulk = GUN_BULK_RIFLE
 	burst_delay = 4
 	wielded_item_state = "z8carbine-wielded"
 	mag_insert_sound = 'sound/weapons/guns/interaction/batrifle_magin.ogg'
@@ -237,6 +245,7 @@
 	icon_state = "l6closed100"
 	item_state = "l6closedmag"
 	w_class = ITEM_SIZE_HUGE
+	bulk = 10
 	force = 10
 	slot_flags = 0
 	max_shells = 50

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -73,7 +73,8 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	one_hand_penalty = 1
+	accuracy = 2
+	one_hand_penalty = 4
 
 	//SMG
 	firemodes = list(
@@ -103,7 +104,8 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/rifle
 	allowed_magazines = /obj/item/ammo_magazine/rifle
-	one_hand_penalty = 3
+	accuracy = 0
+	one_hand_penalty = 8
 	wielded_item_state = "arifle-wielded"
 	mag_insert_sound = 'sound/weapons/guns/interaction/ltrifle_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/ltrifle_magout.ogg'
@@ -171,12 +173,13 @@
 	allowed_magazines = /obj/item/ammo_magazine/mil_rifle
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	one_hand_penalty = 5
+	accuracy = 1
+	accuracy_power = 7
+	one_hand_penalty = 8
 	burst_delay = 4
 	wielded_item_state = "z8carbine-wielded"
 	mag_insert_sound = 'sound/weapons/guns/interaction/batrifle_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/batrifle_magout.ogg'
-	//would have one_hand_penalty=4,5 but the added weight of a grenade launcher makes one-handing even harder
 	firemodes = list(
 		list(mode_name="semi auto",       burst=1,    fire_delay=0,    move_delay=null, use_launcher=null, one_hand_penalty=5, burst_accuracy=null, dispersion=null),
 		list(mode_name="3-round bursts", burst=3,    fire_delay=null, move_delay=6,    use_launcher=null, one_hand_penalty=6, burst_accuracy=list(0,-1,-1), dispersion=list(0.0, 0.6, 1.0)),
@@ -244,7 +247,7 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/box/machinegun
 	allowed_magazines = list(/obj/item/ammo_magazine/box/machinegun, /obj/item/ammo_magazine/rifle)
-	one_hand_penalty = 6
+	one_hand_penalty = 10
 	wielded_item_state = "gun_wielded"
 	mag_insert_sound = 'sound/weapons/guns/interaction/lmg_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/lmg_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -63,8 +63,9 @@
 	allowed_magazines = /obj/item/ammo_magazine/magnum
 	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/hpistol_magout.ogg'
-	accuracy = 1
+	accuracy = 2
 	one_hand_penalty = 2
+	bulk = 3
 
 /obj/item/weapon/gun/projectile/pistol/throwback
 	name = "pistol"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -4,6 +4,7 @@
 	caliber = CALIBER_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	allowed_magazines = /obj/item/ammo_magazine/pistol
+	accuracy_power = 7
 	var/empty_icon = TRUE  //If it should change icon when empty
 
 /obj/item/weapon/gun/projectile/pistol/on_update_icon()
@@ -62,6 +63,8 @@
 	allowed_magazines = /obj/item/ammo_magazine/magnum
 	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/hpistol_magout.ogg'
+	accuracy = 1
+	one_hand_penalty = 2
 
 /obj/item/weapon/gun/projectile/pistol/throwback
 	name = "pistol"
@@ -69,7 +72,8 @@
 	icon = 'icons/obj/guns/pistol_throwback.dmi'
 	icon_state = "pistol1"
 	magazine_type = /obj/item/ammo_magazine/pistol/throwback
-	accuracy = -2
+	accuracy_power = 5
+	one_hand_penalty = 2
 	fire_delay = 5
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	var/base_icon = "pistol1"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -16,6 +16,7 @@
 	accuracy = 2
 	accuracy_power = 8
 	one_hand_penalty = 2
+	bulk = 3
 
 /obj/item/weapon/gun/projectile/revolver/AltClick()
 	if(CanPhysicallyInteract(usr))
@@ -52,6 +53,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	desc = "The Lumoco Arms' Solid is a rugged revolver for people who don't keep their guns well-maintained."
 	accuracy = 1
+	bulk = 0
 
 /obj/item/weapon/gun/projectile/revolver/holdout
 	name = "holdout revolver"
@@ -63,6 +65,7 @@
 	w_class = ITEM_SIZE_SMALL
 	accuracy = 1
 	one_hand_penalty = 0
+	bulk = 0
 
 /obj/item/weapon/gun/projectile/revolver/capgun
 	name = "cap gun"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -13,6 +13,9 @@
 	var/chamber_offset = 0 //how many empty chambers in the cylinder until you hit a round
 	mag_insert_sound = 'sound/weapons/guns/interaction/rev_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/rev_magout.ogg'
+	accuracy = 2
+	accuracy_power = 8
+	one_hand_penalty = 2
 
 /obj/item/weapon/gun/projectile/revolver/AltClick()
 	if(CanPhysicallyInteract(usr))
@@ -48,6 +51,7 @@
 	caliber = CALIBER_PISTOL
 	ammo_type = /obj/item/ammo_casing/pistol
 	desc = "The Lumoco Arms' Solid is a rugged revolver for people who don't keep their guns well-maintained."
+	accuracy = 1
 
 /obj/item/weapon/gun/projectile/revolver/holdout
 	name = "holdout revolver"
@@ -57,6 +61,8 @@
 	caliber = CALIBER_PISTOL_SMALL
 	ammo_type = /obj/item/ammo_casing/pistol/small
 	w_class = ITEM_SIZE_SMALL
+	accuracy = 1
+	one_hand_penalty = 0
 
 /obj/item/weapon/gun/projectile/revolver/capgun
 	name = "cap gun"

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -14,7 +14,7 @@
 	load_method = SINGLE_CASING
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	handle_casings = HOLD_CASINGS
-	one_hand_penalty = 2
+	one_hand_penalty = 8
 	var/recentpump = 0 // to prevent spammage
 	wielded_item_state = "gun_wielded"
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
@@ -53,7 +53,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	max_shells = 7 //match the ammo box capacity, also it can hold a round in the chamber anyways, for a total of 8.
 	ammo_type = /obj/item/ammo_casing/shotgun
-	one_hand_penalty = 3 //a little heavier than the regular shotgun
+	one_hand_penalty = 8
 
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel
 	name = "double-barreled shotgun"
@@ -107,7 +107,7 @@
 			item_state = "sawnshotgun"
 			w_class = ITEM_SIZE_NORMAL
 			force = 5
-			one_hand_penalty = 0
+			one_hand_penalty = 4
 			slot_flags &= ~SLOT_BACK	//you can't sling it on your back
 			slot_flags |= (SLOT_BELT|SLOT_HOLSTER) //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally) - or in a holster, why not.
 			SetName("sawn-off shotgun")
@@ -125,4 +125,4 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/pellet
 	w_class = ITEM_SIZE_NORMAL
 	force = 5
-	one_hand_penalty = 0
+	one_hand_penalty = 4

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -15,6 +15,7 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 8
+	bulk = 6
 	var/recentpump = 0 // to prevent spammage
 	wielded_item_state = "gun_wielded"
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
@@ -108,6 +109,7 @@
 			w_class = ITEM_SIZE_NORMAL
 			force = 5
 			one_hand_penalty = 4
+			bulk = 2
 			slot_flags &= ~SLOT_BACK	//you can't sling it on your back
 			slot_flags |= (SLOT_BELT|SLOT_HOLSTER) //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally) - or in a holster, why not.
 			SetName("sawn-off shotgun")
@@ -126,3 +128,4 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = 5
 	one_hand_penalty = 4
+	bulk = 2

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -16,6 +16,7 @@
 	ammo_type = /obj/item/ammo_casing/shell
 	one_hand_penalty = 6
 	accuracy = -2
+	bulk = 8
 	scoped_accuracy = 8 //increased accuracy over the LWAP because only one shot
 	scope_zoom = 2
 	var/bolt_open = 0

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -16,7 +16,7 @@
 	ammo_type = /obj/item/ammo_casing/shell
 	one_hand_penalty = 6
 	accuracy = -2
-	scoped_accuracy = 5 //increased accuracy over the LWAP because only one shot
+	scoped_accuracy = 8 //increased accuracy over the LWAP because only one shot
 	scope_zoom = 2
 	var/bolt_open = 0
 	wielded_item_state = "heavysniper-wielded" //sort of placeholder

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -26,8 +26,9 @@
 	var/p_x = 16
 	var/p_y = 16 // the pixel location of the tile that the player clicked. Default is the center
 
-	var/accuracy = 0
+	var/hitchance_mod = 0
 	var/dispersion = 0.0
+	var/distance_falloff = 2  //multiplier, higher value means accuracy drops faster with distance
 
 	var/damage = 10
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE, PAIN are the only things that should be in here
@@ -189,12 +190,21 @@
 	setup_trajectory(starting_loc, new_target)
 
 //Called when the projectile intercepts a mob. Returns 1 if the projectile hit the mob, 0 if it missed and should keep flying.
-/obj/item/projectile/proc/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier=0)
+/obj/item/projectile/proc/attack_mob(var/mob/living/target_mob, var/distance, var/special_miss_modifier=0)
 	if(!istype(target_mob))
 		return
 
 	//roll to-hit
-	miss_modifier = max(15*(distance-2) - round(15*accuracy) + miss_modifier, 0)
+	var/miss_modifier = max(distance_falloff*(distance)*(distance) - hitchance_mod + special_miss_modifier, -30)
+	//makes moving targets harder to hit, and stationary easier to hit
+	var/movment_mod = min(5, (world.time - target_mob.l_move_time) - 20)
+	//running in a straight line isnt as helpful tho
+	if(movment_mod < 0)
+		if(target_mob.last_move == get_dir(firer, target_mob))
+			movment_mod *= 0.25
+		else if(target_mob.last_move == get_dir(target_mob,firer))
+			movment_mod *= 0.5
+	miss_modifier -= movment_mod
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 
 	var/result = PROJECTILE_FORCE_MISS

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -11,6 +11,7 @@
 	hitscan = 1
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
 	penetration_modifier = 0.3
+	distance_falloff = 2.5
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer
@@ -28,6 +29,7 @@
 /obj/item/projectile/beam/midlaser
 	damage = 50
 	armor_penetration = 20
+	distance_falloff = 1
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
@@ -35,6 +37,7 @@
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	damage = 60
 	armor_penetration = 30
+	distance_falloff = 0.5
 
 	muzzle_type = /obj/effect/projectile/laser/heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser/heavy/tracer
@@ -214,6 +217,7 @@
 	check_armour = "laser"
 	kill_count = 5
 	pass_flags = PASS_FLAG_TABLE
+	distance_falloff = 4
 
 	muzzle_type = /obj/effect/projectile/trilaser/muzzle
 	tracer_type = /obj/effect/projectile/trilaser/tracer

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -124,16 +124,19 @@
 /obj/item/projectile/bullet/pistol
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	damage = 30
+	distance_falloff = 3.5
 
 /obj/item/projectile/bullet/pistol/holdout
 	damage = 25
 	penetration_modifier = 1.2
+	distance_falloff = 5
 
 /obj/item/projectile/bullet/pistol/strong
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 50
 	armor_penetration = 20
 	penetration_modifier = 0.8
+	distance_falloff = 3
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -150,6 +153,7 @@
 	penetrating = 1
 	armor_penetration = 70
 	embed = 0
+	distance_falloff = 2.5
 
 /* shotgun projectiles */
 
@@ -167,6 +171,7 @@
 	embed = 0
 	sharp = 0
 	armor_penetration = 0
+	distance_falloff = 3
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
@@ -186,6 +191,7 @@
 	armor_penetration = 25
 	penetration_modifier = 1.5
 	penetrating = 1
+	distance_falloff = 1.5
 
 /obj/item/projectile/bullet/rifle/military
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
@@ -202,6 +208,7 @@
 	armor_penetration = 80
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
 	penetration_modifier = 1.25
+	distance_falloff = 0.5
 
 /obj/item/projectile/bullet/rifle/shell/apds
 	damage = 75
@@ -256,6 +263,7 @@
 	damage = 40
 	armor_penetration = 25
 	kill_count = 255
+	distance_falloff = 0
 
 /obj/item/projectile/bullet/rock/New()
 	icon_state = "rock[rand(1,3)]"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -124,19 +124,19 @@
 /obj/item/projectile/bullet/pistol
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	damage = 30
-	distance_falloff = 3.5
+	distance_falloff = 3
 
 /obj/item/projectile/bullet/pistol/holdout
 	damage = 25
 	penetration_modifier = 1.2
-	distance_falloff = 5
+	distance_falloff = 4
 
 /obj/item/projectile/bullet/pistol/strong
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 50
 	armor_penetration = 20
 	penetration_modifier = 0.8
-	distance_falloff = 3
+	distance_falloff = 2.5
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -153,7 +153,7 @@
 	penetrating = 1
 	armor_penetration = 70
 	embed = 0
-	distance_falloff = 2.5
+	distance_falloff = 2
 
 /* shotgun projectiles */
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -4,6 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	check_armour = "energy"
+	distance_falloff = 2.5
 
 
 //releases a burst of light on impact or after travelling a distance

--- a/code/modules/projectiles/projectile/magnetic.dm
+++ b/code/modules/projectiles/projectile/magnetic.dm
@@ -7,6 +7,7 @@
 	armor_penetration = 70
 	penetration_modifier = 1.1
 	fire_sound = 'sound/weapons/railgun.ogg'
+	distance_falloff = 1
 
 /obj/item/projectile/bullet/magnetic/slug
 	name = "slug"
@@ -21,3 +22,4 @@
 	damage = 20
 	armor_penetration = 100
 	fire_sound = 'sound/weapons/rapidslice.ogg'
+	distance_falloff = 0.5

--- a/html/changelogs/chinsky - gunsuck.yml
+++ b/html/changelogs/chinsky - gunsuck.yml
@@ -1,0 +1,12 @@
+author: Chinsky
+delete-after: True
+
+changes: 
+  - rscadd: "Guns suck now."
+  - tweak: "When you have a gun in activa hand, you're considered to be 'aiming'. Moving or changing active hand resets timer."
+  - tweak: "Aiming gives bonuses to accuracy, longer you aim, capped by accuracy of the gun - so no point in aiming longer than few secs with pistol, but with sniper rifle, take your time."
+  - tweak: "If you haven't stood still for at least a second, you get penalties based on size of your gun. Pistols are almost not affected, but rifles are affected greatly."
+  - tweak: "Accuracy falloff differs for different calibers. Pistol rounds are best used 4 tiles or closer, rifles can be used from any range without ok results. Lasers mirror that setup, with higher range."
+  - tweak: "Overall, pistols are now useless at range, but don't suffer much if you move around or change hand to do something else."
+  - tweak: "Rifles are oppsite, can hit if you aim even from other end of screen, but if you move around, you're not going to hit shit."
+  - tweak: "Moving around (not towards gun) will make you harder to hit now. Yakkety sax away."


### PR DESCRIPTION
First off, guns suck now.

Previously, when you missed, instead there was a 70% chance that you hit anyway, just different part. This effectively resulted in almost no misses no matter the accuracy.
Now that only happens for melee weapons (which it was added for in the first place IIRC).

'Aiming' changed a bit. At the moment if you stand still for few seconds, you get bonus to accuracy. This bonus is now capped by gun's accuracy.
Also 'aiming' time is not just moving now, every time you switch active hand away or tinker with your gun, that timer is reset (except for Master skill level).
Another important thing is that if you have no 'aiming' level (meaning you hadn't stood still for a second) you get a great penalty to accuracy depending on w_class of your gun.

Next, accuracy and miss chance calculations. The law has changed, now it's proportional to square of distance because linear wasn't giving me fast enough falloff.
Miss chance from distance is now decided by a bullet's variable, 'distance_falloff'. The higher it is, the faster miss chance grows with distance.

Guns also have new var 'accuracy_power' which decides how much accuracy bonuses affect the final miss chance.

Then I used new law and these coefs to muck up accuracy stuff for all guns. Now it works sorta like this.

Smol guns (low w_class, low two-handed penalty) are good at run&gun, if you're moving around a lot or switching hand away to do something, their accuracy won't suffer that much.
Bigger guns (rifles and such) are more accurate, but are rendered pretty useless without at least 1 second of aiming.
Within that, pistol rounds generally drop off accuracy fast with distance, meaning pistol-round guns will usually miss if fired further than 4 tiles.
Rifle rounds aren't as affected by distance, so they're good at firing from higher distances.
Lasers are rifle-tier, slightly worse for laser pistols just to maintain their close/far range roles. Think of it as shittier cooling or blurring or whatever realismo.

Another smol thing - moving now helps, moving around will give further miss chance (up to +10% miss chance), except when you move TOWARD the gun, then it's 0.25x of usual bonus. Standing still will instead give +5% chance to get hit.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->