### PR TITLE
Holdout Revolver Uplink Tweaks

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -10,6 +10,11 @@
 	item_cost = 3
 	path = /obj/item/ammo_magazine/pistol/small
 
+/datum/uplink_item/item/ammo/holdout_speedloader
+	name = "Holdout Revolver Speedloader"
+	item_cost = 3
+	path = /obj/item/ammo_magazine/speedloader/small
+
 /datum/uplink_item/item/ammo/darts
 	name = "Darts"
 	path = /obj/item/ammo_magazine/chemdart

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -101,7 +101,7 @@
 
 /datum/uplink_item/item/visible_weapons/detective_revolver
 	name = "Holdout Revolver"
-	item_cost = 38
+	item_cost = 24
 	path = /obj/item/weapon/gun/projectile/revolver/holdout
 
 /datum/uplink_item/item/visible_weapons/pulserifle


### PR DESCRIPTION
Makes it much much cheaper. It now costs same as e-bow, cheaper than any firearm.
Why? Because it's worst firearm. Weakest boolet, low ammo capacity, finnicky reload, higher fire delay. And it costed /more/ than /holdout pistol with suppressor and ammo/.
So it's now cheapest slugthrower when you just want to shoot boolet.

Also adds actual ammo for it in uplink whoops.