### PR TITLE
Research Assistant needs access

### DIFF
--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -115,4 +115,7 @@
 	                    SKILL_DEVICES     = SKILL_MAX,
 	                    SKILL_SCIENCE     = SKILL_MAX)
 
-	access = list(access_research, access_mining_office, access_nanotrasen, access_petrov, access_expedition_shuttle, access_guppy, access_hangar)
+	access = list(access_tox, access_tox_storage, access_research, access_petrov,
+						access_mining_office, access_mining_station, access_xenobiology,
+						access_xenoarch, access_nanotrasen, access_expedition_shuttle, access_guppy, access_hangar,
+						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry)


### PR DESCRIPTION
Research assistant didn't have access to assist in research. This has been rectified. They now have access to much of the same areas as Research, sans a few cockpit areas.

:cl:
Tweak: Research Assistant now has access to the same research labs as the people they are assisting. 
:cl: