### PR TITLE
Makes VSC stop complaining about `SETUP_SUBTYPE_DECLS_BY_NAME`.

### DIFF
--- a/code/modules/client/preference_setup/_defines.dm
+++ b/code/modules/client/preference_setup/_defines.dm
@@ -3,7 +3,7 @@
 #define EQUIP_PREVIEW_ALL (EQUIP_PREVIEW_LOADOUT|EQUIP_PREVIEW_JOB)
 
 #define SETUP_SUBTYPE_DECLS_BY_NAME(decl_prototype, decls_by_name) \
-if(!decls_by_name);\
+if(!decls_by_name) \
 {\
 	decls_by_name = list();\
 	var/decls_by_type = decls_repository.get_decls_of_subtype(decl_prototype);\


### PR DESCRIPTION
I have no idea if that semicolon even had any effect on the code. VSC just kept nagging me about it.