### PR TITLE
Disables R-UST deuterium-deuterium reaction

### DIFF
--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -52,11 +52,13 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	energy_production = 2
 	products = list("helium" = 1)
 
+/* this reaction is interfering with other, more interesting reactions because it's reacting with itself. unless someone wants to add in a reaction priority, this needs to be removed.
 /decl/fusion_reaction/deuterium_deuterium
 	p_react = "deuterium"
 	s_react = "deuterium"
 	energy_consumption = 1
 	energy_production = 2
+*/
 
 // Advanced production reactions (todo)
 /decl/fusion_reaction/deuterium_helium


### PR DESCRIPTION
There are several reactions that work with deuterium, but can't be taken advantage of because deuterium tends to react to itself as well.

This removes deut-deut. A pretty standard path for reaction is now deuterium - tritium - deuterium, as tritium-deuterium will form helium and then react with the extra deuterium for power.

🆑 
rscdel: Removed deuterium deuterium reaction on R-UST. It prevented other reactions from working fully as expected. Note, this WILL mean increased field instability with some reactions, as these will now work properly. Monitor the R-UST when reacting.
/:cl: