### PR TITLE
Fixes inconsistency with dmm reader parsing.

### DIFF
--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -488,8 +488,11 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 		if(!length(trim_left))
 			continue
 		var/left = readlistitem(trim_left)
-		if(!left && equal_position && trim_left != "null")
-			left = trim_left // This is dm behavior: unindentifiable keys in associative lists are parsed as literal strings.
+		if(equal_position)
+			if(!left && trim_left != "null")
+				left = trim_left // This is dm behavior: unindentifiable keys in associative lists are parsed as literal strings.
+			if(left == 1.#INF || left == -1.#INF)
+				left = trim_left // This is not valid as a list index; we could let it runtime, but if associative it should be parsed as "inf" or "-inf" instead.
 		to_return.len++
 		to_return[list_index++] = left
 

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -447,7 +447,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 		. = copytext(text,2,findtext(text,"\"",3,0))
 
 	//Check for number
-	else if(isnum(text2num(text)))
+	else if(isnum(text2num(text)) && text == "[text2num(text)]") //text2num will parse truthy false positives; this demands that the only numbers parsed as such are properly formatted ones.
 		. = text2num(text)
 
 	//Check for null


### PR DESCRIPTION
While it's true that dm parses otherwise unidentifiable input in keys to associative lists as literal strings (for unholy reasons, I'm sure), it does parse identifiable input as written (i.e. lists, properly formatted strings like "text", paths), not as string literals. This makes the map reader respect that as well.

As an example: this makes it parse "list("hello" = "foo")" as `list("hello" = "foo")` instead of `list("\"hello\"" = "foo")`, and similar anomalies. It also makes it no longer incorrectly parse lists without associations containing strings: prior behavior would strip the quotes in "list("foo")" and then attempt to parse the entry, which was deemed invalid, giving `list(null)`.