### PR TITLE
Adds Eggs to Biogenerator

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -25,7 +25,8 @@
 		"Food" = list(
 			/obj/item/weapon/reagent_containers/food/drinks/milk/smallcarton = 30,
 			/obj/item/weapon/reagent_containers/food/drinks/milk = 50,
-			/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh = 50),
+			/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh = 50,
+			/obj/item/weapon/storage/fancy/egg_box = 300),
 		"Nutrients" = list(
 			/obj/item/weapon/reagent_containers/glass/bottle/eznutrient = 60,
 			/obj/item/weapon/reagent_containers/glass/bottle/left4zed = 120,

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -146,11 +146,8 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		for(var/obj/item/organ/external/affecting in H.organs)
-			if(affecting && istype(affecting) && affecting.status != ORGAN_ROBOTIC)
+			if(affecting && istype(affecting))
 				affecting.heal_damage(amt_organ, amt_organ)
-				continue
-			if(affecting && istype(affecting) && affecting.status == ORGAN_ROBOTIC)
-				affecting.heal_damage(-((amt_dam_brute)/2), -((amt_dam_fire)/2), robo_repair = 1)
 		H.vessel.add_reagent(/datum/reagent/blood,amt_blood)
 		H.adjustBrainLoss(amt_brain)
 		H.radiation += min(H.radiation, amt_radiation)

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -146,8 +146,11 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		for(var/obj/item/organ/external/affecting in H.organs)
-			if(affecting && istype(affecting))
+			if(affecting && istype(affecting) && affecting.status != ORGAN_ROBOTIC)
 				affecting.heal_damage(amt_organ, amt_organ)
+				continue
+			if(affecting && istype(affecting) && affecting.status == ORGAN_ROBOTIC)
+				affecting.heal_damage(-((amt_dam_brute)/2), -((amt_dam_fire)/2), robo_repair = 1)
 		H.vessel.add_reagent(/datum/reagent/blood,amt_blood)
 		H.adjustBrainLoss(amt_brain)
 		H.radiation += min(H.radiation, amt_radiation)


### PR DESCRIPTION
Adds eggs to the biogenerator as an alternative to ordering expensive, messy chickens from cargo. Costs 300 points for a dozen eggs.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Cronac
tweak: Adds egg cartons as an item the biogenerator can produce.
/:cl: