### PR TITLE
Make Plasma cutter a universal cutting tool + fixes

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -384,19 +384,16 @@
 
 	if(busy)
 		return 0
-	if(!WT.isOn())
-		return 0
 
-	// Do after stuff here
-	to_chat(user, "<span class='notice'>You start to weld the [src]..</span>")
-	playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-	WT.eyecheck(user)
-	busy = 1
-	if(do_after(user, 100, src))
-		busy = 0
-		if(!WT.isOn())
-			return 0
-		return 1
+	if(WT.remove_fuel(0, user))
+		to_chat(user, "<span class='notice'>You start to weld \the [src]..</span>")
+		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+		busy = 1
+		if(do_after(user, 100, src) && WT.isOn())
+			playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+			busy = 0
+			return 1
+
 	busy = 0
 	return 0
 

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -156,17 +156,15 @@
 
 	if(busy)
 		return 0
-	if(!WT.isOn())
-		return 0
 
-	to_chat(user, "<span class='notice'>You start to weld \the [src]..</span>")
-	playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-	WT.eyecheck(user)
-	busy = 1
-	if(do_after(user, 20, src))
-		busy = 0
-		if(!WT.isOn())
-			return 0
-		return 1
+	if(WT.remove_fuel(0, user))
+		to_chat(user, "<span class='notice'>You start to weld \the [src]..</span>")
+		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+		busy = 1
+		if(do_after(user, 20, src) && WT.isOn())
+			playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+			busy = 0
+			return 1
+
 	busy = 0
 	return 0

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -179,7 +179,6 @@ var/list/global/tank_gauge_cache = list()
 						maxintegrity -= rand(2,6)
 						integrity = min(integrity,maxintegrity)
 						air_contents.add_thermal_energy(rand(2000,50000))
-				WT.eyecheck(user)
 			else
 				to_chat(user, "<span class='notice'>The emergency pressure relief valve has already been welded.</span>")
 		add_fingerprint(user)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -175,7 +175,7 @@
 	if(get_fuel() >= amount)
 		burn_fuel(amount)
 		if(M)
-			eyecheck(M)
+			M.welding_eyecheck()//located in mob_helpers.dm
 		return 1
 	else
 		if(M)
@@ -269,42 +269,6 @@
 		src.damtype = BRUTE
 		src.welding = 0
 		update_icon()
