### PR TITLE
Prevents buckling mobs while the user is prone

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -62,7 +62,7 @@
 			animate(M, pixel_x = M.default_pixel_x, pixel_y = M.default_pixel_y, 4, 1, LINEAR_EASING)
 
 /obj/proc/user_buckle_mob(mob/living/M, mob/user)
-	if(!user.Adjacent(M) || user.restrained() || user.stat || istype(user, /mob/living/silicon/pai))
+	if(!user.Adjacent(M) || istype(user, /mob/living/silicon/pai) || (M != user && user.incapacitated()))
 		return 0
 	if(M == buckled_mob)
 		return 0


### PR DESCRIPTION
 - Fixes #24830

:cl:
tweak: Prone mobs can no longer buckle other mobs to beds/chairs. This prevents crawling bucklespam during combat.
/:cl: