### PR TITLE
Fix Deck 2 safe room APC positioning

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -5174,6 +5174,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/power/apc/super{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/green{


### PR DESCRIPTION
Fixes this:
<img width="285" alt="dreamseeker_2019-03-25_14-32-07" src="https://user-images.githubusercontent.com/11140088/54956521-60e06a80-4f0d-11e9-8152-cd3f974a1441.png">
