### PR TITLE
Adding Ore box to Supply crate

### DIFF
--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -36,6 +36,13 @@
 	containertype = /obj/structure/largecrate/hoverpod
 	containername = "hoverpod crate"
 
+/decl/hierarchy/supply_pack/operations/orebox
+	name = "Equipment - Ore box"
+	contains = list(/obj/structure/ore_box)
+	cost = 15
+	containertype = /obj/structure/largecrate
+	containername = "Ore box crate"
+
 /decl/hierarchy/supply_pack/operations/webbing
 	name = "Gear - Webbing, vests, holsters."
 	num_contained = 4


### PR DESCRIPTION
🆑
rscadd: Ore boxes can now be ordered in supply 
/🆑

Just thought I'd add ore boxes into the supply packs since there are no other ways to obtain ore boxes.