### PR TITLE
Merges contractor jobs into their counterparts 

### DIFF
--- a/html/changelogs/chinsky - merge.yml
+++ b/html/changelogs/chinsky - merge.yml
@@ -1,0 +1,6 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - rscdel: "Removes Medical Contractor job. It's merged into Physician/Corpsman, number of slots for those bumped. GAS can join Corpsman only."
+  - rscadd: "Physician and Corpsman jobs can now be joined with Contractor rank."
+  - rscadd: "Engineering Contractor and Supply Assistant were merged into Engineer and Deck Technician respectively, pick Civilian branch to join as contractor"

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -41,12 +41,12 @@
 	job_access_type = /datum/job/doctor
 	detail_color = COLOR_PALE_BLUE_GRAY
 
+/obj/item/weapon/card/id/torch/contractor/medical
+	job_access_type = /datum/job/doctor
+	detail_color = COLOR_PALE_BLUE_GRAY
+
 /obj/item/weapon/card/id/torch/crew/medical/senior
 	job_access_type = /datum/job/senior_doctor
-
-/obj/item/weapon/card/id/torch/contractor/medical
-	job_access_type = /datum/job/doctor_contractor
-	detail_color = COLOR_PALE_BLUE_GRAY
 
 /obj/item/weapon/card/id/torch/contractor/chemist
 	job_access_type = /datum/job/chemist
@@ -89,7 +89,7 @@
 	extra_details = list("onegoldstripe")
 
 /obj/item/weapon/card/id/torch/contractor/engineering
-	job_access_type = /datum/job/engineer_contractor
+	job_access_type = /datum/job/engineer
 	detail_color = COLOR_SUN
 
 /obj/item/weapon/card/id/torch/contractor/engineering/roboticist
@@ -106,9 +106,8 @@
 	detail_color = COLOR_BROWN
 
 /obj/item/weapon/card/id/torch/contractor/supply
-	job_access_type = /datum/job/cargo_contractor
+	job_access_type = /datum/job/cargo_tech
 	detail_color = COLOR_BROWN
-
 
 /obj/item/weapon/card/id/torch/crew/service //unused
 	job_access_type = /datum/job/assistant

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -50,8 +50,8 @@
 
 /datum/job/engineer
 	title = "Engineer"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 6
+	spawn_positions = 6
 	supervisors = "the Chief Engineer"
 	economic_power = 5
 	minimal_player_age = 0
@@ -67,7 +67,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/fleet
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e5,
@@ -75,7 +76,8 @@
 		/datum/mil_rank/ec/e5,
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/ec/e3,
-		/datum/mil_rank/fleet/e2
+		/datum/mil_rank/fleet/e2,
+		/datum/mil_rank/civ/contractor
 	)
 	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
 	                    SKILL_EVA          = SKILL_BASIC,
@@ -105,53 +107,6 @@
 
 /datum/job/engineer/get_description_blurb()
 	return "You are an Engineer. You operate under one of many titles and may be highly specialised in a specific area of engineering. You probably have at least a general familiarity with most other areas though this is not expected. You are subordinate to the Senior Engineer and the Chief Engineer and are expected to follow them."
-
-/datum/job/engineer_contractor
-	title = "Engineering Contractor"
-	department = "Engineering"
-	department_flag = ENG
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the Chief Engineer, the Corporate Liaison and Engineering Personnel"
-	minimal_player_age = 0
-	selection_color = "#5b4d20"
-	alt_titles = list(
-		"Maintenance Assistant",
-		"Structural Integrity Specialist",
-		"Electrical Systems Specialist",
-		"Information Systems Technician",
-		"Reactor Technician",
-		"Life Support Systems Specialist")
-	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/contractor
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(   SKILL_COMPUTER      = SKILL_BASIC,
-	                    SKILL_EVA           = SKILL_BASIC,
-	                    SKILL_CONSTRUCTION	= SKILL_ADEPT,
-	                    SKILL_ELECTRICAL    = SKILL_BASIC,
-	                    SKILL_ATMOS         = SKILL_BASIC,
-	                    SKILL_ENGINES       = SKILL_BASIC)
-
-	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
-	                    SKILL_ELECTRICAL   = SKILL_MAX,
-	                    SKILL_ATMOS        = SKILL_MAX,
-	                    SKILL_ENGINES      = SKILL_MAX)
-	skill_points = 20
-
-	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-			            access_solgov_crew, access_hangar)
-
-	software_on_spawn = list(/datum/computer_file/program/power_monitor,
-							 /datum/computer_file/program/supermatter_monitor,
-							 /datum/computer_file/program/alarm_monitor,
-							 /datum/computer_file/program/atmos_control,
-							 /datum/computer_file/program/rcon_console,
-							 /datum/computer_file/program/camera_monitor,
-							 /datum/computer_file/program/shields_monitor)
-
-/datum/job/engineer_contractor/get_description_blurb()
-	return "You are an Engineering Contractor. Hired for either general maintenance duties or because of your specialist training and knowledge in a specific area of engineering you are either highly skilled or intermediate in your knowledge of engineering tasks related to your profession. You are subordinate to the Corporate Liaison and the rest of the engineering team."
 
 /datum/job/engineer_trainee
 	title = "Engineer Trainee"

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -5,8 +5,8 @@
 
 	minimal_player_age = 2
 	ideal_character_age = 45
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "the Chief Medical Officer"
 	selection_color = "#013d3b"
 	economic_power = 8
@@ -16,12 +16,14 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/senior
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/senior/fleet
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/medical/senior/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o1,
 		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o1
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/civ/contractor
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_MEDICAL     = SKILL_ADEPT,
@@ -44,9 +46,9 @@
 
 /datum/job/doctor
 	title = "Corpsman"
-	total_positions = 3
-	spawn_positions = 3
-	supervisors = "the Chief Medical Officer"
+	total_positions = 4
+	spawn_positions = 4
+	supervisors = "Physicians and the Chief Medical Officer"
 	economic_power = 7
 	ideal_character_age = 40
 	minimal_player_age = 0
@@ -57,7 +59,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/doctor/fleet
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/medical/doctor,
-		/datum/mil_branch/fleet
+		/datum/mil_branch/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/paramedic
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/ec/e3,
@@ -65,7 +68,8 @@
 		/datum/mil_rank/fleet/e3,
 		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/fleet/e6
+		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/civ/contractor
 	)
 	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
 	                    SKILL_MEDICAL = SKILL_BASIC,
@@ -83,40 +87,6 @@
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
 	skill_points = 26
-
-/datum/job/doctor_contractor
-	title = "Medical Contractor"
-	department = "Medical"
-	department_flag = MED
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the Chief Medical Officer, the Corporate Liaison and Medical Personnel"
-	selection_color = "#013d3b"
-	economic_power = 3
-	ideal_character_age = 30
-	alt_titles = list(
-		"Orderly" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/orderly,
-		"Virologist" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist,
-		"Xenosurgeon" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/xenosurgeon,
-		"Paramedic" = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/paramedic)
-	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
-	                    SKILL_MEDICAL = SKILL_BASIC,
-	                    SKILL_ANATOMY = SKILL_BASIC)
-
-	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
-	                    SKILL_ANATOMY     = SKILL_MAX,
-	                    SKILL_CHEMISTRY   = SKILL_MAX,
-	                    SKILL_VIROLOGY    = SKILL_MAX)
-	skill_points = 32
-
-	access = list(access_medical, access_morgue, access_crematorium, access_virology, access_surgery, access_medical_equip, access_solgov_crew,
-		            access_eva, access_maint_tunnels, access_emergency_storage, access_external_airlocks, access_hangar)
-
-	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
-							 /datum/computer_file/program/camera_monitor)
 
 /datum/job/biomech
 	title = "Biomechanical Engineer"

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -40,20 +40,22 @@
 	title = "Deck Technician"
 	department = "Supply"
 	department_flag = SUP
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "the Deck Chief and Executive Officer"
 	ideal_character_age = 24
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/supply/tech/fleet
+		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/supply/tech/fleet,
+		/datum/mil_branch/civilian = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/ec/e3,
 		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/fleet/e4
