### PR TITLE
Fixes shuttles ripping up asteroid tiles

### DIFF
--- a/maps/away/mining/mining_areas.dm
+++ b/maps/away/mining/mining_areas.dm
@@ -3,6 +3,7 @@
 	icon_state = "mining"
 	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
 	sound_env = ASTEROID
+	base_turf = /turf/simulated/floor/asteroid
 
 /area/mine/explored
 	name = "Mine"


### PR DESCRIPTION
:cl:
fix: Shuttles no longer steal asteroid tiles when undocking.
/:cl:

Fixes #24568

Solution was far easier than I anticipated at first...