### PR TITLE
Makes rogue drones spawn in seperate groups

### DIFF
--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -2,12 +2,15 @@
 	var/drons = severity * 2 - 1
 	var/groups = rand(3,8)
 
-	var/list/spots = get_infestation_turfs()
+	var/list/spots
 	for(var/i = 0 to groups)
-		if(!LAZYLEN(spots))
-			break
-		var/turf/T = pick(spots)
+		spots = get_infestation_turfs()
+
 		for(var/j = 0 to drons)
+			if(!LAZYLEN(spots))
+				continue
+			
+			var/turf/T = pick_n_take(spots)
 			new/mob/living/simple_animal/hostile/rogue_drone(T)
 
 /datum/event/rogue_maint_drones/announce()


### PR DESCRIPTION
With the presence of a `groups` var in the event, it looks like separate groups were probably the intended result, instead of one massive blob of drones that could reach up to 40 drones in a single area.

Also: Prevents spawning multiple drones on the same tile.

:cl:
tweak: Rogue maintenance drones now spawn in separate smaller groups instead of one massive blob. Total number of drones spawned per event is unchanged.
/:cl: