### PR TITLE
Makes maintenance unlocked properly during rad storms.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -12,8 +12,12 @@
 	return check_access_list(M.GetAccess())
 
 /atom/movable/proc/GetAccess()
+	. = list()
 	var/obj/item/weapon/card/id/id = GetIdCard()
-	return id ? id.GetAccess() : list()
+	if(id)
+		. += id.GetAccess()
+	if(maint_all_access)
+		. |= access_maint_tunnels
 
 /atom/movable/proc/GetIdCard()
 	return null

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -188,8 +188,3 @@
 	return SSticker.mode && SSticker.mode.ert_disabled
 
 var/global/maint_all_access = 0
-
-/obj/machinery/door/airlock/allowed(mob/M)
-	if(maint_all_access && src.check_access_list(list(access_maint_tunnels)))
-		return 1
-	return ..(M)


### PR DESCRIPTION
Adds maint access more aggressively, so in particular if a door needs access X and maint, and it's a radstorm, and you have X, you can use the door. It will now work with _anything_ requiring maint access; if this has side effects, that seems fine to me.