### PR TITLE
Add a travis webhook to report failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,8 @@ addons:
 
 script:
   - test/run-test.sh
+
+ after_failure:
+  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh failure $WEBHOOK_URL


### PR DESCRIPTION
We lost the travis report when we switched over to the Checks tab version. Found this: https://github.com/DiscordHooks/travis-ci-discord-webhook

Added the WEBHOOK_URL already to travis-ci.com. This should report travis failures to the #coding channel.

Not sure if this is only for `dev` fails or all PRs.