### PR TITLE
Adds the Paramount gamemode

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -594,6 +594,7 @@
 #include "code\game\gamemodes\ninja\ninja.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"
+#include "code\game\gamemodes\paramount\paramount.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"
 #include "code\game\gamemodes\traitor\traitor.dm"
 #include "code\game\gamemodes\wizard\wizard.dm"

--- a/code/game/antagonist/outsider/paramount.dm
+++ b/code/game/antagonist/outsider/paramount.dm
@@ -29,6 +29,7 @@ GLOBAL_DATUM_INIT(paramounts, /datum/antagonist/paramount, new)
 	player.psi.update(TRUE)
 
 	player.equip_to_slot_or_del(new /obj/item/clothing/under/psysuit(player), slot_w_uniform)
+	create_id("Visitor", player)
 	player.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/psypurple(player), slot_wear_suit)
 	player.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(player), slot_shoes)
 	player.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(player), slot_back)

--- a/code/game/gamemodes/paramount/paramount.dm
+++ b/code/game/gamemodes/paramount/paramount.dm
@@ -1,0 +1,9 @@
+/datum/game_mode/paramount
+	name = "Paramount"
+	round_description = "There is a powerful psionic Paramount on board."
+	extended_round_description = "A powerful psionic individual known as a Paramount has come aboard. Their powers of the mind make them leaps and bounds more powerful than mortal men. Will they use them for good, or evil?"
+	config_tag = "paramount"
+	required_players = 5
+	required_enemies = 1
+	end_on_antag_death = FALSE
+	antag_tags = list(MODE_PARAMOUNT)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds the Paramount gamemode. All the code for the antag and system itself was created by @MistakeNot4892 (so please don't come to me asking exactly how it works)

:cl: 
rscadd: Added the Paramount gamemode, featuring a psionic antag known as a Paramount.
/:cl: