### PR TITLE
Titanium and Rutile are now obtainable via mining.

### DIFF
--- a/code/__defines/materials.dm
+++ b/code/__defines/materials.dm
@@ -22,6 +22,7 @@
 #define MATERIAL_REINFORCED_CULT         "cult2"
 #define MATERIAL_VOX                     "voxalloy"
 #define MATERIAL_TITANIUM                "titanium"
+#define MATERIAL_RUTILE					 "rutile"
 #define MATERIAL_OSMIUM_CARBIDE_PLASTEEL "osmium-carbide plasteel"
 #define MATERIAL_OSMIUM                  "osmium"
 #define MATERIAL_HYDROGEN                "hydrogen"

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -82,6 +82,9 @@
 /turf/simulated/wall/sandstone/New(var/newloc)
 	..(newloc,MATERIAL_SANDSTONE)
 
+/turf/simulated/wall/rutile/New(var/newloc)
+	..(newloc,MATERIAL_RUTILE)
+
 /turf/simulated/wall/wood
 	blend_turfs = list(/turf/simulated/wall/cult, /turf/simulated/wall)
 	icon_state = "woodneric"

--- a/code/modules/materials/definitions/materials_metal.dm
+++ b/code/modules/materials/definitions/materials_metal.dm
@@ -186,7 +186,7 @@
 	integrity = 200
 	melting_point = 3000
 	weight = 18
-	stack_type = null
+	stack_type = /obj/item/stack/material/titanium
 	icon_base = "metal"
 	door_icon_base = "metal"
 	icon_colour = "#d1e6e3"
@@ -362,3 +362,15 @@
 	ore_name = "hematite"
 	ore_icon_overlay = "lump"
 	sale_price = 1
+
+/material/rutile
+	name = MATERIAL_RUTILE
+	stack_type = null
+	icon_colour = "#d8ad97"
+	ore_smelts_to = MATERIAL_TITANIUM
+	ore_result_amount = 5
+	ore_spread_chance = 15
+	ore_scan_icon = "mineral_uncommon"
+	ore_name = "rutile"
+	ore_icon_overlay = "lump"
+	sale_price = 2

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -319,6 +319,18 @@
 /obj/item/stack/material/aluminium/fifty
 	amount = 50
 
+/obj/item/stack/material/titanium
+	name = "titanium"
+	icon_state = "sheet"
+	plural_icon_state = "sheet-mult"
+	default_type = MATERIAL_TITANIUM
+
+/obj/item/stack/material/titanium/ten
+	amount = 10
+
+/obj/item/stack/material/titanium/fifty
+	amount = 50
+
 /obj/item/stack/material/plasteel
 	name = "plasteel"
 	icon_state = "sheet-reinf"

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -75,3 +75,5 @@
 	..(newloc, MATERIAL_PHORON)
 /obj/item/weapon/ore/aluminium/New(var/newloc)
 	..(newloc, MATERIAL_BAUXITE)
+/obj/item/weapon/ore/rutile/New(var/newloc)
+	..(newloc, MATERIAL_RUTILE)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -29,7 +29,8 @@
 		MATERIAL_HYDROGEN = /obj/item/weapon/ore/hydrogen,
 		MATERIAL_SAND =     /obj/item/weapon/ore/glass,
 		MATERIAL_GRAPHENE = /obj/item/weapon/ore/coal,
-		MATERIAL_ALUMINIUM = /obj/item/weapon/ore/aluminium
+		MATERIAL_ALUMINIUM = /obj/item/weapon/ore/aluminium,
+		MATERIAL_RUTILE = /obj/item/weapon/ore/rutile
 		)
 
 	//Upgrades

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -39,7 +39,7 @@
 			switch(metal)
 				if(MATERIAL_SAND, MATERIAL_GRAPHENE, MATERIAL_IRON)
 					ore_type = "surface minerals"
-				if(MATERIAL_GOLD, MATERIAL_SILVER, MATERIAL_DIAMOND)
+				if(MATERIAL_GOLD, MATERIAL_SILVER, MATERIAL_DIAMOND, MATERIAL_RUTILE)
 					ore_type = "precious metals"
 					data_value = 2
 				if(MATERIAL_URANIUM)

--- a/code/modules/organs/internal/species/vox.dm
+++ b/code/modules/organs/internal/species/vox.dm
@@ -78,7 +78,8 @@
 		MATERIAL_POTASH =      TRUE,
 		MATERIAL_BAUXITE =     TRUE,
 		MATERIAL_COPPER =      TRUE,
-		MATERIAL_ALUMINIUM =   TRUE
+		MATERIAL_ALUMINIUM =   TRUE,
+		MATERIAL_RUTILE = 	   TRUE
 	)
 	var/list/stored_matter = list()
 

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -15,7 +15,8 @@ GLOBAL_LIST_INIT(weighted_minerals_sparse, \
 		MATERIAL_PHOSPHORITE =  3, \
 		MATERIAL_ROCK_SALT =    3, \
 		MATERIAL_POTASH =       3, \
-		MATERIAL_BAUXITE =      3  \
+		MATERIAL_BAUXITE =      3, \
+		MATERIAL_RUTILE = 		3
 	))
 
 GLOBAL_LIST_INIT(weighted_minerals_rich, \
@@ -35,7 +36,8 @@ GLOBAL_LIST_INIT(weighted_minerals_rich, \
 		MATERIAL_PHOSPHORITE =  1, \
 		MATERIAL_ROCK_SALT =    1, \
 		MATERIAL_POTASH =       1, \
-		MATERIAL_BAUXITE =      1  \
+		MATERIAL_BAUXITE =      1, \
+		MATERIAL_RUTILE = 		1
 	))
 
 /datum/random_map/automata/cave_system

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -67,6 +67,7 @@
 				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+				T.resources[MATERIAL_RUTILE] = 0
 				T.resources[MATERIAL_DIAMOND] =  0
 				T.resources[MATERIAL_PHORON] =   0
 				T.resources[MATERIAL_OSMIUM] =   0
@@ -77,6 +78,7 @@
 				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources[MATERIAL_RUTILE] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_HYDROGEN] = 0
 				T.resources[MATERIAL_DIAMOND] =  0
 				T.resources[MATERIAL_IRON] =     0
@@ -86,6 +88,7 @@
 				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
 				T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
 				T.resources[MATERIAL_HYDROGEN] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources[MATERIAL_RUTILE] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_IRON] =     0
 				T.resources[MATERIAL_GOLD] =     0
 				T.resources[MATERIAL_SILVER] =   0

--- a/html/changelogs/myazaki - titanium.yml
+++ b/html/changelogs/myazaki - titanium.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: MikoMyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Titanium and its ore Rutile are now available via mining, allowing repair of shuttles and the ship exterior."

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -499,6 +499,35 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics/storage)
+"bz" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
+	},
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
+	},
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/item/stack/material/titanium/ten,
+/obj/item/stack/material/titanium/ten,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/engineering/hardstorage)
 "bA" = (
 /turf/simulated/wall/prepainted,
 /area/hydroponics)
@@ -4801,33 +4830,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/holocontrol)
-"ke" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 20
-	},
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 20
-	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/engineering/hardstorage)
 "ki" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -42676,7 +42678,7 @@ da
 dD
 bv
 nA
-ke
+bz
 Xz
 Ve
 VY


### PR DESCRIPTION
Because I hate repairing the shuttle with reinforced plasteel and it looking inconsistent!

Adds rutile to ores that can spawn.
Can smelt rutile into titanium, which acts the same as plasteel for construction options.