### PR TITLE
bridge officer locker access

### DIFF
--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -98,7 +98,7 @@
 
 /obj/structure/closet/secure_closet/bridgeofficer
 	name = "bridge officer's locker"
-	req_access = list(access_bridge)
+	req_access = list(access_bridge, access_keycard_auth)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/command/bo
 
 /obj/structure/closet/secure_closet/bridgeofficer/WillContain()


### PR DESCRIPTION
:cl:
tweak: Bridge officer lockers are harder to get into.
/:cl:

~~Adds a distinct bridge officer access. Gives this access to bridge officers and the XO (the CO can open anything already). Prevents everyone with bridge access constantly looting BO lockers.~~

Uses bridge + authenticator access to less thoroughly restrict access to bridge officer lockers, but still better than current.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->