### PR TITLE
Adds Supply access to the outside of the Auxiliary Warehouse shutters

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2068,7 +2068,8 @@
 	id = "starboardaux_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = -24;
-	pixel_y = 6
+	pixel_y = 6;
+	req_access = list("ACCESS_CARGO")
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
@@ -8407,7 +8408,8 @@
 	id = "portaux_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = -24;
-	pixel_y = -6
+	pixel_y = -6;
+	req_access = list("ACCESS_CARGO")
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4


### PR DESCRIPTION
:cl: Randall
maptweak: The Auxiliary Warehouse shutter buttons now require Supply access from the outside.
/:cl: