### PR TITLE
artery bleed visibility tweak

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -153,7 +153,7 @@
 				if(bleed_amount)
 					if(open_wound)
 						blood_max += bleed_amount
-						do_spray += "the [temp.artery_name] in \the [owner]'s [temp.name]"
+						do_spray += "[temp.name]"
 					else
 						owner.vessel.remove_reagent(/datum/reagent/blood, bleed_amount)
 
@@ -169,9 +169,16 @@
 			blood_max *= 0.8
 
 		if(world.time >= next_blood_squirt && istype(owner.loc, /turf) && do_spray.len)
-			owner.visible_message("<span class='danger'>Blood squirts from [pick(do_spray)]!</span>")
-			// It becomes very spammy otherwise. Arterial bleeding will still happen outside of this block, just not the squirt effect.
-			next_blood_squirt = world.time + 100
+			var/spray_organ = pick(do_spray)
+			owner.visible_message(
+				SPAN_DANGER("Blood sprays out from \the [owner]'s [spray_organ]!"),
+				FONT_HUGE(SPAN_DANGER("Blood sprays out from your [spray_organ]!"))
+			)
+			owner.Stun(1)
+			owner.eye_blurry = 2
+
+			//AB occurs every heartbeat, this only throttles the visible effect
+			next_blood_squirt = world.time + 80
 			var/turf/sprayloc = get_turf(owner)
 			blood_max -= owner.drip(ceil(blood_max/3), sprayloc)
 			if(blood_max > 0)


### PR DESCRIPTION
:cl:
tweak: Arterial bleeding is now much more obvious to the bleeder.
/:cl:

Especially in fights, people are just completely missing normal size danger texts about spraying bleeds. This causes the person bleeding to a) have larger danger text than is shown to others, and b) be very gently stunned and vision blurred per spray.

Outdated text content, but example of size for the new user message.
![https://i.imgur.com/i6Vrtcy.png](https://i.imgur.com/i6Vrtcy.png)