### PR TITLE
Charon and Guppy now only need Basic skill for overmap flight

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -201,7 +201,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 	if (href_list["move"])
 		var/ndir = text2num(href_list["move"])
-		if(prob(user.skill_fail_chance(SKILL_PILOT, 50, SKILL_ADEPT, factor = 1)))
+		if(prob(user.skill_fail_chance(SKILL_PILOT, 50, linked.skill_needed, factor = 1)))
 			ndir = turn(ndir,pick(90,-90))
 		linked.relaymove(user, ndir)
 

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -30,6 +30,7 @@
 	var/engines_state = 1 //global on/off toggle for all engines
 	var/thrust_limit = 1  //global thrust limit for all engines, 0..1
 	var/halted = 0        //admin halt or other stop.
+	var/skill_needed = SKILL_ADEPT  //piloting skill needed to steer it without going in random dir
 
 /obj/effect/overmap/ship/Initialize()
 	. = ..()

--- a/html/changelogs/chinsky - ezpz.yml
+++ b/html/changelogs/chinsky - ezpz.yml
@@ -1,0 +1,4 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Charon and Guppy now only need Basic skill for flying on overmap without random turns."

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -49,6 +49,7 @@
 	max_speed = 1/(4 SECONDS)
 	burn_delay = 2 SECONDS
 	fore_dir = NORTH
+	skill_needed = SKILL_BASIC
 
 /obj/effect/overmap/ship/landable/aquila
 	name = "Aquila"
@@ -65,6 +66,7 @@
 	burn_delay = 2 SECONDS
 	vessel_mass = 2000
 	fore_dir = SOUTH
+	skill_needed = SKILL_BASIC
 
 /obj/machinery/computer/shuttle_control/explore/aquila
 	name = "aquila control console"


### PR DESCRIPTION
Makes piloting difficulty skill set per ship, sets it to Basic for Charon and Guppy.
