### PR TITLE
Make officer's mess booze-o-mat accessible by officers

### DIFF
--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -582,7 +582,9 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/boozeomat{
+	req_access = list(list(19, 25, 28))
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "cr" = (


### PR DESCRIPTION
:cl:
map: The Officer's Mess booze-o-mat is now accessible by officers. If you can open the door, you can vend things.
/:cl: