### PR TITLE
Unapolegetic shuttle buffs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -56,6 +56,7 @@
 #include "code\__defines\misc.dm"
 #include "code\__defines\mobs.dm"
 #include "code\__defines\movement.dm"
+#include "code\__defines\overmap.dm"
 #include "code\__defines\proc_presets.dm"
 #include "code\__defines\psi.dm"
 #include "code\__defines\qdel.dm"

--- a/code/__defines/overmap.dm
+++ b/code/__defines/overmap.dm
@@ -1,0 +1,7 @@
+#define SHIP_SIZE_TINY	1
+#define SHIP_SIZE_SMALL	2
+#define SHIP_SIZE_LARGE	3
+
+//multipliers for max_speed to find 'slow' and 'fast' speeds for the ship
+#define SHIP_SPEED_SLOW  1/(40 SECONDS) 
+#define SHIP_SPEED_FAST  1/(5 SECONDS)

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -117,11 +117,23 @@
 	. = ..()
 	if(!victim)
 		return
-	if(victim.get_helm_skill() == SKILL_PROF)
+	var/skill = victim.get_helm_skill()
+	var/speed = victim.get_speed()
+	if(skill >= SKILL_PROF)
 		. = round(. * 0.5)
 	if(victim.is_still()) //Standing still means less shit flies your way
-		. = round(. * 0.25)
-	if(victim.get_speed() < victim.min_speed * 5) //Slow and steady
-		. = round(. * 0.6)
-	if(victim.get_speed() > victim.max_speed * 0.75) //Sanic stahp
+		. = round(. * 0.1)
+	if(speed < SHIP_SPEED_SLOW) //Slow and steady
+		. = round(. * 0.5)
+	if(speed > SHIP_SPEED_FAST) //Sanic stahp
 		. *= 2
+	
+	//Smol ship evasion
+	if(victim.vessel_size < SHIP_SIZE_LARGE && speed < SHIP_SPEED_FAST)
+		var/skill_needed = SKILL_PROF
+		if(speed < SHIP_SPEED_SLOW)
+			skill_needed = SKILL_ADEPT
+		if(victim.vessel_size < SHIP_SIZE_SMALL)
+			skill_needed = skill_needed - 1
+		if(skill >= max(skill_needed, victim.skill_needed))
+			return 0

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -102,12 +102,18 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		data["d_x"] = dx
 		data["d_y"] = dy
 		data["speedlimit"] = speedlimit ? speedlimit*1000 : "None"
-		data["speed"] = round(linked.get_speed()*1000, 0.01)
 		data["accel"] = round(linked.get_acceleration()*1000, 0.01)
 		data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
 		data["autopilot"] = autopilot
 		data["manual_control"] = manual_control
 		data["canburn"] = linked.can_burn()
+
+		var/speed = round(linked.get_speed()*1000, 0.01)
+		if(linked.get_speed() < SHIP_SPEED_SLOW)
+			speed = "<span class='good'>[speed]</span>"
+		if(linked.get_speed() > SHIP_SPEED_FAST)
+			speed = "<span class='average'>[speed]</span>"
+		data["speed"] = speed
 
 		if(linked.get_speed())
 			data["ETAnext"] = "[round(linked.ETA()/10)] seconds"

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -16,6 +16,7 @@
 	var/moving_state = "ship_moving"
 
 	var/vessel_mass = 10000             //tonnes, arbitrary number, affects acceleration provided by engines
+	var/vessel_size = SHIP_SIZE_LARGE	//arbitrary number, affects how likely are we to evade meteors
 	var/max_speed = 1/(1 SECOND)        //"speed of light" for the ship, in turfs/tick.
 	var/min_speed = 1/(2 MINUTES)       // Below this, we round speed to 0 to avoid math errors.
 

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -17,6 +17,7 @@
 	fore_dir = WEST
 	color = "#ff00ff"
 	vessel_mass = 1000
+	vessel_size = SHIP_SIZE_SMALL
 	initial_restricted_waypoints = list(
 		"Skrellian Shuttle" = list("nav_skrellscoutsh_dock")
 	)
@@ -32,6 +33,7 @@
 	fore_dir = WEST
 	color = "#880088"
 	vessel_mass = 750
+	vessel_size = SHIP_SIZE_TINY
 
 /datum/shuttle/autodock/overmap/skrellscoutship
 	name = "Skrellian Scout"

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -1,7 +1,8 @@
 /obj/effect/overmap/ship/torch
 	name = "SEV Torch"
 	fore_dir = WEST
-	vessel_mass = 40000
+	vessel_mass = 100000
+	burn_delay = 2 SECONDS
 	start_x = 4
 	start_y = 5
 	base = TRUE
@@ -46,18 +47,20 @@
 /obj/effect/overmap/ship/landable/exploration_shuttle
 	name = "Charon"
 	shuttle = "Charon"
-	max_speed = 1/(4 SECONDS)
-	burn_delay = 2 SECONDS
+	max_speed = 1/(2 SECONDS)
+	burn_delay = 1 SECONDS
 	fore_dir = NORTH
 	skill_needed = SKILL_BASIC
+	vessel_size = SHIP_SIZE_SMALL
 
 /obj/effect/overmap/ship/landable/aquila
 	name = "Aquila"
 	shuttle = "Aquila"
 	vessel_mass = 20000
-	max_speed = 1/(2 SECONDS)
+	max_speed = 1/(1 SECONDS)
 	burn_delay = 0.5 SECONDS //spammable, but expensive
 	fore_dir = NORTH
+	vessel_size = SHIP_SIZE_SMALL
 
 /obj/effect/overmap/ship/landable/guppy
 	name = "Guppy"
@@ -67,6 +70,7 @@
 	vessel_mass = 2000
 	fore_dir = SOUTH
 	skill_needed = SKILL_BASIC
+	vessel_size = SHIP_SIZE_TINY
 
 /obj/machinery/computer/shuttle_control/explore/aquila
 	name = "aquila control console"


### PR DESCRIPTION
As it stands now, there's very little reason to pilot Charon on overmap over just taking Torch there. This intends to give it an edge - faster acceleration and ability to pass through meteor fields if going slow enough.

Gives ships 'size' var, set to large by default, small on shuttles.
Small ships can evade meteors when going through meteor field completely if they're going slowly.
'Slow' speed is 2.5 (as seen in helm), 'Fast' is 20. Added visual indication to helm for what kind of speed are you going at (green = slow, red = fast)
Fattened Torch considerably, increasing mass from 40K to 100K, to make shuttles a viable option to use.

:cl: Chinsky
rscadd: Added speed indication to helm console. Green means 'slow', red means 'too fast'.
rscadd: Pilotable shuttles now can pass through meteor fields safely. Keep at green speed and you'll make it. Need Trained skill for Charon/Aquila and Basic for GUP. At Master/Experienced can do this at normal speed too.
tweak: Torch now accelerates roughly 2x slower
/:cl: