### PR TITLE
fixes #24399

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -110,6 +110,7 @@ var/const/DTH_FREQ	= 1341
 var/const/SYND_FREQ = 1213
 var/const/RAID_FREQ	= 1277
 var/const/ENT_FREQ	= 1461 //entertainment frequency. This is not a diona exclusive frequency.
+var/const/SPY_FREQ  = 1433
 
 // department channels
 var/const/PUB_FREQ = 1459

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1125,13 +1125,12 @@
 	else if(eyeobj)
 		if(eyeobj.owner != src)
 			reset_view(null)
-	else
-		var/isRemoteObserve = 0
-		if(shadow && client.eye == shadow && !is_physically_disabled())
-			isRemoteObserve = 1
-		else if((mRemote in mutations) && remoteview_target)
-			if(remoteview_target.stat == CONSCIOUS)
-				isRemoteObserve = 1
+	else if (mRemote in mutations)
+		var/isRemoteObserve = FALSE
+		if (shadow && client.eye == shadow && !is_physically_disabled())
+			isRemoteObserve = TRUE
+		else if (remoteview_target && remoteview_target.stat == CONSCIOUS)
+			isRemoteObserve = TRUE
 		if(!isRemoteObserve && client && !client.adminobs)
 			remoteview_target = null
 			reset_view(null, 0)


### PR DESCRIPTION
:cl:
bugfix: Traitor spy camera bugs work correctly.
/:cl:

The life.dm block previously caused reset_view to be called every vision tick under most circumstances as sort of a fall-through which I believe was originally accidental and causes fighting with some things that move the camera. Some things rely on it, though, like exiting camera console views which don't explicitly reset view on their own. This needs some more work as a result.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->