### PR TITLE
Fixes #24621

### DIFF
--- a/code/controllers/subsystems/initialization/misc.dm
+++ b/code/controllers/subsystems/initialization/misc.dm
@@ -4,9 +4,6 @@ SUBSYSTEM_DEF(misc)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/misc/Initialize()
-	var/decl/asset_cache/asset_cache = decls_repository.get_decl(/decl/asset_cache)
-	asset_cache.load()
-
 	if(config.generate_map)
 		GLOB.using_map.perform_map_generation()
 

--- a/code/controllers/subsystems/misc_late.dm
+++ b/code/controllers/subsystems/misc_late.dm
@@ -8,5 +8,9 @@ SUBSYSTEM_DEF(misc_late)
 
 /datum/controller/subsystem/misc_late/Initialize()
 	GLOB.using_map.build_exoplanets()
+
+	var/decl/asset_cache/asset_cache = decls_repository.get_decl(/decl/asset_cache)
+	asset_cache.load()
+
 	populate_lathe_recipes() // This creates and deletes objects; could use improvement.
 	. = ..()


### PR DESCRIPTION
Fixes #24621 

Currently the only files in the folder it looks in are files that should be loaded anyway, so there should be no harm in the removal of this check unless somebody dumps a lot of files in there that really shouldn't be there in the first place.