### PR TITLE
Various access fixes

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -213,7 +213,7 @@
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX)
 
-	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_psychiatrist, access_solgov_crew)
+	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_psychiatrist, access_solgov_crew, access_medical_equip)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,

--- a/maps/torch/torch-0.dmm
+++ b/maps/torch/torch-0.dmm
@@ -522,9 +522,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	frequency = 1431;
 	id_tag = "guppy_shuttle_outer";
-	name = "Guppy External Access"
+	name = "Guppy External Access";
+	req_access = list(89)
 	},
 /obj/machinery/shield_diffuser,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -790,9 +792,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	frequency = 1431;
 	id_tag = "guppy_shuttle_outer";
-	name = "Guppy External Access"
+	name = "Guppy External Access";
+	req_access = list(89)
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1254,7 +1258,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
 "cS" = (
-/turf/simulated/floor/tiled/dark,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
@@ -1382,6 +1385,7 @@
 /area/exploration_shuttle/airlock)
 "dd" = (
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	density = 1;
 	frequency = 1331;
 	id_tag = "calypso_shuttle_outer";
@@ -1431,6 +1435,7 @@
 /area/exploration_shuttle/airlock)
 "dh" = (
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	frequency = 1331;
 	id_tag = "calypso_shuttle_inner";
 	name = "Charon External Access"

--- a/maps/torch/torch-1.dmm
+++ b/maps/torch/torch-1.dmm
@@ -4420,6 +4420,7 @@
 	name = "Supply Desk"
 	},
 /obj/machinery/door/window/southleft{
+	autoset_access = 0;
 	dir = 4;
 	name = "Supply Desk"
 	},

--- a/maps/torch/torch-4.dmm
+++ b/maps/torch/torch-4.dmm
@@ -10524,6 +10524,7 @@
 /area/security/brig)
 "aJC" = (
 /obj/machinery/door/airlock/civilian{
+	autoset_access = 0;
 	name = "Head"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18144,6 +18145,7 @@
 /area/medical/infirmary)
 "fbQ" = (
 /obj/machinery/door/airlock/glass/civilian{
+	autoset_access = 0;
 	name = "Brig Bunk Room"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -31688,6 +31690,7 @@
 /area/maintenance/firstdeck/aftstarboard)
 "wAK" = (
 /obj/machinery/door/airlock/civilian{
+	autoset_access = 0;
 	name = "Stall"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,

--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -1330,8 +1330,10 @@
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
 	dir = 4;
-	name = "CMO's suit storage"
+	name = "CMO's suit storage";
+	req_access = list(40)
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/corner/paleblue/diagonal{
@@ -7251,9 +7253,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/glass/command{
+	autoset_access = 0;
 	dir = 8;
 	id_tag = "starboardbridgeaccess";
-	name = "Bridge Access"
+	name = "Bridge Access";
+	req_access = list(list(19,80))
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge)
@@ -7285,8 +7289,10 @@
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/rig/command/science,
 /obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
 	dir = 4;
-	name = "CSO's suit storage"
+	name = "CSO's suit storage";
+	req_access = list(30)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -12309,8 +12315,10 @@
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/rig/command/xo/equipped,
 /obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
 	dir = 8;
-	name = "XO's suit storage"
+	name = "XO's suit storage";
+	req_access = list(57)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -14815,9 +14823,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/glass/command{
+	autoset_access = 0;
 	dir = 8;
 	id_tag = "portbridgeaccess";
-	name = "Bridge Access"
+	name = "Bridge Access";
+	req_access = list(list(19,80))
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge)
@@ -15261,7 +15271,7 @@
 	id_tag = "aquila_shuttle_dock_airlock";
 	pixel_x = 24;
 	pixel_y = 24;
-	req_access = list(0, list(13,80));
+	req_access = list(0,list(13,80));
 	tag_airpump = "aquila_shuttle_dock_pump";
 	tag_chamber_sensor = "aquila_shuttle_dock_sensor";
 	tag_exterior_door = "aquila_shuttle_dock_outer";
@@ -15480,11 +15490,13 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	frequency = 1331;
 	icon_state = "closed";
 	id_tag = "aquila_shuttle_dock_inner";
 	locked = 1;
-	name = "Docking Port Airlock"
+	name = "Docking Port Airlock";
+	req_access = list(80)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15632,11 +15644,13 @@
 "Ug" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	frequency = 1331;
 	icon_state = "closed";
 	id_tag = "aquila_shuttle_dock_outer";
 	locked = 1;
-	name = "Docking Port Airlock"
+	name = "Docking Port Airlock";
+	req_access = list(80)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15661,8 +15675,10 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
 	dir = 8;
-	name = "CO's suit storage"
+	name = "CO's suit storage";
+	req_access = list(20)
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -15828,12 +15844,14 @@
 /area/crew_quarters/heads/office/rd)
 "Vg" = (
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	density = 1;
 	frequency = 1331;
 	icon_state = "closed";
 	id_tag = "aquila_shuttle_outer";
 	locked = 1;
-	name = "Aquila External Access"
+	name = "Aquila External Access";
+	req_access = list(80)
 	},
 /obj/machinery/shield_diffuser,
 /obj/structure/cable{
@@ -16018,11 +16036,13 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
+	autoset_access = 0;
 	frequency = 1331;
 	icon_state = "closed";
 	id_tag = "aquila_shuttle_inner";
 	locked = 1;
-	name = "Aquila External Access"
+	name = "Aquila External Access";
+	req_access = list(80)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -16193,8 +16213,10 @@
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
 	dir = 4;
-	name = "CoS' suit storage"
+	name = "CoS' suit storage";
+	req_access = list(58)
 	},
 /obj/effect/floor_decal/corner/red/full,
 /obj/item/weapon/tank/emergency/oxygen/double,


### PR DESCRIPTION
:cl:
fix: Fixed access flags for bridge foyer, charon guppy and aquila airlocks, communal brig, and supply office windoor.
fix: Counselors can now access medical storage again
fix: Bridge EVA storage windoors have the proper access restrictions again
/:cl: