### PR TITLE
Resolves issues with prosthetic limbs restrictions

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -24,7 +24,7 @@ var/datum/robolimb/basic_robolimb
 	var/list/species_cannot_use = list()
 	var/list/restricted_to = list()
 	var/list/applies_to_part = list() //TODO.
-	var/list/allowed_bodytypes
+	var/list/allowed_bodytypes = list(SPECIES_HUMAN, SPECIES_IPC, SPECIES_SKRELL, SPECIES_UNATHI)
 
 /datum/robolimb/bishop
 	company = "Bishop"

--- a/html/changelogs/Datraen-ProstheticsFix.yml
+++ b/html/changelogs/Datraen-ProstheticsFix.yml
@@ -1,0 +1,4 @@
+author: Datraen
+delete-after: True
+changes: 
+  - bugfix: "Prosthetic limbs no longer swap to default limbs."


### PR DESCRIPTION
Fixes #24693

https://github.com/Baystation12/Baystation12/blob/f750f2e5e10e2bcdd469cd191ad9924465eafd0b/code/modules/organs/external/_external.dm#L1078 is looking for species in a null list, resulting in a basic robotic limb being used.