### PR TITLE
Fixes #25007

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -40,6 +40,7 @@
 /obj/structure/closet/secure_closet/RD/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/scientist = 2,
+		/obj/item/clothing/head/bio_hood/scientist = 2,
 		/obj/item/clothing/under/rank/research_director,
 		/obj/item/clothing/under/rank/research_director/rdalt,
 		/obj/item/clothing/under/rank/research_director/dress_rd,


### PR DESCRIPTION
Adds missing biohoods to the CSO Locker. Fixes #25007 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Cronac
bugfix: Adds missing biohoods to CSO locker.
/:cl: