### PR TITLE
Makes Ion Thrusters Respect Thrust Goals, On State

### DIFF
--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -67,10 +67,10 @@
 	if(!on && !powered())
 		return 0
 	use_power_oneoff(burn_cost)
-	. = generated_thrust
+	. = thrust_limit * generated_thrust
 	
 /obj/machinery/engine/ion/proc/get_thrust()
-	return generated_thrust
+	return thrust_limit * generated_thrust * on
 	
 /obj/item/weapon/circuitboard/engine/ion
 	name = T_BOARD("ion propulsion device")


### PR DESCRIPTION
Ion Thrusters did not properly use thrust modifiers, nor did they use on states when calculating thrust.

:cl:
bugfix: Ion Thrusters now respect on state and thrust modifier when calculating thrust
/:cl: