### PR TITLE
Makes closets give all their steel back when deconstructed

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -319,7 +319,7 @@
 	if(!WT.remove_fuel(0,user))
 		to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 		return
-	new /obj/item/stack/material/steel(src.loc)
+	new /obj/item/stack/material/steel(src.loc, 2)
 	user.visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", \
 						 "<span class='notice'>You have cut \the [src] apart with \the [WT].</span>", \
 						 "You hear welding.")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
fixes #25407