### PR TITLE
Nerf unathi brute mod and regen

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -1,24 +1,26 @@
 /obj/aura/regenerating
 	name = "regenerating aura"
-	var/brute_mult = 1
-	var/fire_mult = 1
-	var/tox_mult = 1
+	var/brute_per_tick = 1 //how much is natively healed per tick
+	var/fire_per_tick = 1
+	var/tox_per_tick = 1
 
 /obj/aura/regenerating/life_tick()
-	user.adjustBruteLoss(-brute_mult)
-	user.adjustFireLoss(-fire_mult)
-	user.adjustToxLoss(-tox_mult)
+	user.adjustBruteLoss(-brute_per_tick)
+	user.adjustFireLoss(-fire_per_tick)
+	user.adjustToxLoss(-tox_per_tick)
 
 /obj/aura/regenerating/human
-	var/nutrition_damage_mult = 1 //How much nutrition it takes to heal regular damage
-	var/external_nutrition_mult = 50 // How much nutrition it takes to regrow a limb
-	var/organ_mult = 2
 	var/regen_message = "<span class='warning'>Your body throbs as you feel your ORGAN regenerate.</span>"
-	var/grow_chance = 0
-	var/grow_threshold = 0
-	var/ignore_tag//organ tag to ignore
+	var/heal_cost = 2 //How much nutrition it takes to heal regular damage
+	var/nutrition_required_to_regenerate = 150 //nutrition must be over this to do the serious regen stuff
 	var/last_nutrition_warning = 0
 
+	var/grow_chance = 0 //each tick, this is rolled to determine if a limb regrow should be attempted
+	var/grow_cost = 50 // How much nutrition it takes to regrow a limb
+
+	var/organ_chance = 2 //each tick, this is rolled to determine if an organ heal should be attempted
+	var/organ_heal = 2 //how much organs can be healed by
+	var/organ_heal_cost = 5 //how much nutrition it takes to heal an organ
 
 /obj/aura/regenerating/human/proc/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	return
@@ -30,39 +32,39 @@
 		return 0
 	if(!H.innate_heal || H.InStasis() || H.stat == DEAD)
 		return 0
-	if(H.nutrition < nutrition_damage_mult)
+	if(H.nutrition < heal_cost)
 		low_nut_warning()
 		return 0
 
-	if(brute_mult && H.getBruteLoss())
-		H.adjustBruteLoss(-brute_mult * config.organ_regeneration_multiplier)
-		H.nutrition -= nutrition_damage_mult
-	if(fire_mult && H.getFireLoss())
-		H.adjustFireLoss(-fire_mult * config.organ_regeneration_multiplier)
-		H.nutrition -= nutrition_damage_mult
-	if(tox_mult && H.getToxLoss())
-		H.adjustToxLoss(-tox_mult * config.organ_regeneration_multiplier)
-		H.nutrition -= nutrition_damage_mult
+	if(brute_per_tick && H.getBruteLoss())
+		H.adjustBruteLoss(-brute_per_tick * config.organ_regeneration_multiplier)
+		H.nutrition -= heal_cost
+	if(fire_per_tick && H.getFireLoss())
+		H.adjustFireLoss(-fire_per_tick * config.organ_regeneration_multiplier)
+		H.nutrition -= heal_cost
+	if(tox_per_tick && H.getToxLoss())
+		H.adjustToxLoss(-tox_per_tick * config.organ_regeneration_multiplier)
+		H.nutrition -= heal_cost
 
-	if(organ_mult)
-		if(prob(10) && H.nutrition >= 150 && !H.getBruteLoss() && !H.getFireLoss())
-			var/obj/item/organ/external/head/D = H.organs_by_name["head"]
-			if (D.status & ORGAN_DISFIGURED)
-				if (H.nutrition >= 20)
-					D.status &= ~ORGAN_DISFIGURED
-					H.nutrition -= 20
-				else
-					low_nut_warning("head")
+	if(prob(organ_chance) && H.nutrition >= nutrition_required_to_regenerate && !H.getBruteLoss() && !H.getFireLoss())
+		var/obj/item/organ/external/head/D = H.organs_by_name["head"]
+		if (D.status & ORGAN_DISFIGURED)
+			if (H.nutrition > organ_heal_cost)
+				D.status &= ~ORGAN_DISFIGURED
+				H.nutrition -= organ_heal_cost
+			else
+				low_nut_warning("head")
 
+	if(prob(organ_chance))
 		for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
 			var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
 			if(BP_IS_ROBOTIC(regen_organ))
 				continue
 			if(istype(regen_organ))
 				if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
-					if (H.nutrition >= organ_mult)
-						regen_organ.damage = max(regen_organ.damage - organ_mult, 0)
-						H.nutrition -= organ_mult
+					if (H.nutrition > organ_heal_cost)
+						regen_organ.damage = max(regen_organ.damage - organ_heal, 0)
+						H.nutrition -= organ_heal_cost
 						if(prob(5))
 							to_chat(H, replacetext(regen_message,"ORGAN", regen_organ.name))
 					else
@@ -72,7 +74,7 @@
 		for(var/limb_type in H.species.has_limbs)
 			var/obj/item/organ/external/E = H.organs_by_name[limb_type]
 			if(E && E.organ_tag != BP_HEAD && !E.vital && !E.is_usable())	//Skips heads and vital bits...
-				if (H.nutrition > grow_threshold)
+				if (H.nutrition > nutrition_required_to_regenerate)
 					E.removed()			//...because no one wants their head to explode to make way for a new one.
 					qdel(E)
 					E= null
@@ -86,7 +88,7 @@
 				organ_data["descriptor"] = O.name
 				H.update_body()
 				return
-			else if (H.nutrition > grow_threshold) //We don't subtract any nut here, but let's still only heal wounds when we have nut.
+			else if (H.nutrition > nutrition_required_to_regenerate) //We don't subtract any nut here, but let's still only heal wounds when we have nut.
 				for(var/datum/wound/W in E.wounds)
 					if(W.wound_damage() == 0 && prob(50))
 						E.wounds -= W
@@ -101,38 +103,38 @@
 
 
 /obj/aura/regenerating/human/unathi
-	brute_mult = 2
-	organ_mult = 4
+	brute_per_tick = 0
+	fire_per_tick = 0
+	organ_chance = 4
 	regen_message = "<span class='warning'>You feel a soothing sensation as your ORGAN mends...</span>"
 	grow_chance = 2
-	grow_threshold = 150
-	ignore_tag = BP_HEAD
+	nutrition_required_to_regenerate = 250
+	grow_cost = 150
 
 /obj/aura/regenerating/human/unathi/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	to_chat(H, "<span class='danger'>With a shower of fresh blood, a new [O.name] forms.</span>")
 	H.visible_message("<span class='danger'>With a shower of fresh blood, a length of biomass shoots from [H]'s [O.amputation_point], forming a new [O.name]!</span>")
-	H.nutrition -= external_nutrition_mult
+	H.nutrition -= grow_cost
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in H.vessel.reagent_list
 	blood_splatter(H,B,1)
 	O.set_dna(H.dna)
-
+	O.stun_act(4, 100)
+	O.add_pain(O.max_damage) //adds as much pain as possible
 
 /obj/aura/regenerating/human/diona
-	brute_mult = 4
-	fire_mult = 4
-	tox_mult = 0
-	nutrition_damage_mult = 2
-	organ_mult = 2
+	brute_per_tick = 4
+	fire_per_tick = 4
+	tox_per_tick = 0
+	organ_chance = 2
 	regen_message = "<span class='warning'>You sense your nymphs shifting internally to regenerate your ORGAN..</span>"
 	grow_chance = 5
-	grow_threshold = 100
-	external_nutrition_mult = 60
+	nutrition_required_to_regenerate = 100
+	grow_cost = 60
 
 /obj/aura/regenerating/human/diona/external_regeneration_effect(var/obj/item/organ/external/O, var/mob/living/carbon/human/H)
 	to_chat(H, "<span class='warning'>Some of your nymphs split and hurry to reform your [O.name].</span>")
-	H.nutrition -= external_nutrition_mult
+	H.nutrition -= grow_cost
 
 /obj/aura/regenerating/human/unathi/yeosa
-	brute_mult = 1.5
-	organ_mult = 3
-	tox_mult = 2
+	organ_chance = 3
+	tox_per_tick = 2

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -20,7 +20,7 @@
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
 	slowdown = 0.5
-	brute_mod = 0.8
+	brute_mod = 0.95
 	flash_mod = 1.2
 	blood_volume = 800
 

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -8,7 +8,7 @@
 	darksight_range = 5
 	darksight_tint = DARKTINT_GOOD
 	slowdown = 0.4
-	brute_mod = 0.6
+	brute_mod = 0.85
 	flash_mod = 1.4
 	blood_volume = 700
 	water_soothe_amount = 5

--- a/code/modules/species/station/machine.dm
+++ b/code/modules/species/station/machine.dm
@@ -18,9 +18,6 @@
 	min_age = 1
 	max_age = 90
 
-	brute_mod = 1 // Because of the introduction of FBPs, IPCs are rebalanced back to 1.
-	burn_mod = 1  //
-
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
 


### PR DESCRIPTION
:cl:
balance: Unathi have had their native brute damage reduction reduced. (Baseline unathi changed from 0.8 damage taken to 0.95; subspecies changed from 0.60 to 0.85.)
balance: Unathi now spend three times as much nutrition to regenerate limbs.  (50n to 150n)
balance: Unathi now require more nutrition to be able to regenerate organs and limbs. (150n to 250n)
balance: Unathi will now suffer a stun effect upon regenerating a limb. 
balance: Unathi will now suffer a large amount of pain upon regenerating a limb.
balance: Unathi no longer passively heal brute or burn damage each tick.
/:cl:

Goal is to make unathi less of an unstoppable juggernaut, continually healing throughout combat. They can still passively heal internal injuries, just not a guaranteed brute/burn heal per tick. All of their flashier things like spawning new limbs now costs more nutrition to do, and requires them to be more satiated before it can be attempted. Fully regenerating an external limb will now also cause a great deal of pain, and stun that new limb.

End result here is that unathi are still much more adept at healing than everyone else (basically free internal heals, and in cases, free limbs). In both short and protracted fights, they should go down a **little** bit easier, since they won't be continually healing their external limbs.

Hopefully I've made the changelog and the above explanation as clear as possible so those who don't understand the code can get a grasp of what I'm changing.

Also renames vars so hopefully this file makes a little more sense to those who do understand the code