### PR TITLE
Some GC stuff

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1241,6 +1241,7 @@
 #include "code\modules\admin\secrets\admin_secrets\toggle_circuits.dm"
 #include "code\modules\admin\secrets\admin_secrets\toggle_overmap_movement.dm"
 #include "code\modules\admin\secrets\admin_secrets\traitors_and_objectives.dm"
+#include "code\modules\admin\secrets\debug\toggle_harddel.dm"
 #include "code\modules\admin\secrets\debug\world_types.dm"
 #include "code\modules\admin\secrets\fun_secrets\break_all_lights.dm"
 #include "code\modules\admin\secrets\fun_secrets\break_some_lights.dm"

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -92,7 +92,7 @@
 			else if (H.nutrition > grow_threshold) //We don't subtract any nut here, but let's still only heal wounds when we have nut.
 				for(var/datum/wound/W in E.wounds)
 					if(W.wound_damage() == 0 && prob(50))
-						E.wounds -= W
+						qdel(W)
 	return 1
 
 /obj/aura/regenerating/human/proc/low_nut_warning(var/wound_type)

--- a/code/modules/admin/secrets/debug/toggle_harddel.dm
+++ b/code/modules/admin/secrets/debug/toggle_harddel.dm
@@ -1,0 +1,11 @@
+/datum/admin_secret_item/debug/toggle_harddel
+	name = "Toggle Harddelete Queue"
+
+/datum/admin_secret_item/debug/toggle_harddel/do_execute(mob/user)
+	var/choice = alert(user, "Harddeletes are currently [SSgarbage.harddel_halt ? "inactive" : "active"].","Toggle Harddelete Queue", SSgarbage.harddel_halt ? "Enable" : "Disable","Cancel")
+	if(choice == "Disable")
+		SSgarbage.toggle_harddel_halt(TRUE)
+		log_and_message_admins("disabled harddels in SSgarbage.", user)
+	else if(choice == "Enable")
+		SSgarbage.toggle_harddel_halt(FALSE)
+		log_and_message_admins("re-enabled harddels in SSgarbage.", user)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -232,7 +232,7 @@
 		else
 			if(E.is_stump())
 				wound_flavor_text[E.name] += "<b>[T.He] [T.has] a stump where [T.his] [organ_descriptor] should be.</b>\n"
-				if(E.wounds.len && E.parent)
+				if(LAZYLEN(E.wounds) && E.parent)
 					wound_flavor_text[E.name] += "[T.He] [T.has] [E.get_wounds_desc()] on [T.his] [E.parent.name].<br>"
 			else
 				if(!is_synth && BP_IS_ROBOTIC(E) && (E.parent && !BP_IS_ROBOTIC(E.parent) && !BP_IS_ASSISTED(E.parent)))
@@ -248,7 +248,7 @@
 
 		for(var/datum/wound/wound in E.wounds)
 			var/list/embedlist = wound.embedded_objects
-			if(embedlist.len)
+			if(LAZYLEN(embedlist))
 				shown_objects += embedlist
 				var/parsedembed[0]
 				for(var/obj/embedded in embedlist)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -54,10 +54,9 @@
 					Stun(2)
 
 				//Moving makes open wounds get infected much faster
-				if (E.wounds.len)
-					for(var/datum/wound/W in E.wounds)
-						if (W.infection_check())
-							W.germ_level += 1
+				for(var/datum/wound/W in E.wounds)
+					if (W.infection_check())
+						W.germ_level += 1
 
 /mob/living/carbon/human/proc/handle_stance()
 	// Don't need to process any of this if they aren't standing anyways

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -865,7 +865,7 @@
 	if(affected)
 		affected.implants -= implant
 		for(var/datum/wound/wound in affected.wounds)
-			wound.embedded_objects -= implant
+			LAZYREMOVE(wound.embedded_objects, implant)
 		if(!surgical_removal)
 			shock_stage+=20
 			affected.take_external_damage((implant.w_class * 3), 0, DAM_EDGE, "Embedded object extraction")

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -42,7 +42,7 @@
 
 	// Wound and structural data.
 	var/wound_update_accuracy = 1      // how often wounds should be updated, a higher number means less often
-	var/list/wounds = list()           // wound datum list.
+	var/list/wounds                    // wound datum list.
 	var/number_wounds = 0              // number of wounds, which is NOT wounds.len!
 	var/obj/item/organ/external/parent // Master-limb.
 	var/list/children                  // Sub-limbs.
@@ -103,8 +103,7 @@
 
 	if(wounds)
 		for(var/datum/wound/wound in wounds)
-			wound.embedded_objects.Cut()
-		wounds.Cut()
+			qdel(wound)
 
 	if(parent && parent.children)
 		parent.children -= src
@@ -340,7 +339,6 @@
 			parent.children.Add(src)
 			//Remove all stump wounds since limb is not missing anymore
 			for(var/datum/wound/lost_limb/W in parent.wounds)
-				parent.wounds -= W
 				qdel(W)
 				break
 			parent.update_damages()
@@ -406,8 +404,7 @@ This function completely restores a damaged organ to perfect condition.
 	pain = 0
 	genetic_degradation = 0
 	for(var/datum/wound/wound in wounds)
-		wound.embedded_objects.Cut()
-	wounds.Cut()
+		qdel(wound)
 	number_wounds = 0
 
 	// handle internal organs
@@ -482,7 +479,7 @@ This function completely restores a damaged organ to perfect condition.
 		owner.remove_blood(fluid_loss)
 
 	// first check whether we can widen an existing wound
-	if(!surgical && wounds && wounds.len > 0 && prob(max(50+(number_wounds-1)*10,90)))
+	if(!surgical && LAZYLEN(wounds) && prob(max(50+(number_wounds-1)*10,90)))
 		if((type == CUT || type == BRUISE) && damage >= 5)
 			//we need to make sure that the wound we are going to worsen is compatible with the type of damage...
 			var/list/compatible_wounds = list()
@@ -522,7 +519,7 @@ This function completely restores a damaged organ to perfect condition.
 				if(other.can_merge(W))
 					other.merge_wound(W)
 					return
-		wounds += W
+		LAZYADD(wounds, W)
 		return W
 
 /****************************************************
@@ -673,7 +670,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(BP_IS_ROBOTIC(src) || BP_IS_CRYSTAL(src)) //Robotic limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)  //and they disappear right away
-				wounds -= W    //TODO: robot wounds for robot limbs
+				qdel(W)    //TODO: robot wounds for robot limbs
 				update_surgery = TRUE
 		if(owner && update_surgery)
 			owner.update_surgery()
@@ -682,7 +679,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/datum/wound/W in wounds)
 		// wounds can disappear after 10 minutes at the earliest
 		if(W.damage <= 0 && W.created + (10 MINUTES) <= world.time)
-			wounds -= W
+			qdel(W)
 			update_surgery = TRUE
 			continue
 			// let the GC handle the deletion of the wound
@@ -698,7 +695,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//configurable regen speed woo, no-regen hardcore or instaheal hugbox, choose your destiny
 		heal_amt = heal_amt * config.organ_regeneration_multiplier
 		// amount of healing is spread over all the wounds
-		heal_amt = heal_amt / (wounds.len + 1)
+		heal_amt = heal_amt / (LAZYLEN(wounds) + 1)
 		// making it look prettier on scanners
 		heal_amt = round(heal_amt,0.1)
 		var/dam_type = BRUTE
@@ -857,7 +854,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/datum/wound/lost_limb/W = new (src, disintegrate, clean)
 		if(clean)
 			W.parent_organ = parent_organ
-			parent_organ.wounds |= W
+			LAZYADD(parent_organ.wounds, W)
 			parent_organ.update_damages()
 		else
 			var/obj/item/organ/external/stump/stump = new (victim, 0, src)
@@ -866,7 +863,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			stump.arterial_bleed_severity = arterial_bleed_severity
 			stump.add_pain(max_damage)
 			W.parent_organ = stump
-			stump.wounds |= W
+			LAZYADD(stump.wounds, W)
 			victim.organs |= stump
 			if(disintegrate != DROPLIMB_BURN)
 				stump.sever_artery()
@@ -1163,7 +1160,7 @@ obj/item/organ/external/proc/remove_clamps()
 	if(!supplied_wound || (W in supplied_wound.embedded_objects)) // Just in case.
 		return
 
-	supplied_wound.embedded_objects += W
+	LAZYADD(supplied_wound.embedded_objects, W)
 	implants += W
 	owner.embedded_flag = 1
 	owner.verbs += /mob/proc/yank_out_object
@@ -1437,12 +1434,12 @@ obj/item/organ/external/proc/remove_clamps()
 		return
 
 	user.visible_message("<span class='notice'>[user] starts inspecting [owner]'s [name] carefully.</span>")
-	if(wounds.len)
+	if(LAZYLEN(wounds))
 		to_chat(user, "<span class='warning'>You find [get_wounds_desc()]</span>")
 		var/list/stuff = list()
 		for(var/datum/wound/wound in wounds)
-			if(wound.embedded_objects)
-				stuff += wound.embedded_objects
+			if(LAZYLEN(wound.embedded_objects))
+				stuff |= wound.embedded_objects
 		if(stuff.len)
 			to_chat(user, "<span class='warning'>There's [english_list(stuff)] sticking out of [owner]'s [name].</span>")
 	else

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -25,7 +25,7 @@
 	var/autoheal_cutoff = 15   // the maximum amount of damage that this wound can have and still autoheal
 
 	// helper lists
-	var/tmp/list/embedded_objects = list()
+	var/tmp/list/embedded_objects
 	var/tmp/list/desc_list = list()
 	var/tmp/list/damage_list = list()
 
@@ -50,7 +50,10 @@
 		parent_organ = organ
 
 /datum/wound/Destroy()
-	parent_organ = null
+	if(parent_organ)
+		LAZYREMOVE(parent_organ.wounds, src)
+		parent_organ = null
+	LAZYCLEARLIST(embedded_objects)
 	. = ..()
 
 // returns 1 if there's a next stage, 0 otherwise
@@ -68,13 +71,13 @@
 	return src.damage / src.amount
 
 /datum/wound/proc/can_autoheal()
-	if(embedded_objects.len)
+	if(LAZYLEN(embedded_objects))
 		return 0
 	return (wound_damage() <= autoheal_cutoff) ? 1 : is_treated()
 
 // checks whether the wound has been appropriately treated
 /datum/wound/proc/is_treated()
-	if(!embedded_objects.len)
+	if(!LAZYLEN(embedded_objects))
 		switch(damage_type)
 			if(BRUISE, CUT, PIERCE)
 				return bandaged
@@ -96,12 +99,14 @@
 	return 1
 
 /datum/wound/proc/merge_wound(var/datum/wound/other)
-	src.embedded_objects |= other.embedded_objects
+	if(LAZYLEN(other.embedded_objects))
+		LAZYDISTINCTADD(src.embedded_objects, other.embedded_objects)
 	src.damage += other.damage
 	src.amount += other.amount
 	src.bleed_timer += other.bleed_timer
 	src.germ_level = max(src.germ_level, other.germ_level)
 	src.created = max(src.created, other.created)	//take the newer created time
+	qdel(other)
 
 // checks if wound is considered open for external infections
 // untreated cuts (and bleeding bruises) and burns are possibly infectable, chance higher if wound is bigger
@@ -140,7 +145,7 @@
 // heal the given amount of damage, and if the given amount of damage was more
 // than what needed to be healed, return how much heal was left
 /datum/wound/proc/heal_damage(amount)
-	if(embedded_objects.len)
+	if(LAZYLEN(embedded_objects))
 		return amount // heal nothing
 	if(parent_organ)
 		if(damage_type == BURN && !(parent_organ.burn_ratio < 1 || (parent_organ.limb_flags & ORGAN_FLAG_HEALS_OVERKILL)))

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -179,7 +179,8 @@
 		loot = affected.implants
 	else
 		for(var/datum/wound/wound in affected.wounds)
-			loot |= wound.embedded_objects
+			if(LAZYLEN(wound.embedded_objects))
+				loot |= wound.embedded_objects
 			find_prob += 50
 
 	if (loot.len)


### PR DESCRIPTION
:cl:
admin: A new admin tool, Toggle Harddelete Queue, has been added to the Secrets panel, under Debug. Do not use this unless you know what you're doing.
/:cl:

Also fixes wound GC issues, forces them to use qdel, and makes some stuff into lazylists. 

I think the added verb is fairly safe, actually, and can be used in some emergencies to address lag. Note that the harddel queue only deletes one or two instances a tick on the best of days, so if it's flooded things won't be urgently deleted anyway. The main disadvantage is if deleting a lucky bad actor in the queue would have then cleared most of the rest of the queue due to removing the refs on it.

I can do further GC fixes in the future, but I need access to the server qdel logs if you want me to do that.