### PR TITLE
Virus effect limits

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -431,6 +431,11 @@ default behaviour is:
 	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0
+	drowsyness = 0
+	druggy = 0
+	jitteriness = 0
+	confused = 0
+		
 	heal_overall_damage(getBruteLoss(), getFireLoss())
 
 	// fix all of our organs

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -101,7 +101,7 @@
 	stage = 4
 	badness = VIRUS_COMMON
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
-		mob.ear_deaf += 20
+		mob.ear_deaf = min(mob.ear_deaf + 10, 50)
 
 /datum/disease2/effect/monkey
 	name = "Two Percent Syndrome"
@@ -230,7 +230,7 @@
 	stage = 3
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		to_chat(mob, "<span class='notice'>You have trouble telling right and left apart all of a sudden.</span>")
-		mob.confused += 10
+		mob.confused = min(mob.confused + 10, 50)
 
 /datum/disease2/effect/mutation
 	name = "DNA Degradation"
@@ -271,7 +271,7 @@
 	name = "Automated Sleeping Syndrome"
 	stage = 2
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
-		mob.drowsyness += 10
+		mob.drowsyness = min(mob.drowsyness + 10, 50)
 
 /datum/disease2/effect/sleepy
 	name = "Resting Syndrome"
@@ -333,7 +333,7 @@
 		if (mob.reagents.get_reagent_amount(/datum/reagent/hyperzine) < 10)
 			mob.reagents.add_reagent(/datum/reagent/hyperzine, 4)
 		if (prob(30))
-			mob.jitteriness += 10
+			mob.jitteriness = min(mob.jitteriness + 10, 500)
 
 ////////////////////////STAGE 1/////////////////////////////////
 


### PR DESCRIPTION
:cl:
tweak: Viruses no longer infinitely increase the duration of effects like deafness and drowsiness.
/:cl:

Also adds ~~three~~ four missing effect vars to rejuvenate.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->