### PR TITLE
Fixes issue #21916; players rotating in chairs that cannot rotate.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -73,7 +73,7 @@
 		return
 
 	// Do not allow player facing change in fixed chairs
-	if(!istype(src.buckled) || src.buckled.buckle_movable)
+	if(!istype(buckled) || buckled.buckle_movable)
 		face_atom(A) // change direction to face what you clicked on
 
 	if(!canClick()) // in the year 2000...

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -72,7 +72,9 @@
 	if(stat || paralysis || stunned || weakened)
 		return
 
-	face_atom(A) // change direction to face what you clicked on
+	// Do not allow player facing change in fixed chairs
+	if(!istype(src.buckled) || src.buckled.buckle_movable)
+		face_atom(A) // change direction to face what you clicked on
 
 	if(!canClick()) // in the year 2000...
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -696,7 +696,7 @@
 		reset_plane_and_layer()
 
 /mob/proc/facedir(var/ndir)
-	if(!canface() || moving)
+	if(!canface() || moving || (buckled && !buckled.buckle_movable))
 		return 0
 	set_dir(ndir)
 	if(buckled && buckled.buckle_movable)


### PR DESCRIPTION
Fixes issue #21916; players rotating in chairs that cannot rotate. 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->