### PR TITLE
Removed console outside of ship from PR #25153

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -17752,16 +17752,6 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/autopsy)
-"eLm" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/item/modular_computer/console/preset/civilian{
-	icon_state = "console";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/space)
 "eMb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -62008,7 +61998,7 @@ aaa
 aaa
 aaa
 aaa
-eLm
+aaa
 aaa
 aaa
 aaa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1857,7 +1857,7 @@
 	dir = 2;
 	icon_state = "shutter0";
 	id = "hop_office_desk";
-	name = "HoP Office Privacy Shutters";
+	name = "XO Office Privacy Shutters";
 	opacity = 0
 	},
 /obj/item/weapon/material/bell,
@@ -2259,7 +2259,7 @@
 	dir = 2;
 	icon_state = "shutter0";
 	id = "hop_office_desk";
-	name = "HoP Office Privacy Shutters";
+	name = "XO Office Privacy Shutters";
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -14093,7 +14093,7 @@
 	dir = 2;
 	icon_state = "shutter0";
 	id = "hop_office_desk";
-	name = "HoP Office Privacy Shutters";
+	name = "XO Office Privacy Shutters";
 	opacity = 0
 	},
 /obj/effect/floor_decal/industrial/loading{


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixes #25189 
Removed newscaster console and floor outside of the ship introduced in #25153
And renamed the HoP Office Privacy Shutter to XO Office Privacy Shutter

:cl: BiscuitCookie
maptweak: Renamed the HoP Office Privacy Shutters to XO Office Privacy Shutters
bugfix: Removed objects outside the ship that didn't belong there.
/:cl: