### PR TITLE
Delays all turf icon update calls until later in init.

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -38,7 +38,6 @@
 #define SS_INIT_CIRCUIT          5
 #define SS_INIT_OPEN_SPACE       4
 #define SS_INIT_ATOMS            3
-#define SS_INIT_ICON_UPDATE      2
 #define SS_INIT_MACHINES         1
 #define SS_INIT_DEFAULT          0
 #define SS_INIT_AIR             -1
@@ -49,6 +48,7 @@
 #define SS_INIT_XENOARCH        -10
 #define SS_INIT_BAY_LEGACY      -12
 #define SS_INIT_TICKER          -20
+#define SS_INIT_ICON_UPDATE     -50
 #define SS_INIT_UNIT_TESTS      -100
 
 // SS runlevels

--- a/code/controllers/subsystems/processing/icon_updates.dm
+++ b/code/controllers/subsystems/processing/icon_updates.dm
@@ -6,13 +6,15 @@ PROCESSING_SUBSYSTEM_DEF(icon_update)
 	init_order = SS_INIT_ICON_UPDATE
 
 	var/list/queue = list()
+	var/initialization_begun = FALSE
 
 /datum/controller/subsystem/processing/icon_update/stat_entry()
 	..("QU:[queue.len]")
 
 /datum/controller/subsystem/processing/icon_update/Initialize()
+	initialization_begun = TRUE // helps things to not recursively queue.
 	fire(FALSE, TRUE)
-	..()
+	return ..()
 
 /datum/controller/subsystem/processing/icon_update/fire(resumed = FALSE, no_mc_tick = FALSE)
 	var/list/curr = queue

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -40,6 +40,13 @@
 	else
 		luminosity = 1
 
+// This is being done in response to some byond or allocation limit issues we experience with our unit test setup.
+/turf/update_icon()
+	if(!SSicon_update.initialization_begun)
+		queue_icon_update(arglist(args))
+		return
+	..()
+
 /turf/on_update_icon()
 	update_flood_overlay()
 


### PR DESCRIPTION
Not sure how broken and/or how helpful this is. It may also be better to force the SS to fire in lobby and avoid the single fire in init.

Doing this for mobs doesn't work without further changes to the code, while doing it for objs is potentially unsafe with regards to pipe init.

To clarify: I don't seriously suggest this should be done. I'm opening it mostly to run it through Travis repeatedly.