### PR TITLE
Flight manifest adjustments

### DIFF
--- a/code/modules/modular_computers/file_system/reports/people.dm
+++ b/code/modules/modular_computers/file_system/reports/people.dm
@@ -51,9 +51,12 @@
 	var/list/full_manifest = flat_nano_crew_manifest()
 	var/list/formatted_manifest = list()
 	for(var/entry in full_manifest)
-		formatted_manifest[format_output(entry["name"], entry["rank"], entry["milrank"])] = entry
-	var/input = input(user, "[display_name()]:", "Form Input", get_value()) as null|anything in formatted_manifest
-	set_value(formatted_manifest[input])
+		formatted_manifest[format_output(entry["name"], entry["rank"])] = entry
+	if (!length(formatted_manifest))
+		alert(user, "There are no candidates to add from manifest.") // in case someone somehow deletes the entire crew record database.
+	else
+		var/input = input(user, "[display_name()]:", "Form Input", get_value()) as null|anything in formatted_manifest
+		set_value(formatted_manifest[input])
 
 /datum/report_field/people/from_manifest/perform_send(subject, body, attach_report)
 	var/login = find_email(value["name"])
@@ -98,14 +101,20 @@
 			var/list/full_manifest = flat_nano_crew_manifest()
 			for(var/entry in full_manifest)
 				if(!in_as_list(entry, value)) //Only look at those not already selected.
-					formatted_manifest[format_output(entry["name"], entry["rank"], entry["milrank"])] = entry
-			var/input = input(user, "Add to [display_name()]:", "Form Input", null) as null|anything in formatted_manifest
-			set_value(value + list(formatted_manifest[input]))
+					formatted_manifest[format_output(entry["name"], entry["rank"])] = entry
+			if (!length(formatted_manifest))
+				alert(user, "There are no remaining candidates to add from manifest.")
+			else
+				var/input = input(user, "Add to [display_name()]:", "Form Input", null) as null|anything in formatted_manifest
+				set_value(value + list(formatted_manifest[input]))
 		if("Remove")
 			for(var/entry in value)
-				formatted_manifest[format_output(entry["name"], entry["rank"], entry["milrank"])] = entry
-			var/input = input(user, "Remove from [display_name()]:", "Form Input", null) as null|anything in formatted_manifest
-			set_value(value - list(formatted_manifest[input]))
+				formatted_manifest[format_output(entry["name"], entry["rank"])] = entry
+			if (!length(formatted_manifest))
+				alert(user, "There are no remaining candidates to remove from manifest.")
+			else
+				var/input = input(user, "Remove from [display_name()]:", "Form Input", null) as null|anything in formatted_manifest
+				set_value(value - list(formatted_manifest[input]))
 
 //Batch-emails the list.
 /datum/report_field/people/list_from_manifest/perform_send(subject, body, attach_report)


### PR DESCRIPTION
Credit to @SierraKomodo for her *significant* help with this (vscode collab is a neat feature!)

This adjusts flight manifests in deck management so that it no longer shows the rank in the input dialog (the report will still have the rank). This means, as it is an input box, that you can very quickly find the names of personnel by just repeatedly tapping the letter of their first name on your keyboard. Others might also find this easier with eyeballing.

Also displays a notice if there's no eligible candidates left in the manifest to add instead of silently failing.

:cl: SierraKomodo & Anticept
tweak: Flight manifest input box no longer shows the rank to make it easier to find personel in the list. The report itself will show the rank.
/:cl: