### PR TITLE
Monkey and Augment Fixes

### DIFF
--- a/code/modules/augment/augment.dm
+++ b/code/modules/augment/augment.dm
@@ -8,6 +8,7 @@
 	var/list/allowed_organs = list(BP_AUGMENT_R_ARM, BP_AUGMENT_L_ARM)
 	default_action_type = /datum/action/item_action/organ/augment
 	var/descriptor = ""
+	var/known = TRUE
 
 /obj/item/organ/internal/augment/Initialize()
 	. = ..()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1427,6 +1427,9 @@ obj/item/organ/external/proc/remove_clamps()
 				unknown_body++
 		if(unknown_body)
 			. += "Unknown body present"
+	for(var/obj/item/organ/internal/augment/aug in internal_organs)
+		if(istype(aug) && aug.known)
+			. += "[capitalize(aug.name)] implanted"
 
 /obj/item/organ/external/proc/inspect(mob/user)
 	if(is_stump())

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -78,12 +78,13 @@
 			H.unequip_item()
 	if(!held && !H.restrained() && prob(5))
 		var/list/touchables = list()
-		for(var/obj/O in range(1,H))
+		for(var/obj/O in range(1,get_turf(H)))
 			if(O.simulated && O.Adjacent(H))
 				touchables += O
-		var/obj/touchy = pick(touchables)
-		touchy.attack_hand(H)
-	
+		if(touchables.len)
+			var/obj/touchy = pick(touchables)
+			touchy.attack_hand(H)
+
 	if(prob(1))
 		H.emote(pick("scratch","jump","roll","tail"))
 


### PR DESCRIPTION
Fixes #24161 again as well as pass travis and not be loaded with tons of commits.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

🆑 Cronac
bugfix: Monkeys are no longer ripping out their augments and throwing them across the room.
tweak: Augments now show up on medical scanners and related admin scans.
/🆑