### PR TITLE
Unmap the dermal patch gimmick

### DIFF
--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -70,7 +70,6 @@
 	return list(
 		/obj/item/clothing/suit/armor/pcarrier/medium/command/security,
 		/obj/item/clothing/head/helmet/solgov/command,
-		/obj/item/clothing/head/HoS/dermal,
 		/obj/item/device/radio/headset/heads/cos,
 		/obj/item/device/radio/headset/heads/cos/alt,
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,


### PR DESCRIPTION
Gets rid of the dermal head pastie thing. It's a relic of the nazi HoS coat era and is invisible armour, which is bad. Wear a helmet like everyone else