### PR TITLE
Tweak : Blood bag size

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -9,7 +9,7 @@
 	desc = "Flexible bag for IV injectors."
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	volume = 120
 	possible_transfer_amounts = "0.2;1;2"
 	amount_per_transfer_from_this = REM
@@ -25,9 +25,9 @@
 /obj/item/weapon/reagent_containers/ivbag/on_reagent_change()
 	update_icon()
 	if(reagents.total_volume > volume/2)
-		w_class = ITEM_SIZE_NORMAL
-	else
 		w_class = ITEM_SIZE_SMALL
+	else
+		w_class = ITEM_SIZE_TINY
 
 /obj/item/weapon/reagent_containers/attackby(obj/item/weapon/W as obj, mob/user as mob)
 


### PR DESCRIPTION
:cl: Flying_loulou
Tweak: Blood bags are now small if containing a reaggent, and tiny if empty.
/:cl:

Tweak: Blood bags are now small if containing a reaggent, and tiny if empty.

Several reasons to this :
- A blood bag currently has the same size than a full crew kit (containing sizable items such as small O2 tank)  or a medkit. While, with effort, you could fetch a blood bag in a large pocket (IRL), A medkit won't fit, no matter how large is the pocket.
- People used to carry 2/3 stasis bags, and are now instead carrying 1 blood bag, 1 roller bed, 1 auto compressor and 1 rescue bag, so basically this is takes 3x more space in your inventory.
- The blood bag is currently bigger than the rescue bag (which can contain a full-size O2 tank)...

A picture of the new size of the blood bags (With a crew survival kit as comparison) :
![New Blood bag size](https://user-images.githubusercontent.com/49248697/56363754-2d7fbb80-61ed-11e9-9435-b30c3fa0e874.JPG)
