### PR TITLE
Fixed bug to allow emptying paper shredder using a storage object.

### DIFF
--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -9,6 +9,9 @@
 	obj_flags = OBJ_FLAG_ANCHORABLE
 	var/max_paper = 10
 	var/paperamount = 0
+
+	var/obj/item/weapon/shred_temp = null
+
 	var/list/shred_amounts = list(
 		/obj/item/weapon/photo = 1,
 		/obj/item/weapon/shreddedp = 1,
@@ -63,30 +66,44 @@
 	empty_bin(usr)
 
 /obj/machinery/papershredder/proc/empty_bin(var/mob/living/user, var/obj/item/weapon/storage/empty_into)
+	
+	if(empty_into) // If the user tries to empty the bin into something
 
-	// Sanity.
-	if(empty_into && !istype(empty_into))
-		empty_into = null
+		if(paperamount == 0) // Can't empty what is already empty
+			to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
+			return
 
-	if(empty_into && empty_into.contents.len >= empty_into.storage_slots)
-		to_chat(user, "<span class='notice'>\The [empty_into] is full.</span>")
-		return
+		if(empty_into && !istype(empty_into)) // Make sure we can store paper in the thing
+			to_chat(user, "<span class='notice'>You cannot put shredded paper into the [empty_into].</span>")
+			return
 
-	while(paperamount)
-		var/obj/item/weapon/shreddedp/SP = get_shredded_paper()
-		if(!SP) break
-		if(empty_into)
-			empty_into.handle_item_insertion(SP)
-			if(empty_into.contents.len >= empty_into.storage_slots)
-				break
-	if(empty_into)
-		if(paperamount)
-			to_chat(user, "<span class='notice'>You fill \the [empty_into] with as much shredded paper as it will carry.</span>")
-		else
+		if(!istype(shred_temp)) // Assuming we could insert it, check out cached item
+			shred_temp = new /obj/item/weapon/shreddedp() // Could leave paper laying about?
+
+		if(!empty_into.can_be_inserted(shred_temp, user, 0)) // No space in the container
+			to_chat(user, "<span class='notice'>\The [empty_into] is too full to hold any shredded paper.</span>")
+			return
+
+		// Move papers one by one as they fit
+		while(paperamount > 0 && empty_into.can_be_inserted(shred_temp, user, 0))
+			if(paperamount > 1)
+				var/obj/item/weapon/shreddedp/shreddedPaper = get_shredded_paper()
+				empty_into.handle_item_insertion(shreddedPaper)
+			else
+				empty_into.handle_item_insertion(shred_temp)
+				paperamount = 0
+				shred_temp = null
+
+		// Report on how we did
+		if(paperamount == 0)
 			to_chat(user, "<span class='notice'>You empty \the [src] into \the [empty_into].</span>")
+		if(paperamount > 0)
+			to_chat(user, "<span class='notice'>You fill \the [empty_into] with as much shredded paper as it will carry.</span>")
 
-	else
-		to_chat(user, "<span class='notice'>You empty \the [src].</span>")
+	else // Just dump the paper out on the floor
+		while(paperamount > 0)
+			get_shredded_paper()
+
 	update_icon()
 
 /obj/machinery/papershredder/proc/get_shredded_paper()


### PR DESCRIPTION
Refactored paper shredder code to allow emptying the shredder into a container.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->