### PR TITLE
Slash armour values for heavy hardsuits 

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -1,13 +1,12 @@
 /obj/item/weapon/rig/unathi
 	name = "\improper NT breacher chassis control module"
-	desc = "A cheap NanoTrasen-made knock-off of an Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
+	desc = "A NanoTrasen-made Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
 	suit_type = "\improper NT breacher rig"
 	icon_state = "breacher_rig_cheap"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 60, bomb = 70, bio = 100, rad = 50)
+	armor = list(melee = 60, bullet = 60, laser = 60, energy = 60, bomb = 70, bio = 100, rad = 25)
 	emp_protection = -20
 	online_slowdown = 6
 	offline_slowdown = 10
-	vision_restriction = TINT_HEAVY
 	offline_vision_restriction = TINT_BLIND
 
 	chest_type = /obj/item/clothing/suit/space/rig/unathi
@@ -17,11 +16,10 @@
 
 /obj/item/weapon/rig/unathi/fancy
 	name = "breacher chassis control module"
-	desc = "An authentic Unathi breacher chassis. Huge, bulky and absurdly heavy. It must be like wearing a tank."
+	desc = "An (outwardly) authentic Unathi breacher chassis. Huge, bulky and absurdly heavy. It must be like wearing a tank."
 	suit_type = "breacher chassis"
 	icon_state = "breacher_rig"
-	armor = list(melee = 90, bullet = 90, laser = 90, energy = 90, bomb = 90, bio = 100, rad = 80) //Takes TEN TIMES as much damage to stop someone in a breacher. In exchange, it's slow.
-	vision_restriction = TINT_NONE //Still blind when offline. It is fully armoured after all
+	armor = list(melee = 75, bullet = 75, laser = 75, energy = 75, bomb = 75, bio = 100, rad = 45)
 
 /obj/item/clothing/head/helmet/space/rig/unathi
 	species_restricted = list(SPECIES_UNATHI)

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -4,10 +4,10 @@
 
 /obj/item/weapon/rig/merc
 	name = "crimson hardsuit control module"
-	desc = "A blood-red hardsuit featuring some fairly illegal technology."
+	desc = "A blood-red hardsuit module with heavy armour plates."
 	icon_state = "merc_rig"
 	suit_type = "crimson hardsuit"
-	armor = list(melee = 80, bullet = 65, laser = 65, energy = 15, bomb = 80, bio = 100, rad = 60)
+	armor = list(melee = 80, bullet = 65, laser = 65, energy = 15, bomb = 75, bio = 100, rad = 60)
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
@@ -34,19 +34,19 @@
 /obj/item/weapon/rig/merc/empty
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
-		/obj/item/rig_module/electrowarfare_suite, //might as well
+		/obj/item/rig_module/electrowarfare_suite,
 		)
 
 /obj/item/weapon/rig/merc/heavy
-	name = "heavy crimson hardsuit control module"
-	desc = "A blood-red hardsuit featuring some fairly illegal technology and real curves."
+	name = "crimson EOD hardsuit control module"
+	desc = "A blood-red hardsuit with heavy armoured plates. Judging by the abnormally thick plates, this one is for working with explosives."
 	icon_state = "merc_rig_heavy"
-	armor = list(melee = 90, bullet = 80, laser = 80, energy = 25, bomb = 90, bio = 100, rad = 70)
+	armor = list(melee = 80, bullet = 65, laser = 70, energy = 35, bomb = 100, bio = 100, rad = 80)
+	online_slowdown = 3
 	offline_slowdown = 4
-	online_slowdown = 2
 
 /obj/item/weapon/rig/merc/heavy/empty
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
-		/obj/item/rig_module/electrowarfare_suite, //might as well
+		/obj/item/rig_module/electrowarfare_suite,
 		)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -315,7 +315,7 @@
 /obj/item/weapon/rig/zero
 	name = "null suit control module"
 	suit_type = "null hardsuit"
-	desc = "A very lightweight suit designed to allow use inside mechs and starfighters. It feels like you were wearing nothing at all"
+	desc = "A very lightweight suit designed to allow use inside mechs and starfighters. It feels like you're wearing nothing at all."
 	icon_state = "null_rig"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 20)
 	online_slowdown = 0


### PR DESCRIPTION
:cl:
balance: Reduced armour values for the breacher and heavy mercenary rigs.
/:cl:

~~These suits are a double-edged sword of awful. First they're flatly broken, second it makes security feel they need to beat their occupants into submission well beyond what is considered acceptable by the server's rules. Bad all around.~~

~~Removed the icons too since they'll be unused and these files are already chock full of unused icons.~~