### PR TITLE
Allows construction of airtight plastic flaps

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -17,6 +17,7 @@
 		/mob/living/simple_animal/mouse,
 		/mob/living/silicon/robot/drone
 		)
+	var/airtight = 0
 
 /obj/structure/plasticflaps/CanPass(atom/A, turf/T)
 	if(istype(A) && A.checkpass(PASS_FLAG_GLASS))
@@ -41,11 +42,15 @@
 	return ..()
 
 /obj/structure/plasticflaps/attackby(obj/item/W, mob/user)
-	if(isScrewdriver(W) && !anchored)
+	if(isCrowbar(W) && !anchored)
 		user.visible_message("<span class='notice'>\The [user] begins deconstructing \the [src].</span>", "<span class='notice'>You start deconstructing \the [src].</span>")
 		if(user.do_skilled(3 SECONDS, SKILL_CONSTRUCTION, src))
 			user.visible_message("<span class='warning'>\The [user] deconstructs \the [src].</span>", "<span class='warning'>You deconstruct \the [src].</span>")
 			qdel(src)
+	if(isScrewdriver(W) && anchored)
+		airtight = !airtight
+		airtight ? become_airtight() : clear_airtight()
+		user.visible_message("<span class='warning'>\The [user] adjusts \the [src], [airtight ? "preventing" : "allowing"] air flow.</span>")
 	else ..()
 
 /obj/structure/plasticflaps/ex_act(severity)
@@ -59,32 +64,21 @@
 			if (prob(5))
 				qdel(src)
 
-/obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
-	name = "airtight plastic flaps"
-	desc = "Heavy duty, airtight, plastic flaps."
-
-/obj/structure/plasticflaps/mining/Initialize() //set the turf below the flaps to block air
-	become_airtight()
-	. = ..()
-
-/obj/structure/plasticflaps/mining/wrench_floor_bolts(user)
-	..()
-	if(!anchored)
-		clear_airtight()
-	else
-		become_airtight()
-
-/obj/structure/plasticflaps/mining/Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor
+/obj/structure/plasticflaps/Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor
 	clear_airtight()
 	. = ..()
 
-/obj/structure/plasticflaps/mining/proc/become_airtight()
+/obj/structure/plasticflaps/proc/become_airtight()
 	var/turf/T = get_turf(loc)
 	if(T)
 		T.blocks_air = 1
 
-/obj/structure/plasticflaps/mining/proc/clear_airtight()
+/obj/structure/plasticflaps/proc/clear_airtight()
 	var/turf/T = get_turf(loc)
 	if(T)
 		if(istype(T, /turf/simulated/floor))
 			T.blocks_air = 0
+
+
+/obj/structure/plasticflaps/airtight // airtight defaults to on 
+	airtight = 1

--- a/html/changelogs/mikomyazaki - airtight flaps.yml
+++ b/html/changelogs/mikomyazaki - airtight flaps.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Merges plastic flaps and airtight plastic flaps into one item. Can change airtight setting with screwdriver, deconstruct now with crowbar. Can now construct airtight flaps."

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1301,7 +1301,7 @@
 	dir = 8;
 	id = "packageSort1"
 	},
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "ep" = (
@@ -12026,7 +12026,7 @@
 	dir = 8;
 	id = "packageSort1"
 	},
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps/airtight,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)


### PR DESCRIPTION
Makes airtight flaps and normal flaps the same item, toggled by screwdriver.
Changes deconstruction to use crowbar instead.

Will allow people to set up new disposals chutes without causing atmos problems and to fix things if supply deconstructs their airtight flaps.