### PR TITLE
Adjusts renegade weapon spawn list, fixes gyropistol

### DIFF
--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -28,14 +28,16 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 	skill_setter = /datum/antag_skill_setter/station
 
 	var/list/spawn_guns = list(
-		/obj/item/weapon/gun/energy/laser,
+		/obj/item/weapon/gun/energy/retro,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/weapon/gun/energy/crossbow,
-		/obj/item/weapon/gun/energy/crossbow/largecrossbow,
+		/obj/item/weapon/gun/energy/pulse_rifle/pistol,
 		/obj/item/weapon/gun/projectile/automatic,
 		/obj/item/weapon/gun/projectile/automatic/machine_pistol,
-		/obj/item/weapon/gun/projectile/automatic/merc_smg,
 		/obj/item/weapon/gun/projectile/automatic/sec_smg,
+		/obj/item/weapon/gun/projectile/pistol/magnum_pistol,
+		/obj/item/weapon/gun/projectile/pistol/military,
+		/obj/item/weapon/gun/projectile/pistol/military/alt,
 		/obj/item/weapon/gun/projectile/pistol/sec/lethal,
 		/obj/item/weapon/gun/projectile/pistol/holdout,
 		/obj/item/weapon/gun/projectile/revolver,

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -100,8 +100,9 @@
 	max_shells = 8
 	caliber = CALIBER_GYROJET
 	origin_tech = list(TECH_COMBAT = 3)
-	ammo_type = /obj/item/ammo_casing/gyrojet
 	magazine_type = /obj/item/ammo_magazine/gyrojet
+	allowed_magazines = /obj/item/ammo_magazine/gyrojet
+	handle_casings = CLEAR_CASINGS	//the projectile is the casing
 	fire_delay = 25
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'

--- a/html/changelogs/Datraen-RenegadeAndGyro.yml
+++ b/html/changelogs/Datraen-RenegadeAndGyro.yml
@@ -1,0 +1,5 @@
+author: Datraen
+delete-after: True
+changes: 
+  - tweak: "Changes renegade spawn list to allow for any bag to conceal a spawned weapon."
+  - bugfix: "Gyrojet no longer drops casings, now accepts magazines properly."


### PR DESCRIPTION
List pending dev approval, the list contains all current weapons that are of ITEM_SIZE_NORMAL or lower, with the exception of a gyropistol.

The gyropistol is just a little overkill for self-defense.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->