+		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/civ/contractor
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_FINANCE     = SKILL_BASIC,
@@ -64,29 +66,6 @@
 	access = list(access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
 						access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_commissary)
 	minimal_access = list()
-
-	software_on_spawn = list(/datum/computer_file/program/supply,
-							 /datum/computer_file/program/deck_management,
-							 /datum/computer_file/program/reports)
-
-/datum/job/cargo_contractor
-	title = "Supply Assistant"
-	department = "Supply"
-	department_flag = SUP
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the Deck Chief, the Corporate Liaison and Supply Personnel"
-	ideal_character_age = 20
-	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/contractor
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
-	                    SKILL_FINANCE     = SKILL_BASIC,
-	                    SKILL_HAULING     = SKILL_BASIC)
-
-	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
-
-	access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting, access_hangar, access_guppy, access_guppy_helm, access_solgov_crew, access_commissary)
 
 	software_on_spawn = list(/datum/computer_file/program/supply,
 							 /datum/computer_file/program/deck_management,

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -1,9 +1,9 @@
 /datum/map/torch
 	species_to_job_whitelist = list(
-		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor, /datum/job/chef, /datum/job/bartender, /datum/job/cargo_contractor,
-										/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist),
+		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor, /datum/job/chef, /datum/job/bartender, /datum/job/cargo_tech,
+										/datum/job/engineer, /datum/job/roboticist, /datum/job/chemist, /datum/job/scientist_assistant, /datum/job/scientist),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
-									 /datum/job/roboticist, /datum/job/biomech, /datum/job/cargo_contractor, /datum/job/chef, /datum/job/engineer_contractor, /datum/job/doctor_contractor, /datum/job/bartender),
+									 /datum/job/roboticist, /datum/job/biomech, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
 		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway)
 	)
 
@@ -19,11 +19,11 @@
 	allowed_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos,
 						/datum/job/liaison, /datum/job/bodyguard, /datum/job/representative, /datum/job/sea,
 						/datum/job/bridgeofficer, /datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
-						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/engineer_trainee,
+						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee,
 						/datum/job/officer, /datum/job/warden, /datum/job/detective,
-						/datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor,/datum/job/biomech, /datum/job/chemist, /datum/job/medical_trainee,
+						/datum/job/senior_doctor, /datum/job/doctor, /datum/job/biomech, /datum/job/chemist, /datum/job/medical_trainee,
 						/datum/job/psychiatrist,
-						/datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor, /datum/job/mining,
+						/datum/job/qm, /datum/job/cargo_tech, /datum/job/mining,
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
 						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant,
 						/datum/job/ai, /datum/job/cyborg,
@@ -62,15 +62,15 @@
 	..()
 
 /decl/cultural_info/culture/nabber/b/New()
-	LAZYADD(valid_jobs, /datum/job/cargo_contractor)
+	LAZYADD(valid_jobs, /datum/job/cargo_tech)
 	..()
 
 /decl/cultural_info/culture/nabber/a/New()
-	LAZYADD(valid_jobs, /datum/job/engineer_contractor)
+	LAZYADD(valid_jobs, /datum/job/engineer)
 	..()
 
 /decl/cultural_info/culture/nabber/a/plus/New()
-	LAZYADD(valid_jobs, /datum/job/doctor_contractor)
+	LAZYADD(valid_jobs, /datum/job/doctor)
 	..()
 
 /datum/job

--- a/maps/torch/job/torch_outfits.dm
+++ b/maps/torch/job/torch_outfits.dm
@@ -337,18 +337,6 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	shoes = /obj/item/clothing/shoes/white
 	id_type = /obj/item/weapon/card/id/torch/contractor/medical
 
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/orderly
-	name = OUTFIT_JOB_NAME("Orderly")
-	uniform = /obj/item/clothing/under/rank/orderly
-
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/resident
-	name = OUTFIT_JOB_NAME("Medical Resident")
-	uniform = /obj/item/clothing/under/color/white
-
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/xenosurgeon
-	name = OUTFIT_JOB_NAME("Xenosurgeon")
-	uniform = /obj/item/clothing/under/rank/medical/scrubs/purple
-
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/mortus
 	name = OUTFIT_JOB_NAME("Mortician")
 	uniform = /obj/item/clothing/under/rank/medical/scrubs/black
@@ -361,20 +349,11 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	id_type = /obj/item/weapon/card/id/torch/contractor/biomech
 	pda_type = /obj/item/modular_computer/pda/roboticist
 
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist
-	name = OUTFIT_JOB_NAME("Virologist - Torch")
-	uniform = /obj/item/clothing/under/rank/virologist
-
-/decl/hierarchy/outfit/job/torch/crew/medical/contractor/virologist/New()
-	..()
-	BACKPACK_OVERRIDE_VIROLOGY
-
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/paramedic
 	name = OUTFIT_JOB_NAME("Paramedic - Torch")
 	uniform = /obj/item/clothing/under/rank/medical/paramedic
 	suit = /obj/item/clothing/suit/storage/toggle/fr_jacket
 	shoes = /obj/item/clothing/shoes/jackboots
-	l_hand = /obj/item/weapon/storage/firstaid/adv
 	belt = /obj/item/weapon/storage/belt/medical/emt
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -13,22 +13,22 @@
 #define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway)
 
 //For members of the medical department
-#define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/medical_trainee, /datum/job/biomech)
+#define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/medical_trainee, /datum/job/biomech)
 
 //For members of the medical department, roboticists, and some Research
-#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/medical_trainee, /datum/job/biomech)
+#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/medical_trainee, /datum/job/biomech)
 
 //For members of the engineering department
-#define ENGINEERING_ROLES list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/engineer_trainee)
+#define ENGINEERING_ROLES list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee)
 
 //For members of Engineering, Cargo, and Research
-#define TECHNICAL_ROLES list(/datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/chief_engineer, /datum/job/janitor, /datum/job/engineer_trainee, /datum/job/biomech)
+#define TECHNICAL_ROLES list(/datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/chief_engineer, /datum/job/janitor, /datum/job/engineer_trainee, /datum/job/biomech)
 
 //For members of the security department
 #define SECURITY_ROLES list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer)
 
 //For members of the supply department
-#define SUPPLY_ROLES list(/datum/job/qm, /datum/job/cargo_tech, /datum/job/cargo_contractor)
+#define SUPPLY_ROLES list(/datum/job/qm, /datum/job/cargo_tech)
 
 //For members of the service department
 #define SERVICE_ROLES list(/datum/job/janitor, /datum/job/chef, /datum/job/crew, /datum/job/bartender)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -76,7 +76,7 @@
 	allowed_roles = MEDICAL_ROLES
 
 /datum/gear/accessory/armband_emt
-	allowed_roles = list(/datum/job/doctor, /datum/job/doctor_contractor)
+	allowed_roles = list(/datum/job/doctor)
 
 /datum/gear/accessory/armband_corpsman
 	display_name = "medical corps armband"
