### PR TITLE
Fix issue with new keybinds on non hotkey-mode

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -395,13 +395,10 @@ macro "macro"
 		name = "F12"
 		command = "F12"
 	elem 
-		name = "SHIFT+<"
+		name = "CTRL+,"
 		command = "move-upwards"
 	elem 
-		name = ">"
-		command = "move-upwards"
-	elem 
-		name = "<"
+		name = "CTRL+."
 		command = "move-down"
 
 macro "hotkeymode"
@@ -809,13 +806,10 @@ macro "borgmacro"
 		name = "F12"
 		command = "F12"
 	elem 
-		name = "SHIFT+<"
+		name = "CTRL+,"
 		command = "move-upwards"
 	elem 
-		name = ">"
-		command = "move-upwards"
-	elem 
-		name = "<"
+		name = "CTRL+."
 		command = "move-down"
 
 


### PR DESCRIPTION
Fix bug introduced by #25418 : non hotkey-mode only auto-focuses the input-box if there are no non-modifier keybinds defined. The new < and > keybinds now are CTRL+< and CTRL+>.
🆑
bugfix: New < and > keybinds are now CTRL+. and CTRL+ in non hotkey-mode, to circumvent a byond limitation. You will need to update your skin.
/🆑