### PR TITLE
Fix #24748

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
@@ -17,6 +17,7 @@
 	minbodytemp = 0
 	speed = 4
 	mob_size = MOB_TINY
+	var/corpse = /obj/effect/decal/cleanable/blood/gibs/robot
 
 /mob/living/simple_animal/hostile/rogue_drone/Initialize()
 	. = ..()
@@ -35,3 +36,9 @@
 				return FALSE
 			if(istype(H.wear_suit, /obj/item/clothing/suit/cardborg) && istype(H.head, /obj/item/clothing/head/cardborg))
 				return FALSE
+
+/mob/living/simple_animal/hostile/rogue_drone/death(gibbed, deathmessage, show_dead_message)
+	.=..()
+	if(corpse)
+		new corpse (loc)
+	qdel(src)


### PR DESCRIPTION
Fixes #24748 

Rogue drones now leave a cleanable decal when dead to be more consistent with other drone deaths.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Cronac
tweak: Rogue drones now leave cleanable corpses when killed.
/:cl: