### PR TITLE
[WIP] Adds fusion cycles for RUST

### DIFF
--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -18,7 +18,7 @@
 	var/field_strength = 1//0.01
 	var/initial_id_tag
 
-/obj/machinery/power/fusion_core/bluespace_confined
+/obj/machinery/power/fusion_core/bluespace_core
 	name = "\improper R-UST Mk. 9 Bluespace-Confined Tokamak core"
 	desc = "An enormous solenoid for generating extremely high power electromagnetic fields. This upgraded form utilizes a bubble of bluespace to assist with containment, enabling greater instability control at a power cost."
 	idle_power_usage = 1000

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -18,6 +18,13 @@
 	var/field_strength = 1//0.01
 	var/initial_id_tag
 
+/obj/machinery/power/fusion_core/bluespace_confined
+	name = "\improper R-UST Mk. 9 Bluespace-Confined Tokamak core"
+	desc = "An enormous solenoid for generating extremely high power electromagnetic fields. This upgraded form utilizes a bubble of bluespace to assist with containment, enabling greater instability control at a power cost."
+	idle_power_usage = 1000
+	active_power_usage = 2000
+	anchored = 0
+
 /obj/machinery/power/fusion_core/mapped
 	anchored = 1
 

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -19,6 +19,7 @@
 	var/field_strength = 0.01
 	var/tick_instability = 0
 	var/percent_unstable = 0
+	var/confinement_stability = 1 // adjustment to instability per tick due to core upgrades
 
 	var/obj/machinery/power/fusion_core/owned_core
 	var/list/reactants = list()
@@ -38,6 +39,12 @@
 
 	var/last_range
 	var/last_power
+
+/obj/effect/fusion_em_field/bluespace_confined
+	name = "bluespace-confined electromagnetic field"
+	desc = "A coruscating, barely visible field of energy. It is shaped like a slightly flattened torus, held within a bluespace confinement bottle for added stability."
+	confinement_stability = 0.9
+	// Add different lighting / effects for the bluespace part
 
 /obj/effect/fusion_em_field/New(loc, var/obj/machinery/power/fusion_core/new_owned_core)
 	..()
@@ -149,7 +156,7 @@
 
 /obj/effect/fusion_em_field/proc/check_instability()
 	if(tick_instability > 0)
-		percent_unstable += (tick_instability*size)/FUSION_INSTABILITY_DIVISOR
+		percent_unstable += (confinement_stability*tick_instability*size)/FUSION_INSTABILITY_DIVISOR
 		tick_instability = 0
 	else
 		if(percent_unstable < 0)

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -1,7 +1,7 @@
 #define FUSION_ENERGY_PER_K        20
 #define FUSION_INSTABILITY_DIVISOR 50000
 #define FUSION_RUPTURE_THRESHOLD   10000
-#define FUSION_REACTANT_CAP        10000
+#define FUSION_FIELD_CAP_COEFF	   200
 
 /obj/effect/fusion_em_field
 	name = "electromagnetic field"
@@ -20,7 +20,7 @@
 	var/tick_instability = 0
 	var/percent_unstable = 0
 	var/confinement_stability = 1 // adjustment to instability per tick due to core upgrades
-
+	var/fusion_reactant_cap = 0
 	var/obj/machinery/power/fusion_core/owned_core
 	var/list/reactants = list()
 	var/list/particle_catchers = list()
@@ -125,7 +125,7 @@
 		var/amount = reactants[reactant]
 		if(amount < 1)
 			reactants.Remove(reactant)
-		else if(amount >= FUSION_REACTANT_CAP)
+		else if(amount >= fusion_reactant_cap)
 			var/radiate = rand(3 * amount / 4, amount / 4)
 			reactants[reactant] -= radiate
 			radiation += radiate
@@ -237,6 +237,7 @@
 		calc_size = 13
 	field_strength = new_strength
 	change_size(calc_size)
+	fusion_reactant_cap = field_strength * FUSION_FIELD_CAP_COEFF // Excess reactants will be ejected over the next few calls to Process()
 
 /obj/effect/fusion_em_field/proc/AddEnergy(var/a_energy, var/a_plasma_temperature)
 	energy += a_energy
@@ -403,8 +404,10 @@
 					if(max_num_reactants < 1)
 						continue
 
-				//randomly determined amount to react
-				var/amount_reacting = rand(1, max_num_reactants)
+				// //randomly determined amount to react
+				//var/amount_reacting = rand(1, max_num_reactants)
+				// Removed the random reactants amount, to be possibly replaced by an amount_reacting dependent on properties of the reactor environment
+				var/amount_reacting = max_num_reactants
 
 				//removing the reacting substances from the list of substances that are primed to react this cycle
 				//if there aren't enough of that substance (there should be) then modify the reactant amounts accordingly
@@ -471,4 +474,4 @@
 #undef FUSION_HEAT_CAP
 #undef FUSION_INSTABILITY_DIVISOR
 #undef FUSION_RUPTURE_THRESHOLD
-#undef FUSION_REACTANT_CAP
+#undef FUSION_FIELD_CAP_COEFF

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -1,7 +1,7 @@
 #define FUSION_ENERGY_PER_K        20
 #define FUSION_INSTABILITY_DIVISOR 50000
 #define FUSION_RUPTURE_THRESHOLD   10000
-#define FUSION_FIELD_CAP_COEFF	   200
+#define FUSION_FIELD_CAP_COEFF	   5000
 
 /obj/effect/fusion_em_field
 	name = "electromagnetic field"
@@ -97,8 +97,8 @@
 	// Take some gas up from our environment.
 	var/added_particles = FALSE
 	var/datum/gas_mixture/uptake_gas = owned_core.loc.return_air()
-	if(uptake_gas)
-		uptake_gas = uptake_gas.remove_by_flag(XGM_GAS_FUSION_FUEL, rand(50,100))
+	//if(uptake_gas)
+	//	uptake_gas = uptake_gas.remove_by_flag(XGM_GAS_FUSION_FUEL, rand(50,100))
 	if(uptake_gas && uptake_gas.total_moles)
 		for(var/gasname in uptake_gas.gas)
 			if(uptake_gas.gas[gasname]*10 > reactants[gasname])

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -84,7 +84,7 @@
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
 	req_components = list(
 		/obj/item/weapon/stock_parts/manipulator/nano = 2,
-		/obj/item/weapon/gun/energy/gun/nuclear = 1
+		/obj/item/weapon/gun/energy/gun/nuclear = 1,
 		/obj/item/stack/cable_coil = 5
 		)
 
@@ -95,7 +95,7 @@
 	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
 	req_components = list(
 		/obj/item/weapon/stock_parts/manipulator/pico = 2,
-		/obj/item/weapon/gun/energy/gun/nuclear = 1
+		/obj/item/weapon/gun/energy/gun/nuclear = 1,
 		/obj/item/stack/cable_coil = 5
 		// some advanced fusion product material
 		)
@@ -107,7 +107,7 @@
 	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
 	req_components = list(
 		/obj/item/weapon/stock_parts/manipulator/pico = 2,
-		/obj/item/weapon/gun/energy/gun/nuclear = 1
+		/obj/item/weapon/gun/energy/gun/nuclear = 1,
 		/obj/item/stack/cable_coil = 5
 		// some advanced fusion product material
 		)

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -50,6 +50,20 @@
 							/obj/item/stack/cable_coil = 5
 							)
 
+/datum/design/circuit/fusion/core/bluespace_confinement
+	name = "internal circuitry (bluespace-confined fusion core)"
+	build_path = /obj/machinery/power/fusion_core/bluespace_confinement
+	board_type = "machine"
+	origin_tech = list(TECH_BLUESPACE = 4, TECH_MAGNET = 5, TECH_POWER = 5)
+	req_components = list(
+							/obj/item/weapon/stock_parts/manipulator/pico = 2,
+							/obj/item/weapon/stock_parts/micro_laser/ultra = 1,
+							/obj/item/weapon/stock_parts/subspace/crystal = 1,
+							/obj/item/weapon/stock_parts/console_screen = 1,
+							/obj/item/stack/cable_coil = 5
+							// some advanced fusion product material
+							)
+
 /obj/item/weapon/circuitboard/fusion_injector
 	name = "internal circuitry (fusion fuel injector)"
 	build_path = /obj/machinery/fusion_fuel_injector
@@ -62,6 +76,41 @@
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/stack/cable_coil = 5
 							)
+
+/obj/item/weapon/circuitboard/gyrotron
+	name = "internal circuitry (gyrotron)"
+	build_path = /obj/machinery/power/emitter/gyrotron
+	board_type = "machine"
+	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
+	req_components = list(
+		/obj/item/weapon/stock_parts/manipulator/nano = 2,
+		/obj/item/weapon/gun/energy/gun/nuclear = 1
+		/obj/item/stack/cable_coil = 5
+		)
+
+/obj/item/weapon/circuitboard/efficient_gyrotron
+	name = "internal circuitry (efficient gyrotron)"
+	build_path = /obj/machinery/power/emitter/gyrotron/efficient
+	board_type = "machine"
+	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
+	req_components = list(
+		/obj/item/weapon/stock_parts/manipulator/pico = 2,
+		/obj/item/weapon/gun/energy/gun/nuclear = 1
+		/obj/item/stack/cable_coil = 5
+		// some advanced fusion product material
+		)
+
+/obj/item/weapon/circuitboard/overclocked_gyrotron/
+	name = "internal circuitry (overclocked gyrotron)"
+	build_path = /obj/machinery/power/emitter/gyrotron/overclocked
+	board_type = "machine"
+	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
+	req_components = list(
+		/obj/item/weapon/stock_parts/manipulator/pico = 2,
+		/obj/item/weapon/gun/energy/gun/nuclear = 1
+		/obj/item/stack/cable_coil = 5
+		// some advanced fusion product material
+		)
 
 /datum/design/circuit/fusion
 	name = "fusion core control console"
@@ -94,15 +143,42 @@
 	build_path = /obj/item/weapon/circuitboard/fusion_core
 	sort_string = "LAAAH"
 
+/datum/design/circuit/fusion/core/bluespace_confinement
+	name = "bluespace-confinement fusion core"
+	id = "fusion_core"
+	build_path = /obj/item/weapon/circuitboard/fusion_core/bluespace_confinement
+	sort_string = "LAAAI"
+
 /datum/design/circuit/fusion/injector
 	name = "fusion fuel injector"
 	id = "fusion_injector"
 	build_path = /obj/item/weapon/circuitboard/fusion_injector
-	sort_string = "LAAAI"
+	sort_string = "LAAAJ"
 
 /datum/design/circuit/fusion/kinetic_harvester
 	name = "fusion toroid kinetic harvester"
 	id = "fusion_kinetic_harvester"
 	build_path = /obj/item/weapon/circuitboard/kinetic_harvester
-	sort_string = "LAAAJ"
+	sort_string = "LAAAK"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
+
+/datum/design/circuit/fusion/gyrotron
+	name = "gyrotron"
+	id = "fusion_gyrotron"
+	build_path = /obj/item/weapon/circuitboard/gyrotron
+	sort_string = "LAAAL"
+	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
+
+/datum/design/circuit/fusion/efficient_gyrotron
+	name = "efficient gyrotron"
+	id = "fusion_efficient_gyrotron"
+	build_path = /obj/item/weapon/circuitboard/efficient_gyrotron
+	sort_string = "LAAAM"
+	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MATERIAL = 5)
+
+/datum/design/circuit/fusion/overclocked_gyrotron
+	name = "overclocked gyrotron"
+	id = "fusion_overclocked_gyrotron"
+	build_path = /obj/item/weapon/circuitboard/overclocked_gyrotron
+	sort_string = "LAAAN"
+	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MATERIAL = 5)

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -50,9 +50,9 @@
 							/obj/item/stack/cable_coil = 5
 							)
 
-/datum/design/circuit/fusion/core/bluespace_confinement
+/obj/item/weapon/circuitboard/bluespace_core
 	name = "internal circuitry (bluespace-confined fusion core)"
-	build_path = /obj/machinery/power/fusion_core/bluespace_confinement
+	build_path = /obj/machinery/power/fusion_core/bluespace_core
 	board_type = "machine"
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MAGNET = 5, TECH_POWER = 5)
 	req_components = list(
@@ -143,10 +143,10 @@
 	build_path = /obj/item/weapon/circuitboard/fusion_core
 	sort_string = "LAAAH"
 
-/datum/design/circuit/fusion/core/bluespace_confinement
+/datum/design/circuit/fusion/core/bluespace_core
 	name = "bluespace-confinement fusion core"
 	id = "fusion_core"
-	build_path = /obj/item/weapon/circuitboard/fusion_core/bluespace_confinement
+	build_path = /obj/item/weapon/circuitboard/bluespace_core
 	sort_string = "LAAAI"
 
 /datum/design/circuit/fusion/injector

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -51,7 +51,7 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	energy_consumption = 1
 	energy_production = 2
 	products = list("deuterium" = 2)
-	priority = 10
+	priority = 7
 	radiation = 5
 
 /decl/fusion_reaction/deuterium_hydrogen
@@ -60,7 +60,7 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	energy_consumption = 1
 	energy_production = 2
 	products = list("tritium" = 2)
-	priority = 0
+	priority = 8
 	radiation = 5
 
 /decl/fusion_reaction/tritium_tritium
@@ -71,8 +71,9 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	products = list("hydrogen" = 2, "helium" = 1)
 	instability = 0.5
 	radiation = 3
+	priority = 9
 
-/decl/fusion_reaction/helium_hyrdogen
+/decl/fusion_reaction/helium_hydrogen
 	p_react = "helium"
 	s_react = "hydrogen"
 	energy_consumption = 1
@@ -80,6 +81,7 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	products = list("lithium" = 1)
 	instability = 0.5
 	radiation = 3
+	priority = 10
 
 /decl/fusion_reaction/deuterium_lithium
 	p_react = "deuterium"
@@ -89,6 +91,7 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	radiation = 3
 	products = list("tritium"= 2)
 	instability = 1
+	priority = 11
 
 // Phoron-based Heavy Elements Synthesis
 

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -90,6 +90,10 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	products = list("tritium"= 2)
 	instability = 1
 
+// Phoron-based Heavy Elements Synthesis
+
+
+
 // Unideal/material production reactions
 /decl/fusion_reaction/oxygen_oxygen
 	p_react = "oxygen"

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -44,37 +44,40 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 //  lithium
 //  boron
 
-// Basic power production reactions.
-// This is not necessarily realistic, but it makes a basic failure more spectacular.
+// Power Production Cycle -- Loosely based on the Proton-Proton chain.
 /decl/fusion_reaction/hydrogen_hydrogen
 	p_react = "hydrogen"
 	s_react = "hydrogen"
 	energy_consumption = 1
 	energy_production = 2
-	products = list("helium" = 1)
+	products = list("deuterium" = 2)
 	priority = 10
+	radiation = 5
 
-/decl/fusion_reaction/deuterium_deuterium
+/decl/fusion_reaction/deuterium_hydrogen
 	p_react = "deuterium"
-	s_react = "deuterium"
+	s_react = "hydrogen"
 	energy_consumption = 1
 	energy_production = 2
+	products = list("tritium" = 2)
 	priority = 0
+	radiation = 5
 
-// Advanced production reactions (todo)
-/decl/fusion_reaction/deuterium_helium
-	p_react = "deuterium"
-	s_react = "helium"
-	energy_consumption = 1
-	energy_production = 5
-	radiation = 2
-
-/decl/fusion_reaction/deuterium_tritium
-	p_react = "deuterium"
+/decl/fusion_reaction/tritium_tritium
+	p_react = "tritium"
 	s_react = "tritium"
 	energy_consumption = 1
 	energy_production = 1
-	products = list("helium" = 1)
+	products = list("hydrogen" = 2, "helium" = 1)
+	instability = 0.5
+	radiation = 3
+
+/decl/fusion_reaction/helium_hyrdogen
+	p_react = "helium"
+	s_react = "hydrogen"
+	energy_consumption = 1
+	energy_production = 1
+	products = list("lithium" = 1)
 	instability = 0.5
 	radiation = 3
 
@@ -84,7 +87,7 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 	energy_consumption = 2
 	energy_production = 0
 	radiation = 3
-	products = list("tritium"= 1)
+	products = list("tritium"= 2)
 	instability = 1
 
 // Unideal/material production reactions

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -12,7 +12,21 @@
 	var/initial_id_tag
 	var/rate = 3
 	var/mega_energy = 1
+	var/min_power = 1
+	var/max_power = 50
+	var/power_consumption = 1500
 
+/obj/machinery/power/emitter/gyrotron/efficient
+	name = "high-efficiency gyrotron"
+	desc = "It is a more efficient heavy duty industrial gyrotron suited for powering fusion reactors."
+	power_consumption = 1000
+	max_power = 40
+
+/obj/machinery/power/emitter/gyrotron/overclocked
+	name = "overclocked gyrotron"
+	desc = "It is a more powerful heavy duty industrial gyrotron suited for powering fusion reactors."
+	max_power = 75
+	power_consumption = 1750
 
 /obj/machinery/power/emitter/gyrotron/anchored
 	anchored = 1

--- a/html/changelogs/myazaki - RUST fusion cycles.yml
+++ b/html/changelogs/myazaki - RUST fusion cycles.yml
@@ -34,3 +34,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - wip: "Changes RUST fusion power chain to a partially self-sustaining cycle."
+  - rscadd: "Adds upgraded forms of the gyrotron and fusion core."
+  - bugfix: "Fixes an issue where the RUST wouldn't follow its priority reaction as expected."
+  - bugfix: "Fixes an issue where the RUST wouldn't absorb reactants beyond a set value, instead changing it to be dependent upon field size."

--- a/html/changelogs/myazaki - RUST fusion cycles.yml
+++ b/html/changelogs/myazaki - RUST fusion cycles.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - wip: "Changes RUST fusion power chain to a partially self-sustaining cycle."


### PR DESCRIPTION
#### Work In Progress

##### Adding two+ fusion cycles for RUST.

- One that is loosely mirroring the Proton-Proton chain (if your mirror is very far away and very dirty), and becomes somewhat self-sustaining when you have started it up and heated up the fusion reactor. Should only require hydrogen input to keep going. Needs adjustment... but this is the basic idea.

![pp fusion cycle](https://user-images.githubusercontent.com/47489928/53955512-19667b80-40d1-11e9-98b6-eb5a8bbe5c43.png)

- A completely unrealistic Phoron Synthesis Cycle for creating heavy elements (silver, gold, etc.) at a significant cost in phoron and power.

- Maybe something with supermatter.

##### To Do

- Work out power, radiation, instability values.
- Add Phoron Synthesis Cycle.
- Add randomised products on server startup so the Phoron cycle requires experimentation.
- Upgrades for the RUST?
- Edit the RUST map a bit, add breaker switches instead of having to wire it up.
- Maybe make RUST self-destruct less, or make it break in a more easily repairable way, to make expermenting less annoying.