### PR TITLE
Adherent eyes now don't get blinded by welding

### DIFF
--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -109,6 +109,7 @@
 	icon_state = "eyes"
 	status = ORGAN_ROBOTIC
 	phoron_guard = TRUE
+	innate_flash_protection = FLASH_PROTECTION_MAJOR
 
 /obj/item/organ/internal/eyes/adherent/Initialize()
 	. = ..()


### PR DESCRIPTION
🆑
tweak: Adherent eyes have been upgraded. They no longer need a welding mask to not go blind. As a side effect, they also cannot be flashed.
/:cl: