### PR TITLE
Various melee weapon tweaks.

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -472,6 +472,12 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	path = /obj/item/weapon/hand_labeler
 	category = "General"
 
+/datum/autolathe/recipe/machete
+	name = "fabricated machete"
+	path = /obj/item/weapon/material/hatchet/machete/steel
+	category = "Arms and Ammunition"
+	resources = list(MATERIAL_STEEL = 15000, MATERIAL_PLASTIC = 2500)
+
 /datum/autolathe/recipe/flamethrower
 	name = "flamethrower"
 	path = /obj/item/weapon/flamethrower/full

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -481,17 +481,17 @@ var/list/global/slot_flags_enumeration = list(
 //Otherwise should return 0 to indicate that the attack is not affected in any way.
 /obj/item/proc/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	var/parry_chance = get_parry_chance(user)
-	if(attacker)	
+	if(attacker)
 		parry_chance = max(0, parry_chance - 10 * attacker.get_skill_difference(SKILL_COMBAT, user))
 	if(parry_chance)
 		if(default_parry_check(user, attacker, damage_source) && prob(parry_chance))
 			user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 			playsound(user.loc, 'sound/weapons/punchmiss.ogg', 50, 1)
-			on_parry()
+			on_parry(damage_source)
 			return 1
 	return 0
 
-/obj/item/proc/on_parry()
+/obj/item/proc/on_parry(damage_source)
 	return
 
 /obj/item/proc/get_parry_chance(mob/user)

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -56,7 +56,7 @@
 	if(!material)
 		qdel(src)
 	else
-		health = round(material.integrity/10)
+		health = round(material.integrity/5)
 		if(material.products_need_process())
 			START_PROCESSING(SSobj, src)
 		if(material.conductive)
@@ -87,8 +87,9 @@
 	if(material.is_brittle() || target.get_blocked_ratio(hit_zone, BRUTE) * 100 >= material.hardness/5)
 		check_shatter()
 
-/obj/item/weapon/material/on_parry()
-	check_shatter()
+/obj/item/weapon/material/on_parry(damage_source)
+	if(istype(damage_source, /obj/item/weapon/material))
+		check_shatter()
 
 /obj/item/weapon/material/proc/check_shatter()
 	if(!unbreakable && prob(material.hardness))

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -22,7 +22,7 @@
 	audible_message(SPAN_WARNING("\The [src] emits a long, harsh tone!"))
 	playsound(loc, 'sound/weapons/bombwhine.ogg', 100, 0, -3)
 	addtimer(CALLBACK(src, .proc/harpoon_detonate), 4 SECONDS) //for suspense
-	
+
 /obj/item/weapon/material/harpoon/bomb/proc/harpoon_detonate()
 	audible_message(SPAN_DANGER("\The [src] detonates!")) //an actual sound will be handled by explosion()
 	var/turf/T = get_turf(src)
@@ -67,9 +67,17 @@
 	default_material = MATERIAL_TITANIUM
 	base_parry_chance = 50
 	attack_cooldown_modifier = 1
+	force_divisor = 0.20 //20 with hardness 80 (titanium) or 15 with hardness 60 (steel)
 
 /obj/item/weapon/material/hatchet/machete/unbreakable
 	unbreakable = TRUE
+
+/obj/item/weapon/material/hatchet/machete/steel
+	name = "fabricated machete"
+	desc = "A long, machine-stamped blade with a somewhat ungainly handle. Found in military surplus stores, malls, and horror movies since before interstellar travel."
+	default_material = MATERIAL_STEEL
+	base_parry_chance = 40
+	matter = list(MATERIAL_STEEL = 15000, MATERIAL_PLASTIC = 2500)
 
 /obj/item/weapon/material/hatchet/machete/Initialize()
 	icon_state = "machete[pick("","_red","_blue", "_black", "_olive")]"

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -7,7 +7,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	force = 20
 	attack_cooldown = 21
-	melee_accuracy_bonus = -20
+	melee_accuracy_bonus = -15
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 7

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -7,7 +7,7 @@
 	slot_flags = SLOT_BELT
 	force = 14
 	attack_cooldown = 2*DEFAULT_WEAPON_COOLDOWN
-	melee_accuracy_bonus = -20
+	melee_accuracy_bonus = -10
 	throwforce = 7
 	throw_range = 3
 	item_state = "crowbar"


### PR DESCRIPTION
:cl:
tweak: Prevents material weapons from taking damage on parry except against other material weapons.
tweak: Increases material weapon health.
tweak: Reduces crowbar and toolbox accuracy penalties.
rscadd: Adds an inferior, expensive, steel machete to the autolathe.
/:cl: