### PR TITLE
Makes Synaptizine overdose at 5u

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -322,7 +322,7 @@
 	reagent_state = LIQUID
 	color = "#99ccff"
 	metabolism = REM * 0.05
-	overdose = REAGENTS_OVERDOSE
+	overdose = REAGENTS_OVERDOSE / 6 // 5
 	scannable = 1
 
 /datum/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
This brings the chemical's toxicity level inline with what the wiki
states it should be at. Synap's a pretty power-gamey chemical that heals a LOT of stuff at once and metabolizes slowly. I believe the metabolization rate was one unit per minute, which would mean the current overdose would let you stim up for up to 30 minutes without penalty.

```
/datum/reagent/synaptizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
    if(alien == IS_DIONA)
        return
    M.drowsyness = max(M.drowsyness - 5, 0)
    M.AdjustParalysis(-1)
    M.AdjustStunned(-1)
    M.AdjustWeakened(-1)
    holder.remove_reagent(/datum/reagent/mindbreaker, 5)
    M.adjust_hallucination(-10)
    M.add_chemical_effect(CE_MIND, 2)
    M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
    M.add_chemical_effect(CE_PAINKILLER, 20)
```

:cl:
tweak: Synaptizine now overdoses at 5u instead of 30u.
/:cl: