### PR TITLE
Increases Likelihood of Organ Damage

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -68,7 +68,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		if(laser || BP_IS_ROBOTIC(src))
 			damage_amt += burn
 			cur_damage += burn_dam
-		var/organ_damage_threshold = 10
+		var/organ_damage_threshold = 5
 		if(sharp)
 			organ_damage_threshold *= 0.5
 		var/organ_damage_prob = 5 * damage_amt/organ_damage_threshold //more damage, higher chance to damage


### PR DESCRIPTION
Halved threshold above which brute damage has a chance to injure organs. 
Increases chance for organ injury but still keeps it quite low (~1/20 with sharp weapon, then another ~25% chance of failing to pick an organ based on relative_size) at the threshold (5 damage.)

Intention is to give smaller projectiles and sharp weapons a greater chance of dealing lasting damage. Hopefully this will result in people taking the holdout guns a bit more seriously. 