### PR TITLE
Unapolegetic ballistc inflatables nerf

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -39,7 +39,7 @@
 	icon_state = "wall"
 
 	var/undeploy_path = null
-	var/health = 50.0
+	var/health = 10
 
 /obj/structure/inflatable/wall
 	name = "inflatable wall"
@@ -64,7 +64,7 @@
 	..()
 	if(health <= 0)
 		deflate(1)
-	return
+		return PROJECTILE_CONTINUE
 
 /obj/structure/inflatable/ex_act(severity)
 	switch(severity)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -293,7 +293,9 @@
 	//the bullet passes through a dense object!
 	if(passthrough)
 		//move ourselves onto A so we can continue on our way.
-		forceMove(get_turf(A))
+		var/turf/T = get_turf(A)
+		if(T)
+			forceMove(T)
 		permutated.Add(A)
 		bumped = 0 //reset bumped variable!
 		return 0


### PR DESCRIPTION
Drastically lowered health of inflatables so they can't tank stuff.
Made bullets pass through them if they destroy it.
Fixed bullets failing to keep going if thing they passed through was qdel'd in proccess (they were put in nullspace with the thing)
