### PR TITLE
lava removes victims again

### DIFF
--- a/code/modules/overmap/exoplanets/volcanic.dm
+++ b/code/modules/overmap/exoplanets/volcanic.dm
@@ -126,12 +126,13 @@
 		return PROCESS_KILL
 	for(var/weakref/W in victims)
 		var/atom/movable/AM = W.resolve()
-		if(!(AM && AM.is_burnable()))
+		if (AM == null || get_turf(AM) != src || AM.is_burnable() == FALSE)
 			victims -= W
 			continue
 		var/datum/gas_mixture/environment = return_air()
 		var/pressure = environment.return_pressure()
-		if(AM.lava_act(environment, 5000 + environment.temperature, pressure))
+		var/destroyed = AM.lava_act(environment, 5000 + environment.temperature, pressure)
+		if(destroyed == TRUE)
 			victims -= W
 	if(!LAZYLEN(victims))
 		return PROCESS_KILL


### PR DESCRIPTION
:cl:
bugfix: Lava turfs no longer incorrectly reignite and burn you every process forever.
/:cl:

This adds a presence check in process because the Exited override fails nonsensically. Things that aren't destroyed by lava actually being in lava is uncommon. Since this makes sure that a carbon can't be a victim of more than one lava tile at a time anymore as well, it's basically costless anyway.