### PR TITLE
Addresses issue #19896; fixes blood overlay deletion when drawing/sheathing boot knife.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -605,8 +605,6 @@ BLIND     // can't see anything
 
 	if(!holding)
 		verbs -= /obj/item/clothing/shoes/proc/draw_knife
-
-	update_icon()
 	return
 
 /obj/item/clothing/shoes/attack_hand(var/mob/living/M)
@@ -625,14 +623,11 @@ BLIND     // can't see anything
 		holding = I
 		user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>", range = 1)
 		verbs |= /obj/item/clothing/shoes/proc/draw_knife
-		update_icon()
 	else
 		return ..()
 
 /obj/item/clothing/shoes/on_update_icon()
 	overlays.Cut()
-	if(holding)
-		overlays += image(icon, "[icon_state]_knife")
 	return ..()
 
 /obj/item/clothing/shoes/proc/handle_movement(var/turf/walking, var/running)


### PR DESCRIPTION
Boots apparently used to have an icon change for sheathing/drawing, but these graphics were removed. The code remained, though, and would delete the blood overlay when a knife was sheathed/drawn (issue #19896). Calls to update the icon were removed from sheath/draw, and the code for switching to new icons was also trimmed.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->