### PR TITLE
Reduces some armor spam; makes messaging and effects more consistent.

### DIFF
--- a/code/datums/extensions/armor/armor.dm
+++ b/code/datums/extensions/armor/armor.dm
@@ -17,7 +17,7 @@
 		return args.Copy()
 
 	var/blocked = get_blocked(damage_type, damage_flags, armor_pen)
-	if(prob(blocked))
+	if(prob(blocked * 100))
 		if(damage_flags & DAM_LASER)
 			damage *= FLUIDLOSS_CONC_BURN/FLUIDLOSS_WIDE_BURN
 		damage_flags &= ~(DAM_SHARP | DAM_EDGE | DAM_LASER)
@@ -25,7 +25,7 @@
 	on_blocking(damage, blocked)
 
 	if(damage_type == IRRADIATE)
-		damage = max(0, damage - blocked)
+		damage = max(0, damage - 100 * blocked)
 		silent = TRUE
 	damage *= 1 - blocked
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -322,9 +322,9 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	var/burn_avg = burn / parts.len
 	for(var/obj/item/organ/external/E in parts)
 		if(brute_avg)
-			apply_damage(damage = brute_avg, damagetype = BRUTE, damage_flags = dam_flags, used_weapon = used_weapon, given_organ = E)
+			apply_damage(damage = brute_avg, damagetype = BRUTE, damage_flags = dam_flags, used_weapon = used_weapon, silent = TRUE, given_organ = E)
 		if(burn_avg)
-			apply_damage(damage = burn_avg, damagetype = BURN, damage_flags = dam_flags, used_weapon = used_weapon, given_organ = E)
+			apply_damage(damage = burn_avg, damagetype = BURN, damage_flags = dam_flags, used_weapon = used_weapon, silent = TRUE, given_organ = E)
 
 	updatehealth()
 	BITSET(hud_updateflag, HEALTH_HUD)
@@ -374,20 +374,20 @@ This function restores all organs.
 				if(damage_flags & DAM_DISPERSED)
 					var/old_damage = damage
 					var/tally
+					silent = TRUE // Will damage a lot of organs, probably, so avoid spam.
 					for(var/zone in organ_rel_size)
 						tally += organ_rel_size[zone]
 					for(var/zone in organ_rel_size)
 						damage = old_damage * organ_rel_size[zone]/tally
 						def_zone = zone
-						.()
+						. = .() || .
 					return
 				def_zone = ran_zone(def_zone)
 			organ = get_organ(check_zone(def_zone))
 
 	//Handle other types of damage
 	if(!(damagetype in list(BRUTE, BURN, PAIN, CLONE)))
-		..(damage, damagetype, def_zone)
-		return 1
+		return ..()
 
 	handle_suit_punctures(damagetype, damage, def_zone)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -33,12 +33,12 @@
 	//Armor
 	var/damage = P.damage
 	var/flags = P.damage_flags()
-	var/absorb = 100 * get_blocked_ratio(def_zone, P.damage_type, flags, P.armor_penetration)
+	var/damaged
 	if(!P.nodamage)
-		apply_damage(damage, P.damage_type, def_zone, flags, P, P.armor_penetration)
-	P.on_hit(src, absorb, def_zone)
-
-	return absorb
+		damaged = apply_damage(damage, P.damage_type, def_zone, flags, P, P.armor_penetration)
+	if(damaged || P.nodamage) // Run the block computation if we did damage or if we only use armor for effects (nodamage)
+		. = get_blocked_ratio(def_zone, P.damage_type, flags, P.armor_penetration)
+	P.on_hit(src, ., def_zone)
 
 /mob/living/proc/aura_check(var/type)
 	if(!auras)


### PR DESCRIPTION
Makes the more obvious things that deal damage to several organs at once not spam armor messages. Makes `bullet_act` do a better job of checking for random full-defense rolls before applying effects. Makes humans taking weird damage types respect damage flags and other vars properly. Fixes the flag removal math being wrong.

May need some further improvement later.