### PR TITLE
Increased max rated power on multiple atmos devices

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -99,4 +99,4 @@
 #define ATMOSTANK_NITROUSOXIDE  10000 // N2O doesn't have a real useful use, i guess it's on station just to allow refilling of sec's riot control canisters?
 
 #define MAX_PUMP_PRESSURE		15000	// Maximal pressure setting for pumps and vents
-#define MAX_OMNI_PRESSURE		7500	// Maximal output(s) pressure for omni devices (filters/mixers)
+#define MAX_OMNI_PRESSURE		15000	// Maximal output(s) pressure for omni devices (filters/mixers)

--- a/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
@@ -22,7 +22,7 @@
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			// 30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER //connects to regular, supply and scrubbers pipes
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -26,7 +26,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			// 30000 W ~ 40 HP
 
 	var/max_pressure_setting = MAX_PUMP_PRESSURE
 

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -6,7 +6,8 @@
 	name = "high power gas pump"
 	desc = "A pump. Has double the power rating of the standard gas pump."
 
-	power_rating = 15000	//15000 W ~ 20 HP
+	idle_power_usage = 450	// oversized pumps means oversized idle use
+	power_rating = 45000	// 45000 W ~ 60 HP
 
 /obj/machinery/atmospherics/binary/pump/high_power/on
 	use_power = POWER_USE_IDLE

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -11,7 +11,7 @@
 	var/max_output_pressure = MAX_OMNI_PRESSURE
 
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 15000			// 15000 W ~ 20 HP
 
 	var/max_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -6,7 +6,7 @@
 	icon_state = "map_mixer"
 
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 3700			//3700 W ~ 5 HP
+	power_rating = 15000			// 15000 W ~ 20 HP
 
 	var/list/inputs = new()
 	var/datum/omni_port/output

--- a/code/modules/atmospherics/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/components/trinary_devices/filter.dm
@@ -8,7 +8,7 @@
 
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500	//This also doubles as a measure of how powerful the filter is, in Watts. 7500 W ~ 10 HP
+	power_rating = 15000	//This also doubles as a measure of how powerful the filter is, in Watts. 15000 W ~ 20 HP
 
 	var/temp = null // -- TLE
 

--- a/code/modules/atmospherics/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/components/trinary_devices/mixer.dm
@@ -8,7 +8,7 @@
 
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 3700	//This also doubles as a measure of how powerful the mixer is, in Watts. 3700 W ~ 5 HP
+	power_rating = 15000	//This also doubles as a measure of how powerful the mixer is, in Watts. 15000 W ~ 20 HP
 
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_MIXER
 	var/list/mixing_inputs

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -7,11 +7,11 @@
 	icon_state = "map_injector"
 
 	name = "air injector"
-	desc = "Passively injects air into its surroundings. Has a valve attached to it that can control flow rate."
+	desc = "Injects air into its surroundings using a passive or injection mode. Passive mode will only inject when internal pressure is greater."
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 15000	//15000 W ~ 20 HP
+	power_rating = 45000	//45000 W ~ 60 HP
 
 	var/injecting = 0
 

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -15,7 +15,7 @@
 	desc = "Has a valve and pump attached to it."
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			// 30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY //connects to regular and supply pipes
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -6,7 +6,7 @@
 	desc = "Has a valve and pump attached to it."
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			// 30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER //connects to regular and scrubber pipes
 


### PR DESCRIPTION
Unlike the previous atmos PR which changed pump efficiency, this one just increases the max rated power on many atmospheric devices, as well as the max pressure on filters.

Will conflict with https://github.com/Baystation12/Baystation12/pull/24248 . This is meant to be something to help with issues now rather than later.

All atmospheric devices have three limiters:
- volume
- pressure
- power rating

Volume is the maximum amount of air displacement that can be moved per tick. You often see it as 200 litres a second on pumps.

Pressure is obvious: if the output is above the pressure limit, it will not operate.

Power rating: this one takes a little explaining. When a gas goes from high pressure to low pressure, it costs no power. It takes power, however, to move gas from low to high. The greater this difference, the greater the power consumption. Eventually, the pump hits its power rating, which caps the amount of gas it can move per tick.

This PR significantly increases the power rating on pretty much all atmos devices. Some are only a couple times, others 5+ times higher.

As a result, a few things happen. Here are the implications:

- Airlocks cycle a little faster. No, they won't cycle several times faster, because an issue is scavenging gas at low pressures unrelated to pump power.
- Atmospherics works a few times faster. The bottlenecks here are the air injectors, and the low air pressure max that was on filters. Now, filters max are 15000kpa. Air injectors maximum power was only dialed up a little bit, their main issue was that filters weren't supplying a high pressure. 
- Note: filters are not as strong as pumps; they can move a lot of gas but they do not do well at pumping pressures. If dealing with pumping low to high pressure, installing pumps on the inlets and/or outlets will dramatically increase efficiency.
- Atmospherics takes CONSIDERABLE power to operate now. I've seen it hit half a million watts (SMES output limit for atmos) when filtering a lot of different gasses and things maxed out. If ship is in a power emergency, atmos should be depowered or it won't take long to drain the ship under stress. Adding a lot of high power pumps will only further increase this consumption. NOTE: if there is a widespread ship atmospheric emergency, turning off atmos could make things WORSE. See next bullet point.
- Shipwide vents and scrubbers also take considerably more power (4x). An **extreme** atmos emergency will stress the powergrid to power outage, but it's unlikely to occur in normal circumstances. We're talking widespread toxins everywhere kind of emergency and significant backup in the waste system (thus requiring max power per scrubber to scrub).

The following was a test with running around with a custom CO2 canister containing hundreds of thousands of moles of CO2 (trust me, that's about half of the torch being filled with pure CO2), and filling 75% of the torch areas with air alarms, WHILE the waste system was backed up to 6000 kpa, AND pumping pure CO2 into distribution. I repeat, this is *extreme*, but demonstrates how much power running the ship atmospheric system will consume in very poor conditions.
![image](https://user-images.githubusercontent.com/521038/54053704-24dfa280-41b6-11e9-8172-e9015f7d7695.png)

Just purging the waste line would considerably drop the power usage, and all that takes is turning up the injectors and waste to filter pump to max, a basic level of atmos understanding.

Here it is after renabling pumps after 10 minutes:

![image](https://user-images.githubusercontent.com/521038/54054358-f4990380-41b7-11e9-84eb-2069059c3395.png)

Dumping waste to space is a recommended option if there's a widespread power emergency looming and widespread atmos contamination on the ship.

- Scrubbing peak efficiency is considerably increased. Does not affect normal balance operation, at least not in my tests by spawning a few dozen monkies everywhere.
- Does NOT cause the shuttles to drain power any faster when cycling. It just causes a higher power spike for a shorter period of time, and it all balances out.

🆑 
tweak: Atmos pumps have all had their power limits increased considerably. This means atmospherics will operate faster, but at the cost of much more power at peak performance. In addition, vents and scrubbers will operate faster when stressed, but they too will cause a tremendous power spike in a ship wide atmos contamination emergency where a huge number of scrubbers have to work hard (from a badly clogged waste line, for example). A flooded deck can also overload a deck substation, so bypass switching may be required in such cases. Beware of extreme scrubber overload!
tweak: Filter pressure limits raised to 15,000 kpa. They are still not powerful devices when pumping from low to high pressures. You should put pumps around them if you intend them to work quickly with moving pressures in a non-passive manner.
/:cl: