### PR TITLE
A bunch of assorted init improvements and fixes.

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -2,9 +2,10 @@
 #define FLIGHTSUIT_PROCESSING_NONE 0
 #define FLIGHTSUIT_PROCESSING_FULL 1
 
-#define INITIALIZATION_INSSATOMS     0	//New should not call Initialize
-#define INITIALIZATION_INNEW_MAPLOAD 1	//New should call Initialize(TRUE)
-#define INITIALIZATION_INNEW_REGULAR 2	//New should call Initialize(FALSE)
+#define INITIALIZATION_INSSATOMS      0	//New should not call Initialize
+#define INITIALIZATION_INSSATOMS_LATE 1	//New should not call Initialize; after the first pass is complete (handled differently)
+#define INITIALIZATION_INNEW_MAPLOAD  2	//New should call Initialize(TRUE)
+#define INITIALIZATION_INNEW_REGULAR  3	//New should call Initialize(FALSE)
 
 #define INITIALIZE_HINT_NORMAL   0  //Nothing happens
 #define INITIALIZE_HINT_LATELOAD 1  //Call LateInitialize

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -18,6 +18,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/list/landmarks_still_needed = list()     //Stores landmark_tags that need to be assigned to the sector (landmark_tag = sector) when registered.
 	var/list/shuttles_to_initialize              //A queue for shuttles to initialize at the appropriate time.
 	var/list/sectors_to_initialize               //Used to find all sector objects at the appropriate time.
+	var/block_queue = TRUE
 
 	var/tmp/list/working_shuttles
 
@@ -27,22 +28,13 @@ SUBSYSTEM_DEF(shuttle)
 		var/datum/shuttle/shuttle = shuttle_type
 		if(!initial(shuttle.defer_initialisation))
 			LAZYDISTINCTADD(shuttles_to_initialize, shuttle_type)
-	initialize_shuttles() // Order matters here.
-	initialize_sectors()
+	block_queue = FALSE
+	clear_init_queue()
 	. = ..()
 
 /datum/controller/subsystem/shuttle/fire(resumed = FALSE)
 	if (!resumed)
 		working_shuttles = process_shuttles.Copy()
-	
-	if(length(shuttles_to_initialize))
-		initialize_shuttles()
-		if (MC_TICK_CHECK)
-			return
-	if(length(sectors_to_initialize))
-		initialize_sectors()
-		if (MC_TICK_CHECK)
-			return
 
 	while (working_shuttles.len)
 		var/datum/shuttle/shuttle = working_shuttles[working_shuttles.len]
@@ -52,6 +44,12 @@ SUBSYSTEM_DEF(shuttle)
 
 		if (MC_TICK_CHECK)
 			return
+
+/datum/controller/subsystem/shuttle/proc/clear_init_queue()
+	if(block_queue)
+		return
+	initialize_shuttles()
+	initialize_sectors()
 
 /datum/controller/subsystem/shuttle/proc/initialize_shuttles()
 	for(var/shuttle_type in shuttles_to_initialize)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -19,9 +19,9 @@
 	if(GLOB.use_preloader && (src.type == GLOB._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		GLOB._preloader.load(src)
 
-	var/do_initialize = SSatoms.initialized
+	var/do_initialize = SSatoms.init_state
 	var/list/created = SSatoms.created_atoms
-	if(do_initialize != INITIALIZATION_INSSATOMS)
+	if(do_initialize > INITIALIZATION_INSSATOMS_LATE)
 		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD
 		if(SSatoms.InitAtom(src, args))
 			//we were deleted
@@ -30,6 +30,7 @@
 		var/list/argument_list
 		if(length(args) > 1)
 			argument_list = args.Copy(2)
+		if(argument_list || do_initialize == INITIALIZATION_INSSATOMS_LATE)
 			created[src] = argument_list
 
 	if(atom_flags & ATOM_FLAG_CLIMBABLE)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -59,9 +59,11 @@
 
 /obj/effect/spider/stickyweb
 	icon_state = "stickyweb1"
-	New()
-		if(prob(50))
-			icon_state = "stickyweb2"
+
+/obj/effect/spider/stickyweb/Initialize()
+	. = ..()
+	if(prob(50))
+		icon_state = "stickyweb2"
 
 /obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1
@@ -81,15 +83,12 @@
 	icon_state = "eggs"
 	var/amount_grown = 0
 
-/obj/effect/spider/eggcluster/Initialize()
-		. = ..()
-		pixel_x = rand(3,-3)
-		pixel_y = rand(3,-3)
-		START_PROCESSING(SSobj, src)
-
-/obj/effect/spider/eggcluster/New(var/location, var/atom/parent)
+/obj/effect/spider/eggcluster/Initialize(mapload, atom/parent)
+	. = ..()
 	get_light_and_color(parent)
-	..()
+	pixel_x = rand(3,-3)
+	pixel_y = rand(3,-3)
+	START_PROCESSING(SSobj, src)
 
 /obj/effect/spider/eggcluster/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -312,8 +311,9 @@
 	icon_state = "cocoon1"
 	health = 60
 
-	New()
-		icon_state = pick("cocoon1","cocoon2","cocoon3")
+/obj/effect/spider/cocoon/Initialize()
+	. = ..()
+	icon_state = pick("cocoon1","cocoon2","cocoon3")
 
 /obj/effect/spider/cocoon/Destroy()
 	src.visible_message("<span class='warning'>\The [src] splits open.</span>")

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -516,7 +516,8 @@
 	used_capacity = min(used_capacity,index)
 
 //Random colour tapes
-/obj/item/device/tape/random/New()
+/obj/item/device/tape/random/Initialize()
+	. = ..()
 	icon_state = "tape_[pick("white", "blue", "red", "yellow", "purple")]"
 
 /obj/item/device/tape/loose

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -24,7 +24,8 @@
 /obj/item/weapon/lipstick/random
 	name = "lipstick"
 
-/obj/item/weapon/lipstick/random/New()
+/obj/item/weapon/lipstick/random/Initialize()
+	. = ..()
 	colour = pick("red","purple","jade","black")
 	name = "[colour] lipstick"
 

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -7,7 +7,8 @@
 	var/sides = 6
 	attack_verb = list("diced")
 
-/obj/item/weapon/dice/New()
+/obj/item/weapon/dice/Initialize()
+	. = ..()
 	icon_state = "[name][rand(1,sides)]"
 
 /obj/item/weapon/dice/d4

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -220,9 +220,6 @@ obj/item/clothing/mask/smokable/ecig/util/examine(mob/user)
 	volume = 20
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/weapon/reagent_containers/ecig_cartridge/New()
-	create_reagents(volume)
-
 /obj/item/weapon/reagent_containers/ecig_cartridge/examine(mob/user as mob)//to see how much left
 	..()
 	to_chat(user, "The cartridge has [reagents.total_volume] units of liquid remaining.")

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -16,6 +16,7 @@
 	var/affected_area = 3
 
 	New()
+		..()
 		create_reagents(1000)
 
 	attack_self(mob/user as mob)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -176,9 +176,9 @@
 	var/callme = "pimpin' ride"	//how do people refer to it?
 
 
-/obj/structure/bed/chair/janicart/New()
+/obj/structure/bed/chair/janicart/Initialize()
+	. = ..()
 	create_reagents(100)
-
 
 /obj/structure/bed/chair/janicart/examine(mob/user)
 	if(!..(user, 1))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -22,7 +22,8 @@ FLOOR SAFES
 	var/maxspace = 24	//the maximum combined w_class of stuff in the safe
 
 
-/obj/structure/safe/New()
+/obj/structure/safe/Initialize()
+	. = ..()
 	tumbler_1_pos = rand(0, 72)
 	tumbler_1_open = rand(0, 72)
 

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -18,10 +18,9 @@
 /obj/structure/dispenser/phoron
 	oxygentanks = 0
 
-
-/obj/structure/dispenser/New()
+/obj/structure/dispenser/Initialize()
+	. = ..()
 	update_icon()
-
 
 /obj/structure/dispenser/on_update_icon()
 	overlays.Cut()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -85,7 +85,8 @@
 	var/w_items = 0			//the combined w_class of all the items in the cistern
 	var/mob/living/swirlie = null	//the mob being given a swirlie
 
-/obj/structure/hygiene/toilet/New()
+/obj/structure/hygiene/toilet/Initialize()
+	. = ..()
 	open = round(rand(0, 1))
 	update_icon()
 

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -11,7 +11,7 @@
 	icon_state = "bcircuit"
 	initial_flooring = /decl/flooring/reinforced/circuit
 	light_outer_range = 2
-	light_max_bright = 3
+	light_max_bright = 1
 	light_color = COLOR_BLUE
 
 /turf/simulated/floor/bluegrid/airless

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -408,7 +408,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	if(GLOB.use_preloader && .)//second preloader pass, for those atoms that don't ..() in New()
 		GLOB._preloader.load(.)
 
-	//custom CHECK_TICK here because we don't want things created while we're sleeping to not initialize
+	//custom CHECK_TICK here because we don't want things created while we're sleeping to delay initialization.
 	if(TICK_CHECK)
 		SSatoms.map_loader_stop()
 		stoplag()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -37,7 +37,8 @@ var/list/mining_floors = list()
 
 	has_resources = 1
 
-/turf/simulated/mineral/New()
+/turf/simulated/mineral/Initialize()
+	. = ..()
 	if (!mining_walls["[src.z]"])
 		mining_walls["[src.z]"] = list()
 	mining_walls["[src.z]"] += src
@@ -428,7 +429,8 @@ var/list/mining_floors = list()
 	var/overlay_detail
 	has_resources = 1
 
-/turf/simulated/floor/asteroid/New()
+/turf/simulated/floor/asteroid/Initialize()
+	. = ..()
 	if (!mining_floors["[src.z]"])
 		mining_floors["[src.z]"] = list()
 	mining_floors["[src.z]"] += src

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -47,11 +47,11 @@
 /obj/item/weapon/computer_hardware/proc/diagnostics(var/mob/user)
 	to_chat(user, "Hardware Integrity Test... (Corruption: [damage]/[max_damage]) [damage > damage_failure ? "FAIL" : damage > damage_malfunction ? "WARN" : "PASS"]")
 
-/obj/item/weapon/computer_hardware/New(var/obj/L)
+/obj/item/weapon/computer_hardware/Initialize()
+	. = ..()
 	w_class = hardware_size
-	if(istype(L, /obj/item/modular_computer))
-		holder2 = L
-		return
+	if(istype(loc, /obj/item/modular_computer))
+		holder2 = loc
 
 /obj/item/weapon/computer_hardware/Destroy()
 	holder2 = null

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -2,10 +2,11 @@
 var/list/z_levels = list()// Each bit re... haha just kidding this is a list of bools now
 
 // If the height is more than 1, we mark all contained levels as connected.
-/obj/effect/landmark/map_data/New()
+/obj/effect/landmark/map_data/New(turf/loc)
 	..()
-
-	for(var/i = (z - height + 1) to (z-1))
+	if(!istype(loc)) // Using loc.z is safer when using the maploader and New.
+		return
+	for(var/i = (loc.z - height + 1) to (loc.z-1))
 		if (z_levels.len <i)
 			z_levels.len = i
 		z_levels[i] = TRUE

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -121,8 +121,9 @@
 	var/opened = 0
 	var/parent_shuttle
 
-/obj/structure/fuel_port/New()
-	src.contents.Add(new/obj/item/weapon/tank/hydrogen)
+/obj/structure/fuel_port/Initialize()
+	. = ..()
+	new /obj/item/weapon/tank/hydrogen(src)
 
 /obj/structure/fuel_port/attack_hand(mob/user as mob)
 	if(!opened)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -42,6 +42,7 @@
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")
 
 	LAZYADD(SSshuttle.sectors_to_initialize, src) //Queued for further init. Will populate the waypoint lists; waypoints not spawned yet will be added in as they spawn.
+	SSshuttle.clear_init_queue()
 
 //This is called later in the init order by SSshuttle to populate sector objects. Importantly for subtypes, shuttles will be created by then.
 /obj/effect/overmap/proc/populate_sector_objects()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2777,19 +2777,23 @@
 		return
 	..()
 
-/obj/item/pizzabox/margherita/New()
+/obj/item/pizzabox/margherita/Initialize()
+	. = ..()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita(src)
 	boxtag = "Margherita Deluxe"
 
-/obj/item/pizzabox/vegetable/New()
+/obj/item/pizzabox/vegetable/Initialize()
+	. = ..()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza(src)
 	boxtag = "Gourmet Vegatable"
 
-/obj/item/pizzabox/mushroom/New()
+/obj/item/pizzabox/mushroom/Initialize()
+	. = ..()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza(src)
 	boxtag = "Mushroom Special"
 
-/obj/item/pizzabox/meat/New()
+/obj/item/pizzabox/meat/Initialize()
+	. = ..()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza(src)
 	boxtag = "Meatlover's Supreme"
 

--- a/code/unit_tests/subsystem_tests.dm
+++ b/code/unit_tests/subsystem_tests.dm
@@ -26,3 +26,19 @@
 		pass("All susbsystems have initialized properly")
 
 	return 1
+
+/datum/unit_test/all_atoms_shall_be_initialized
+	name = "SUBSYSTEM - ATOMS: All atoms shall be initialized."
+
+/datum/unit_test/all_atoms_shall_be_initialized/start_test()
+	set background = TRUE // avoid infinite loop warning; SS will still wait for us.
+	var/fail = FALSE
+	for(var/atom/atom in world)
+		if(!(atom.atom_flags & ATOM_FLAG_INITIALIZED))
+			log_bad("Uninitialized atom: [log_info_line(atom)]")
+			fail = TRUE
+	if(fail)
+		fail("There were uninitialized atoms.")
+	else
+		pass("All atoms were initialized")
+	return 1

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2558,10 +2558,6 @@
 /obj/random/medical/lite,
 /turf/space,
 /area/constructionsite/medical)
-"is" = (
-/obj/structure/girder,
-/turf/simulated/floor/airless,
-/area/constructionsite/hallway/aft)
 "it" = (
 /obj/effect/shuttle_landmark/derelict/nav5,
 /turf/space,
@@ -23006,7 +23002,7 @@ ii
 gS
 gS
 gO
-is
+hA
 gO
 gQ
 gQ
@@ -25431,7 +25427,7 @@ hP
 hP
 hr
 hr
-hr
+iu
 hs
 hr
 hr

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -2353,7 +2353,13 @@
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fR" = (
-/obj/machinery/atmospherics/omni/mixer,
+/obj/machinery/atmospherics/omni/mixer{
+	tag_east = 1;
+	tag_east_con = 0.21;
+	tag_north = 2;
+	tag_south = 1;
+	tag_south_con = 0.79;
+	},
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fS" = (
@@ -2372,7 +2378,11 @@
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fT" = (
-/obj/machinery/atmospherics/omni/filter,
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 2;
+	tag_south = 1;
+	tag_west = 3
+	},
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fU" = (
@@ -3468,7 +3478,6 @@
 /area/magshield/south)
 "jb" = (
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white/usedup,
 /area/magshield/south)
 "jc" = (
@@ -4378,6 +4387,15 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
+"Eo" = (
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 0;
+	tag_north = 2;
+	tag_south = 1;
+	tag_west = 4
+	},
+/turf/simulated/floor/airless,
+/area/magshield/east)
 
 (1,1,1) = {"
 aa
@@ -28713,7 +28731,7 @@ fi
 fi
 fT
 ge
-fT
+Eo
 ge
 gz
 gE

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -2183,7 +2183,6 @@
 /area/unishi/common)
 "ft" = (
 /obj/machinery/door/airlock/science,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor,
 /area/unishi/common)

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -37,6 +37,7 @@
 		/obj/item/device/radio/headset/heads/torchexec,
 		/obj/item/clothing/glasses/sunglasses,
 		/obj/item/device/radio/headset/heads/torchexec/alt,
+		/obj/item/weapon/storage/belt/general,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/device/megaphone,


### PR DESCRIPTION
Several changes here, especially relevant to maploader use. 

- While the maploader is spawning atoms (including from New of mapped atoms, but not from Initialize) atoms will now queue directly on the SS themselves, and the maploader flushes the queue at the end. This should result in various improvements, including safe handling of new atoms created in New.

- The above does not happen at gamestart (non-maploader map atoms). This is due to performance limitations; it's apparently drastically better to just iterate world.

- LateInitialize will now be consistently called with the same parameters as Initialize is.

- Shuttle init has been cleaned up slightly, and should work reliably with late-loaded maps.

- A new unit test has been added to ensure that all atoms are initialized. The most typical way of failing that is having atoms which don't call parent in `New`. This is actually moderately common, so expect some Travis failures. The test will only reliably call out atoms which are created after SSatoms/Initialize, so also expect this to be a common Travis fail on away site PRs going forward.

- A couple of misc fixes to runtimes with lateloading maps, notably to map data landmarks and, yes, our favorite, `set_light` with too high `light_max_bright`.

- A random fix to the CO's closet which I forgot to add a belt to in a previous PR.