### PR TITLE
Access Restrict SE's Suit and Storage

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -94,7 +94,7 @@
 
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/toolbox,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/inflatable_dispenser,/obj/item/device/t_scanner,/obj/item/weapon/rcd)
 
-	req_access = list(access_engine_equip)
+	req_access = list(access_tcomsat)
 
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/generated/onmob_rig_back_unathi.dmi'

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -5201,8 +5201,10 @@
 	dir = 5
 	},
 /obj/machinery/door/window/brigdoor/southleft{
+	autoset_access = 0;
 	dir = 8;
-	name = "suit storage"
+	name = "SE's suit storage";
+	req_access = list("ACCESS_TELECOMS")
 	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/yellow/mono,


### PR DESCRIPTION
🆑 lorwp
tweak: The SE's Hardsuit and the Storage it is stored in now is access restricted to them. Normies not allowed
/:cl:

Renamed the suit storage too for consistency with the others. Was always intended i believe to only be used by the SE
