### PR TITLE
Makes limb damage collapse more avoidable.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -59,6 +59,17 @@
 						if (W.infection_check())
 							W.germ_level += 1
 
+/mob/living/carbon/human/proc/Check_Proppable_Object()
+	for(var/turf/simulated/T in trange(1,src)) //we only care for non-space turfs
+		if(T.density)	//walls work
+			return 1
+
+	for(var/obj/O in orange(1, src))
+		if(O && O.density && O.anchored)
+			return 1
+
+	return 0
+
 /mob/living/carbon/human/proc/handle_stance()
 	// Don't need to process any of this if they aren't standing anyways
 	// unless their stance is damaged, and we want to check if they should stay down
@@ -107,8 +118,32 @@
 	if (r_hand && istype(r_hand, /obj/item/weapon/cane))
 		stance_damage -= 2
 
+	if(MOVING_DELIBERATELY(src)) //you don't suffer as much if you aren't trying to run
+		var/working_pair = 2
+		if(!organs_by_name[BP_L_LEG] || !organs_by_name[BP_L_FOOT]) //are we down a limb?
+			working_pair -= 1
+		else if((!organs_by_name[BP_L_LEG].is_usable()) || (!organs_by_name[BP_L_FOOT].is_usable())) //if not, is it usable?
+			working_pair -= 1
+		if(!organs_by_name[BP_R_LEG] || !organs_by_name[BP_R_FOOT])
+			working_pair -= 1
+		else if((!organs_by_name[BP_R_LEG].is_usable()) || (!organs_by_name[BP_R_FOOT].is_usable()))
+			working_pair -= 1
+		if(working_pair >= 1)
+			stance_damage -= 1
+			if(Check_Proppable_Object()) //it helps to lean on something if you've got another leg to stand on
+				stance_damage -= 1
+
+	var/list/objects_to_sit_on = list(
+			/obj/item/weapon/stool,
+			/obj/structure/bed,
+		)
+
+	for(var/type in objects_to_sit_on) //things that can't be climbed but can be propped-up-on
+		if(locate(type) in src.loc)
+			return
+
 	// standing is poor
-	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
+	if(stance_damage >= 4 || (stance_damage >= 2 && prob(2)) || (stance_damage >= 3 && prob(8)))
 		if(!(lying || resting))
 			if(limb_pain)
 				emote("scream")


### PR DESCRIPTION
:cl:
tweak: Chances of collapsing from limb damage can now be mitigated by walking and moving along walls/other objects you could reasonably use to prop yourself up.
tweak: This mitigation only works if at least one of your legs fully works.
tweak: Stools and beds are collapse-exempt. IPCs at funerals rejoice.
tweak: The chance of collapsing when not doing these things to mitigate it is now significantly higher to compensate.
/:cl: 

Another set of tweaks directed at the leg meta. Damage capable of causing collapse will still be able to floor people due to pain, but constantly collapsing with no way to mitigate it except a single wheelchair and nonexistent canes was stupidly punishing before. Movement speed is comparably slow to crawling. 

This is likely to make combats longer-lasting and allow both sides more reliable escapes; but it requires that players deliberately switch to walking and avoid open areas to mitigate a now-higher chance of falling down if they do not.

This is another stopgap measure short of doing a rework of weakening. 