### PR TITLE
Submap job tweaks.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2953,7 +2953,6 @@
 #include "maps\random_ruins\space_ruins\space_ruins.dm"
 #include "maps\torch\torch.dm"
 #include "maps\torch\torch_define.dm"
-#include "maps\torch\structures\closets\closet_appearances.dm"
 #include "maps\~mapsystem\map_preferences.dm"
 #include "maps\~mapsystem\map_ranks.dm"
 #include "maps\~mapsystem\maps.dm"

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -455,13 +455,13 @@ SUBSYSTEM_DEF(jobs)
 		// EMAIL GENERATION
 		if(rank != "Robot" && rank != "AI")		//These guys get their emails later.
 			var/domain
-			var/desired_name
-			if(H.char_branch && H.char_branch.email_domain)
-				domain = H.char_branch.email_domain
+			if(H.char_branch)
+				if(H.char_branch.email_domain)
+					domain = H.char_branch.email_domain
 			else
 				domain = "freemail.net"
-			desired_name = H.real_name
-			ntnet_global.create_email(H, desired_name, domain)
+			if(domain)
+				ntnet_global.create_email(H, H.real_name, domain)
 		// END EMAIL GENERATION
 
 		job.equip(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -220,6 +220,7 @@
 
 // Don't use if the map doesn't use branches but jobs do.
 /datum/job/proc/get_branch_rank(var/datum/species/S)
+	. = species_branch_rank_cache_[S]
 	if(.)
 		return
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -220,7 +220,6 @@
 
 // Don't use if the map doesn't use branches but jobs do.
 /datum/job/proc/get_branch_rank(var/datum/species/S)
-	. = species_branch_rank_cache_[S]
 	if(.)
 		return
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -333,7 +333,7 @@
 		if(istype(job))
 			var/datum/species/S = preference_species()
 			var/list/options = job.allowed_branches ? job.get_branch_rank(S) : mil_branches.spawn_branches(S)
-			var/choice = input(user, "Choose your branch of ser@vice.", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in options
+			var/choice = input(user, "Choose your branch of service.", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in options
 			if(choice && CanUseTopic(user) && mil_branches.is_spawn_branch(choice, S))
 				pref.branches[job.title] = choice
 				pref.ranks -= job.title

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -397,7 +397,7 @@
 	if(LAZYLEN(job_summaries))
 		dat += job_summaries
 	else
-		dat += "No available positions."
+		dat += "<tr><td>No available positions.</td></tr>"
 	// END TORCH JOBS
 
 	// SUBMAP JOBS

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -40,8 +40,8 @@
 	var/branch
 	var/list/spawnpoints
 	var/datum/submap/owner
-	var/list/blacklisted_species
-	var/list/whitelisted_species
+	var/list/blacklisted_species = RESTRICTED_SPECIES
+	var/list/whitelisted_species = STATION_SPECIES
 
 /datum/job/submap/New(var/datum/submap/_owner, var/abstract_job = FALSE)
 	if(!abstract_job)

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -49,6 +49,13 @@
 		owner = _owner
 		..()
 
+/datum/job/submap/is_species_allowed(var/datum/species/S)
+	if(LAZYLEN(whitelisted_species) && !(S.name in whitelisted_species))
+		return FALSE
+	if(S.name in blacklisted_species)
+		return FALSE
+	return TRUE
+
 /datum/job/submap/is_restricted(var/datum/preferences/prefs, var/feedback)
 	if(minimum_character_age && (prefs.age < minimum_character_age))
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age].</span>")

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -54,6 +54,11 @@
 		return FALSE
 	if(S.name in blacklisted_species)
 		return FALSE
+	if(owner && owner.archetype)
+		if(LAZYLEN(owner.archetype.whitelisted_species) && !(S.name in owner.archetype.whitelisted_species))
+			return FALSE
+		if(S.name in owner.archetype.blacklisted_species)
+			return FALSE
 	return TRUE
 
 /datum/job/submap/is_restricted(var/datum/preferences/prefs, var/feedback)
@@ -61,11 +66,18 @@
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age].</span>")
 		return TRUE
 	if(LAZYLEN(whitelisted_species) && !(prefs.species in whitelisted_species))
-		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as crew on \a [owner.archetype.descriptor].</span>")
+		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.descriptor].</span>")
 		return TRUE
 	if(prefs.species in blacklisted_species)
-		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as crew on \a [owner.archetype.descriptor].</span>")
+		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.descriptor].</span>")
 		return TRUE
+	if(owner && owner.archetype)
+		if(LAZYLEN(owner.archetype.whitelisted_species) && !(prefs.species in owner.archetype.whitelisted_species))
+			to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted on \a [owner.archetype.descriptor].</span>")
+			return TRUE
+		if(prefs.species in owner.archetype.blacklisted_species)
+			to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted on \a [owner.archetype.descriptor].</span>")
+			return TRUE
 	return FALSE
 
 /datum/job/submap/check_is_active(var/mob/M)

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -10,7 +10,7 @@
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 
 /obj/effect/overmap/sector/vox_base
-	name = "Large Asteroid"
+	name = "large asteroid"
 	desc = "Sensor array detects a large asteroid."
 	in_space = 1
 	icon_state = "meteor4"
@@ -53,11 +53,20 @@
 	fore_dir = NORTH
 
 /obj/effect/submap_landmark/joinable_submap/voxship
-	name = "vox base"
 	archetype = /decl/submap_archetype/derelict/voxship
 
+/obj/effect/submap_landmark/joinable_submap/voxship/New()
+	var/datum/language/vox/pidgin = all_languages[LANGUAGE_VOX]
+	if(pidgin)
+		name = "[pidgin.get_random_name()]-[pidgin.get_random_name()]"
+	else
+		pidgin = new
+		name = "[pidgin.get_random_name()]-[pidgin.get_random_name()]"
+		qdel(pidgin)
+	..()
+
 /decl/submap_archetype/derelict/voxship
-	descriptor = "Shoal derelict"
+	descriptor = "Shoal forward base"
 	map = "Vox Base"
 	crew_jobs = list(
 		/datum/job/submap/voxship_vox

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -63,6 +63,7 @@
 		/datum/job/submap/voxship_vox
 	)
 	whitelisted_species = list(SPECIES_VOX)
+	blacklisted_species = null
 
 /turf/simulated/floor/plating/vox
 	initial_gas = list("nitrogen" = MOLES_N2STANDARD*1.25)

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -57,12 +57,7 @@
 
 /obj/effect/submap_landmark/joinable_submap/voxship/New()
 	var/datum/language/vox/pidgin = all_languages[LANGUAGE_VOX]
-	if(pidgin)
-		name = "[pidgin.get_random_name()]-[pidgin.get_random_name()]"
-	else
-		pidgin = new
-		name = "[pidgin.get_random_name()]-[pidgin.get_random_name()]"
-		qdel(pidgin)
+	name = "[pidgin.get_random_name()]-[pidgin.get_random_name()]"
 	..()
 
 /decl/submap_archetype/derelict/voxship

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -57,7 +57,7 @@
 	archetype = /decl/submap_archetype/derelict/voxship
 
 /decl/submap_archetype/derelict/voxship
-	descriptor = "derelict"
+	descriptor = "Shoal derelict"
 	map = "Vox Base"
 	crew_jobs = list(
 		/datum/job/submap/voxship_vox

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -5,6 +5,8 @@
 	supervisors = "arkship"
 	info = "Scrap is thin. Not much food is left, but thankfully the sector is quite rich, and it's time to get some more supplies. \
 	although staying on base is tempting. Plenty of nitrogen, and not much hazards to worry about."
+	whitelisted_species = list(SPECIES_VOX)
+	blacklisted_species = null
 
 #define VOXSHIP_OUTFIT_JOB_NAME(job_name) ("Vox Asteroid Base - Job - " + job_name)
 /decl/hierarchy/outfit/job/voxship

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -7,10 +7,6 @@
 	although staying on base is tempting. Plenty of nitrogen, and not much hazards to worry about."
 	whitelisted_species = list(SPECIES_VOX)
 	blacklisted_species = null
-	rank =   /datum/mil_rank/alien
-	branch = /datum/mil_branch/alien
-	allowed_branches = list(/datum/mil_branch/alien)
-	allowed_ranks = list(/datum/mil_rank/alien)
 
 #define VOXSHIP_OUTFIT_JOB_NAME(job_name) ("Vox Asteroid Base - Job - " + job_name)
 /decl/hierarchy/outfit/job/voxship

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -1,8 +1,8 @@
 /datum/job/submap/voxship_vox
-	title = "Vox"
+	title = "Shoal Scavenger"
 	total_positions = 4
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
-	supervisors = "arkship"
+	supervisors = "apex and the arkship"
 	info = "Scrap is thin. Not much food is left, but thankfully the sector is quite rich, and it's time to get some more supplies. \
 	although staying on base is tempting. Plenty of nitrogen, and not much hazards to worry about."
 	whitelisted_species = list(SPECIES_VOX)
@@ -15,7 +15,7 @@
 	r_ear = null
 
 /decl/hierarchy/outfit/job/voxship/crew
-	name = VOXSHIP_OUTFIT_JOB_NAME("Vox")
+	name = VOXSHIP_OUTFIT_JOB_NAME("Shoal Scavenger")
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/device/radio
 	shoes = /obj/item/clothing/shoes/magboots/vox
@@ -24,6 +24,6 @@
 	l_pocket = /obj/item/weapon/crowbar/prybar
 
 /obj/effect/submap_landmark/spawnpoint/voxship_crew
-	name = "Vox"
+	name = "Shoal Scavenger"
 
 #undef VOXSHIP_OUTFIT_JOB_NAME

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -7,6 +7,10 @@
 	although staying on base is tempting. Plenty of nitrogen, and not much hazards to worry about."
 	whitelisted_species = list(SPECIES_VOX)
 	blacklisted_species = null
+	rank =   /datum/mil_rank/alien
+	branch = /datum/mil_branch/alien
+	allowed_branches = list(/datum/mil_branch/alien)
+	allowed_ranks = list(/datum/mil_rank/alien)
 
 #define VOXSHIP_OUTFIT_JOB_NAME(job_name) ("Vox Asteroid Base - Job - " + job_name)
 /decl/hierarchy/outfit/job/voxship

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -6,7 +6,6 @@
 	info = "Scrap is thin. Not much food is left, but thankfully the sector is quite rich, and it's time to get some more supplies. \
 	although staying on base is tempting. Plenty of nitrogen, and not much hazards to worry about."
 
-
 #define VOXSHIP_OUTFIT_JOB_NAME(job_name) ("Vox Asteroid Base - Job - " + job_name)
 /decl/hierarchy/outfit/job/voxship
 	hierarchy_type = /decl/hierarchy/outfit/job/voxship

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -58,8 +58,14 @@ Civilian
 	minimal_player_age = 0
 	create_record = 0
 	outfit_type = /decl/hierarchy/outfit/job/torch/merchant
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/civ)
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/alien
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/civ,
+		/datum/mil_rank/alien
+	)
 	latejoin_at_spawnpoints = 1
 	access = list(access_merchant)
 	announced = FALSE
@@ -82,7 +88,13 @@ Civilian
 	create_record = 0
 	account_allowed = 0
 	outfit_type = /decl/hierarchy/outfit/job/torch/stowaway
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/civ)
+	allowed_branches = list(
+		/datum/mil_branch/civilian,
+		/datum/mil_branch/alien
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/civ,
+		/datum/mil_rank/alien
+	)
 	latejoin_at_spawnpoints = 1
 	announced = FALSE

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -13,6 +13,7 @@
 	#include "torch_ranks.dm"
 	#include "torch_security_state.dm"
 	#include "torch_shuttles.dm"
+	#include "torch_submaps.dm"
 	#include "torch_unit_testing.dm"
 
 	#include "datums/uniforms.dm"

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -68,8 +68,9 @@
 	#include "machinery/keycard authentication.dm"
 	#include "machinery/suit_storage.dm"
 
-	#include "structures/closets.dm"
 	#include "structures/signs.dm"
+	#include "structures/closets.dm"
+	#include "structures/closets/closet_appearances.dm"
 	#include "structures/closets/command.dm"
 	#include "structures/closets/engineering.dm"
 	#include "structures/closets/medical.dm"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -23,7 +23,7 @@
 		/datum/species/nabber     = list(/datum/mil_branch/civilian),
 		/datum/species/skrell     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/unathi     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
-		/datum/species/vox        = list(),
+		/datum/species/vox        = list(/datum/mil_branch/civilian),
 		/datum/species/adherent   = list(/datum/mil_branch/civilian)
 	)
 

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -1,6 +1,8 @@
 /datum/job/submap
 	branch = /datum/mil_branch/civilian
 	rank =   /datum/mil_rank/civ/civ
+	allowed_branches = list(/datum/mil_branch/civilian)
+	allowed_ranks = list(/datum/mil_rank/civ/civ)
 
 /datum/map/torch
 	branch_types = list(

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -18,7 +18,19 @@
 		/datum/mil_branch/expeditionary_corps,
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/solgov
+		/datum/mil_branch/solgov,
+		/datum/mil_branch/alien
+	)
+
+	species_to_branch_blacklist = list(
+		/datum/species/human   = list(/datum/mil_branch/alien),
+		/datum/species/machine = list(/datum/mil_branch/alien),
+		/datum/species/vox     = list(
+			/datum/mil_branch/expeditionary_corps,
+			/datum/mil_branch/fleet,
+			/datum/mil_branch/civilian,
+			/datum/mil_branch/solgov
+		)
 	)
 
 	species_to_branch_whitelist = list(

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -10,7 +10,8 @@
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/solgov,
-		/datum/mil_branch/army
+		/datum/mil_branch/army,
+		/datum/mil_branch/alien
 	)
 
 	spawn_branch_types = list(
@@ -25,8 +26,8 @@
 		/datum/species/nabber     = list(/datum/mil_branch/civilian),
 		/datum/species/skrell     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/unathi     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
-		/datum/species/vox        = list(/datum/mil_branch/civilian),
-		/datum/species/adherent   = list(/datum/mil_branch/civilian)
+		/datum/species/adherent   = list(/datum/mil_branch/civilian),
+		/datum/species/vox        = list(/datum/mil_branch/alien)
 	)
 
 	species_to_rank_whitelist = list(
@@ -64,9 +65,13 @@
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5
 			)
+		),
+		/datum/species/vox = list(
+			/datum/mil_branch/alien = list(
+				/datum/mil_rank/alien
+			)
 		)
 	)
-
 
 /*
  *  Branches
@@ -781,3 +786,13 @@
 	name_short = "AdmNvy"
 	accessory = list(/obj/item/clothing/accessory/terran/rank/navy/flag/o10)
 	sort_order = 20
+
+// Vox/foreign alien branch.
+/datum/mil_branch/alien
+	name = "Alien"
+	name_short = "Alien"
+	rank_types = list(/datum/mil_rank/alien)
+	spawn_rank_types = list(/datum/mil_rank/alien)
+
+/datum/mil_rank/alien
+	name = "Alien"

--- a/maps/torch/torch_submaps.dm
+++ b/maps/torch/torch_submaps.dm
@@ -1,0 +1,5 @@
+/datum/job/submap/voxship_vox
+	rank =   /datum/mil_rank/alien
+	branch = /datum/mil_branch/alien
+	allowed_branches = list(/datum/mil_branch/alien)
+	allowed_ranks = list(/datum/mil_rank/alien)


### PR DESCRIPTION
- Added civ branch to vox. This is so the anal-retentive branch and rank code will allow them to join on a map with branches defined.
- Tweaked blacklist/whitelist configuration on vox submap. Should now be joinable.
- Added owner archetype white/blacklist checks. Doesn't impact anything currently, future proofing mostly. Thought it was related to the following fix.
- Added default blacklist/whitelist settings to the submap job datum so that it will properly show restricted jobs in the occupations UI.
- Gave the Vox base a fluffier name.
- Gave the Vox base role a fluffier name.
- Gave Vox a fluffier rank/branch.

![image](https://user-images.githubusercontent.com/2468979/52542421-8c8f1180-2df3-11e9-9e7e-a660daa57a0a.png)
