### PR TITLE
Lizard nerfs: yet another attempt.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -102,8 +102,6 @@
 	var/datum/unarmed_attack/default_attack	//default unarmed attack
 
 	var/obj/machinery/machine_visual //machine that is currently applying visual effects to this mob. Only used for camera monitors currently.
-
-	var/innate_heal = 1
 	var/shock_stage
 
 	var/obj/item/grab/current_grab_type 	// What type of grab they use when they grab someone.

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -190,10 +190,17 @@
 ***********/
 /mob/living/carbon/human/proc/diona_heal_toggle()
 	set name = "Toggle Heal"
-	set desc = "Turn your inate healing on or off."
+	set desc = "Turn your innate healing on or off."
 	set category = "Abilities"
-	innate_heal = !innate_heal
-	if (innate_heal)
+	var/obj/aura/regenerating/human/aura = locate() in auras
+	if(!aura)
+		to_chat(src, SPAN_WARNING("You don't possess an innate healing ability."))
+		return
+	if(!aura.can_toggle())
+		to_chat(src, SPAN_WARNING("You can't toggle the healing at this time!"))
+		return
+	aura.toggle()
+	if (aura.innate_heal)
 		to_chat(src, "<span class='alium'>You are now using nutrients to regenerate.</span>")
 	else
 		to_chat(src, "<span class='alium'>You are no longer using nutrients to regenerate.</span>")

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -20,7 +20,7 @@
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
 	slowdown = 0.5
-	brute_mod = 0.8
+	brute_mod = 0.85
 	flash_mod = 1.2
 	blood_volume = 800
 

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -20,7 +20,7 @@
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
 	slowdown = 0.5
-	brute_mod = 0.85
+	brute_mod = 0.8
 	flash_mod = 1.2
 	blood_volume = 800
 

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -8,7 +8,7 @@
 	darksight_range = 5
 	darksight_tint = DARKTINT_GOOD
 	slowdown = 0.4
-	brute_mod = 0.8
+	brute_mod = 0.85
 	flash_mod = 1.4
 	blood_volume = 700
 	water_soothe_amount = 5

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -8,7 +8,7 @@
 	darksight_range = 5
 	darksight_tint = DARKTINT_GOOD
 	slowdown = 0.4
-	brute_mod = 0.6
+	brute_mod = 0.8
 	flash_mod = 1.4
 	blood_volume = 700
 	water_soothe_amount = 5


### PR DESCRIPTION
:cl:
tweak: Unathi brute mod for the subspecies has been decreased a lot.
tweak: Unathi healing can only be toggled once every two minutes. It cannot be toggled within a minute of being hit in combat.
tweak: Unathi limb and organ regeneration is only possible when the heal can be toggled.
tweak: When an unathi is at extreme levels of hunger, it no longer receives healing from the passive heal ability. Instead, it takes internal organ damage, converting it into nutrition. This is inefficient, so if the healing ability is left on, it will die quickly.
tweak: Unathi passive healing is less nutrition-efficient now.
/:cl: