### PR TITLE
Make common reagents medically scannable

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -16,6 +16,7 @@
 	reagent_state = LIQUID
 	metabolism = REM * 5
 	color = "#c80000"
+	scannable = 1
 	taste_description = "iron"
 	taste_mult = 1.3
 	glass_name = "tomato juice"
@@ -124,6 +125,7 @@
 	description = "A ubiquitous chemical substance that is composed of hydrogen and oxygen."
 	reagent_state = LIQUID
 	color = "#0064c877"
+	scannable = 1
 	metabolism = REM * 10
 	taste_description = "water"
 	glass_name = "water"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -405,6 +405,7 @@
 	taste_mult = 1.8
 	reagent_state = SOLID
 	color = "#ffffff"
+	scannable = 1
 
 	glass_name = "sugar"
 	glass_desc = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -53,11 +53,12 @@
 /datum/reagent/nutriment/glucose
 	name = "Glucose"
 	color = "#ffffff"
+	scannable = 1
 
 	injectable = 1
 
 /datum/reagent/nutriment/protein // Bad for Skrell!
-	name = "animal protein"
+	name = "Animal Protein"
 	taste_description = "some sort of protein"
 	color = "#440000"
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -314,6 +314,7 @@
 	description = "An effective and very addictive painkiller. Don't mix with alcohol."
 	taste_description = "bitterness"
 	color = "#800080"
+	scannable = 1
 	overdose = 20
 	pain_power = 200
 	effective_dose = 2
@@ -373,6 +374,7 @@
 	description = "Venixalin is a strong, specialised antivenom for dealing with advanced toxins and venoms."
 	taste_description = "overpowering sweetness"
 	color = "#dadd98"
+	scannable = 1
 	metabolism = REM * 2
 	remove_generic = 0
 	remove_toxins = list(
@@ -450,6 +452,7 @@
 	taste_description = "acid"
 	reagent_state = SOLID
 	color = "#004000"
+	scannable = 1
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/ryetalyn/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -486,6 +489,7 @@
 	description = "A powerful oxidizer that reacts with ethanol."
 	reagent_state = SOLID
 	color = "#605048"
+	scannable = 1
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/ethylredoxrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -613,7 +617,7 @@
 	heating_products = null
 	heating_point = null
 	heating_message = null
-	scannable = 0
+	scannable = 1
 
 /datum/reagent/leporazine/hot/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature < 330)
@@ -627,7 +631,7 @@
 	heating_products = list(/datum/reagent/leporazine)
 	heating_point = 100 CELSIUS
 	heating_message = "Becomes clear and smooth."
-	scannable = 0
+	scannable = 1
 
 /datum/reagent/leporazine/cold/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(M.bodytemperature > 290)
@@ -643,6 +647,7 @@
 	taste_description = "sourness"
 	reagent_state = LIQUID
 	color = "#bf80bf"
+	scannable = 1
 	metabolism = 0.01
 	data = 0
 
@@ -663,6 +668,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#ff80ff"
+	scannable = 1
 	metabolism = 0.01
 	data = 0
 
@@ -683,6 +689,7 @@
 	description = "Stabilizes the mind greatly, but has a chance of adverse effects."
 	reagent_state = LIQUID
 	color = "#ff80bf"
+	scannable = 1
 	metabolism = 0.01
 	data = 0
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: GooeyChickenman
tweak: More common medicines and reagents will appear on medical scanners.
/:cl:

This sets the most commonly seen harmless reagents to be scannable and can appear on the health analyzer/advanced body scan/sleeper.

The purpose of this is to hopefully fix a very common routine seen in medbay - tons of unnecessary stomach pumping. For example, taking citalopram will show as an alert on the scan and will almost certainly get your stomach pumped.

Drink a cup of water and walk into medbay if you want to watch yourself get rushed to the sleeper to get that pumped out.

---
This makes the following reagents scannable:
```
Blood
Water
Sugar
Glucose
Oxycodone
Venaxilin
Ryetalyn
Ethylredoxrazine
Pyrogenic Leporazine
Cryogenic Leporazine
Methylphenidate
Citalopram
Paroxetine
```

Also notably (this can be changed if we prefer) I did not include any harmful chemicals (other than overdose), sedatives, or alcohol.