### PR TITLE
Allows changing emag icon and name like a chameleon item

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -108,6 +108,8 @@
 	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 2)
 	var/uses = 10
 
+	var/static/list/card_choices
+
 var/const/NO_EMAG_ACT = -50
 /obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)
 	var/used_uses = A.emag_act(uses, user, src)
@@ -126,6 +128,50 @@ var/const/NO_EMAG_ACT = -50
 		qdel(src)
 
 	return 1
+
+/obj/item/weapon/card/emag/proc/generate_emag_choices(var/card_choices)
+	. = list()
+
+	var/i = 1 //in case there is a collision with both name AND icon_state
+	for(var/typepath in card_choices)
+		var/obj/O = typepath
+		if(initial(O.icon) && initial(O.icon_state))
+			var/name = initial(O.name)
+			if(name in .)
+				name += " ([initial(O.icon_state)])"
+			if(name in .)
+				name += " \[[i++]\]"
+			.[name] = typepath
+
+/obj/item/weapon/card/emag/Initialize()
+	. = ..()
+	if(!card_choices)
+		card_choices = list(/obj/item/weapon/card/union,
+							/obj/item/weapon/card/data,
+							/obj/item/weapon/card/data/full_color,
+							/obj/item/weapon/card/data/disk,
+							/obj/item/weapon/card/id,
+						) //Should be enough of a selection for most purposes
+		card_choices = generate_emag_choices(card_choices)
+
+/obj/item/weapon/card/emag/verb/change(picked in card_choices)
+	set name = "Change Cryptographic Sequencer Appearance"
+	set category = "Chameleon Items"
+	set src in usr
+
+	if(!ispath(card_choices[picked]))
+		return
+
+	disguise(card_choices[picked], usr)
+	update_icon()
+
+/obj/item/weapon/card/emag/examine(mob/user)
+	. = ..()
+	if(!.)
+		return
+		
+	if(user.skill_check(SKILL_DEVICES,SKILL_ADEPT))
+		to_chat(user, SPAN_WARNING("This ID card has some non-standard modifications commonly used to gain illicit access to computer systems."))
 
 /obj/item/weapon/card/id
 	name = "identification card"

--- a/html/changelogs/myazaki - emag_disguise.yml
+++ b/html/changelogs/myazaki - emag_disguise.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes: 
+  - tweak: "Allows changing a cryptographic sequencer's icon and name in a similar way to chameleon items."


### PR DESCRIPTION
I've been dealing with a _great deal_ of metagaming regarding cryptographic sequencers recently. This allows disguising of the sequencer to prevent this, because it is getting tiring having to ahelp it every round.

Examining it with high forensics / complex devices reveals something is fishy.

Bit more work to do on working on which card items it shouldn't be allowed to copy. But most of the stuff is done.