### PR TITLE
Codex adjustments.

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -2,11 +2,11 @@ SUBSYSTEM_DEF(codex)
 	name = "Codex"
 	flags = SS_NO_FIRE
 	init_order = SS_INIT_MISC_LATE
-	var/list/entries_by_path = list()
+
+	var/list/entries_by_path =   list()
 	var/list/entries_by_string = list()
-	var/list/index_file = list()
-	var/list/search_cache = list()
-	var/list/entry_cache = list()
+	var/list/index_file =        list()
+	var/list/search_cache =      list()
 
 /datum/controller/subsystem/codex/Initialize()
 
@@ -18,9 +18,10 @@ SUBSYSTEM_DEF(codex)
 			for(var/associated_path in centry.associated_paths)
 				entries_by_path[associated_path] = centry
 			for(var/associated_string in centry.associated_strings)
-				entries_by_string[associated_string] = centry
+				add_entry_by_string(associated_string, centry)
 			if(centry.display_name)
-				entries_by_string[centry.display_name] = centry
+				add_entry_by_string(centry.display_name, centry)
+			centry.update_links()
 
 	// Create categorized entries.
 	for(var/ctype in subtypesof(/datum/codex_category))
@@ -38,26 +39,22 @@ SUBSYSTEM_DEF(codex)
 	index_file = sortAssoc(index_file)
 	. = ..()
 
-/datum/controller/subsystem/codex/proc/get_codex_entry(var/datum/codex_entry/entry)
-	if(!initialized)
-		return
-	var/searching = "\ref[entry]"
-	if(!entry_cache[searching])
-		if(istype(entry))
-			entry_cache[searching] = entry
-		else
-			entry_cache[searching] = FALSE
-			if(ispath(entry))
-				entry_cache[searching] = entries_by_path[entry]
-			else if(istype(entry, /atom))
-				var/atom/entity = entry
-				if(entries_by_string[lowertext(entity.name)])
-					entry_cache[searching] = entries_by_string[lowertext(entity.name)]
-				else if(entries_by_path[entity.type])
-					entry_cache[searching] = entries_by_path[entity.type]
-				else if(entity.get_specific_codex_entry())
-					entry_cache[searching] = entity.get_specific_codex_entry()
-	return entry_cache[searching]
+/datum/controller/subsystem/codex/proc/get_codex_entry(var/entry)
+	if(istype(entry, /atom))
+		var/atom/entity = entry
+		if(entity.get_specific_codex_entry())
+			return entity.get_specific_codex_entry()
+		return get_entry_by_string(entity.name) || entries_by_path[entity.type]
+	else if(entries_by_path[entry])
+		return entries_by_path[entry]
+	else if(entries_by_string[lowertext(entry)])
+		return entries_by_string[lowertext(entry)]
+
+/datum/controller/subsystem/codex/proc/add_entry_by_string(var/string, var/entry)
+	entries_by_string[lowertext(trim(string))] = entry
+
+/datum/controller/subsystem/codex/proc/get_entry_by_string(var/string)
+	return entries_by_string[lowertext(trim(string))]
 
 /datum/controller/subsystem/codex/proc/present_codex_entry(var/mob/presenting_to, var/datum/codex_entry/entry)
 	if(entry && istype(presenting_to) && presenting_to.client)
@@ -101,9 +98,18 @@ SUBSYSTEM_DEF(codex)
 /datum/controller/subsystem/codex/Topic(href, href_list)
 	. = ..()
 	if(!. && href_list["show_examined_info"] && href_list["show_to"])
-		var/atom/showing_atom = locate(href_list["show_examined_info"])
 		var/mob/showing_mob =   locate(href_list["show_to"])
-		var/entry = get_codex_entry(showing_atom)
-		if(entry && showing_mob.can_use_codex())
+		if(!istype(showing_mob) || !showing_mob.can_use_codex())
+			return 
+		var/atom/showing_atom = locate(href_list["show_examined_info"])
+		var/entry
+		if(istype(showing_atom, /datum/codex_entry))
+			entry = showing_atom
+		else
+			if(istype(showing_atom))
+				entry = get_codex_entry(showing_atom.get_codex_value())
+			else
+				entry = get_codex_entry(showing_atom)
+		if(entry)
 			present_codex_entry(showing_mob, entry)
 			return TRUE

--- a/code/modules/codex/categories/category_cultures.dm
+++ b/code/modules/codex/categories/category_cultures.dm
@@ -5,4 +5,5 @@
 		if(!culture.hidden_from_codex)
 			var/datum/codex_entry/entry = new(_display_name = "[culture.name] ([lowertext(culture.desc_type)])")
 			entry.lore_text = culture.description
-			SScodex.entries_by_string[culture.name] = entry
+			entry.update_links()
+			SScodex.add_entry_by_string(culture.name, entry)

--- a/code/modules/codex/categories/category_materials.dm
+++ b/code/modules/codex/categories/category_materials.dm
@@ -1,5 +1,4 @@
 /datum/codex_category/materials/Initialize()
-
 	for(var/thing in SSmaterials.materials)
 		var/material/mat = thing
 		if(!mat.hidden_from_codex)
@@ -7,4 +6,5 @@
 			entry.lore_text = mat.lore_text
 			entry.antag_text = mat.antag_text
 			entry.mechanics_text = mat.mechanics_text ? mat.mechanics_text : ""
-			SScodex.entries_by_string[entry.display_name] = entry
+			entry.update_links()
+			SScodex.add_entry_by_string(entry.display_name, entry)

--- a/code/modules/codex/categories/category_reagents.dm
+++ b/code/modules/codex/categories/category_reagents.dm
@@ -44,4 +44,5 @@
 				entry.mechanics_text += "<br><br>It can be produced as follows:<br>"
 			entry.mechanics_text += jointext(production_strings, "<br>")
 
-		SScodex.entries_by_string[entry.display_name] = entry
+		entry.update_links()
+		SScodex.add_entry_by_string(entry.display_name, entry)

--- a/code/modules/codex/categories/category_species.dm
+++ b/code/modules/codex/categories/category_species.dm
@@ -4,4 +4,7 @@
 		if(!species.hidden_from_codex)
 			var/datum/codex_entry/entry = new(_display_name = "[species.name] (species)")
 			entry.lore_text = species.codex_description
-			SScodex.entries_by_string[species.name] = entry
+			entry.mechanics_text = species.ooc_codex_information
+			entry.update_links()
+			SScodex.add_entry_by_string(entry.display_name, entry)
+			SScodex.add_entry_by_string(species.name, entry)

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -15,10 +15,13 @@
 	return entry
 
 /atom/proc/get_mechanics_info()
+	return
 
 /atom/proc/get_antag_info()
+	return
 
 /atom/proc/get_lore_info()
+	return
 
 /atom/examine(var/mob/user, var/distance = -1, var/infix = "", var/suffix = "")
 	. = ..()

--- a/code/modules/codex/codex_mob.dm
+++ b/code/modules/codex/codex_mob.dm
@@ -12,3 +12,6 @@
 
 /mob/living/carbon/human/can_use_codex()
 	return TRUE //has_implant(/obj/item/implant/codex, functioning = TRUE)
+
+/mob/living/carbon/human/get_codex_value()
+	return "[lowertext(species.name)] (species)"

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -9,6 +9,9 @@
 /datum/codex_entry/dd_SortValue()
 	return display_name
 
+/datum/codex_entry/proc/update_links()
+	return
+
 /datum/codex_entry/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
 
 	if(_display_name)       display_name =       _display_name

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -49,7 +49,8 @@
 		if(is_synth && species.cyborg_noun)
 			species_name += "[species.cyborg_noun] "
 		species_name += "[species.name]"
-		msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [species_name]!</font></b>"
+		msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value())) ?  SPAN_NOTICE(" \[<a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
+
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)
 		msg += "[extra_species_text]<br>"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -9,6 +9,7 @@
 	var/name_plural                                      // Pluralized name (since "[name]s" is not always valid)
 	var/description
 	var/codex_description
+	var/ooc_codex_information
 	var/cyborg_noun = "Cyborg"
 	var/hidden_from_codex = TRUE
 


### PR DESCRIPTION
- Removes unnecessary and confusing caching on codex entry retrieval.
- Removes odd assumption that `get_codex_entry` would be supplied a preexisting codex entry as an argument.
- Adjusts human examine, material stack codex value and species codex generation to be slightly more consistently labelled.
- Fixes codex info link not showing for human mobs and material stacks.
- A little bit of prep work snuck in from another project but is harmless (`update_link` proc and `ooc_codex_information` species var).