### PR TITLE
Rename Petrov areas to use SRV prefix instead of NSV

### DIFF
--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -424,79 +424,79 @@
 //Petrov
 
 /area/shuttle/petrov
-	name = "\improper NSV Petrov"
+	name = "\improper SRV Petrov"
 	requires_power = 1
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 	req_access = list(access_petrov)
 
 /area/shuttle/petrov/cell1
-	name = "\improper NSV Petrov - Isolation Cell 1"
+	name = "\improper SRV Petrov - Isolation Cell 1"
 	icon_state = "shuttle"
 /area/shuttle/petrov/cell2
-	name = "\improper NSV Petrov - Isolation Cell 2"
+	name = "\improper SRV Petrov - Isolation Cell 2"
 	icon_state = "shuttlegrn"
 /area/shuttle/petrov/cell3
-	name = "\improper NSV Petrov - Isolation Cell 3"
+	name = "\improper SRV Petrov - Isolation Cell 3"
 	icon_state = "shuttle"
 
 /area/shuttle/petrov/hallwaya
-	name = "\improper NSV Petrov - Lower Hallway"
+	name = "\improper SRV Petrov - Lower Hallway"
 	icon_state = "hallA"
 
 /area/shuttle/petrov/security
-	name = "\improper NSV Petrov - Security Office"
+	name = "\improper SRV Petrov - Security Office"
 	icon_state = "checkpoint1"
 	req_access = list(access_petrov_security)
 
 /area/shuttle/petrov/rd
-	name = "\improper NSV Petrov - CSO's Office"
+	name = "\improper SRV Petrov - CSO's Office"
 	icon_state = "head_quarters"
 	req_access = list(access_petrov_rd)
 
 /area/shuttle/petrov/cockpit
-	name = "\improper NSV Petrov - Cockpit"
+	name = "\improper SRV Petrov - Cockpit"
 	icon_state = "shuttlered"
 	req_access = list(access_petrov_helm)
 
 /area/shuttle/petrov/maint
-	name = "\improper NSV Petrov - Maintenance"
+	name = "\improper SRV Petrov - Maintenance"
 	icon_state = "engine"
 	req_access = list(access_petrov_maint)
 
 /area/shuttle/petrov/analysis
-	name = "\improper NSV Petrov - Analysis Lab"
+	name = "\improper SRV Petrov - Analysis Lab"
 	icon_state = "devlab"
 	req_access = list(access_petrov_analysis)
 
 /area/shuttle/petrov/toxins
-	name = "\improper NSV Petrov - Toxins Lab"
+	name = "\improper SRV Petrov - Toxins Lab"
 	icon_state = "toxstorage"
 	req_access = list(access_petrov_toxins)
 
 /area/shuttle/petrov/rnd
-	name = "\improper NSV Petrov - Fabricator Lab"
+	name = "\improper SRV Petrov - Fabricator Lab"
 	icon_state = "devlab"
 
 /area/shuttle/petrov/isolation
-	name = "\improper NSV Petrov - Isolation Lab"
+	name = "\improper SRV Petrov - Isolation Lab"
 	icon_state = "xeno_lab"
 
 /area/shuttle/petrov/phoron
-	name = "\improper NSV Petrov - Sublimation Lab"
+	name = "\improper SRV Petrov - Sublimation Lab"
 	icon_state = "toxstorage"
 	req_access = list(access_petrov_phoron)
 
 /area/shuttle/petrov/custodial
-	name = "\improper NSV Petrov - Custodial"
+	name = "\improper SRV Petrov - Custodial"
 	icon_state = "decontamination"
 
 /area/shuttle/petrov/equipment
-	name = "\improper NSV Petrov - Equipment Storage"
+	name = "\improper SRV Petrov - Equipment Storage"
 	icon_state = "locker"
 
 /area/shuttle/petrov/eva
-	name = "\improper NSV Petrov - EVA Storage"
+	name = "\improper SRV Petrov - EVA Storage"
 	icon_state = "locker"
 
 //Turbolift


### PR DESCRIPTION
SSV is the name people seem to be using IC for it now. If lore wants it named something else, I can accomodate.

:cl:
tweak: Renamed NSV Petrov area tags to SRV Petrov.
/:cl: