### PR TITLE
Adds a way to synthesize crystallizing agent.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2324,7 +2324,7 @@
 	name = "Resin Globule"
 	result = null
 	required_reagents = list(
-		/datum/reagent/crystal = 1, 
+		/datum/reagent/crystal = 1,
 		/datum/reagent/silicon = 2
 	)
 	catalysts = list(
@@ -2340,3 +2340,10 @@
 		var/create_stacks = Floor(created_volume)
 		if(create_stacks > 0)
 			new /obj/item/stack/medical/resin/handmade(T, create_stacks)
+
+/datum/chemical_reaction/crystal_agent
+	result = /datum/reagent/crystal
+	required_reagents = list(/datum/reagent/silicon = 1, /datum/reagent/tungsten = 1, /datum/reagent/acid/polyacid = 1)
+	minimum_temperature = 150 CELSIUS
+	maximum_temperature = 200 CELSIUS
+	result_amount = 3


### PR DESCRIPTION
Since the addition of crystallizing agent and the ability to perform surgical interventions on golems or use medpacks on Adherent , I've never seen it used. As it currently stands, crystallizing agent can only be isolated from adamantine slime cores, which makes it pretty rare, especially in the hands of medical.

This PR is intended to offer an alternative way to synthesize crystallizing agent with the following recipe:
1 unit of silicon
1 unit of tungsten
1 unit of polytrinic acid
Heat to 150C

This can then be used for antag shenanigans via injection, or made into resin globules for repairing adherent or golems.

This PR is open to feedback on the recipes and whatnot.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Cronac
rscadd: Adds the ability to synthesize crystallizing agent via chemistry with polytrinic acid, tungsten, and silicon (and a bit of heat).
/:cl: