### PR TITLE
Removes stronger breacher chassis from random hardsuit list

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1053,8 +1053,7 @@ something, make sure it's not in one of the other lists.*/
 				/obj/item/weapon/rig/light/hacker,
 				/obj/item/weapon/rig/light/stealth,
 				/obj/item/weapon/rig/light,
-				/obj/item/weapon/rig/unathi,
-				/obj/item/weapon/rig/unathi/fancy)
+				/obj/item/weapon/rig/unathi)
 
 /obj/random/hostile
 	name = "Random Hostile Mob"


### PR DESCRIPTION
This breacher suit is insanely OP and results in a one man tank that requires a mob to bring down. Removal from this list prevents Unathi death-tanks from occuring without adminbus.

:cl:
tweak: The Unathi Breacher Chassis no longer spawns as a random hardsuit option. NT Breacher is still available.
/:cl: