### PR TITLE
Add atmospheric scanner module to pda of EVA jobs

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -106,6 +106,10 @@
 	icon_state = "pda-sup"
 	icon_state_unpowered = "pda-sup"
 
+/obj/item/modular_computer/pda/mining
+	icon_state = "pda-nt"
+	icon_state_unpowered = "pda-nt"
+
 /obj/item/modular_computer/pda/syndicate
 	icon_state = "pda-syn"
 	icon_state_unpowered = "pda-syn"

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -66,6 +66,14 @@
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)
 
+/obj/item/modular_computer/pda/mining/install_default_hardware()
+	..()
+	scanner = new /obj/item/weapon/computer_hardware/scanner/atmos(src)
+
+/obj/item/modular_computer/pda/explorer/install_default_hardware()
+	..()
+	scanner = new /obj/item/weapon/computer_hardware/scanner/atmos(src)
+
 /obj/item/modular_computer/pda/captain/install_default_hardware()
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)

--- a/maps/torch/job/outfits/supply_outfits.dm
+++ b/maps/torch/job/outfits/supply_outfits.dm
@@ -43,7 +43,7 @@
 	uniform = /obj/item/clothing/under/rank/ntwork
 	shoes = /obj/item/clothing/shoes/workboots
 	id_type = /obj/item/weapon/card/id/torch/passenger/research/mining
-	pda_type = /obj/item/modular_computer/pda/science
+	pda_type = /obj/item/modular_computer/pda/mining
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 	l_ear = /obj/item/device/radio/headset/headset_mining
 


### PR DESCRIPTION
Pathfinder, Explorers and Miners now have an atmospheric scanner module in their pda.
(This replaces the miner's reagent scanner module, seriously why do they have this?)
Since they're all EVA heavy job, having an atmospheric scanner would make sense.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->