### PR TITLE
mesons only prevent hallucinations when active

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -392,11 +392,18 @@
 
 		env.merge(removed)
 
-	for(var/mob/living/carbon/human/l in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
-		var/obj/item/organ/internal/eyes/E = l.internal_organs_by_name[BP_EYES]
-		if(E && !BP_IS_ROBOTIC(E) && !istype(l.glasses, /obj/item/clothing/glasses/meson)) //Synthetics eyes stop evil hallucination rays
-			var/effect = max(0, min(200, power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)))) )
-			l.adjust_hallucination(effect, 0.25*effect)
+	for(var/mob/living/carbon/human/subject in view(src, min(7, round(sqrt(power/6)))))
+		var/obj/item/organ/internal/eyes/eyes = subject.internal_organs_by_name[BP_EYES]
+		if (!eyes)
+			continue
+		if (BP_IS_ROBOTIC(eyes))
+			continue
+		if (istype(subject.glasses, /obj/item/clothing/glasses/meson))
+			var/obj/item/clothing/glasses/meson/mesons = subject.glasses
+			if (mesons.active)
+				continue
+		var/effect = max(0, min(200, power * config_hallucination_power * sqrt( 1 / max(1,get_dist(subject, src)))) )
+		subject.adjust_hallucination(effect, 0.25 * effect)
 
 
 	SSradiation.radiate(src, power * radiation_release_modifier) //Better close those shutters!


### PR DESCRIPTION
:cl:
tweak: Optical Meson Scanner glasses only protect from supermatter hallucinations when turned on.
/:cl:

now with less opinions