### PR TITLE
Make Ryetalyn properly reset genes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -455,14 +455,13 @@
 /datum/reagent/ryetalyn/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	var/needs_update = M.mutations.len > 0
 
-	M.mutations = list()
 	M.disabilities = 0
 	M.sdisabilities = 0
 
-	// Might need to update appearance for hulk etc.
 	if(needs_update && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.update_mutations()
+		M.dna.ResetUI()
+		M.dna.ResetSE()
+		domutcheck(M, null, MUTCHK_FORCED)
 
 /datum/reagent/hyperzine
 	name = "Hyperzine"


### PR DESCRIPTION
:cl: GooeyChickenman
bugfix: Ryetalyn will now fix a characters appearance after resetting genes.
/:cl:

Ryetalyn currently resets your mutations and disabilities, but it doesn't fix the appearance. I.e. someone has telepathy, give them Ryetalyn, their head is still glowing and cannot be fixed.

This changes it to run through `domutcheck`. This is required in order to run the deactivate functions on the active genes so they can fully cleanup.