### PR TITLE
Hide typing bubbles while hidden/cloaked

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -260,7 +260,10 @@
 	return FALSE
 
 // Returns true if the human is cloaked, otherwise false (technically returns the number of cloaking sources)
-/mob/living/carbon/human/proc/is_cloaked()
+/mob/proc/is_cloaked()
+	return FALSE
+
+/mob/living/carbon/human/is_cloaked()
 	if(clean_cloaking_sources())
 		update_icons()
 		visible_message(CLOAK_APPEAR_OTHER, CLOAK_APPEAR_SELF)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -33,7 +33,7 @@ I IS TYPIN'!'
 	forceMove(get_turf(master))
 
 /mob/proc/create_typing_indicator()
-	if(client && !stat && get_preference_value(/datum/client_preference/show_typing_indicator) == GLOB.PREF_SHOW)
+	if(client && !stat && get_preference_value(/datum/client_preference/show_typing_indicator) == GLOB.PREF_SHOW && !src.is_cloaked() && isturf(src.loc))
 		if(typing_indicator)
 			qdel(typing_indicator)
 


### PR DESCRIPTION
Because being able to meta where someone is while they're typing but before they've actually said anything is bad.

:cl:
tweak: Typing indicator bubbles no longer appear for hidden mobs (Cloaked or inside objects such as lockers). Indicators after you say or emote still appear.
/:cl: