### PR TITLE
Slight Cryotube Buffs, Bug Fix 

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -376,10 +376,10 @@
 		user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
 	O = user.get_equipped_item(slot_wear_suit)
 	if(O && !istype(O, /obj/item/clothing/suit/cultrobes) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)	
+		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
 	O = user.get_equipped_item(slot_shoes)
 	if(O && !istype(O, /obj/item/clothing/shoes/cult) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)	
+		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 
 	O = user.get_equipped_item(slot_back)
 	if(istype(O, /obj/item/weapon/storage) && !istype(O, /obj/item/weapon/storage/backpack/cultpack) && user.unEquip(O)) // We don't want to make the vox drop their nitrogen tank, though
@@ -518,7 +518,7 @@
 			charges -= healburn
 			healbrute = min(healbrute, charges)
 			charges -= healbrute
-		user.heal_organ_damage(healbrute, healburn)
+		user.heal_organ_damage(healbrute, healburn, 1)
 		statuses += "your wounds mend"
 		if(!charges)
 			return statuses
@@ -572,7 +572,7 @@
 		M.add_chemical_effect(CE_PAINKILLER, 40)
 		M.add_chemical_effect(CE_SPEEDBOOST, 1)
 		M.adjustOxyLoss(-10 * removed)
-		M.heal_organ_damage(5 * removed, 5 * removed)
+		M.heal_organ_damage(5 * removed, 5 * removed, 1)
 		M.adjustToxLoss(-5 * removed)
 	else
 		M.fire_stacks = max(2, M.fire_stacks)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -215,7 +215,7 @@
 		var/obj/item/organ/internal/I = internal
 		if(amount <= 0)
 			break
-		if(heal)
+		if(heal && !BP_IS_ROBOTIC(I))
 			if(I.damage < amount)
 				amount -= I.damage
 				I.damage = 0
@@ -261,11 +261,11 @@
 //Heals ONE external organ, organ gets randomly selected from damaged ones.
 //It automatically updates damage overlays if necesary
 //It automatically updates health status
-/mob/living/carbon/human/heal_organ_damage(var/brute, var/burn)
+/mob/living/carbon/human/heal_organ_damage(var/brute, var/burn, var/affect_robo = 0)
 	var/list/obj/item/organ/external/parts = get_damaged_organs(brute,burn)
 	if(!parts.len)	return
 	var/obj/item/organ/external/picked = pick(parts)
-	if(picked.heal_damage(brute,burn))
+	if(picked.heal_damage(brute,burn, robo_repair = affect_robo))
 		BITSET(hud_updateflag, HEALTH_HUD)
 	updatehealth()
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -172,8 +172,19 @@
 	if(M.bodytemperature < 170)
 		M.adjustCloneLoss(-100 * removed)
 		M.add_chemical_effect(CE_OXYGENATED, 1)
-		M.heal_organ_damage(10 * removed, 10 * removed)
+		M.heal_organ_damage(15 * removed, 15 * removed)
 		M.add_chemical_effect(CE_PULSE, -2)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			for(var/obj/item/organ/internal/I in H.internal_organs)
+				if(BP_IS_ROBOTIC(I))
+					continue
+				if(I.organ_tag == BP_BRAIN)
+					H.confused++
+					H.drowsyness++
+					if(I.damage >= I.min_bruised_damage)
+						continue
+					I.damage = max(I.damage - (15*removed), 0)
 
 /datum/reagent/clonexadone
 	name = "Clonexadone"
@@ -195,6 +206,17 @@
 		M.add_chemical_effect(CE_OXYGENATED, 2)
 		M.heal_organ_damage(30 * removed, 30 * removed)
 		M.add_chemical_effect(CE_PULSE, -2)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			for(var/obj/item/organ/internal/I in H.internal_organs)
+				if(BP_IS_ROBOTIC(I))
+					continue
+				if(I.organ_tag == BP_BRAIN)
+					H.confused++
+					H.drowsyness++
+					if(I.damage >= I.min_bruised_damage)
+						continue
+					I.damage = max(I.damage - (25*removed), 0)
 
 /* Painkillers */
 


### PR DESCRIPTION
Cryogenic tubes will no longer heal robotic organs. 
Clonexadone and Cryoxadone have been slightly buffed and will now SLOWLY heal damage to organic internal organs. They should heal external organs as intended.
For code geeks, heal_organ_damage now has a check for if it should affect robotic organs.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Cronac
bugfix: Cryogenic tubes will no longer heal robotic organs. 
tweak: Clonexadone and Cryoxadone have been slightly buffed and will now SLOWLY heal damage to organic internal organs. They should heal external organs as intended.
/:cl: