### PR TITLE
More check to prevent flipping reinforced tables

### DIFF
--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -21,7 +21,7 @@
 	if (!can_touch(usr) || ismouse(usr))
 		return
 
-	if(flipped < 0 || !flip(get_cardinal_dir(usr,src)))
+	if(reinforced || flipped < 0 || !flip(get_cardinal_dir(usr,src)))
 		to_chat(usr, "<span class='notice'>It won't budge.</span>")
 		return
 


### PR DESCRIPTION
We don't have assets for flipped reinforced tables. Prior to this you could flip reinforced wood tables, but not steel ones. I don't know why.