### PR TITLE
Makes flooring decls use the decls repository.

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -429,8 +429,6 @@
 			return global.floor_light_cache;
 		if("flooring_cache")
 			return global.flooring_cache;
-		if("flooring_types")
-			return global.flooring_types;
 		if("fluidtrack_cache")
 			return global.fluidtrack_cache;
 		if("follow_repository")
@@ -1376,8 +1374,6 @@
 			global.floor_light_cache=newval;
 		if("flooring_cache")
 			global.flooring_cache=newval;
-		if("flooring_types")
-			global.flooring_types=newval;
 		if("fluidtrack_cache")
 			global.fluidtrack_cache=newval;
 		if("follow_repository")
@@ -2108,7 +2104,6 @@
 	"floor_decals",
 	"floor_light_cache",
 	"flooring_cache",
-	"flooring_types",
 	"fluidtrack_cache",
 	"follow_repository",
 	"forced_ambiance_list",

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -25,7 +25,7 @@
 	cultify_wall()
 
 /turf/simulated/floor/proc/cultify_floor()
-	set_flooring(get_flooring_data(/decl/flooring/reinforced/cult))
+	set_flooring(decls_repository.get_decl(/decl/flooring/reinforced/cult))
 	GLOB.cult.add_cultiness(CULTINESS_PER_TURF)
 
 

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -105,8 +105,9 @@
 			ST.in_use = 0
 			src.add_fingerprint(user)
 			if(ST.use(1))
-				for(var/flooring_type in flooring_types)
-					var/decl/flooring/F = flooring_types[flooring_type]
+				var/list/decls = decls_repository.get_decls_of_subtype(/decl/flooring)
+				for(var/flooring_type in decls)
+					var/decl/flooring/F = decls[flooring_type]
 					if(!F.build_type)
 						continue
 					if(ispath(C.type, F.build_type))

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -1,12 +1,3 @@
-var/list/flooring_types
-
-/proc/get_flooring_data(var/flooring_path)
-	if(!flooring_types)
-		flooring_types = list()
-	if(!flooring_types["[flooring_path]"])
-		flooring_types["[flooring_path]"] = new flooring_path
-	return flooring_types["[flooring_path]"]
-
 // State values:
 // [icon_base]: initial base icon_state without edges or corners.
 // if has_base_range is set, append 0-has_base_range ie.

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -35,7 +35,7 @@
 	if(!floortype && initial_flooring)
 		floortype = initial_flooring
 	if(floortype)
-		set_flooring(get_flooring_data(floortype))
+		set_flooring(decls_repository.get_decl(floortype))
 
 /turf/simulated/floor/proc/set_flooring(var/decl/flooring/newflooring)
 	make_plating(defer_icon_update = 1)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -61,8 +61,9 @@
 				return
 			var/obj/item/stack/S = C
 			var/decl/flooring/use_flooring
-			for(var/flooring_type in flooring_types)
-				var/decl/flooring/F = flooring_types[flooring_type]
+			var/list/decls = decls_repository.get_decls_of_subtype(/decl/flooring)
+			for(var/flooring_type in decls)
+				var/decl/flooring/F = decls[flooring_type]
 				if(!F.build_type)
 					continue
 				if(ispath(S.type, F.build_type) || ispath(S.build_type, F.build_type))

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -175,7 +175,7 @@
 			anchored = TRUE
 			if(do_after(src, 50, F))
 				if(!F.flooring)
-					F.set_flooring(get_flooring_data(floor_build_type))
+					F.set_flooring(decls_repository.get_decl(floor_build_type))
 					addTiles(-1)
 			anchored = FALSE
 			target = null

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -242,7 +242,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '9fcbd08f0c328eb32fb3c3a6dac760e4 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '43bffb49a9a03d8f0e69695e9bd52b36 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
In particular, this will fix #24639 and is an alternative to #24718. The old caching was unsatisfactory. The whole thing would be cleaner if the decls were stored on the stacks rather than the way it was set up, but I don't have it in me to change it right now.