### PR TITLE
Rename areas to be more descriptive

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2551,7 +2551,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "ir" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/waterstore)
@@ -4769,7 +4769,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "qg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6830,7 +6830,7 @@
 /area/hallway/primary/fourthdeck/center)
 "vK" = (
 /turf/simulated/wall/prepainted,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "vQ" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/office)
@@ -7208,7 +7208,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "xo" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7971,7 +7971,7 @@
 /area/security/hangcheck)
 "zM" = (
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "zP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8022,7 +8022,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Ae" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -10821,13 +10821,13 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "La" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Lb" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -10984,10 +10984,10 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Lz" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "LA" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/aft)
@@ -12202,7 +12202,7 @@
 	name = "DO Office Shutters"
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Pc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12292,7 +12292,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Pk" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12606,7 +12606,7 @@
 "PT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "PU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12802,7 +12802,7 @@
 /obj/structure/table/standard,
 /obj/item/device/megaphone,
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Qy" = (
 /obj/structure/railing/mapped,
 /obj/random/trash,
@@ -12833,7 +12833,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "QG" = (
 /obj/structure/table/standard,
 /obj/structure/cable/green{
@@ -13478,7 +13478,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Si" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13631,7 +13631,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Sz" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -13756,7 +13756,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "SL" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -13848,7 +13848,7 @@
 	pixel_x = 21
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "SU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14184,7 +14184,7 @@
 /obj/structure/closet/secure_closet/deckofficer,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "TP" = (
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
@@ -14753,7 +14753,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Vo" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -15317,7 +15317,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "WX" = (
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -15674,7 +15674,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "XP" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -15687,7 +15687,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "XQ" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -16333,7 +16333,7 @@
 	name = "DO Office Shutters"
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "Zo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16577,7 +16577,7 @@
 	sortType = "Deck Chief"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/deckofficer)
+/area/quartermaster/deckchief)
 "ZR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -290,7 +290,7 @@
 	name = "\improper Bridge Safe Room"
 
 /area/bridge/storage
-	name = "\improper Bridge Storage Room"
+	name = "\improper Bridge Storage"
 	req_access = list(access_bridge)
 
 // Shuttles
@@ -853,7 +853,7 @@
 	req_access = list(access_cargo)
 
 /area/storage/expedition
-	name = "Expedition Storage"
+	name = "Auxiliary Expedition Storage"
 	icon_state = "storage"
 	sound_env = SMALL_ENCLOSED
 	req_access = list(list(access_mining, access_xenoarch))
@@ -872,8 +872,8 @@
 
 // Supply
 
-/area/quartermaster/deckofficer
-	name = "\improper Deck Chief"
+/area/quartermaster/deckchief
+	name = "\improper Deck Chief's Office"
 	icon_state = "quart"
 	req_access = list(access_qm)
 
@@ -888,7 +888,7 @@
 	req_access = list(list(access_mining, access_xenoarch))
 
 /area/quartermaster/expedition/storage
-	name = "\improper Expedition Storage"
+	name = "\improper Hangar Expedition Storage"
 	icon_state = "mining"
 	req_access = list(list(access_mining, access_explorer, access_xenoarch))
 
@@ -909,7 +909,7 @@
 	req_access = list(access_hangar)
 
 /area/quartermaster/hangar/top
-	name = "\improper Hangar Maintenance"
+	name = "\improper Hangar Upper Walkway"
 
 /area/quartermaster/flightcontrol
 	name = "\improper Flight Control Tower"
@@ -955,12 +955,12 @@
 	icon_state = "locker"
 
 /area/crew_quarters/head
-	name = "\improper Head"
+	name = "\improper Third Deck Head"
 	icon_state = "toilet"
 	sound_env = SMALL_ENCLOSED
 
 /area/crew_quarters/head/aux
-	name = "\improper Auxiliary Head"
+	name = "\improper First Deck Head"
 
 /area/crew_quarters/gym
 	name = "\improper Gym"
@@ -1003,7 +1003,7 @@
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/crew_quarters/sleep/cryo/aux
-	name = "\improper Auxiliary Cryogenic Storage"
+	name = "\improper First Deck Cryogenic Storage"
 	icon_state = "Sleep"
 
 /area/crew_quarters/diplomat
@@ -1082,7 +1082,7 @@
 // Medbay
 
 /area/medical/equipstorage
-	name = "\improper Equipment Storage"
+	name = "\improper Infirmary Equipment Storage"
 	icon_state = "medbay4"
 	ambience = list('sound/ambience/signal.ogg')
 	req_access = list(access_medical_equip)
@@ -1223,7 +1223,7 @@
 	name = "\improper Bridge Starboard Access Hallway"
 
 /area/bridge/meeting_room
-	name = "\improper Heads of Staff Meeting Room"
+	name = "\improper Command Meeting Room"
 	icon_state = "bridge_meeting"
 	ambience = list()
 	sound_env = MEDIUM_SOFTFLOOR
@@ -1534,7 +1534,7 @@
 	icon_state = "misclab"
 
 /area/rnd/research
-	name = "\improper Research and Development"
+	name = "\improper Research Hallway"
 	icon_state = "research"
 
 /area/rnd/breakroom
@@ -1606,7 +1606,7 @@
 	req_access = list(access_heads_vault)
 
 /area/security/range
-	name = "\improper Security - Firing Range"
+	name = "\improper Decommissioned Firing Range"
 	icon_state = "firingrange"
 	req_access = list(access_solgov_crew)
 
@@ -1619,17 +1619,17 @@
 	icon_state = "quartoffice"
 
 /area/quartermaster/storage
-	name = "\improper Warehouse"
+	name = "\improper Supply Warehouse"
 	icon_state = "quartstorage"
 	sound_env = LARGE_ENCLOSED
 
 /area/quartermaster/storage/upper
-	name = "\improper Upper Warehouse"
+	name = "\improper Supply Upper Warehouse"
 
 // Crew
 
 /area/crew_quarters/sleep/cryo
-	name = "\improper Cryogenic Storage"
+	name = "\improper Third Deck Cryogenic Storage"
 	icon_state = "Sleep"
 
 /area/hydroponics


### PR DESCRIPTION
Also changed Deck Chief area tag to deckchief instead of deckofficer

:cl:
map: Various areas on the SEV Torch have been renamed to be more descriptive of their purpose/location.
/:cl: