### PR TITLE
Sanitizes underwear on species change

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -372,6 +372,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 			pref.cultural_info = mob_species.default_cultural_info.Copy()
 
+			if(!has_flag(pref.species, HAS_UNDERWEAR))
+				pref.all_underwear.Cut()
+
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["hair_color"])

--- a/code/modules/client/preference_setup/general/03_equipment.dm
+++ b/code/modules/client/preference_setup/general/03_equipment.dm
@@ -46,6 +46,10 @@
 					pref.all_underwear[WRC.name] = WRI.name
 					break
 
+	var/datum/species/mob_species = all_species[pref.species]
+	if(!(mob_species && mob_species.appearance_flags & HAS_UNDERWEAR))
+		pref.all_underwear.Cut()
+
 	if(!istype(pref.all_underwear_metadata))
 		pref.all_underwear_metadata = list()
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -64,6 +64,10 @@
 		previewJob.equip_preview(mannequin, player_alt_titles[previewJob.title], branch, rank)
 		update_icon = TRUE
 
+	if(!(mannequin.species.appearance_flags && mannequin.species.appearance_flags & HAS_UNDERWEAR))
+		if(all_underwear)
+			all_underwear.Cut()
+
 	if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && (previewJob.type == /datum/job/ai || previewJob.type == /datum/job/cyborg)))
 		// Equip custom gear loadout, replacing any job items
 		var/list/loadout_taken_slots = list()


### PR DESCRIPTION
:cl:
bugfix: Underwear will now no longer be kept on species change, if the species you are changing into cannot wear underwear.
/:cl:

Makes sure that characters cannot keep underwear equipped when changing races to a race that does not get underwear.

Lingerie Model 34-X is now unemployed.

![for_posterity](https://user-images.githubusercontent.com/47489928/56133793-366e5400-5f85-11e9-91c1-417f43ebc6a2.png)
