### PR TITLE
Exports of virus dishes + litte Pathogen Incubator fix

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -25,10 +25,13 @@ SUBSYSTEM_DEF(supply)
 		"time" = "Base station supply",
 		"manifest" = "From exported manifests",
 		"crate" = "From exported crates",
-		"virology" = "From uploaded antibody data",
+		"virology_antibodies" = "From uploaded antibody data",
+		"virology_dishes" = "From exported virus dishes",
 		"gep" = "From uploaded good explorer points",
 		"total" = "Total" // If you're adding additional point sources, add it here in a new line. Don't forget to put a comma after the old last line.
 	)
+	//virus dishes uniqueness
+	var/list/sold_virus_strains = list()
 
 /datum/controller/subsystem/supply/Initialize()
 	. = ..()
@@ -112,6 +115,16 @@ SUBSYSTEM_DEF(supply)
 					if(istype(A, /obj/item/weapon/disk/survey))
 						var/obj/item/weapon/disk/survey/D = A
 						add_points_from_source(round(D.Value() * 0.005), "gep")
+
+					// Sell virus dishes.
+					if(istype(A, /obj/item/weapon/virusdish))
+						//Obviously the dish must be unique and never sold before.
+						var/obj/item/weapon/virusdish/dish = A
+						if(dish.analysed && istype(dish.virus2) && dish.virus2.uniqueID)
+							if(!(dish.virus2.uniqueID in sold_virus_strains))
+								add_points_from_source(5, "virology_dishes")
+								sold_virus_strains += dish.virus2.uniqueID
+
 			qdel(AM)
 
 	if(material_count.len)

--- a/code/modules/virus2/antibodyanalyser.dm
+++ b/code/modules/virus2/antibodyanalyser.dm
@@ -43,7 +43,7 @@
 				var/list/unknown_antibodies = common_antibodies ^ given_antibodies
 				if(unknown_antibodies.len)
 					var/payout = unknown_antibodies.len * 45
-					SSsupply.add_points_from_source(payout, "virology")
+					SSsupply.add_points_from_source(payout, "virology_antibodies")
 					ping("\The [src] pings, \"Successfully uploaded new antibodies to the ExoNet.\"")
 					known_antibodies |= unknown_antibodies //Add the new antibodies to list
 				else

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -138,7 +138,7 @@
 			foodsupply = min(100, foodsupply+(food_taken * 2))
 			SSnano.update_uis(src)
 
-		if (locate(/datum/reagent/toxin) in beaker.reagents.reagent_list && toxins < 100)
+		if ((locate(/datum/reagent/toxin) in beaker.reagents.reagent_list) && toxins < 100)
 			for(var/datum/reagent/toxin/T in beaker.reagents.reagent_list)
 				toxins += max(T.strength,1)
 				beaker.reagents.remove_reagent(T.type,1)

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -2,7 +2,7 @@
 	core_skill = SKILL_VIROLOGY
 
 /obj/machinery/proc/infect_nearby(datum/disease2/disease/disease, base_chance = 10, skill_threshold = SKILL_BASIC, dist = 2)
-	if(operator_skill <= skill_threshold)
+	if(istype(disease) && operator_skill <= skill_threshold)
 		for(var/mob/living/carbon/victim in range(dist, src))
 			if(prob(base_chance * 2**(SKILL_MIN - operator_skill)))
 				infect_virus2(victim, disease)


### PR DESCRIPTION
:cl:
rscadd: now it is possible to export virus dishes to earn credits (supply points).

bugfix: now Toxicity related to a virus dish (Incubator) works again.

tweak: checking for virus dishes already exported in the past or not analyzed at all (those MUST NOT be exported!).
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->