### PR TITLE
Scales down traitor gun selection

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -28,16 +28,19 @@
 	name = "Assault Rifle Magazine"
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo
 	name = "Sniper Shells"
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/sniperammo
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo/apds
 	name = "Sniper APDS Shells"
 	item_cost = 12
 	path = /obj/item/weapon/storage/box/ammo/sniperammo/apds
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/shotgun_shells
 	name = "Shotgun Shells box"
@@ -58,6 +61,7 @@
 	name = "SMG Magazine"
 	item_cost = 8
 	path = /obj/item/ammo_magazine/smg
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol
 	name = "Pistol Magazine"
@@ -78,6 +82,7 @@
 	name = "Flechette Rifle Magazine"
 	item_cost = 8
 	path = /obj/item/weapon/magnetic_ammo
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol_emp
 	name = "Pistol EMP Ammmo Box (10 rounds)"

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -38,3 +38,4 @@
 	name = "\improper Mounted Laser Cannon"
 	item_cost = 64
 	path = /obj/item/rig_module/mounted
+	antag_roles = list(MODE_MERCENARY)

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -58,11 +58,13 @@
 	name = "Submachine Gun"
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
 	item_cost = 60
 	path = /obj/item/weapon/gun/projectile/automatic/assault_rifle
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/advanced_energy_gun
 	name = "Advanced Energy Gun"
@@ -73,6 +75,7 @@
 	name = "Anti-materiel Rifle with ammunition"
 	item_cost = 68
 	path = /obj/item/weapon/storage/secure/briefcase/heavysniper
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/machine_pistol
 	name = "Machine Pistol"
@@ -83,6 +86,7 @@
 	name = "Combat Shotgun"
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/sawnoff
 	name = "Sawnoff Shotgun"
@@ -108,22 +112,24 @@
 	name = "Pulse Rifle"
 	item_cost = 68
 	path = /obj/item/weapon/gun/energy/pulse_rifle
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/flechetterifle
 	name = "Flechette Rifle"
 	item_cost = 60
 	path = /obj/item/weapon/gun/magnetic/railgun/flechette
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/railgun // Like a semi-auto AMR
 	name = "Railgun"
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
-	antag_costs = list(MODE_MERCENARY = DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6)
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6
+	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/gun/magnetic/railgun
 
 /datum/uplink_item/item/visible_weapons/railguntcc // Only slightly better than the normal railgun; but cooler looking
 	name = "Advanced Railgun"
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT + (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6// Only available to traitors if they share TCs.
-	antag_costs = list(MODE_MERCENARY = DEFAULT_TELECRYSTAL_AMOUNT) // This, on the other hand, is to encourage usage specifically by mercs with high budgets.
+	antag_roles = list(MODE_MERCENARY)
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
 	path = /obj/item/weapon/gun/magnetic/railgun/tcc
 
 /datum/uplink_item/item/visible_weapons/harpoonbomb


### PR DESCRIPTION
Restricts big guns to merc only, and their ammo. Basically only pistol-likes allowed.
Ripley laser is an exception because of makeshift nature of it.
:cl: 
tweak: Uplink gun selection for traitors was scaled down. Assault rifles and similary big guns are gone, only pistol-likes available now.
/:cl: