### PR TITLE
makes the casino ship reasonably flyable

### DIFF
--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -5,9 +5,9 @@
 	name = "passenger liner"
 	desc = "Sensors detect an undamaged vessel without any signs of activity."
 	color = "#bd6100"
-	vessel_mass = 100
+	vessel_mass = 5000
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 20 SECONDS
+	burn_delay = 1 SECOND
 	initial_generic_waypoints = list(
 		"nav_casino_1",
 		"nav_casino_2",


### PR DESCRIPTION
:cl:
tweak: IPV Fortuna can now fly on the overmap without being doomed.
/:cl:

The previous 20 second burn delay and 100 acceleration was not exactly fun or functional. This reduces it to a 1 second burn delay and 2 acceleration.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->