### PR TITLE
Fixes issues with stomach ingested reagent processing

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -69,6 +69,12 @@
 			return stomach.ingested
 	return touching // Kind of a shitty hack, but makes more sense to me than digesting them.
 
+/mob/living/carbon/human/proc/metabolize_ingested_reagents()
+	if(should_have_organ(BP_STOMACH))
+		var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+		if(stomach)
+			stomach.metabolize()
+
 /mob/living/carbon/human/get_fullness()
 	if(!should_have_organ(BP_STOMACH))
 		return ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -526,12 +526,14 @@
 	if(isSynthetic())
 		return
 
+	var/datum/reagents/metabolism/ingested = get_ingested_reagents()
+
 	if(reagents)
 		if(touching) touching.metabolize()
 		if(bloodstr) bloodstr.metabolize()
+		if(ingested) metabolize_ingested_reagents()
 
 	// Trace chemicals
-	var/datum/reagents/metabolism/ingested = get_ingested_reagents()
 	for(var/T in chem_doses)
 		if(bloodstr.has_reagent(T) || ingested.has_reagent(T) || touching.has_reagent(T))
 			continue

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -42,17 +42,17 @@
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
 
-	var/pulse_chem_level = owner.chem_effects[CE_PULSE]
+	// pulse mod starts out as just the chemical effect amount
+	var/pulse_mod = owner.chem_effects[CE_PULSE]
 	var/is_stable = owner.chem_effects[CE_STABLE]
 		
 	// If you have enough heart chemicals to be over 2, you're likely to take extra damage.
-	if(pulse_chem_level > 2 && !is_stable)
-		var/damage_chance = (pulse_chem_level - 2) ** 2
+	if(pulse_mod > 2 && !is_stable)
+		var/damage_chance = (pulse_mod - 2) ** 2
 		if(prob(damage_chance))
 			take_internal_damage(0.5)
 	
-	var/pulse_mod = pulse_chem_level
-
+	// Now pulse mod is impacted by shock stage and other things too
 	if(owner.shock_stage > 30)
 		pulse_mod++
 	if(owner.shock_stage > 80)

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -10,6 +10,8 @@
 	var/stomach_capacity
 	var/datum/reagents/metabolism/ingested
 	var/next_cramp = 0
+	var/functioning = TRUE
+	var/functioning_set = FALSE
 
 /obj/item/organ/internal/stomach/Destroy()
 	QDEL_NULL(ingested)
@@ -86,18 +88,33 @@
 /obj/item/organ/internal/stomach/return_air()
 	return null
 
-/obj/item/organ/internal/stomach/Process()
+// This call needs to be split out to make sure that all the ingested things are metabolised
+// before the process call is made on any of the other organs
+/obj/item/organ/internal/stomach/proc/metabolize()
+	if(is_usable())
+		ingested.metabolize()
+	
+// This makes sure that the ingested metabolism call and the Process() call both have the
+// same value for is_usable() due to the probability involved
+/obj/item/organ/internal/stomach/is_usable()
+	if(functioning_set)
+		return functioning
+	
+	functioning_set = TRUE
+	functioning = ..()
+	
+	if(damage >= min_bruised_damage && prob((damage / max_damage) * 100))
+		functioning = FALSE
+		
+	return functioning
 
+#define STOMACH_VOLUME 65
+	
+/obj/item/organ/internal/stomach/Process()
 	..()
 
 	if(owner)
-
-		var/functioning = is_usable()
-		if(functioning && damage >= min_bruised_damage && prob(damage))
-			functioning = FALSE
-		
-		if(functioning)
-			ingested.metabolize()
+		if(is_usable())
 			for(var/mob/living/M in contents)
 				if(M.stat == DEAD)
 					qdel(M)
@@ -115,11 +132,18 @@
 			next_cramp = world.time + rand(200,800)
 			owner.custom_pain("Your stomach cramps agonizingly!",1)
 
-		var/alcohol_threshold_met = (ingested.get_reagent_amount(/datum/reagent/ethanol) > 60)
+		var/alcohol_threshold_met = (ingested.get_reagent_amount(/datum/reagent/ethanol) > STOMACH_VOLUME / 2)
 		if(alcohol_threshold_met && (owner.disabilities & EPILEPSY) && prob(20))
 			owner.seizure()
-
-		if(ingested.total_volume > 60 || ((alcohol_threshold_met || ingested.total_volume > 35) && prob(15)))
+		
+		// Just over the limit, the probability will be low. It rises a lot such that at double ingested it's 64% chance.
+		var/vomit_probability = (ingested.total_volume / STOMACH_VOLUME) ** 6
+		
+		// They need to have had more than their volume of reagent to vomit from it
+		if((alcohol_threshold_met || ingested.total_volume > STOMACH_VOLUME) && prob(vomit_probability))
 			owner.vomit()
 
+	functioning_set = FALSE
+
+#undef STOMACH_VOLUME
 #undef PUKE_ACTION_NAME

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -762,7 +762,7 @@
 	adj_drowsy = -3
 	adj_sleepy = -2
 	adj_temp = 25
-	overdose = 45
+	overdose = 60
 
 	glass_name = "coffee"
 	glass_desc = "Don't drop it, or you'll send scalding liquid and glass shards everywhere."
@@ -772,9 +772,12 @@
 	if(alien == IS_DIONA)
 		return
 	..()
+
 	if(adj_temp > 0)
 		holder.remove_reagent(/datum/reagent/frostoil, 10 * removed)
 	if(volume > 15)
+		M.add_chemical_effect(CE_PULSE, 1)
+	if(volume > 45)
 		M.add_chemical_effect(CE_PULSE, 1)
 
 /datum/reagent/nutriment/coffee/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -785,7 +788,7 @@
 	if(alien == IS_DIONA)
 		return
 	M.make_jittery(5)
-	M.add_chemical_effect(CE_PULSE, 2)
+	M.add_chemical_effect(CE_PULSE, 1)
 
 /datum/reagent/drink/coffee/icecoffee
 	name = "Iced Coffee"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -450,7 +450,7 @@
 	if(prob(5))
 		M.emote(pick("twitch", "blink_r", "shiver"))
 	M.add_chemical_effect(CE_SPEEDBOOST, 1)
-	M.add_chemical_effect(CE_PULSE, 2)
+	M.add_chemical_effect(CE_PULSE, 3)
 
 /datum/reagent/ethylredoxrazine
 	name = "Ethylredoxrazine"


### PR DESCRIPTION
- Fixes #25256

- Tweaks caffeine and hyperzine pulse impact

- Adjusts stomach volume and vomit chance

🆑 FTangSteve
bugfix: ingested reagents are now handled properly
tweak: pulse impacting reagents now have stronger effects when compounded
tweak: stomach volume is now 65 units instead of 30
tweak: vomiting when stomach is overfull now based on chance, higher with the more you're over the limit
/🆑

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->