### PR TITLE
Attempt to fix some admin prefs resetting on login.

### DIFF
--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -49,7 +49,8 @@
 		client_preference_keys |= client_pref.key
 
 		// if the preference has never been set, or if the player is no longer allowed to set the it, set it to default
-		if(!client_pref.may_set(preference_mob()) || !(client_pref.key in pref.preference_values))
+		preference_mob() // we don't care about the mob it returns, but it finds the correct client.
+		if(!client_pref.may_set(pref.client) || !(client_pref.key in pref.preference_values))
 			pref.preference_values[client_pref.key] = client_pref.default_value
 
 

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -74,7 +74,7 @@ var/list/_client_preferences_by_type
 	if(!default_value)
 		default_value = options[1]
 
-/datum/client_preference/proc/may_set(var/mob/preference_mob)
+/datum/client_preference/proc/may_set(client/given_client)
 	return TRUE
 
 /datum/client_preference/proc/changed(var/mob/preference_mob, var/new_value)
@@ -236,11 +236,16 @@ var/list/_client_preferences_by_type
 /datum/client_preference/staff
 	var/flags
 
-/datum/client_preference/staff/may_set(var/mob/preference_mob)
+/datum/client_preference/staff/may_set(client/given_client)
+	if(ismob(given_client))
+		var/mob/M = given_client
+		given_client = M.client
+	if(!given_client)
+		return FALSE
 	if(flags)
-		return check_rights(flags, 0, preference_mob)
+		return check_rights(flags, 0, given_client)
 	else
-		return preference_mob && preference_mob.client && preference_mob.client.holder
+		return given_client && given_client.holder
 
 /datum/client_preference/staff/show_chat_prayers
 	description = "Chat Prayers"


### PR DESCRIPTION
Generally speaking, that code can run before `client/New` calls parent, meaning that no mob has been assigned yet. If that was the entire story, then this would be a clear fix. 

However, I can't replicate the issue locally without the db set up, so I (a) don't know if this fixes it and (b) am not sure why it _works_ locally. It's possible that this is bypassed in `client/New` when there is no db, but I'm not sure. It's also possible that it works differently at server startup vs. when connecting later due to some changes made semi-recently.