### PR TITLE
Adds some pressure sanity on air alarm heaters

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -159,7 +159,8 @@
 	var/datum/gas_mixture/environment = location.return_air()
 
 	//Handle temperature adjustment here.
-	handle_heating_cooling(environment)
+	if(environment.return_pressure() > ONE_ATMOSPHERE*0.05)
+		handle_heating_cooling(environment)
 
 	var/old_level = danger_level
 	var/old_pressurelevel = pressure_dangerlevel


### PR DESCRIPTION
This is to prevent annoying spam when air alarm is in a depressurized room.
It would get 0.01 kPa of air and oh no it's not optimal 20C, we must heat it- wait it's gone, we stop now, WITH A MESSAGE
Repeat every second or more often.

Now it'll wait until there's at least 5 kPa of air before bothering
