### PR TITLE
Scales down welding tool sizes by one level.

### DIFF
--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -16,7 +16,7 @@
 	throwforce = 5.0
 	throw_speed = 1
 	throw_range = 5
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_SMALL
 
 	//Cost to make in the autolathe
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 30)
@@ -342,7 +342,7 @@
 	desc = "A smaller welder, meant for quick or emergency use."
 	origin_tech = list(TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_GLASS = 5)
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	tank = /obj/item/weapon/welder_tank/mini
 
 /obj/item/weapon/weldingtool/largetank
@@ -352,7 +352,7 @@
 	desc = "A heavy-duty portable welder, made to ensure it won't suddenly go cold on you."
 	origin_tech = list(TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 60)
-	w_class = ITEM_SIZE_LARGE
+	w_class = ITEM_SIZE_NORMAL
 	tank = /obj/item/weapon/welder_tank/large
 
 /obj/item/weapon/weldingtool/hugetank
@@ -360,7 +360,7 @@
 	icon_state = "welder_h"
 	item_state = "welder"
 	desc = "A sizable welding tool with room to accomodate the largest of fuel tanks."
-	w_class = ITEM_SIZE_HUGE
+	w_class = ITEM_SIZE_LARGE
 	origin_tech = list(TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 120)
 	tank = /obj/item/weapon/welder_tank/huge
@@ -370,7 +370,7 @@
 	icon_state = "welder_l"
 	item_state = "welder"
 	desc = "This welding tool feels heavier in your possession than is normal. There appears to be no external fuel port."
-	w_class = ITEM_SIZE_LARGE
+	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_PHORON = 3)
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 120)
 	tank = /obj/item/weapon/welder_tank/experimental


### PR DESCRIPTION
Going to explain how things will change with this PR:
Basic welder (20u) is now small, fits in toolbelts, toolboxes, webbings and pockets.

Industrial and experimental welders (40u, experimental regenerates fuel) are now normal-sized and fit in toolbelts and toolboxes.

Upgraded welder (80u) is now large and can fit in a bag, but takes a lot of space.

Making all welders except the basic one not fit in toolbelts was a spontaneous change explained only by "muh realism", which doesn't really apply for the space future setting we have. QoL PR by several requests I've seen from engineering players.

🆑
tweak: Sizes for welding tools have been adjusted, most of them will fit in a toolbelt once more.
/🆑
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->