### PR TITLE
Bandaid fix for the ore unloader lag also other mining fixes.

### DIFF
--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -154,8 +154,8 @@
 			status_string = "<font color='red'>not processing</font>"
 		result += "<tr><td>[line]</td><td><a href='?src=\ref[src];toggle_smelting=[ore]'>[status_string]</a></td></tr>"
 	. += "<table>[result]</table>"
-	. += "Currently displaying [report_all_ores ? "all ore types" : "only available ore types"]. <A href='?src=\ref[src];toggle_ores=1'>[report_all_ores ? "Show less." : "Show more."]</a>"
-	. += "The ore processor is currently <A href='?src=\ref[src];toggle_power=1'>[(active ? "enabled" : "disabled")].</a>"
+	. += "Currently displaying [report_all_ores ? "all ore types" : "only available ore types"]. <A href='?src=\ref[src];toggle_ores=1'>[report_all_ores ? "Show less" : "Show more."]</a>"
+	. += "The ore processor is currently <A href='?src=\ref[src];toggle_power=1'>[(active ? "enabled" : "disabled")]</a>"
 
 /obj/machinery/mineral/processing_unit/Topic(href, href_list)
 	if((. = ..()))

--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -10,7 +10,7 @@
 	input_turf =  NORTH
 	output_turf = SOUTH
 
-	var/sheets_per_tick = 10
+	var/sheets_per_tick = 50
 	var/list/ores_processing
 	var/list/ores_stored
 	var/report_all_ores

--- a/code/modules/mining/machinery/mineral_stacker.dm
+++ b/code/modules/mining/machinery/mineral_stacker.dm
@@ -43,18 +43,18 @@
 /obj/machinery/mineral/stacking_machine/get_console_data()
 	. = ..()
 	. += "<h1>Sheet Stacking</h1>"
-	. += "Stacking: [stack_amt] <a href='?srcsay =\ref[src];change_stack=1'>\[change\]</a>"
+	. += "Stacking: [stack_amt] <A href='?src=\ref[src];change_stack=1'>\[change\]</a>"
 	var/line = ""
 	for(var/stacktype in stacks)
 		if(stacks[stacktype] > 0)
-			line += "<tr><td>[capitalize(stacktype)]</td><td>[stacks[stacktype]]</td><td><A href='?src=\ref[src];release_stack=[stacktype]'>Release.</a></td></tr>"
+			line += "<tr><td>[capitalize(stacktype)]: </td><td>[stacks[stacktype]]</td><td><A href='?src=\ref[src];release_stack=[stacktype]'>Release</a></td></tr>"
 	. += "<table>[line]</table>"
 
 /obj/machinery/mineral/stacking_machine/Topic(href, href_list)
 	if((. = ..()))
 		return
 	if(href_list["change_stack"])
-		var/choice = input("What would you like to set the stack amount to?") as null|anything in list(1,5,10,20,50)
+		var/choice = input("What would you like to set the stack amount to?") as null|anything in list(1,5,10,20,50,60)
 		if(!choice) return
 		stack_amt = choice
 		. = TRUE

--- a/code/modules/mining/machinery/mineral_unloader.dm
+++ b/code/modules/mining/machinery/mineral_unloader.dm
@@ -14,7 +14,7 @@
 
 /obj/machinery/mineral/unloading_machine/Process()
 	if(input_turf && output_turf)
-		var/ore_this_tick = 25
+		var/ore_this_tick = 50
 		for(var/obj/structure/ore_box/unloading in input_turf)
 			for(var/obj/item/weapon/ore/_ore in unloading)
 				_ore.dropInto(output_turf)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -3832,6 +3832,11 @@
 /obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/colony/airlock)
+"gS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/exoplanet/concrete,
+/area/map_template/colony/mineralprocessing)
 "gT" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/effect/floor_decal/corner_techfloor_grid{
@@ -5151,6 +5156,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/map_template/colony/commons)
+"jb" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/stacking_machine{
+	input_turf = 8;
+	output_turf = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/map_template/colony/mineralprocessing)
 "jc" = (
 /obj/structure/sign/warning/smoking{
 	pixel_y = -28
@@ -5481,10 +5499,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "jC" = (
-/obj/machinery/conveyor{
-	id = "colonymine"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "jD" = (
 /obj/effect/floor_decal/borderfloorwhite,
@@ -5949,9 +5970,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
 "ko" = (
-/obj/machinery/mineral/processing_unit{
-	input_turf = 2;
-	output_turf = 1
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -6228,12 +6249,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/atmospherics)
 "kK" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/exoplanet/concrete,
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/colony/mineralprocessing)
 "kL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6314,6 +6331,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
+"kU" = (
+/turf/simulated/floor/tiled/steel_ridged,
+/area/map_template/colony/mineralprocessing)
 "kV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -6367,13 +6387,19 @@
 /turf/simulated/floor/plating,
 /area/map_template/colony/airlock)
 "kZ" = (
-/obj/machinery/computer/mining,
-/obj/structure/table/steel_reinforced,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1";
 	tag = "icon-railing0 (EAST)"
+	},
+/obj/machinery/computer/mining,
+/obj/structure/table/steel_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
@@ -6408,6 +6434,17 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/map_template/colony/atmospherics)
+"ld" = (
+/obj/machinery/computer/mining,
+/obj/structure/table/steel_reinforced,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/map_template/colony/mineralprocessing)
 "le" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6458,12 +6495,9 @@
 	icon_state = "railing0-1";
 	tag = "icon-railing0 (EAST)"
 	},
-/obj/machinery/conveyor_switch{
-	id = "colonymine"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/recharge_station,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lj" = (
 /obj/structure/cable{
@@ -6614,14 +6648,12 @@
 /turf/simulated/floor/plating,
 /area/map_template/colony/commons)
 "lz" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 1
 	},
-/obj/machinery/computer/mining,
-/obj/structure/table/steel_reinforced,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
@@ -6675,6 +6707,16 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/exoplanet/concrete,
+/area/map_template/colony/mineralprocessing)
+"lE" = (
+/obj/structure/railing/mapped,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/exoplanet/concrete,
+/area/map_template/colony/mineralprocessing)
+"lF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
 /turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lG" = (
@@ -7476,15 +7518,12 @@
 /turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "mQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
+/obj/machinery/mineral/processing_unit{
+	input_turf = 2;
+	output_turf = 1
 	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/exoplanet/concrete,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/colony/mineralprocessing)
 "mR" = (
 /obj/structure/bed/chair/comfy/beige{
@@ -8130,12 +8169,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "nT" = (
-/obj/machinery/mineral/stacking_machine{
-	input_turf = 8;
-	output_turf = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nU" = (
 /obj/structure/cable{
@@ -8259,23 +8298,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
-"od" = (
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/exoplanet/concrete,
-/area/map_template/colony/mineralprocessing)
-"oe" = (
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/exoplanet/concrete,
-/area/map_template/colony/mineralprocessing)
 "of" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -8947,16 +8969,6 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/hydroponics)
-"Og" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/exoplanet/concrete,
-/area/map_template/colony/mineralprocessing)
 "Ot" = (
 /turf/simulated/floor/tiled/white,
 /area/map_template/colony/bathroom)
@@ -9357,13 +9369,13 @@ ku
 du
 mN
 bd
-jC
-jC
-jC
+kK
 ko
-jC
+mQ
+kU
 nX
-od
+lz
+nT
 ny
 fc
 "}
@@ -9398,13 +9410,13 @@ kO
 lO
 kv
 bd
-nT
+lF
+jb
 kZ
+ld
 li
-lz
-Og
-mQ
-oe
+lE
+nT
 nz
 fc
 "}
@@ -9439,13 +9451,13 @@ hr
 jT
 hr
 bd
-kK
-la
-la
+kL
+jC
 la
 la
 kL
-oe
+kL
+of
 nz
 fc
 "}
@@ -9480,7 +9492,7 @@ lf
 lP
 mA
 bd
-kL
+gS
 kL
 kL
 kL

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -13,6 +13,21 @@
 /obj/item/weapon/pen/fancy,
 /turf/simulated/floor/lino,
 /area/command/pilot)
+"ad" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
+"ae" = (
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
+"af" = (
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled,
+/area/quartermaster/hangar)
 "ag" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/hangar)
@@ -56,6 +71,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
+"aj" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
 "ak" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	icon_state = "map";
@@ -81,6 +100,26 @@
 "an" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/fore)
+"ao" = (
+/obj/machinery/mineral/stacking_machine{
+	input_turf = 2;
+	output_turf = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
+"ap" = (
+/obj/machinery/mineral/unloading_machine{
+	input_turf = 1;
+	output_turf = 2
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
+"aq" = (
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -148,6 +187,49 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
+"ax" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
+"ay" = (
+/obj/machinery/mineral/processing_unit{
+	input_turf = 4;
+	output_turf = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
+"az" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/hangar{
+	icon_state = "camera";
+	dir = 1
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"aA" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
+"aB" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
 "aC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -166,6 +248,10 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
+"aE" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
 "aF" = (
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
@@ -4265,14 +4351,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
-"jZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/mineral/stacking_machine{
-	input_turf = 2;
-	output_turf = 1
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "ka" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light/spot{
@@ -4971,68 +5049,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"lF" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"lG" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"lH" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"lK" = (
-/obj/machinery/conveyor{
-	dir = 5;
-	id = "mining_internal"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"lL" = (
-/obj/machinery/mineral/processing_unit{
-	input_turf = 4;
-	output_turf = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"lM" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining_internal"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
-"lN" = (
-/obj/machinery/mineral/unloading_machine{
-	input_turf = 1;
-	output_turf = 2
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
-"lQ" = (
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
-"lR" = (
-/obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
 "lS" = (
 /obj/machinery/computer/mining,
 /turf/simulated/wall/r_wall/prepainted,
@@ -5040,23 +5056,6 @@
 "lT" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
-/area/quartermaster/hangar)
-"lV" = (
-/obj/machinery/light/spot,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
-"lW" = (
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled,
-/area/quartermaster/hangar)
-"lX" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_internal";
-	name = "mining conveyor"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light/spot,
-/turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "lZ" = (
 /obj/structure/closet/crate,
@@ -5954,13 +5953,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"nJ" = (
-/obj/machinery/light/spot,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
 "nK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -33300,11 +33292,11 @@ kU
 aX
 aX
 aX
-aX
-lQ
-lM
-jZ
-lH
+kU
+UH
+UH
+aj
+aj
 ag
 ny
 ob
@@ -33503,10 +33495,10 @@ Ho
 Ho
 hT
 aX
-lV
+UH
+ad
 lS
-pF
-lG
+aq
 ag
 nz
 oc
@@ -33706,9 +33698,9 @@ bi
 fS
 aX
 UH
-lW
-pF
-lG
+ae
+ao
+ax
 ag
 nz
 oc
@@ -33910,7 +33902,7 @@ aX
 UH
 kD
 lS
-lL
+ay
 ag
 nz
 oc
@@ -34110,9 +34102,9 @@ gy
 fS
 aX
 UH
-kD
-pF
-lH
+af
+ap
+ax
 ag
 uD
 hb
@@ -34311,10 +34303,10 @@ gi
 gz
 fS
 aX
-lX
-pF
+UH
+ad
 lT
-lG
+aq
 ag
 nz
 oc
@@ -34513,10 +34505,10 @@ gj
 gz
 fS
 aX
-lR
-lN
-lF
-lK
+UH
+UH
+aj
+aj
 ag
 nW
 og
@@ -34714,7 +34706,7 @@ Kz
 gx
 gy
 fS
-oO
+az
 gO
 gO
 gO
@@ -35522,7 +35514,7 @@ Cp
 gm
 gz
 fS
-Bm
+aA
 gO
 gO
 gO
@@ -35927,7 +35919,7 @@ gx
 gy
 fS
 nR
-nJ
+aB
 aJ
 mS
 mX
@@ -36129,7 +36121,7 @@ go
 bi
 fS
 Bm
-UH
+aE
 aJ
 mK
 nD


### PR DESCRIPTION
🆑
tweak: The mining unloading/smelting area was reworked to remove/minimalise lag/crashes when unloading after a big haul.
tweak: The smelter and unloader is lightning fast now, reducing the time needed to wait for those precious minerals.
bugfix: The mineral stacker can have its stacking size set once again.
/🆑
Alternative to #25249 this solves the issue in a probably more favorable way until someone feels like reworking ores to be stacks, but I'm neither experienced enough for that nor do I wish to take that up.

![image](https://user-images.githubusercontent.com/6581435/56767306-af528480-67ab-11e9-8292-57fce5c52fa4.png)
![image](https://user-images.githubusercontent.com/6581435/56767352-cc875300-67ab-11e9-91a0-de6a10bffce0.png)