### PR TITLE
Make autotraitor care about how many total were ever spawned and stop after 2 hours

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -58,7 +58,8 @@
 
 	// Runtime vars.
 	var/datum/mind/leader                   // Current leader, if any.
-	var/cur_max = 0                         // Autotraitor current effective maximum.
+	var/lifetime_spawned = 0                // Number spawned in this round
+	var/lifetime_max                        // Number allowed to spawn
 	var/spawned_nuke                        // Has a bomb been spawned?
 	var/nuke_spawn_loc                      // If so, where should it be placed?
 	var/list/current_antagonists = list()   // All marked antagonists for this type.
@@ -87,7 +88,7 @@
 	..()
 
 /datum/antagonist/proc/Initialize()
-	cur_max = hard_cap
+	lifetime_max = hard_cap
 	get_starting_locations()
 	if(!role_text_plural)
 		role_text_plural = role_text
@@ -154,10 +155,9 @@
 		return 0
 
 	update_current_antag_max(SSticker.mode)
-	var/active_antags = get_active_antag_count()
-	log_debug("[uppertext(id)]: Found [active_antags]/[cur_max] active [role_text_plural].")
+	log_debug("[uppertext(id)]: There are [lifetime_spawned]/[lifetime_max] active [role_text_plural].")
 
-	if(active_antags >= cur_max)
+	if(lifetime_spawned >= lifetime_max)
 		log_debug("Could not auto-spawn a [role_text], active antag limit reached.")
 		return 0
 

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -19,6 +19,9 @@
 			equip(player.current)
 
 	player.current.faction = faction
+
+	lifetime_spawned++
+
 	return 1
 
 /datum/antagonist/proc/add_antagonist_mind(var/datum/mind/player, var/ignore_role, var/nonstandard_role_type, var/nonstandard_role_msg)

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -34,17 +34,6 @@
 /datum/antagonist/proc/get_antag_count()
 	return current_antagonists ? current_antagonists.len : 0
 
-/datum/antagonist/proc/get_active_antag_count()
-	var/active_antags = 0
-	for(var/datum/mind/player in current_antagonists)
-		var/mob/living/L = player.current
-		if(!L || L.stat == DEAD)
-			continue //no mob or dead
-		if(!L.client && !L.teleop)
-			continue //SSD
-		active_antags++
-	return active_antags
-
 /datum/antagonist/proc/is_antagonist(var/datum/mind/player)
 	if(player in current_antagonists)
 		return 1

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -79,9 +79,9 @@
 							qdel(I)
 
 /datum/antagonist/proc/update_current_antag_max(datum/game_mode/mode)
-	cur_max = hard_cap
-	if(mode.antag_tags && (mode.antag_tags))
-		cur_max = hard_cap_round
+	lifetime_max = hard_cap
+	if(id in mode.antag_tags)
+		lifetime_max = hard_cap_round
 
 	if(mode.antag_scaling_coeff)
 
@@ -92,4 +92,4 @@
 
 		// Minimum: initial_spawn_target
 		// Maximum: hard_cap or hard_cap_round
-		cur_max = max(initial_spawn_target,min(round(count/mode.antag_scaling_coeff),cur_max))
+		lifetime_max = max(initial_spawn_target,min(round(count/mode.antag_scaling_coeff),lifetime_max))

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -50,7 +50,7 @@
 
 		if(spawn_antag.attempt_auto_spawn())
 			message_admins("[uppertext(name)]: Auto-added a new [spawn_antag.role_text].")
-			message_admins("There are now [spawn_antag.get_active_antag_count()]/[spawn_antag.cur_max] active [spawn_antag.role_text_plural].")
+			message_admins("There are now [spawn_antag.lifetime_spawned]/[spawn_antag.lifetime_max] active [spawn_antag.role_text_plural].")
 			next_spawn = world.time + rand(min_autotraitor_delay, max_autotraitor_delay)
 			return
 

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/var/next_spawn = 0
 /datum/game_mode/var/min_autotraitor_delay = 4200  // Approx 7 minutes.
 /datum/game_mode/var/max_autotraitor_delay = 12000 // Approx 20 minutes.
-/datum/game_mode/var/process_count = 0
+/datum/game_mode/var/last_spawn_time = 2 HOURS // last time we'll consider spawning
 
 ///process()
 ///Called by the gameticker
@@ -11,6 +11,8 @@
 
 /datum/game_mode/proc/shall_process_autoantag()
 	if(!round_autoantag || world.time < next_spawn)
+		return FALSE
+	if(world.time > last_spawn_time)
 		return FALSE
 	if(evacuation_controller.is_evacuating() || evacuation_controller.has_evacuated())
 		return FALSE

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1199,7 +1199,7 @@ var/global/floorIsLava = 0
 		for(var/datum/antagonist/antag in SSticker.mode.antag_templates)
 			antag.update_current_antag_max(SSticker.mode)
 			out += " <a href='?src=\ref[SSticker.mode];debug_antag=[antag.id]'>[antag.id]</a>"
-			out += " ([antag.get_antag_count()]/[antag.cur_max]) "
+			out += " ([antag.get_antag_count()]/[antag.lifetime_max]) "
 			out += " <a href='?src=\ref[SSticker.mode];remove_antag_type=[antag.id]'>\[-\]</a><br/>"
 	else
 		out += " None."


### PR DESCRIPTION
:cl:
tweak: Autotraitor now adds up to a limit of traitors, it does not add more when someone is dead/logged out.
tweak: Autotraitor will not add traitors after 2 hours in the round.
/:cl: