### PR TITLE
Fix personal goal adding

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -177,8 +177,9 @@
 		if(can_modify)
 			if(is_admin)
 				log_admin("[key_name_admin(usr)] added a random goal to [key_name(current)].")
-			to_chat(current, SPAN_NOTICE("You have received a new goal. Use <b>Show Goals</b> to view it."))
-			generate_goals(assigned_job, TRUE, 1)
+			var/did_generate_goal = generate_goals(assigned_job, TRUE, 1)
+			if(did_generate_goal)
+				to_chat(current, SPAN_NOTICE("You have received a new goal. Use <b>Show Goals</b> to view it."))
 		return TRUE // To avoid 'you are not an admin' spam.
 
 	if(href_list["abandon_goal"])
@@ -203,7 +204,7 @@
 		if(caller && caller == current) can_modify = TRUE
 
 		if(goal && (goal in goals) && can_modify)
-			qdel(goal) 
+			qdel(goal)
 			generate_goals(assigned_job, TRUE, 1)
 			if(goals)
 				goal = goals[LAZYLEN(goals)]

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -238,7 +238,7 @@ var/global/list/additional_antag_types = list()
 	// Update goals, now that antag status and jobs are both resolved.
 	for(var/thing in SSticker.minds)
 		var/datum/mind/mind = thing
-		mind.generate_goals(mind.assigned_job)
+		mind.generate_goals(mind.assigned_job, is_spawning=TRUE)
 		mind.current.show_goals()
 
 	if(evacuation_controller && auto_recall_shuttle)
@@ -368,7 +368,7 @@ var/global/list/additional_antag_types = list()
 		text += "There were <b>no survivors</b> (<b>[ghosts] ghosts</b>)."
 
 	to_world(text)
-	
+
 	if(clients > 0)
 		SSstatistics.set_field("round_end_clients",clients)
 	if(ghosts > 0)

--- a/code/game/gamemodes/game_mode_latespawn.dm
+++ b/code/game/gamemodes/game_mode_latespawn.dm
@@ -23,7 +23,7 @@
 //This can be overriden in case a game mode needs to do stuff when a player latejoins
 /datum/game_mode/proc/handle_latejoin(var/mob/living/carbon/human/character)
 	if(character.mind)
-		character.mind.generate_goals(character.mind.assigned_job)
+		character.mind.generate_goals(character.mind.assigned_job, is_spawning=TRUE)
 		character.show_goals()
 	return 0
 

--- a/code/modules/goals/goal_mind.dm
+++ b/code/modules/goals/goal_mind.dm
@@ -22,30 +22,29 @@
 		goals = null
 
 	var/pref_val = current.get_preference_value(/datum/client_preference/give_personal_goals)
-	if(pref_val != GLOB.PREF_NEVER && (pref_val != GLOB.PREF_NON_ANTAG || !player_is_antag(src)))
-		var/list/available_goals = SSgoals.global_personal_goals ? SSgoals.global_personal_goals.Copy() : list()
-		if(ishuman(current))
-			var/mob/living/carbon/human/H = current
-			for(var/token in H.cultural_info)
-				var/decl/cultural_info/culture = H.get_cultural_value(token)
-				var/list/new_goals = culture.get_possible_personal_goals(job ? job.department_flag : null)
-				if(LAZYLEN(new_goals))
-					available_goals |= new_goals
-
-		if(isnull(add_amount))
-			var/min_goals = 1
-			var/max_goals = 3
-			if(job && LAZYLEN(job.possible_goals))
-				available_goals |= job.possible_goals
-				min_goals = job.min_goals
-				max_goals = job.max_goals
-			add_amount = rand(min_goals, max_goals)
-
-		for(var/i = 1 to min(LAZYLEN(available_goals), add_amount))
-			var/goal = pick_n_take(available_goals)
-			new goal(src)
-		return TRUE
-	else
+	if(pref_val == GLOB.PREF_NEVER || (pref_val == GLOB.PREF_NON_ANTAG && player_is_antag(src)))
 		if(!is_spawning)
 			to_chat(src.current, "<span class='warning'>Your preferences do not allow you to add random goals.</span>")
 		return FALSE
+
+	var/list/available_goals = SSgoals.global_personal_goals ? SSgoals.global_personal_goals.Copy() : list()
+	if(ishuman(current))
+		var/mob/living/carbon/human/H = current
+		for(var/token in H.cultural_info)
+			var/decl/cultural_info/culture = H.get_cultural_value(token)
+			var/list/new_goals = culture.get_possible_personal_goals(job ? job.department_flag : null)
+			if(LAZYLEN(new_goals))
+				available_goals |= new_goals
+	if(isnull(add_amount))
+		var/min_goals = 1
+		var/max_goals = 3
+		if(job && LAZYLEN(job.possible_goals))
+			available_goals |= job.possible_goals
+			min_goals = job.min_goals
+			max_goals = job.max_goals
+		add_amount = rand(min_goals, max_goals)
+
+	for(var/i = 1 to min(LAZYLEN(available_goals), add_amount))
+		var/goal = pick_n_take(available_goals)
+		new goal(src)
+	return TRUE

--- a/code/modules/goals/goal_mind.dm
+++ b/code/modules/goals/goal_mind.dm
@@ -3,7 +3,7 @@
 
 /datum/mind/proc/show_roundend_summary(var/department_goals)
 	if(current)
-		if(department_goals && current.get_preference_value(/datum/client_preference/show_department_goals) == GLOB.PREF_SHOW) 
+		if(department_goals && current.get_preference_value(/datum/client_preference/show_department_goals) == GLOB.PREF_SHOW)
 			to_chat(current, SPAN_NOTICE(department_goals))
 		if(LAZYLEN(goals))
 			to_chat(current, SPAN_NOTICE("<br><br><b>You had the following personal goals this round:</b><br>[jointext(summarize_goals(TRUE), "<br>")]"))
@@ -16,13 +16,13 @@
 			. += "[i]. [goal.summarize(show_success, allow_modification, caller, position = i)]"
 
 // Create and display personal goals for this round.
-/datum/mind/proc/generate_goals(var/datum/job/job, var/adding_goals = FALSE, var/add_amount)
+/datum/mind/proc/generate_goals(var/datum/job/job, var/adding_goals = FALSE, var/add_amount, var/is_spawning = FALSE)
 
 	if(!adding_goals)
 		goals = null
 
 	var/pref_val = current.get_preference_value(/datum/client_preference/give_personal_goals)
-	if(pref_val != GLOB.PREF_NEVER && (pref_val != GLOB.PREF_NON_ANTAG || player_is_antag(src)))
+	if(pref_val != GLOB.PREF_NEVER && (pref_val != GLOB.PREF_NON_ANTAG || !player_is_antag(src)))
 		var/list/available_goals = SSgoals.global_personal_goals ? SSgoals.global_personal_goals.Copy() : list()
 		if(ishuman(current))
 			var/mob/living/carbon/human/H = current
@@ -44,3 +44,8 @@
 		for(var/i = 1 to min(LAZYLEN(available_goals), add_amount))
 			var/goal = pick_n_take(available_goals)
 			new goal(src)
+		return TRUE
+	else
+		if(!is_spawning)
+			to_chat(src.current, "<span class='warning'>Your preferences do not allow you to add random goals.</span>")
+		return FALSE


### PR DESCRIPTION
Adding personal goals has been broken for a while. The `Non-Antag` option for the `Give Personal Goals` preference does the opposite of what you'd expect: it only gives you goals when you are an antagonist. On top of that, the user would be informed that their random goal was created, even when it actually was not. This PR makes the `Non-Antag` option do what someone would expect, and replaces the successful message when adding goals with a warning if your preferences don't allow adding random goals. 

Fixes #25357.