### PR TITLE
Add duffle bag to mining Locker

### DIFF
--- a/maps/torch/structures/closets/supply.dm
+++ b/maps/torch/structures/closets/supply.dm
@@ -99,6 +99,6 @@
 		/obj/item/weapon/crowbar,
 		/obj/item/clothing/glasses/material,
 		/obj/item/clothing/glasses/meson,
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/eng, /obj/item/weapon/storage/backpack/messenger/engi))
+		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel/eng, /obj/item/weapon/storage/backpack/messenger/engi)),
+		/obj/item/weapon/storage/backpack/dufflebag/eng
 	)


### PR DESCRIPTION
:cl:
rscadd: Prospector locker will now always spawn with a duffle bag
/:cl:

Mining is a job where inventory management is very crucial.
Making the duffle bag always spawn inside the mining locker would be a quality of life change as many miners use them.
(also cuts down on prep time of them running around bugging other department for duffle bags)