### PR TITLE
Makes wizards able to sacrifice more than once and changes the items

### DIFF
--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -250,6 +250,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 		if(uses > spellbook.max_uses)
 			spellbook.max_uses = uses
 		investing_time = 0
+		has_sacrificed = 0
 		STOP_PROCESSING(SSobj, src)
 	return 1
 

--- a/code/modules/spells/spellbook/battlemage.dm
+++ b/code/modules/spells/spellbook/battlemage.dm
@@ -35,6 +35,7 @@
 							/obj/item/weapon/material/twohanded/fireaxe,
 							/obj/item/weapon/melee,
 							/obj/item/weapon/material/knife/ritual,
-							/obj/item/weapon/material/knife/butch,
-							/obj/item/weapon/material/butterfly,
+							/obj/item/weapon/material/knife/kitchen/cleaver,
+							/obj/item/weapon/material/knife/folding/combat/balisong,
+							/obj/item/weapon/material/knife/folding/tacticool,
 							/obj/item/weapon/material/star)

--- a/code/modules/spells/spellbook/battlemage.dm
+++ b/code/modules/spells/spellbook/battlemage.dm
@@ -32,4 +32,9 @@
 					)
 
 	sacrifice_objects = list(/obj/item/weapon/material/sword,
-							/obj/item/weapon/material/twohanded/fireaxe)
+							/obj/item/weapon/material/twohanded/fireaxe,
+							/obj/item/weapon/melee,
+							/obj/item/weapon/material/knife/ritual,
+							/obj/item/weapon/material/knife/butch,
+							/obj/item/weapon/material/butterfly,
+							/obj/item/weapon/material/star)

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -37,4 +37,10 @@
 
 	sacrifice_reagents = list(/datum/reagent/peridaxon,
 							/datum/reagent/adminordrazine)
-	sacrifice_objects = list(/obj/item/seeds/mtearseed)
+	sacrifice_objects = list(/obj/item/stack/nanopaste,
+							/obj/item/device/healthanalyzer,
+							/obj/item/stack/medical/advanced/bruise_pack,
+							/obj/item/stack/medical/advanced/ointment,
+							/obj/item/bodybag/rescue,
+							/obj/item/weapon/defibrillator,
+							/obj/item/weapon/virusdish)

--- a/code/modules/spells/spellbook/druid.dm
+++ b/code/modules/spells/spellbook/druid.dm
@@ -34,5 +34,8 @@
 				/obj/item/weapon/contract/wizard/telepathy = 		1,
 				/obj/item/weapon/contract/apprentice = 				1
 				)
-	sacrifice_objects = list(/obj/item/seeds/ambrosiavulgarisseed,
-							/obj/item/seeds/ambrosiadeusseed)
+	sacrifice_objects = list(/obj/item/seeds,
+							/obj/item/weapon/wirecutters/clippers,
+							/obj/item/device/analyzer/plant_analyzer,
+							/obj/item/weapon/material/hatchet,
+							/obj/item/weapon/material/minihoe)

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -38,4 +38,5 @@
 				)
 
 	sacrifice_reagents = list(/datum/reagent/hyperzine)
-	sacrifice_objects = list(/obj/item/stack/telecrystal)
+	sacrifice_objects = list(/obj/item/stack/telecrystal,
+							/obj/item/stack/material/diamond)

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -36,5 +36,16 @@
 							/obj/item/weapon/contract/apprentice = 				1
 							)
 
-	sacrifice_objects = list(/obj/item/stack/material/gold,
-							/obj/item/stack/material/silver)
+	sacrifice_objects = list(/obj/item/weapon/storage/toolbox,
+							/obj/item/weapon/cane,
+							/obj/item/weapon/flamethrower,
+							/obj/item/weapon/plastique,
+							/obj/item/weapon/dice,
+							/obj/item/weapon/soap,
+							/obj/item/weapon/flame/candle,
+							/obj/item/weapon/caution,
+							/obj/item/weapon/towel,
+							/obj/item/weapon/tank/jetpack,
+							/obj/item/clothing/mask/plunger,
+							/obj/item/device/megaphone,
+							/obj/item/weapon/deck/cards)


### PR DESCRIPTION
🆑Roland410:
tweak:Wizards can sacrifice items any number of times they can, but only once during an investing.
tweak:Changed around sacrifice items for each class.
/🆑
The purpose of this PR is to allow wizards more variety and to not be outright locked to their choices they make at the beginning of the round.
I feel like this still needs adjustments, but I have no idea what other items to give each class.
Input/feedback would be highly appreciated.