### PR TITLE
Removes giant spiders from random exoplanet fauna spawn

### DIFF
--- a/code/modules/overmap/exoplanets/grass.dm
+++ b/code/modules/overmap/exoplanets/grass.dm
@@ -81,12 +81,6 @@
 	grass_color = pick(colors)
 	..()
 
-/datum/random_map/noise/exoplanet/grass/spawn_fauna(var/turf/T, value)
-	if(prob(5))
-		new/mob/living/simple_animal/hostile/giant_spider/nurse(T)
-	else
-		..()
-
 /datum/random_map/noise/exoplanet/grass/get_additional_spawns(var/value, var/turf/T)
 	..()
 	if(istype(T,/turf/simulated/floor/exoplanet/grass))

--- a/code/modules/overmap/exoplanets/shrouded.dm
+++ b/code/modules/overmap/exoplanets/shrouded.dm
@@ -39,7 +39,7 @@
 	water_level_min = 2
 	land_type = /turf/simulated/floor/exoplanet/shrouded
 	water_type = /turf/simulated/floor/exoplanet/water/shallow/tar
-	fauna_types = list(/mob/living/simple_animal/hostile/retaliate/royalcrab, /mob/living/simple_animal/hostile/retaliate/jelly/alt, /mob/living/simple_animal/hostile/retaliate/beast/shantak/alt, /mob/living/simple_animal/hostile/giant_spider/hunter)
+	fauna_types = list(/mob/living/simple_animal/hostile/retaliate/royalcrab, /mob/living/simple_animal/hostile/retaliate/jelly/alt, /mob/living/simple_animal/hostile/retaliate/beast/shantak/alt)
 	plantcolors = list("#3c5434", "#2f6655", "#0e703f", "#495139", "#394c66", "#1a3b77", "#3e3166", "#52457c", "#402d56", "#580d6d")
 
 /area/exoplanet/shrouded


### PR DESCRIPTION
They're too much of a show-stopper and force missions to go back to Torch after a single encounter.
