### PR TITLE
Actually switches the emergency softsuit icons

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -103,7 +103,7 @@
 
 /obj/item/clothing/suit/space/emergency
 	name = "Emergency Softsuit"
-	icon_state = "syndicate-orange"
+	icon_state = "space_emergency"
 	desc = "A thin, ungainly softsuit colored in blaze orange for rescuers to easily locate, looks pretty fragile."
 
 /obj/item/clothing/suit/space/emergency/New()


### PR DESCRIPTION
Fixing an oopsie from #25374

The new icons were created, but the item's `icon_state` hadn't been changed.