### PR TITLE
Add rechargers to merchant shuttle and merchant base

### DIFF
--- a/maps/torch/torch-6.dmm
+++ b/maps/torch/torch-6.dmm
@@ -18651,6 +18651,7 @@
 "aRs" = (
 /obj/structure/table/steel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "aRt" = (
@@ -21705,6 +21706,7 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
+/obj/machinery/recharger,
 /obj/item/device/eftpos,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/merchant/home)


### PR DESCRIPTION
As requested here: https://forums.baystation12.net/threads/add-a-recharger-to-the-merchant-station.7413/

![dreammaker_2019-02-09_04-03-24](https://user-images.githubusercontent.com/11140088/52520588-d6270300-2c1f-11e9-8bd8-c5d4f45ff19e.png)

![dreammaker_2019-02-09_04-03-28](https://user-images.githubusercontent.com/11140088/52520589-d7f0c680-2c1f-11e9-9c06-0cc5979c519a.png)

:cl: SierraKomodo
maptweak: Added rechargers to merchant shuttle and merchant base
/:cl: