### PR TITLE
Access strings must exist

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -750,29 +750,43 @@ datum/unit_test/ladder_check/start_test()
 		current_dir = next_pipe.nextdir(current_dir, sort.sortType)
 		our_pipe = next_pipe
 
-/datum/unit_test/check_for_numeric_req_access
-	name = "MAP: Check for numbers in mapped objs' req_access"
+/datum/unit_test/req_access_shall_have_valid_strings
+	name = "MAP: every obj shall have valid access strings in req_access"
+	var/list/accesses
 
-/datum/unit_test/check_for_numeric_req_access/start_test()
-	var/list/objs_with_numeric_req_access = list()
+/datum/unit_test/req_access_shall_have_valid_strings/start_test()
+	if(!accesses)
+		accesses = get_all_access_datums()
+
+	var/list/obj_access_pairs = list()
 	for(var/obj/O in world)
 		if(O.req_access)
 			for(var/req in O.req_access)
 				if(islist(req))
 					for(var/req_one in req)
-						if(isnum(req_one))
-							objs_with_numeric_req_access |= O
-				else if(isnum(req))
-					objs_with_numeric_req_access |= O
-			
-	if(objs_with_numeric_req_access.len)
-		for(var/entry in objs_with_numeric_req_access)
-			log_bad("[log_info_line(entry)] has a numeric value in req_access.")
-		fail("Mapped objs with numeric req_access must be set up to use strings instead.")
+						if(is_invalid(req_one))
+							obj_access_pairs += list(list(O, req_one))
+				else if(is_invalid(req))
+					obj_access_pairs += list(list(O, req))
+
+	if(obj_access_pairs.len)
+		for(var/entry in obj_access_pairs)
+			log_bad("[log_info_line(entry[1])] has an invalid value ([entry[2]]) in req_access.")
+		fail("Mapped objs with req_access must be set up to use existing access strings.")
 	else
 		pass("All mapped objs have correctly set req_access.")
 
 	return 1
+
+/datum/unit_test/req_access_shall_have_valid_strings/proc/is_invalid(var/value)
+	if(!istext(value))
+		return TRUE //Someone tried to use a non-string as an access. There is no case where this is allowed.
+
+	for(var/datum/access/A in accesses)
+		if(value == A.id)
+			return FALSE
+
+	return TRUE
 
 #undef SUCCESS
 #undef FAILURE

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -12129,7 +12129,7 @@
 	name = "Counter Shutters";
 	pixel_x = 0;
 	pixel_y = 24;
-	req_access = list(list("ACCESS_HEADS","ACCESS_SHOP"))
+	req_access = list(list("ACCESS_HEADS","ACCESS_TORCH_SHOP"))
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -25,7 +25,7 @@
 /area/medical/virology)
 "aag" = (
 /obj/machinery/smartfridge/secure/virology{
-	req_access = list(list("ACCESS_VIROLOGY","ACCESS_SURGERY"))
+	req_access = list(list("ACCESS_VIRO","ACCESS_SURGERY"))
 	},
 /obj/machinery/requests_console{
 	department = "Virology";

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -15538,7 +15538,7 @@
 	id_tag = "aquila_shuttle_dock_inner";
 	locked = 1;
 	name = "Docking Port Airlock";
-	req_access = list("ACCESS_CREW")
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15692,7 +15692,7 @@
 	id_tag = "aquila_shuttle_dock_outer";
 	locked = 1;
 	name = "Docking Port Airlock";
-	req_access = list("ACCESS_CREW")
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15893,7 +15893,7 @@
 	id_tag = "aquila_shuttle_outer";
 	locked = 1;
 	name = "Aquila External Access";
-	req_access = list("ACCESS_CREW")
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /obj/machinery/shield_diffuser,
 /obj/structure/cable{
@@ -16084,7 +16084,7 @@
 	id_tag = "aquila_shuttle_inner";
 	locked = 1;
 	name = "Aquila External Access";
-	req_access = list("ACCESS_CREW")
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /obj/structure/cable{
 	d1 = 4;


### PR DESCRIPTION
Tweaks the unit test in such a way that if there is an access on the map it must also have a corresponding access datum.