### PR TITLE
Solgov glove tweaks

### DIFF
--- a/maps/torch/items/clothing/solgov-hands.dm
+++ b/maps/torch/items/clothing/solgov-hands.dm
@@ -1,48 +1,47 @@
 /obj/item/clothing/gloves/thick/duty/solgov
+	name = "solgov duty gloves parent object"
 	desc = "You should never see this."
-	name = "Solgov duty gloves parent object"
 	item_icons = list(slot_gloves_str = 'maps/torch/icons/mob/onmob_hands_solgov.dmi')
 	icon = 'maps/torch/icons/obj/obj_hands_solgov.dmi'
 
 /obj/item/clothing/gloves/thick/duty/solgov/eng
-	desc = "These black duty gloves are made from durable synthetic and insulated materials, and have a lovely orange accent color."
 	name = "engineering duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely orange accent color."
 	icon_state = "duty_gloves_eng"
 	item_state = "duty_gloves_eng"
-	siemens_coefficient = 0	
 
 /obj/item/clothing/gloves/thick/duty/solgov/cmd
-	desc = "These black duty gloves are made from a durable synthetic materials, and have a lovely yellow accent color."
 	name = "command duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely gold accent color."
 	icon_state = "duty_gloves_cmd"
 	item_state = "duty_gloves_cmd"	
 
 /obj/item/clothing/gloves/thick/duty/solgov/exp
-	desc = "These black duty gloves are made from a durable synthetic material, and have a lovely yellow accent color."
 	name = "exploration duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely purple accent color."
 	icon_state = "duty_gloves_exp"
 	item_state = "duty_gloves_exp"
 
 /obj/item/clothing/gloves/thick/duty/solgov/med
-	desc = "These black duty gloves are made from durable synthetic and anti-biological materials, and have a lovely blue accent color."
 	name = "medical duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely blue accent color."
 	icon_state = "duty_gloves_med"
 	item_state = "duty_gloves_med"
 
 /obj/item/clothing/gloves/thick/duty/solgov/sec
-	desc = "These black duty gloves are made from a durable synthetic material, and have a lovely red accent color."
 	name = "security duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely red accent color."
 	icon_state = "duty_gloves_sec"
 	item_state = "duty_gloves_sec"
 
 /obj/item/clothing/gloves/thick/duty/solgov/svc
-	desc = "These black duty gloves are made from a durable synthetic material, and have a lovely green accent color."
 	name = "service duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely green accent color."
 	icon_state = "duty_gloves_svc"
 	item_state = "duty_gloves_svc"
 
 /obj/item/clothing/gloves/thick/duty/solgov/sup
-	desc = "These black duty gloves are made from a durable synthetic material, and have a lovely brown accent color."
 	name = "supply duty gloves"
+	desc = "These black duty gloves are made from durable synthetic materials, and have a lovely brown accent color."
 	icon_state = "duty_gloves_sup"
 	item_state = "duty_gloves_sup"


### PR DESCRIPTION
Addresses a few things I missed in my review.

These were approved as uniform items, or general-purpose gloves. Not intended to replace work-related gloves (insulated, latex, etc) or provide substantial amounts of vital hand armour.

Engineering department gloves are no longer insulated.

Adjusts description of medical and engineering gloves. Medical incorrectly stated they were useful for medical work, and engineering correctly stated that they were insulated.  Moved all `desc` down below `name`, as God intended.

I wouldn't ordinarily think a changelog would be warranted here but some people may get fried if they're using the new gloves expecting them to be insulated, so

:cl:
rscdel: Engineering duty gloves are no longer insulated.
/:cl: