### PR TITLE
Removes arms and armor from command lockers.

### DIFF
--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -34,13 +34,9 @@
 
 /obj/structure/closet/secure_closet/CO/WillContain()
 	return list(
-		/obj/item/clothing/suit/armor/pcarrier/medium/command,
-		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/radio/headset/heads/torchexec,
 		/obj/item/clothing/glasses/sunglasses,
-		/obj/item/weapon/gun/energy/revolver/secure,
 		/obj/item/device/radio/headset/heads/torchexec/alt,
-		/obj/item/weapon/storage/belt/holster/general,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
@@ -60,11 +56,8 @@
 /obj/structure/closet/secure_closet/XO/WillContain()
 	return list(
 		/obj/item/clothing/glasses/sunglasses,
-		/obj/item/clothing/suit/armor/pcarrier/medium/command,
-		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/radio/headset/heads/torchexec,
-		/obj/item/weapon/storage/belt/holster/general,
-		/obj/item/weapon/gun/energy/revolver/secure,
+		/obj/item/weapon/storage/belt/general,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
@@ -89,12 +82,9 @@
 /obj/structure/closet/secure_closet/sea/WillContain()
 	return list(
 		/obj/item/clothing/glasses/sunglasses,
-		/obj/item/clothing/suit/armor/pcarrier/medium/command,
-		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/radio/headset/sea,
 		/obj/item/device/radio/headset/sea/alt,
-		/obj/item/weapon/gun/energy/gun/secure,
-		/obj/item/weapon/storage/belt/holster/general,
+		/obj/item/weapon/storage/belt/general,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,
@@ -115,8 +105,6 @@
 		/obj/item/device/radio,
 		/obj/item/weapon/pen,
 		/obj/item/device/tape/random,
-		/obj/item/clothing/suit/armor/pcarrier/medium/command,
-		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/device/taperecorder,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -142,5 +142,6 @@
 		/obj/item/weapon/gun/energy/gun/small/secure = 2,
 		/obj/item/weapon/storage/belt/holster/general = 2,
 		/obj/item/weapon/gun/energy/gun/secure = 2,
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/gun/energy/gun/secure, /obj/item/weapon/gun/energy/gun/small/secure))
+		/obj/item/clothing/suit/armor/pcarrier/medium/command = 3,
+		/obj/item/clothing/head/helmet/solgov/command = 3
 	)


### PR DESCRIPTION
:cl:
rscdel: Guns and armor are no longer available in personal command lockers.
tweak: The bridge sidearms closet now also has three sets of command armor.
/:cl: