### PR TITLE
Adds binoculars, prybar and radio to CoS Office

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -5631,6 +5631,9 @@
 	pixel_y = 32
 	},
 /obj/structure/table/rack,
+/obj/item/device/radio,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mG" = (
@@ -5695,6 +5698,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/device/binoculars,
 /obj/structure/disposalpipe/segment,
+/obj/item/weapon/crowbar/prybar,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "mM" = (


### PR DESCRIPTION
:cl:
maptweak: Adds binoculars, prybar and a station bounced radio to the CoS Office.
/:cl: