### PR TITLE
Added support for languages being spoken poorly by a given mob.

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -22,6 +22,12 @@
 	var/shorthand = "UL"			  // Shorthand that shows up in chat for this language.
 	var/list/partial_understanding				  // List of languages that can /somehwat/ understand it, format is: name = chance of understanding a word
 
+/datum/language/proc/can_be_spoken_properly_by(var/mob/speaker)
+	return TRUE
+
+/datum/language/proc/muddle(var/message)
+	return message
+
 /datum/language/proc/get_random_name(var/gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	if(!syllables || !syllables.len)
 		if(gender==FEMALE)

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -55,6 +55,22 @@
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
 	shorthand = "SK"
 
+/datum/language/skrell/can_be_spoken_properly_by(var/mob/living/speaker)
+	if(ishuman(speaker))
+		var/mob/living/carbon/human/H = speaker
+		if(H.species.name == SPECIES_SKRELL)
+			return TRUE
+	if(speaker.isSynthetic())
+		return TRUE
+	return FALSE
+
+/datum/language/skrell/muddle(var/message)
+	. = replacetext(message, "a", "o")
+	. = replacetext(., "e", "o")
+	. = replacetext(., "i", "o")
+	. = replacetext(., "u", "o")
+	. = replacetext(., "y", "o")
+
 /datum/language/human
 	name = LANGUAGE_SOL_COMMON
 	desc = "A bastardized hybrid of informal English and elements of Mandarin Chinese; the common language of the Sol system."

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -207,6 +207,9 @@ proc/get_radio_key_from_channel(var/channel)
 	message = handle_autohiss(message, speaking)
 	message = format_say_message(message)
 
+	if(speaking && !speaking.can_be_spoken_properly_by(src))
+		message = speaking.muddle(message)
+
 	if(!(speaking && (speaking.flags & NO_STUTTER)))
 		var/list/message_data = list(message, verb, 0)
 		if(handle_speech_problems(message_data))

--- a/html/changelogs/mistakenot4892-skrellian.yml
+++ b/html/changelogs/mistakenot4892-skrellian.yml
@@ -1,0 +1,4 @@
+author: MistakeNot4892
+delete-after: True
+changes: 
+  - tweak: "Non-Skrell and non-synthetics speaking Skrellian will now be a bit less understandable."


### PR DESCRIPTION
Still more Ascent prep.

This is for languages that can be spoken by the speaker, but may not be spoken properly (Skrellian lacking high tones, etc). Specifically this will force Skrell/humans speaking Ascent vocal language to do so in a slow monotone.