-
-//Decides whether or not to damage a player's eyes based on what they're wearing as protection
-//Note: This should probably be moved to mob
-/obj/item/weapon/weldingtool/proc/eyecheck(mob/user as mob)
-	if(!iscarbon(user))	return 1
-	if(istype(user, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[H.species.vision_organ]
-		if(!E)
-			return
-		var/safety = H.eyecheck()
-		switch(safety)
-			if(FLASH_PROTECTION_MODERATE)
-				to_chat(H, SPAN_WARNING("Your eyes sting a little."))
-				E.damage += rand(1, 2)
-				if(E.damage > 12)
-					H.eye_blurry += rand(3,6)
-			if(FLASH_PROTECTION_NONE)
-				to_chat(H, SPAN_WARNING("Your eyes burn!"))
-				E.damage += rand(2, 4)
-				if(E.damage > 10)
-					E.damage += rand(4,10)
-			if(FLASH_PROTECTION_REDUCED)
-				to_chat(H, SPAN_DANGER("Your equipment intensifies the welder's glow. Your eyes burn severely!"))
-				H.eye_blurry += rand(12,20)
-				E.damage += rand(12, 16)
-		if(safety<FLASH_PROTECTION_MAJOR)
-			if(E.damage > 10)
-				to_chat(user, SPAN_WARNING("Your eyes are really starting to hurt. This can't be good for you!"))
-			if (E.damage >= E.min_bruised_damage)
-				to_chat(H, SPAN_DANGER("You go blind!"))
-				H.eye_blind = 5
-				H.eye_blurry = 5
-				H.disabilities |= NEARSIGHTED
-				spawn(100)
-					H.disabilities &= ~NEARSIGHTED
 
 /obj/item/weapon/weldingtool/attack(mob/living/M, mob/living/user, target_zone)
 	if(ishuman(M))

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -66,20 +66,26 @@
 	if(Adjacent(user))
 		attack_hand(user)
 
+/obj/structure/catwalk/proc/deconstruct(mob/user)
+	playsound(src, 'sound/items/Welder.ogg', 100, 1)
+	to_chat(user, "<span class='notice'>Slicing \the [src] joints ...</span>")
+	new /obj/item/stack/material/rods(src.loc)
+	new /obj/item/stack/material/rods(src.loc)
+	//Lattice would delete itself, but let's save ourselves a new obj
+	if(istype(src.loc, /turf/space) || istype(src.loc, /turf/simulated/open))
+		new /obj/structure/lattice/(src.loc)
+	if(plated_tile)
+		new plated_tile.build_type(src.loc)
+	qdel(src)
+
 /obj/structure/catwalk/attackby(obj/item/C as obj, mob/user as mob)
 	if(isWelder(C))
 		var/obj/item/weapon/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
-			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			to_chat(user, "<span class='notice'>Slicing \the [src] joints ...</span>")
-			new /obj/item/stack/material/rods(src.loc)
-			new /obj/item/stack/material/rods(src.loc)
-			//Lattice would delete itself, but let's save ourselves a new obj
-			if(istype(src.loc, /turf/space) || istype(src.loc, /turf/simulated/open))
-				new /obj/structure/lattice/(src.loc)
-			if(plated_tile)
-				new plated_tile.build_type(src.loc)
-			qdel(src)
+			deconstruct(user)
+		return
+	if(istype(C, /obj/item/weapon/gun/energy/plasmacutter))
+		deconstruct(user)
 		return
 	if(isCrowbar(C) && plated_tile)
 		hatch_open = !hatch_open

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -46,8 +46,6 @@
 		I.color = plated_tile.color
 		overlays += I
 
-
-
 /obj/structure/catwalk/ex_act(severity)
 	switch(severity)
 		if(1)
@@ -85,6 +83,8 @@
 			deconstruct(user)
 		return
 	if(istype(C, /obj/item/weapon/gun/energy/plasmacutter))
+		var/obj/item/weapon/gun/energy/plasmacutter/cutter = C
+		cutter.slice(user)
 		deconstruct(user)
 		return
 	if(isCrowbar(C) && plated_tile)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -78,6 +78,9 @@
 				reset_girder()
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter) || istype(W, /obj/item/psychic_power/psiblade/master/grand/paramount))
+		if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+			var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+			cutter.slice(user)
 		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing apart the girder...</span>")
 		if(do_after(user,30,src))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -67,7 +67,6 @@
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>Now disassembling the girder...</span>")
 			if(do_after(user, 40,src))
-				if(QDELETED(src)) return
 				to_chat(user, "<span class='notice'>You dissasembled the girder!</span>")
 				dismantle()
 		else if(!anchored)
