### PR TITLE
Fixes surgery safety off the optable.

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -202,6 +202,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 					return FALSE
 			to_chat(user, SPAN_WARNING("You aren't sure what you could do to \the [M] with \the [src]."))
 			return TRUE
+		return FALSE
 
 	// Otherwise we can make a start on surgery!
 	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)


### PR DESCRIPTION
This makes it so that if you use a surgery instrument on someone on a roller, chair, etc., and there is no valid surgery, it will do the normal attack. Optables don't work like that; you won't be able to do normal attacks unless you're on a whitelist of auxiliary medical devices, at least on help intent. That is not a bug.

Fixes #24783  (not on optables, but that's not a bug).