### PR TITLE
Makes upgrading medical sleepers do something, adds emag effects.

### DIFF
--- a/html/changelogs/mikomyazaki - medical machine upgrades.yml
+++ b/html/changelogs/mikomyazaki - medical machine upgrades.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Upgrading a sleeper now reduces power requirements, unlocks new chemicals, and increases pump rate."
+  - rscadd: "Adds emag effects to sleeper."


### PR DESCRIPTION
Currently some medical machines are upgradeable, but this has no effect on their operation. I've done some sleeper upgrades so far. Depending on feedback/interest I will continue to other medical machines.

- Upgrading the Sleeper will add Kelotane (with nano-manipulators) and Hyrolanin (with pico-manipulators). These are quite basic chemicals on purpose.
- Upgrading the scanning module will decrease synthesis power requirements (down to 1/2 then 1/3) and increase pumping/filtering speed up to 33/66% faster.
- Emagging the sleeper will allow it to produce hair remover and chloral. There is a warning on examine that it is able to, and anyone could see them on the list.

So far as I know none of this allows production of further chemicals in the patient's bloodstream through the sleeper alone. 

I'd welcome feedback from medical players in #feedback about how powerful these upgrades would be. Don't want it to be too over the top, just make a useful difference. I'm a bit ambivalent about chloral through emagging, since the machine can already produce a sedative.