### PR TITLE
Fixes window icons and material count

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -114,9 +114,6 @@
 	var/list/dirs = list()
 	var/list/other_dirs = list()
 
-	if(!anchored)
-		return
-
 	for(var/obj/structure/S in orange(src, 1))
 		if(can_visually_connect_to(S))
 			if(S.can_visually_connect())
@@ -124,6 +121,11 @@
 					S.update_connections()
 					S.update_icon()
 				dirs += get_dir(src, S)
+
+	if(!can_visually_connect())
+		connections = list("0", "0", "0", "0")
+		other_connections = list("0", "0", "0", "0")
+		return
 
 	for(var/direction in GLOB.cardinal)
 		var/turf/T = get_step(src, direction)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -249,7 +249,7 @@
 		else
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 			visible_message("<span class='notice'>[user] dismantles \the [src].</span>")
-			var/obj/item/stack/material/S = material.place_sheet(loc, is_fulltile() ? 4 : 2)
+			var/obj/item/stack/material/S = material.place_sheet(loc, is_fulltile() ? 4 : 1)
 			if(S && reinf_material)
 				S.reinf_material = reinf_material
 				S.update_strings()
@@ -358,9 +358,8 @@
 		return
 	anchored = new_anchored
 	update_verbs()
-	update_nearby_icons()
 	update_connections(1)
-	update_icon()
+	update_nearby_icons()
 
 //This proc is used to update the icons of nearby windows. It should not be confused with update_nearby_tiles(), which is an atmos proc!
 /obj/structure/window/proc/update_nearby_icons()
@@ -571,6 +570,10 @@
 	return
 
 /proc/place_window(mob/user, loc, dir_to_set, obj/item/stack/material/ST)
+	var/required_amount = (dir_to_set & (dir_to_set - 1)) ? 4 : 1
+	if (ST.amount < required_amount)
+		to_chat(user, "<span class='notice'>You do not have enough sheets.</span>")
+		return
 	for(var/obj/structure/window/WINDOW in loc)
 		if(WINDOW.dir == dir_to_set)
 			to_chat(user, "<span class='notice'>There is already a window facing this way there.</span>")
@@ -588,7 +591,11 @@
 				to_chat(user, "<span class='notice'>There is already a window there.</span>")
 				return
 
-		if (ST.use(1))
+		if (ST.use(required_amount))
 			var/obj/structure/window/WD = new(loc, dir_to_set, FALSE, ST.material.name, ST.reinf_material && ST.reinf_material.name)
-			to_chat(user, "<span class='notice'>You place the [WD] on [src].</span>")
-			WD.update_icon()
+			to_chat(user, "<span class='notice'>You place [WD].</span>")
+			WD.construction_state = 0
+			WD.set_anchored(FALSE)
+		else
+			to_chat(user, "<span class='notice'>You do not have enough sheets.</span>")
+			return


### PR DESCRIPTION
- Fixes windows not consistently using up and dropping the same amount of material (they are currently dropping four or two sheets depending on whether they are being fulltile or not while always using a single sheet to set up).
- Fixes window icons not being disconnected when not anchored.
- Fixes windows spawning fully constructed when placed by hand.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->