### PR TITLE
Fix 25168

### DIFF
--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -62,6 +62,7 @@
 	max_duration = 90
 	shock_level = 40
 	delicate = 1
+	strict_access_requirement = FALSE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
 
 /decl/surgery_step/fix_vein/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
Fix #25168 

You can once again fix arterial bleeding while the chest cavity is open. Thanks to Afterthought on this one.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Cronac
bugfix: A damaged aorta can once again be repaired while the chest cavity is open.
/:cl: