### PR TITLE
Removes tracking beacon from excavation locker

### DIFF
--- a/code/modules/xenoarcheaology/misc.dm
+++ b/code/modules/xenoarcheaology/misc.dm
@@ -49,7 +49,6 @@
 	new /obj/item/device/core_sampler(src)
 	new /obj/item/device/gps(src)
 	new /obj/item/weapon/pinpointer/radio(src)
-	new /obj/item/device/radio/beacon(src)
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/weapon/pickaxe(src)
 	new /obj/item/device/measuring_tape(src)


### PR DESCRIPTION
This locker is only used for the Bluespace River away site.
Closes #25046 

:cl:
fix: Bluespace River away site no longer spawns with a teleporter beacon.
/:cl: