### PR TITLE
Autogenerate away site area names

### DIFF
--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -9,10 +9,13 @@
 	if (map_name != null)
 		SetName(map_name)
 	
-	for (var/area/A in world)
-		if (istype(A, area_type))
-			A.SetName("\improper [name] - [A.name]")
-			GLOB.using_map.area_purity_test_exempt_areas += A.type
+	var/list/area_list = area_repository.get_areas_by_name(area_type)
+	var/area/a
+	for (var/i = 1, i <= area_list.len, i++)
+		a = area_list[i]
+		world.log << "Prefixing '[name]' to '[a.name]'"
+		a.SetName("\improper [name] - [a.name]")
+		GLOB.using_map.area_purity_test_exempt_areas += a.type
 	
 	if (map_name != null)
 		SetName("[name], \a [initial(name)]")

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -3,3 +3,16 @@
 /datum/map_template/ruin/away_site
 	var/spawn_weight = 1
 	prefix = "maps/away/"
+
+// Used to ensure unique and identifiable area names for overmapped away sites
+/obj/effect/overmap/proc/renameAreas(area_type, map_name = null)
+	if (map_name != null)
+		SetName(map_name)
+	
+	for (var/area/A in world)
+		if (istype(A, area_type))
+			A.SetName("\improper [name] - [A.name]")
+			GLOB.using_map.area_purity_test_exempt_areas += A.type
+	
+	if (map_name != null)
+		SetName("[name], \a [initial(name)]")

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -22,11 +22,7 @@
 	burn_delay = 10 SECONDS
 
 /obj/effect/overmap/ship/bearcat/New()
-	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")]"
-	for(var/area/ship/scrap/A)
-		A.name = "\improper [name] - [A.name]"
-		GLOB.using_map.area_purity_test_exempt_areas += A.type
-	name = "[name], \a [initial(name)]"
+	renameAreas(/area/ship/scrap, "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")]")
 	..()
 
 /datum/map_template/ruin/away_site/bearcat_wreck

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -21,7 +21,7 @@
 	)
 
 /obj/effect/overmap/ship/casino/New(nloc, max_x, max_y)
-	name = "IPV [pick("Fortuna","Gold Rush","Ebisu","Lucky Paw","Four Leaves")], \a [name]"
+	renameAreas(/area/casino, "IPV [pick("Fortuna","Gold Rush","Ebisu","Lucky Paw","Four Leaves")]")
 	..()
 
 /datum/map_template/ruin/away_site/casino

--- a/maps/away/casino/casino_areas.dm
+++ b/maps/away/casino/casino_areas.dm
@@ -2,73 +2,73 @@ area/casino
 	icon = 'maps/away/casino/casino_sprites.dmi'
 
 area/casino/casino_mainfloor
-	name = "\improper Casino Hall"
+	name = "\improper Hall"
 	icon_state = "main_area"
 
 /area/casino/casino_maintenance
-	name = "\improper Casino Maintenance"
+	name = "\improper Maintenance"
 	icon_state = "maintenance"
 
 /area/casino/casino_bow
-	name = "\improper Casino Ship Bow"
+	name = "\improper Ship Bow"
 	icon_state = "bow"
 
 /area/casino/casino_crew_bunk
-	name = "\improper Casino Crew Bunk Room"
+	name = "\improper Crew Bunk Room"
 	icon_state = "crew_bunk"
 
 /area/casino/casino_crew_atmos
-	name = "\improper Casino Atmos room"
+	name = "\improper Atmos room"
 	icon_state = "atmos"
 
 /area/casino/casino_kitchen
-	name = "\improper Casino Kitchen"
+	name = "\improper Kitchen"
 	icon_state = "kitchen"
 
 /area/casino/casino_crew_cantina
-	name = "\improper Casino Canteen"
+	name = "\improper Canteen"
 	icon_state = "crew_cantina"
 
 /area/casino/casino_security
-	name = "\improper Casino Security Wing"
+	name = "\improper Security Wing"
 	icon_state = "sec"
 
 /area/casino/casino_hangar
-	name = "\improper Casino Hangar"
+	name = "\improper Hangar"
 	icon_state = "hangar"
 
 /area/casino/casino_private1
-	name = "\improper Casino Private Room 1"
+	name = "\improper Private Room 1"
 	icon_state = "pr1"
 
 /area/casino/casino_private2
-	name = "\improper Casino Private room 1"
+	name = "\improper Private room 1"
 	icon_state = "pr2"
 
 /area/casino/casino_private_vip
-	name = "\improper Casino VIP Private Room"
+	name = "\improper VIP Private Room"
 	icon_state = "pr_vip"
 
 /area/casino/casino_crew_bathroom
-	name = "\improper Casino Crew Bathroom"
+	name = "\improper Crew Bathroom"
 	icon_state = "crew_bathroom"
 
 /area/casino/casino_patron_bathroom
-	name = "\improper Casino Patrons Bathroom"
+	name = "\improper Patrons Bathroom"
 	icon_state = "patron_bathroom"
 
 /area/casino/casino_bridge
-	name = "\improper Casino Bridge"
+	name = "\improper Bridge"
 	icon_state = "bridge"
 
 /area/casino/casino_storage
-	name = "\improper Casino Storage Room"
+	name = "\improper Storage Room"
 	icon_state = "storage"
 
 /area/casino/casino_solar_control
-	name = "\improper Casino Solar Controls"
+	name = "\improper Solar Controls"
 	icon_state = "solar_control"
 
 /area/casino/casino_cutter
-	name = "\improper Casino Cutter"
+	name = "\improper Cutter"
 	icon_state = "shuttle"

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -1,11 +1,15 @@
 #include "errant_pisces_areas.dm"
 
 /obj/effect/overmap/ship/errant_pisces
-	name = "XCV Ahab's Harpoon"
+	name = "carp trawler"
 	desc = "Sensors detect civilian vessel with unusual signs of life aboard."
 	color = "#bd6100"
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 15 SECONDS
+
+/obj/effect/overmap/ship/errant_pisces/New()
+	renameAreas(/area/errant_pisces, "XCV [pick("Ahab's Harpoon", "Errant Pisces")]")
+	..()
 
 /datum/map_template/ruin/away_site/errant_pisces
 	name = "Errant Pisces"

--- a/maps/away/errant_pisces/errant_pisces_areas.dm
+++ b/maps/away/errant_pisces/errant_pisces_areas.dm
@@ -1,4 +1,5 @@
 area/errant_pisces
+	name = "XCV Ahab's Harpoon"
 	icon = 'maps/away/errant_pisces/errant_pisces_areas_sprites.dmi'//24 areas so sprites are in a separate .dmi
 
 area/errant_pisces/bow_port

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -1,10 +1,14 @@
 #include "lar_maria_areas.dm"
 
 /obj/effect/overmap/sector/lar_maria
-	name = "Lar Maria space station"
+	name = "medical research station"
 	desc = "Sensors detect an orbital station with low energy profile and sporadic life signs."
 	icon_state = "object"
 	known = 0
+
+/obj/effect/overmap/sector/lar_maria/New()
+	renameAreas(/area/lar_maria, "ZSS Lar Maria")
+	..()
 
 /datum/map_template/ruin/away_site/lar_maria
 	name = "Lar Maria"
@@ -275,7 +279,7 @@
 	name = "paper note"
 	info = {"<center><b><font color='green'>Zeng-Hu Pharmaceuticals</font></b></center>
 			<center><font color='red'><small>CONFIDENTIAL USE ONLY</small></font></center>
-			<i>Tedd, don't get into the cells with the Type 8 subjects anymore, something's off about them the last couple days. They haven't been moving right, and they seem distracted nearly constantly, and not in a normal way. They also look like they're turning kinda... green? One of the other guys says it's probably just a virus or something reacting with it, but I don't know, something seems off.</i>
+			<i>Tedd, don't get into the cells with the Type 8 subjects anymore, something's off about them the last couple days. They haven't been moving right, and they seem distracted nearly constantly, and not in a normal way. They also look like they're turning kinda green? One of the other guys says it's probably just a virus or something reacting with it, but I don't know, something seems off.</i>
 			"}
 
 /obj/item/weapon/paper/lar_maria/note_5

--- a/maps/away/lar_maria/lar_maria_areas.dm
+++ b/maps/away/lar_maria/lar_maria_areas.dm
@@ -3,69 +3,69 @@
 
 /////////////////////////////Upper level areas
 /area/lar_maria/solar_control
-	name = "Lar Maria Solar Control Room"
+	name = "Solar Control Room"
 	icon_state = "solar_control"
 
 /area/lar_maria/atmos
-	name = "Lar Maria Atmos Control Room"
+	name = "Atmos Control Room"
 	icon_state = "atmos"
 
 /area/lar_maria/library
-	name = "Lar Maria Library"
+	name = "Library"
 	icon_state = "library"
 
 /area/lar_maria/head_m
-	name = "Lar Maria Head M"
+	name = "Head M"
 	icon_state = "head_m"
 
 /area/lar_maria/head_f
-	name = "Lar Maria Head F"
+	name = "Head F"
 	icon_state = "head_f"
 
 /area/lar_maria/hallway
-	name = "Lar Maria Hallway"
+	name = "Hallway"
 	icon_state = "hallway"
 
 /area/lar_maria/office
-	name = "Lar Maria Office and Infirmary"
+	name = "Office and Infirmary"
 	icon_state = "office"
 
 /area/lar_maria/mess_hall
-	name = "Lar Maria Mess Hall"
+	name = "Mess Hall"
 	icon_state = "mess_hall"
 
 /area/lar_maria/dorms
-	name = "Lar Maria Dormitory"
+	name = "Dormitory"
 	icon_state = "dorms"
 /////////////////////////////Lower level areas
 /area/lar_maria/cells
-	name = "Lar Maria Holding Area"
+	name = "Holding Area"
 	icon_state = "cells"
 
 /area/lar_maria/sec_wing
-	name = "Lar Maria Security Wing"
+	name = "Security Wing"
 	icon_state = "sec_wing"
 
 /area/lar_maria/vir_access
-	name = "Lar Maria Virology Access"
+	name = "Virology Access"
 	icon_state = "vir_access"
 
 /area/lar_maria/morgue
-	name = "Lar Maria Morgue"
+	name = "Morgue"
 	icon_state = "morgue"
 
 /area/lar_maria/vir_hallway
-	name = "Lar Maria Virology Hallway"
+	name = "Virology Hallway"
 	icon_state = "vir_hallway"
 
 /area/lar_maria/vir_ward
-	name = "Lar Maria Virology Ward"
+	name = "Virology Ward"
 	icon_state = "vir_ward"
 
 /area/lar_maria/vir_main
-	name = "Lar Maria Virology Main Lab"
+	name = "Virology Main Lab"
 	icon_state = "vir_main"
 
 /area/lar_maria/vir_aux
-	name = "Lar Maria Virology Auxilary Lab"
+	name = "Virology Auxilary Lab"
 	icon_state = "vir_aux"

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -14,6 +14,10 @@
 		"nav_lost_supply_base_antag"
 	)
 
+/obj/effect/overmap/sector/lost_supply_base/New()
+	renameAreas(/area/lost_supply_base, "[pick("FTS", "ITS", "ISS", "FSS")] [pick("Hermes", "Troy", "Farpoint")]")
+	..()
+
 /datum/map_template/ruin/away_site/lost_supply_base
 	name = "Lost Supply Base"
 	id = "awaysite_lost_supply_base"

--- a/maps/away/lost_supply_base/lost_supply_base_areas.dm
+++ b/maps/away/lost_supply_base/lost_supply_base_areas.dm
@@ -1,24 +1,24 @@
 /area/lost_supply_base
-	name = "\improper Abandoned supply station"
+	name = "\improper supply station"
 	icon_state = "lost_supply_base"
 	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/solar
-	name = "\improper Abandoned supply station solars control room"
+	name = "\improper Solars Control Room"
 	icon_state = "lost_supply_base_solar"
 	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/office
-	name = "\improper Abandoned supply station office"
+	name = "\improper Office"
 	icon_state = "lost_supply_base_office"
 	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/supply
-	name = "\improper Abandoned supply station supplies room"
+	name = "\improper Supplies Room"
 	icon_state = "lost_supply_base_supply"
 	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/common
-	name = "\improper Abandoned supply station common area"
+	name = "\improper Common Area"
 	icon_state = "lost_supply_base_common"
 	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -14,6 +14,10 @@
 		"nav_magshield_antag"
 	)
 
+/obj/effect/overmap/sector/magshield/New()
+	renameAreas(/area/ship/scrap, "[pick("FTS", "ITS", "ISS", "FSS")] [pick("Aegis", "Magneto", "Pulsar", "Demeter")]")
+	..()
+
 /datum/map_template/ruin/away_site/magshield
 	name = "Magshield"
 	id = "awaysite_magshield"

--- a/maps/away/magshield/magshield_areas.dm
+++ b/maps/away/magshield/magshield_areas.dm
@@ -1,29 +1,29 @@
 /area/magshield/south
-	name = "Orbital Station South Wing"
+	name = "South Wing"
 	icon_state = "south"
 	icon = 'magshield_sprites.dmi'
 
 /area/magshield/north
-	name = "Orbital Station North Wing"
+	name = "North Wing"
 	icon_state = "north"
 	icon = 'magshield_sprites.dmi'
 
 /area/magshield/east
-	name = "Orbital Station East Wing"
+	name = "East Wing"
 	icon_state = "east"
 	icon = 'magshield_sprites.dmi'
 
 /area/magshield/west
-	name = "Orbital Station West Wing"
+	name = "West Wing"
 	icon_state = "west"
 	icon = 'magshield_sprites.dmi'
 
 /area/magshield/engine
-	name = "Orbital Station Engine"
+	name = "Engine"
 	icon_state = "engine"
 	icon = 'magshield_sprites.dmi'
 
 /area/magshield/smes_storage
-	name = "Orbital Station SMES Battery Room"
+	name = "SMES Battery Room"
 	icon_state = "smes_storage"
 	icon = 'magshield_sprites.dmi'

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -23,7 +23,7 @@
 
 
 /obj/effect/overmap/ship/landable/skrellscoutship/New()
-	name = "SSV [pick("Xilvuxix", "Zuuvixix", "Quizuu", "Vulzxixvuu","Quumzoox","Quuvuzxuu")]"
+	renameAreas(/area/ship/skrellscoutship, "SSV [pick("Xilvuxix", "Zuuvixix", "Quizuu", "Vulzxixvuu","Quumzoox","Quuvuzxuu")]")
 	..()
 	
 /obj/effect/overmap/ship/landable/skrellscoutshuttle

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -14,7 +14,7 @@
 	)
 
 /obj/effect/overmap/ship/unishi
-	name = "SRV Verne"
+	name = "research vessel"
 	desc = "Sensor array detects unknown class medium size vessel. The vessel appears unarmed.\
 	A small amount of radiation has been detected at the aft of the ship"
 	vessel_mass = 5000
@@ -24,6 +24,10 @@
 		"nav_unishi_2",
 		"nav_unishi_3",
 	)
+
+/obj/effect/overmap/ship/unishi/New()
+	renameAreas(/area/unishi, "SRV [pick("Verne", "Unishi")]")
+	..()
 
 /datum/map_template/ruin/away_site/unishi
 	name = "University Ship"

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -14,7 +14,7 @@
 	)
 
 /obj/effect/overmap/ship/yacht/New(nloc, max_x, max_y)
-	name = "IPV [pick("Razorshark", "Aurora", "Lighting", "Pequod", "Anansi")], \a [name]"
+	renameAreas(/area/yacht, "IPV [pick("Razorshark", "Aurora", "Lightning", "Pequod", "Anansi")]")
 	..()
 
 /datum/map_template/ruin/away_site/yacht

--- a/maps/away/yacht/yacht_areas.dm
+++ b/maps/away/yacht/yacht_areas.dm
@@ -1,12 +1,14 @@
+/area/yacht
+	name = "\improper Private Yacht"
 /area/yacht/bridge
-	name = "\improper Yacht Bridge"
+	name = "\improper Bridge"
 	icon_state = "bridge"
 	icon = 'yacht_icons.dmi'
 /area/yacht/living
-	name = "\improper Yacht Living"
+	name = "\improper Living"
 	icon_state = "living"
 	icon = 'yacht_icons.dmi'
 /area/yacht/engine
-	name = "\improper Yacht Engine"
+	name = "\improper Engine"
 	icon_state = "engine"
 	icon = 'yacht_icons.dmi'


### PR DESCRIPTION
Taking the method already used by the Bearcat to autogenerate names for other ships/stations/sites/etc, so that area tags are better descriptive of what they're for (Primarily for the pesky alarms the AI still gets spammed with, and for runtime errors as requested by @Spookerton ).