### PR TITLE
Removes the last of the mobile teleporters

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1720,7 +1720,6 @@
 #include "code\modules\integrated_electronics\core\saved_circuits.dm"
 #include "code\modules\integrated_electronics\core\wirer.dm"
 #include "code\modules\integrated_electronics\core\prefab\prefab.dm"
-#include "code\modules\integrated_electronics\core\prefab\prefabs.dm"
 #include "code\modules\integrated_electronics\core\special_pins\boolean_pin.dm"
 #include "code\modules\integrated_electronics\core\special_pins\char_pin.dm"
 #include "code\modules\integrated_electronics\core\special_pins\color_pin.dm"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -408,7 +408,6 @@ datum/objective/steal
 
 	var/global/possible_items[] = list(
 		"the captain's antique laser gun" = /obj/item/weapon/gun/energy/captain,
-		"a bluespace rift generator" = /obj/item/integrated_circuit/manipulation/bluespace_rift,
 		"an RCD" = /obj/item/weapon/rcd,
 		"a jetpack" = /obj/item/weapon/tank/jetpack,
 		"a captain's jumpsuit" = /obj/item/clothing/under/rank/captain,
@@ -864,4 +863,3 @@ datum/objective/heist/salvage
 			rval = 2
 		return 0
 	return rval
-

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -168,7 +168,6 @@
 
 	// These items are preserved when the process() despawn proc occurs.
 	var/list/preserve_items = list(
-		/obj/item/integrated_circuit/manipulation/bluespace_rift,
 		/obj/item/integrated_circuit/input/teleporter_locator,
 		/obj/item/weapon/card/id/captains_spare,
 		/obj/item/weapon/aicard,

--- a/code/modules/integrated_electronics/core/prefab/prefabs.dm
+++ b/code/modules/integrated_electronics/core/prefab/prefabs.dm
@@ -1,8 +1,0 @@
-/decl/prefab/ic_assembly/hand_teleporter
-	assembly_name = "hand-teleporter"
-	data = {"{'assembly':{'type':'type-a electronic mechanism','name':'Hand Teleporter', 'detail_color':'#5d99be'},'components':\[{'type':'teleporter locator'},{'type':'bluespace rift generator'},{'type':'button','name':'Open Rift'}\],'wires':\[\[\[1,'O',1\],\[2,'I',1\]\],\[\[2,'A',1\],\[3,'A',1\]\]\]}"}
-	power_cell_type = /obj/item/weapon/cell/hyper
-
-/obj/prefab/hand_teleporter
-	name = "hand teleporter"
-	prefab_type = /decl/prefab/ic_assembly/hand_teleporter

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -539,55 +539,6 @@
 	if(istype(G))
 		G.update_outputs()
 
-/obj/item/integrated_circuit/manipulation/bluespace_rift
-	name = "bluespace rift generator"
-	desc = "This powerful circuit can open rifts to another realspace location through bluespace."
-	extended_desc = "If a valid teleporter console is supplied as input then its selected teleporter beacon will be used as destination point, \
-					and if not an undefined destination point is selected. \
-					Rift direction is a cardinal value determening in which direction the rift will be opened, relative the local north. \
-					A direction value of 0 will open the rift on top of the assembly, and any other non-cardinal values will open the rift in the assembly's current facing."
-	icon_state = "bluespace"
-	complexity = 100
-	size = 3
-	cooldown_per_use = 10 SECONDS
-	power_draw_per_use = 300
-	inputs = list("teleporter", "rift direction")
-	outputs = list()
-	activators = list("open rift" = IC_PINTYPE_PULSE_IN)
-	spawn_flags = IC_SPAWN_RESEARCH
-	action_flags = IC_ACTION_LONG_RANGE
-
-	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
-	matter = list(MATERIAL_STEEL = 10000, MATERIAL_SILVER = 2000, MATERIAL_GOLD = 200)
-
-/obj/item/integrated_circuit/manipulation/bluespace_rift/do_work()
-	var/obj/machinery/computer/teleporter/tporter = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/computer/teleporter)
-	var/step_dir = get_pin_data(IC_INPUT, 2)
-	if(!(get(z) in GetConnectedZlevels(get_z(tporter))))
-		tporter = null
-
-	var/turf/rift_location = get_turf(src)
-	if(!rift_location || !isPlayerLevel(rift_location.z))
-		playsound(src, 'sound/effects/sparks2.ogg', 50, 1)
-		return
-
-	if(isnum(step_dir) && (!step_dir || (step_dir in GLOB.cardinal)))
-		rift_location = get_step(rift_location, step_dir) || rift_location
-	else
-		var/obj/item/device/electronic_assembly/assembly = get_object()
-		if(assembly)
-			rift_location = get_step(rift_location, assembly.dir) || rift_location
-
-	if(tporter && tporter.locked && !tporter.one_time_use && tporter.operable())
-		new /obj/effect/portal(rift_location, get_turf(tporter.locked))
-	else
-		var/turf/destination = get_random_turf_in_range(src, 10)
-		if(destination)
-			new /obj/effect/portal(rift_location, destination, 30 SECONDS, 33)
-		else
-			playsound(src, 'sound/effects/sparks2.ogg', 50, 1)
-
-
 /obj/item/integrated_circuit/manipulation/ai
 	name = "integrated intelligence control circuit"
 	desc = "Similar in structure to a intellicard, this circuit allows the AI to pulse four different activators for control of a circuit."

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -246,7 +246,6 @@ var/list/worths = list(
 					/obj/item/weapon/FixOVein = 500,
 					/obj/item/weapon/bonesetter = 150,
 					/obj/item/weapon/locator = 100,
-					/obj/item/integrated_circuit/manipulation/bluespace_rift = 7600,
 					/obj/item/weapon/wrench = 30,
 					/obj/item/weapon/screwdriver = 15,
 					/obj/item/weapon/wirecutters = 25,
@@ -768,4 +767,3 @@ var/list/worths = list(
 					/obj/machinery/bookbinder = -1200,
 					/obj/machinery = -1000,
 					) //Must be in descending order. Child before parents, otherwise it doesn't work.,
-

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -651,7 +651,6 @@
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/chemistry(src)
-	src.emag = new /obj/prefab/hand_teleporter(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)
 	synths += nanite

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1549,7 +1549,6 @@
 /turf/simulated/floor/airless,
 /area/space)
 "dE" = (
-/obj/prefab/hand_teleporter,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "CO's Desk";

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -3898,7 +3898,6 @@
 /area/rescue_base/base)
 "ajq" = (
 /obj/structure/table/reinforced,
-/obj/prefab/hand_teleporter,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1
@@ -10364,7 +10363,6 @@
 "ayS" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/gun/energy/gun/nuclear,
-/obj/prefab/hand_teleporter,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 1


### PR DESCRIPTION
🆑 
rscdel: Removes the last of the mobile teleporters on the Torch
/🆑 

We removed the majority of these things a few months ago and the world hasn't come to an end. These things can make exploration trivial, can be abused to create impenetrable walls and make the (large) teleporters on the ship completely irrelevant. I really just don't think they add anything to the game and they make jobs that are supposed to be dangerous trivial.