### PR TITLE
Fixes radio runtimes with announcement computers

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -257,7 +257,7 @@
 
 	// Sedation chemical effect should prevent radio use (Chloral and Soporific)
 	var/mob/living/carbon/C = M
-	if (C.chem_effects[CE_SEDATE])
+	if ((istype(C)) && (C.chem_effects[CE_SEDATE]))
 		to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
 		return 0
 


### PR DESCRIPTION
Fixes the below:

```[02:08:21] Runtime in radio.dm, line 260: undefined variable /mob/living/silicon/ai/var/chem_effects
proc name: talk into (/obj/item/device/radio/talk_into)
usr: Aticius (/mob/new_player) ([0x300004d]) (NULL) (0,0,0) (NULL)
usr.loc: null
src: the shortwave radio (/obj/item/device/radio/announcer)
src.loc: space (1,1,1) (/turf/space)
call stack:
the shortwave radio (/obj/item/device/radio/announcer): talk into(Arrivals Announcement Computer (/mob/living/silicon/ai), "Asil Verenkethus, Atmospheric ...", "Engineering", "states", null)
the shortwave radio (/obj/item/device/radio/announcer): autosay("Asil Verenkethus, Atmospheric ...", "Arrivals Announcement Computer", "Engineering")
AnnounceArrivalSimple("Asil Verenkethus", "Atmospheric Technician", "has completed cryogenic reviva...", "Engineering")
AnnounceArrival(Asil Verenkethus (/mob/living/carbon/human), /datum/job/engineer (/datum/job/engineer), "has completed cryogenic reviva...")
Aticius (/mob/new_player): AttemptLateSpawn(/datum/job/engineer (/datum/job/engineer), "Default")
Aticius (/mob/new_player): Topic("src=[0x300004d];SelectedJob=E...", /list (/list))
Aticius (/client): Topic("src=[0x300004d];SelectedJob=E...", /list (/list), Aticius (/mob/new_player))
Aticius (/client): Topic("src=[0x300004d];SelectedJob=E...", /list (/list), Aticius (/mob/new_player))```