### PR TITLE
Fixes subtypes improperly configuring sector landmark lists.

### DIFF
--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(shuttle)
 		else if(istype(shuttle_landmark, /obj/effect/shuttle_landmark/automatic)) //These find their sector automatically
 			var/obj/effect/shuttle_landmark/automatic/automatic = shuttle_landmark
 			O = map_sectors["[automatic.z]"]
-			O ? O.add_landmark(automatic, automatic.shuttle_restricted) : (landmarks_awaiting_sector += shuttle_landmark)
+			O ? try_add_landmark_tag(shuttle_landmark_tag, O) : (landmarks_awaiting_sector += shuttle_landmark)
 
 /datum/controller/subsystem/shuttle/proc/get_landmark(var/shuttle_landmark_tag)
 	return registered_shuttle_landmarks[shuttle_landmark_tag]
@@ -99,7 +99,7 @@ SUBSYSTEM_DEF(shuttle)
 	for(var/thing in landmarks_to_check)
 		var/obj/effect/shuttle_landmark/automatic/landmark = thing
 		if(landmark.z in given_sector.map_z)
-			given_sector.add_landmark(landmark, landmark.shuttle_restricted)
+			try_add_landmark_tag(landmark.landmark_tag, given_sector)
 			landmarks_awaiting_sector -= landmark
 
 /datum/controller/subsystem/shuttle/proc/try_add_landmark_tag(landmark_tag, obj/effect/overmap/given_sector)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -71,7 +71,7 @@
 
 //If shuttle_name is false, will add to generic waypoints; otherwise will add to restricted. Does not do checks.
 /obj/effect/overmap/proc/add_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
-	landmark.sector_set(src)
+	landmark.sector_set(src, shuttle_name)
 	if(shuttle_name)
 		LAZYADD(restricted_waypoints[shuttle_name], landmark)
 	else

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -62,7 +62,8 @@
 			map_destination.add_landmark(src, shuttle_restricted)
 
 //Called when the landmark is added to an overmap sector.
-/obj/effect/shuttle_landmark/proc/sector_set(var/obj/effect/overmap/O)
+/obj/effect/shuttle_landmark/proc/sector_set(var/obj/effect/overmap/O, shuttle_name)
+	shuttle_restricted = shuttle_name
 
 /obj/effect/shuttle_landmark/proc/is_valid(var/datum/shuttle/shuttle)
 	if(shuttle.current_location == src)

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -1,128 +1,22 @@
-/*
-/datum/unit_test/shuttle
-	name = "SHUTTLE template"
-	async = 0
+/datum/unit_test/generic_shuttle_landmarks_shall_not_appear_in_restricted_list
+	name = "SHUTTLE: Generic shuttle landmarks shall not appear in the restricted landmark list."
 
-/datum/unit_test/shuttle/shuttles_shall_have_a_name
-	name = "SHUTTLE - Shuttles shall have a name"
+/datum/unit_test/generic_shuttle_landmarks_shall_not_appear_in_restricted_list/start_test()
+	var/fail = FALSE
 
-/datum/unit_test/shuttle/shuttles_shall_have_a_name/start_test()
-	var/failed_shuttles = 0
-	for(var/datum/shuttle/shuttle in SSshuttle.shuttles)
-		if(!shuttle.name)
-			failed_shuttles++
+	for(var/obj/effect/overmap/sector in world)
+		var/list/failures = list()
+		for(var/generic in sector.initial_generic_waypoints)
+			for(var/shuttle in sector.initial_restricted_waypoints)
+				if(generic == sector.initial_restricted_waypoints[shuttle])
+					failures += generic
+					break
+			if(length(failures))
+				log_bad("The sector [log_info_line(sector)] has the following generic landmarks also appearing on the restricted list: [english_list(failures)]")
+				fail = TRUE
 
-	if(failed_shuttles)
-		fail("[failed_shuttles] nameless shuttle\s")
+	if (fail)
+		fail("Some sector landmark lists were misconfigured.")
 	else
-		pass("All shuttles are named.")
+		pass("All sector landmark lists were configured properly.")
 	return 1
-
-/datum/unit_test/shuttle/shuttles_shall_use_mapped_areas
-	name = "SHUTTLE - Shuttles shall use mapped areas"
-
-/datum/unit_test/shuttle/shuttles_shall_use_mapped_areas/start_test()
-	var/failed_shuttles = 0
-	for(var/shuttle_name in SSshuttle.shuttles)
-		var/datum/shuttle/shuttle = SSshuttle.shuttles[shuttle_name]
-		var/failed = FALSE
-		if(istype(shuttle, /datum/shuttle/autodock/ferry))
-			var/datum/shuttle/autodock/ferry/f = shuttle
-			if(!f.shuttle_area || !f.shuttle_area.x)
-				log_bad("[f.name]: Invalid shuttle area.")
-
-		else if(istype(shuttle, /datum/shuttle/multi_shuttle))
-			var/datum/shuttle/multi_shuttle/ms = shuttle
-			if(!ms.origin || !ms.origin.x)
-				log_bad("[ms.name]: Invalid origin area.")
-				failed = TRUE
-			if(!ms.interim || !ms.interim.x)
-				log_bad("[ms.name]: Invalid interim area.")
-				failed = TRUE
-			for(var/destination in ms.destinations)
-				var/area/destination_area = ms.destinations[destination]
-				if(!(destination_area && destination_area.x))
-					log_bad("[ms.name] - [destination]: Invalid destination area.")
-					failed = TRUE
-		else
-			log_bad("[shuttle_name] was of an unchecked shuttle type.")
-			failed = TRUE
-
-		if(failed)
-			failed_shuttles++
-
-	if(failed_shuttles)
-		fail("Found [failed_shuttles] bad shuttle\s.")
-	else
-		pass("All shuttles had proper areas.")
-
-	return 1
-
-/datum/unit_test/shuttle/shuttles_shall_use_equally_sized_areas
-	name = "SHUTTLE - Shuttles shall use equally sized areas"
-
-/datum/unit_test/shuttle/shuttles_shall_use_equally_sized_areas/start_test()
-	var/failed_shuttles = 0
-	for(var/shuttle_name in SSshuttle.shuttles)
-		var/datum/shuttle/shuttle = SSshuttle.shuttles[shuttle_name]
-		var/failed = FALSE
-		if(istype(shuttle, /datum/shuttle/multi_shuttle))
-			var/datum/shuttle/multi_shuttle/ms = shuttle
-			if(is_bad_area_size(ms, ms.origin, ms.interim))
-				failed = TRUE
-			for(var/destination in ms.destinations)
-				if(is_bad_area_size(ms, ms.origin, ms.destinations[destination]))
-					failed = TRUE
-		if(failed)
-			failed_shuttles++
-
-	if(failed_shuttles)
-		fail("Found [failed_shuttles] bad shuttle\s.")
-	else
-		pass("All shuttles had proper area sizes.")
-
-	return 1
-
-/datum/unit_test/shuttle/shuttles_shall_use_unique_areas
-	name = "SHUTTLE - Shuttles shall use unique areas"
-
-#define SHUTTLE_NAME_AID(shuttle) "[shuttle] ([shuttle.type])"
-
-/datum/unit_test/shuttle/shuttles_shall_use_unique_areas/start_test()
-	var/list/shuttle_areas = list()
-	for(var/shuttle_name in SSshuttle.shuttles)
-		var/datum/shuttle/shuttle = SSshuttle.shuttles[shuttle_name]
-		if(istype(shuttle, /datum/shuttle/autodock/ferry))
-			var/datum/shuttle/autodock/ferry/f = shuttle
-			group_by(shuttle_areas, f.shuttle_area.type, SHUTTLE_NAME_AID(f))
-			//TODO sector_shuttles
-		else if(istype(shuttle, /datum/shuttle/multi_shuttle))
-			var/datum/shuttle/multi_shuttle/ms = shuttle
-			group_by(shuttle_areas, ms.origin.type, SHUTTLE_NAME_AID(ms))
-			group_by(shuttle_areas, ms.interim.type, SHUTTLE_NAME_AID(ms))
-			for(var/destination in ms.destinations)
-				var/area/dest_area = ms.destinations[destination]
-				group_by(shuttle_areas, dest_area.type, SHUTTLE_NAME_AID(ms))
-
-	var/number_of_issues = number_of_issues(shuttle_areas, "Shuttle Areas")
-	if(number_of_issues)
-		fail("[number_of_issues] duplicate shuttle area re-use\s exist.")
-	else
-		pass("All used shuttle areas are unique.")
-	return 1
-
-#undef SHUTTLE_NAME_AID
-
-/datum/unit_test/shuttle/shuttles_shall_use_equally_sized_areas/proc/is_bad_area_size(var/shuttle, var/area/main_area, var/area/checked_area)
-	var/main_size = 0
-	var/checked_size = 0
-	for(var/turf/T in main_area)
-		main_size++
-	for(var/turf/T in checked_area)
-		checked_size++
-	if(main_size == checked_size)
-		return FALSE
-
-	log_bad("[shuttle]: [main_area.type] had a size of [main_size] but [checked_area.type] had a size of [checked_size].")
-	return TRUE
-*/

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -33,7 +33,6 @@
 		"nav_deck3_guppy",
 		"nav_deck4_guppy",
 		"nav_bridge_guppy",
-		"nav_hangar_aquila",
 		"nav_deck1_aquila",
 		"nav_deck2_aquila",
 		"nav_deck3_aquila",


### PR DESCRIPTION
:cl:
tweak: Arbitrary shuttles can no longer land at restricted landmarks.
/:cl:

There is a var, on landmarks, that you are supposed to set if it's to be restricted. Apparently no one was using it properly, so this makes it derive the value from the sector lists instead, in all cases. 

Also adds a unit test to avoid a stupid thing you can do that, while not affecting anything in game, breaks assumptions in the system and probably implies a logic error on the part of whoever does it.