### PR TITLE
Adds warning for silicon unconsciousness

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -59,8 +59,7 @@
 
 /mob/living/silicon/robot/proc/power_down()
 	if (has_power)
-		to_chat(src, "<span class='warning'>You are now running on emergency backup power.</span>")
-		visible_message("[src] beeps stridently as it begins to run on emergency backup power!")
+		visible_message("[src] beeps stridently as it begins to run on emergency backup power!", SPAN_WARNING("You beep stridently as you begin to run on emergency backup power!"))
 		has_power = 0
 		set_stat(UNCONSCIOUS)
 	if(lights_on) // Light is on but there is no power!

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -60,6 +60,7 @@
 /mob/living/silicon/robot/proc/power_down()
 	if (has_power)
 		to_chat(src, "<span class='warning'>You are now running on emergency backup power.</span>")
+		visible_message("[src] beeps stridently as it begins to run on emergency backup power!")
 		has_power = 0
 		set_stat(UNCONSCIOUS)
 	if(lights_on) // Light is on but there is no power!


### PR DESCRIPTION
Inserts a warning when a robot enters non-functionality, so that spam-inspecting is no longer needed when forcefully disabling (but not junking) a robot.

:cl: Draxtheros
rscadd: Robots will now announce via chatlog when they enter an emergency power state.
/:cl: