### PR TITLE
Fixes new chairs building with default materials

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -22,11 +22,9 @@
 	var/material_alteration = MATERIAL_ALTERATION_ALL
 	var/buckling_sound = 'sound/effects/buckle.ogg'
 
-/obj/structure/bed/New(var/newloc, var/new_material, var/new_padding_material)
+/obj/structure/bed/New(newloc, new_material = DEFAULT_FURNITURE_MATERIAL, new_padding_material)
 	..(newloc)
 	color = null
-	if(!new_material)
-		new_material = MATERIAL_ALUMINIUM
 	material = SSmaterials.get_material_by_name(new_material)
 	if(!istype(material))
 		qdel(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -108,35 +108,35 @@
 	src.set_dir(turn(src.dir, 90))
 	return
 
-/obj/structure/bed/chair/padded/red/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_CARPET)
+/obj/structure/bed/chair/padded/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_CARPET)
 
-/obj/structure/bed/chair/padded/brown/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_LEATHER)
+/obj/structure/bed/chair/padded/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_LEATHER)
 
-/obj/structure/bed/chair/padded/teal/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"teal")
+/obj/structure/bed/chair/padded/teal/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "teal")
 
-/obj/structure/bed/chair/padded/black/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"black")
+/obj/structure/bed/chair/padded/black/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "black")
 
-/obj/structure/bed/chair/padded/green/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"green")
+/obj/structure/bed/chair/padded/green/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "green")
 
-/obj/structure/bed/chair/padded/purple/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"purple")
+/obj/structure/bed/chair/padded/purple/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "purple")
 
-/obj/structure/bed/chair/padded/blue/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"blue")
+/obj/structure/bed/chair/padded/blue/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "blue")
 
-/obj/structure/bed/chair/padded/beige/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"beige")
+/obj/structure/bed/chair/padded/beige/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "beige")
 
-/obj/structure/bed/chair/padded/lime/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"lime")
+/obj/structure/bed/chair/padded/lime/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "lime")
 
-/obj/structure/bed/chair/padded/yellow/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"yellow")
+/obj/structure/bed/chair/padded/yellow/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "yellow")
 
 // Leaving this in for the sake of compilation.
 /obj/structure/bed/chair/comfy
@@ -145,35 +145,35 @@
 	icon_state = "comfychair_preview"
 	base_icon = "comfychair"
 
-/obj/structure/bed/chair/comfy/brown/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_LEATHER)
+/obj/structure/bed/chair/comfy/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_LEATHER)
 
-/obj/structure/bed/chair/comfy/red/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_CARPET)
+/obj/structure/bed/chair/comfy/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_CARPET)
 
-/obj/structure/bed/chair/comfy/teal/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"teal")
+/obj/structure/bed/chair/comfy/teal/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "teal")
 
-/obj/structure/bed/chair/comfy/black/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"black")
+/obj/structure/bed/chair/comfy/black/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "black")
 
-/obj/structure/bed/chair/comfy/green/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"green")
+/obj/structure/bed/chair/comfy/green/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "green")
 
-/obj/structure/bed/chair/comfy/purple/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"purple")
+/obj/structure/bed/chair/comfy/purple/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "purple")
 
-/obj/structure/bed/chair/comfy/blue/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"blue")
+/obj/structure/bed/chair/comfy/blue/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "blue")
 
-/obj/structure/bed/chair/comfy/beige/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"beige")
+/obj/structure/bed/chair/comfy/beige/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "beige")
 
-/obj/structure/bed/chair/comfy/lime/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"lime")
+/obj/structure/bed/chair/comfy/lime/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "lime")
 
-/obj/structure/bed/chair/comfy/yellow/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"yellow")
+/obj/structure/bed/chair/comfy/yellow/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "yellow")
 
 /obj/structure/bed/chair/comfy/captain
 	name = "captain chair"
@@ -189,7 +189,7 @@
 	I.layer = ABOVE_HUMAN_LAYER
 	overlays |= I
 
-/obj/structure/bed/chair/comfy/captain/New(var/newloc,var/newmaterial)
+/obj/structure/bed/chair/comfy/captain/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc,MATERIAL_STEEL,"blue")
 
 /obj/structure/bed/chair/armchair
@@ -198,35 +198,35 @@
 	icon_state = "armchair_preview"
 	base_icon = "armchair"
 
-/obj/structure/bed/chair/armchair/brown/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_LEATHER)
+/obj/structure/bed/chair/armchair/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_LEATHER)
 
-/obj/structure/bed/chair/armchair/red/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_CARPET)
+/obj/structure/bed/chair/armchair/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_CARPET)
 
-/obj/structure/bed/chair/armchair/teal/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"teal")
+/obj/structure/bed/chair/armchair/teal/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "teal")
 
-/obj/structure/bed/chair/armchair/black/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"black")
+/obj/structure/bed/chair/armchair/black/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "black")
 
-/obj/structure/bed/chair/armchair/green/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"green")
+/obj/structure/bed/chair/armchair/green/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "green")
 
-/obj/structure/bed/chair/armchair/purple/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"purple")
+/obj/structure/bed/chair/armchair/purple/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "purple")
 
-/obj/structure/bed/chair/armchair/blue/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"blue")
+/obj/structure/bed/chair/armchair/blue/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "blue")
 
-/obj/structure/bed/chair/armchair/beige/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"beige")
+/obj/structure/bed/chair/armchair/beige/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "beige")
 
-/obj/structure/bed/chair/armchair/lime/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"lime")
+/obj/structure/bed/chair/armchair/lime/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "lime")
 
-/obj/structure/bed/chair/armchair/yellow/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"yellow")
+/obj/structure/bed/chair/armchair/yellow/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "yellow")
 
 /obj/structure/bed/chair/office
 	name = "office chair"
@@ -272,11 +272,11 @@
 			victim.apply_damage(10, BRUTE, def_zone)
 		occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")
 
-/obj/structure/bed/chair/office/light/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_COTTON)
+/obj/structure/bed/chair/office/light/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_COTTON)
 
-/obj/structure/bed/chair/office/dark/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"black")
+/obj/structure/bed/chair/office/dark/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "black")
 
 /obj/structure/bed/chair/office/comfy
 	name = "comfy office chair"
@@ -284,35 +284,35 @@
 	icon_state = "comfyofficechair_preview"
 	base_icon = "comfyofficechair"
 
-/obj/structure/bed/chair/office/comfy/brown/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_LEATHER)
+/obj/structure/bed/chair/office/comfy/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_LEATHER)
 
-/obj/structure/bed/chair/office/comfy/red/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,MATERIAL_CARPET)
+/obj/structure/bed/chair/office/comfy/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, MATERIAL_CARPET)
 
-/obj/structure/bed/chair/office/comfy/teal/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"teal")
+/obj/structure/bed/chair/office/comfy/teal/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "teal")
 
-/obj/structure/bed/chair/office/comfy/black/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"black")
+/obj/structure/bed/chair/office/comfy/black/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "black")
 
-/obj/structure/bed/chair/office/comfy/green/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"green")
+/obj/structure/bed/chair/office/comfy/green/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "green")
 
-/obj/structure/bed/chair/office/comfy/purple/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"purple")
+/obj/structure/bed/chair/office/comfy/purple/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "purple")
 
-/obj/structure/bed/chair/office/comfy/blue/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"blue")
+/obj/structure/bed/chair/office/comfy/blue/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "blue")
 
-/obj/structure/bed/chair/office/comfy/beige/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"beige")
+/obj/structure/bed/chair/office/comfy/beige/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "beige")
 
-/obj/structure/bed/chair/office/comfy/lime/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"lime")
+/obj/structure/bed/chair/office/comfy/lime/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "lime")
 
-/obj/structure/bed/chair/office/comfy/yellow/New(var/newloc,var/newmaterial)
-	..(newloc,DEFAULT_FURNITURE_MATERIAL,"yellow")
+/obj/structure/bed/chair/office/comfy/yellow/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, "yellow")
 
 /obj/structure/bed/chair/shuttle
 	name = "shuttle seat"
@@ -338,13 +338,13 @@
 			I.color = material.icon_colour
 		overlays |= I
 
-/obj/structure/bed/chair/shuttle/blue/New(var/newloc,var/newmaterial)
+/obj/structure/bed/chair/shuttle/blue/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc,MATERIAL_STEEL,"blue")
 
-/obj/structure/bed/chair/shuttle/black/New(var/newloc,var/newmaterial)
+/obj/structure/bed/chair/shuttle/black/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc,MATERIAL_STEEL,"black")
 
-/obj/structure/bed/chair/shuttle/white/New(var/newloc,var/newmaterial)
+/obj/structure/bed/chair/shuttle/white/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc,MATERIAL_STEEL,MATERIAL_COTTON)
 
 /obj/structure/bed/chair/wood

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -18,10 +18,8 @@ var/global/list/stool_cache = list() //haha stool
 /obj/item/weapon/stool/padded
 	icon_state = "stool_padded_preview" //set for the map
 
-/obj/item/weapon/stool/New(var/newloc, var/new_material, var/new_padding_material)
+/obj/item/weapon/stool/New(newloc, new_material = DEFAULT_FURNITURE_MATERIAL, new_padding_material)
 	..(newloc)
-	if(!new_material)
-		new_material = DEFAULT_FURNITURE_MATERIAL
 	material = SSmaterials.get_material_by_name(new_material)
 	if(new_padding_material)
 		padding_material = SSmaterials.get_material_by_name(new_padding_material)
@@ -31,8 +29,8 @@ var/global/list/stool_cache = list() //haha stool
 	force = round(material.get_blunt_damage()*0.4)
 	update_icon()
 
-/obj/item/weapon/stool/padded/New(var/newloc, var/new_material)
-	..(newloc, DEFAULT_FURNITURE_MATERIAL, MATERIAL_CARPET)
+/obj/item/weapon/stool/padded/New(newloc, new_material = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, new_material, MATERIAL_CARPET)
 
 /obj/item/weapon/stool/bar
 	name = "bar stool"
@@ -43,8 +41,8 @@ var/global/list/stool_cache = list() //haha stool
 /obj/item/weapon/stool/bar/padded
 	icon_state = "bar_stool_padded_preview"
 
-/obj/item/weapon/stool/bar/padded/New(var/newloc, var/new_material)
-	..(newloc, DEFAULT_FURNITURE_MATERIAL, MATERIAL_CARPET)
+/obj/item/weapon/stool/bar/padded/New(newloc, new_material = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, new_material, MATERIAL_CARPET)
 
 /obj/item/weapon/stool/on_update_icon()
 	// Prep icon.


### PR DESCRIPTION
 - Fixes #24834

:cl:
fix: Chairs and stools now have the correct materials when constructed and deconstructed.
/:cl: