### PR TITLE
Add skill requirements to loadout items

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -409,11 +409,16 @@ SUBSYSTEM_DEF(jobs)
 					else
 						permitted = 1
 
+				if(permitted && G.allowed_skills)
+					for(var/required in G.allowed_skills)
+						if(!H.skill_check(required,G.allowed_skills[required]))
+							permitted = 0
+
 				if(G.whitelisted && (!(H.species.name in G.whitelisted)))
 					permitted = 0
 
 				if(!permitted)
-					to_chat(H, "<span class='warning'>Your current species, job, branch or whitelist status does not permit you to spawn with [thing]!</span>")
+					to_chat(H, "<span class='warning'>Your current species, job, branch, skills or whitelist status does not permit you to spawn with [thing]!</span>")
 					continue
 
 				if(!G.slot || G.slot == slot_tie || (G.slot in loadout_taken_slots) || !G.spawn_on_mob(H, H.client.prefs.Gear()[G.display_name]))

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -73,6 +73,17 @@ var/list/gear_datums = list()
 			continue
 		. += gear_name
 
+/datum/category_item/player_setup_item/loadout/proc/skill_check(var/list/jobs, var/list/skills_required)
+	for(var/datum/job/J in jobs)
+		var/list/skills = pref.skills_allocated[J]
+		. = TRUE
+		for(var/R in skills_required)
+			if(skills[R] + pref.get_min_skill(J, R) < skills_required[R])
+				. = FALSE
+				break
+		if(.)
+			return
+
 /datum/category_item/player_setup_item/loadout/sanitize_character()
 	pref.gear_slot = sanitize_integer(pref.gear_slot, 1, config.loadout_slots, initial(pref.gear_slot))
 	if(!islist(pref.gear_list)) pref.gear_list = list()
@@ -202,8 +213,30 @@ var/list/gear_datums = list()
 					else
 						branch_checks += "<font color=cc5555>[player_branch.name]</font>"
 				allowed = good_branch
-					
+
 				entry += "[english_list(branch_checks)]</i>"
+
+		if(allowed && G.allowed_skills)
+			var/list/skills_required = list()//make it into instances? instead of path
+			for(var/skill in G.allowed_skills)
+				var/decl/hierarchy/skill/instance = decls_repository.get_decl(skill)
+				skills_required[instance] = G.allowed_skills[skill]
+
+			allowed = skill_check(jobs, skills_required)//Checks if a single job has all the skills required
+
+			entry += "<br><i>"
+			var/list/skill_checks = list()
+			for(var/R in skills_required)
+				var/decl/hierarchy/skill/S = R
+				var/skill_entry
+				skill_entry += "[S.levels[skills_required[R]]]"
+				if(allowed)
+					skill_entry = "<font color=55cc55>[skill_entry] [R]</font>"
+				else
+					skill_entry = "<font color=cc5555>[skill_entry] [R]</font>"
+				skill_checks += skill_entry
+
+			entry += "[english_list(skill_checks)]</i>"
 
 		entry += "</tr>"
 		if(ticked)
@@ -313,6 +346,7 @@ var/list/gear_datums = list()
 	var/slot               //Slot to equip to.
 	var/list/allowed_roles //Roles that can spawn with this item.
 	var/list/allowed_branches //Service branches that can spawn with it.
+	var/list/allowed_skills //Skills required to spawn with this item.
 	var/whitelisted        //Term to check the whitelist for..
 	var/sort_category = "General"
 	var/flags              //Special tweaks in new

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -53,7 +53,7 @@
 /datum/gear/accessory/pilot_pin
 	display_name = "pilot's qualification pin"
 	path = /obj/item/clothing/accessory/solgov/specialty/pilot
-	allowed_roles = list(/datum/job/captain, /datum/job/hop, /datum/job/bridgeofficer, /datum/job/pathfinder, /datum/job/nt_pilot)
+	allowed_skills = list(SKILL_PILOT = SKILL_ADEPT)
 
 /datum/gear/accessory/fleetpatch
 	display_name = "fleet patch"


### PR DESCRIPTION
🆑
tweak: Pilot's qualification pin will now require trained piloting skills to spawn from loadout.
/🆑

Added a system to do skill requirement checks for load out gear.
Changed pilot's qualification pin to check for trained piloting skills
Hopefully this will be a start for other skill required items, such as an EVA patch, weapon license and mechsuit certificate and others along those lines.

As Psi requested, a mock up visual requirement
![WAax6oMgmF](https://user-images.githubusercontent.com/43085828/57195708-1389fb00-6f99-11e9-8806-e67792e6c85e.png)