### PR TITLE
Makes fuel ports visible.

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -159,3 +159,7 @@
 		if(contents.len == 0)
 			user.unEquip(W, src)
 	update_icon()
+
+// Walls hide stuff inside them, but we want to be visible.
+/obj/structure/fuel_port/hide()
+	return


### PR DESCRIPTION
The bigger question, I guess, is why some were visible at all; presumably this has to do with the new wall subtypes vs. the old ones, and possibly the order of New/object creation. Moral: use Initialize if you want consistent behavior.