### PR TITLE
Tries to cut down a little on spawn log noise

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -122,8 +122,6 @@
 		H.mind.store_memory(remembered_info)
 		H.mind.initial_account = M
 
-	to_chat(H, "<span class='notice'><b>Your account number is: [M.account_number], your account pin is: [M.remote_access_pin]</b></span>")
-
 // overrideable separately so AIs/borgs can have cardborg hats without unneccessary new()/qdel()
 /datum/job/proc/equip_preview(mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade, var/additional_skips)
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -340,7 +340,6 @@ var/list/gear_datums = list()
 /datum/gear/proc/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
 	var/obj/item/item = spawn_item(H, metadata)
 	if(H.equip_to_slot_if_possible(item, slot, del_on_fail = 1, force = 1))
-		to_chat(H, "<span class='notice'>Equipping you with \the [item]!</span>")
 		. = item
 
 /datum/gear/proc/spawn_in_storage_or_drop(var/mob/living/carbon/human/H, var/metadata)

--- a/code/modules/goals/goal_mob.dm
+++ b/code/modules/goals/goal_mob.dm
@@ -20,6 +20,14 @@
 		to_chat(src, SPAN_WARNING("You are mindless and cannot have goals."))
 		return
 
+	var/datum/department/dept
+	if(mind.assigned_job && mind.assigned_job.department_flag && SSgoals.departments["[mind.assigned_job.department_flag]"])
+		dept = SSgoals.departments["[mind.assigned_job.department_flag]"]
+
+	//No goals to display
+	if(!(allow_modification || LAZYLEN(mind.goals)) && !(dept && LAZYLEN(dept.goals)))
+		return
+
 	to_chat(src, "<hr>")
 	if(LAZYLEN(mind.goals))
 		to_chat(src, SPAN_NOTICE("<b>This round, you have the following personal goals:</b><br>[jointext(mind.summarize_goals(show_success, allow_modification), "<br>")]"))
@@ -28,13 +36,10 @@
 	if(allow_modification && LAZYLEN(mind.goals) < 5)
 		to_chat(src, SPAN_NOTICE("<a href='?src=\ref[mind];add_goal=1;add_goal_caller=\ref[mind.current]'>Add Random Goal</a>"))
 
-	if(mind.assigned_job && mind.assigned_job.department_flag && SSgoals.departments["[mind.assigned_job.department_flag]"])
-		to_chat(src, " ")
-		var/datum/department/dept = SSgoals.departments["[mind.assigned_job.department_flag]"]
-		if(LAZYLEN(dept.goals))
-			to_chat(src, SPAN_NOTICE("<b>This round, [dept.name] has the following departmental goals:</b><br>[jointext(dept.summarize_goals(show_success), "<br>")]"))
-		else
-			to_chat(src, SPAN_NOTICE("<b>[dept.name] has no departmental goals this round.</b>"))
+	if(LAZYLEN(dept.goals))
+		to_chat(src, SPAN_NOTICE("<br><b>This round, [dept.name] has the following departmental goals:</b><br>[jointext(dept.summarize_goals(show_success), "<br>")]"))
+	else
+		to_chat(src, SPAN_NOTICE("<br><b>[dept.name] has no departmental goals this round.</b>"))
 
 	if(LAZYLEN(mind.goals))
 		to_chat(mind.current, SPAN_NOTICE("<br><br>You can check your round goals with the <b>Show Goals</b> verb."))

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -242,7 +242,6 @@ var/global/datum/ntnet/ntnet_global = new()
 		var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account()
 		EA.password = GenerateKey()
 		EA.login = login
-		to_chat(user, "Your email account address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
 		if(user.mind)
 			user.mind.initial_email_login["login"] = EA.login
 			user.mind.initial_email_login["password"] = EA.password


### PR DESCRIPTION
Email details and account details are now not displayed on spawn, just look at your damn notes.
Loadout items are now equipped quietly, you can just see them in your inv. Messages are still done for things that are put in storage etc so you can find them.
If you have no goals, you just don't get shown anything instead of big padded YOU HAVE NO GOALS LOL message.
