### PR TITLE
Buffs tactical armor brute/bullet values.

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -70,9 +70,10 @@
 
 /obj/item/clothing/accessory/armorplate/tactical
 	name = "tactical armor plate"
-	desc = "A medium armor plate with additional ablative coating. Attaches to a plate carrier."
+	desc = "A heavier armor plate with additional ablative coating. Attaches to a plate carrier."
 	icon_state = "armor_tactical"
-	armor = list(melee = 40, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 50, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
+	slowdown = 0.5
 
 /obj/item/clothing/accessory/armorplate/merc
 	name = "heavy armor plate"


### PR DESCRIPTION
:cl: 
tweak: Tactical armor plates now offer extra resistance against brute and bullet damage over regular medium plates.
/:cl:

Why? Because tactical armor doesn't have many selling points otherwise, and this makes it more of a step between regular armor and heavy armor in terms of all-around protection.