### PR TITLE
Makes stasis bags non-orderable

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -79,12 +79,6 @@
 	cost = 10
 	containername = "body bag crate"
 
-/decl/hierarchy/supply_pack/medical/cryobag
-	name = "Equipment - Stasis bags"
-	contains = list(/obj/item/bodybag/cryobag = 2)
-	cost = 80
-	containername = "stasis bag crate"
-
 /decl/hierarchy/supply_pack/medical/stretcher
 	name = "Equipment - Roller bed crate"
 	contains = list(/obj/item/roller = 3)


### PR DESCRIPTION
:cl: 
rscdel: Stasis bags are no longer orderable from cargo.
/:cl:
I believe that trying to 'balance' with cargo costs is as pointless as 'balancing' with power costs, so I think bags should go for real.
