### PR TITLE
Gives Bearcat and Unishi holopads

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -57,6 +57,8 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	var/holopadType = HOLOPAD_SHORT_RANGE //Whether the holopad is short-range or long-range.
 	var/base_icon = "holopad-B"
 
+	var/allow_ai = TRUE
+
 /obj/machinery/hologram/holopad/New()
 	..()
 	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[loc.loc]'"
@@ -79,7 +81,12 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 		audible_message("Severing connection to distant holopad.")
 		end_call(user)
 		return
-	switch(alert(user,"Would you like to request an AI's presence or establish communications with another pad?", "Holopad","AI","Holocomms","Cancel"))
+	
+	var/handle_type = "Holocomms"
+	if(allow_ai)
+		handle_type = alert(user,"Would you like to request an AI's presence or establish communications with another pad?", "Holopad","AI","Holocomms","Cancel")
+	
+	switch(handle_type)
 		if("AI")
 			if(last_request + 200 < world.time) //don't spam the AI with requests you jerk!
 				last_request = world.time
@@ -158,6 +165,8 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	This may change in the future but for now will suffice.*/
 	if(user.eyeobj && (user.eyeobj.loc != src.loc))//Set client eye on the object if it's not already.
 		user.eyeobj.setLoc(get_turf(src))
+	else if (!allow_ai)
+		to_chat(user, SPAN_WARNING("Access denied."))
 	else if(!masters[user])//If there is no hologram, possibly make one.
 		activate_holo(user)
 	else//If there is a hologram, remove it.
@@ -411,6 +420,10 @@ Holographic project of everything else.
 	power_per_hologram = 1000 //per usage per hologram
 	holopadType = HOLOPAD_LONG_RANGE
 	base_icon = "holopad-Y"
+
+// Used for overmap capable ships that should have communications, but not be AI accessible
+/obj/machinery/hologram/holopad/longrange/remoteship
+	allow_ai = FALSE
 
 #undef RANGE_BASED
 #undef AREA_BASED

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -144,6 +144,7 @@
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad/longrange/remoteship,
 /turf/simulated/floor/tiled/dark/usedup,
 /area/ship/scrap/command/bridge)
 "aw" = (

--- a/maps/away/skrellscoutship/skrellscoutship-2.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-2.dmm
@@ -1910,7 +1910,7 @@
 /area/ship/skrellscoutship/crew/rec)
 "Lg" = (
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/leader,
-/obj/machinery/hologram/holopad/longrange,
+/obj/machinery/hologram/holopad/longrange/remoteship,
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/command/bridge)
 "Mg" = (

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -2051,6 +2051,10 @@
 /obj/random/clothing,
 /turf/simulated/floor/wood,
 /area/unishi/living)
+"ur" = (
+/obj/machinery/hologram/holopad/longrange/remoteship,
+/turf/simulated/floor/tiled,
+/area/unishi/bridge)
 "vn" = (
 /obj/structure/bed/padded,
 /obj/structure/curtain/open/bed,
@@ -7299,7 +7303,7 @@ aa
 aa
 af
 ak
-aq
+ur
 as
 au
 aq


### PR DESCRIPTION
With the changes to longrange holopads requiring you to be nearby on the overmap to communicate, the previous issue of across-the-map distress spamming shouldn't be a factor anymore. This allows the overmap capable ships to communicate with eachother without needing someone with a shuttle to physically fly over.

:cl:
map: Unishi and Bearcat now have long-range holopads.
/:cl: