### PR TITLE
Carp spawn tweaks

### DIFF
--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -2737,6 +2737,12 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/broken1)
+"oJ" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "vU" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -7472,7 +7478,7 @@ aa
 aa
 aa
 aa
-aa
+oJ
 aa
 aa
 aa
@@ -9695,7 +9701,7 @@ aa
 aa
 aa
 aa
-aa
+oJ
 aa
 aa
 aa
@@ -12109,7 +12115,7 @@ aa
 aa
 aa
 aa
-aa
+oJ
 aa
 aa
 aa

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -5752,6 +5752,12 @@
 /obj/machinery/meter/turf,
 /turf/simulated/floor/airless,
 /area/ship/scrap/maintenance/atmos)
+"mB" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "nS" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -9214,7 +9220,7 @@ aa
 aa
 aa
 aa
-aa
+mB
 aa
 aa
 aa
@@ -10102,7 +10108,7 @@ aa
 aa
 aa
 aa
-aa
+mB
 aa
 aa
 aa
@@ -12924,7 +12930,7 @@ aa
 aa
 aa
 aa
-aa
+mB
 aa
 aa
 aa
@@ -13098,7 +13104,7 @@ aa
 aa
 aa
 aa
-aa
+mB
 aa
 aa
 aa
@@ -15593,7 +15599,7 @@ aa
 aa
 aa
 aa
-aa
+mB
 aa
 aa
 aa
@@ -16898,7 +16904,7 @@ aa
 aa
 aa
 aa
-aa
+mB
 aa
 aa
 aa

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -838,6 +838,12 @@
 /obj/effect/shuttle_landmark/nav_unishi/nav3,
 /turf/space,
 /area/space)
+"lB" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 
 (1,1,1) = {"
 aa
@@ -4444,7 +4450,7 @@ aa
 aa
 aa
 aa
-aa
+lB
 aa
 aa
 aa
@@ -7697,7 +7703,7 @@ aa
 aa
 aa
 aa
-aa
+lB
 aa
 aa
 aa

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -3112,6 +3112,12 @@
 /obj/structure/lattice,
 /turf/space,
 /area/unishi/smresearch)
+"Ul" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 
 (1,1,1) = {"
 aa
@@ -6426,7 +6432,7 @@ aa
 aa
 aa
 aa
-aa
+Ul
 aa
 aa
 aa
@@ -8119,7 +8125,7 @@ aa
 aa
 aa
 aa
-aa
+Ul
 aa
 aa
 aa
@@ -9205,7 +9211,7 @@ gJ
 aa
 aa
 aa
-aa
+Ul
 aa
 aa
 aa
@@ -9793,7 +9799,7 @@ aa
 aa
 aa
 aa
-aa
+Ul
 aa
 aa
 aa

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -2017,6 +2017,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/unishi/living)
+"nC" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "pd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5384,7 +5390,7 @@ aa
 aa
 aa
 aa
-aa
+nC
 aa
 aa
 aa
@@ -7148,7 +7154,7 @@ aa
 aa
 aa
 aa
-aa
+nC
 aa
 aa
 aa
@@ -8304,7 +8310,7 @@ aa
 aa
 aa
 aa
-aa
+nC
 aa
 aa
 aa
@@ -9354,7 +9360,7 @@ aa
 aa
 aa
 aa
-aa
+nC
 aa
 aa
 aa

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -47725,7 +47725,7 @@ aa
 aa
 lk
 aa
-ad
+aa
 aa
 ik
 ji

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -15751,6 +15751,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Ut" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "UP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21575,7 +21581,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -21818,7 +21824,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -22201,7 +22207,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -26411,7 +26417,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -26675,7 +26681,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -33286,7 +33292,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -33337,7 +33343,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -37512,7 +37518,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -37594,7 +37600,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -41769,7 +41775,7 @@ aa
 aa
 aa
 aa
-aa
+Ut
 aa
 ad
 ad
@@ -42024,7 +42030,7 @@ ad
 ae
 aa
 aa
-aa
+Ut
 aa
 aa
 aa
@@ -46630,6 +46636,7 @@ aa
 aa
 aa
 aa
+Ut
 aa
 aa
 aa
@@ -46654,8 +46661,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ut
 aa
 aa
 aa


### PR DESCRIPTION
Adds carp spawns to various z-levels that lacked them, and makes a couple takes to existing carp spawns
 - Carp added around SEV Torch bridge deck
 - Carp spawn in the deck 2 reactor coolant section was removed due to the tendency to spawn carp inside/behind active shielding.
 - Carp added to Bearcat and Unishi

I can't figure out how to map in carp spawns for traveling shuttles, so this will just have to be bridge deck, bearcat, and unishi updates.

:cl:
map: Added carp spawn zones to Torch bridge deck, Bearcat, and Unishi for overmap events.
map: Moved a Torch deck 2 carp spawn from outside the reactor area to avoid carp spawning inside the shields.
/:cl: