### PR TITLE
Restructure mirror code

### DIFF
--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -10,7 +10,7 @@
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	use_sound = 'sound/effects/closet_open.ogg'
 	var/shattered = 0
-	var/list/ui_users = list()
+	var/list/ui_users
 
 	startswith = list(
 		/obj/item/weapon/haircomb/random,
@@ -33,14 +33,7 @@
 	if(shattered)
 		to_chat(user, "<spawn class='notice'>You enter the key combination for the style you want on the panel, but the nanomachines inside \the [src] refuse to come out.")
 		return
-
-	if(ishuman(user))
-		var/datum/nano_module/appearance_changer/AC = ui_users[user]
-		if(!AC)
-			AC = new(src, user)
-			AC.name = "SalonPro Nano-Mirror&trade;"
-			ui_users[user] = AC
-		AC.ui_interact(user)
+	open_mirror_ui(user, ui_users, "SalonPro Nano-Mirror&trade;")
 
 /obj/item/weapon/storage/mirror/proc/shatter()
 	if(shattered)	return
@@ -81,11 +74,8 @@
 	return 1
 
 /obj/item/weapon/storage/mirror/Destroy()
-	for(var/user in ui_users)
-		var/datum/nano_module/appearance_changer/AC = ui_users[user]
-		qdel(AC)
-	ui_users.Cut()
-	..()
+	clear_ui_users(ui_users)
+	. = ..()
 
 // The following mirror is ~special~.
 /obj/item/weapon/storage/mirror/raider
@@ -119,21 +109,30 @@
 	desc = "A SalonPro Nano-Mirror(TM) brand mirror! Now a portable version."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "mirror"
-	var/list/ui_users = list()
+	var/list/ui_users
 
 /obj/item/weapon/mirror/attack_self(mob/user as mob)
-	if(ishuman(user))
-		var/datum/nano_module/appearance_changer/AC = ui_users[user]
-		if(!AC)
-			AC = new(src, user)
-			AC.name = "SalonPro Nano-Mirror&trade;"
-			AC.flags = APPEARANCE_HAIR
-			ui_users[user] = AC
-		AC.ui_interact(user)
+	open_mirror_ui(user, ui_users, "SalonPro Nano-Mirror&trade;")
 
 /obj/item/weapon/mirror/Destroy()
-	for(var/user in ui_users)
-		var/datum/nano_module/appearance_changer/AC = ui_users[user]
+	clear_ui_users(ui_users)
+	. = ..()
+
+/proc/open_mirror_ui(var/mob/user, var/ui_users, var/title)
+	if(!ishuman(user))
+		return
+
+	var/W = weakref(user)
+	var/datum/nano_module/appearance_changer/AC = LAZYACCESS(ui_users, W)
+	if(!AC)
+		AC = new(src, user)
+		AC.name = title
+		AC.flags = APPEARANCE_HAIR
+		LAZYSET(ui_users, W, AC)
+	AC.ui_interact(user)
+
+/proc/clear_ui_users(var/list/ui_users)
+	for(var/W in ui_users)
+		var/AC = ui_users[W]
 		qdel(AC)
-	ui_users.Cut()
-	..()
+	LAZYCLEARLIST(ui_users)


### PR DESCRIPTION
Now uses weakrefs instead of hard references to mobs.
The different types of mirrors now share code.

Don't see how the prior code would end up deleting mobs but the use of
 weakrefs should prevent it.
Leaving the issue open until a cause that be determined or show to be
 non-reproducible without additional issues.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->