### PR TITLE
Makes typing indicators not delete constantly.

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -145,7 +145,7 @@ var/list/_client_preferences_by_type
 
 /datum/client_preference/show_typing_indicator/changed(var/mob/preference_mob, var/new_value)
 	if(new_value == GLOB.PREF_HIDE)
-		QDEL_NULL(preference_mob.typing_indicator)
+		preference_mob.remove_typing_indicator()
 
 /datum/client_preference/show_ooc
 	description ="OOC chat"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -9,8 +9,7 @@
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
-	if(typing_indicator)
-		qdel(typing_indicator)
+	remove_typing_indicator()
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)
@@ -19,8 +18,7 @@
 
 	message = sanitize(message)
 
-	if(typing_indicator)
-		qdel(typing_indicator)
+	remove_typing_indicator()
 	if(use_me)
 		usr.emote("me",usr.emote_type,message)
 	else

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -16,17 +16,9 @@ I IS TYPIN'!'
 	if(!istype(master, /mob))
 		crash_with("Master of typing_indicator has invalid type: [master.type].")
 
-	GLOB.stat_set_event.register(master, src, /datum/proc/qdel_self) // Making the assumption master is conscious at creation
-	GLOB.logged_out_event.register(master, src, /datum/proc/qdel_self)
-
 /atom/movable/overlay/typing_indicator/Destroy()
-
-	GLOB.stat_set_event.unregister(master, src)
-	GLOB.logged_out_event.unregister(master, src)
-
 	var/mob/M = master
 	M.typing_indicator = null
-
 	. = ..()
 
 /atom/movable/overlay/typing_indicator/SetInitLoc()
@@ -34,13 +26,22 @@ I IS TYPIN'!'
 
 /mob/proc/create_typing_indicator()
 	if(client && !stat && get_preference_value(/datum/client_preference/show_typing_indicator) == GLOB.PREF_SHOW && !src.is_cloaked() && isturf(src.loc))
-		if(typing_indicator)
-			qdel(typing_indicator)
-
-		typing_indicator = new(src)
+		if(!typing_indicator)
+			typing_indicator = new(src)
+		typing_indicator.set_invisibility(0)
 
 /mob/proc/remove_typing_indicator() // A bit excessive, but goes with the creation of the indicator I suppose
-	QDEL_NULL(typing_indicator)
+	if(typing_indicator)
+		typing_indicator.set_invisibility(INVISIBILITY_MAXIMUM)
+
+/mob/set_stat(new_stat)
+	. = ..()
+	if(.)
+		remove_typing_indicator()
+
+/mob/Logout()
+	remove_typing_indicator()
+	. = ..()	
 
 /mob/verb/say_wrapper()
 	set name = ".Say"


### PR DESCRIPTION
I think this is better anyway, but the main reason is that they fail to GC cleanly and I don't know why. Large amounts (order of 10K) are made and deleted every round.

Making them an overlay would be even better, but is also painful without the overlays SS.