### PR TITLE
Fixes vagrants not gibbing on death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -54,9 +54,9 @@
 		MoveToTarget()
 
 /mob/living/simple_animal/hostile/vagrant/death(gibbed)
-	if(!gibbed)
+	. = ..()
+	if(. && !gibbed)
 		gib()
-		..()
 
 /mob/living/simple_animal/hostile/vagrant/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -53,6 +53,11 @@
 		turns_per_move = 2
 		MoveToTarget()
 
+/mob/living/simple_animal/hostile/vagrant/death(gibbed)
+	if(!gibbed)
+		gib()
+		..()
+
 /mob/living/simple_animal/hostile/vagrant/Life()
 	. = ..()
 	if(!.)
@@ -81,9 +86,6 @@
 		new/mob/living/simple_animal/hostile/vagrant(src.loc)
 		new/mob/living/simple_animal/hostile/vagrant(src.loc)
 		gib()
-		return
-	if(health < 1)
-		gib() //Leave no identifiable evidence.
 		return
 
 /mob/living/simple_animal/hostile/vagrant/on_update_icon()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->