### PR TITLE
Updated mapmerge2 requirements to fuzzy version

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
-pygit2==0.27.2
-bidict==0.13.1
-Pillow==5.1.0
+pygit2>=0.27.2
+bidict>=0.13.1
+Pillow>=5.1.0


### PR DESCRIPTION
Backend stuff to mapmerge2. Tells pip to accept a minimum version, but also accept higher versions. This should futureproof updating python and package versions.

Note, that if we run into an issue where a requirement doesn't work with mapmerge, constraints can easily be implemented.

Example.
pkg3>=1.0,<=2.0

This forces pip to only allow pkg3 versions between and including 1.0 and 2.0.