### PR TITLE
Add hand labeler to bridge storage

### DIFF
--- a/maps/torch/torch-5.dmm
+++ b/maps/torch/torch-5.dmm
@@ -9614,6 +9614,7 @@
 /obj/random/technology_scanner,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "uE" = (


### PR DESCRIPTION
Because every other department gets one for their locker rooms.

:cl:
map: Added a hand labeler to the bridge storage/locker room.
/:cl: