### PR TITLE
Adds a weak TTV to the traitor uplink

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -115,3 +115,10 @@
 	item_cost = 30
 	path = /obj/item/device/radio/intercept
 	desc = "A radio that can intercept secure radio channels. Doesn't fit in pockets."
+	
+/datum/uplink_item/item/tools/ttv
+	name = "Binary Gas Bomb"
+	item_cost = 40
+	path = /obj/effect/spawner/newbomb/traitor
+	desc = "A remote-activated phoron-oxygen bomb assembly with built-in signaler. \
+			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -137,6 +137,12 @@
 	var/oxygen_amt = 18
 	var/carbon_amt = 0
 
+/obj/effect/spawner/newbomb/traitor
+	name = "TTV bomb - traitor"
+	assembly_type = /obj/item/device/assembly/signaler
+	phoron_amt = 14
+	oxygen_amt = 21
+
 /obj/effect/spawner/newbomb/timer
 	name = "TTV bomb - timer"
 	assembly_type = /obj/item/device/assembly/timer


### PR DESCRIPTION
40TC for a bomb which can only reliably destroy the tile it sits on.
Offers regular traitors a way to make more credible bomb threats without giving them the power to easily blow everything to Hell. 

Detonator not included (but available in every tool storage and maint.)

:cl: Higgin
rscadd: Added a moderately weak TTV to the traitor uplink. 40 TC cost.
/ :cl: 