### PR TITLE
Supply Program Empty Contents Fix + Makes MULEs not orderable

### DIFF
--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -1,13 +1,6 @@
 /decl/hierarchy/supply_pack/operations
 	name = "Operations"
 
-/decl/hierarchy/supply_pack/operations/mule
-	name = "Equipment - MULEbot"
-	contains = list()
-	cost = 20
-	containertype = /obj/structure/largecrate/animal/mulebot
-	containername = "mulebot crate"
-
 /decl/hierarchy/supply_pack/operations/cargotrain
 	name = "Equipment - Cargo Train Tug"
 	contains = list(/obj/vehicle/train/cargo/engine)

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -136,10 +136,10 @@
 		clear_order_contents()
 		screen = text2num(href_list["set_screen"])
 		return 1
-	
+
 	if(href_list["show_contents"])
 		generate_order_contents(href_list["show_contents"])
-	
+
 	if(href_list["hide_contents"])
 		clear_order_contents()
 
@@ -222,10 +222,10 @@
 				SSsupply.requestlist -= SO
 				SSsupply.shoppinglist += SO
 				SSsupply.points -= SO.object.cost
-		
+
 		else
 			to_chat(user, "<span class='warning'>Could not find order number [id] to approve.</span>")
-		
+
 		return 1
 
 	if(href_list["deny_order"])
@@ -235,7 +235,7 @@
 			SSsupply.requestlist -= SO
 		else
 			to_chat(user, "<span class='warning'>Could not find order number [id] to deny.</span>")
-		
+
 		return 1
 
 	if(href_list["cancel_order"])
@@ -246,7 +246,7 @@
 			SSsupply.points += SO.object.cost
 		else
 			to_chat(user, "<span class='warning'>Could not find order number [id] to cancel.</span>")
-		
+
 		return 1
 
 	if(href_list["delete_order"])
@@ -256,14 +256,14 @@
 			SSsupply.donelist -= SO
 		else
 			to_chat(user, "<span class='warning'>Could not find order number [id] to delete.</span>")
-		
+
 		return 1
-	
+
 	if(href_list["print_receipt"])
 		if(!can_print())
 			to_chat(user, "<span class='warning'>No printer connected to print receipts.</span>")
 			return 1
-		
+
 		var/id = text2num(href_list["print_receipt"])
 		var/list_id = text2num(href_list["list_id"])
 		var/list/list_to_search
@@ -277,15 +277,15 @@
 			else
 				to_chat(user, "<span class='warning'>Invalid list ID for order number [id]. Receipt not printed.</span>")
 				return 1
-		
+
 		var/datum/supply_order/SO = find_order_by_id(id, list_to_search)
 		if(SO)
 			print_order(SO, user)
 		else
 			to_chat(user, "<span class='warning'>Could not find order number [id] to print receipt.</span>")
-		
+
 		return 1
-	
+
 	if(href_list["toggle_notifications"])
 		notifications_enabled = !notifications_enabled
 		return 1
@@ -321,15 +321,22 @@
 		var/amount = sp.contains[item_path] || 1 // If it's just one item (has no number associated), fallback to 1.
 		if(ispath(item_path, /obj/item/stack)) // And if it is a stack, consider the amount
 			amount *= initial(OB.amount)
-		
+
+
 		contents_of_order.Add(list(list(
 			"name" = name,
 			"amount" = amount
 		)))
-	
+
+	if(sp.contains.len == 0) // Handles the case where sp.contains is empty, e.g. for livecargo
+		contents_of_order.Add(list(list(
+			"name" = sp.containername,
+			"amount" = 1
+		)))
+
 	return TRUE
-	
-	
+
+
 /datum/nano_module/supply/proc/clear_order_contents()
 	contents_of_order.Cut()
 	showing_contents_of_ref = null

--- a/html/changelogs/myazaki - supply fixes.yml
+++ b/html/changelogs/myazaki - supply fixes.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki2
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes the case where the supply pack contents will be blank when ordering live cargo."
+  - rscdel: "MULE is no longer orderable, since it does not work on the Torch."


### PR DESCRIPTION
- MULEs do not work on the Torch, so there is no point having them be orderable. This PR removes the option from the supply ordering program.
- With livecargo there is no contents listed for the crate, which I think can look a bit confusing. This PR makes sure that if it is the case that the contents list would be blank, it puts in the container name. 