### PR TITLE
Changes bridge officer count to 3

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -346,8 +346,8 @@
 	title = "Bridge Officer"
 	department = "Support"
 	department_flag = SPT
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "the Commanding Officer and heads of staff"
 	selection_color = "#2f2f7f"
 	minimal_player_age = 0

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -13308,7 +13308,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/padded/blue,
+/obj/structure/closet/secure_closet/bridgeofficer,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "Ii" = (


### PR DESCRIPTION
With how often admins are adminbussing a third bridge officer into a round, it's probably a good idea to just up the limit.

:cl:
tweak: There can now be 3 bridge officers in a round.
/:cl: