### PR TITLE
Adjusts geiger counter sound range and falloff to be larger

### DIFF
--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -23,7 +23,7 @@
 
 /obj/item/device/geiger/proc/update_sound(var/playing)
 	if(playing && !sound_token)
-		sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, "sound/items/geiger.ogg", volume = geiger_volume, range = 3, falloff = 1, prefer_mute = TRUE)
+		sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, "sound/items/geiger.ogg", volume = geiger_volume, range = 4, falloff = 3, prefer_mute = TRUE)
 	else if(!playing && sound_token)
 		QDEL_NULL(sound_token)
 

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -75,15 +75,15 @@
 			sound_token.SetVolume(geiger_volume)
 		if(RAD_LEVEL_MODERATE + 0.1 to RAD_LEVEL_HIGH)
 			icon_state = "geiger_on_3"
-			geiger_volume = 33
+			geiger_volume = 25
 			sound_token.SetVolume(geiger_volume)
 		if(RAD_LEVEL_HIGH + 1 to RAD_LEVEL_VERY_HIGH)
 			icon_state = "geiger_on_4"
-			geiger_volume = 66
+			geiger_volume = 40
 			sound_token.SetVolume(geiger_volume)
 		if(RAD_LEVEL_VERY_HIGH + 1 to INFINITY)
 			icon_state = "geiger_on_5"
-			geiger_volume = 100
+			geiger_volume = 60
 			sound_token.SetVolume(geiger_volume)
 
 

--- a/html/changelogs/myazaki - geiger sound range.yml
+++ b/html/changelogs/myazaki - geiger sound range.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Made the Geiger Counter sound falloff and range larger."


### PR DESCRIPTION
Adjusts Geiger counter sound range/falloff to be larger in response to feedback.

Apparently people like to drop them in spots and be able to hear them. The previous settings were with people with the geiger counter in their pockets/hands/backpack in mind.