### PR TITLE
Rename Soviet Cola to TerraCola

### DIFF
--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -154,8 +154,8 @@
 	reagents.add_reagent(/datum/reagent/drink/juice/turnip, 30)
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/syndicola
-	name = "\improper Soviet Cola"
-	desc = "A can of the only soft drink state approved for the benefit of the people's revolution. Served at room temperature regardless of ambient temperatures thanks to innovative Soviet insulation technology."
+	name = "\improper TerraCola"
+	desc = "A can of the only soft drink state approved for the benefit of the people. Served at room temperature regardless of ambient temperatures thanks to innovative Terran insulation technology."
 	icon_state = "syndi_cola"
 	center_of_mass = "x=16;y=10"
 


### PR DESCRIPTION
One less thing in the game to be a slav meme reference. Lack of space intended (It's branding.)

:cl:
tweak: Soviet Cola has been renamed to TerraCola.
/:cl: