### PR TITLE
Makes a bunch of stack quantity checks more consistent

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -153,7 +153,7 @@
 			to_chat(user, "<span class='notice'>\The [src] is already fully functional.</span>")
 			return
 		var/obj/item/stack/P = C
-		if(P.amount < amt)
+		if(!P.can_use(amt))
 			to_chat(user, "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>")
 			return
 		to_chat(user, "<span class='notice'>You begin repairing \the [src]...</span>")

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -104,9 +104,8 @@
 			return 1
 		if(istype(O, /obj/item/stack)) // This is bad, but I can't think of how to change it
 			var/obj/item/stack/S = O
-			if(S.get_amount() > 1)
+			if(S.use(1))
 				new O.type (src)
-				S.use(1)
 				user.visible_message( \
 					"<span class='notice'>\The [user] has added one of [O] to \the [src].</span>", \
 					"<span class='notice'>You add one of [O] to \the [src].</span>")

--- a/code/game/machinery/robot_fabricator.dm
+++ b/code/game/machinery/robot_fabricator.dm
@@ -20,9 +20,8 @@
 				if(M)
 					if(!M.get_amount())
 						return
-					while(metal_amount < 150000 && M.amount)
+					while(metal_amount < 150000 && M.use(1))
 						src.metal_amount += O.matter[MATERIAL_STEEL] /*O:height * O:width * O:length * 100000.0*/
-						M.use(1)
 						count++
 
 					to_chat(user, "You insert [count] metal sheet\s into the fabricator.")

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1232,10 +1232,9 @@
 		occupant_message("Cable depleted, [src] deactivated.")
 		log_message("Cable depleted, [src] deactivated.")
 		return
-	if(cable.amount < amount)
+	if(!cable.use(amount))
 		occupant_message("No enough cable to finish the task.")
 		return
-	cable.use(amount)
 	update_equip_info()
 	return 1
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -177,7 +177,7 @@
 		return
 
 	if(materials[material] + amnt <= res_max_amount)
-		if(stack && stack.amount >= 1)
+		if(stack && stack.can_use(1))
 			var/count = 0
 			overlays += "fab-load-metal"
 			spawn(10)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -27,7 +27,7 @@
 			return 0
 	else if(istype(used_atom, /obj/item/stack))
 		var/obj/item/stack/S = used_atom
-		if(S.get_amount() < 5)
+		if(!S.can_use(5))
 			to_chat(user, ("There's not enough material in this stack."))
 			return 0
 		else
@@ -59,7 +59,7 @@
 			return 0
 	else if(istype(used_atom, /obj/item/stack))
 		var/obj/item/stack/S = used_atom
-		if(S.get_amount() < 5)
+		if(!S.can_use(5))
 			to_chat(user, ("There's not enough material in this stack."))
 			return 0
 		else

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -135,7 +135,6 @@ Using robohead because of restricting to roboticist */
 					to_chat(user, "<span class='notice'>You need three cable coils to wire the devices.</span>")
 					..()
 					return
-				C.use(3)
 				buildstep++
 				to_chat(user, "<span class='notice'>You wire the assembly</span>")
 				desc = "This TV camera assembly has wires sticking out"
@@ -149,12 +148,11 @@ Using robohead because of restricting to roboticist */
 		if(4)
 			if(istype(W, /obj/item/stack/material/steel))
 				var/obj/item/stack/material/steel/S = W
-				buildstep++
-				S.use(1)
-				to_chat(user, "<span class='notice'>You encase the assembly.</span>")
-				var/turf/T = get_turf(src)
-				new /obj/item/device/camera/tvcamera(T)
-				qdel(src)
-				return
-
+				if(S.use(1))
+					buildstep++
+					to_chat(user, "<span class='notice'>You encase the assembly.</span>")
+					var/turf/T = get_turf(src)
+					new /obj/item/device/camera/tvcamera(T)
+					qdel(src)
+					return
 	..()

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -119,9 +119,9 @@
 			return
 		else
 			var/obj/item/stack/cable_coil/coil = W
-			coil.use(1)
-			src.wires = 1.0
-			to_chat(user, "<span class='notice'>You insert the wire!</span>")
+			if(coil.use(1))
+				src.wires = 1.0
+				to_chat(user, "<span class='notice'>You insert the wire!</span>")
 	if(istype(W, /obj/item/robot_parts/head))
 		var/obj/item/robot_parts/head/head_part = W
 		// Attempt to create full-body prosthesis.

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -43,7 +43,7 @@
 	if(isWelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
 
-		if(get_amount() < 2)
+		if(!can_use(2))
 			to_chat(user, "<span class='warning'>You need at least two rods to do this.</span>")
 			return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -571,7 +571,7 @@
 
 /proc/place_window(mob/user, loc, dir_to_set, obj/item/stack/material/ST)
 	var/required_amount = (dir_to_set & (dir_to_set - 1)) ? 4 : 1
-	if (ST.amount < required_amount)
+	if (!ST.can_use(required_amount))
 		to_chat(user, "<span class='notice'>You do not have enough sheets.</span>")
 		return
 	for(var/obj/structure/window/WINDOW in loc)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -280,8 +280,7 @@
 					return
 				else if( istype(W, /obj/item/stack/material/rods) )
 					var/obj/item/stack/O = W
-					if(O.get_amount()>0)
-						O.use(1)
+					if(O.use(1))
 						construction_stage = 6
 						update_icon()
 						to_chat(user, "<span class='notice'>You replace the outer grille.</span>")

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -80,11 +80,10 @@
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
-			if (S.get_amount() < 1)
+			if (!S.use(1))
 				return
 			qdel(L)
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			S.use(1)
 			ChangeTurf(/turf/simulated/floor/airless)
 			return
 		else

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -95,7 +95,7 @@
 				return
 
 		var/obj/item/stack/cable_coil/cable = W
-		if(!cable.amount >= 5)
+		if(!cable.can_use(5))
 			to_chat(user, "You need five units of cable to repair \the [src].")
 			return
 

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -121,12 +121,12 @@
 
 // Placeholders for light tiles and rglass.
 /material/proc/reinforce(var/mob/user, var/obj/item/stack/material/used_stack, var/obj/item/stack/material/target_stack)
-	if(used_stack.get_amount() < 1)
+	if(!used_stack.can_use(1))
 		to_chat(user, "<span class='warning'>You need need at least one [used_stack.singular_name] to reinforce [target_stack].</span>")
 		return
 
 	var/needed_sheets = 2 * used_stack.matter_multiplier
-	if(target_stack.get_amount() < needed_sheets)
+	if(!target_stack.can_use(needed_sheets))
 		to_chat(user, "<span class='warning'>You need need at least [needed_sheets] [target_stack.plural_name] for reinforcement with [used_stack].</span>")
 		return
 
@@ -147,7 +147,7 @@
 	if(!wire_product)
 		to_chat(user, "<span class='warning'>You cannot make anything out of \the [target_stack]</span>")
 		return
-	if(used_stack.get_amount() < 5 || target_stack.get_amount() < 1)
+	if(!used_stack.can_use(5) || !target_stack.can_use(1))
 		to_chat(user, "<span class='warning'>You need five wires and one sheet of [display_name] to make anything useful.</span>")
 		return
 

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -144,7 +144,7 @@
 		if(6)
 			if(isCoil(W))
 				var/obj/item/stack/cable_coil/C = W
-				if (C.get_amount() < 1)
+				if (!C.can_use(1))
 					to_chat(user, "<span class='warning'>You need one coil of wire to wire [src].</span>")
 					return
 				to_chat(user, "<span class='notice'>You start to wire [src].</span>")

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -37,8 +37,7 @@
 						M.death()
 					if(istype(I,/obj/item/stack/material))//Only deconstructs one sheet at a time instead of the entire stack
 						var/obj/item/stack/material/S = I
-						if(S.get_amount() > 1)
-							S.use(1)
+						if(S.use(1))
 							loaded_item = S
 						else
 							qdel(S)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -159,11 +159,10 @@
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
-			if (S.get_amount() < 1)
+			if (!S.use(1))
 				return
 			qdel(L)
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			S.use(1)
 			ChangeTurf(/turf/simulated/floor/airless)
 			return
 		else

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -542,14 +542,14 @@
 			to_chat(user, "<span class='warning'>You must remove the floor plating in front of the APC first.</span>")
 			return
 		var/obj/item/stack/cable_coil/C = W
-		if(C.get_amount() < 10)
+		if(!C.can_use(10))
 			to_chat(user, "<span class='warning'>You need ten lengths of cable for APC.</span>")
 			return
 		user.visible_message("<span class='warning'>[user.name] adds cables to the APC frame.</span>", \
 							"You start adding cables to the APC frame...")
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 20, src))
-			if (C.amount >= 10 && !terminal && opened && has_electronics != 2)
+			if (C.can_use(10) && !terminal && opened && has_electronics != 2)
 				var/obj/structure/cable/N = T.get_cable_node()
 				if (prob(50) && electrocute_mob(usr, N, N))
 					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -592,13 +592,12 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 	if(ishuman(M) && !M.incapacitated())
 		if(!istype(usr.loc,/turf)) return
-		if(src.amount <= 14)
+		if(!src.use(15))
 			to_chat(usr, "<span class='warning'>You need at least 15 lengths to make restraints!</span>")
 			return
 		var/obj/item/weapon/handcuffs/cable/B = new /obj/item/weapon/handcuffs/cable(usr.loc)
 		B.color = color
 		to_chat(usr, "<span class='notice'>You wind some cable together to make some restraints.</span>")
-		src.use(15)
 	else
 		to_chat(usr, "<span class='notice'>You cannot do that.</span>")
 	..()

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -45,12 +45,11 @@
 		if(!mat.is_fusion_fuel)
 			to_chat(user, "<span class='warning'>It would be pointless to make a fuel rod out of [mat.use_name].</span>")
 			return
-		if(M.get_amount() < 5)
+		if(!M.use(5))
 			to_chat(user, "<span class='warning'>You need at least five [mat.sheet_plural_name] to make a fuel rod.</span>")
 			return
 		var/obj/item/weapon/fuel_assembly/F = new(get_turf(src), mat.name)
 		visible_message("<span class='notice'>\The [src] compresses the [mat.use_name] into a new fuel assembly.</span>")
-		M.use(5)
 		user.put_in_hands(F)
 		return 1
 	return 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -286,7 +286,7 @@
 	if(isCoil(W) && !building_terminal)
 		building_terminal = 1
 		var/obj/item/stack/cable_coil/CC = W
-		if (CC.get_amount() < 10)
+		if (!CC.can_use(10))
 			to_chat(user, "<span class='warning'>You need more cables.</span>")
 			building_terminal = 0
 			return 0

--- a/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
@@ -13,10 +13,9 @@
 		var/obj/item/stack/material/reinforcing = thing
 		var/material/reinforcing_with = reinforcing.get_material()
 		if(reinforcing_with.name == MATERIAL_STEEL) // Steel
-			if(reinforcing.get_amount() < 5)
+			if(!reinforcing.use(5))
 				to_chat(user, "<span class='warning'>You need at least 5 [reinforcing.singular_name]\s for this task.</span>")
 				return
-			reinforcing.use(5)
 			user.visible_message("<span class='notice'>\The [user] shapes some steel sheets around \the [src] to form a body.</span>")
 			increment_construction_stage()
 			return
@@ -50,7 +49,7 @@
 
 	if(isCoil(thing) && construction_stage == 5)
 		var/obj/item/stack/cable_coil/cable = thing
-		if(cable.get_amount() < 5)
+		if(!cable.can_use(5))
 			to_chat(user, "<span class='warning'>You need at least 5 lengths of cable for this task.</span>")
 			return
 		cable.use(5)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -471,8 +471,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			qdel(M)
 		if(istype(I,/obj/item/stack/material))//Only deconsturcts one sheet at a time instead of the entire stack
 			var/obj/item/stack/material/S = I
-			if(S.get_amount() > 1)
-				S.use(1)
+			if(S.use(1))
 				linked_destroy.loaded_item = S
 			else
 				qdel(S)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -294,10 +294,9 @@
 		else
 			var/obj/item/stack/cable_coil/C = tool
 			if(istype(C))
-				if(C.get_amount() < 3)
+				if(!C.use(3))
 					to_chat(user, SPAN_WARNING("You need three or more cable pieces to repair this damage."))
 				else
-					C.use(3)
 					return TRUE
 	return FALSE
 


### PR DESCRIPTION
Turns a bunch of stack quantity checks into `can_use` calls, which would fail with robot stacks (that don't use the `quantity` attribute), for consistency and future-proofing of weird stack children.

🆑
bugfix: Robots can once again build windows using their synthesizers.
/🆑