### PR TITLE
Fixes Hangar Access Loophole

### DIFF
--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -5491,8 +5491,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
 	name = "Hangar Maintenance";
-	req_access = newlist();
-	req_one_access = list(12,73)
+	req_access = list(12, 73)
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/hangar)
@@ -6762,8 +6761,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
 	name = "Hangar Maintenance";
-	req_access = newlist();
-	req_one_access = list(12,73)
+	req_access = list(12, 73)
 	},
 /obj/structure/cable/green{
 	d1 = 1;


### PR DESCRIPTION
Apparently a bug since at least April 10th 2018 ( Baystation12/Baystation12#21135 )
🆑 Datraen
bugfix: Fixes incorrect access on hangar maintenance doors.
/:cl: