### PR TITLE
Adjusts some surgery steps to make less popup menus appear

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -102,15 +102,14 @@
 	var/fail_string = "slicing open"
 	var/access_string = "an incision"
 
-/decl/surgery_step/generic/cut_open/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	. = FALSE
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(istype(affected))
+/decl/surgery_step/generic/cut_open/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	. = ..()
+	if(.)
+		var/obj/item/organ/external/affected = .
 		if(affected.how_open())
 			var/datum/wound/cut/incision = affected.get_incision()
-			to_chat(user, SPAN_NOTICE("The [incision.desc] provides enough access, another incision isn't needed."))
-		else
-			. = TRUE
+			to_chat(user, SPAN_NOTICE("The [incision.desc] provides enough access."))
+			return FALSE
 
 /decl/surgery_step/generic/cut_open/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -150,6 +150,14 @@
 	min_duration = 80
 	max_duration = 100
 
+/decl/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = ..()
+	if(affected)
+		for(var/obj/O in affected.implants)
+			if(!istype(O, /obj/item/organ/internal))
+				return affected
+	return FALSE
+
 /decl/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts poking around inside [target]'s [affected.name] with \the [tool].", \

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -105,7 +105,9 @@
 	if(!LAZYLEN(attached_organs))
 		to_chat(user, SPAN_WARNING("You can't find any organs to separate."))
 	else
-		var/organ_to_remove = input(user, "Which organ do you want to separate?") as null|anything in attached_organs
+		var/obj/item/organ/organ_to_remove = attached_organs[1]
+		if(attached_organs.len > 1)
+			organ_to_remove = input(user, "Which organ do you want to separate?") as null|anything in attached_organs
 		if(organ_to_remove)
 			return organ_to_remove
 	return FALSE
@@ -154,7 +156,9 @@
 		if(!LAZYLEN(removable_organs))
 			to_chat(user, SPAN_WARNING("You can't find any removable organs."))
 		else
-			var/organ_to_remove = input(user, "Which organ do you want to remove?") as null|anything in removable_organs
+			var/obj/item/organ/organ_to_remove = removable_organs[1]
+			if(removable_organs.len > 1)
+				organ_to_remove = input(user, "Which organ do you want to remove?") as null|anything in removable_organs
 			if(organ_to_remove)
 				return organ_to_remove
 	return FALSE


### PR DESCRIPTION
Incision step is now not trying to happen when there's already an incision. All it did was giving you failure message anyway.
Remove foreign body now only happens if there's non-organs present in implant list, otherwise organ removal step is used.
Internal organ removal surgery now skips organ selection if there's only one to pick from, both detach and yank-out steps.
