### PR TITLE
Curing viruses adds antigens correctly

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -9,7 +9,7 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	var/clicks = 0
 	var/uniqueID = 0
 	var/list/datum/disease2/effect/effects = list()
-	var/antigen = list() // 16 bits describing the antigens, when one bit is set, a cure with that bit can dock here
+	var/antigen = list() //A list of characters that represent antigens that cure this virus.
 	var/max_stage = 4
 	var/list/affected_species = list(SPECIES_HUMAN,SPECIES_UNATHI,SPECIES_SKRELL)
 
@@ -115,7 +115,7 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	if(!mob.chem_effects[CE_ANTIVIRAL])
 		mob.bodytemperature = max(mob.bodytemperature, min(310+5*min(stage,max_stage) ,mob.bodytemperature+5*min(stage,max_stage)))
 
-/datum/disease2/disease/proc/cure(var/mob/living/carbon/mob, antigen)
+/datum/disease2/disease/proc/cure(var/mob/living/carbon/mob, mob_gains_antigens)
 	for(var/datum/disease2/effect/e in effects)
 		e.deactivate(mob)
 
@@ -126,7 +126,7 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 		var/mob/living/carbon/human/H = mob
 		H.cure_virus(uniqueID)
 
-	if(antigen)
+	if (mob_gains_antigens)
 		mob.antibodies |= antigen
 
 	BITSET(mob.hud_updateflag, STATUS_HUD)


### PR DESCRIPTION
:cl:
fix: Being cured of a virus now correctly adds its antigens where appropriate.
/:cl:
scope confusion is an ancient evil.
