### PR TITLE
Fixes #25284 and #25352

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -48,6 +48,8 @@
 	var/radio_filter_out
 	var/radio_filter_in
 
+	var/controlled = TRUE  //if we should register with an air alarm on spawn
+
 /obj/machinery/atmospherics/unary/vent_pump/on
 	use_power = POWER_USE_IDLE
 	icon_state = "map_vent_out"
@@ -223,8 +225,8 @@
 	signal.source = src
 
 	signal.data = list(
-		"area" = src.area_uid,
-		"tag" = src.id_tag,
+		"area" = controlled ? area_uid : "NONE",
+		"tag" = id_tag,
 		"device" = "AVP",
 		"power" = use_power,
 		"direction" = pump_direction?("release"):("siphon"),
@@ -237,11 +239,12 @@
 		"flow_rate" = last_flow_rate,
 	)
 
-	if(!initial_loc.air_vent_names[id_tag])
-		var/new_name = "[initial_loc.name] Vent Pump #[initial_loc.air_vent_names.len+1]"
-		initial_loc.air_vent_names[id_tag] = new_name
-		src.SetName(new_name)
-	initial_loc.air_vent_info[id_tag] = signal.data
+	if(controlled)
+		if(!initial_loc.air_vent_names[id_tag])
+			var/new_name = "[initial_loc.name] Vent Pump #[initial_loc.air_vent_names.len+1]"
+			initial_loc.air_vent_names[id_tag] = new_name
+			SetName(new_name)
+		initial_loc.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)
 

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -47,6 +47,7 @@
 	power_rating = 7500			//7500 W ~ 10 HP
 	opacity = 1
 	density = 1
+	atmos_canpass = CANPASS_DENSITY
 	var/on = 1
 	var/datum/ship_engine/gas_thruster/controller
 	var/thrust_limit = 1	//Value between 1 and 0 to limit the resulting thrust

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -2281,10 +2281,15 @@
 	icon_state = "techfloor_edges";
 	dir = 9
 	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargobay";
+	name = "mining conveyor"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "eY" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 4;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump"
@@ -2362,6 +2367,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 8;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump"
@@ -2430,6 +2436,7 @@
 /area/exploration_shuttle/cargo)
 "fo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 1;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump"
@@ -2444,6 +2451,7 @@
 "fq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 1;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump"
@@ -2452,6 +2460,7 @@
 /area/exploration_shuttle/cargo)
 "fr" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 2;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump_out_internal"
@@ -2580,6 +2589,7 @@
 /area/exploration_shuttle/cargo)
 "fK" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 4;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump_out_internal"
@@ -2613,6 +2623,7 @@
 /area/exploration_shuttle/cargo)
 "fP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 8;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump_out_internal"
@@ -3028,6 +3039,7 @@
 	pixel_y = 20
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 1;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump_out_external"
@@ -12144,7 +12156,7 @@
 "Ep" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "garbage"
+	id = "cargobay"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light{
@@ -13079,7 +13091,7 @@
 "Id" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "garbage"
+	id = "cargobay"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/sign/warning/moving_parts{
@@ -14198,7 +14210,7 @@
 "Mk" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "garbage"
+	id = "cargobay"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -14821,6 +14833,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
 	dir = 1;
 	frequency = 1331;
 	id_tag = "calypso_cargo_pump_out_external"
@@ -17380,6 +17393,14 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/toxins)
+"Yu" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "Yw" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/dispenser,
@@ -36724,7 +36745,7 @@ mC
 mC
 im
 mE
-mF
+Yu
 mF
 mF
 mF


### PR DESCRIPTION
Lets you set if vents are controlled by air alarm
Adds controlled var, if set to false, vents form signals that aren't picked up by air alarms, nor add themselves to area list.
Used in Charon's cargo bay so air alarm would stop fucking killing cycling vents. They're not connected to air supply anyway so controlling them there was pointless.

Adds lever for the conveyor belt.

~3rd part of that thing isn't a bug, bay is just too big to drain midflight, if you want proper draining either park in space first, or cycle properly.~
Fixed 3rd part too, I misunderstood what was the problem. Thrusters now properly block air so it shouldn't leak into their turfs

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->