### PR TITLE
Adds Pulling Across Zlevels

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -4,6 +4,7 @@
 
 	if(zMove(UP))
 		to_chat(src, "<span class='notice'>You move upwards.</span>")
+		zPull(UP)
 
 /mob/verb/down()
 	set name = "Move Down"
@@ -11,6 +12,7 @@
 
 	if(zMove(DOWN))
 		to_chat(src, "<span class='notice'>You move down.</span>")
+		zPull(DOWN)
 
 /mob/proc/zMove(direction)
 	if(eyeobj)
@@ -52,6 +54,31 @@
 
 	forceMove(destination)
 	return 1
+
+/mob/proc/zPull(direction)
+	//checks and handles pulled items across z levels
+	if(!pulling)
+		return 0
+
+	var/turf/start = loc
+	var/turf/destination = (direction == UP) ? GetAbove(pulling) : GetBelow(pulling)
+
+	if(!start.CanZPass(pulling, direction))
+		to_chat(src, "<span class='warning'>\The [start] blocked your pulled object!</span>")
+		return 0
+
+	if(!destination.CanZPass(pulling, direction))
+		to_chat(src, "<span class='warning'>Your pulled object bumbs up against \the [destination].</span>")
+		return 0
+
+	for(var/atom/A in destination)
+		if(!A.CanMoveOnto(pulling, start, 1.5, direction))
+			to_chat(src, "<span class='warning'>\The [A] blocks your pulled object.</span>")
+			return 0
+
+	pulling.forceMove(destination)
+	return 1
+
 
 
 /atom/proc/CanMoveOnto(atom/movable/mover, turf/target, height=1.5, direction = 0)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -60,7 +60,7 @@
 	if(!pulling)
 		return 0
 
-	var/turf/start = loc
+	var/turf/start = pulling.loc
 	var/turf/destination = (direction == UP) ? GetAbove(pulling) : GetBelow(pulling)
 
 	if(!start.CanZPass(pulling, direction))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -65,15 +65,18 @@
 
 	if(!start.CanZPass(pulling, direction))
 		to_chat(src, "<span class='warning'>\The [start] blocked your pulled object!</span>")
+		stop_pulling()
 		return 0
 
 	if(!destination.CanZPass(pulling, direction))
-		to_chat(src, "<span class='warning'>Your pulled object bumbs up against \the [destination].</span>")
+		to_chat(src, "<span class='warning'>The [pulling] you were pulling bumps up against \the [destination].</span>")
+		stop_pulling()
 		return 0
 
 	for(var/atom/A in destination)
 		if(!A.CanMoveOnto(pulling, start, 1.5, direction))
-			to_chat(src, "<span class='warning'>\The [A] blocks your pulled object.</span>")
+			to_chat(src, "<span class='warning'>\The [A] blocks the [pulling] you were pulling.</span>")
+			stop_pulling()
 			return 0
 
 	pulling.forceMove(destination)


### PR DESCRIPTION
When verbing between Z-Levels, player will attempt to pull the object aswell.

:cl:
tweak: Players can pull items across Z-Levels
/:cl: