### PR TITLE
Adds an extra supply & denied stamp to the Deck Tech lockers.

### DIFF
--- a/html/changelogs/myazaki - supply stamps.yml
+++ b/html/changelogs/myazaki - supply stamps.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki2
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "QOL Change - Adds an extra Supply & Denied Stamp to the Deck Tech lockers."

--- a/maps/torch/structures/closets/supply.dm
+++ b/maps/torch/structures/closets/supply.dm
@@ -42,6 +42,8 @@
 		/obj/item/weapon/marshalling_wand,
 		/obj/item/weapon/marshalling_wand,
 		/obj/item/weapon/storage/belt/general,
+		/obj/item/weapon/stamp/cargo,
+		/obj/item/weapon/stamp/denied,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack = 75, /obj/item/weapon/storage/backpack/satchel/grey = 25)),
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/messenger = 75, /obj/item/weapon/storage/backpack/dufflebag = 25))
 	)


### PR DESCRIPTION
Unlike other departments, everyone in the Supply Dept. should have access to their own stamp for stampin'. So they don't need to go without if someone goes to cryo / dies with it. 

Adds a supply stamp and denied stamp to the Deck Tech. lockers.