### PR TITLE
Adherent Healing Fixes

### DIFF
--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -28,6 +28,7 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(power_cell)
 		user.visible_message("<span class='notice'>There is a loud crack and the smell of ozone as \the [user] touches \the [src].</span>")
+		playsound(loc, 'sound/effects/snap.ogg', 50, 1)
 		power_cell.charge = power_cell.maxcharge
 		to_chat(user, "<span class='notice'><b>Your [power_cell] has been charged to capacity.</b></span>")
 		if(istype(H) && H.species.name == SPECIES_ADHERENT)
@@ -41,7 +42,7 @@
 		visible_message("<span class='danger'>\The [user] has been shocked by \the [src]!</span>")
 
 /obj/structure/adherent_pylon/attackby(obj/item/grab/normal/G, mob/user)
-	if(!istype(G))		
+	if(!istype(G))
 		return
-	var/mob/M = G.affecting	
+	var/mob/M = G.affecting
 	charge_user(M)

--- a/code/modules/organs/external/species/adherent.dm
+++ b/code/modules/organs/external/species/adherent.dm
@@ -13,7 +13,7 @@
 	encased = "ceramic hull"
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
-	limb_flags = ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_HEALS_OVERKILL
 
 /obj/item/organ/external/groin/crystal
 	name =                    "trailing tendrils"


### PR DESCRIPTION
Fix #25050 

The Adherent mineral bath will now no longer delete your tendril junction and kill you. 
Leaving the mineral bath will now update your icons to match your shiny repaired pieces. 
Embedded objects like shrapnel (but not brig or traitor implants etc) will now be removed by the mineral bath. 
You can now hear the charge pylon filling up your power cell.

Spoke to Gentlefood on discord, should be ok.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Cronac
bugfix: The Adherent mineral bath will no longer kill Adherent users by deleting their tendril junction.
tweak: The Adherent mineral bath now removed embedded objects like shrapnel, but will not remove implants such as tracking implants etc.
/:cl: