### PR TITLE
Fixes issue where an autolathe could become permanently busy

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -247,6 +247,7 @@
 		for(var/material in making.resources)
 			if(!isnull(stored_material[material]))
 				if(stored_material[material] < round(making.resources[material] * mat_efficiency) * multiplier)
+					busy = 0
 					return TOPIC_REFRESH
 
 		//Consume materials.

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -226,7 +226,7 @@
 		show_category = choice
 		. = TOPIC_REFRESH
 
-	else if(href_list["make"] && machine_recipes)
+	else if(!busy && href_list["make"] && machine_recipes)
 		. = TOPIC_REFRESH
 		var/index = text2num(href_list["make"])
 		var/multiplier = text2num(href_list["multiplier"])


### PR DESCRIPTION
Makes sure the Autolathe isn't busy before starting a new construction job. Fixes issue #21478.

Issue occurred because Autolathe would try to start another construction job which it did not have the materials for, before it recalculated possible constructions after previous build had taken its resources.