### PR TITLE
Extinguisher Text - Fixes #24156

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -92,8 +92,12 @@
 	if( istype(target, /obj/structure/reagent_dispensers) && flag)
 		var/obj/o = target
 		var/amount = o.reagents.trans_to_obj(src, 500)
-		to_chat(user, "<span class='notice'>You fill [src] with [amount] units of the contents of [target].</span>")
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
+
+		if (amount == null)
+			to_chat(user, "<span class='notice'>[src] is full.</span>")
+		else
+			to_chat(user, "<span class='notice'>You fill [src] with [amount] units of the contents of [target].</span>")
+			playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		if(istype(target, /obj/structure/reagent_dispensers/acid))
 			to_chat(user, "<span class='warning'>You can only watch as the acid begins violently eating away at the bottom of \the [src]!</span>")
 			if(prob(50))

--- a/html/changelogs/myazaki - full extinguisher message.yml
+++ b/html/changelogs/myazaki - full extinguisher message.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes an issue where full fire extinguishers would report an incorrect message when you tried to fill them further."


### PR DESCRIPTION
Fixes #24156

Makes fire extinguishers say "The Fire Extinguisher is full." 

Instead of saying: "You fill the extinguisher with units of water."

When they are full.