@@ -84,14 +83,12 @@
 		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing apart the girder...</span>")
 		if(do_after(user,30,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You slice apart the girder!</span>")
 			dismantle()
 
 	else if(istype(W, /obj/item/weapon/pickaxe/diamonddrill))
 		playsound(src.loc, 'sound/weapons/Genhit.ogg', 100, 1)
 		if(do_after(user,40,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You drill through the girder!</span>")
 			dismantle()
 
@@ -100,7 +97,6 @@
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>Now unsecuring support struts...</span>")
 			if(do_after(user, 40,src))
-				if(QDELETED(src)) return
 				to_chat(user, "<span class='notice'>You unsecured the support struts!</span>")
 				state = 1
 		else if(anchored && !reinf_material)
@@ -112,7 +108,6 @@
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now removing support struts...</span>")
 		if(do_after(user, 40,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You removed the support struts!</span>")
 
 			if(reinf_material)
@@ -125,7 +120,6 @@
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now dislodging the girder...</span>")
 		if(do_after(user, 40,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You dislodged the girder!</span>")
 			icon_state = "displaced"
 			anchored = 0
@@ -252,7 +246,6 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now disassembling the girder...</span>")
 		if(do_after(user,40,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You dissasembled the girder!</span>")
 			dismantle()
 
@@ -260,13 +253,11 @@
 		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing apart the girder...</span>")
 		if(do_after(user,30,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You slice apart the girder!</span>")
 			dismantle()
 
 	else if(istype(W, /obj/item/weapon/pickaxe/diamonddrill))
 		playsound(src.loc, 'sound/weapons/Genhit.ogg', 100, 1)
 		if(do_after(user,40,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You drill through the girder!</span>")
 			dismantle()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -67,7 +67,7 @@
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>Now disassembling the girder...</span>")
 			if(do_after(user, 40,src))
-				if(!src) return
+				if(QDELETED(src)) return
 				to_chat(user, "<span class='notice'>You dissasembled the girder!</span>")
 				dismantle()
 		else if(!anchored)
@@ -78,22 +78,26 @@
 				reset_girder()
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter) || istype(W, /obj/item/psychic_power/psiblade/master/grand/paramount))
+		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing apart the girder...</span>")
 		if(do_after(user,30,src))
-			if(!src) return
+			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You slice apart the girder!</span>")
 			dismantle()
 
 	else if(istype(W, /obj/item/weapon/pickaxe/diamonddrill))
-		to_chat(user, "<span class='notice'>You drill through the girder!</span>")
-		dismantle()
+		playsound(src.loc, 'sound/weapons/Genhit.ogg', 100, 1)
+		if(do_after(user,40,src))
+			if(QDELETED(src)) return
+			to_chat(user, "<span class='notice'>You drill through the girder!</span>")
+			dismantle()
 
 	else if(isScrewdriver(W))
 		if(state == 2)
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>Now unsecuring support struts...</span>")
 			if(do_after(user, 40,src))
-				if(!src) return
+				if(QDELETED(src)) return
 				to_chat(user, "<span class='notice'>You unsecured the support struts!</span>")
 				state = 1
 		else if(anchored && !reinf_material)
@@ -105,7 +109,7 @@
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now removing support struts...</span>")
 		if(do_after(user, 40,src))
-			if(!src) return
+			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You removed the support struts!</span>")
 
 			if(reinf_material)
@@ -118,7 +122,7 @@
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now dislodging the girder...</span>")
 		if(do_after(user, 40,src))
-			if(!src) return
+			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You dislodged the girder!</span>")
 			icon_state = "displaced"
 			anchored = 0
@@ -245,16 +249,21 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now disassembling the girder...</span>")
 		if(do_after(user,40,src))
+			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You dissasembled the girder!</span>")
 			dismantle()
 
-	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter) || istype(W, /obj/item/psychic_power/psiblade/master/grand/paramount))
+		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing apart the girder...</span>")
 		if(do_after(user,30,src))
+			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You slice apart the girder!</span>")
-		dismantle()
+			dismantle()
 
 	else if(istype(W, /obj/item/weapon/pickaxe/diamonddrill))
-		to_chat(user, "<span class='notice'>You drill through the girder!</span>")
-		new /obj/item/remains/human(get_turf(src))
-		dismantle()
+		playsound(src.loc, 'sound/weapons/Genhit.ogg', 100, 1)
+		if(do_after(user,40,src))
+			if(QDELETED(src)) return
+			to_chat(user, "<span class='notice'>You drill through the girder!</span>")
+			dismantle()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -53,6 +53,11 @@
 	if(severity <= 2)
 		qdel(src)
 
+/obj/structure/lattice/proc/deconstruct(var/mob/user)
+	to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
+	new /obj/item/stack/material/rods(loc, 1, material.name)
+	qdel(src)
+
 /obj/structure/lattice/attackby(obj/item/C as obj, mob/user as mob)
 
 	if (istype(C, /obj/item/stack/tile/floor))
@@ -62,13 +67,13 @@
 	if(isWelder(C))
 		var/obj/item/weapon/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
-			to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
-		new /obj/item/stack/material/rods(loc, 1, material.name)
-		qdel(src)
+			deconstruct(user)
+		return
 	if(istype(C, /obj/item/weapon/gun/energy/plasmacutter))
-		to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
-		new /obj/item/stack/material/rods(loc, 1, material.name)
-		qdel(src)
+		var/obj/item/weapon/gun/energy/plasmacutter/cutter = C
+		cutter.slice(user)
+		deconstruct(user)
+		return
 	if (istype(C, /obj/item/stack/material/rods))
 		var/obj/item/stack/material/rods/R = C
 		if(R.use(2))

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -65,6 +65,10 @@
 			to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
 		new /obj/item/stack/material/rods(loc, 1, material.name)
 		qdel(src)
+	if(istype(C, /obj/item/weapon/gun/energy/plasmacutter))
+		to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
+		new /obj/item/stack/material/rods(loc, 1, material.name)
+		qdel(src)
 	if (istype(C, /obj/item/stack/material/rods))
 		var/obj/item/stack/material/rods/R = C
 		if(R.use(2))

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -81,7 +81,6 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now disassembling the low wall...</span>")
 		if(do_after(user, 40,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You dissasembled the low wall!</span>")
 			dismantle()
 
@@ -91,7 +90,6 @@
 		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing through the low wall...</span>")
 		if(do_after(user, 20,src))
-			if(QDELETED(src)) return
 			to_chat(user, "<span class='warning'>You have sliced through the low wall!</span>")
 			dismantle()
 	return ..()

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -86,13 +86,15 @@
 			dismantle()
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+		var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+		cutter.slice(user)
 		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now slicing through the low wall...</span>")
 		if(do_after(user, 20,src))
 			if(QDELETED(src)) return
 			to_chat(user, "<span class='warning'>You have sliced through the low wall!</span>")
 			dismantle()
-	return  ..()
+	return ..()
 
 /obj/structure/wall_frame/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -81,10 +81,17 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now disassembling the low wall...</span>")
 		if(do_after(user, 40,src))
-			if(!src) return
+			if(QDELETED(src)) return
 			to_chat(user, "<span class='notice'>You dissasembled the low wall!</span>")
 			dismantle()
 
+	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
+		to_chat(user, "<span class='notice'>Now slicing through the low wall...</span>")
+		if(do_after(user, 20,src))
+			if(QDELETED(src)) return
+			to_chat(user, "<span class='warning'>You have sliced through the low wall!</span>")
+			dismantle()
 	return  ..()
 
 /obj/structure/wall_frame/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -271,6 +271,8 @@
 			to_chat(user, "<span class='notice'>The new ID of the window is [id]</span>")
 		return
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter) && anchored)
+		var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+		cutter.slice(user)
 		playsound(src, 'sound/items/Welder.ogg', 80, 1)
 		visible_message("<span class='notice'>[user] has started slicing through the window's frame!</span>")
 		if(do_after(user,30,src))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -270,6 +270,14 @@
 			src.id = t
 			to_chat(user, "<span class='notice'>The new ID of the window is [id]</span>")
 		return
+	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter) && anchored)
+		playsound(src, 'sound/items/Welder.ogg', 80, 1)
+		visible_message("<span class='notice'>[user] has started slicing through the window's frame!</span>")
+		if(do_after(user,30,src))
+			visible_message("<span class='warning'>[user] has sliced through the window's frame!</span>")
+			playsound(src, 'sound/items/Welder.ogg', 80, 1)
+			construction_state = 0
+			set_anchored(0)
 	else
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(W.damtype == BRUTE || W.damtype == BURN)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -93,6 +93,7 @@
 				if(T)
 					T.visible_message("<span class='warning'>The ceiling above looks as if it's being pried off.</span>")
 				if(do_after(user, 10 SECONDS))
+					if(!broken && !burnt || !(is_plating()))return
 					visible_message("<span class='warning'>[user] has pried off the damaged plating.</span>")
 					new /obj/item/stack/tile/floor(src)
 					src.ReplaceWithLattice()
@@ -119,17 +120,28 @@
 					if(welder.isOn())
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
-						if(do_after(user, 5 SECONDS) && welder.isOn())
+						if(do_after(user, 5 SECONDS) && welder.isOn() && welder_melt())
 							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
 							playsound(src, 'sound/items/Welder.ogg', 80, 1)
-							burnt = 1
-							remove_decals()
-							update_icon()
 					else
 						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
+		else if(istype(C, /obj/item/weapon/gun/energy/plasmacutter) && (is_plating()) && !broken && !burnt)
+			playsound(src, 'sound/items/Welder.ogg', 80, 1)
+			visible_message("<span class='notice'>[user] has started slicing through the plating's reinforcements!</span>")
+			if(do_after(user, 3 SECONDS) && welder_melt())
+				visible_message("<span class='warning'>[user] has sliced through the plating's reinforcements! It should be possible to pry it off.</span>")
+				playsound(src, 'sound/items/Welder.ogg', 80, 1)
 
 	return ..()
+
+/turf/simulated/floor/proc/welder_melt()
+	if(!(is_plating()) || broken || burnt)
+		return 0
+	burnt = 1
+	remove_decals()
+	update_icon()
+	return 1
 
 /turf/simulated/floor/acid_melt()
 	. = FALSE

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -107,26 +107,24 @@
 			var/obj/item/weapon/weldingtool/welder = C
 			if(welder.isOn() && (is_plating()))
 				if(broken || burnt)
-					if(welder.isOn())
+					if(welder.remove_fuel(0, user))
 						to_chat(user, "<span class='notice'>You fix some dents on the broken plating.</span>")
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						icon_state = "plating"
 						burnt = null
 						broken = null
-					else
-						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
 				else
-					if(welder.isOn())
+					if(welder.remove_fuel(0, user))
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
 						if(do_after(user, 5 SECONDS) && welder.isOn() && welder_melt())
 							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
 							playsound(src, 'sound/items/Welder.ogg', 80, 1)
-					else
-						to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 					return
 		else if(istype(C, /obj/item/weapon/gun/energy/plasmacutter) && (is_plating()) && !broken && !burnt)
+			var/obj/item/weapon/gun/energy/plasmacutter/cutter = C
+			cutter.slice(user)
 			playsound(src, 'sound/items/Welder.ogg', 80, 1)
 			visible_message("<span class='notice'>[user] has started slicing through the plating's reinforcements!</span>")
 			if(do_after(user, 3 SECONDS) && welder_melt())

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -185,18 +185,12 @@
 
 		var/obj/item/weapon/weldingtool/WT = W
 
-		if(!WT.isOn())
-			return
-
 		if(WT.remove_fuel(0,user))
 			to_chat(user, "<span class='notice'>You start repairing the damage to [src].</span>")
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, max(5, damage / 5), src) && WT && WT.isOn())
 				to_chat(user, "<span class='notice'>You finish repairing the damage to [src].</span>")
 				take_damage(-damage)
-		else
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-			return
 		return
 
 	// Basic dismantling.
@@ -208,15 +202,15 @@
 
 		if(istype(W,/obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = W
-			if(!WT.isOn())
-				return
 			if(!WT.remove_fuel(0,user))
-				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 				return
 			dismantle_verb = "cutting"
 			dismantle_sound = 'sound/items/Welder.ogg'
 			cut_delay *= 0.7
 		else if(istype(W,/obj/item/weapon/melee/energy/blade) || istype(W,/obj/item/psychic_power/psiblade/master) || istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+			if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+				var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+				cutter.slice(user)
 			dismantle_sound = "sparks"
 			dismantle_verb = "slicing"
 			cut_delay *= 0.5
@@ -290,14 +284,14 @@
 				var/cut_cover
 				if(istype(W,/obj/item/weapon/weldingtool))
 					var/obj/item/weapon/weldingtool/WT = W
-					if(!WT.isOn())
-						return
 					if(WT.remove_fuel(0,user))
 						cut_cover=1
 					else
-						to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 						return
 				else if (istype(W, /obj/item/weapon/gun/energy/plasmacutter) || istype(W, /obj/item/psychic_power/psiblade/master))
+					if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+						var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+						cutter.slice(user)
 					cut_cover = 1
 				if(cut_cover)
 					to_chat(user, "<span class='notice'>You begin slicing through the metal cover.</span>")
@@ -335,9 +329,11 @@
 					if( WT.remove_fuel(0,user) )
 						cut_cover=1
 					else
-						to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 						return
 				else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter) || istype(W,/obj/item/psychic_power/psiblade/master))
+					if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+						var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+						cutter.slice(user)
 					cut_cover = 1
 				if(cut_cover)
 					to_chat(user, "<span class='notice'>You begin slicing through the support rods.</span>")

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -216,7 +216,7 @@
 			dismantle_verb = "cutting"
 			dismantle_sound = 'sound/items/Welder.ogg'
 			cut_delay *= 0.7
-		else if(istype(W,/obj/item/weapon/melee/energy/blade) || istype(W,/obj/item/psychic_power/psiblade/master))
+		else if(istype(W,/obj/item/weapon/melee/energy/blade) || istype(W,/obj/item/psychic_power/psiblade/master) || istype(W, /obj/item/weapon/gun/energy/plasmacutter))
 			dismantle_sound = "sparks"
 			dismantle_verb = "slicing"
 			cut_delay *= 0.5

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -229,24 +229,25 @@
 
 /obj/item/rig_module/mounted/plasmacutter/engage(atom/target)
 
-	if(!check())
+	if(!check() || !gun)
 		return 0
 
 	if(!target)
 		playsound(src.loc, 'sound/weapons/guns/selector.ogg', 50, 1)
 		if(!active)
 			active=1
-			to_chat(usr, "<span class='notice'>\The [src] is now set to close range mode.</span>")
+			to_chat(holder.wearer, "<span class='notice'>\The [src] is now set to close range mode.</span>")
 		else
 			active=0
-			to_chat(usr, "<span class='notice'>\The [src] is now set to firing mode.</span>")
+			to_chat(holder.wearer, "<span class='notice'>\The [src] is now set to firing mode.</span>")
 		return
 
 	if(!active)
 		gun.Fire(target,holder.wearer)
+		return 1
 	else
 		var/turf/T = get_turf(target)
-		if(istype(T) && !T.Adjacent(get_turf(src)))
+		if(istype(T) && !target.Adjacent(holder.wearer))
 			return 0
 
 		var/resolved = target.attackby(gun,holder.wearer)
@@ -254,7 +255,6 @@
 			gun.afterattack(target,holder.wearer,1)
 			holder.check_power_cost(usr, 9000, 0, src, (istype(usr,/mob/living/silicon ? 1 : 0) ) )//Uses 5 wh per use
 			return 1
-	return 1
 
 /obj/item/rig_module/mounted/energy_blade
 

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -253,7 +253,7 @@
 		var/resolved = target.attackby(gun,holder.wearer)
 		if(!resolved && gun && target)
 			gun.afterattack(target,holder.wearer,1)
-			holder.check_power_cost(usr, 9000, 0, src, (istype(usr,/mob/living/silicon ? 1 : 0) ) )//Uses 5 wh per use
+			holder.check_power_cost(usr, 18000, 0, src, (istype(usr,/mob/living/silicon ? 1 : 0) ) )//Uses 10 wh per use
 			return 1
 
 /obj/item/rig_module/mounted/energy_blade

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -99,7 +99,7 @@
 		return 1
 
 	var/turf/T = get_turf(target)
-	if(istype(T) && !T.Adjacent(get_turf(src)))
+	if(istype(T) && !target.Adjacent(holder.wearer))
 		return 0
 
 	var/resolved = target.attackby(device,holder.wearer)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -218,6 +218,38 @@
 /mob/living/carbon/human/proc/has_headset_in_ears()
 	return istype(get_equipped_item(slot_l_ear), /obj/item/device/radio/headset) || istype(get_equipped_item(slot_r_ear), /obj/item/device/radio/headset)
 
+/mob/living/carbon/human/welding_eyecheck()
+	var/mob/living/carbon/human/H = src
+	var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[H.species.vision_organ]
+	if(!E)
+		return
+	var/safety = H.eyecheck()
+	switch(safety)
+		if(FLASH_PROTECTION_MODERATE)
+			to_chat(H, "<span class='warning'>Your eyes sting a little.</span>")
+			E.damage += rand(1, 2)
+			if(E.damage > 12)
+				H.eye_blurry += rand(3,6)
+		if(FLASH_PROTECTION_NONE)
+			to_chat(H, "<span class='warning'>Your eyes burn.</span>")
+			E.damage += rand(2, 4)
+			if(E.damage > 10)
+				E.damage += rand(4,10)
+		if(FLASH_PROTECTION_REDUCED)
+			to_chat(H, "<span class='danger'>Your equipment intensifies the welder's glow. Your eyes itch and burn severely.</span>")
+			H.eye_blurry += rand(12,20)
+			E.damage += rand(12, 16)
+	if(safety<FLASH_PROTECTION_MAJOR)
+		if(E.damage > 10)
+			to_chat(H, "<span class='warning'>Your eyes are really starting to hurt. This can't be good for you!</span>")
+		if (E.damage >= E.min_bruised_damage)
+			to_chat(H, "<span class='danger'>You go blind!</span>")
+			H.eye_blind = 5
+			H.eye_blurry = 5
+			H.disabilities |= NEARSIGHTED
+			spawn(100)
+				H.disabilities &= ~NEARSIGHTED
+
 /mob/living/carbon/human/proc/make_grab(var/mob/living/carbon/human/attacker, var/mob/living/carbon/human/victim, var/grab_tag)
 	var/obj/item/grab/G
 	if(!grab_tag)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -219,36 +219,35 @@
 	return istype(get_equipped_item(slot_l_ear), /obj/item/device/radio/headset) || istype(get_equipped_item(slot_r_ear), /obj/item/device/radio/headset)
 
 /mob/living/carbon/human/welding_eyecheck()
-	var/mob/living/carbon/human/H = src
-	var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[H.species.vision_organ]
+	var/obj/item/organ/internal/eyes/E = src.internal_organs_by_name[species.vision_organ]
 	if(!E)
 		return
-	var/safety = H.eyecheck()
+	var/safety = eyecheck()
 	switch(safety)
 		if(FLASH_PROTECTION_MODERATE)
-			to_chat(H, "<span class='warning'>Your eyes sting a little.</span>")
+			to_chat(src, "<span class='warning'>Your eyes sting a little.</span>")
 			E.damage += rand(1, 2)
 			if(E.damage > 12)
-				H.eye_blurry += rand(3,6)
+				eye_blurry += rand(3,6)
 		if(FLASH_PROTECTION_NONE)
-			to_chat(H, "<span class='warning'>Your eyes burn.</span>")
+			to_chat(src, "<span class='warning'>Your eyes burn.</span>")
 			E.damage += rand(2, 4)
 			if(E.damage > 10)
 				E.damage += rand(4,10)
 		if(FLASH_PROTECTION_REDUCED)
-			to_chat(H, "<span class='danger'>Your equipment intensifies the welder's glow. Your eyes itch and burn severely.</span>")
-			H.eye_blurry += rand(12,20)
+			to_chat(src, "<span class='danger'>Your equipment intensifies the welder's glow. Your eyes itch and burn severely.</span>")
+			eye_blurry += rand(12,20)
 			E.damage += rand(12, 16)
 	if(safety<FLASH_PROTECTION_MAJOR)
 		if(E.damage > 10)
-			to_chat(H, "<span class='warning'>Your eyes are really starting to hurt. This can't be good for you!</span>")
+			to_chat(src, "<span class='warning'>Your eyes are really starting to hurt. This can't be good for you!</span>")
 		if (E.damage >= E.min_bruised_damage)
-			to_chat(H, "<span class='danger'>You go blind!</span>")
-			H.eye_blind = 5
-			H.eye_blurry = 5
-			H.disabilities |= NEARSIGHTED
+			to_chat(src, "<span class='danger'>You go blind!</span>")
+			eye_blind = 5
+			eye_blurry = 5
+			disabilities |= NEARSIGHTED
 			spawn(100)
-				H.disabilities &= ~NEARSIGHTED
+				disabilities &= ~NEARSIGHTED
 
 /mob/living/carbon/human/proc/make_grab(var/mob/living/carbon/human/attacker, var/mob/living/carbon/human/victim, var/grab_tag)
 	var/obj/item/grab/G

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -411,6 +411,9 @@ proc/is_blind(A)
 			return 1
 	return 0
 
+/mob/proc/welding_eyecheck()
+	return
+
 /proc/broadcast_security_hud_message(var/message, var/broadcast_source)
 	broadcast_hud_message(message, broadcast_source, GLOB.sec_hud_users, /obj/item/clothing/glasses/hud/security)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -219,15 +219,14 @@
 	max_shots = 4
 	has_safety = FALSE
 
-/obj/item/weapon/gun/energy/plasmacutter/New()
-	..()
+/obj/item/weapon/gun/energy/plasmacutter/Initialize()
+	. = ..()
 	src.spark_system = new /datum/effect/effect/system/spark_spread
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
 /obj/item/weapon/gun/energy/plasmacutter/Destroy()
-	qdel(spark_system)
-	spark_system = null
+	QDEL_NULL(spark_system)
 	return ..()
 
 /obj/item/weapon/gun/energy/plasmacutter/proc/slice(var/mob/M = null)//makes spark and eyecheck for deconstructing things

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -211,9 +211,26 @@
 	projectile_type = /obj/item/projectile/beam/plasmacutter
 	max_shots = 10
 	self_recharge = 1
+	var/datum/effect/effect/system/spark_spread/spark_system
 
 /obj/item/weapon/gun/energy/plasmacutter/mounted
 	name = "mounted plasma cutter"
 	use_external_power = 1
 	max_shots = 4
 	has_safety = FALSE
+
+/obj/item/weapon/gun/energy/plasmacutter/New()
+	..()
+	src.spark_system = new /datum/effect/effect/system/spark_spread
+	spark_system.set_up(5, 0, src)
+	spark_system.attach(src)
+
+/obj/item/weapon/gun/energy/plasmacutter/Destroy()
+	qdel(spark_system)
+	spark_system = null
+	return ..()
+
+/obj/item/weapon/gun/energy/plasmacutter/proc/slice(var/mob/M = null)//makes spark and eyecheck for deconstructing things
+	src.spark_system.start()
+	if(M)
+		M.welding_eyecheck()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -97,6 +97,9 @@
 //this is largely hacky and bad :(	-Pete
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(w_class > 3 && (istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/gun/energy/plasmacutter)))
+		if(istype(A, /obj/item/weapon/gun/energy/plasmacutter))
+			var/obj/item/weapon/gun/energy/plasmacutter/cutter = A
+			cutter.slice(user)
 		to_chat(user, "<span class='notice'>You begin to shorten the barrel of \the [src].</span>")
 		if(loaded.len)
 			for(var/i in 1 to max_shells)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -202,6 +202,9 @@
 			var/obj/item/weapon/weldingtool/welder = tool
 			if(!welder.isOn() || !welder.remove_fuel(1,user))
 				return FALSE
+		if(istype(tool, /obj/item/weapon/gun/energy/plasmacutter))
+			var/obj/item/weapon/gun/energy/plasmacutter/cutter = tool
+			cutter.slice(user)
 		return TRUE
 	return FALSE
 
@@ -496,7 +499,7 @@
 			to_chat(user, SPAN_WARNING("You're pretty sure [target.species.name_plural] don't normally have a brain."))
 		else if(target.internal_organs[BP_BRAIN])
 			to_chat(user, SPAN_WARNING("Your subject already has a brain."))
-		else 
+		else
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
🆑
rscadd: Plasma cutters can now cut through the following: bulkhead walls, floor platings, girders, catwalks, windows, low wall frames and lattices.
rscadd: Plasma cutters will now spark and require eye protection when interacting with object.
tweak: Mounted plasma cutter has an increased object interaction energy cost, 10 Wh per use. 
bugfix: Drills will now have a delay and sound when drilling through girders.
/🆑
The failed abomination of #25348, lessons were learned

https://drive.google.com/file/d/1GSIzVadeTH33N-3MyMaBmB5sdRZB_539/view?usp=sharing

Make the plasma cutter a universal cutting tool.
Allow them to cut through:
Catwalks
Lattices
Girders
Floor platings
Normal bulkhead walls
Windows (all of them)
Low wall frames
(reinforce walls are untouched although plasma cutter can already be used on them in place of the welder steps)

Also fixed up some messy mounted plasma cutter code (ty Psi)
Also added sound back for the drilling through girders
Fixed up a bit more code with the girders and floor code (ty Psi again)

Also did a bunch of bug fixes
Welding floor plating now checks for eye protection.
Welding through lattice checks if the welder is on.
Moved eyecheck() for welding into mob_helpers.dm and human_helpers.dm as welding_eyecheck()