### PR TITLE
Ports Downloader Bugfix

### DIFF
--- a/nano/templates/ntnet_downloader.tmpl
+++ b/nano/templates/ntnet_downloader.tmpl
@@ -89,10 +89,13 @@
 	{{if data.hackedavailable}}
 		<h2>*UNKNOWN* software repository</h2>
 		<i>Please note that NanoTrasen does not recommend download of software from non-official servers.</i>
+		<table>
 		{{for data.hacked_programs}}
-		<tr><td>{{:helper.link(value.filedesc, value.icon, {'PRG_downloadfile' : value.filename})}}	
-			<td>{{:value.fileinfo}}
-			<td>{{:value.size}} GQ
+			<tr><td>{{:helper.link('', value.icon, {'PRG_downloadfile' : value.filename})}}	
+				<td><span class='white'>{{:value.filedesc}}</span>
+				<td>{{:value.fileinfo}}
+				<td>{{:value.size}} GQ
 		</div>
 		{{/for}}
+		</table>
 	{{/if}}


### PR DESCRIPTION
Back when I was porting Modular Computers to Polaris, I found a bug with the downloader where antag programs were not listed properly. This fixes that.

:cl: Novacat
   tweak: Fixes a UI bug with the modular computer downloader and antag programs
   /:cl: