### PR TITLE
Prevent disposaling things with ITEM_SIZE_NO_CONTAINER

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -174,6 +174,13 @@
 	if(AM == user)
 		user.visible_message("<span class='warning'>[user] starts climbing into [src].</span>", \
 							 "<span class='notice'>You start climbing into [src].</span>")
+	else if(istype(AM, /obj))
+		var/obj/O = AM
+		if(O.w_class >= ITEM_SIZE_NO_CONTAINER)
+			user.visible_message("<span class='[is_dangerous ? "warning" : "notice"]'>[user] tries stuffing [AM] into [src], but it doesn't fit.</span>", \
+							 "<span class='notice'>You try to stuff [AM] into [src] but it doesn't fit.</span>")
+			return
+
 	else
 		user.visible_message("<span class='[is_dangerous ? "warning" : "notice"]'>[user] starts stuffing [AM] into [src].</span>", \
 							 "<span class='notice'>You start stuffing [AM] into [src].</span>")


### PR DESCRIPTION
- Includes lockers, crates, etc

If it's too big to ever fit in a container, it's too big to fit in disposals.

This only impacts objects, it doesn't impact mobs at all.

🆑 FTangSteve
tweak: lockers, crates, and similar items that don't fit in containers are now unable to be put in disposals
/🆑

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->