### PR TITLE
Adds a spare explorer equipment crate to supply - Take Two

### DIFF
--- a/html/changelogs/WatermelonsEverywhere-explorerscelebrate.yml
+++ b/html/changelogs/WatermelonsEverywhere-explorerscelebrate.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: WatermelonsEverywhere
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a spare explorer equipment crate to Supply."

--- a/maps/torch/datums/supplypacks/science.dm
+++ b/maps/torch/datums/supplypacks/science.dm
@@ -99,3 +99,20 @@
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "utlity shells crate"
 	access = access_pathfinder
+
+/decl/hierarchy/supply_pack/science/exploration_extragear
+	name = "Gear - Exploration equipment"
+	contains = list(/obj/item/weapon/material/hatchet/machete = 2,
+					/obj/item/device/gps = 2,
+					/obj/item/device/geiger = 2,
+					/obj/item/device/slime_scanner = 2,
+					/obj/item/device/radio/headset/exploration = 2,
+					/obj/item/weapon/storage/belt/holster/machete = 2,
+					/obj/item/weapon/storage/plants = 2,
+					/obj/item/device/analyzer/plant_analyzer = 2,
+					/obj/item/weapon/mining_scanner = 2,
+					/obj/item/device/binoculars = 2)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure
+	containername = "exploration equipment crate"
+	access = access_explorer


### PR DESCRIPTION
This adds an explorer equipment crate balanced around security's equipment crate.

Many thanks to afterthought for linking me those guides! Managed to successfully squash two commits into one.