### PR TITLE
Add a few small BYOND member perks

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -154,6 +154,7 @@
 
 #define ANIMAL_SPAWN_DELAY round(config.respawn_delay / 6)
 #define DRONE_SPAWN_DELAY  round(config.respawn_delay / 3)
+#define MEMBER_SPAWN_DELAY round(config.respawn_delay / 10)
 
 // Incapacitation flags, used by the mob/proc/incapacitated() proc
 #define INCAPACITATION_NONE 0

--- a/code/datums/communication/ooc.dm
+++ b/code/datums/communication/ooc.dm
@@ -26,6 +26,9 @@
 	var/is_stealthed = C.is_stealthed()
 
 	var/ooc_style = "everyone"
+
+	if(C.IsByondMember())
+		ooc_style = "member"
 	if(holder && !is_stealthed)
 		ooc_style = "elevated"
 		if(holder.rights & R_MOD)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -111,8 +111,12 @@
 			to_chat(user, "<span class='danger'> Your account is not old enough to play as a maintenance drone.</span>")
 			return
 
-	if(!user.MayRespawn(1, DRONE_SPAWN_DELAY))
-		return
+	if(user.client.IsByondMember())
+		if(!user.MayRespawn(1, MEMBER_SPAWN_DELAY))
+			return
+	else
+		if(!user.MayRespawn(1, DRONE_SPAWN_DELAY))
+			return
 
 	if(!fabricator)
 

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -21,6 +21,7 @@ em						{font-style: normal;font-weight: bold;}
 .ooc .everyone			{color: #002eb8;}
 .ooc .looc				{color: #3a9696;}
 .ooc .elevated			{color: #2e78d9;}
+.ooc .member            {color: #006464;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}
 .ooc .admin				{color: #b82e00;}


### PR DESCRIPTION
:cl:
rscadd: BYOND members now have a different OOC text colour.
rscadd: BYOND members now enjoy a shorter respawn period when attempting to respawn as a maintenance drone.
/:cl:

I've wanted to add some member perks for a while, but most of the things other servers offer (additional save slots, for example) we offer to everyone. I ended up with these two, being easy to implement. More perks are coming in the future as I think of them.