### PR TITLE
Make implants harder to find and deny self-implantation of dangerous ones

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -13,6 +13,7 @@
 	var/implant_color = "b"
 	var/malfunction = 0
 	var/known //if advanced scanners would name these in results
+	var/can_implant_self = TRUE // if you can self-implant this
 
 /obj/item/weapon/implant/proc/trigger(emote, source)
 	return
@@ -59,10 +60,6 @@
 		part.implants -= src
 		part = null
 	implanted = 0
-
-//Called in surgery when incision is retracted open / ribs are opened - basically before you can take implant out
-/obj/item/weapon/implant/proc/exposed()
-	return
 
 /obj/item/weapon/implant/proc/get_data()
 	return "No information available"

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -68,6 +68,10 @@
 	if (!istype(M, /mob/living/carbon))
 		return
 	if (user && src.imp)
+		if (M == user && !imp.can_implant_self)
+			log_and_message_admins("attempted to implant themselves with the [imp], which is not allowed", user)
+			to_chat(user, "<span class='warning'>On second thought, you don't think implanting yourself with that would be a very good idea.</span>")
+			return
 		M.visible_message("<span class='warning'>[user] is attemping to implant [M].</span>")
 
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -4,12 +4,12 @@
 	desc = "A military grade micro bio-explosive. Highly dangerous."
 	icon_state = "implant_evil"
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
+	can_implant_self = FALSE
 	var/elevel
 	var/phrase
 	var/code = 13
 	var/frequency = 1443
 	var/datum/radio_frequency/radio_connection
-	var/warning_message = "Tampering detected. Tampering detected."
 
 /obj/item/weapon/implant/explosive/get_data()
 	. = {"
@@ -39,10 +39,7 @@
 		<A href='byond://?src=\ref[src];code=-1'>-</A>
 		<A href='byond://?src=\ref[src];code=set'>[src.code]</A>
 		<A href='byond://?src=\ref[src];code=1'>+</A>
-		<A href='byond://?src=\ref[src];code=5'>+</A><BR>
-		<B>Tampering warning message:</B><BR>
-		This will be broadcasted on radio if implant is exposed during surgery.<BR>
-		<A href='byond://?src=\ref[src];msg=1'>[warning_message ? warning_message : "NONE SET"]</A>
+		<A href='byond://?src=\ref[src];code=5'>+</A>
 		"}
 
 /obj/item/weapon/implant/explosive/Initialize()
@@ -70,11 +67,6 @@
 		if(mod)
 			elevel = mod
 		interact(usr)
-	if (href_list["msg"])
-		var/msg = input("Set tampering message, or leave blank for no broadcasting.", "Anti-tampering", warning_message) as text|null
-		if(msg)
-			warning_message = msg
-		interact(usr)
 	if (href_list["phrase"])
 		var/talk = input("Set activation phrase", "Audio activation", phrase) as text|null
 		if(talk)
@@ -99,10 +91,6 @@
 	if(findtext(sanitize_phrase(msg),phrase))
 		activate()
 		qdel(src)
-
-/obj/item/weapon/implant/explosive/exposed()
-	if(warning_message)
-		GLOB.global_headset.autosay(warning_message, "Anti Tampering System")
 
 /obj/item/weapon/implant/explosive/proc/sanitize_phrase(phrase)
 	var/list/replacechars = list("'" = "","\"" = "",">" = "","<" = "","(" = "",")" = "")

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -2,6 +2,7 @@
 	name = "imprinting implant"
 	desc = "Latest word in training your peons."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_DATA = 3)
+	can_implant_self = FALSE
 	var/list/instructions = list("Do your job.", "Respect your superiours.", "Wash you hands after using the toilet.")
 	var/brainwashing = 0
 	var/last_reminder

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1001,10 +1001,6 @@ obj/item/organ/external/proc/remove_clamps()
 	if(!W)	return
 	W.open_wound(min(W.damage * 2, W.damage_list[1] - W.damage))
 
-	if(!encased)
-		for(var/obj/item/weapon/implant/I in implants)
-			I.exposed()
-
 /obj/item/organ/external/proc/fracture()
 	if(!config.bones_can_break)
 		return

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1399,10 +1399,8 @@ obj/item/organ/external/proc/remove_clamps()
 			var/obj/item/weapon/implant/imp = I
 			if(istype(imp) && imp.known)
 				. += "[capitalize(imp.name)] implanted"
-			else
-				unknown_body++
 		if(unknown_body)
-			. += "Unknown body present"
+			. += "Foreign body present"
 
 /obj/item/organ/external/proc/inspect(mob/user)
 	if(is_stump())


### PR DESCRIPTION
Initial version of this, by request of game staff. People metagame the implants too much; this way, exploratory surgery is required to find them. I also think this didn't work right, reporting some synthetic organs or something as "unknown body" because of how `istype` was making assumptions.

:cl:
tweak: Implants are harder to find.
tweak: You can no longer self-implant with dangerous implants (explosive, imprinting).
/:cl: