### PR TITLE
Corrects runtime error in issue #22851, fixes Power Trans. Circuits

### DIFF
--- a/code/modules/integrated_electronics/subtypes/power.dm
+++ b/code/modules/integrated_electronics/subtypes/power.dm
@@ -55,7 +55,7 @@
 			var/transmitter_count = 0
 			for(var/obj/item/integrated_circuit/power/transmitter in A.GetAllContents())
 				transmitter_count++
-			if(!number)
+			if(!transmitter_count)
 				return FALSE
 			transfer_amount /= transmitter_count
 			set_pin_data(IC_OUTPUT, 1, cell.charge)

--- a/code/modules/integrated_electronics/subtypes/power.dm
+++ b/code/modules/integrated_electronics/subtypes/power.dm
@@ -52,8 +52,12 @@
 		if(A.Adjacent(B))
 			if(O.loc != assembly)
 				transfer_amount *= 0.8 // Losses due to distance.
-			var/list/U=A.GetAllContents(/obj/item/integrated_circuit/power/transmitter)
-			transfer_amount *= 1 / U.len
+			var/transmitter_count = 0
+			for(var/obj/item/integrated_circuit/power/transmitter in A.GetAllContents())
+				transmitter_count++
+			if(!number)
+				return FALSE
+			transfer_amount /= transmitter_count
 			set_pin_data(IC_OUTPUT, 1, cell.charge)
 			set_pin_data(IC_OUTPUT, 2, cell.maxcharge)
 			set_pin_data(IC_OUTPUT, 3, cell.percent())


### PR DESCRIPTION
Corrects runtime error in issue #22851, allows Power Transmission Circuits to operate.

GetAllContents will no longer try to find the len of a null, instead correctly finding the contents of a tile or the contents of a tile that match the search_for argument.