### PR TITLE
Re-add medical accesses to the officers mess door

### DIFF
--- a/maps/torch/torch-2.dmm
+++ b/maps/torch/torch-2.dmm
@@ -19299,7 +19299,7 @@
 /obj/machinery/door/airlock/command{
 	autoset_access = 0;
 	name = "Officer's Mess";
-	req_access = list(list(19,28))
+	req_access = list(list(19,28,64,91))
 	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4


### PR DESCRIPTION
Chaplains and physicians can get down into the food dungeon again now

Solves https://github.com/Baystation12/Baystation12/issues/24597#issuecomment-468129478