### PR TITLE
Corrects behavior of armbands and webbing to hide when jumpsuit is rolled down.

### DIFF
--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -4,6 +4,7 @@
 	icon_state = "red"
 	slot = ACCESSORY_SLOT_ARMBAND
 	species_restricted = null
+	on_rolled = list("down" = "none")
 	sprite_sheets = list(SPECIES_NABBER = 'icons/mob/species/nabber/onmob_accessories_gas.dmi')
 
 /obj/item/clothing/accessory/armband/cargo

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -8,6 +8,7 @@
 	var/obj/item/weapon/storage/internal/pockets/hold
 	w_class = ITEM_SIZE_NORMAL
 	high_visibility = 1
+	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/storage/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl: ajkrupka
bugfix: Fixed an oversight to make armbands and webbing hide when jumpsuits are rolled down.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->