### PR TITLE
Fixes #24817 Disassembling sleepers with an occupant will now eject t…

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -156,6 +156,7 @@
 /obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
 	if(default_deconstruction_screwdriver(user, I))
 		updateUsrDialog()
+		go_out()
 		return
 	if(default_deconstruction_crowbar(user, I))
 		return
@@ -182,6 +183,9 @@
 	if(target.buckled)
 		to_chat(user, "<span class='warning'>Unbuckle the subject before attempting to move them.</span>")
 		return
+	if(panel_open)
+		to_chat(user, "<span class='warning'>Close the maintenance panel before attempting to place the subject in the sleeper.</span>")
+		return
 	go_in(target, user)
 
 /obj/machinery/sleeper/relaymove(var/mob/user)
@@ -196,8 +200,7 @@
 		..(severity)
 		return
 
-	if(occupant)
-		go_out()
+	go_out()
 
 	..(severity)
 /obj/machinery/sleeper/proc/toggle_filter()

--- a/html/changelogs/myazaki - sleeper trap fix.yml
+++ b/html/changelogs/myazaki - sleeper trap fix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Disassembling sleepers with an occupant will now eject the occupant."


### PR DESCRIPTION
Fixes #24817 by making opening the maintenance panel auto-eject an occupant, and preventing occupants being added while the panel is open.

Also removes a redundant occupant check.