### PR TITLE
Makes merchant, antag, and admin shuttles rad/ion shielded

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -173,6 +173,7 @@ area/space/atmosalert()
 /area/shuttle/specops/centcom
 	icon_state = "shuttlered"
 	req_access = list(access_cent_specops)
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/shuttle/syndicate_elite/mothership
 	icon_state = "shuttlered"
@@ -186,6 +187,7 @@ area/space/atmosalert()
 	name = "\improper Skipjack"
 	icon_state = "yellow"
 	req_access = list(access_syndicate)
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/supply
 	name = "Supply Shuttle"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -572,6 +572,7 @@
 	name = "\improper Merchant Vessel"
 	icon_state = "shuttlegrn"
 	req_access = list(access_merchant)
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 //Merc
 
@@ -1545,6 +1546,7 @@
 	name = "\improper Administration Shuttle"
 	icon_state = "shuttlered"
 	req_access = list(access_cent_general)
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/shuttle/escape_pod1/centcom
 	icon_state = "shuttle"


### PR DESCRIPTION
Because antags and merchants being completely wrecked by a badly timed rad storm before they've even docked is bad.

:cl:
map: Antag shuttles, merchant shuttle, and admin shuttles are now shielded against rad and ion storms.
/:cl: