### PR TITLE
Shuttle Pilot Fax Machine Access - Fixes #24154

### DIFF
--- a/html/changelogs/myazaki - pilot fax machine removal.yml
+++ b/html/changelogs/myazaki - pilot fax machine removal.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes fax machine from Pilot's Office."

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -8,6 +8,11 @@
 	},
 /turf/space,
 /area/space)
+"ac" = (
+/obj/structure/table/steel,
+/obj/item/weapon/pen/fancy,
+/turf/simulated/floor/lino,
+/area/command/pilot)
 "ag" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/hangar)
@@ -3806,13 +3811,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/storage)
-"iN" = (
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "Pilot's Lounge"
-	},
-/turf/simulated/floor/lino,
-/area/command/pilot)
 "iO" = (
 /obj/structure/table/steel,
 /obj/item/weapon/paper_bin{
@@ -30865,7 +30863,7 @@ iE
 rd
 lt
 iC
-iN
+ac
 jx
 jQ
 wF


### PR DESCRIPTION
Allows Shuttle Pilots to use fax machines, such as the one in their office, by adding access_pilot to the fax machine access list.

Fixes #24154