### PR TITLE
Revert "Adjusts traitor TTVs to be in line with merc TTVs in terms of power."

### DIFF
--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -140,8 +140,8 @@
 /obj/effect/spawner/newbomb/traitor
 	name = "TTV bomb - traitor"
 	assembly_type = /obj/item/device/assembly/signaler
-	phoron_amt = 18.5
-	oxygen_amt = 28.5
+	phoron_amt = 14
+	oxygen_amt = 21
 
 /obj/effect/spawner/newbomb/timer
 	name = "TTV bomb - timer"


### PR DESCRIPTION
:cl:
tweak: Traitor TTVs are less overwhelmingly powerful.
/:cl:

Reverts Baystation12/Baystation12#24828 because a single 40TC item (ie, up to 3 per traitor or many more if on sale) mailed to the brig office shouldn't be able to take out the entire brig and forward D1 corridors, most of the bridge floor, the fusion engine, leave damage on deck 3, and vent half the ship. It was already powerful when added.