### PR TITLE
Fixes typo in tech define.

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -162,7 +162,7 @@
 	name = "subspace wavelength analyzer"
 	icon_state = "wavelength_analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
-	origin_tech = list(TECH_DATA = 3, TECH_MAGNETS = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
+	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	matter = list(MATERIAL_STEEL = 30,MATERIAL_GLASS = 10)
 
 /obj/item/weapon/stock_parts/subspace/crystal


### PR DESCRIPTION
Before I forget; picked it up while doing something else. I'd unit test these, but I don't know of a good way to do it, as you can't reliably spawn items with no args in `new` without getting runtimes.