### PR TITLE
Fixes shooting at the Torch with the BSA

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -48,6 +48,7 @@
 /obj/effect/overmap/proc/populate_sector_objects()
 
 /obj/effect/overmap/proc/get_areas()
+	return get_filtered_areas(list(/proc/area_belongs_to_zlevels = map_z))
 
 /obj/effect/overmap/proc/find_z_levels()
 	map_z = GetConnectedZlevels(z)
@@ -104,9 +105,6 @@
 		plane = EFFECTS_ABOVE_LIGHTING_PLANE
 		for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
 			H.get_known_sectors()
-
-/obj/effect/overmap/sector/get_areas()
-	return get_filtered_areas(list(/proc/area_belongs_to_zlevels = map_z))
 
 /proc/build_overmap()
 	if(!GLOB.using_map.use_overmap)


### PR DESCRIPTION
🆑 
fix: The Torch is now a valid target for the BSA (for BSAs not on the Torch).
/🆑 

Big thanks to Xales for finding this.