### PR TITLE
Makes people spawn inside cryopods

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -480,6 +480,7 @@ SUBSYSTEM_DEF(jobs)
 		else
 			var/datum/spawnpoint/spawnpoint = job.get_spawnpoint(H.client)
 			H.forceMove(pick(spawnpoint.turfs))
+			spawnpoint.after_join(H)
 
 		// Moving wheelchair if they have one
 		if(H.buckled && istype(H.buckled, /obj/structure/bed/chair/wheelchair))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -304,7 +304,7 @@
 	if(occupant)
 		if(applies_stasis && iscarbon(occupant))
 			var/mob/living/carbon/C = occupant
-			C.SetStasis(3)
+			C.SetStasis(2)
 
 		//Allow a ten minute gap between entering the pod and actually despawning.
 		if(world.time - time_entered < time_till_despawn)
@@ -544,7 +544,7 @@
 
 	return
 
-/obj/machinery/cryopod/proc/set_occupant(var/mob/living/carbon/occupant)
+/obj/machinery/cryopod/proc/set_occupant(var/mob/living/carbon/occupant, var/silent)
 	src.occupant = occupant
 	if(!occupant)
 		SetName(initial(name))
@@ -552,8 +552,9 @@
 
 	occupant.stop_pulling()
 	if(occupant.client)
-		to_chat(occupant, "<span class='notice'>[on_enter_occupant_message]</span>")
-		to_chat(occupant, "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>")
+		if(!silent)
+			to_chat(occupant, "<span class='notice'>[on_enter_occupant_message]</span>")
+			to_chat(occupant, "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>")
 		occupant.client.perspective = EYE_PERSPECTIVE
 		occupant.client.eye = src
 	occupant.forceMove(src)
@@ -561,3 +562,6 @@
 
 	SetName("[name] ([occupant])")
 	icon_state = occupied_icon_state
+
+/obj/machinery/cryopod/relaymove(var/mob/user)
+	go_out()

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -191,5 +191,6 @@
 	..()
 
 /proc/equip_wheelchair(mob/living/carbon/human/H) //Proc for spawning in a wheelchair if a new character has no legs. Used in new_player.dm
-	var/obj/structure/bed/chair/wheelchair/W = new(H.loc)
-	W.buckle_mob(H)
+	var/obj/structure/bed/chair/wheelchair/W = new(get_turf(H))
+	if(isturf(H.loc))
+		W.buckle_mob(H)

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -27,6 +27,10 @@ GLOBAL_VAR(spawntypes)
 
 	return 1
 
+//Called after mob is created, moved to a turf and equipped.
+/datum/spawnpoint/proc/after_join(mob/victim)
+	return
+
 #ifdef UNIT_TEST
 /datum/spawnpoint/Del()
 	crash_with("Spawn deleted: [log_info_line(src)]")
@@ -61,6 +65,17 @@ GLOBAL_VAR(spawntypes)
 /datum/spawnpoint/cryo/New()
 	..()
 	turfs = GLOB.latejoin_cryo
+
+/datum/spawnpoint/cryo/after_join(mob/living/carbon/human/victim)
+	if(!istype(victim))
+		return
+	var/area/A = get_area(victim)
+	for(var/obj/machinery/cryopod/C in A)
+		if(!C.occupant)
+			C.set_occupant(victim, 1)
+			victim.Sleeping(rand(1,3))
+			to_chat(victim,SPAN_NOTICE("You are slowly waking up from the cryostasis aboard [GLOB.using_map.full_name]. It might take a few seconds."))
+			return
 
 /datum/spawnpoint/cyborg
 	display_name = "Cyborg Storage"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1664,3 +1664,11 @@
 		Paralyse(rand(8,16))
 		make_jittery(rand(150,200))
 		adjustHalLoss(rand(50,60))
+
+/mob/living/carbon/human/needs_wheelchair()
+	var/stance_damage = 0
+	for(var/limb_tag in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
+		var/obj/item/organ/external/E = organs_by_name[limb_tag]
+		if(!E || !E.is_usable())
+			stance_damage += 2
+	return stance_damage >= 4

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -823,3 +823,6 @@ default behaviour is:
 		var/atom/movable/A = thing
 		if(A.simulated && !A.waterproof)
 			A.water_act(depth)
+
+/mob/living/proc/needs_wheelchair()
+	return FALSE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -339,6 +339,7 @@
 
 	SSticker.mode.handle_latejoin(character)
 	GLOB.universe.OnPlayerLatejoin(character)
+	spawnpoint.after_join(character)
 	if(job.create_record)
 		if(character.mind.assigned_role != "Robot")
 			CreateModularRecord(character)
@@ -349,7 +350,7 @@
 		matchmaker.do_matchmaking()
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 
-	if(character.cannot_stand())
+	if(character.needs_wheelchair())
 		equip_wheelchair(character)
 
 	qdel(src)

--- a/html/changelogs/chinsky - zzz.yml
+++ b/html/changelogs/chinsky - zzz.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscadd: "Crypods now have more immulsion. When joining round you will spawn inside a pod, asleep for 1-5 seconds. Roleplay accordingly."


### PR DESCRIPTION
Stole idea from Eris. Low effort ripoff of https://github.com/discordia-space/CEV-Eris/pull/2886

People who join via cryo will now spawn inside pod, asleep for 1-3 seconds.
Intent is increased immulsions, staggering out initial equip rush in cryo rooms a little bit, and natural handling of fucks who SSD as soon as they don't get antag :^)

Side changes include lowering cryopods stasis factor so it won't reach 'fall asleep' drowsyness, adding 'try to move = go out of pod', and better detection of if dude really needs a wheel chair or not (previously just being downed for any reason worked)
