### PR TITLE
Updates Workplace Liaison description & access

### DIFF
--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -20,15 +20,14 @@
 	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
-	access = list(access_liaison, access_tox, access_tox_storage, access_bridge, access_research,
-						access_mining, access_mining_office, access_mining_station, access_xenobiology,
-						access_xenoarch, access_nanotrasen, access_sec_guard, access_hangar,
-						access_petrov, access_petrov_helm, access_maint_tunnels, access_emergency_storage,
-						access_janitor, access_hydroponics, access_kitchen, access_bar, access_commissary)
+	access = list(access_liaison, access_security, access_medical,
+						access_engine, access_research, access_bridge,
+						access_cargo, access_solgov_crew, access_hangar,
+						access_nanotrasen, access_commissary, access_petrov)
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
 /datum/job/liaison/get_description_blurb()
-	return "You are the Workplace Liaison. You are a civilian employee of the Expeditionary Corps Organisation, the corporate conglomerate partially funding the Torch, assigned to the vessel to promote corporate interests and protect the rights of the contractors on board. You are not internal affairs. You assume command of the Research Department in the absence of the RD and the Senior Researcher. You advise the RD on corporate matters and try to push corporate interests on the CO, and speak for the workers where required. Maximise profit. Be the shady corporate shill you always wanted to be."
+	return "You are the Workplace Liaison. You are a civilian employee of EXO, the Expeditionary Corps Organisation, the government-owned corporate conglomerate that partially funds the Torch. You are on board the vessel to promote corporate interests and protect the rights of the contractors on board as their union leader. You are not internal affairs. You advise command on corporate and union matters and contractors on their rights and obligations. Maximise profit. Be the shady corporate shill you always wanted to be."
 
 /datum/job/liaison/post_equip_rank(var/mob/person)
 	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Loss Prevention Associate")]"]"
@@ -64,11 +63,11 @@
 		"Asset Protection Agent"
 	)
 	skill_points = 20
-	access = list(access_liaison, access_tox, access_tox_storage, access_bridge, access_research,
-						access_mining, access_mining_office, access_mining_station, access_xenobiology,
-						access_xenoarch, access_nanotrasen, access_sec_guard, access_hangar,
-						access_petrov, access_petrov_helm, access_maint_tunnels, access_emergency_storage,
-						access_janitor, access_hydroponics, access_kitchen, access_bar, access_commissary)
+	access = list(access_liaison, access_security, access_medical,
+						access_engine, access_research, access_bridge,
+						access_cargo, access_solgov_crew, access_hangar,
+						access_nanotrasen, access_commissary, access_petrov,
+						access_sec_guard)
 	defer_roundstart_spawn = TRUE
 
 /datum/job/bodyguard/is_position_available()


### PR DESCRIPTION
:cl:
tweak: Updated Workplace Liason and LPA job descriptions and access to match their current role.
/:cl:

After swapping Research over to being run and mostly operated by the EC, the WL is no longer in its chain of command and has no business having access to bomb labs and slime pens. This updates the job blurb to reflect this, and job access to match the SCGR, plus engineering and research front doors, the commissary, and access required for some reports templates. Also changes LPA access to match, plus their personal locker.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->