### PR TITLE
Fixes shrapnel being too big, tweaks embedded item damage a bit

### DIFF
--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -90,13 +90,10 @@
 			return
 
 // Preset types - left here for the code that uses them
-/obj/item/weapon/material/shrapnel
+/obj/item/weapon/material/shard/phoron/New(loc)
+	..(loc, MATERIAL_PHORON_GLASS)
+
+/obj/item/weapon/material/shard/shrapnel
 	name = "shrapnel"
 	default_material = MATERIAL_STEEL
 	w_class = ITEM_SIZE_TINY	//it's real small
-
-/obj/item/weapon/material/shard/shrapnel/New(loc)
-	..(loc, MATERIAL_STEEL)
-
-/obj/item/weapon/material/shard/phoron/New(loc)
-	..(loc, MATERIAL_PHORON_GLASS)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -220,7 +220,7 @@
 	var/list/shrapnel = list()
 
 	for(var/I = 3, I<3 , I++) //Toolbox shatters.
-		shrapnel += new /obj/item/weapon/material/shrapnel(Tsec)
+		shrapnel += new /obj/item/weapon/material/shard/shrapnel(Tsec)
 
 	for(var/Amt = amount, Amt>0, Amt--) //Why not just spit them out in a disorganized jumble?
 		shrapnel += new /obj/item/stack/tile/floor(Tsec)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -933,7 +933,7 @@
 
 /mob/living/carbon/human/proc/jossle_internal_object(var/obj/item/organ/external/organ, var/obj/item/O)
 	// All kinds of embedded objects cause bleeding.
-	if(!can_feel_pain())
+	if(!organ.can_feel_pain())
 		to_chat(src, "<span class='warning'>You feel [O] moving inside your [organ.name].</span>")
 	else
 		var/msg = pick( \
@@ -942,10 +942,7 @@
 			"<span class='warning'>Your movement jostles [O] in your [organ.name] painfully.</span>")
 		custom_pain(msg,40,affecting = organ)
 
-	organ.take_external_damage(rand(1,3), 0, 0)
-	if(!BP_IS_ROBOTIC(organ) && (should_have_organ(BP_HEART))) //There is no blood in protheses.
-		organ.status |= ORGAN_BLEEDING
-		src.adjustToxLoss(rand(1,3))
+	organ.take_external_damage(rand(1,3) + O.w_class, DAM_EDGE, 0)
 
 /mob/living/carbon/human/verb/check_pulse()
 	set category = "Object"


### PR DESCRIPTION
Fixes 2 years old pathing error, when I fucked up and repathed base define but not like, anything else referencing it. Brought up to single path now.
Tweaks embedded damage to not do toxins damge on jostling. No more shrapnel in right foot tanking your liver. On other side w_class of embedded item now directly affects damage and damage dealt is sharp, so internal organ damage can happen still naturally.
Also made that check use organ's pain-feels status so that meat humans with things in their non-pain robolimbs don't get agonized.
