### PR TITLE
Turns Torch map so aft = upper part of map

### DIFF
--- a/html/changelogs/chinsky - memes.yml
+++ b/html/changelogs/chinsky - memes.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - bugfix: "Torch is now facing upper side of the map."

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -15,7 +15,7 @@
 	#include "torch_shuttles.dm"
 	#include "torch_submaps.dm"
 	#include "torch_unit_testing.dm"
-
+	#include "torch_immersion.dm"
 	#include "datums/uniforms.dm"
 	#include "datums/uniforms_expedition.dm"
 	#include "datums/uniforms_fleet.dm"

--- a/maps/torch/torch_immersion.dm
+++ b/maps/torch/torch_immersion.dm
@@ -1,0 +1,20 @@
+//Turns map so fore is located in the top of the map, to further enhance spatial immersion
+/mob/forceMove()
+	var/old_z = z
+	. = ..()
+	if(. && client && z != old_z)
+		client.align_to_ship()
+		
+/client/New()
+	..()
+	spawn(2)
+		align_to_ship()
+
+/client/proc/align_to_ship()
+	var/ndir = NORTH
+	if(GLOB.using_map.use_overmap && mob)
+		var/obj/effect/overmap/ship/S = map_sectors["[get_z(mob)]"]
+		if(istype(S))
+			ndir = S.fore_dir
+	dir = ndir
+


### PR DESCRIPTION
It is important to maintain spatial immersion, as science showed that 85% of players conflate 'fore' direction and north, which is further supported by Torch having fore direction already set, so all that is needed is to adjust clients not picking that up.
