### PR TITLE
Adds an extremely small chance for offmap roles to have latent psionic powers

### DIFF
--- a/maps/torch/torch_submaps.dm
+++ b/maps/torch/torch_submaps.dm
@@ -3,3 +3,6 @@
 	branch = /datum/mil_branch/alien
 	allowed_branches = list(/datum/mil_branch/alien)
 	allowed_ranks = list(/datum/mil_rank/alien)
+
+/datum/job/submap
+	psi_latency_chance = 2.5


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
These can only be activated by being mind-assayed by a Redactor, going into hardcrit, or overdosing on Three Eye. 

The chance is 2.5%.
If there's a better way of doing this, please let me know.