### PR TITLE
Adds mop to auxiliary janitor's closet

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -4182,6 +4182,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
+/obj/item/weapon/mop,
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor/aux)
 "nZ" = (


### PR DESCRIPTION
:cl: Randall
maptweak: The auxiliary sanitation closet now holds a spare mop.
/:cl:

I found it strange that there are two open slots for janitors at a time but only one mop available, this leads to a lot of rounds where janitors ask Supply to order a crate just to get both janitors a mop.