### PR TITLE
Removes (as Fake ID) from speaking messages

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,9 +1,6 @@
 /mob/living/carbon/human/say(var/message, var/datum/language/speaking = null, whispering)
-	var/alt_name = ""
 	if(name != GetVoice())
-		if(get_id_name("Unknown") != GetVoice())
-			alt_name = "(as [get_id_name("Unknown")])"
-		else
+		if(get_id_name("Unknown") == GetVoice())
 			SetName(get_id_name("Unknown"))
 
 	//parse the language code and consume it
@@ -23,16 +20,16 @@
 			if(world.time < L.last_successful_breath + 2 MINUTES) //if we're in grace suffocation period, give it up for last words
 				to_chat(src, "<span class='warning'>You use your remaining air to say something!</span>")
 				L.last_successful_breath = world.time - 2 MINUTES
-				return ..(message, alt_name = alt_name, speaking = speaking)
+				return ..(message, speaking = speaking)
 
 			to_chat(src, "<span class='warning'>You don't have enough air in [L] to make a sound!</span>")
 			return
 		else if(L.breath_fail_ratio > 0.7)
-			whisper_say(length(message) > 5 ? stars(message) : message, speaking, alt_name)
+			whisper_say(length(message) > 5 ? stars(message) : message, speaking)
 		else if(L.breath_fail_ratio > 0.4 && length(message) > 10)
-			whisper_say(message, speaking, alt_name)
+			whisper_say(message, speaking)
 	else
-		return ..(message, alt_name = alt_name, speaking = speaking, whispering = whispering)
+		return ..(message, speaking = speaking, whispering = whispering)
 
 
 /mob/living/carbon/human/proc/forcesay(list/append)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -13,14 +13,10 @@
 	if (src.stat)
 		return
 
-	var/alt_name = ""
-	if(name != GetVoice())
-		if(get_id_name("Unknown") != GetVoice())
-			alt_name = "(as [get_id_name("Unknown")])"
-		else
-			SetName(get_id_name("Unknown"))
+	if(get_id_name("Unknown") == GetVoice())
+		SetName(get_id_name("Unknown"))
 
-	whisper_say(message, alt_name = alt_name)
+	whisper_say(message)
 
 
 //This is used by both the whisper verb and human/say() to handle whispering


### PR DESCRIPTION
Now it straight up uses your voice
instead of Urist McDude (as Urist McIDname) it's now just Urist McDude
Don't like it how speaking makes it IMMEDIATELY apparent that your ID is WRONG, you can HEAR IT BEING WRONG.
