### PR TITLE
Fixes #25246

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -75,14 +75,6 @@
 	else animate_movement = NO_STEPS
 	. = ..()
 
-/obj/item/projectile/Destroy()
-	return ..()
-
-/obj/item/projectile/forceMove()
-	..()
-	if(istype(loc, /turf/space/) && istype(loc.loc, /area/space))
-		qdel(src)
-
 /obj/item/projectile/damage_flags()
 	return damage_flags
 


### PR DESCRIPTION
Removes some chaokocode that claimed to clean up trajectory segments but actually flat out deleted bullets in space. Not sure how it wasn't noticed earlier, any shot originating in space would've been deleted right away.
