### PR TITLE
Makes full anomaly suit anomaly-proof again

### DIFF
--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -170,8 +170,9 @@
 	if (get_dist(user, src) > 1)
 		to_chat(user, "<span class='warning'>You can't reach \the [src] from here.</span>")
 		return
-	if(ishuman(user) && user:gloves)
-		to_chat(user, "<b>You touch [src]</b> with your gloved hands, [pick("but nothing of note happens","but nothing happens","but nothing interesting happens","but you notice nothing different","but nothing seems to have happened")].")
+	var/bodypart = user.hand ? BP_R_HAND : BP_L_HAND
+	if(ishuman(user) && user.get_covering_equipped_item(bodypart))
+		to_chat(user, "<b>You touch [src]</b> with your covered hands, [pick("but nothing of note happens","but nothing happens","but nothing interesting happens","but you notice nothing different","but nothing seems to have happened")].")
 		return
 
 	src.add_fingerprint(user)

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -129,9 +129,9 @@
 			protected += 1
 
 	if(istype(H.wear_suit,/obj/item/clothing/suit/bio_suit/anomaly))
-		protected += 0.6
+		protected += 0.7
 	else if(istype(H.wear_suit,/obj/item/clothing/suit/space/void/excavation))
-		protected += 0.5
+		protected += 0.6
 
 	if(istype(H.head,/obj/item/clothing/head/bio_hood/anomaly))
 		protected += 0.3


### PR DESCRIPTION
No longer requiring glasses/gloves since it was bit of a gotcha, especially considering suit COVERS hands both codewise and spritewise.

Also makes suits that cover hands work to prevent touchy trigger too

Anomaly protection is pretty binary, either you're fully safe, or you're completely fucked, so it doesn't play well with 'oh heres your anti-anomaly suit but 1 in 10 times you get fucked anyway'