### PR TITLE
Added symbiotes as a crew job slot.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -625,6 +625,7 @@
 #include "code\game\jobs\job\science.dm"
 #include "code\game\jobs\job\security.dm"
 #include "code\game\jobs\job\silicon.dm"
+#include "code\game\jobs\job\symbiote.dm"
 #include "code\game\machinery\ai_slipper.dm"
 #include "code\game\machinery\air_sensor.dm"
 #include "code\game\machinery\alarm.dm"

--- a/code/__defines/culture.dm
+++ b/code/__defines/culture.dm
@@ -70,6 +70,8 @@
 #define CULTURE_STOK           "Stok Business"
 #define CULTURE_ALIUM          "Mysterious Aliens"
 #define CULTURE_CULTIST        "Blood Cult"
+#define CULTURE_SYMBIOTIC      "Symbiote Host"
+
 #define RELIGION_OTHER         "Other Religion"
 #define RELIGION_JUDAISM       "Judaism"
 #define RELIGION_HINDUISM      "Hinduism"

--- a/code/game/jobs/job/symbiote.dm
+++ b/code/game/jobs/job/symbiote.dm
@@ -1,0 +1,93 @@
+/decl/cultural_info/culture/symbiotic
+	name = CULTURE_SYMBIOTIC
+	description = "Your culture has always welcomed a form of brain-slug called cortical borers into their bodies, \
+	and your upbringing taught that this was a normal and beneficial state of affairs. Taking this background will \
+	allow symbiote players to join as your mind-partner. Symbiotes can secrete beneficial chemicals, translate languages \
+	and are rendered docile by sugar. Unlike feral cortical borers, they cannot take control of your body or cause brain damage."
+	economic_power = 0.8
+	var/matches_to_role = /datum/job/symbiote
+
+/datum/job/symbiote
+	title = "Symbiote"
+	department = "Civilian"
+	department_flag = CIV
+	total_positions = -1
+	spawn_positions = -1
+	supervisors = "your host"
+	selection_color = "#ad6bad"
+	access = list()
+	minimal_access = list()
+	minimal_player_age = 14
+	economic_power = 0
+	defer_roundstart_spawn = TRUE
+	create_record = FALSE
+	var/check_whitelist = "Symbiote"
+	var/global/mob/living/simple_animal/borer/symbiote/preview_slug = new
+
+/datum/job/symbiote/post_equip_rank(var/mob/person, var/alt_title)
+
+	var/mob/living/simple_animal/borer/symbiote = person
+	symbiote.SetName(symbiote.truename)
+	symbiote.real_name = symbiote.truename
+
+	to_chat(person, "<b>You are a [alt_title || title].</b>")
+	to_chat(person, "<b>As the [alt_title || title] you answer directly to [supervisors]. Special circumstances may change this.</b>")
+
+	if(symbiote.host)
+		if(symbiote.host.mind)
+			var/a_the = (symbiote.host.mind.assigned_job && symbiote.host.mind.assigned_job.total_positions == 1) ? "the" : "a"
+			var/use_title = symbiote.host.mind.role_alt_title || symbiote.host.mind.assigned_role
+			to_chat(symbiote, SPAN_NOTICE("Your current host is <b>\the [symbiote.host.real_name]</b>, [a_the] <b>[use_title]</b>. Help them stay safe and happy, and assist them in achieving their goals. <b>Remember, your host's desires take precedence over everyone else's.</b>"))
+			to_chat(symbiote.host, SPAN_NOTICE("Your current symbiote, <b>[symbiote.name]</b>, has awakened. They will help you in whatever way they can. Treat them kindly."))
+		else
+			to_chat(symbiote, SPAN_NOTICE("Your host is <b>\the [symbiote.host.real_name]</b>. They are mindless and you should probably find a new one soon."))
+	else
+		to_chat(symbiote, SPAN_DANGER("You do not currently have a host."))
+
+/datum/job/symbiote/is_restricted(var/datum/preferences/prefs, var/feedback)
+	. = ..()
+	if(. && check_whitelist && !is_alien_whitelisted(prefs.client.mob, check_whitelist))
+		if(feedback)
+			to_chat(prefs.client.mob, SPAN_WARNING("You are not whitelisted for [check_whitelist] roles."))
+		. = FALSE
+
+/datum/job/symbiote/handle_variant_join(var/mob/living/carbon/human/H, var/alt_title)
+	var/mob/living/carbon/human/host = find_valid_host()
+	var/mob/living/simple_animal/borer/symbiote/symbiote = new
+	if(symbiote)
+		if(host)
+			if(H.mind)
+				H.mind.transfer_to(symbiote)
+			else
+				symbiote.key = H.key
+			var/obj/item/organ/external/head = host.get_organ(BP_HEAD)
+			symbiote.host = host
+			head.implants += symbiote
+			symbiote.forceMove(head)
+			if(!symbiote.host_brain)
+				symbiote.host_brain = new(symbiote)
+			symbiote.host_brain.SetName(host.real_name)
+			symbiote.host_brain.real_name = host.real_name
+			qdel(H)
+	else
+		; // Find a xenobiology cell to spawn in or something. This should never execute anyway.
+	return symbiote
+
+/datum/job/symbiote/equip_preview(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade, var/additional_skips)
+	H.appearance = preview_slug
+	return TRUE
+
+/datum/job/symbiote/proc/find_valid_host()
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat == DEAD || !H.client || !H.ckey || H.has_brain_worms() || !H.internal_organs_by_name[BP_BRAIN])
+			continue
+		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
+		if(BP_IS_ROBOTIC(head) || BP_IS_CRYSTAL(head))
+			continue
+		var/decl/cultural_info/culture/symbiotic/culture = H.get_cultural_value(TAG_CULTURE)
+		if(!istype(culture) || culture.matches_to_role != type)
+			continue
+		return H
+
+/datum/job/symbiote/is_position_available()
+	. = ..() && find_valid_host()

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -187,3 +187,8 @@
 /mob/living/simple_animal/borer/proc/request_player()
 	var/datum/ghosttrap/G = get_ghost_trap("cortical borer")
 	G.request_player(src, "A cortical borer needs a player.")
+
+/mob/living/simple_animal/borer/symbiote
+	name = "symbiote"
+	real_name = "symbiote"
+	//neutered = TRUE

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -28,7 +28,7 @@
 						/datum/job/janitor, /datum/job/chef, /datum/job/bartender,
 						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant,
 						/datum/job/ai, /datum/job/cyborg,
-						/datum/job/crew, /datum/job/assistant,
+						/datum/job/crew, /datum/job/assistant, /datum/job/symbiote,
 						/datum/job/merchant, /datum/job/stowaway
 						)
 


### PR DESCRIPTION
Depends on #25906 and #25887.

I am not really anticipating this being merged, but I'd like to leave it up until the borer changes are in and tested, and we can get a solid ruling either way based on a modernized version of the mob.

- Symbiotes are 'neutered' cortical borers who cannot use the Dominate Victim verb and cannot assume direct control. They aren't considered antagonists and neither are their hosts.
- The positive aspects are their access to chemicals, their language translation, and their access to the Cortical Link broadcast language.
- Humans are able to select a Symbiote Host background that makes them a symbiote candidate.
- When a valid host is available, a Symbiote job slot becomes joinable. The joining player will become a symbiote in the host and they will be informed of each other's presence.
- Hosts do not get to choose symbiotes and vice-versa.