### PR TITLE
Immediately flushes people who ghost

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -307,7 +307,8 @@
 			C.SetStasis(2)
 
 		//Allow a ten minute gap between entering the pod and actually despawning.
-		if(world.time - time_entered < time_till_despawn)
+		// Only provide the gap if the occupant hasn't ghosted
+		if ((world.time - time_entered < time_till_despawn) && (occupant.ckey))
 			return
 
 		if(!occupant.client && occupant.stat<2) //Occupant is living and has no client.


### PR DESCRIPTION
Intended to help mitigate the issue with people joining as roles and cryoing at roundstart, thereby locking roles for the first 15 or so minutes of a round. Also allows roles to open up quicker if someone does not intend to return after cryoing (Indicated by that person ghosting).

The following cases will immediately flush someone in cryo:
 - Ghosting after entering a cryopod
 - Stuffing someone who's ghosted into a cryopod
 - Also works for robots in robotic storage

The following cases have been tested and verified to NOT immediately flush someone and still gives the 10 minutes window:
 - Disconnecting
 - Aghosting
 - AFKing in a pod

:cl:
tweak: Characters that have ghosted (NOT aghosted) will be immediately flushed when placed into cryo.
/:cl: