### PR TITLE
Updates girders to new material system

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -10,15 +10,15 @@
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0
-	var/dismantle_material = material
+	var/dismantle_material = MATERIAL_STEEL
 
 /obj/structure/girder/Initialize()
 	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/simple, 100)
 	. = ..()
-	if(dismantle_material)
-		var/material/mat = SSmaterials.get_material_by_name(dismantle_material)
-		if(mat)
-			name = "[mat.display_name] girder"
+	if(material && !istype(material))
+		material = SSmaterials.get_material_by_name(material)
+	if(istype(material))
+		name = "[material.display_name] girder
 
 /obj/structure/girder/displaced
 	icon_state = "displaced"
@@ -208,9 +208,9 @@
 	icon_state = "reinforced"
 	reinforcing = 0
 
-/obj/structure/girder/proc/dismantle()
-	new /obj/item/stack/material/steel(get_turf(src))
-	qdel(src)
+/obj/structure/girder/dismantle()
+	if(material)
+		material.place_sheet(get_turf(src))
 
 /obj/structure/girder/attack_hand(mob/user as mob)
 	if (MUTATION_HULK in user.mutations)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -10,7 +10,7 @@
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0
-	var/dismantle_material = MATERIAL_STEEL
+	var/dismantle_material = material
 
 /obj/structure/girder/Initialize()
 	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/simple, 100)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -10,10 +10,15 @@
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0
+	var/dismantle_material = MATERIAL_STEEL
 
 /obj/structure/girder/Initialize()
 	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/simple, 100)
 	. = ..()
+	if(dismantle_material)
+		var/material/mat = SSmaterials.get_material_by_name(dismantle_material)
+		if(mat)
+			name = "[mat.display_name] girder"
 
 /obj/structure/girder/displaced
 	icon_state = "displaced"
@@ -236,8 +241,13 @@
 	icon_state= "cultgirder"
 	health = 250
 	cover = 70
+	dismantle_material = MATERIAL_CULT
 
 /obj/structure/girder/cult/dismantle()
+	if(dismantle_material)
+		var/material/mat = SSmaterials.get_material_by_name(dismantle_material)
+		if(mat)
+			mat.place_sheet(get_turf(src), rand(1,3))
 	qdel(src)
 
 /obj/structure/girder/cult/attackby(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
Changes the girder that appears from breaking a cult wall from simply "cult" to the correct "disturbing brick girder". Also makes cult girder drop cult bricks, and brings the materials for regular steel and cult girders in line with the new material system.

:cl: Crystalnole
tweak: Brings girders in line with material update
tweak: Fixes "cult" girder to be "disturbing stone girder"
tweak: Adds cult brick drop to cult girder disassembly
/:cl: