### PR TITLE
De-grillifies most windows

### DIFF
--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -4,8 +4,9 @@
 	icon_state = "wingrille"
 	density = 1
 	anchored = 1.0
-	var/win_path = /obj/structure/window/basic
+	var/win_path = /obj/structure/window/basic/full
 	var/frame_path = /obj/structure/wall_frame/standard
+	var/grille_path = /obj/structure/grille
 	var/activated = FALSE
 	var/fulltile = TRUE
 
@@ -33,20 +34,21 @@
 /obj/effect/wallframe_spawn/proc/activate()
 	if(activated) return
 
-	if(locate(/obj/structure/wall_frame) in loc)
+	if(locate(frame_path) in loc)
 		warning("Frame Spawner: A frame structure already exists at [loc.x]-[loc.y]-[loc.z]")
 	else
 		var/obj/structure/wall_frame/F = new frame_path(loc)
 		handle_frame_spawn(F)
 
-	if(locate(/obj/structure/window) in loc)
+	if(locate(win_path) in loc)
 		warning("Frame Spawner: A window structure already exists at [loc.x]-[loc.y]-[loc.z]")
 
-	if(locate(/obj/structure/grille) in loc)
-		warning("Frame Spawner: A grille already exists at [loc.x]-[loc.y]-[loc.z]")
-	else
-		var/obj/structure/grille/G = new /obj/structure/grille(loc)
-		handle_grille_spawn(G)
+	if(grille_path)
+		if(locate(grille_path) in loc)
+			warning("Frame Spawner: A grille already exists at [loc.x]-[loc.y]-[loc.z]")
+		else
+			var/obj/structure/grille/G = new grille_path (loc)
+			handle_grille_spawn(G)
 
 	var/list/neighbours = list()
 	if(fulltile)
@@ -88,10 +90,18 @@
 /obj/effect/wallframe_spawn/proc/handle_grille_spawn(var/obj/structure/grille/G)
 	return
 
+/obj/effect/wallframe_spawn/no_grille
+	name = "wall frame window spawner (no grille)"
+	grille_path = null
+
 /obj/effect/wallframe_spawn/reinforced
 	name = "reinforced wall frame window spawner"
 	icon_state = "r-wingrille"
 	win_path = /obj/structure/window/reinforced/full
+
+/obj/effect/wallframe_spawn/reinforced/no_grille
+	name = "reinforced wall frame window spawner (no grille)"
+	grille_path = null
 
 /obj/effect/wallframe_spawn/reinforced/titanium
 	name = "reinforced titanium wall frame window spawner"
@@ -130,6 +140,10 @@
 	color = "#444444"
 	win_path = /obj/structure/window/reinforced/polarized/full
 	var/id
+
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille
+	name = "polarized wall frame window spawner (no grille)"
+	grille_path = null
 
 /obj/effect/wallframe_spawn/reinforced/polarized/full
 	name = "polarized wall frame window spawner - full tile"

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -621,13 +621,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "bN" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "bP" = (
@@ -2554,6 +2554,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
+"fH" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled,
+/area/quartermaster/exploration)
 "fI" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -3092,7 +3096,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/expedition/storage)
 "hl" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/exploration)
 "hm" = (
@@ -3444,7 +3448,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/expedition/storage)
 "iy" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/command/pilot)
 "iz" = (
@@ -4172,7 +4176,7 @@
 /area/command/pilot)
 "jR" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/shuttlefuel)
 "jS" = (
@@ -4378,8 +4382,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "kq" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/exploration)
 "kr" = (
@@ -4428,7 +4432,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/item/weapon/stool,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
 "kx" = (
@@ -4608,11 +4611,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/quartermaster/exploration)
-"kO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/quartermaster/exploration)
 "kP" = (
 /obj/machinery/suit_storage_unit/explorer,
@@ -4888,17 +4886,17 @@
 /area/hallway/primary/fifthdeck/aft)
 "lv" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "lw" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "lx" = (
@@ -5832,8 +5830,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "ny" = (
@@ -6912,7 +6910,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "pF" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "pG" = (
@@ -7212,7 +7210,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
 "ql" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/expedition)
 "qm" = (
@@ -8017,7 +8015,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "rF" = (
@@ -9558,12 +9556,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "uU" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "uV" = (
@@ -9652,9 +9650,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "vj" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "vm" = (
@@ -9906,7 +9904,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "wk" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "wl" = (
@@ -10781,6 +10779,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
+"zv" = (
+/turf/simulated/floor/plating,
+/area/quartermaster/expedition)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/junk,
@@ -13251,6 +13252,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"IQ" = (
+/obj/effect/wallframe_spawn/no_grille,
+/turf/simulated/wall/prepainted,
+/area/quartermaster/expedition)
 "IR" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/light_switch{
@@ -15067,7 +15072,6 @@
 /area/shuttle/petrov/hallwaya)
 "Pv" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/sign/directions/bridge{
 	dir = 1;
 	pixel_y = 3;
@@ -15078,6 +15082,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
 "Px" = (
@@ -17612,12 +17617,12 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
 "Zm" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Zn" = (
@@ -32686,7 +32691,7 @@ rT
 oW
 hl
 kn
-hz
+fH
 hz
 kw
 ky
@@ -33095,9 +33100,9 @@ kq
 kq
 OX
 OX
-kO
+kq
 kt
-kO
+kq
 eu
 OX
 OX
@@ -39548,7 +39553,7 @@ Lp
 UG
 UG
 sp
-WU
+IQ
 qz
 um
 Xz
@@ -39750,7 +39755,7 @@ qe
 qf
 qh
 Eg
-ql
+zv
 qA
 un
 qG

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2344,6 +2344,10 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
+"hE" = (
+/obj/effect/wallframe_spawn/no_grille,
+/turf/simulated/floor/plating,
+/area/storage/primary)
 "hO" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -2697,6 +2701,9 @@
 "iS" = (
 /turf/simulated/wall/walnut,
 /area/crew_quarters/lounge)
+"iW" = (
+/turf/simulated/floor/plating,
+/area/storage/primary)
 "iZ" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2815,10 +2822,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
 "jn" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "offmess_windows"
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/command/captainmess)
 "jq" = (
@@ -4761,12 +4768,12 @@
 /turf/simulated/wall/prepainted,
 /area/command/pathfinder)
 "qe" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "pathfinder_office"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+	id = "pathfinder_office"
+	},
 /turf/simulated/floor/plating,
 /area/command/pathfinder)
 "qf" = (
@@ -6163,7 +6170,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "ud" = (
@@ -6294,12 +6301,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
 "uq" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	dir = 4;
 	id = "sup_office";
 	name = "Supply Desk Shutters"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "ur" = (
@@ -6844,8 +6852,8 @@
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
 "vJ" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
 "vK" = (
@@ -7198,6 +7206,13 @@
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
+"wT" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "wW" = (
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced/airless,
@@ -8517,12 +8532,13 @@
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
 "Cr" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "sup_office";
 	name = "Supply Office Shutters"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "Cs" = (
@@ -9828,6 +9844,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/lounge)
+"HE" = (
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/center)
 "HF" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -10220,7 +10240,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "IT" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "IX" = (
@@ -10709,7 +10729,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/office)
 "KF" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "KG" = (
@@ -11543,11 +11563,6 @@
 /obj/item/weapon/book/manual/stasis,
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
-"Nc" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
-/area/quartermaster/flightcontrol)
 "Nd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -12110,7 +12125,7 @@
 /area/maintenance/fourthdeck/aft)
 "OL" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/flightcontrol)
 "OM" = (
@@ -12164,7 +12179,6 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "OU" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/sign/directions/engineering{
 	dir = 1;
 	pixel_y = 3;
@@ -12174,6 +12188,7 @@
 	dir = 4;
 	pixel_y = -4
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "OV" = (
@@ -12218,12 +12233,12 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "Pa" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "do_office";
 	name = "DO Office Shutters"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/deckchief)
 "Pc" = (
@@ -12648,7 +12663,7 @@
 	id = "sup_office";
 	name = "Supply Desk Shutters"
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "PY" = (
@@ -12734,12 +12749,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "Qk" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	dir = 4;
 	id = "sup_office";
 	name = "Supply Desk Shutters"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/storage/upper)
 "Qn" = (
@@ -13202,7 +13217,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "Ry" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/sign/directions/bridge{
 	dir = 1;
 	pixel_y = 3;
@@ -13213,6 +13227,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "RC" = (
@@ -14225,10 +14240,10 @@
 /turf/simulated/open,
 /area/maintenance/fourthdeck/forestarboard)
 "TT" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "pathfinder_office"
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/command/pathfinder)
 "TU" = (
@@ -14769,13 +14784,6 @@
 	},
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
-"Vp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/port)
 "Vq" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/lounge)
@@ -15355,7 +15363,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/fourthdeck)
 "Xf" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor,
 /area/crew_quarters/adherent)
 "Xg" = (
@@ -15416,7 +15424,6 @@
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
 "Xk" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/sign/directions/science{
 	dir = 1;
 	pixel_y = 3;
@@ -15427,6 +15434,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "Xl" = (
@@ -15607,7 +15615,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/commissary)
 "XF" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor,
 /area/hallway/primary/fourthdeck/aft)
 "XG" = (
@@ -15826,7 +15834,7 @@
 /area/crew_quarters/laundry)
 "Yd" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/lounge)
 "Ye" = (
@@ -16426,7 +16434,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "Zy" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/waterstore)
 "Zz" = (
@@ -28671,7 +28679,7 @@ ld
 mm
 ns
 Zj
-oB
+iW
 pQ
 ra
 su
@@ -29485,7 +29493,7 @@ Xk
 sy
 Ye
 vx
-oB
+hE
 yb
 Le
 le
@@ -29687,7 +29695,7 @@ Ry
 sy
 Ye
 vy
-oB
+hE
 nx
 Bm
 le
@@ -29889,7 +29897,7 @@ OU
 sy
 ub
 vz
-oB
+hE
 nx
 ZZ
 le
@@ -30088,7 +30096,7 @@ ct
 ct
 ct
 rd
-oB
+hE
 uc
 wF
 wF
@@ -32918,7 +32926,7 @@ TT
 Xo
 sK
 up
-vJ
+HE
 aY
 aY
 aY
@@ -35964,7 +35972,7 @@ Sd
 Ie
 Ss
 Ss
-Vp
+wT
 IT
 GT
 GT
@@ -36563,8 +36571,8 @@ vQ
 uq
 Dq
 vQ
-FK
-FK
+vQ
+vQ
 vQ
 vQ
 vQ
@@ -36752,11 +36760,11 @@ YC
 VW
 WI
 vH
-Nc
+OL
 rE
 sY
 uD
-Nc
+OL
 Ga
 Ga
 mG

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1548,13 +1548,13 @@
 /turf/simulated/floor/plating,
 /area/command/bsa)
 "dA" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "kitchen";
 	name = "Kitchen Shutters"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hydroponics/storage)
 "dD" = (
@@ -1978,13 +1978,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/engineering/hardstorage)
 "ey" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "kitchen";
 	name = "Kitchen Shutters"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/galley)
 "eA" = (
@@ -3977,7 +3977,6 @@
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d3port)
 "iu" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -3986,6 +3985,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/mess)
 "iv" = (
@@ -5186,6 +5186,16 @@
 "ld" = (
 /turf/simulated/open,
 /area/crew_quarters/mess)
+"le" = (
+/obj/effect/floor_decal/corner/green/half{
+	icon_state = "bordercolorhalf";
+	dir = 1
+	},
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/thirddeck/center)
 "lg" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -6133,7 +6143,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "nn" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/holocontrol)
 "no" = (
@@ -6249,51 +6259,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "nL" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/ai_monitored/storage/eva)
-"nM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "nN" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/command{
 	name = "E.V.A. Storage"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/ai_monitored/storage/eva)
-"nO" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "nP" = (
 /obj/structure/cable/green{
@@ -6739,11 +6714,6 @@
 /turf/simulated/open,
 /area/maintenance/thirddeck/starboard)
 "oI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -6757,13 +6727,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"oK" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 4
-	},
-/turf/simulated/wall/prepainted,
 /area/ai_monitored/storage/eva)
 "oL" = (
 /obj/structure/cable/green{
@@ -7265,17 +7228,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
-"pC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "pD" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -7283,14 +7235,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"pE" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "pF" = (
 /obj/structure/cable/green{
@@ -7463,7 +7407,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall/prepainted,
+/obj/effect/wallframe_spawn/no_grille,
+/turf/simulated/floor/plating,
 /area/crew_quarters/mess)
 "pZ" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -7475,12 +7420,8 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
-"qa" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/mess)
 "qb" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/mess)
 "qc" = (
@@ -7667,14 +7608,6 @@
 "qA" = (
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
-"qB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "qC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio/off,
@@ -7683,19 +7616,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"qD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "qF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8125,11 +8045,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -8148,16 +8063,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ai_monitored/storage/eva)
 "rQ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass/command{
 	name = "E.V.A.";
@@ -8487,7 +8392,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/center)
 "si" = (
@@ -8699,7 +8605,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/aft)
 "sw" = (
@@ -9087,11 +8994,6 @@
 "ti" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -9113,16 +9015,6 @@
 /obj/item/weapon/cell/high,
 /obj/item/weapon/cell/high,
 /turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"tk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "tl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9579,17 +9471,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
-"uu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "uv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9597,11 +9478,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"uw" = (
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "ux" = (
 /obj/effect/floor_decal/corner/lime{
@@ -9763,7 +9639,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/cryo)
 "uS" = (
@@ -9855,7 +9731,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/bsa)
 "vg" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "vacantoffice_windows"
 	},
 /turf/simulated/floor/plating,
@@ -10010,11 +9886,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ai_monitored/storage/eva)
 "vC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -10038,10 +9909,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ai_monitored/storage/eva)
 "vE" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
-	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/wall/prepainted,
 /area/ai_monitored/storage/eva)
 "vF" = (
@@ -10378,11 +10246,11 @@
 /turf/simulated/floor/lino,
 /area/vacant/office)
 "ws" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "vacantoffice_windows"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+	id = "vacantoffice_windows"
 	},
 /turf/simulated/floor/plating,
 /area/vacant/office)
@@ -10478,16 +10346,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ai_monitored/storage/eva)
 "wI" = (
@@ -13111,7 +12969,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
 "CO" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
 	dir = 4;
@@ -13119,6 +12976,7 @@
 	name = "Kitchen Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/galley)
 "CU" = (
@@ -13703,7 +13561,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/range)
 "Em" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/sign/directions/supply{
 	dir = 2;
 	pixel_y = -4;
@@ -13713,6 +13570,7 @@
 	dir = 2;
 	pixel_y = 3
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/aft)
 "En" = (
@@ -16459,13 +16317,13 @@
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d3port)
 "Lb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
 	dir = 4;
 	id = "kitchen";
 	name = "Kitchen Shutters"
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/galley)
 "Lc" = (
@@ -17773,7 +17631,6 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/hardstorage)
 "OW" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/sign/directions/engineering{
 	dir = 1;
 	pixel_y = 3;
@@ -17786,6 +17643,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/aft)
 "OX" = (
@@ -18367,9 +18225,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
-	},
-/obj/structure/noticeboard{
-	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
@@ -19688,7 +19543,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Vd" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage)
 "Ve" = (
@@ -21088,7 +20943,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/tools)
 "Zb" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/gym)
 "Zc" = (
@@ -30970,7 +30825,7 @@ kw
 ll
 ma
 mP
-nM
+nL
 Yz
 pB
 qA
@@ -30978,7 +30833,7 @@ rN
 th
 ut
 Yz
-nM
+nL
 Mo
 yI
 yI
@@ -31174,11 +31029,11 @@ mb
 mQ
 nN
 oI
-pC
-qB
+pB
+qA
 rO
 ti
-uu
+ut
 vC
 wH
 xG
@@ -31374,7 +31229,7 @@ ky
 ll
 mc
 mR
-nO
+nL
 oJ
 pD
 qC
@@ -31382,7 +31237,7 @@ rP
 tj
 uv
 vD
-nO
+nL
 xH
 zB
 zB
@@ -31577,12 +31432,12 @@ ll
 ll
 lY
 lY
-oK
-pE
-qD
+lY
+nL
+nL
 rQ
-tk
-uw
+nL
+nL
 vE
 lY
 lY
@@ -38850,8 +38705,8 @@ lz
 Ko
 RN
 pg
-qa
-qP
+fB
+le
 VM
 tH
 uO

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1479,7 +1479,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/disposal)
 "dh" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "di" = (
@@ -4006,7 +4006,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
 "iI" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
@@ -4017,6 +4016,7 @@
 	name = "Engineering Desk Shutters";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/engineering/locker_room)
 "iJ" = (
@@ -5687,11 +5687,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/modular_computer/console/preset/engineering{
 	icon_state = "console";
 	dir = 8
@@ -5927,7 +5922,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/engineering/storage)
 "mW" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -5941,6 +5935,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/engineering/locker_room)
 "mX" = (
@@ -6501,11 +6496,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod10/station)
 "om" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -6516,6 +6506,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/engineering/engineering_monitoring)
 "on" = (
@@ -7384,7 +7375,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/vacant/prototype/engine)
 "qi" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/vacant/prototype/control)
 "qj" = (
@@ -8065,13 +8056,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "rq" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -8081,6 +8065,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/engineering/engineering_monitoring)
 "rs" = (
@@ -13847,7 +13832,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/fore)
 "GA" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -13857,6 +13841,7 @@
 	name = "Engineering Desk Shutters";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/engineering/locker_room)
 "GF" = (
@@ -14656,11 +14641,6 @@
 /obj/machinery/door/window/northright{
 	dir = 2;
 	name = "engineering front desk"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "engineering front desk"
@@ -18880,11 +18860,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2794,7 +2794,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "agg" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "surgery_windows"
 	},
 /turf/simulated/floor/plating,
@@ -5118,7 +5118,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "anH" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "exam_windows"
 	},
 /turf/simulated/floor/plating,
@@ -5129,11 +5129,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/sleeper)
 "anM" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "anN" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "recov_windows"
 	},
 /turf/simulated/floor/plating,
@@ -5359,7 +5359,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "apR" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "counsel_windows"
 	},
 /turf/simulated/floor/plating,
@@ -5524,7 +5524,7 @@
 /turf/simulated/wall/prepainted,
 /area/medical/equipstorage)
 "aqP" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/equipstorage)
 "aqQ" = (
@@ -5727,7 +5727,6 @@
 /turf/simulated/wall/prepainted,
 /area/medical/infirmreception)
 "arL" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -5736,6 +5735,7 @@
 	name = "Infirmary Emergency Quarantine Shutters";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/infirmreception)
 "arT" = (
@@ -6900,7 +6900,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
 "awg" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "robotics_external_windows"
 	},
 /turf/simulated/floor/plating,
@@ -6943,7 +6943,7 @@
 	name = "Infirmary Emergency Quarantine Shutters";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/equipstorage)
 "awu" = (
@@ -7014,12 +7014,12 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/chapel/main)
 "awB" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "awC" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "awE" = (
@@ -8180,7 +8180,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/sleep/cryo/aux)
 "aAt" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/cryo/aux)
 "aAu" = (
@@ -8216,7 +8216,6 @@
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "aAJ" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -8228,6 +8227,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "aAK" = (
@@ -8239,7 +8239,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -8247,6 +8246,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/breakroom)
 "aAN" = (
@@ -8266,7 +8266,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -8274,6 +8273,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/breakroom)
 "aAO" = (
@@ -8281,7 +8281,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -8289,6 +8288,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/breakroom)
 "aAP" = (
@@ -9406,7 +9406,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aFb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
@@ -9433,6 +9432,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "aFd" = (
@@ -9804,7 +9804,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aGE" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "aGG" = (
@@ -9812,7 +9812,7 @@
 /area/rnd/breakroom)
 "aGI" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/breakroom)
 "aGJ" = (
@@ -14674,7 +14674,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
 "bmb" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "bmB" = (
@@ -19664,7 +19664,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "gUb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -19674,6 +19673,7 @@
 	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/infirmreception)
 "gVb" = (
@@ -19717,9 +19717,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "gWb" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "exam_windows"
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -19727,6 +19724,9 @@
 	id = "infirmaryquar";
 	name = "Infirmary Emergency Quarantine Shutters";
 	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+	id = "exam_windows"
 	},
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
@@ -20148,7 +20148,6 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/opscheck)
 "htb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -20157,6 +20156,7 @@
 	name = "Ladderwell Checkpoint Shutters";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/entry)
 "htK" = (
@@ -20276,7 +20276,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/development)
 "hyb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -20294,6 +20293,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "hyj" = (
@@ -20765,7 +20765,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "hZb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
@@ -20778,6 +20777,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "ibb" = (
@@ -21025,7 +21025,7 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftport)
 "imK" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "conference_window"
 	},
 /turf/simulated/floor/plating,
@@ -21375,13 +21375,12 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/security/detectives_office)
 "iGb" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "robotics_windows"
 	},
 /turf/simulated/floor/plating,
 /area/medical/surgery2)
 "iHb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
@@ -21391,6 +21390,7 @@
 	opacity = 0
 	},
 /obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "iKb" = (
@@ -22540,7 +22540,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "jZb" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "misc_lab"
 	},
 /turf/simulated/floor/plating,
@@ -22981,7 +22981,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "kyb" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
 "kym" = (
@@ -23073,13 +23073,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics/surgery)
 "kEb" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "robotics_surg"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+	id = "robotics_surg"
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics/surgery)
@@ -23317,7 +23317,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/chargebay)
 "kUb" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "robotics_surg"
 	},
 /turf/simulated/floor/plating,
@@ -25406,8 +25406,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
 "npQ" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "robotics_external_windows"
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+	id = "robotics_surg"
 	},
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
@@ -27283,10 +27283,10 @@
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "pBb" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "misc_lab"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "pBL" = (
@@ -27852,7 +27852,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "qtb" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qtQ" = (
@@ -27961,9 +27961,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "qzb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qAb" = (
@@ -28453,11 +28453,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "rdb" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	icon_state = "intact";
 	dir = 4
 	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "reb" = (


### PR DESCRIPTION
Went around and replaced most windows with no grille version.
Setup is like this:
Do we need to stop people from breaking this window / it's space facing? - reinforced and grille
Does this window need to withstand some nastiness fairly often (e.g hangar or windows with shutters e.g. sci or med quarantine)? - reinforced.
Otherwise it's simple window.

Did couple small changes along the way:
-Moved stool in exploration prep to paperdesk/computers instead of having it next to racks

![](https://i.imgur.com/f9Hgblx.png)

-Removed weird window in supply office that offered view of 1 tile maint corridor.

![](https://i.imgur.com/ScmPwL0.png)

-Moved noticeboard at Mess doors couple tiles to the right, to put a window between doors instead (for putting people through in bar fights)

![](https://i.imgur.com/JstntQl.png)

