### PR TITLE
Tweak the Start Now verb

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(ticker)
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
 	var/pregame_timeleft = 3 MINUTES
+	var/start_ASAP = FALSE          //the game will start as soon as possible, bypassing all pre-game nonsense
 	var/list/gamemode_vote_results  //Will be a list, in order of preference, of form list(config_tag = number of votes).
 	var/bypass_gamemode_vote = 0    //Intended for use with admin tools. Will avoid voting and ignore any results.
 
@@ -43,6 +44,9 @@ SUBSYSTEM_DEF(ticker)
 			post_game_tick()
 
 /datum/controller/subsystem/ticker/proc/pregame_tick()
+	if(start_ASAP)
+		start_now()
+		return
 	if(round_progressing && last_fire)
 		pregame_timeleft -= world.time - last_fire
 	if(pregame_timeleft <= 0)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -813,7 +813,12 @@ var/global/floorIsLava = 0
 	set desc="Start the round RIGHT NOW"
 	set name="Start Now"
 	if(GAME_STATE < RUNLEVEL_LOBBY)
-		alert("Unable to start the game as it is not set up.")
+		to_chat(usr, "<span class='danger'>Unable to start the game as it is not yet set up.</span>")
+		SSticker.start_ASAP = !SSticker.start_ASAP
+		if(SSticker.start_ASAP)
+			to_chat(usr, "<span class='warning'>The game will begin as soon as possible.</span>")
+		else
+			to_chat(usr, "<span class='warning'>The game will begin as normal.</span>")
 		return 0
 	if(SSticker.start_now())
 		log_admin("[usr.key] has started the game.")


### PR DESCRIPTION
Start Now no longer has a popup alert, just prints to chat. Will set the `start_ASAP` var and report its status to chat - if the game cannot yet be started by Start Now, it will start as soon as it can.

End result is you don't need to mash it and then close the alert popups - just press it once and you can alt-tab away until the round start sound plays.