### PR TITLE
Fixes #24410

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -69,8 +69,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	switch(return_name)
 		if(MATERIAL_STEEL)
 			return_name = "Steel"
+		if(MATERIAL_ALUMINIUM)
+			return_name = "Aluminium"
 		if(MATERIAL_GLASS)
 			return_name = "Glass"
+		if(MATERIAL_PLASTIC)
+			return_name = "Plastic"
 		if(MATERIAL_GOLD)
 			return_name = "Gold"
 		if(MATERIAL_SILVER)

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -6673,9 +6673,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/hallway)
 "pf" = (
-/obj/structure/table/steel,
-/obj/item/weapon/aicard,
-/obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -10250,6 +10247,7 @@
 /obj/item/organ/internal/posibrain,
 /obj/item/organ/internal/posibrain,
 /obj/item/device/robotanalyzer,
+/obj/item/weapon/aicard,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics/lower)
 "xG" = (
@@ -14998,7 +14996,7 @@
 	},
 /obj/machinery/computer/rdconsole/robotics{
 	id = 3;
-	name = "fabrication lab fabrication console"
+	name = "robotics fabrication console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics/lower)
@@ -15944,6 +15942,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics/lower)
 "OR" = (
@@ -16448,17 +16447,6 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/fuelbay)
-"Qq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/assembly/robotics/lower)
 "Qu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -16958,8 +16946,8 @@
 "Sz" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Fabrication Maintenance";
-	req_access = list(82)
+	name = "Robotics Maintenance";
+	req_access = list(12,82)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18211,25 +18199,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/central)
 "XK" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/acid{
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/device/multitool{
-	pixel_x = 3
-	},
-/obj/item/clothing/glasses/welding,
-/obj/item/device/integrated_electronics/debugger,
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/analyzer,
-/obj/item/weapon/storage/belt/utility/full,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics/lower)
 "XO" = (
 /obj/structure/cable/green{
@@ -36348,7 +36325,7 @@ Yr
 gg
 UX
 MB
-Qq
+yI
 XK
 gg
 SQ

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -12447,18 +12447,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aRb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "aRd" = (
@@ -12947,9 +12945,7 @@
 	icon_state = "warning";
 	dir = 4
 	},
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
+/obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "aSd" = (
@@ -17408,15 +17404,24 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
 "ehb" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
-/obj/structure/reagent_dispensers/acid{
-	density = 0;
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/device/multitool{
+	pixel_x = 3
+	},
+/obj/item/clothing/glasses/welding,
+/obj/item/device/integrated_electronics/debugger,
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_electronics/analyzer,
+/obj/item/weapon/storage/belt/utility/full,
+/turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "ehT" = (
 /obj/structure/railing/mapped,
@@ -17644,8 +17649,8 @@
 "esb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Fabrication Maintenance";
-	req_access = list(82)
+	name = "Robotics Maintenance";
+	req_access = list(12,82)
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/centralstarboard)
@@ -20732,7 +20737,6 @@
 /turf/simulated/open,
 /area/assembly/robotics)
 "hNb" = (
-/obj/machinery/autolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 1
@@ -20748,6 +20752,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "hOb" = (
@@ -23171,11 +23176,6 @@
 	dir = 1
 	},
 /obj/machinery/photocopier,
-/obj/structure/reagent_dispensers/acid{
-	density = 0;
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Robotics Laboratory";
@@ -23350,7 +23350,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Charging Bay";
+	name = "Robotics";
 	req_access = list(82)
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -23714,7 +23714,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Fabrication Laboratory";
+	name = "Robotics";
 	req_access = list(82)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -31255,8 +31255,8 @@
 "uSl" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Fabrication Maintenance";
-	req_access = list(82)
+	name = "Robotics Maintenance";
+	req_access = list(12,82)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/robotics/surgery)

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1367,11 +1367,11 @@
 	icon_state = "mechbay"
 
 /area/assembly/robotics
-	name = "\improper Fabrication Lab"
+	name = "\improper Robotics Lab"
 	icon_state = "robotics"
 
 /area/assembly/robotics/lower
-	name = "\improper Lower Fabrication Lab"
+	name = "\improper Lower Robotics Lab"
 
 /area/assembly/robotics/surgery
 	name = "\improper Robotics Operating Theatre"


### PR DESCRIPTION
:cl:
maptweak: The robotics lab has been messed with again, everything should work now hopefully.
/:cl:

Fixes #24410 

Moves all the `r_n_d` stuff onto bottom level, top level is basically for looking at dead bodies or whatever goes on in surgery zone. Stupid having 2 different consoles for 2 machines spread out over 2 different levels.

Corrects area names, door access and so on
