### PR TITLE
extinguisher refilling clarifications

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -56,13 +56,13 @@
 		if(src.safety || (world.time < src.last_use + 20)) // We still catch help intent to not randomly attack people
 			return
 		if(src.reagents.total_volume < 1)
-			to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
+			to_chat(user, SPAN_NOTICE("\The [src] is empty."))
 			return
 
 		src.last_use = world.time
 		reagents.splash(M, min(reagents.total_volume, spray_amount))
 
-		user.visible_message("<span class='notice'>\The [user] sprays \the [M] with \the [src].</span>")
+		user.visible_message(SPAN_NOTICE("\The [user] sprays \the [M] with \the [src]."))
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
 		return 1 // No afterattack
@@ -87,28 +87,28 @@
 		sleep(3)
 
 /obj/item/weapon/extinguisher/afterattack(var/atom/target, var/mob/user, var/flag)
-	//TODO; Add support for reagents in water.
 
-	if( istype(target, /obj/structure/reagent_dispensers) && flag)
-		var/obj/o = target
-		var/amount = o.reagents.trans_to_obj(src, 500)
-
+	if(istype(target, /obj/structure/reagent_dispensers) && flag)
+		var/obj/dispenser = target
+		if (dispenser.reagents.total_volume == 0)
+			to_chat(user, SPAN_NOTICE("\The [dispenser] is empty."))
+			return
+		var/amount = dispenser.reagents.trans_to_obj(src, 500)
 		if (amount == null)
-			to_chat(user, "<span class='notice'>[src] is full.</span>")
+			to_chat(user, SPAN_NOTICE("\The [src] is full."))
 		else
-			to_chat(user, "<span class='notice'>You fill [src] with [amount] units of the contents of [target].</span>")
+			to_chat(user, SPAN_NOTICE("You fill \the [src] with [amount] units from \the [dispenser]."))
 			playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		if(istype(target, /obj/structure/reagent_dispensers/acid))
-			to_chat(user, "<span class='warning'>You can only watch as the acid begins violently eating away at the bottom of \the [src]!</span>")
-			if(prob(50))
+		if (istype(target, /obj/structure/reagent_dispensers/acid))
+			to_chat(user, SPAN_WARNING("The acid violently eats away at \the [src]!"))
+			if (prob(50))
 				reagents.splash(user, 5)
 			qdel(src)
-			return
 		return
 
 	if (!safety)
 		if (src.reagents.total_volume < 1)
-			to_chat(usr, "<span class='notice'>\The [src] is empty.</span>")
+			to_chat(usr, SPAN_NOTICE("\The [src] is empty."))
 			return
 
 		if (world.time < src.last_use + 20)


### PR DESCRIPTION
:cl:
bugfix: Refilling a fire extinguisher from a tank no longer tells you the extinguisher is full when the tank is empty.
/:cl:

Also macrofies nearby messages.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->