### PR TITLE
Replaces abandoned D1 checkpoint with smoking parlour

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -9163,6 +9163,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
 /turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aEC" = (
@@ -14382,6 +14386,29 @@
 	},
 /turf/space,
 /area/space)
+"aXZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "aYb" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "virology_airlock_control";
@@ -15903,6 +15930,9 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/firstdeck/center)
+"cGt" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "cHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16114,6 +16144,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"cWw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/padded/brown{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "cWR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16566,6 +16606,11 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"dsW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor/tiled/monotile,
+/area/security/wing)
 "dtb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -16926,10 +16971,6 @@
 /area/medical/locker)
 "dQA" = (
 /obj/machinery/light/small,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
 /obj/structure/table/woodentable/ebony,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/smokingparlour)
@@ -17414,11 +17455,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/autopsy)
-"erQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled/monotile,
-/area/security/wing)
 "esb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -20289,6 +20325,9 @@
 /obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"hCP" = (
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "hDb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -20437,9 +20476,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/development)
-"hJk" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/smokingparlour)
 "hJq" = (
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 1
@@ -22531,16 +22567,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1starboard)
-"kfN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair/padded/brown{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/smokingparlour)
 "kgi" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	icon_state = "edge";
@@ -23688,12 +23714,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
-"lvI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/wall/prepainted,
-/area/medical/autopsy)
 "lwb" = (
 /obj/structure/table/steel,
 /obj/machinery/button/remote/blast_door{
@@ -28671,16 +28691,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
-"ryZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "rzb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30592,29 +30602,6 @@
 "tOV" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/processing)
-"tQs" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
 "tRX" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -30840,6 +30827,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
+"uKi" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/wall/prepainted,
+/area/medical/autopsy)
 "uLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31570,6 +31563,16 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"wIm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "wMh" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/orange,
@@ -31887,9 +31890,6 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
-"xZK" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/smokingparlour)
 "ycp" = (
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/white/monotile,
@@ -42934,8 +42934,8 @@ aKH
 aLH
 aMK
 aNL
-erQ
-erQ
+dsW
+dsW
 aOK
 aRs
 aSq
@@ -52211,8 +52211,8 @@ gub
 gJb
 arK
 jiq
-tQs
-ryZ
+aXZ
+wIm
 rsu
 nAb
 nIb
@@ -55433,7 +55433,7 @@ dRb
 emb
 evb
 fjb
-lvI
+uKi
 aoK
 lXb
 aqR
@@ -56657,11 +56657,11 @@ aqU
 jsa
 hnN
 cgu
-hJk
-hJk
-hJk
-hJk
-hJk
+cGt
+cGt
+cGt
+cGt
+cGt
 aGJ
 kab
 pgb
@@ -56859,12 +56859,12 @@ awC
 jYD
 ayD
 jpb
-xZK
+hCP
 vOv
 wQB
 ogv
 hle
-hJk
+cGt
 kbb
 phb
 pPb
@@ -57066,7 +57066,7 @@ aCm
 aDx
 aEx
 aFH
-hJk
+cGt
 hvY
 pib
 pDb
@@ -57268,7 +57268,7 @@ aCn
 aCo
 aEy
 dQA
-hJk
+cGt
 kpb
 pjb
 pEb
@@ -57468,9 +57468,9 @@ aGx
 sOg
 aCo
 aCo
-kfN
+cWw
 aFI
-hJk
+cGt
 eGb
 pbb
 pFb
@@ -57667,12 +57667,12 @@ aqU
 bBm
 ruz
 dJp
-xZK
+hCP
 kym
 aDz
 aEA
 aFK
-hJk
+cGt
 qpb
 pnb
 pGb
@@ -57870,11 +57870,11 @@ jqn
 ayF
 jqn
 hPN
-xZK
-xZK
-xZK
+hCP
+hCP
+hCP
 ijh
-hJk
+cGt
 aHQ
 aHQ
 aHQ

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -8285,7 +8285,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aAT" = (
 /obj/machinery/ai_status_display,
@@ -8685,16 +8685,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aCn" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aCo" = (
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aCp" = (
 /obj/machinery/teleport/hub,
@@ -8925,7 +8925,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aDz" = (
 /obj/machinery/alarm{
@@ -8934,7 +8934,7 @@
 	pixel_y = 0;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aDA" = (
 /obj/structure/cable/green{
@@ -9149,7 +9149,7 @@
 	icon_state = "chair_preview";
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/red,
 /area/crew_quarters/smokingparlour)
 "aEy" = (
 /obj/structure/table/woodentable/ebony,
@@ -9157,7 +9157,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/red,
 /area/crew_quarters/smokingparlour)
 "aEA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9167,7 +9167,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aEC" = (
 /obj/structure/cable/green{
@@ -9505,20 +9505,20 @@
 	icon_state = "chair_preview";
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/red,
 /area/crew_quarters/smokingparlour)
 "aFI" = (
 /obj/structure/bed/chair/padded/brown{
 	icon_state = "chair_preview";
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/red,
 /area/crew_quarters/smokingparlour)
 "aFK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "aFL" = (
 /obj/structure/cable/green{
@@ -14386,29 +14386,6 @@
 	},
 /turf/space,
 /area/space)
-"aXZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
 "aYb" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "virology_airlock_control";
@@ -15930,9 +15907,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/firstdeck/center)
-"cGt" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/smokingparlour)
 "cHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16144,16 +16118,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
-"cWw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair/padded/brown{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/smokingparlour)
 "cWR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16606,11 +16570,6 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
-"dsW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled/monotile,
-/area/security/wing)
 "dtb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -16972,7 +16931,7 @@
 "dQA" = (
 /obj/machinery/light/small,
 /obj/structure/table/woodentable/ebony,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/red,
 /area/crew_quarters/smokingparlour)
 "dRb" = (
 /obj/structure/morgue,
@@ -19123,6 +19082,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
+"gne" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor/tiled/monotile,
+/area/security/wing)
 "gnt" = (
 /obj/structure/bed/chair/padded/blue,
 /obj/effect/floor_decal/scglogo{
@@ -19989,7 +19953,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "hml" = (
 /obj/machinery/air_sensor{
@@ -20325,9 +20289,6 @@
 /obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
-"hCP" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/smokingparlour)
 "hDb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -22932,7 +22893,7 @@
 /area/assembly/robotics)
 "kym" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "kyt" = (
 /obj/effect/floor_decal/techfloor,
@@ -23093,6 +23054,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
+"kJS" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "kKb" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning{
@@ -23977,6 +23941,16 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"lJD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/padded/brown{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/crew_quarters/smokingparlour)
 "lKb" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26057,7 +26031,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "ohy" = (
 /obj/structure/cable/green{
@@ -27368,6 +27342,16 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"pKC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "pLb" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -29896,6 +29880,29 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/brig)
+"sMr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "sNb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29946,7 +29953,7 @@
 /area/command/conference)
 "sOg" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "sOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30827,12 +30834,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
-"uKi" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/wall/prepainted,
-/area/medical/autopsy)
 "uLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31285,7 +31286,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "vUl" = (
 /obj/structure/cable/green{
@@ -31563,16 +31564,6 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
-"wIm" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "wMh" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/orange,
@@ -31605,7 +31596,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/wood/usedup,
+/turf/simulated/floor/lino,
 /area/crew_quarters/smokingparlour)
 "wRs" = (
 /obj/structure/bed/chair/office/dark{
@@ -31650,6 +31641,9 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"wZQ" = (
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "xaC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -31723,6 +31717,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
+"xou" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/wall/prepainted,
+/area/medical/autopsy)
 "xqk" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_cycler,
@@ -42934,8 +42934,8 @@ aKH
 aLH
 aMK
 aNL
-dsW
-dsW
+gne
+gne
 aOK
 aRs
 aSq
@@ -52211,8 +52211,8 @@ gub
 gJb
 arK
 jiq
-aXZ
-wIm
+sMr
+pKC
 rsu
 nAb
 nIb
@@ -55433,7 +55433,7 @@ dRb
 emb
 evb
 fjb
-uKi
+xou
 aoK
 lXb
 aqR
@@ -56657,11 +56657,11 @@ aqU
 jsa
 hnN
 cgu
-cGt
-cGt
-cGt
-cGt
-cGt
+kJS
+kJS
+kJS
+kJS
+kJS
 aGJ
 kab
 pgb
@@ -56859,12 +56859,12 @@ awC
 jYD
 ayD
 jpb
-hCP
+wZQ
 vOv
 wQB
 ogv
 hle
-cGt
+kJS
 kbb
 phb
 pPb
@@ -57066,7 +57066,7 @@ aCm
 aDx
 aEx
 aFH
-cGt
+kJS
 hvY
 pib
 pDb
@@ -57268,7 +57268,7 @@ aCn
 aCo
 aEy
 dQA
-cGt
+kJS
 kpb
 pjb
 pEb
@@ -57468,9 +57468,9 @@ aGx
 sOg
 aCo
 aCo
-cWw
+lJD
 aFI
-cGt
+kJS
 eGb
 pbb
 pFb
@@ -57667,12 +57667,12 @@ aqU
 bBm
 ruz
 dJp
-hCP
+wZQ
 kym
 aDz
 aEA
 aFK
-cGt
+kJS
 qpb
 pnb
 pGb
@@ -57870,11 +57870,11 @@ jqn
 ayF
 jqn
 hPN
-hCP
-hCP
-hCP
+wZQ
+wZQ
+wZQ
 ijh
-cGt
+kJS
 aHQ
 aHQ
 aHQ

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2410,11 +2410,6 @@
 /obj/machinery/computer/diseasesplicer,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/virology)
-"afj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled/monotile,
-/area/security/wing)
 "afn" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -8007,26 +8002,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
-"azM" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "azN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -8298,21 +8276,17 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
 "aAR" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aAT" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
@@ -8700,36 +8674,28 @@
 /turf/simulated/wall/prepainted,
 /area/rnd/development)
 "aCm" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aCn" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aCo" = (
-/obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aCp" = (
 /obj/machinery/teleport/hub,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -8952,46 +8918,33 @@
 /turf/simulated/floor/carpet/green,
 /area/rnd/breakroom)
 "aDx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/bed/chair/armchair/brown{
+	icon_state = "armchair_preview";
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "aDy" = (
-/obj/structure/table/steel,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/obj/structure/table/woodentable/ebony,
+/obj/item/weapon/storage/fancy/cigar,
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "aDz" = (
-/obj/structure/closet/secure_closet{
-	name = "Security Equipment Locker";
-	req_access = list("ACCESS_SECURITY")
-	},
-/obj/item/device/radio/intercom/department/security{
+/obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 21
+	pixel_x = 25;
+	pixel_y = 0;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aDA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9193,19 +9146,34 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/breakroom)
-"aEy" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
-"aEA" = (
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
+"aEx" = (
+/obj/structure/bed/chair/armchair/brown{
+	icon_state = "armchair_preview";
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
+"aEy" = (
+/obj/structure/table/woodentable/ebony,
+/obj/item/weapon/storage/fancy/cigarettes/jerichos,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
+"aEA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aEC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9537,31 +9505,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/breakroom)
-"aFH" = (
-/obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
-"aFI" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
 "aFK" = (
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "aFL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9818,7 +9767,7 @@
 "aGJ" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
-/area/security/oldopscheck)
+/area/crew_quarters/smokingparlour)
 "aGL" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light{
@@ -15506,9 +15455,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "chb" = (
@@ -16811,16 +16757,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"dDc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "dEb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/paleblue{
@@ -16984,16 +16920,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "dQA" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/machinery/recharger/wallcharger{
+/obj/machinery/light/small,
+/obj/item/device/radio/intercom{
 	dir = 1;
-	icon_state = "wrecharger0";
-	pixel_y = -22
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "dRb" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -17213,9 +17146,6 @@
 "efb" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/subacute)
-"efR" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/oldopscheck)
 "egb" = (
 /obj/structure/bed/padded,
 /obj/machinery/firealarm{
@@ -17416,6 +17346,16 @@
 /obj/item/weapon/storage/box/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"eoL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "epb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -19288,29 +19228,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
-"gxX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
 "gyb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/green{
@@ -19416,6 +19333,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
+"gCz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/wall/prepainted,
+/area/medical/autopsy)
 "gDb" = (
 /obj/machinery/door/airlock/medical{
 	name = "Examination Room"
@@ -19898,6 +19821,11 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"hfE" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor/tiled/monotile,
+/area/security/wing)
 "hgb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20032,13 +19960,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "hle" = (
-/obj/effect/floor_decal/corner/red/mono,
-/obj/item/modular_computer/console/preset/civilian{
-	icon_state = "console";
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "hml" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -20638,7 +20564,7 @@
 	dir = 1
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/security/oldopscheck)
+/area/crew_quarters/smokingparlour)
 "hQb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20926,12 +20852,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
 "ijh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Checkpoint Maintenance"
-	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/area/crew_quarters/smokingparlour)
 "ikb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21693,12 +21617,6 @@
 "jfb" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"jfc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
 "jfn" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -21880,7 +21798,6 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "jpt" = (
@@ -22985,9 +22902,9 @@
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "kym" = (
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "kyt" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -24043,12 +23960,6 @@
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
-"lLF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
 "lMb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24477,8 +24388,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
 "moh" = (
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/obj/structure/bed/chair/armchair/brown{
+	icon_state = "armchair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "mpb" = (
 /obj/structure/bed/chair/office/light{
 	icon_state = "officechair_white_preview";
@@ -26112,21 +26027,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "ogv" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -32;
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
-	},
-/obj/structure/table/steel,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "ohy" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -27806,17 +27716,8 @@
 /area/rnd/misc_lab)
 "qmw" = (
 /obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "operation_checkpoint_shutters";
-	name = "Operation Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/structure/barricade,
 /turf/simulated/floor/plating,
-/area/security/oldopscheck)
+/area/crew_quarters/smokingparlour)
 "qnb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	icon_state = "intact";
@@ -28512,6 +28413,9 @@
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
+"riq" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "riD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -28688,6 +28592,29 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"run" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "ruz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29930,11 +29857,6 @@
 /area/hallway/primary/firstdeck/aft)
 "sLb" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -29955,6 +29877,11 @@
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
@@ -30022,9 +29949,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "sOg" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/security/oldopscheck)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "sOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -31046,12 +30973,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
-"uZi" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "uZO" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -31358,18 +31279,12 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/evidence)
 "vOv" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/frame/apc,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "vUl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31669,28 +31584,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "wQB" = (
-/obj/machinery/disposal,
-/obj/machinery/camera/network/security{
-	c_tag = "Decomissioned Checkpoint - Deck One";
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 18
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/oldopscheck)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/smokingparlour)
 "wRs" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -31992,6 +31896,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
+"yjJ" = (
+/obj/structure/bed/chair/armchair/brown{
+	icon_state = "armchair_preview";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "ykr" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -43018,8 +42932,8 @@ aKH
 aLH
 aMK
 aNL
-afj
-afj
+hfE
+hfE
 aOK
 aRs
 aSq
@@ -52295,8 +52209,8 @@ gub
 gJb
 arK
 jiq
-gxX
-dDc
+run
+eoL
 rsu
 nAb
 nIb
@@ -55517,7 +55431,7 @@ dRb
 emb
 evb
 fjb
-jCM
+gCz
 aoK
 lXb
 aqR
@@ -56741,11 +56655,11 @@ aqU
 jsa
 hnN
 cgu
-efR
-efR
-efR
-efR
-efR
+riq
+riq
+riq
+riq
+riq
 aGJ
 kab
 pgb
@@ -56943,12 +56857,12 @@ awC
 jYD
 ayD
 jpb
-efR
+riq
 vOv
 wQB
 ogv
 hle
-efR
+riq
 kbb
 phb
 pPb
@@ -57144,13 +57058,13 @@ sIb
 sJb
 sKb
 sLb
-azM
+hcb
 aAR
 aCm
 aDx
-jfc
-aFH
-efR
+aEx
+aCo
+riq
 hvY
 pib
 pDb
@@ -57352,7 +57266,7 @@ aCn
 aDy
 aEy
 dQA
-efR
+riq
 kpb
 pjb
 pEb
@@ -57548,13 +57462,13 @@ avw
 awB
 fhx
 hnN
-uZi
+aGx
 sOg
 aCo
-lLF
 moh
-aFI
-efR
+yjJ
+aCo
+riq
 eGb
 pbb
 pFb
@@ -57751,12 +57665,12 @@ aqU
 bBm
 ruz
 dJp
-qmw
+riq
 kym
 aDz
 aEA
 aFK
-efR
+riq
 qpb
 pnb
 pGb
@@ -57954,11 +57868,11 @@ jqn
 ayF
 jqn
 hPN
-efR
-efR
-efR
+riq
+riq
+riq
 ijh
-efR
+riq
 aHQ
 aHQ
 aHQ

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -8285,7 +8285,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aAT" = (
 /obj/machinery/ai_status_display,
@@ -8685,16 +8685,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aCn" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aCo" = (
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aCp" = (
 /obj/machinery/teleport/hub,
@@ -8918,10 +8918,6 @@
 /turf/simulated/floor/carpet/green,
 /area/rnd/breakroom)
 "aDx" = (
-/obj/structure/bed/chair/armchair/brown{
-	icon_state = "armchair_preview";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -8929,12 +8925,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/smokingparlour)
-"aDy" = (
-/obj/structure/table/woodentable/ebony,
-/obj/item/weapon/storage/fancy/cigar,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aDz" = (
 /obj/machinery/alarm{
@@ -8943,7 +8934,7 @@
 	pixel_y = 0;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aDA" = (
 /obj/structure/cable/green{
@@ -9147,16 +9138,16 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/breakroom)
 "aEx" = (
-/obj/structure/bed/chair/armchair/brown{
-	icon_state = "armchair_preview";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/bed/chair/padded/brown{
+	icon_state = "chair_preview";
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/smokingparlour)
@@ -9172,7 +9163,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aEC" = (
 /obj/structure/cable/green{
@@ -9505,11 +9496,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/breakroom)
+"aFH" = (
+/obj/structure/bed/chair/padded/brown{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
+"aFI" = (
+/obj/structure/bed/chair/padded/brown{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "aFK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "aFL" = (
 /obj/structure/cable/green{
@@ -16925,7 +16930,8 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/wood/walnut,
+/obj/structure/table/woodentable/ebony,
+/turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/smokingparlour)
 "dRb" = (
 /obj/structure/morgue,
@@ -17346,16 +17352,6 @@
 /obj/item/weapon/storage/box/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
-"eoL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
 "epb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -17418,6 +17414,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/autopsy)
+"erQ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor/tiled/monotile,
+/area/security/wing)
 "esb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -19333,12 +19334,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
-"gCz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/wall/prepainted,
-/area/medical/autopsy)
 "gDb" = (
 /obj/machinery/door/airlock/medical{
 	name = "Examination Room"
@@ -19821,11 +19816,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
-"hfE" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled/monotile,
-/area/security/wing)
 "hgb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19963,7 +19953,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "hml" = (
 /obj/machinery/air_sensor{
@@ -20447,6 +20437,9 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/development)
+"hJk" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "hJq" = (
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 1
@@ -20563,7 +20556,7 @@
 	icon_state = "shock";
 	dir = 1
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/smokingparlour)
 "hQb" = (
 /obj/structure/cable/green{
@@ -20854,7 +20847,7 @@
 "ijh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/plating,
 /area/crew_quarters/smokingparlour)
 "ikb" = (
 /obj/structure/cable/green{
@@ -22538,6 +22531,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1starboard)
+"kfN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/padded/brown{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/smokingparlour)
 "kgi" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	icon_state = "edge";
@@ -22903,7 +22906,7 @@
 /area/assembly/robotics)
 "kym" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "kyt" = (
 /obj/effect/floor_decal/techfloor,
@@ -23685,6 +23688,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
+"lvI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/wall/prepainted,
+/area/medical/autopsy)
 "lwb" = (
 /obj/structure/table/steel,
 /obj/machinery/button/remote/blast_door{
@@ -24387,13 +24396,6 @@
 /obj/item/bodybag/rescue/loaded,
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
-"moh" = (
-/obj/structure/bed/chair/armchair/brown{
-	icon_state = "armchair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/smokingparlour)
 "mpb" = (
 /obj/structure/bed/chair/office/light{
 	icon_state = "officechair_white_preview";
@@ -26035,7 +26037,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "ohy" = (
 /obj/structure/cable/green{
@@ -28413,9 +28415,6 @@
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
-"riq" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/smokingparlour)
 "riD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -28592,29 +28591,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
-"run" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
 "ruz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28695,6 +28671,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
+"ryZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "rzb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29950,7 +29936,7 @@
 /area/command/conference)
 "sOg" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "sOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30606,6 +30592,29 @@
 "tOV" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/processing)
+"tQs" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "tRX" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -31283,7 +31292,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "vUl" = (
 /obj/structure/cable/green{
@@ -31593,7 +31602,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/usedup,
 /area/crew_quarters/smokingparlour)
 "wRs" = (
 /obj/structure/bed/chair/office/dark{
@@ -31878,6 +31887,9 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"xZK" = (
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/smokingparlour)
 "ycp" = (
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/white/monotile,
@@ -31896,16 +31908,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
-"yjJ" = (
-/obj/structure/bed/chair/armchair/brown{
-	icon_state = "armchair_preview";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/smokingparlour)
 "ykr" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -42932,8 +42934,8 @@ aKH
 aLH
 aMK
 aNL
-hfE
-hfE
+erQ
+erQ
 aOK
 aRs
 aSq
@@ -52209,8 +52211,8 @@ gub
 gJb
 arK
 jiq
-run
-eoL
+tQs
+ryZ
 rsu
 nAb
 nIb
@@ -55431,7 +55433,7 @@ dRb
 emb
 evb
 fjb
-gCz
+lvI
 aoK
 lXb
 aqR
@@ -56655,11 +56657,11 @@ aqU
 jsa
 hnN
 cgu
-riq
-riq
-riq
-riq
-riq
+hJk
+hJk
+hJk
+hJk
+hJk
 aGJ
 kab
 pgb
@@ -56857,12 +56859,12 @@ awC
 jYD
 ayD
 jpb
-riq
+xZK
 vOv
 wQB
 ogv
 hle
-riq
+hJk
 kbb
 phb
 pPb
@@ -57063,8 +57065,8 @@ aAR
 aCm
 aDx
 aEx
-aCo
-riq
+aFH
+hJk
 hvY
 pib
 pDb
@@ -57263,10 +57265,10 @@ ayB
 azN
 qmw
 aCn
-aDy
+aCo
 aEy
 dQA
-riq
+hJk
 kpb
 pjb
 pEb
@@ -57465,10 +57467,10 @@ hnN
 aGx
 sOg
 aCo
-moh
-yjJ
 aCo
-riq
+kfN
+aFI
+hJk
 eGb
 pbb
 pFb
@@ -57665,12 +57667,12 @@ aqU
 bBm
 ruz
 dJp
-riq
+xZK
 kym
 aDz
 aEA
 aFK
-riq
+hJk
 qpb
 pnb
 pGb
@@ -57868,11 +57870,11 @@ jqn
 ayF
 jqn
 hPN
-riq
-riq
-riq
+xZK
+xZK
+xZK
 ijh
-riq
+hJk
 aHQ
 aHQ
 aHQ

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1017,6 +1017,10 @@
 /area/hydroponics/storage
 	name = "\improper Hydroponics Storage"
 
+/area/crew_quarters/smokingparlour
+	name = "\improper Smoking Parlour"
+	icon_state = "bar"
+
 // Tcomms
 /area/tcommsat/storage
 	name = "\improper Telecoms Storage"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1057,10 +1057,6 @@
 	name = "\improper First Deck Security Checkpoint"
 	icon_state = "checkpoint"
 
-/area/security/oldopscheck
-	name = "\improper Decommissioned First Deck Security Checkpoint"
-	icon_state = "checkpoint"
-
 /area/security/habcheck
 	name = "\improper Third Deck Security Checkpoint"
 	icon_state = "checkpoint"


### PR DESCRIPTION
Replaces the abandoned D1 checkpoint with a small place to relax and smoke. Don't think there are enough small crew areas to lounge around in honestly myself, that and having lots of empty unused space on a ship makes no sense to me.

![](https://i.imgur.com/vRG6UjO.png)


:cl: Minijar
maptweak: Replaces the abandoned D1 checkpoint with a smoking room.
/:cl:
