### PR TITLE
merc and raider don't autovote on leaving

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,6 +13,6 @@
 	config_tag = "changeling"
 	required_players = 2
 	required_enemies = 1
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_scaling_coeff = 10
 	antag_tags = list(MODE_CHANGELING)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -5,5 +5,5 @@
 	config_tag = "cult"
 	required_players = 10
 	required_enemies = 3
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -6,31 +6,31 @@ var/global/list/additional_antag_types = list()
 	var/round_description = "How did you even vote this in?"
 	var/extended_round_description = "This roundtype should not be spawned, let alone votable. Someone contact a developer and tell them the game's broken again."
 	var/config_tag = null
-	var/votable = 1
+	var/votable = TRUE
 	var/probability = 0
 
 	var/required_players = 0                 // Minimum players for round to start if voted in.
 	var/required_enemies = 0                 // Minimum antagonists for round to start.
 	var/newscaster_announcements = null
-	var/end_on_antag_death = 0               // Round will end when all antagonists are dead.
-	var/ert_disabled = 0                     // ERT cannot be called.
-	var/deny_respawn = 0	                 // Disable respawn during this round.
+	var/end_on_antag_death = FALSE           // Round will end when all antagonists are dead.
+	var/ert_disabled = FALSE                 // ERT cannot be called.
+	var/deny_respawn = FALSE	             // Disable respawn during this round.
 
-	var/list/disabled_jobs = list()           // Mostly used for Malf.  This check is performed in job_controller so it doesn't spawn a regular AI.
+	var/list/disabled_jobs = list()          // Mostly used for Malf.  This check is performed in job_controller so it doesn't spawn a regular AI.
 
 	var/shuttle_delay = 1                    // Shuttle transit time is multiplied by this.
-	var/auto_recall_shuttle = 0              // Will the shuttle automatically be recalled?
+	var/auto_recall_shuttle = FALSE          // Will the shuttle automatically be recalled?
 
 	var/list/antag_tags = list()             // Core antag templates to spawn.
 	var/list/antag_templates                 // Extra antagonist types to include.
-	var/list/latejoin_antag_tags = list()        // Antags that may auto-spawn, latejoin or otherwise come in midround.
-	var/round_autoantag = 0                  // Will this round attempt to periodically spawn more antagonists?
+	var/list/latejoin_antag_tags = list()    // Antags that may auto-spawn, latejoin or otherwise come in midround.
+	var/round_autoantag = FALSE              // Will this round attempt to periodically spawn more antagonists?
 	var/antag_scaling_coeff = 5              // Coefficient for scaling max antagonists to player count.
-	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
+	var/require_all_templates = FALSE        // Will only start if all templates are checked and can spawn.
 	var/addantag_allowed = ADDANTAG_ADMIN | ADDANTAG_AUTO
 
-	var/station_was_nuked = 0                // See nuclearbomb.dm and malfunction.dm.
-	var/explosion_in_progress = 0            // Sit back and relax
+	var/station_was_nuked = FALSE            // See nuclearbomb.dm and malfunction.dm.
+	var/explosion_in_progress = FALSE        // Sit back and relax
 
 	var/event_delay_mod_moderate             // Modifies the timing of random events.
 	var/event_delay_mod_major                // As above.

--- a/code/game/gamemodes/godmode/godmode.dm
+++ b/code/game/gamemodes/godmode/godmode.dm
@@ -5,5 +5,5 @@
 	config_tag = "god"
 	required_players = 10
 	required_enemies = 3
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_DEITY, MODE_GODCULTIST)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -12,11 +12,5 @@
 		station to be a highly valuable target for many competing organizations and individuals. Being a \
 		colony of sizable population and considerable wealth causes it to often be the target of various \
 		attempts of robbery, fraud and other malicious actions."
-	end_on_antag_death = 1
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER)
-
-/datum/game_mode/heist/check_finished()
-	var/datum/shuttle/autodock/multi/antag/skipjack = SSshuttle.shuttles["Skipjack"]
-	if (skipjack && skipjack.return_warning && skipjack.home_waypoint == skipjack.current_location)
-		return 1
-	return ..()

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -5,8 +5,8 @@
 	config_tag = "malfunction"
 	required_players = 2
 	required_enemies = 1
-	end_on_antag_death = 0
-	auto_recall_shuttle = 0
+	end_on_antag_death = FALSE
+	auto_recall_shuttle = FALSE
 	antag_tags = list(MODE_MALFUNCTION)
 	disabled_jobs = list("AI")
 	cinematic_icon_states = list(
@@ -31,5 +31,5 @@
 		if(R.connected_ai)
 			continue
 		R.connect_to_ai(master)
-		R.lawupdate = 1
+		R.lawupdate = TRUE
 		R.sync()

--- a/code/game/gamemodes/mixed/bughunt.dm
+++ b/code/game/gamemodes/mixed/bughunt.dm
@@ -5,9 +5,9 @@
 	config_tag = "bughunt"
 	required_players = 15
 	required_enemies = 1
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_XENOMORPH, MODE_DEATHSQUAD)
-	require_all_templates = 1
-	votable = 0
-	auto_recall_shuttle = 1
-	ert_disabled = 1
+	require_all_templates = TRUE
+	votable = FALSE
+	auto_recall_shuttle = TRUE
+	ert_disabled = TRUE

--- a/code/game/gamemodes/mixed/conflux.dm
+++ b/code/game/gamemodes/mixed/conflux.dm
@@ -5,6 +5,6 @@
 	config_tag = "conflux"
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_WIZARD, MODE_CULTIST)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -5,6 +5,6 @@
 	config_tag = "crossfire"
 	required_players = 25
 	required_enemies = 6
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/faithless.dm
+++ b/code/game/gamemodes/mixed/faithless.dm
@@ -5,5 +5,5 @@
 	config_tag = "faithless"
 	required_players = 15
 	required_enemies = 6
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST, MODE_DEITY, MODE_GODCULTIST)

--- a/code/game/gamemodes/mixed/infestation.dm
+++ b/code/game/gamemodes/mixed/infestation.dm
@@ -5,10 +5,10 @@
 	config_tag = "infestation"
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_BORER, MODE_XENOMORPH, MODE_CHANGELING)
-	require_all_templates = 1
-	votable = 0
+	require_all_templates = TRUE
+	votable = FALSE
 
 /datum/game_mode/infestation/create_antagonists()
 	// Two of the three.

--- a/code/game/gamemodes/mixed/intrigue.dm
+++ b/code/game/gamemodes/mixed/intrigue.dm
@@ -4,9 +4,9 @@
 	config_tag = "intrigue"
 	required_players = 15
 	required_enemies = 4
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_NINJA, MODE_TRAITOR)
-	require_all_templates = 1
+	require_all_templates = TRUE
 	latejoin_antag_tags = list(MODE_TRAITOR)
 
 /datum/game_mode/intrigue/New()

--- a/code/game/gamemodes/mixed/lizard.dm
+++ b/code/game/gamemodes/mixed/lizard.dm
@@ -5,6 +5,6 @@
 	config_tag = "lizard"
 	required_players = 15
 	required_enemies = 4
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_WIZARD, MODE_CHANGELING)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/paranoia.dm
+++ b/code/game/gamemodes/mixed/paranoia.dm
@@ -5,8 +5,8 @@
 	config_tag = "paranoia"
 	required_players = 15
 	required_enemies = 1
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_MALFUNCTION, MODE_RENEGADE, MODE_CHANGELING)
 	disabled_jobs = list("AI")
-	require_all_templates = 1
-	votable = 0
+	require_all_templates = TRUE
+	votable = FALSE

--- a/code/game/gamemodes/mixed/siege.dm
+++ b/code/game/gamemodes/mixed/siege.dm
@@ -5,8 +5,8 @@
 	extended_round_description = "GENERAL QUARTERS! OH GOD WE GAVE THE REVOLUTIONARIES GUNS!"
 	required_players = 20
 	required_enemies = 5
-	end_on_antag_death = 0
-	auto_recall_shuttle = 0
+	end_on_antag_death = FALSE
+	auto_recall_shuttle = FALSE
 	shuttle_delay = 2
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_MERCENARY)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/spyvspy.dm
+++ b/code/game/gamemodes/mixed/spyvspy.dm
@@ -5,8 +5,8 @@
 	config_tag = "spyvspy"
 	required_players = 4
 	required_enemies = 4
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_TRAITOR, MODE_RENEGADE)
-	require_all_templates = 1
+	require_all_templates = TRUE
 	antag_scaling_coeff = 5
 	latejoin_antag_tags = list(MODE_TRAITOR)

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -5,6 +5,6 @@
 	config_tag = "traitorling"
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/unity.dm
+++ b/code/game/gamemodes/mixed/unity.dm
@@ -5,8 +5,8 @@
 	extended_round_description = "I pledge allegiance to the Banner of the One True King, and to the Federation for which He stands, one Empire under Our Dear Leader, indivisible, with liberty and justice for all."
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 0
-	auto_recall_shuttle = 0
+	end_on_antag_death = FALSE
+	auto_recall_shuttle = FALSE
 	shuttle_delay = 2
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_WIZARD)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/uprising.dm
+++ b/code/game/gamemodes/mixed/uprising.dm
@@ -5,8 +5,8 @@
 	config_tag = "uprising"
 	required_players = 20
 	required_enemies = 6
-	end_on_antag_death = 0
-	auto_recall_shuttle = 0
+	end_on_antag_death = FALSE
+	auto_recall_shuttle = FALSE
 	shuttle_delay = 2
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_CULTIST)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/visitors.dm
+++ b/code/game/gamemodes/mixed/visitors.dm
@@ -5,6 +5,6 @@
 	config_tag = "visitors"
 	required_players = 15
 	required_enemies = 2
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_WIZARD, MODE_NINJA)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -11,5 +11,5 @@
 	config_tag = "ninja"
 	required_players = 1
 	required_enemies = 1
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_NINJA)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -14,7 +14,7 @@ var/list/nuke_disks = list()
 	config_tag = "mercenary"
 	required_players = 15
 	required_enemies = 1
-	end_on_antag_death = 1
+	end_on_antag_death = FALSE
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 	antag_tags = list(MODE_MERCENARY)
@@ -28,19 +28,19 @@ var/list/nuke_disks = list()
 /datum/game_mode/nuclear/proc/check_mob(mob/living/L)
 	for(var/obj/item/weapon/disk/nuclear/N in nuke_disks)
 		if(N.storage_depth(L) >= 0)
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /datum/game_mode/nuclear/declare_completion()
 	var/datum/antagonist/merc = GLOB.all_antag_types_[MODE_MERCENARY]
 	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || (merc && !merc.global_objectives.len))
 		..()
 		return
-	var/disk_rescued = 1
+	var/disk_rescued = TRUE
 	for(var/obj/item/weapon/disk/nuclear/D in world)
 		var/disk_area = get_area(D)
 		if(!is_type_in_list(disk_area, GLOB.using_map.post_round_safe_areas))
-			disk_rescued = 0
+			disk_rescued = FALSE
 			break
 	var/crew_evacuated = (evacuation_controller.has_evacuated())
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -5,8 +5,8 @@
 	extended_round_description = "Revolutionaries - Remove the heads of staff from power. Convert other crewmembers to your cause using the 'Convert Bourgeoise' verb. Protect your leaders."
 	required_players = 4
 	required_enemies = 3
-	auto_recall_shuttle = 0
-	end_on_antag_death = 0
+	auto_recall_shuttle = FALSE
+	end_on_antag_death = FALSE
 	shuttle_delay = 2
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST)
-	require_all_templates = 1
+	require_all_templates = TRUE

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -15,5 +15,5 @@
 	required_enemies = 1
 	antag_tags = list(MODE_TRAITOR)
 	antag_scaling_coeff = 5
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	latejoin_antag_tags = list(MODE_TRAITOR)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -5,5 +5,5 @@
 	config_tag = "wizard"
 	required_players = 1
 	required_enemies = 1
-	end_on_antag_death = 0
+	end_on_antag_death = FALSE
 	antag_tags = list(MODE_WIZARD)

--- a/code/modules/shuttles/shuttles_multi.dm
+++ b/code/modules/shuttles/shuttles_multi.dm
@@ -32,7 +32,6 @@
 	var/announcer
 	var/arrival_message
 	var/departure_message
-	var/return_warning = 0
 
 	category = /datum/shuttle/autodock/multi/antag
 
@@ -59,10 +58,3 @@
 	if(cloaked || isnull(arrival_message))
 		return
 	command_announcement.Announce(arrival_message, announcer || "[GLOB.using_map.boss_name]")
-
-/datum/shuttle/autodock/multi/antag/set_destination(var/destination_key, mob/user)
-	if(!return_warning && destination_key == home_waypoint.name)
-		to_chat(user, "<span class='danger'>Returning to your home base will end your mission. If you are sure, press the button again.</span>")
-		return_warning = 1
-		return
-	..()


### PR DESCRIPTION
:cl:
tweak: Mercenary and Raider game modes no longer do early round-end votes when the antagonists leave or die.
/:cl:
No other modes do this and it's a bit dissonant when it occurs.

Also swaps out numbers for macros in game mode definitions.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->