### PR TITLE
Adds OCIE Agent Jacket to loadout

### DIFF
--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -108,3 +108,9 @@
 	armors["green plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/green
 	armors["tan plate carrier"] = /obj/item/clothing/suit/armor/pcarrier/tan
 	gear_tweaks += new/datum/gear_tweak/path(armors)
+
+/datum/gear/suit/ocie
+	display_name = "Agent's jacket"
+	path = /obj/item/clothing/suit/storage/toggle/agent_jacket
+	allowed_roles = list(/datum/job/detective)
+	allowed_branches = list(/datum/mil_branch/solgov)


### PR DESCRIPTION
Added for OCIE Agents. When you edit your overwear as an agent, the jacket gets deleted from your loadout entirely, so this fixes that problem by adding the jacket as an manual choice loadout item. 