### PR TITLE
Fix the weird issue with floor tiles, simple animal flash check

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -91,13 +91,13 @@
 	else if(isanimal(M))
 		var/mob/living/simple_animal/SA = M
 		var/safety = SA.eyecheck()
-		if(safety < FLASH_PROTECTION_MODERATE)
-			SA.Stun(flash_strength - 2)
-			SA.flash_eyes(2)
-			SA.eye_blurry += flash_strength
-			SA.confused += flash_strength
-			if(safety <= FLASH_PROTECTION_MAJOR)
-				SA.Weaken(2)
+		if(safety < FLASH_PROTECTION_MAJOR)
+			SA.Weaken(2)
+			if(safety < FLASH_PROTECTION_MODERATE)
+				SA.Stun(flash_strength - 2)
+				SA.flash_eyes(2)
+				SA.eye_blurry += flash_strength
+				SA.confused += flash_strength
 		else 
 			flashfail = 1
 

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -145,7 +145,8 @@
 
 /decl/flooring/tiling/dark/mono
 	icon_base = "monotile"
-
+	build_type = null
+	
 /decl/flooring/tiling/freezer
 	desc = "Don't slip."
 	icon_base = "freezer"
@@ -167,13 +168,16 @@
 /decl/flooring/tiling/new_tile
 	icon_base = "tile_full"
 	color = null
-
+	build_type = null
+	
 /decl/flooring/tiling/new_tile/cargo_one
 	icon_base = "cargo_one_full"
-
+	build_type = null
+	
 /decl/flooring/tiling/new_tile/kafel
 	icon_base = "kafel_full"
-
+	build_type = null
+	
 /decl/flooring/tiling/stone
 	icon_base = "stone"
 	build_type = /obj/item/stack/tile/stone


### PR DESCRIPTION
Fixes the issue where an incorrect flooring decl was being assigned to a floor type. Every subtype of 'tiling' needs a build_type or it to be nulled

Also fixes simple animal flash check