### PR TITLE
Gun safety tweaks

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -75,8 +75,9 @@
 			sound_vol = 50
 			if(istype(holstered, /obj/item/weapon/gun))
 				var/obj/item/weapon/gun/G = holstered
-				if(user.skill_check(SKILL_WEAPONS, SKILL_EXPERT) && G.safety()) //Experienced shooter will disable safety before shooting.
-					G.safety_state = 0
+				G.check_accidents(user)
+				if(G.safety() && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //Experienced shooter will disable safety before shooting.
+					G.toggle_safety(user)
 			usr.visible_message(
 				"<span class='danger'>\The [user] draws \the [holstered], ready to go!</span>",
 				"<span class='warning'>You draw \the [holstered], ready to go!</span>"

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -117,6 +117,10 @@
 	else
 		return fail_chance * 2 ** (factor*(SKILL_MIN - points))
 
+// Simple prob using above
+/mob/proc/skill_fail_prob(skill_path, fail_chance, no_more_fail = SKILL_MAX, factor = 1)
+	return prob(skill_fail_chance(skill_path, fail_chance, no_more_fail, factor ))
+
 // Show skills verb
 
 mob/living/verb/show_skills()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -181,12 +181,7 @@
 		return ..() //Pistolwhippin'
 
 /obj/item/weapon/gun/dropped(var/mob/living/user)
-	if(istype(user))
-		if(!safety() && prob(5) && !user.skill_check(SKILL_WEAPONS, SKILL_BASIC) && special_check(user))
-			to_chat(user, "<span class='warning'>[src] fires on its own!</span>")
-			var/list/targets = list(user)
-			targets += trange(2, src)
-			afterattack(pick(targets), user)
+	check_accidents(user)
 	update_icon()
 	return ..()
 
@@ -200,8 +195,11 @@
 		return
 
 	if(safety())
-		handle_click_empty(user)
-		return
+		if(user.a_intent == I_HURT && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //reflex un-safeying
+			toggle_safety(user)
+		else
+			handle_click_empty(user)
+			return
 
 	if(world.time < next_fire_time)
 		if (world.time % 3) //to prevent spam
@@ -571,3 +569,11 @@
 			if(istype(gun) && gun.can_autofire())
 				M.set_dir(get_dir(M, over_object))
 				gun.Fire(get_turf(over_object), mob, params, (get_dist(over_object, mob) <= 1), FALSE)
+
+/obj/item/weapon/gun/proc/check_accidents(mob/living/user)
+	if(istype(user))
+		if(!safety() && user.skill_fail_prob(SKILL_WEAPONS, 20, SKILL_EXPERT, 2) && special_check(user))
+			to_chat(user, "<span class='warning'>[src] fires on its own!</span>")
+			var/list/targets = list(user)
+			targets += trange(2, src)
+			afterattack(pick(targets), user)

--- a/html/changelogs/chinsky - safetyfirst.yml
+++ b/html/changelogs/chinsky - safetyfirst.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Accidental gun discharge chances upped, and now it can happen when aggressively unholstering (hurt intent). Chance is now 20% at unskilled, 5% at Basic and 1% at Trained."
+  - tweak: "When unholstering or trying to fire a safetied gun on hurt intent, there's now a chance you automatically unsafety it. Chance is 0% at unskilled, 25% at Basic and 50% at Trained, guaranteed above."


### PR DESCRIPTION
Increases chance of accidental gun discharge
Now it starts at 20% at unskilled, and can happen at Basic (5%) and Trained (1.25%) too.

I think it basically never happens as is, everyone has at least Basic, and so safety is completely disregarded by people. If they want to shave off that click for maximum tacticool without investing into gun skill, gotta tax them, such is the law.

Adds check for accidental discharge when drawing gun all ready-like too.

In good news, auto-unsafety can now happen to people with less than Experienced skill. When drawing gun on harm intent, there's 25% chance you unsafe it with Basic skill, 50% with Trained, guaranteed on Experienced.
Same chances apply on trying to shoot with harm intent.