### PR TITLE
Can't use headsets when incapacitated

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -46,6 +46,7 @@
 #define CE_BLOCKAGE	     "blockage"     // Gets in the way of blood circulation, higher the worse
 #define CE_SQUEAKY		 "squeaky"      // Helium voice. Squeak squeak.
 #define CE_THIRDEYE      "thirdeye"     // Gives xray vision.
+#define CE_SEDATE        "sedate"       // Applies sedation effects, i.e. paralysis, inability to use items, etc.
 
 //reagent flags
 #define IGNORE_MOB_SIZE 0x1

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -248,12 +248,18 @@
 	// If we were to send to a channel we don't have, drop it.
 	return null
 
-/obj/item/device/radio/talk_into(mob/living/M as mob, message, channel, var/verb = "says", var/datum/language/speaking = null)
+/obj/item/device/radio/talk_into(mob/living/M, message, channel, var/verb = "says", var/datum/language/speaking = null)
 	if(!on) return 0 // the device has to be on
 	//  Fix for permacell radios, but kinda eh about actually fixing them.
 	if(!M || !message) return 0
 
 	if(speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) return 0
+
+	// Sedation chemical effect should prevent radio use (Chloral and Soporific)
+	var/mob/living/carbon/C = M
+	if (C.chem_effects[CE_SEDATE])
+		to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
+		return 0
 
 	if(istype(M)) M.trigger_aiming(TARGET_CAN_RADIO)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -394,10 +394,12 @@
 	else if(M.chem_doses[type] < 5 * threshold)
 		if(prob(50))
 			M.Weaken(2)
+			M.add_chemical_effect(CE_SEDATE, 1)
 		M.drowsyness = max(M.drowsyness, 20)
 	else
 		M.sleeping = max(M.sleeping, 20)
 		M.drowsyness = max(M.drowsyness, 60)
+		M.add_chemical_effect(CE_SEDATE, 1)
 	M.add_chemical_effect(CE_PULSE, -1)
 
 /datum/reagent/chloralhydrate
@@ -423,8 +425,10 @@
 	else if(M.chem_doses[type] < 2 * threshold)
 		M.Weaken(30)
 		M.eye_blurry = max(M.eye_blurry, 10)
+		M.add_chemical_effect(CE_SEDATE, 1)
 	else
 		M.sleeping = max(M.sleeping, 30)
+		M.add_chemical_effect(CE_SEDATE, 1)
 
 	if(M.chem_doses[type] > 1 * threshold)
 		M.adjustToxLoss(removed)


### PR DESCRIPTION
This makes it so you cannot use a radio if you're incapacitated, cuffed, or otherwise not able to use your hands. Primarily, this includes:
 - Being sleepy-penned or sedated

This does not include:
 - Any other condition not listed above

IC justification is headsets that are not set to constantly broadcast require _something_ to trigger them. That something is assumed to be a button or switch you press to talk.

OOC justification is one of the more prominent complaints from antags - People that immediately scream 'HELP X IS DOING Y AT Z' when they get attacked or sleepy penned. This is to help mitigate that and give antags a bit more breathing room to antag.

As a note for devs, this PR also includes a tweak to chemical effects that adds a `CE_SEDATE` effect. Currently, this is applied to soporific and chloral hydrate under the same conditions what Weaken() or Sleeping() are applied, and only affects radio usage.

<img width="538" alt="dreamseeker_2019-03-08_15-41-27" src="https://user-images.githubusercontent.com/11140088/54062051-b94b0480-41b8-11e9-8178-cb22b86fea60.png">

Things that should block you from using a headset:
 - [X] Chloral Hydrate
 - [x] Soporific


Headset variants to test
 - [x] Headset on ear
 - [x] Shortwave in pocket
 - [x] Intercom on adjacent tile
 - [x] Emoting on radios


:cl:
tweak: You can no longer use headsets while sedated or sleepy-penned due to paralysis making you unable to use your hands.
/:cl: