### PR TITLE
Carpet fix - Fixes #24639

### DIFF
--- a/html/changelogs/myazaki - carpetfix.yml
+++ b/html/changelogs/myazaki - carpetfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes an issue where it wouldn't be possible to lay red carpet."

--- a/maps/torch/torch-6.dmm
+++ b/maps/torch/torch-6.dmm
@@ -691,6 +691,9 @@
 	dir = 2
 	},
 /area/rescue_base/base)
+"abT" = (
+/turf/simulated/floor/carpet,
+/area/rescue_base/base)
 "abU" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Showers";
@@ -2586,6 +2589,24 @@
 /obj/structure/window/reinforced/holowindow,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_boxingcourt)
+"agf" = (
+/turf/simulated/floor/carpet/blue,
+/area/rescue_base/base)
+"agg" = (
+/turf/simulated/floor/carpet/blue2,
+/area/rescue_base/base)
+"agh" = (
+/turf/simulated/floor/carpet/green,
+/area/rescue_base/base)
+"agi" = (
+/turf/simulated/floor/carpet/orange,
+/area/rescue_base/base)
+"agj" = (
+/turf/simulated/floor/carpet/purple,
+/area/rescue_base/base)
+"agk" = (
+/turf/simulated/floor/carpet/red,
+/area/rescue_base/base)
 "agl" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass{
@@ -23480,13 +23501,13 @@ aab
 "}
 (3,1,1) = {"
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+abT
+agf
+agg
+agh
+agi
+agj
+agk
 aad
 aad
 aad


### PR DESCRIPTION
Fixes issue #24639 by adding a line of all the carpet turfs to Torch 6 map.