### PR TITLE
Ore Unloader tweaks 2.0!

### DIFF
--- a/code/modules/mining/machinery/_mineral.dm
+++ b/code/modules/mining/machinery/_mineral.dm
@@ -48,7 +48,7 @@
 		. += "<b>Output</b>: [dir2text(get_dir(src, output_turf))]."
 	else
 		. += "<b>Output</b>: disabled."
-	. += "<br><a href='?src=\ref[src];configure_input_output=1'>Configure.</a>"
+	. += "<br><a href='?src=\ref[src];configure_input_output=1'>Configure</a>"
 
 /obj/machinery/mineral/CanUseTopic(var/mob/user)
 	return max(..(), (console && console.CanUseTopic(user)))

--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -154,7 +154,7 @@
 			status_string = "<font color='red'>not processing</font>"
 		result += "<tr><td>[line]</td><td><a href='?src=\ref[src];toggle_smelting=[ore]'>[status_string]</a></td></tr>"
 	. += "<table>[result]</table>"
-	. += "Currently displaying [report_all_ores ? "all ore types" : "only available ore types"]. <A href='?src=\ref[src];toggle_ores=1'>[report_all_ores ? "Show less." : "Show more."]</a>"
+	. += "Currently displaying [report_all_ores ? "all ore types" : "only available ore types"]. <A href='?src=\ref[src];toggle_ores=1'>[report_all_ores ? "Show less" : "Show more"]</a>"
 	. += "The ore processor is currently <A href='?src=\ref[src];toggle_power=1'>[(active ? "enabled" : "disabled")].</a>"
 
 /obj/machinery/mineral/processing_unit/Topic(href, href_list)

--- a/code/modules/mining/machinery/mineral_stacker.dm
+++ b/code/modules/mining/machinery/mineral_stacker.dm
@@ -43,18 +43,18 @@
 /obj/machinery/mineral/stacking_machine/get_console_data()
 	. = ..()
 	. += "<h1>Sheet Stacking</h1>"
-	. += "Stacking: [stack_amt] <a href='?srcsay =\ref[src];change_stack=1'>\[change\]</a>"
+	. += "Stacking: [stack_amt] <a href='?src=\ref[src];change_stack=1'>\[change\]</a>"
 	var/line = ""
 	for(var/stacktype in stacks)
 		if(stacks[stacktype] > 0)
-			line += "<tr><td>[capitalize(stacktype)]</td><td>[stacks[stacktype]]</td><td><A href='?src=\ref[src];release_stack=[stacktype]'>Release.</a></td></tr>"
+			line += "<tr><td>[capitalize(stacktype)]</td><td>[stacks[stacktype]]</td><td><A href='?src=\ref[src];release_stack=[stacktype]'>Release</a></td></tr>"
 	. += "<table>[line]</table>"
 
 /obj/machinery/mineral/stacking_machine/Topic(href, href_list)
 	if((. = ..()))
 		return
 	if(href_list["change_stack"])
-		var/choice = input("What would you like to set the stack amount to?") as null|anything in list(1,5,10,20,50)
+		var/choice = input("What would you like to set the stack amount to?") as null|anything in list(1,5,10,20,30,50,60)
 		if(!choice) return
 		stack_amt = choice
 		. = TRUE

--- a/code/modules/mining/machinery/mineral_unloader.dm
+++ b/code/modules/mining/machinery/mineral_unloader.dm
@@ -14,12 +14,13 @@
 
 /obj/machinery/mineral/unloading_machine/Process()
 	if(input_turf && output_turf)
-		var/ore_this_tick = 25
-		for(var/obj/structure/ore_box/unloading in input_turf)
-			for(var/obj/item/weapon/ore/_ore in unloading)
-				_ore.dropInto(output_turf)
-				if(--ore_this_tick<=0) return
-		for(var/obj/item/_ore in input_turf)
-			if(_ore.simulated && !_ore.anchored)
-				_ore.dropInto(output_turf)
-				if(--ore_this_tick<=0) return
+		if(length(output_turf.contents) < 15)
+			var/ore_this_tick = 10
+			for(var/obj/structure/ore_box/unloading in input_turf)
+				for(var/obj/item/weapon/ore/_ore in unloading)
+					_ore.dropInto(output_turf)
+					if(--ore_this_tick<=0) return
+			for(var/obj/item/_ore in input_turf)
+				if(_ore.simulated && !_ore.anchored)
+					_ore.dropInto(output_turf)
+					if(--ore_this_tick<=0) return


### PR DESCRIPTION
🆑
:bugfix: The mineral stacker can have its stacking size set once again.
/🆑
Made the ore unloader machine transfer at the same rate as conveyor belts, to bottle neck the ore amount present and reduce lag, hopefully.
2.0! 
the ore unloader machine now checks how many ores is on the output tile, stopping at twenty ores. and overall stops it from building up a large pile that will freeze the game upon right clicking!!!
also same bug fix as #25308! HA, take that Roland! My factorio dream lives! (love ya buddy)
also remove pesky full stops that makes the interface looks bad. Just a small gripe.