### PR TITLE
Add keybinds to move up/down for robots and non-hotkey mode

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -218,6 +218,12 @@ macro "borghotkeymode"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem 
+		name = ","
+		command = "move-upwards"
+	elem 
+		name = "."
+		command = "move-down"
 
 macro "macro"
 	elem 
@@ -388,6 +394,15 @@ macro "macro"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem 
+		name = "SHIFT+<"
+		command = "move-upwards"
+	elem 
+		name = ">"
+		command = "move-upwards"
+	elem 
+		name = "<"
+		command = "move-down"
 
 macro "hotkeymode"
 	elem 
@@ -793,6 +808,15 @@ macro "borgmacro"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem 
+		name = "SHIFT+<"
+		command = "move-upwards"
+	elem 
+		name = ">"
+		command = "move-upwards"
+	elem 
+		name = "<"
+		command = "move-down"
 
 
 menu "menu"


### PR DESCRIPTION
🆑
rscadd: Robots can now use the , and . hotkeys to move up and down z-levels in hotkey-mode.
rscadd: Everyone can now use > and < in non hotkey-mode to move up and down z-levels.
/🆑