### PR TITLE
Allows doctors to colorpick scrubs again

### DIFF
--- a/maps/torch/loadout/loadout_uniform.dm
+++ b/maps/torch/loadout/loadout_uniform.dm
@@ -20,6 +20,7 @@
 
 /datum/gear/uniform/scrubs
 	allowed_roles = STERILE_ROLES
+	allowed_branches = null
 
 /datum/gear/uniform/dress
 	allowed_roles = FORMAL_ROLES


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

#24661 prevents doctors from color picking any color of scrub. The scrubs that spawn in the locker are only a small subset of possible combinations and on top of that, are random. This change prevents doctors from getting exactly what color of clothing they enjoy.