### PR TITLE
Add three starting anomalies for science.

### DIFF
--- a/html/changelogs/HeyBanditoz - torch_starts_with_anomalies.yml
+++ b/html/changelogs/HeyBanditoz - torch_starts_with_anomalies.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes: 
+  - maptweak: "Added three anomalies (inside their containers) in the Petrov for scientsts to experiment with."

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -140,6 +140,12 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
+"ax" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/anomaly_container,
+/obj/machinery/artifact,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "aC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -13189,6 +13195,12 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/cockpit)
+"IG" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/anomaly_container,
+/obj/machinery/artifact,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "IH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15810,6 +15822,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"SY" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/anomaly_container,
+/obj/machinery/artifact,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "Tc" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/binary/pump,
@@ -45819,7 +45837,7 @@ xO
 Nq
 Mo
 Kb
-Zy
+ax
 Oq
 aa
 aa
@@ -46627,7 +46645,7 @@ gZ
 Dh
 Fy
 At
-RX
+IG
 Sb
 aa
 aa
@@ -47435,7 +47453,7 @@ zp
 Di
 Vy
 AP
-GM
+SY
 Bi
 aa
 aa


### PR DESCRIPTION
If I remember right, NT used to have some before the Petrov was remapped.

They'll get moved to the anomaly container on `Initialize()` aswell.
https://github.com/Baystation12/Baystation12/blob/afe988dc4c525f04e53ba040f8eb6810ceca748a/code/modules/xenoarcheaology/anomaly_container.dm#L10-L15