### PR TITLE
Tweaks global base miss chances, organ damage, and brain damage.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -61,7 +61,7 @@ meteor_act
 			def_zone = zone
 			. += .() * organ_rel_size/tally
 		return
-	return ..()		
+	return ..()
 
 /mob/living/carbon/human/get_armors_by_zone(obj/item/organ/external/def_zone, damage_type, damage_flags)
 	. = ..()
@@ -199,8 +199,8 @@ meteor_act
 						visible_message("<span class='danger'>[src] [species.knockout_message]</span>")
 			else
 				//Easier to score a stun but lasts less time
-				if(prob(effective_force + 10))
-					apply_effect(6, WEAKEN, blocked)
+				if(prob(effective_force + 5))
+					apply_effect(3, WEAKEN, blocked)
 					if(lying)
 						visible_message("<span class='danger'>[src] has been knocked down!</span>")
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -88,17 +88,17 @@ proc/getsensorlevel(A)
 
 //The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
-	BP_HEAD = 50,
+	BP_HEAD = 70,
 	BP_CHEST = 10,
 	BP_GROIN = 20,
-	BP_L_LEG = 50,
-	BP_R_LEG = 50,
+	BP_L_LEG = 60,
+	BP_R_LEG = 60,
 	BP_L_ARM = 30,
 	BP_R_ARM = 30,
 	BP_L_HAND = 50,
 	BP_R_HAND = 50,
-	BP_L_FOOT = 60,
-	BP_R_FOOT = 60,
+	BP_L_FOOT = 70,
+	BP_R_FOOT = 70,
 )
 
 //Used to weight organs when an organ is hit randomly (i.e. not a directed, aimed attack).
@@ -172,13 +172,17 @@ var/list/global/organ_rel_size = list(
 				return zone
 
 	var/miss_chance = 10
+	var/scatter_chance
 	if (zone in base_miss_chance)
 		miss_chance = base_miss_chance[zone]
 	miss_chance = max(miss_chance + miss_chance_mod, 0)
+	scatter_chance = min(95, miss_chance + 60)
 	if(prob(miss_chance))
-		if(ranged_attack || prob(70))
+		if(ranged_attack && prob(scatter_chance))
 			return null
-		return pick(base_miss_chance)
+		else if(prob(70))
+			return null
+		return (ran_zone())
 	return zone
 
 //Replaces some of the characters with *, used in whispers. pr = probability of no star.

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -62,7 +62,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 					return
 
 	//blunt damage is gud at fracturing
-	if(brute_dam + brute > min_broken_damage && prob(brute_dam + brute * (1+blunt)) ) 
+	if(brute_dam + brute > min_broken_damage && prob(brute_dam + brute * (1+blunt)) )
 		fracture()
 
 	// High brute damage or sharp objects may damage internal organs
@@ -75,9 +75,12 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		var/organ_damage_threshold = 5
 		if(sharp)
 			organ_damage_threshold *= 0.5
-		var/organ_damage_prob = 5 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
+		var/organ_damage_prob = 10 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
 		if(encased && !(status & ORGAN_BROKEN)) //ribs protect
-			organ_damage_prob *= 0.5
+			if(!laser)
+				organ_damage_prob *= 0.2
+			else
+				organ_damage_prob *= 0.5
 		if ((cur_damage + damage_amt >= max_damage || damage_amt >= organ_damage_threshold) && prob(organ_damage_prob))
 			// Damage an internal organ
 			var/list/victims = list()
@@ -91,7 +94,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 				brute /= 2
 				if(laser)
 					burn /= 2
-				damage_amt /= 2
+				damage_amt -= max(damage_amt*victim.damage_reduction, 0)
 				victim.take_internal_damage(damage_amt)
 
 	if(status & ORGAN_BROKEN && brute)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -6,6 +6,7 @@
 	var/surface_accessible = FALSE
 	var/relative_size = 25   // Relative size of the organ. Roughly % of space they take in the target projection :D
 	var/min_bruised_damage = 10       // Damage before considered bruised
+	var/damage_reduction = 0.5     //modifier for internal organ injury
 
 /obj/item/organ/internal/New(var/mob/living/carbon/holder)
 	if(max_damage)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -12,7 +12,8 @@
 	throw_range = 5
 	origin_tech = list(TECH_BIO = 3)
 	attack_verb = list("attacked", "slapped", "whacked")
-	relative_size = 60
+	relative_size = 85
+	damage_reduction = 0
 
 	var/can_use_mmi = TRUE
 	var/mob/living/carbon/brain/brainmob = null


### PR DESCRIPTION
:cl: 
tweak: Increased global miss chances to head, feet, and legs. 
tweak: Additionally reduced knockdown chances.
tweak: Made organ damage much less likely before ribs/skull are broken. 
tweak: Increased likelihood of organ damage after encasing bones are broken
tweak: Increased damage to brain when dealt and probability of brain damage from damage to the head.
/:cl:

This new PR is the result of some feedback and seeks to nerf the leg meta, add some sanity to the organ damage we've been seeing since my last round of tweaks, and make heads/brains less bullet-spongy.

Blowing/beating legs off has been a staple of Bay combat for quite some time. Bar finding a chair, you can't do anything when you're down a leg. A lot of armor doesn't cover the legs. They were pretty easy to hit. It's not great. Legs move around a lot in combat, and until we have a more robust system to allow the use of items while down or create ways to reduce stance damage while dismembered, making them harder to hit seems like a good compromise. Also, knockdowns are weaker and less probable.

Organ damage was doing some fun stuff. Getting punched in the chest and gasping for breath is still possible, but less likely now. To have a decent chance of dealing sometimes-debilitating organ damage, you'll now need to break the ribs/skull first - by which point you've usually got the upper hand in a combat anyway.

Organ damage is more likely after the encasing bones are broken. This helps compensate for the above change and feeds into the final tweak of this PR.

Brains take more damage now and are easier to damage - why? Because people were doubling their heads' weight in lead (or getting their faces stomped into the next z-level) and cruising along just fine. There are consequences to getting shot or repeatedly beaten in the head now. To help compensate for this, the global miss chance for the head has also been increased - you will need to have your target disabled or held captive to have as much of a real hope of hitting, and this is going to be especially noticeable with ranged weapons: they don't try to target another area if you miss while aiming for the head.