@@ -105,24 +105,24 @@
 	allowed_roles = STERILE_ROLES
 
 /datum/gear/storage/brown_vest
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
-						/datum/job/cargo_contractor, /datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/nt_pilot)
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
+						/datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant, /datum/job/nt_pilot)
 
 /datum/gear/storage/black_vest
 	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant)
 
 /datum/gear/storage/white_vest
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/storage/brown_drop_pouches
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
-						/datum/job/cargo_contractor, /datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant)
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/qm, /datum/job/cargo_tech,
+						/datum/job/mining, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/merchant)
 
 /datum/gear/storage/black_drop_pouches
 	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/merchant)
 
 /datum/gear/storage/white_drop_pouches
-	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/doctor_contractor, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/roboticist, /datum/job/merchant)
 
 /datum/gear/tactical/holster
 	allowed_roles = ARMED_ROLES

--- a/maps/torch/loadout/loadout_eyes.dm
+++ b/maps/torch/loadout/loadout_eyes.dm
@@ -14,7 +14,7 @@
 	allowed_roles = MEDICAL_ROLES
 
 /datum/gear/eyes/meson
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/pathfinder, /datum/job/explorer, /datum/job/scientist, /datum/job/rd, /datum/job/senior_scientist)
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/pathfinder, /datum/job/explorer, /datum/job/scientist, /datum/job/rd, /datum/job/senior_scientist)
 
 /datum/gear/eyes/material
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_contractor, /datum/job/mining, /datum/job/scientist_assistant)
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant)

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -17,10 +17,12 @@
 	allowed_roles = list(/datum/job/merchant)
 
 /datum/gear/suit/medical_poncho
-	allowed_roles = list(/datum/job/doctor_contractor, /datum/job/psychiatrist, /datum/job/biomech, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/senior_doctor, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/biomech, /datum/job/roboticist, /datum/job/merchant)
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/engineering_poncho
-	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/roboticist, /datum/job/merchant)
+	allowed_roles = list(/datum/job/engineer, /datum/job/roboticist, /datum/job/merchant)
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/science_poncho
 	allowed_roles = list(/datum/job/scientist, /datum/job/senior_scientist, /datum/job/scientist_assistant)
@@ -31,7 +33,8 @@
 	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/cargo_poncho
-	allowed_roles = list(/datum/job/cargo_contractor, /datum/job/merchant)
+	allowed_roles = list(/datum/job/cargo_tech, /datum/job/merchant)
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/suit_jacket
 	allowed_roles = FORMAL_ROLES
@@ -67,7 +70,7 @@
 
 /datum/gear/suit/wintercoat_dais
 	display_name = "winter coat, DAIS"
-	allowed_roles = list(/datum/job/engineer_contractor, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/rd)
+	allowed_roles = list(/datum/job/engineer, /datum/job/scientist_assistant, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/rd)
 	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/suit/coat

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -2,12 +2,6 @@
  * Torch Engineering
  */
 
-/decl/closet_appearance/secure_closet/torch/engineering/contractor
-	extra_decals = list(
-		"stripe_vertical_mid_full" = COLOR_BOTTLE_GREEN,
-		"exped" = COLOR_BOTTLE_GREEN
-	)
-
 /decl/closet_appearance/secure_closet/torch/engineering
 	extra_decals = list(
 		"stripe_vertical_mid_full" = COLOR_WARM_YELLOW,
@@ -91,28 +85,6 @@
 		/obj/item/taperoll/engineering,
 		/obj/item/device/flashlight,
 		/obj/item/taperoll/atmos,
-		/obj/item/clothing/gloves/insulated,
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))
-	)
-
-/obj/structure/closet/secure_closet/engineering_contractor
-	name = "engineering contractor's locker"
-	req_access = list(access_engine)
-	closet_appearance = /decl/closet_appearance/secure_closet/torch/engineering/contractor
-
-/obj/structure/closet/secure_closet/engineering_contractor/WillContain()
-	return list(
-		/obj/item/clothing/head/soft/orange,
-		/obj/item/clothing/under/rank/engineer,
-		/obj/item/clothing/accessory/storage/webbing,
-		/obj/item/weapon/storage/belt/utility/full,
-		/obj/item/device/radio/headset/headset_eng,
-		/obj/item/device/radio/headset/headset_eng/alt,
-		/obj/item/clothing/suit/storage/hazardvest,
-		/obj/item/clothing/mask/gas,
-		/obj/item/device/flashlight,
-		/obj/item/taperoll/engineering,
 		/obj/item/clothing/gloves/insulated,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -1,12 +1,6 @@
 /*
  * Torch Medical
  */
-/decl/closet_appearance/secure_closet/torch/medical/contractor
-	extra_decals = list(
-		"stripe_vertical_mid_full" = COLOR_BOTTLE_GREEN,
-		"medical" = COLOR_BOTTLE_GREEN
-	)
-
 /decl/closet_appearance/secure_closet/torch/medical
 	extra_decals = list(
 		"stripe_vertical_mid_full" = COLOR_BABY_BLUE,
@@ -108,34 +102,6 @@
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/weapon/storage/box/autoinjectors,
-		/obj/item/device/healthanalyzer,
-		/obj/item/clothing/glasses/hud/health,
-		/obj/item/weapon/storage/firstaid/adv,
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel/med)),
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/med, /obj/item/weapon/storage/backpack/messenger/med))
-	)
-
-/obj/structure/closet/secure_closet/medical_contractor
-	name = "medical contractor's locker"
-	req_access = list(access_medical)
-	closet_appearance = /decl/closet_appearance/secure_closet/torch/medical/contractor
-
-
-/obj/structure/closet/secure_closet/medical_contractor/WillContain()
-	return list(
-		/obj/item/clothing/under/sterile,
-		/obj/item/clothing/head/soft/mime,
-		/obj/item/clothing/under/rank/orderly,
-		/obj/item/clothing/accessory/storage/white_vest,
-		/obj/item/clothing/suit/storage/toggle/labcoat,
-		/obj/item/clothing/suit/storage/toggle/fr_jacket,
-		/obj/item/clothing/shoes/white,
-		/obj/item/device/radio/headset/headset_med,
-		/obj/item/device/radio/headset/headset_med/alt,
-		/obj/item/taperoll/medical,
-		/obj/item/weapon/storage/belt/medical/emt,
-		/obj/item/clothing/mask/gas/half,
-		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/device/healthanalyzer,
 		/obj/item/clothing/glasses/hud/health,
 		/obj/item/weapon/storage/firstaid/adv,

--- a/maps/torch/torch-3.dmm
+++ b/maps/torch/torch-3.dmm
@@ -16925,11 +16925,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Sr" = (
-/obj/structure/closet/secure_closet/engineering_torch{
-	name = "engineering contractor's locker"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/closet/secure_closet/engineering_torch,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "Ss" = (

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -16363,7 +16363,6 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/wardrobe/chemistry_white,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -16374,6 +16373,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/closet/secure_closet/medical_torch,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "cYb" = (
@@ -16747,11 +16747,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "dqb" = (
-/obj/structure/closet/secure_closet/medical_contractor,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/wardrobe/chemistry_white,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "dqU" = (
@@ -16988,7 +16988,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/structure/closet/secure_closet/medical_contractor,
+/obj/structure/closet/secure_closet/medical_torchsenior,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "dFb" = (


### PR DESCRIPTION
Adds contractor branch to Physician and Corpsman jobs, adds Paramedic alt-title to Corpsman, bumps their slots.
Also tweaked 'you answer to' blurb for Corpsmen to include Physicians as their bosses, as I was told there're concerns people won't listen to them without shiny ranks.
Gives same treatment to engineering and supply contractors

As for why, I think this job outlived its use. From initial 'niche specialists' it went to parallel Physician/Corpsman merged job, but with merged accesses of both, mostly kept to keep loadouts clean. Now we have better support for multibranch jobs (see scientists) and I think they can be merged without problems.
