### PR TITLE
Turns off dsay.

### DIFF
--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -346,7 +346,7 @@ EVENT_CUSTOM_START_MAJOR 80;100
 #DISABLE_AOOC
 
 ## Uncomment to disable ghost chat by default.
-#DISABLE_DSAY
+DISABLE_DSAY
 
 ## Uncomment to disable respawning by default.
 #DISABLE_RESPAWN


### PR DESCRIPTION
This is a suggested config change to the actual config.

:cl:
tweak: Dsay has been disabled by default.
/:cl:

The place is a cesspit, serves no legitimate game purpose, and encourages a bunch of bad behavior. Admins could still toggle it on if they so desire; this is less drastic than removing it wholesale.