### PR TITLE
Robotics R&D consoles can no longer link with destructive analyzers.

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -61,7 +61,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/screen = 1.0	//Which screen is currently showing.
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
-	var/can_analyze = FALSE //If the console is allowed to use destructive analyzers
+	var/can_analyze = TRUE //If the console is allowed to use destructive analyzers
 
 	req_access = list(access_research)	//Data and setting manipulation requires scientist access.
 
@@ -886,11 +886,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	name = "robotics fabrication console"
 	id = 2
 	req_access = list(access_robotics)
+	can_analyze = FALSE
 
 /obj/machinery/computer/rdconsole/core
 	name = "core fabricator console"
 	id = 1
-	can_analyze = TRUE
+	
 
 #undef CHECK_LATHE
 #undef CHECK_IMPRINTER

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -95,7 +95,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	for(var/obj/machinery/r_n_d/D in range(4, src))
 		if(D.linked_console != null || D.panel_open)
 			continue
-		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer))
+		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer) && id == 1) // Prevents robotics R&D console from linking to a destructive analyzer
 			if(linked_destroy == null)
 				linked_destroy = D
 				D.linked_console = src
@@ -675,7 +675,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(linked_destroy)
 				dat += "<LI>Destructive Analyzer <A href='?src=\ref[src];disconnect=destroy'>(Disconnect)</A>"
 			else
-				dat += "<LI>(No Destructive Analyzer Linked)"
+				if (id == 1) dat += "<LI>(No Destructive Analyzer Linked)"
 			if(linked_lathe)
 				dat += "<LI>Protolathe <A href='?src=\ref[src];disconnect=lathe'>(Disconnect)</A>"
 			else

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -61,6 +61,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/screen = 1.0	//Which screen is currently showing.
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
+	var/can_analyze = FALSE //If the console is allowed to use destructive analyzers
 
 	req_access = list(access_research)	//Data and setting manipulation requires scientist access.
 
@@ -95,7 +96,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	for(var/obj/machinery/r_n_d/D in range(4, src))
 		if(D.linked_console != null || D.panel_open)
 			continue
-		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer) && id == 1) // Only science R&D consoles can do research
+		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer) && can_analyze == TRUE) // Only science R&D consoles can do research
 			if(linked_destroy == null)
 				linked_destroy = D
 				D.linked_console = src
@@ -675,7 +676,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(linked_destroy)
 				dat += "<LI>Destructive Analyzer <A href='?src=\ref[src];disconnect=destroy'>(Disconnect)</A>"
 			else
-				if (id == 1) 
+				if (can_analyze == TRUE) 
 					dat += "<LI>(No Destructive Analyzer Linked)"
 			if(linked_lathe)
 				dat += "<LI>Protolathe <A href='?src=\ref[src];disconnect=lathe'>(Disconnect)</A>"
@@ -889,6 +890,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/core
 	name = "core fabricator console"
 	id = 1
+	can_analyze = TRUE
 
 #undef CHECK_LATHE
 #undef CHECK_IMPRINTER

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -95,7 +95,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	for(var/obj/machinery/r_n_d/D in range(4, src))
 		if(D.linked_console != null || D.panel_open)
 			continue
-		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer) && id == 1) // Prevents robotics R&D console from linking to a destructive analyzer
+		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer) && id == 1) // Only science R&D consoles can do research
 			if(linked_destroy == null)
 				linked_destroy = D
 				D.linked_console = src
@@ -675,7 +675,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(linked_destroy)
 				dat += "<LI>Destructive Analyzer <A href='?src=\ref[src];disconnect=destroy'>(Disconnect)</A>"
 			else
-				if (id == 1) dat += "<LI>(No Destructive Analyzer Linked)"
+				if (id == 1) 
+					dat += "<LI>(No Destructive Analyzer Linked)"
 			if(linked_lathe)
 				dat += "<LI>Protolathe <A href='?src=\ref[src];disconnect=lathe'>(Disconnect)</A>"
 			else

--- a/html/changelogs/mikomyazaki - robotics R&D destructive analyzer.yml
+++ b/html/changelogs/mikomyazaki - robotics R&D destructive analyzer.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Robotics R&D consoles can no longer link with destructive analyzers."
+


### PR DESCRIPTION
- Removes the ability for Robotics R&D consoles to connect to destructive analyzers.
- Removes destructive analyzers from the linking list for Robotics R&D consoles.

Purpose is to stop robotics from being able to subvert R&D's job.