### PR TITLE
Increases how long it takes to print new organs

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -14,7 +14,7 @@
 
 	var/stored_matter = 0
 	var/max_stored_matter = 0
-	var/print_delay = 100
+	var/print_delay = 300
 	var/printing
 
 	// These should be subtypes of /obj/item/organ


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This change was made after feedback from medical players that it's too easy to just completely forgo repairing organs (and dealing with scarring), since just printing a new one is easier. This value (30 seconds instead of 10) should mean you can still print organs if you need to, but it isn't your first resort if you don't.

:cl:
tweak: Organ printers now take three times as long to print
/:cl: