### PR TITLE
Fixes automatic landmarks.

### DIFF
--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -74,9 +74,8 @@ SUBSYSTEM_DEF(shuttle)
 			try_add_landmark_tag(shuttle_landmark_tag, O)
 			landmarks_still_needed -= shuttle_landmark_tag
 		else if(istype(shuttle_landmark, /obj/effect/shuttle_landmark/automatic)) //These find their sector automatically
-			var/obj/effect/shuttle_landmark/automatic/automatic = shuttle_landmark
-			O = map_sectors["[automatic.z]"]
-			O ? try_add_landmark_tag(shuttle_landmark_tag, O) : (landmarks_awaiting_sector += shuttle_landmark)
+			O = map_sectors["[shuttle_landmark.z]"]
+			O ? O.add_landmark(shuttle_landmark, shuttle_landmark.shuttle_restricted) : (landmarks_awaiting_sector += shuttle_landmark)
 
 /datum/controller/subsystem/shuttle/proc/get_landmark(var/shuttle_landmark_tag)
 	return registered_shuttle_landmarks[shuttle_landmark_tag]
@@ -99,7 +98,7 @@ SUBSYSTEM_DEF(shuttle)
 	for(var/thing in landmarks_to_check)
 		var/obj/effect/shuttle_landmark/automatic/landmark = thing
 		if(landmark.z in given_sector.map_z)
-			try_add_landmark_tag(landmark.landmark_tag, given_sector)
+			given_sector.add_landmark(landmark, landmark.shuttle_restricted)
 			landmarks_awaiting_sector -= landmark
 
 /datum/controller/subsystem/shuttle/proc/try_add_landmark_tag(landmark_tag, obj/effect/overmap/given_sector)


### PR DESCRIPTION
I broke them recently when trying to enforce proper landmark mapping.

For mappers: if you want to add shuttle landmarks, you can:

- Add a `/shuttle_landmark/automatic`. This will automatically handle everything, including naming, turf and area inheritance, and adding to overmap sectors. You can restrict to a particular shuttle by setting the `shuttle_restricted` var.
- Add a `/shuttle_landmark`. This will not autoset anything by default, but you can add `SLANDMARK_FLAG_AUTOSET` to make it autoset turf and area. They will not autoset their overmap sector; you need to add their `landmark_tag` to the sector obj's `initial_generic_waypoints` or `initial_restricted_waypoints` lists, the latter if you want to restrict to a specific shuttle. Do not add it to both. If you don't add it to any sector, only ferry-type shuttles and other nonstandard shuttles will make use of it, and only if you properly set them up to do so. Do not set the `shuttle_restricted` var on these.