### PR TITLE
Give Deck Chief exploration comms access

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -31,7 +31,7 @@
 /obj/item/device/encryptionkey/headset_deckofficer
 	name = "deck chief's encryption key"
 	icon_state = "qm_cypherkey"
-	channels = list("Supply" = 1, "Command" = 1)
+	channels = list("Supply" = 1, "Command" = 1, "Exploration" = 1)
 
 /obj/item/device/encryptionkey/bridgeofficer
 	name = "bridge officer's encryption key"


### PR DESCRIPTION
As the person responsible for all shuttles in the hanger, this would give the Deck Chief a line to coordinate with exploration if there's no pathfinder available, and a line to communicate that isn't over the command channel.

:cl:
tweak: Deck Chiefs now have access to Exploration comms.
/:cl: