### PR TITLE
Re-add cult stun talisman and re-implement obscure/reveal runes.

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -145,8 +145,11 @@ var/list/Tier1Runes = list(
 	/mob/proc/wall_rune,
 	/mob/proc/ajorney_rune,
 	/mob/proc/defile_rune,
+	/mob/proc/stun_imbue,
 	/mob/proc/emp_imbue,
-	/mob/proc/cult_communicate
+	/mob/proc/cult_communicate,
+	/mob/proc/obscure,
+	/mob/proc/reveal
 	)
 
 var/list/Tier2Runes = list(
@@ -273,6 +276,12 @@ var/list/Tier4Runes = list(
 
 	make_rune(/obj/effect/rune/tearreality, cost = 50, tome_required = 1)
 
+/mob/proc/stun_imbue()
+	set category = "Cult Magic"
+	set name = "Imbue: Stun"
+
+	make_rune(/obj/effect/rune/imbue/stun, cost = 20, tome_required = 1)
+
 /mob/proc/emp_imbue()
 	set category = "Cult Magic"
 	set name = "Imbue: EMP"
@@ -313,3 +322,15 @@ var/list/Tier4Runes = list(
 
 /mob/living/carbon/human/message_cult_communicate()
 	visible_message("<span class='warning'>\The [src] cuts \his finger and starts drawing on the back of \his hand.</span>")
+
+/mob/proc/obscure()
+	set category = "Cult Magic"
+	set name = "Rune: Obscure"
+
+	make_rune(/obj/effect/rune/obscure)
+
+/mob/proc/reveal()
+	set category = "Cult Magic"
+	set name = "Rune: Reveal"
+
+	make_rune(/obj/effect/rune/reveal)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -360,6 +360,34 @@
 	visible_message("<span class='warning'>\The [src] embeds into the floor and walls around it, changing them!</span>", "You hear liquid flow.")
 	qdel(src)
 
+/obj/effect/rune/obscure
+	cultname = "obscure"
+
+/obj/effect/rune/obscure/cast(var/mob/living/user)
+	var/runecheck = 0
+	for(var/obj/effect/rune/R in orange(1, src))
+		if(R != src)
+			R.set_invisibility(INVISIBILITY_OBSERVER)
+		runecheck = 1
+	if(runecheck)
+		speak_incantation(user, "Kla[pick("'","`")]atu barada nikt'o!")
+		visible_message("<span class='warning'>\ The rune turns into gray dust that conceals the surrounding runes.</span>")
+		qdel(src)
+
+/obj/effect/rune/reveal
+	cultname = "reveal"
+
+/obj/effect/rune/reveal/cast(var/mob/living/user)
+	var/irunecheck = 0
+	for(var/obj/effect/rune/R in orange(1, src))
+		if(R != src)
+			R.set_invisibility(SEE_INVISIBLE_NOLIGHTING)
+		irunecheck = 1
+	if(irunecheck)
+		speak_incantation(user, "Nikt[pick("'","`")]o barada kla'atu!")
+		visible_message("<span class='warning'>\ The rune turns into red dust that reveals the surrounding runes.</span>")
+		qdel(src)
+
 /* Tier 2 runes */
 
 
@@ -376,10 +404,10 @@
 		user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
 	O = user.get_equipped_item(slot_wear_suit)
 	if(O && !istype(O, /obj/item/clothing/suit/cultrobes) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)	
+		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
 	O = user.get_equipped_item(slot_shoes)
 	if(O && !istype(O, /obj/item/clothing/shoes/cult) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)	
+		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 
 	O = user.get_equipped_item(slot_back)
 	if(istype(O, /obj/item/weapon/storage) && !istype(O, /obj/item/weapon/storage/backpack/cultpack) && user.unEquip(O)) // We don't want to make the vox drop their nitrogen tank, though
@@ -834,6 +862,10 @@
 	new papertype(get_turf(src))
 	qdel(target)
 	qdel(src)
+
+/obj/effect/rune/imbue/stun
+	cultname = "stun imbue"
+	papertype = /obj/item/weapon/paper/talisman/stun
 
 /obj/effect/rune/imbue/emp
 	cultname = "destroy technology imbue"

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -12,6 +12,34 @@
 /obj/item/weapon/paper/talisman/attack(var/mob/living/M, var/mob/living/user)
 	return
 
+/obj/item/weapon/paper/talisman/stun/attack_self(var/mob/living/user)
+	if(iscultist(user))
+		to_chat(user, "This is a stun talisman.")
+	..()
+
+/obj/item/weapon/paper/talisman/stun/attack(var/mob/living/M, var/mob/living/user)
+	if(!iscultist(user))
+		return
+	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
+	var/obj/item/weapon/nullrod/nrod = locate() in M
+	if(nrod)
+		user.visible_message("<span class='danger'>\The [user] invokes \the [src] at [M], but they are unaffected.</span>", "<span class='danger'>You invoke \the [src] at [M], but they are unaffected.</span>")
+		return
+	else
+		user.visible_message("<span class='danger'>\The [user] invokes \the [src] at [M].</span>", "<span class='danger'>You invoke \the [src] at [M].</span>")
+
+	if(issilicon(M))
+		M.Weaken(15)
+		M.silent += 15
+	else if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.silent += 15
+		C.Weaken(20)
+		C.Stun(20)
+	admin_attack_log(user, M, "Used a stun talisman.", "Was victim of a stun talisman.", "used a stun talisman on")
+	user.unEquip(src)
+	qdel(src)
+
 /obj/item/weapon/paper/talisman/emp/attack_self(var/mob/living/user)
 	if(iscultist(user))
 		to_chat(user, "This is an emp talisman.")
@@ -25,4 +53,5 @@
 	user.say("Ta'gh fara[pick("'","`")]qha fel d'amar det!")
 	user.visible_message("<span class='danger'>\The [user] invokes \the [src] at [target].</span>", "<span class='danger'>You invoke \the [src] at [target].</span>")
 	target.emp_act(1)
+	user.unEquip(src)
 	qdel(src)


### PR DESCRIPTION
:cl:
rscadd: Cult members can now make stun talismans again. Requires a tome, paper, and a substantial amount of blood.
rscadd: Ported obscure and reveal runes back into cult. Obscure runes make all runes around them invisible, reveal runes reveal them. Runes cannot be used while invisible.
/:cl:
https://puu.sh/Dc6t0/d41865bc9b.png

Compared to other antagonists, Bay left cult behind. 
This PR seeks to 
-give cultists a reliable tool to disable people at a cost (something most all other antagonists have,) 
-give people more of a reason to be scared of cultists at close range, 
-and give cultists more resistance to meta up to the point of going loud if they do. 

Why?
Because "do you want to join my book club," "stone floors in old brig/Petrov," or "SECURITY HELP HE TRIED TO PUSH ME" are not good options for full-round antagonists; but cultists trying to get off the ground don't get much else. 
A major part of cult progression is conversion/sacrifice. Making this less of a non-starter by giving them back the equivalent of a sleepy pen and the ability to hide runes around the ship will lead to much more interesting, feature-length cult rounds. 