### PR TITLE
Remade Bridge Deck

### DIFF
--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -73,6 +73,27 @@
 	material = MATERIAL_WALNUT
 	reinforced = MATERIAL_WALNUT
 
+/obj/structure/table/woodentable_reinforced/walnut/maple
+	reinforced = MATERIAL_MAPLE
+
+/obj/structure/table/woodentable_reinforced/mahogany
+	icon_state = "reinf_preview"
+	color = WOOD_COLOR_RICH
+	material = MATERIAL_MAHOGANY
+	reinforced = MATERIAL_MAHOGANY
+
+/obj/structure/table/woodentable_reinforced/mahogany/walnut
+	reinforced = MATERIAL_WALNUT
+
+/obj/structure/table/woodentable_reinforced/ebony
+	icon_state = "reinf_preview"
+	color = WOOD_COLOR_BLACK
+	material = MATERIAL_EBONY
+	reinforced = MATERIAL_WALNUT
+
+/obj/structure/table/woodentable_reinforced/ebony/walnut
+	reinforced = MATERIAL_WALNUT
+
 /obj/structure/table/woodentable/mahogany
 	color = WOOD_COLOR_RICH
 	material = MATERIAL_MAHOGANY

--- a/maps/torch/items/manuals.dm
+++ b/maps/torch/items/manuals.dm
@@ -105,7 +105,11 @@
 	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - TORCH UMBRA'."
 
 /obj/item/weapon/folder/envelope/captain/Initialize()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/item/weapon/folder/envelope/captain/LateInitialize()
+	..()
 	var/obj/effect/overmap/torch = map_sectors["[z]"]
 	var/memo = {"
 	<tt><center><b><font color='red'>SECRET - CODE WORDS: TORCH</font></b>
@@ -139,7 +143,6 @@
 	<i>This paper has been stamped with the stamp of SCG Expeditionary Command.</i>
 	"}
 	new/obj/item/weapon/paper(src, memo, "Standing Orders")
-
 	new/obj/item/weapon/paper/umbra(src)
 
 /obj/item/weapon/folder/envelope/rep

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -138,9 +138,17 @@
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/combined/WillContain()
 	return list(
-		/obj/item/weapon/gun/energy/gun/small/secure = 2,
-		/obj/item/weapon/storage/belt/holster/general = 2,
-		/obj/item/weapon/gun/energy/gun/secure = 2,
+		/obj/item/weapon/storage/belt/holster/general = 3,
+		/obj/item/weapon/gun/energy/gun/secure = 3,
+		/obj/item/weapon/gun/energy/gun/small/secure = 1,
+	)
+
+/obj/structure/closet/secure_closet/guncabinet/PPE
+	name = "Bridge PPE cabinet"
+
+/obj/structure/closet/secure_closet/guncabinet/PPE/WillContain()
+	return list(
+		/obj/item/weapon/gun/energy/gun/small/secure = 3,
 		/obj/item/clothing/suit/armor/pcarrier/medium/command = 3,
 		/obj/item/clothing/head/helmet/solgov/command = 3
 	)

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -4782,6 +4782,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/airlock_sensor{
+	command = "cycle_exterior";
+	frequency = 1379;
+	id_tag = "engine_airlock_exterior_sensor";
+	master_tag = "engine_airlock";
+	pixel_x = -24;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "ks" = (
@@ -5057,11 +5065,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "kY" = (
-/obj/machinery/door/airlock/hatch{
-	frequency = 1379;
-	id_tag = "engine_airlock_exterior";
-	name = "Engine Airlock Exterior"
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -5069,6 +5072,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/door/airlock/hatch{
+	frequency = 1379;
+	id_tag = "engine_airlock_interior";
+	name = "Engine Airlock Interior"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -5082,27 +5090,28 @@
 	icon_state = "warning";
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "la" = (
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
-	id_tag = "engine_room_airlock";
+	cycle_to_external_air = 1;
+	id_tag = "engine_airlock";
 	name = "Engine Room Airlock";
 	pixel_x = 0;
 	pixel_y = 24;
 	tag_airpump = "engine_airlock_pump";
-	tag_chamber_sensor = "eng_al_c_snsr";
+	tag_chamber_sensor = "engine_airlock_sensor";
 	tag_exterior_door = "engine_airlock_exterior";
-	tag_exterior_sensor = "eng_al_ext_snsr";
+	tag_exterior_sensor = "engine_airlock_exterior_sensor";
 	tag_interior_door = "engine_airlock_interior";
-	tag_interior_sensor = "eng_al_int_snsr"
+	tag_interior_sensor = "engine_airlock_interior_sensor"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
-	id_tag = "eng_al_c_snsr";
+	id_tag = "engine_airlock_sensor";
 	pixel_x = -24;
 	pixel_y = 24
 	},
@@ -5115,7 +5124,7 @@
 	icon_state = "warning";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -5129,25 +5138,26 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "engine_airlock_pump"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lc" = (
-/obj/machinery/door/airlock/hatch{
-	frequency = 1379;
-	id_tag = "engine_airlock_interior";
-	name = "Engine Airlock Interior"
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	frequency = 1379;
+	id_tag = "engine_airlock_exterior";
+	name = "Engine Airlock Exterior"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -5449,39 +5459,35 @@
 	pixel_x = 5;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lQ" = (
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume{
-	dir = 8;
-	frequency = 1379;
-	id = "engine_airlock_pump"
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/camera/network/engine{
 	c_tag = "Engine - Access";
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lR" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "engine_airlock_pump_out_internal"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lT" = (
@@ -5729,18 +5735,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "mD" = (
-/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
-	id_tag = "engine_room_airlock";
-	name = "Engine Room Airlock";
-	pixel_x = 24;
-	pixel_y = 24;
-	tag_airpump = "engine_airlock_pump";
-	tag_chamber_sensor = "eng_al_c_snsr";
-	tag_exterior_door = "engine_airlock_exterior";
-	tag_exterior_sensor = "eng_al_ext_snsr";
-	tag_interior_door = "engine_airlock_interior";
-	tag_interior_sensor = "eng_al_int_snsr"
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -5755,6 +5749,14 @@
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 4
+	},
+/obj/machinery/airlock_sensor{
+	command = "cycle_interior";
+	frequency = 1379;
+	id_tag = "engine_airlock_interior_sensor";
+	master_tag = "engine_airlock";
+	pixel_x = 24;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3,19 +3,12 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Command Hallway - Center Fore Staboard";
-	dir = 4;
-	network = list("Bridge")
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "ac" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -50,23 +43,15 @@
 /obj/effect/floor_decal/solarpanel,
 /turf/simulated/floor/reinforced/airless,
 /area/solar/bridge)
-"ai" = (
-/obj/structure/largecrate,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
 "aj" = (
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"ak" = (
-/obj/structure/bed/chair/comfy/teal,
-/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
 "al" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/forestarboard)
 "am" = (
 /obj/random/closet,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
 "an" = (
@@ -157,22 +142,9 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/bridge)
-"ax" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
 "ay" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/catwalk,
+/obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "az" = (
@@ -202,69 +174,41 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "aA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/catwalk,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "aB" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/reagent_containers/food/drinks/flask{
-	pixel_x = 8
-	},
-/obj/item/clothing/mask/smokable/cigarette/cigar,
-/obj/item/weapon/storage/box/matches,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"aC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"aD" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"aD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "aE" = (
@@ -324,20 +268,18 @@
 /obj/effect/floor_decal/solarpanel,
 /turf/simulated/floor/reinforced/airless,
 /area/solar/bridge)
-"aJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
 "aK" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/cobed)
 "aL" = (
-/obj/structure/grille,
+/obj/structure/table/rack,
+/obj/random/tech_supply,
+/obj/random/maintenance/solgov,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "aM" = (
@@ -347,32 +289,18 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_x = -32;
+	req_access = newlist()
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/vending/wallmed1{
-	dir = 4;
-	name = "Emergency NanoMed";
-	pixel_x = -30;
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
-"aN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/maintenance/bridge/forestarboard)
 "aO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
@@ -481,91 +409,65 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "aY" = (
-/obj/structure/closet/secure_closet/CO,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"aZ" = (
-/obj/item/modular_computer/console/preset/civilian,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/uniform_vendor,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"ba" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"bb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/area/bridge/storage)
+"aZ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"ba" = (
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 4
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/xo)
+"bb" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "bc" = (
-/obj/structure/closet/secure_closet/XO,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
-"bd" = (
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Office"
-	},
-/obj/structure/sign/ecplaque{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"be" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"bf" = (
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/stamp/co,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/area/crew_quarters/heads/office/cl)
+"bd" = (
+/obj/structure/bed/chair/padded/beige{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"be" = (
+/obj/item/modular_computer/console/preset/command,
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/xo)
+"bf" = (
+/obj/structure/closet/secure_closet/bridgeofficer,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/button/remote/blast_door{
+	name = "Bridge Sensor Shroud Control";
+	pixel_x = -28;
+	req_access = list("ACCESS_BRIDGE");
+	id = "bridge sensors"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "bg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -628,15 +530,14 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/bridge/forestarboard)
 "bj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/effect/floor_decal/corner/b_green,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "bk" = (
 /obj/effect/floor_decal/corner/white/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -649,40 +550,53 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
 "bo" = (
-/obj/random/plushie/large,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "bq" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/co)
 "br" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "bs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/device/radio/intercom{
+/obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 21
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"bt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/obj/machinery/meter,
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "bx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -758,11 +672,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/bridge)
-"bG" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
 "bH" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -770,82 +679,129 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "bI" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
-"bM" = (
-/obj/machinery/keycard_auth/torch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/photocopier/faxmachine{
-	department = "CO"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"bN" = (
-/obj/item/modular_computer/console/preset/command,
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "captaindoor";
-	name = "Aft Office Door Control";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "captaindoorfore";
-	name = "Fore Office Door Control";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "xo_windows";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"bO" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/tableflag,
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"bQ" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/hallway/starboard)
-"bT" = (
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"bU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"bJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"bK" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"bN" = (
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"bO" = (
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"bP" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
+"bQ" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge entry star";
+	name = "Bridge Starboard Lockdown Window Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/xo)
+"bT" = (
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"bU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "bV" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/heads/office/xo)
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cl)
+"bX" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "cb" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -893,94 +849,61 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
-"cg" = (
-/obj/effect/floor_decal/corner/grey/three_quarters,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	anchored = 1;
-	department = "SolGov Representative"
-	},
-/obj/item/weapon/book/manual/solgov_law,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
 "ch" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Bridge Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
-"ci" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/maintenance/solgov,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
 "cj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/item/weapon/tableflag{
-	pixel_x = 4
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
-"ck" = (
-/obj/machinery/door/airlock/civilian{
-	name = "Head"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
-"cn" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"co" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/heads/office/co)
-"cp" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"cq" = (
-/obj/structure/bed/chair/comfy/captain{
-	icon_state = "capchair_preview";
-	dir = 4;
-	color = "#666666"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"cw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/light{
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"cl" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"co" = (
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"cp" = (
+/obj/structure/table/woodentable/mahogany,
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"cq" = (
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/beige{
+	icon_state = "comfychair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "cx" = (
 /obj/effect/paint/hull,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -989,6 +912,42 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
+"cF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Fore Port";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"cG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "cH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -1040,7 +999,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
 "cK" = (
 /obj/structure/cable/green{
@@ -1152,200 +1111,134 @@
 /turf/simulated/floor/airless,
 /area/solar/bridge)
 "cR" = (
-/obj/structure/table/rack,
-/obj/random/toolbox,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
-"cT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"cU" = (
-/obj/structure/filingcabinet,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"cW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"cX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"cZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"da" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/grille/broken,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"db" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/structure/table/woodentable/mahogany,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
-"dc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/shoot,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
-"dd" = (
-/obj/structure/sign/double/solgovflag/left{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"de" = (
-/obj/structure/filingcabinet/wallcabinet{
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/stamp/xo,
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"df" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"cS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/research{
+	id_tag = "csodoor";
+	name = "Chief Science Officer";
+	secured_wires = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "XO's Office";
-	sortType = "XO's Office"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"cT" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/cash,
+/obj/random/cash,
+/obj/random_multi/single_item/boombox,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"cV" = (
+/obj/item/modular_computer/console/preset/sysadmin{
+	icon_state = "console";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/power/apc/super/critical{
+	dir = 2;
+	is_critical = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"dc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor2";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"dd" = (
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/stamp/xo,
+/obj/structure/table/woodentable_reinforced/mahogany/walnut,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Command Hallway - Center Fore Staboard";
+	dir = 4;
+	network = list("Bridge")
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"dg" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"dg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/sol{
-	id_tag = "hopdoor";
-	name = "Executive Officer";
-	secured_wires = 1
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/xo)
 "dh" = (
-/obj/effect/floor_decal/scglogo,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/table/glass,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "di" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1384,16 +1277,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"dk" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/cl/backroom)
 "dm" = (
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_foyer)
 "dn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"dp" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "ce_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/ce)
 "dq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1552,85 +1458,142 @@
 /turf/simulated/floor/airless,
 /area/space)
 "dE" = (
-/obj/prefab/hand_teleporter,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "CO's Desk";
-	departmentType = 5;
-	name = "CO Request Console";
-	pixel_x = -30;
-	pixel_y = 32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"dF" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/item/device/flashlight/lamp/green,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dG" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"dH" = (
-/obj/structure/cable/green,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
 "dI" = (
-/obj/item/device/radio/intercom{
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -21
+	pixel_x = 21
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/camera/network/command{
+	c_tag = "Executive Officer - Quarters"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"dJ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"dJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/area/crew_quarters/heads/office/xo)
+"dM" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"dO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bridge entry port";
+	name = "Port Bridge Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/bridge/hallway/port)
+"dQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	icon_state = "spline_fancy_corner";
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"dR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"dN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/area/crew_quarters/heads/office/xo)
+"dT" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/obj/structure/flora/pottedplant/deskleaf{
+	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "dV" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarbridge)
@@ -1661,44 +1624,16 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/cockpit)
-"ed" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "cap_window";
-	name = "CO's Quarters Shutters"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/cobed)
 "ee" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	id = "cap_window";
-	name = "CO's Quarters Shutters"
-	},
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/cobed)
-"ef" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 1;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
+/obj/structure/closet/secure_closet/bridgeofficer,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "eg" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -1722,154 +1657,94 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_outer_chamber)
-"ek" = (
-/obj/structure/cable/green,
-/obj/machinery/shieldwallgen{
-	anchored = 1;
-	max_range = 21;
-	req_access = list("ACCESS_BRIDGE")
+"en" = (
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"eo" = (
-/obj/machinery/disposal,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/camera/network/command{
+	c_tag = "Executive Officer - Office"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/obj/structure/flora/pottedplant/fern,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
 "eq" = (
-/obj/structure/displaycase,
-/obj/item/weapon/gun/projectile/revolver/medium/captain{
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"es" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"et" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"ev" = (
 /obj/machinery/door/airlock/sol{
-	id_tag = "captaindoor";
-	name = "Commanding Officer";
+	name = "XO's Quarters";
 	secured_wires = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/xo)
+"er" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/co)
-"ex" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Commanding Officer";
-	sortType = "Commanding Officer"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"ey" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "xo_windows"
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/xo)
-"ez" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/xo)
-"eA" = (
-/obj/machinery/door/firedoor/border_only,
+/area/maintenance/bridge/forestarboard)
+"et" = (
 /obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/door/firedoor/border_only,
+/obj/item/weapon/material/bell,
 /obj/machinery/door/window/brigdoor/eastright{
-	dir = 1;
+	dir = 8;
 	name = "Executive Officer's Desk"
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 2;
-	icon_state = "right";
-	name = "Executive Officer's Desk"
-	},
-/obj/structure/noticeboard{
-	pixel_x = 32
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
 /obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
 	id = "hop_office_desk";
-	name = "XO Office Privacy Shutters";
-	opacity = 0
+	name = "XO Queue Privacy Shutters";
+	opacity = 1
 	},
-/obj/item/weapon/material/bell,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
+"ew" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"ey" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"ez" = (
+/obj/structure/bed/chair/padded/green{
+	icon_state = "chair_preview";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"eA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "eH" = (
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
@@ -1882,129 +1757,146 @@
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
-"eM" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8
+"eK" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/wall/r_wall/hull,
-/area/crew_quarters/heads/cobed)
-"eN" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"eM" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/bridge/storage)
+"eN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "eP" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge)
 "eQ" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	icon_state = "spline_fancy_corner";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"eR" = (
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"eS" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"eS" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
+	id = "hop_office_desk";
+	name = "XO Queue Privacy Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/xo)
 "eT" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -6
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/button/windowtint{
-	id = "co_windows";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
+/area/crew_quarters/heads/office/xo)
 "eU" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "eV" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/bridge/fore)
-"eY" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"eZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"fa" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"eY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"eZ" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"fb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"fc" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"fb" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"fc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "fd" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2108,6 +2000,21 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"fl" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/random/clipboard,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "fm" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -2163,90 +2070,52 @@
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_outer_chamber)
 "fu" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge Exterior - Starboard";
-	dir = 2
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/turf/simulated/wall/r_wall/hull,
+/area/maintenance/bridge/forestarboard)
 "fv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/bridge/storage)
-"fw" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fx" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fy" = (
-/obj/machinery/door/airlock/sol{
-	id_tag = "captaindoorfore";
-	name = "Commanding Officer";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/co)
-"fz" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/co)
-"fA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
+"fx" = (
+/obj/structure/sign/warning/secure_area{
+	pixel_y = -7
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/xo)
+"fz" = (
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "XO's Desk";
+	departmentType = 5;
+	name = "XO Request Console";
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "fB" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/fore)
@@ -2254,33 +2123,18 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"fE" = (
-/obj/effect/floor_decal/industrial/loading,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"fF" = (
+/obj/structure/flora/pottedplant/smelly{
+	desc = "This is some kind of tropical plant. It reeks of rotten eggs. This one has a hand-painted Nametag on the rim. It reads 'Steve'"
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "hop_office_desk";
-	name = "XO Office Privacy Shutters";
-	opacity = 0
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"fH" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
 "fI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
@@ -2312,6 +2166,23 @@
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
+"fN" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "fO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -2328,133 +2199,65 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
 "fP" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/sign/dedicationplaque{
-	desc = "S.E.V. Torch - Mako Class - Sol Expeditionary Corps Registry 95519 - Shiva Fleet Yards, Mars - First Vessel To Bear The Name - Launched 2560 - Sol Central Government - 'Never was anything great achieved without danger.' This one is printed on a cheap replica plaque.";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
 "fQ" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fR" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fS" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 2;
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"fT" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fU" = (
+"fR" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge - Entry Starboard"
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"fS" = (
+/obj/effect/floor_decal/corner/blue,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"fU" = (
+/obj/effect/floor_decal/corner/blue,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
 "fV" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
+"fW" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
 "fX" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -2467,43 +2270,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/medical)
-"fY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"fZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Bridge";
-	sortType = "Bridge"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "ga" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -2515,55 +2281,38 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "gb" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/hop,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/flora/pottedplant/large,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Executive Officer - Quarters"
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "gc" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/dogbed,
-/obj/random/plushie,
-/mob/living/simple_animal/corgi/Ian,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "gd" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"ge" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gf" = (
@@ -2572,7 +2321,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/alarm{
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -2581,16 +2332,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gg" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Science Officer's Office - Torch"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
 "gh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2617,26 +2367,25 @@
 "gi" = (
 /turf/simulated/wall/prepainted,
 /area/shield/bridge)
-"gj" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
 "gk" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gl" = (
@@ -2744,6 +2493,28 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_outer_chamber)
+"gv" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "repdoor";
+	name = "SCGR's Office Door Control";
+	pixel_x = 27;
+	pixel_y = 5;
+	req_access = list("ACCESS_TORCH_REPRESENTATIVE")
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 25;
+	pixel_y = -6;
+	id = "sgr_windows";
+	range = 11
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "gw" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
@@ -2751,29 +2522,39 @@
 "gz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftstarboard)
-"gA" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
+"gB" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"gB" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+"gC" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"gE" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"gF" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2781,9 +2562,63 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"gC" = (
-/obj/effect/floor_decal/corner/blue{
+"gG" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"gI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"gJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"gK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"gL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2791,150 +2626,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gD" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"gM" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gE" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gF" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gG" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"gJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"gK" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"gL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"gM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 8;
-	name = "Chief Engineer";
-	sortType = "Chief Engineer"
-	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -2961,34 +2675,41 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "gQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Starboard";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"gT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "gV" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external{
@@ -3101,96 +2822,110 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "hj" = (
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "hn" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "ho" = (
-/obj/machinery/door/airlock/glass/command{
-	id_tag = "starboardbridgedoor";
-	name = "Bridge";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
+/area/bridge/hallway/starboard)
 "hp" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "hq" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/meeting_room)
 "hr" = (
-/obj/machinery/door/airlock/command{
-	name = "Conference Room"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 10
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/area/bridge/hallway/starboard)
 "hs" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/meeting_room)
 "hu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 1
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "hv" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "hw" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 8
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/ce)
+/obj/machinery/atm{
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "hx" = (
 /obj/structure/sign/warning/high_voltage{
 	icon_state = "shock";
@@ -3198,40 +2933,25 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/ce)
-"hy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Chief Engineer";
-	secured_wires = 1
-	},
+"hz" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/ce)
-"hz" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "ce_windows"
-	},
-/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/engineering{
+	id_tag = "cedoor";
+	name = "Chief Engineer";
+	secured_wires = 1
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "hA" = (
 /obj/structure/cable/green{
@@ -3248,11 +2968,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "hE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "hF" = (
 /obj/structure/cable/green{
@@ -3271,6 +2991,14 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"hH" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Exterior";
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "hI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
@@ -3408,97 +3136,103 @@
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
 "hV" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Starboard"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/sol{
+	id_tag = "starboardbridgedoor";
+	name = "Bridge";
+	secured_wires = 1
 	},
-/obj/structure/closet/walllocker/emerglocker/north,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"hX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"hW" = (
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
+/area/bridge/hallway/starboard)
+"hX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "hZ" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"ia" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "ib" = (
-/obj/machinery/photocopier,
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/turf/simulated/wall/r_wall/prepainted,
+/area/bridge/meeting_room)
+"id" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
 	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"id" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "ie" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/ce)
-"if" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+"ig" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
 	},
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/button/windowtint{
 	id = "ce_windows";
 	pixel_x = -24;
@@ -3510,47 +3244,39 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
-"ig" = (
+"ih" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
-"ih" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "ii" = (
-/obj/machinery/photocopier,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "ij" = (
-/obj/machinery/papershredder,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
+/obj/structure/bed/chair/padded/yellow,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
-"ik" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "il" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -3580,12 +3306,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "ip" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -3712,6 +3439,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/passenger)
+"iB" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
 "iC" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -3727,104 +3464,73 @@
 "iE" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/turret_protected/ai)
-"iG" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
-/obj/structure/bed/chair/office/comfy/blue{
-	icon_state = "comfyofficechair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "iI" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"iJ" = (
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"iK" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"iM" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/meeting_room)
-"iN" = (
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"iO" = (
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_starboard"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"iP" = (
+/turf/simulated/floor/plating,
+/area/bridge)
+"iJ" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_starboard"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"iK" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/chair/padded/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"iM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"iN" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"iP" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "CE"
+	},
+/obj/machinery/recharger/wallcharger{
+	dir = 4;
+	icon_state = "wrecharger0";
+	pixel_x = -23;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "iQ" = (
 /turf/simulated/floor/tiled,
@@ -3835,56 +3541,33 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "iS" = (
-/obj/structure/table/steel,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd,
-/obj/structure/noticeboard{
-	pixel_x = 32
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
-"iT" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+"iU" = (
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Stairs";
-	dir = 4
-	},
-/obj/machinery/vending/cola{
-	icon_state = "Cola_Machine";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"iU" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -3892,55 +3575,50 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iX" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"iY" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"iY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "iZ" = (
@@ -3949,10 +3627,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -3974,6 +3655,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
+"jc" = (
+/obj/structure/drain,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
 "je" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -4039,6 +3724,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4117,18 +3803,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
-"jt" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/weapon/storage/box/donut,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"ju" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/heads/office/rd)
 "jw" = (
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
@@ -4138,144 +3812,121 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "jy" = (
-/obj/effect/floor_decal/corner/blue/full,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"jz" = (
-/obj/item/modular_computer/console/preset/command,
+/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/weapon/storage/secure/briefcase{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/secure/briefcase,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"jz" = (
+/obj/item/modular_computer/console/preset/command,
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 1
+	},
+/obj/machinery/button/remote/airlock{
+	name = "Bridge Access Starboard Door Control";
+	pixel_x = 38;
+	pixel_y = 24;
+	req_access = list("ACCESS_BRIDGE");
+	id = "starboardbridgeaccess"
+	},
+/obj/machinery/button/remote/airlock{
+	name = "Bridge Starboard Door Control";
+	pixel_x = 26;
+	pixel_y = 24;
+	req_access = list("ACCESS_BRIDGE");
+	id = "starboardbridgedoor"
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 24;
+	pixel_y = 34;
+	id = "bridge_starboard"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"jA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "jB" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridgehallway";
+	name = "Bridge Interior Hallway Shutters";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/bridge/hallway/port)
+"jH" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
 /obj/machinery/light{
-	dir = 8;
 	icon_state = "tube1";
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"jD" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+"jM" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/obj/structure/bed/chair/comfy/yellow{
+	icon_state = "comfychair_preview";
 	dir = 4
 	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"jE" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
+"jO" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
-	dir = 4;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "heads_meeting";
 	name = "Meeting Room Window Shutters";
 	opacity = 0
 	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"jG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"jH" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/ce)
-"jI" = (
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "CE"
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"jL" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
-"jM" = (
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/structure/closet/secure_closet/engineering_chief_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"jN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/vending/snack{
-	icon_state = "snack";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"jO" = (
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "jR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "jS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jT" = (
 /obj/structure/cable/green{
@@ -4283,17 +3934,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jU" = (
 /obj/structure/sign/directions/bridge{
@@ -4389,21 +4036,25 @@
 /turf/simulated/floor/tiled/freezer,
 /area/aquila/head)
 "kd" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "XO"
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "XO's Desk";
-	departmentType = 5;
-	name = "XO Request Console";
-	pixel_y = 30
-	},
 /obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/documents/nanotrasen,
+/obj/item/weapon/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/item/weapon/folder/envelope/blanks,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "ke" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4554,150 +4205,126 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/turret_protected/ai_outer_chamber)
-"ks" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/ship/engines{
-	icon_state = "computer";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"kt" = (
+"kv" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"kv" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"kx" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Conference Room";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"kB" = (
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
+/area/crew_quarters/heads/office/sea)
+"kw" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"kx" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"kA" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
 /obj/machinery/door/blast/shutters{
-	density = 0;
+	density = 1;
 	dir = 4;
-	icon_state = "shutter0";
-	id = "heads_meeting";
-	name = "Meeting Room Window Shutters";
-	opacity = 0
+	icon_state = "shutter1";
+	id = "hop_office";
+	name = "XO Office Privacy Shutters";
+	opacity = 1
 	},
 /turf/simulated/floor/plating,
-/area/bridge/meeting_room)
-"kD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atm{
-	pixel_x = 32
+/area/crew_quarters/heads/office/xo)
+"kE" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"kF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/structure/bed/chair/office/comfy/yellow{
-	tag = "icon-comfyofficechair_preview (NORTH)";
-	icon_state = "comfyofficechair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
-"kH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"kF" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 4;
+	name = "CE's Equipment Storage"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/weapon/rig/ce/equipped,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"kH" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Chief Engineer - Office";
 	dir = 1;
 	network = list("Command","Engineering")
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 6;
-	name = "Chief Engineer RC";
+/obj/structure/closet/secure_closet/engineering_chief_torch,
+/obj/machinery/button/remote/airlock{
+	name = "CE's Office Door Control";
+	desc = "A remote control-switch for the office door.";
 	pixel_x = 0;
-	pixel_y = -34
+	pixel_y = -27;
+	req_access = list("ACCESS_CHIEF_ENGINEER");
+	id = "cedoor"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "kI" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/machinery/door/window/brigdoor/westright{
-	name = "suit storage"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/item/toy/desk/newtoncradle,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
-/obj/structure/window/reinforced,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/weapon/rig/ce/equipped,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "kJ" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -4750,6 +4377,9 @@
 "kP" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "kQ" = (
@@ -4804,12 +4434,23 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
+"kV" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
+	id = "hop_office";
+	name = "XO Office Privacy Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/xo)
 "kW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
@@ -5018,35 +4659,26 @@
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_outer_chamber)
-"ll" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "lm" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/landmark{
+	name = "lightsout"
 	},
-/obj/structure/bed/chair/office/comfy/blue{
-	icon_state = "comfyofficechair_preview";
-	dir = 8
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "lo" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
+/obj/effect/floor_decal/scglogo,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -5062,59 +4694,57 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
-"lq" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "captaindoor";
-	name = "Command Chair"
+"lt" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"lr" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"lv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Fore";
-	dir = 8
-	},
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"lw" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/item/device/radio/intercom/department/security{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
-"ly" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"lz" = (
-/obj/item/modular_computer/console/preset/security,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"lu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"lx" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"ly" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"lz" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "lA" = (
 /obj/structure/sign/warning/high_voltage{
 	icon_state = "shock";
@@ -5123,34 +4753,37 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cmo)
 "lB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Aft";
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "lC" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/item/device/radio/beacon,
@@ -5177,9 +4810,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5187,6 +4817,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
@@ -5203,6 +4836,26 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
+"lL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass/command{
+	name = "Bridge Storage"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "lN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5256,6 +4909,20 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/aft)
+"lQ" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "lR" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
@@ -5285,13 +4952,36 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "lS" = (
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (WEST)";
-	icon_state = "corner_white";
-	dir = 8
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "bottom-right";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"lT" = (
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
+"lW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
 "lX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -5346,6 +5036,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
+"mc" = (
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "md" = (
 /obj/machinery/teleport/station,
 /obj/structure/sign/kiddieplaque{
@@ -5608,224 +5309,150 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
-"mC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
+"mz" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/security/bridgecheck)
-"mD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"mE" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cos)
-"mF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/structure/table/rack,
-/obj/item/device/radio,
-/obj/item/weapon/crowbar/prybar,
-/obj/item/device/binoculars,
-/obj/machinery/recharger/wallcharger{
-	dir = 4;
-	icon_state = "wrecharger0";
-	pixel_x = -23;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"mG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"mH" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"mI" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/bed/chair/office/comfy/red,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"mJ" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Head of Security - Office";
-	network = list("Command","Security")
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief of Security's Desk";
-	departmentType = 5;
-	name = "Chief of Security RC";
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/mono,
+/obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/keycard_auth/torch{
-	pixel_x = 38;
-	pixel_y = 0
+	pixel_x = 0;
+	pixel_y = -24
 	},
-/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/weapon/stamp/sea,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"mK" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/device/binoculars,
-/obj/structure/disposalpipe/segment,
-/obj/item/weapon/crowbar/prybar,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
-"mM" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cl)
-"mN" = (
+/area/crew_quarters/heads/office/sea)
+"mA" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"mO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 8;
-	name = "Security Checkpoint"
-	},
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Security Checkpoint"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
-	dir = 4;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "bridge_checkpoint_shutters";
 	name = "Bridge Deck Checkpoint Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/security/bridgecheck)
-"mP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"mC" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/vending/coffee{
+	icon_state = "coffee";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"mE" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/cos)
+"mG" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/item/device/radio,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/device/binoculars,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"mH" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/cos)
+"mI" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Head of Security - Office";
+	network = list("Command","Security")
+	},
+/obj/machinery/button/remote/airlock{
+	name = "COS's Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = 0;
+	pixel_y = 27;
+	req_access = list("ACCESS_HEAD_OF_SECURITY");
+	id = "cosdoor"
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/catwalk_plated,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/cos)
+"mJ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/item/weapon/stamp/cos,
+/obj/item/toy/figure/secofficer{
+	desc = "A 'Space Life' brand Security Officer action figure. This one seems rather old. A small heart is sewn into the armor vest."
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"mN" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/security/bridgecheck)
+"mO" = (
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 4
+	},
+/turf/simulated/wall/prepainted,
+/area/security/bridgecheck)
 "mQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"mR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass/civilian,
-/turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "mS" = (
 /obj/structure/cable/green{
@@ -5833,14 +5460,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
+"mT" = (
+/obj/structure/table/woodentable/walnut,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "mV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -5848,9 +5479,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -5869,17 +5497,10 @@
 	pixel_y = -28
 	},
 /obj/structure/cable/green,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "mX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
@@ -5960,49 +5581,19 @@
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "nf" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge)
-"ng" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge entry star";
-	name = "Starboard Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/starboard)
-"nh" = (
-/obj/effect/floor_decal/scglogo{
-	tag = "icon-center-right";
-	icon_state = "center-right"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "ni" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -6024,10 +5615,19 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "nj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "nk" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -6308,16 +5908,21 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "nG" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
+/obj/structure/filingcabinet/chestdrawer{
 	dir = 1
 	},
-/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/noticeboard{
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "nH" = (
@@ -6326,116 +5931,135 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"nJ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"nL" = (
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"nO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "heads_meeting";
-	name = "Meeting Room Window Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
-"nP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"nQ" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cos)
-"nU" = (
+"nI" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"nV" = (
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "COS"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/airlock/sol{
+	name = "Deliberation Room";
+	secured_wires = 0
 	},
-/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"nZ" = (
+/area/bridge/disciplinary_board_room/deliberation)
+"nJ" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 4
+	},
+/obj/machinery/button/remote/airlock{
+	name = "Bridge Access Port Door Control";
+	pixel_x = 38;
+	pixel_y = -26;
+	req_access = list("ACCESS_BRIDGE");
+	id = "portbridgeaccess"
+	},
+/obj/machinery/button/remote/airlock{
+	name = "Bridge Port Door Control";
+	pixel_x = 26;
+	pixel_y = -26;
+	req_access = list("ACCESS_BRIDGE");
+	id = "portbridgedoor"
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 24;
+	pixel_y = -35;
+	id = "bridge_port"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"nK" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/remote/airlock{
+	id = "bridgesafe_back";
+	name = "Emergency Exit door-control";
+	pixel_x = 25;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/effect/floor_decal/techfloor/orange,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"nM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"nN" = (
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"nU" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/table/steel,
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "bridge_checkpoint_shutters";
-	name = "Checkpoint Window Shutters";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "bridge_hallway_shutters";
-	name = "Hallway Checkpoint Shutters";
-	pixel_x = -3;
-	pixel_y = -4
-	},
-/obj/item/weapon/folder/red{
-	pixel_x = 6
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/cos)
+"nV" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/chair/comfy/red,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"nZ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/binoculars,
+/obj/item/weapon/crowbar/prybar,
+/obj/random/maintenance/solgov/clean,
+/obj/machinery/button/remote/blast_door{
+	name = "Checkpoint Window Shutters";
+	desc = "A remote control-switch for shutters.";
+	pixel_x = 26;
+	pixel_y = 25;
+	id = "bridge_checkpoint_shutters"
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Hallway Checkpoint Shutters";
+	desc = "A remote control-switch for shutters.";
+	pixel_x = 26;
+	pixel_y = 37;
+	id = "bridge_hallway_shutters"
+	},
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 4
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "oa" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6444,13 +6068,14 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ob" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "oc" = (
 /obj/structure/cable/green{
@@ -6458,21 +6083,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "oe" = (
-/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "cmo_windows"
 	},
@@ -6574,102 +6200,110 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
-"ov" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters,
-/obj/structure/bed/chair/office/comfy/blue{
-	icon_state = "comfyofficechair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "ox" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_port"
+	},
+/turf/simulated/floor/plating,
 /area/bridge)
 "oy" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"oB" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
-"oD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"oF" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/bed/chair/padded/red{
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"oG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/corner/red/mono,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_port"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"oz" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"oA" = (
+/obj/structure/lattice,
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Exterior - Starboard";
+	dir = 2
+	},
+/turf/space,
+/area/space)
+"oB" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/bridge/foreport)
+"oD" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "COS"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
+"oF" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/cos)
+"oG" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"oI" = (
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/papershredder,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"oJ" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "oK" = (
-/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 4;
@@ -6678,37 +6312,61 @@
 	name = "Bridge Deck Checkpoint Shutters";
 	opacity = 0
 	},
-/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/security/bridgecheck)
 "oO" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/papershredder,
-/obj/machinery/button/windowtint{
-	id = "cmo_windows";
-	pixel_x = -24;
-	pixel_y = 6;
-	range = 11
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -4
+	pixel_x = -23;
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "oP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "oR" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/closet/secure_closet/CMO_torch,
+/obj/structure/flora/pottedplant/overgrown,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
 /obj/machinery/camera/network/command{
 	c_tag = "Chief Medical Officer - Office";
 	network = list("Command","Medical")
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -6735,6 +6393,10 @@
 "oW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -6774,6 +6436,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
+"pe" = (
+/obj/structure/lattice,
+/obj/machinery/light/navigation/delay5,
+/turf/space,
+/area/space)
 "pf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6855,223 +6522,151 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "pq" = (
-/obj/machinery/computer/robotics{
-	icon_state = "computer";
-	dir = 1
-	},
+/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"pr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"pt" = (
-/obj/structure/table/steel,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
+/obj/item/weapon/pen/red,
 /obj/item/weapon/pen,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/weapon/hand_labeler,
-/obj/item/device/destTagger,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/sticky_pad/random,
+/obj/item/weapon/pen/blue,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"pu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/area/bridge)
+"pr" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"pt" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "pv" = (
-/obj/machinery/disposal,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/machinery/button/windowtint{
-	id = "meeting_windows";
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "heads_meeting";
-	name = "Conference Room Shutters Control";
-	pixel_x = 0;
-	pixel_y = -34
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall/prepainted,
 /area/bridge/meeting_room)
-"pw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"py" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 6
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"px" = (
 /obj/machinery/button/windowtint{
 	id = "cos_windows";
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/structure/flora/pottedplant/smelly,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
-"py" = (
+"pz" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"pz" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "pA" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "pB" = (
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"pC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/padded/red{
+	icon_state = "chair_preview";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
+/area/crew_quarters/heads/office/cos)
 "pE" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Security";
-	departmentType = 5;
-	pixel_y = -32
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/red/half,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "pF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 1
 	},
-/obj/random/maintenance/solgov/clean,
-/obj/structure/closet/secure_closet{
-	name = "Security Equipment Locker";
-	req_access = list("ACCESS_SECURITY")
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "pG" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4
+	},
+/turf/simulated/wall/prepainted,
 /area/security/bridgecheck)
-"pH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
 "pI" = (
+/obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "cmo_windows"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cmo)
 "pJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 2;
-	layer = 2.4;
-	level = 2
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -7079,27 +6674,16 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "pM" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "pQ" = (
@@ -7245,6 +6829,12 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
+"qa" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7277,51 +6867,63 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
 "qf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/scglogo{
-	tag = "icon-top-left";
-	icon_state = "top-left"
+	tag = "icon-top-right";
+	icon_state = "top-right"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "qg" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge entry star";
-	name = "Starboard Bridge Blast Doors";
-	opacity = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/glass/command{
-	autoset_access = 0;
-	dir = 8;
-	id_tag = "starboardbridgeaccess";
-	name = "Bridge Access";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/starboard)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "qh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/scglogo{
-	tag = "icon-bottom-left";
-	icon_state = "bottom-left"
+	tag = "icon-bottom-right";
+	icon_state = "bottom-right"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "qi" = (
@@ -7351,104 +6953,83 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "qj" = (
-/obj/machinery/door/airlock/glass/command{
-	id_tag = "portbridgedoor";
-	name = "Bridge";
-	secured_wires = 1
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
+/area/bridge/hallway/port)
 "qk" = (
-/obj/machinery/door/airlock/command{
-	name = "Conference Room"
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/guestpass{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"ql" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"ql" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "qm" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cos)
-"qn" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+"qo" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	id_tag = "cosdoor";
 	name = "Chief of Security";
 	secured_wires = 1
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"qo" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cos_windows"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cos)
 "qp" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "cos_windows"
@@ -7465,98 +7046,90 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cos)
-"qr" = (
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/bridgecheck)
-"qt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
+"qs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Chief Medical Officer";
-	sortType = "Chief Medical Officer"
-	},
-/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"qt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"qu" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/door/airlock/medical{
-	name = "Chief Medical Officer";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
 "qv" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blue,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qw" = (
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/security/bridgecheck)
 "qx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/reagent_containers/food/snacks/cookie,
+/obj/item/weapon/storage/lunchbox/cat,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qy" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/disposal,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"qz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"qA" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Exterior - Port";
+	dir = 1
+	},
+/turf/space,
+/area/space)
+"qB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
 "qD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/crew,
@@ -7587,6 +7160,7 @@
 /obj/random/tech_supply,
 /obj/machinery/firealarm{
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /obj/machinery/light/small{
@@ -7658,294 +7232,312 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/storage)
 "qP" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"qQ" = (
-/obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"qS" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
+"qQ" = (
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
+"qR" = (
+/obj/structure/flora/pottedplant/large,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"qS" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qT" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qU" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 23
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qV" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qW" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Entry Port";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qX" = (
-/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/airlock_sensor{
+	command = null;
+	id_tag = "bridge_safe_exterior_sensor";
+	master_tag = "bridge_safe";
+	pixel_x = 26;
+	pixel_y = -35
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qY" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bridge entry port";
+	name = "Port Bridge Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/multi_tile/glass/command{
+	autoset_access = 0;
+	dir = 8;
+	id_tag = "portbridgeaccess";
+	name = "Bridge Access";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/port)
 "ra" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"rb" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "rc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"rd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"re" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"rd" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"re" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rf" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rk" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"rl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Chief Science Officer";
-	sortType = "Chief Science Officer"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"rm" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"rg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"rk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"rl" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"rm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/structure/bed/chair/padded/teal{
-	icon_state = "chair_preview";
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
 	dir = 4
 	},
+/obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "rp" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/office/comfy/teal{
-	tag = "icon-comfyofficechair_preview (WEST)";
-	icon_state = "comfyofficechair_preview";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "rt" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/door/airlock/command{
+	name = "Conference Room"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "rv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8002,6 +7594,39 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
+"rz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"rA" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "bottom-left";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"rC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/item/toy/torchmodel,
+/obj/structure/table/woodentable_reinforced/mahogany/walnut,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
 "rE" = (
 /obj/structure/table/standard,
 /obj/item/weapon/defibrillator/loaded,
@@ -8031,99 +7656,62 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
 "rI" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"rJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
+/area/crew_quarters/heads/office/co)
+"rJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
 "rK" = (
-/obj/machinery/door/airlock/command{
-	name = "Bridge Storage"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"rL" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rM" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock/sol{
+	id_tag = "captaindoor";
+	name = "Commanding Officer";
+	secured_wires = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8138,86 +7726,77 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/co)
+"rL" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"rM" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "rN" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "rO" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "rP" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rQ" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Entry Port";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -28;
@@ -8225,109 +7804,46 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
+"rQ" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/safe_room/bridge)
 "rR" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rS" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"rW" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/vault/bolted{
+	frequency = 1379;
+	id_tag = "bridge_safe_exterior";
+	name = "Bridge Safe Room"
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 4;
-	name = "Bridge Conference Room";
-	sortType = "Bridge Conference Room"
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"rS" = (
+/obj/structure/sign/warning/detailed{
+	name = "\improper SECURE AREA";
+	icon_state = "securearea2";
+	dir = 1;
+	pixel_y = -4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"rX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/safe_room/bridge)
+"rT" = (
+/obj/structure/closet/toolcloset,
+/obj/random/action_figure,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/powercell,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
+"rV" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
+/obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
-	dir = 10
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -8337,20 +7853,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 4;
-	name = "Chief Of Security";
-	sortType = "Chief Of Security"
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/b_green,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rZ" = (
@@ -8359,22 +7870,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Corporate Liaison";
-	sortType = "Corporate Liaison"
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/blue{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -8384,64 +7889,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (WEST)";
-	icon_state = "corner_white";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"sb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/half,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"sc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "SolGov Representative";
-	sortType = "SolGov Representative"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
@@ -8453,11 +7911,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -8477,50 +7933,51 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"sg" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/research,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "sh" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/paleblue{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"si" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/hop,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"sl" = (
+/obj/structure/flora/pottedplant/shoot,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"sm" = (
+/obj/machinery/shipsensors,
+/turf/simulated/floor/reinforced/airless,
+/area/bridge/storage)
 "sn" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Secure Storage"
@@ -8592,162 +8049,87 @@
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_outer_chamber)
 "sx" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge Exterior - Port";
-	dir = 1
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/turf/simulated/wall/r_wall/hull,
+/area/maintenance/bridge/foreport)
 "sy" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"sz" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"sB" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/sea)
-"sD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"sE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Bridge Storage";
-	sortType = "Bridge Storage"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"sG" = (
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cl_windows"
+	id = "sea_windows"
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cl)
+/area/crew_quarters/heads/office/sea)
+"sz" = (
+/obj/machinery/door/airlock/sol{
+	id_tag = "seaforedoor";
+	name = "Senior Enlisted Advisor";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"sB" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/sea)
+"sC" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/military_law,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "sH" = (
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cl_windows"
+	id = "sgr_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/sgr)
+"sI" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "sgr_windows"
+	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cl)
-"sI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research{
-	id_tag = "liaisondoor";
-	name = "Corporate Liaison";
-	secured_wires = 1
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/cl)
+/area/crew_quarters/heads/office/sgr)
 "sJ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cl)
 "sL" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/sgr)
-"sM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/sol{
-	id_tag = "repdoor";
-	name = "SolGov Representative";
-	secured_wires = 1
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/sgr)
-"sN" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sgr_windows"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/sgr)
-"sO" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sgr_windows"
-	},
-/turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/sgr)
 "sP" = (
 /obj/structure/sign/warning/high_voltage{
@@ -8766,41 +8148,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/rd)
-"sR" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/rd)
 "sS" = (
+/obj/machinery/door/airlock/sol{
+	name = "Disciplinary Board Room";
+	secured_wires = 0
+	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Chief Science Officer";
-	secured_wires = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/crew_quarters/heads/office/rd)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
 "sT" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/rd)
@@ -8870,6 +8232,22 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
+"ta" = (
+/obj/machinery/door/airlock/command{
+	name = "Conference Room"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "tb" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -8927,256 +8305,190 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/foreport)
 "th" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge/storage)
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "ti" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/bridge)
 "tj" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
-"tk" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 1
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/safe_room/bridge)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "tm" = (
-/obj/machinery/door/airlock/sol{
-	id_tag = "seaforedoor";
-	name = "Senior Enlisted Advisor";
-	secured_wires = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/flora/pottedplant/unusual,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "to" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/safe_room/bridge)
 "tp" = (
+/obj/machinery/door/airlock/glass/command{
+	autoset_access = 0;
+	frequency = 1379;
+	id_tag = "bridge_safe_interior";
+	name = "Bridge Safe Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"ts" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "sgr_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/sgr)
+"tt" = (
 /obj/machinery/disposal,
-/obj/machinery/light{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"ts" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/device/camera{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/obj/item/weapon/hand_labeler,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"tt" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
 "tu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"tv" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"tv" = (
-/obj/machinery/disposal,
-/obj/machinery/light_switch{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "cl_windows";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"tw" = (
-/obj/machinery/disposal,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "sgr_windows";
-	pixel_x = 6;
-	pixel_y = 24;
-	range = 11
-	},
-/obj/effect/floor_decal/corner/grey/three_quarters{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/military_law,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"ty" = (
+/obj/structure/closet/secure_closet/representative,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/random/drinkbottle,
+/obj/structure/sign/warning/nosmoking_1{
+	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"tz" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/sticky_pad/random,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"tA" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/carafe,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+/obj/structure/sign/double/icarus/solgovflag/left{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"tB" = (
+/obj/structure/bed/chair/padded/blue,
+/obj/structure/sign/double/icarus/solgovflag/right{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"tC" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"ty" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"tz" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/device/camera{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/obj/item/weapon/hand_labeler,
-/obj/effect/floor_decal/corner/grey/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"tA" = (
-/obj/machinery/photocopier,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/research/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"tB" = (
-/obj/machinery/papershredder,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/research/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"tC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "tD" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
+/obj/structure/sign/double/icarus/solgovflag/left{
+	pixel_y = 32
 	},
-/obj/machinery/computer/rdconsole,
-/obj/machinery/button/windowtint{
-	id = "rd_windows";
-	pixel_x = 6;
-	pixel_y = 24;
-	range = 11
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/structure/bed/chair/padded/blue,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "tE" = (
-/obj/machinery/light{
+/obj/structure/sign/double/icarus/solgovflag/right{
+	pixel_y = 32
+	},
+/obj/structure/bed/chair/padded/blue,
+/obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 1
 	},
-/obj/machinery/computer/rdservercontrol,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "tH" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -9245,303 +8557,220 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_outer_chamber)
-"tQ" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/shieldwallgen{
-	anchored = 1;
-	max_range = 21;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
 "tR" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"tS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "tT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"tW" = (
-/obj/item/device/radio/intercom/entertainment{
-	pixel_y = 24
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/folder/blue,
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
-	},
-/obj/item/weapon/deck/cards,
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"tX" = (
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Safe Room"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
-	},
-/obj/machinery/button/remote/airlock{
-	id = "bridgesafedoor";
-	name = "safe room door-control";
-	pixel_x = 0;
-	pixel_y = 32;
-	specialfunctions = 4
-	},
-/obj/structure/bed/chair/padded/blue,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"tZ" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/machinery/button/windowtint{
-	id = "sea_windows";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"ua" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"tW" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/obj/structure/noticeboard{
-	pixel_y = 30
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"tX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"tZ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "ub" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
+	cycle_to_external_air = 1;
+	id_tag = "bridge_safe";
+	name = "Bridge Safe Room Airlock Controller";
+	pixel_x = -27;
+	pixel_y = 1;
+	tag_airpump = "bridge_safe_pump";
+	tag_chamber_sensor = "bridge_safe_sensor";
+	tag_exterior_door = "bridge_safe_exterior";
+	tag_exterior_sensor = "bridge_safe_exterior_sensor";
+	tag_interior_door = "bridge_safe_interior";
+	tag_interior_sensor = "bridge_safe_interior_sensor"
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -26;
+	pixel_y = 9;
+	id_tag = "bridge_safe_interior_sensor";
+	master_tag = "bridge_safe"
+	},
+/obj/machinery/suit_storage_unit/standard_unit{
+	req_access = newlist()
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"uc" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	icon_state = "map";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"ud" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 8;
+	start_pressure = 450
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"uc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/button/remote/airlock{
+	name = "safe room door-control";
+	pixel_x = 25;
+	pixel_y = 0;
+	id = "bridgesafe_front";
+	specialfunctions = 4
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"ug" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "sgr_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/sgr)
+"uh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"ui" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"ud" = (
-/obj/machinery/door/airlock/sol{
-	id_tag = "seaaftdoor";
-	name = "Senior Enlisted Advisor";
-	secured_wires = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"ue" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"uf" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"uj" = (
+/obj/structure/bed/chair/padded/blue,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Senior Enlisted Advisor";
-	sortType = "Senior Enlisted Advisor"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"ug" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"uh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"ui" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"uj" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/structure/closet/secure_closet/bodyguard,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
 "uk" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/flora/pottedplant/large,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/airlock/sol{
+	id_tag = null;
+	name = "SolGov Representative";
+	secured_wires = 1
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "ul" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "um" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "un" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/table/woodentable/walnut,
+/obj/structure/noticeboard{
+	pixel_y = -30
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 36;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/weapon/folder/envelope/rep,
+/obj/item/documents/scgr,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "uo" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/research/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
+/obj/structure/bed/chair/padded/red{
+	icon_state = "chair_preview";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "up" = (
-/obj/effect/floor_decal/corner/b_green,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"uq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 10
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "top-right";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"uq" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "center-right";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "us" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -9613,58 +8842,67 @@
 /turf/simulated/floor/airless,
 /area/aquila/maintenance)
 "ux" = (
-/obj/structure/closet/toolcloset,
-/obj/random/action_figure,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
+/obj/structure/sign/double/icarus/solgovflag/left{
+	dir = 4;
+	icon_state = "solgovflag-left";
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "uy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/wall/walnut,
+/area/crew_quarters/heads/cobed)
+"uz" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/flashlight/lamp/green,
+/obj/structure/noticeboard{
+	pixel_x = 32
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "uB" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/multitool,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"uC" = (
-/obj/structure/table/rack,
-/obj/item/device/megaphone,
-/obj/random/coin,
-/obj/random/technology_scanner,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"uE" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"uF" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"uC" = (
+/obj/item/weapon/reagent_containers/food/drinks/flask{
+	pixel_x = 8
+	},
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"uE" = (
+/obj/structure/bed/chair/padded/blue,
+/obj/structure/sign/double/icarus/solgovflag/left{
+	dir = 8;
+	icon_state = "solgovflag-left";
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "uG" = (
@@ -9672,169 +8910,118 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "uH" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
 "uI" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sea_windows"
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge - Safe Room";
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/sea)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
 "uJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
-	},
-/obj/structure/closet/hydrant{
+/obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "uK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
+/obj/machinery/atmospherics/valve/shutoff,
+/obj/machinery/alarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = -23;
+	pixel_y = 0
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"uL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"uM" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"uN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/structure/bed/chair/padded/green,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"uO" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Corporate Liaison - Office";
-	dir = 8;
-	network = list("Command")
-	},
-/obj/structure/filingcabinet,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"uP" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/grey{
 	dir = 9
+	},
+/obj/effect/floor_decal/industrial/shutoff,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"uM" = (
+/obj/effect/floor_decal/spline/plain/brown{
+	icon_state = "spline_plain";
+	dir = 1
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Sol Government Representative - Office";
 	dir = 4;
 	network = list("Command","Security")
 	},
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
-"uQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+"uN" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/effect/floor_decal/spline/plain/brown{
+	icon_state = "spline_plain";
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/structure/bed/chair/padded/blue,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"uR" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"uS" = (
+/obj/item/weapon/pen,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"uO" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/effect/floor_decal/spline/plain/brown{
+	icon_state = "spline_plain";
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/item/weapon/tableflag,
+/turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "uT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/hologram/holopad/longrange,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"uU" = (
-/obj/structure/bed/chair/padded/green,
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
+/obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"uU" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "top-center";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "uV" = (
 /obj/structure/sign/deck/bridge{
 	icon_state = "deck-b";
@@ -9843,9 +9030,18 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "uW" = (
-/obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "uX" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarbridge)
@@ -9888,11 +9084,19 @@
 /turf/simulated/floor/plating,
 /area/shield/bridge)
 "ve" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "vf" = (
 /obj/effect/floor_decal/scglogo{
 	tag = "icon-top-center";
@@ -9901,76 +9105,86 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "vg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge)
-"vh" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/storage)
-"vi" = (
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"vj" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"vk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"vl" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 9
+	dir = 1
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Senior Enlisted Advisor - Office";
-	dir = 4;
-	network = list("Command")
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/bridge)
+"vj" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Senior Enlisted Advisor - Office";
+	dir = 4;
+	network = list("Command")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"vk" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"vl" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/structure/sign/double/icarus/solgovflag/right{
+	dir = 8;
+	icon_state = "solgovflag-right";
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"vm" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
 "vn" = (
 /obj/structure/cable/cyan{
@@ -9981,26 +9195,16 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/passenger)
 "vp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sea_windows"
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/sea)
-"vr" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
 "vs" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -10010,75 +9214,48 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
 "vu" = (
-/obj/item/weapon/folder{
-	pixel_x = -4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/item/weapon/folder/red{
-	pixel_y = 3
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 4
 	},
-/obj/item/weapon/folder/blue{
-	pixel_x = 5
-	},
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/item/weapon/stamp/nt,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/item/sticky_pad/random,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "vv" = (
-/obj/item/weapon/folder{
-	pixel_x = -4
+/turf/simulated/wall/r_wall/prepainted,
+/area/bridge/disciplinary_board_room/deliberation)
+"vx" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/item/weapon/folder/red{
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/item/weapon/folder/blue{
-	pixel_x = 5
-	},
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/item/weapon/stamp/solgov,
-/obj/item/documents/scgr,
-/obj/item/sticky_pad/random,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "vy" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/noticeboard{
+	pixel_x = 32
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room/deliberation)
 "vE" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down{
@@ -10133,243 +9310,204 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"vM" = (
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"vN" = (
-/obj/structure/curtain/open/bed,
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
+"vO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"vO" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	target_pressure = 200
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"vP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"vQ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
+/obj/effect/floor_decal/corner/blue/three_quarters,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
-"vR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"vS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/bed/chair/office/comfy/blue{
-	tag = "icon-comfyofficechair_preview (NORTH)";
-	icon_state = "comfyofficechair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"vT" = (
+"vP" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "SEA"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"vU" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sea_windows"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/sea)
-"vV" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"vW" = (
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"vX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"vY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "liaisondoor";
-	name = "Office Door Control";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/structure/bed/chair/office/comfy/green{
-	tag = "icon-comfyofficechair_preview (NORTH)";
-	icon_state = "comfyofficechair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"wb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "repdoor";
-	name = "Office Door Control";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/structure/bed/chair/office/comfy/blue{
-	tag = "icon-comfyofficechair_preview (NORTH)";
-	icon_state = "comfyofficechair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"wc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"wd" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"we" = (
-/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"wf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/area/crew_quarters/heads/office/sea)
+"vQ" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/comfy/green{
-	tag = "icon-comfyofficechair_preview (NORTH)";
-	icon_state = "comfyofficechair_preview";
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"vS" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"vT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"vU" = (
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"vX" = (
+/obj/structure/filingcabinet/chestdrawer{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"vY" = (
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"vZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"wb" = (
+/obj/structure/bed/chair/padded/beige{
+	icon_state = "chair_preview";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"wg" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room/deliberation)
+"wc" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room/deliberation)
+"wd" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room/deliberation)
+"we" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
+"wf" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"wg" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/tableflag{
+	pixel_x = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHEAST)";
-	icon_state = "corner_white";
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "wh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/book/manual/military_law,
+/obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
-	dir = 1
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "wi" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -10588,216 +9726,186 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/bridge)
-"wv" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/hop,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
 "ww" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"wx" = (
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/blue/three_quarters,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Senior Enlisted Advisor's Desk";
-	departmentType = 6;
-	name = "Senior Enlisted Advisor RC";
-	pixel_x = 0;
-	pixel_y = -34
-	},
-/obj/structure/cable/green,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"wy" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
+/obj/structure/closet/secure_closet/sea,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/noticeboard{
+	pixel_x = -32
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control-switch for the office door.";
 	id = "seaforedoor";
-	name = "Fore Office Door Control";
+	name = "SEA's Office Door Control";
 	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "seaaftdoor";
-	name = "Aft Office Door Control";
-	pixel_x = 6;
-	pixel_y = -24
+	pixel_y = -25;
+	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
 	},
 /obj/machinery/button/windowtint{
-	id = "sea_windows";
-	pixel_x = 0;
-	pixel_y = -32
+	pixel_x = 9;
+	pixel_y = -24;
+	id = "sea_windows"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"wx" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/toy/bosunwhistle,
+/obj/item/sticky_pad/random,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
 "wz" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 4
 	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
 	},
-/obj/structure/closet/secure_closet/sea,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/toy/bosunwhistle,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
 "wA" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual/solgov_law,
-/obj/item/weapon/book/manual/sol_sop,
-/obj/item/weapon/book/manual/military_law,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
 "wB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"wC" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/liaison,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
 "wD" = (
-/obj/machinery/papershredder,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/photocopier/faxmachine{
+	anchored = 1;
+	department = "SolGov Representative"
 	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"wE" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
 	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/structure/flora/pottedplant/large,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
-"wH" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"wI" = (
-/obj/machinery/papershredder,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"wJ" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 10;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/corner/grey/three_quarters{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/representative,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
-"wL" = (
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"wN" = (
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"wE" = (
+/obj/structure/table/woodentable/walnut,
+/obj/structure/sign/double/icarus/solgovflag/right{
+	dir = 1;
+	icon_state = "solgovflag-right";
+	pixel_z = -32
 	},
-/obj/structure/disposalpipe/segment{
+/obj/item/weapon/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/item/weapon/hand_labeler,
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/device/camera{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"wH" = (
+/obj/structure/bed/chair/padded/beige{
+	icon_state = "chair_preview";
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/RD,
-/obj/effect/floor_decal/corner/b_green/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
-	icon_state = "corner_white_diagonal";
-	dir = 4
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"wO" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room/deliberation)
+"wI" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/b_green/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
-	icon_state = "corner_white_diagonal";
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room/deliberation)
+"wJ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room/deliberation)
+"wL" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
+"wM" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"wN" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/camera/network/command{
+	c_tag = "Disciplinary Board Room";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
 "wP" = (
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
@@ -10866,20 +9974,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarbridge)
-"wX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "wY" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -10889,12 +9983,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
-"xa" = (
-/obj/structure/closet/crate,
-/obj/random/junk,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
 "xb" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/solgov,
@@ -10904,18 +9992,21 @@
 "xc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/foreport)
-"xd" = (
+"xe" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/bed/chair/comfy/blue,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"xe" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/vault/bolted{
+	autoset_access = 0;
+	id_tag = "bridgesafe_back";
+	name = "Emergency Exit"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
 "xg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -11062,31 +10153,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"xp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/maintenance/bridge/foreport)
-"xq" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
 "xr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11132,78 +10198,46 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
-"xw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
 "xx" = (
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"xy" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"xy" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/bridge/foreport)
-"xz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
-"xA" = (
+"xz" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "xB" = (
@@ -11249,26 +10283,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
-"xG" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
-"xH" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
-"xI" = (
-/obj/structure/largecrate,
-/turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "xJ" = (
 /obj/structure/ladder,
@@ -11349,31 +10363,27 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (WEST)";
+	icon_state = "corner_white";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "xV" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/valve/shutoff{
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "xW" = (
 /obj/structure/cable/green{
@@ -11381,8 +10391,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -11390,56 +10400,52 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "xX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "xY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"xZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"xZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "ya" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
 	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Port"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -11449,77 +10455,45 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"yc" = (
+/obj/structure/catwalk,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "yd" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/valve/shutoff,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/shutoff,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"ye" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "yf" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_starboard"
 	},
-/obj/machinery/button/remote/airlock{
-	id = "starboardbridgedoor";
-	name = "Bridge Starboard Door Control";
-	pixel_x = 26;
-	pixel_y = 6
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge blast";
-	name = "Bridge Window Lockdown Control";
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge entry star";
-	name = "Starboard Bridge Entrance Lockdown Control";
-	pixel_x = 38;
-	pixel_y = -6
-	},
-/obj/machinery/button/remote/airlock{
-	id = "starboardbridgeaccess";
-	name = "Bridge Access Starboard Door Control";
-	pixel_x = 38;
-	pixel_y = 6;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/effect/floor_decal/scglogo{
-	tag = "icon-top-right";
-	icon_state = "top-right"
-	},
-/obj/structure/bed/chair/office/comfy/blue{
-	tag = "icon-comfyofficechair_preview (NORTH)";
-	icon_state = "comfyofficechair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/bridge)
+"yg" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/xo)
 "yh" = (
 /obj/effect/floor_decal/scglogo{
 	tag = "icon-bottom-center";
@@ -11533,17 +10507,6 @@
 /obj/machinery/suit_storage_unit/security/alt,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"yj" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
 "yk" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
@@ -11567,13 +10530,12 @@
 /area/aquila/medical)
 "yw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/structure/flora/pottedplant/overgrown,
+/obj/structure/table/glass,
+/obj/item/sticky_pad/random,
+/obj/item/weapon/storage/box/cups,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "yy" = (
@@ -11595,18 +10557,102 @@
 /obj/effect/shuttle_landmark/ninja/deck5,
 /turf/space,
 /area/space)
+"yD" = (
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"yL" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/structure/fireaxecabinet{
+	pixel_x = 32
+	},
+/obj/item/weapon/deck/cards,
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"yM" = (
+/obj/structure/sign/dedicationplaque{
+	desc = "S.E.V. Torch - Mako Class - Sol Expeditionary Corps Registry 95519 - Shiva Fleet Yards, Mars - First Vessel To Bear The Name - Launched 2302 - Sol Central Government - 'Never was anything great achieved without danger.'";
+	pixel_x = 0
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/bridge/storage)
+"yR" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
+"yS" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "yV" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/aftstarboard)
-"yZ" = (
-/obj/structure/disposalpipe/segment{
+"yW" = (
+/turf/simulated/wall/prepainted,
+/area/security/bridgecheck)
+"yY" = (
+/obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"yZ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
+"za" = (
+/obj/structure/closet/secure_closet/XO,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "zb" = (
 /obj/effect/shuttle_landmark/torch/deck5/guppy,
 /turf/space,
@@ -11621,24 +10667,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
-"zd" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/bed/chair/comfy/blue,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
 "ze" = (
-/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/weapon/material/ashtray/plastic,
+/obj/item/weapon/flame/lighter/random,
+/obj/random/smokes,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "zf" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -11647,67 +10683,69 @@
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "zg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable/green,
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge)
-"zh" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/button/remote/airlock{
-	id = "portbridgeaccess";
-	name = "Bridge Access Port Door Control";
-	pixel_x = 38;
-	pixel_y = -6;
-	req_access = list("ACCESS_BRIDGE")
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/button/remote/airlock{
-	id = "portbridgedoor";
-	name = "Bridge Port Door Control";
-	pixel_x = 26;
-	pixel_y = -6
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge blast";
-	name = "Bridge Window Lockdown Control";
-	pixel_x = 26;
-	pixel_y = 6
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 8
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge entry port";
-	name = "Port Bridge Entrance Lockdown Control";
-	pixel_x = 38;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/scglogo{
-	tag = "icon-bottom-right";
-	icon_state = "bottom-right"
-	},
-/obj/structure/bed/chair/office/comfy/blue,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"zh" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_port"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "zo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/half,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/catwalk_plated,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"zp" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 36;
+	pixel_y = 0
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "zq" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -11715,8 +10753,88 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"zE" = (
-/turf/simulated/wall/mahogany,
+"zz" = (
+/obj/effect/floor_decal/corner/white/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/command,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"zC" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/PDAs{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/ids,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/random/coin,
+/obj/random/firstaid,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"zD" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"zM" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 8;
+	name = "Security Checkpoint"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
+"zN" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"zP" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/folder/blue,
+/obj/machinery/light,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "zQ" = (
 /obj/structure/railing/mapped{
@@ -11726,9 +10844,38 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"zS" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"zT" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
 "zW" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
+"zY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "Ab" = (
 /obj/effect/shuttle_landmark/merc/deck5,
 /turf/space,
@@ -11746,43 +10893,36 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Ad" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/sign/double/solgovflag/right{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"Ae" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/bed/chair/office/comfy/blue{
-	icon_state = "comfyofficechair_preview";
+/obj/structure/bed/chair/comfy/beige{
+	icon_state = "comfychair_preview";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/heads/office/xo)
+"Ae" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Corporate Liaison - Office";
+	dir = 8;
+	network = list("Command")
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "Af" = (
-/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
 "Ag" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -11811,64 +10951,217 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Aj" = (
-/obj/structure/bed/chair{
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Am" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"An" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/machinery/light,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"Ao" = (
+/obj/structure/bed/chair/padded/green{
+	icon_state = "chair_preview";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "Aq" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 4;
-	name = "Security Checkpoint - Bridge Deck";
-	sortType = "Security Checkpoint - Bridge Deck"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Au" = (
-/obj/structure/grille,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
+"Av" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/random/drinkbottle,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"Aw" = (
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 8
+	},
+/turf/simulated/wall/r_wall/hull,
+/area/bridge)
+"Ax" = (
+/obj/structure/table/woodentable/mahogany,
+/obj/random/clipboard,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
 "Ay" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"AB" = (
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
 	},
-/obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/security/bridgecheck)
-"AI" = (
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
+/area/bridge)
+"AE" = (
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/structure/bed/chair/comfy/green,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"AH" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_starboard"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"AI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/vending/cola{
+	icon_state = "Cola_Machine";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "AN" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
+"AP" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "AR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -11886,21 +11179,37 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
-"Bb" = (
+"AX" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"AZ" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 6;
+	name = "Chief Engineer RC";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
 "Bc" = (
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Aquila"
@@ -11909,105 +11218,134 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Bd" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"Be" = (
+/obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Bf" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/flora/pottedplant/fern,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
-"Be" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Bf" = (
-/obj/structure/table/steel,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/weapon/paper/monitorkey,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
-"Bg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge)
-"Bh" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/computer/ship/sensors,
-/obj/structure/sign/ecplaque{
-	pixel_x = 29
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/rcd,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
 "Bi" = (
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_storage_unit/engineering/alt/sol,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"Bn" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
+"Bp" = (
+/obj/effect/floor_decal/corner/red/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/security/alt,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"Bs" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"Bu" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"By" = (
 /obj/structure/table/glass,
-/obj/random/clipboard,
-/obj/item/weapon/stamp/cmo,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "medbay emergency radio link"
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"BB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/button/remote/airlock{
+	name = "CL's Backroom Door Bolt Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = -26;
+	pixel_y = -7;
+	req_access = list("ACCESS_TORCH_CORPORATE_LIAISON");
+	id = "liaisondoor3";
+	specialfunctions = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"BE" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/button/remote/blast_door{
+	name = "Bridge Window Lockdown Control";
+	pixel_x = -30;
+	pixel_y = 0;
+	id = "bridge blast"
+	},
+/obj/item/weapon/storage/box/donut,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"BF" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"BB" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/bed/chair/office/comfy/blue{
-	tag = "icon-comfyofficechair_preview (EAST)";
-	icon_state = "comfyofficechair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"BC" = (
-/obj/structure/lattice,
-/obj/machinery/light/navigation/delay3,
-/turf/space,
-/area/space)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "BG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12031,10 +11369,43 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"BI" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "cap_window";
+	name = "CO's Quarters Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/co)
 "BO" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"BR" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"BV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "BW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -12050,10 +11421,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"Ca" = (
-/obj/random/junk,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
 "Cb" = (
 /obj/effect/shuttle_landmark/torch/deck5/aquila,
 /turf/space,
@@ -12081,29 +11448,40 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Cd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Ce" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 5
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
-"Ce" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/folder/envelope/captain,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
 "Cf" = (
-/obj/item/modular_computer/console/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "Cg" = (
@@ -12123,15 +11501,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
 "Ch" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/bed/chair/comfy/captain{
+	color = "#666666";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "center-left"
 	},
-/obj/effect/overmap/ship/torch,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -12145,6 +11536,43 @@
 /obj/machinery/suit_storage_unit/medical/alt/sol,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"Cj" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
+"Ck" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"Cl" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "CO's Desk";
+	departmentType = 5;
+	name = "CO Request Console";
+	pixel_x = -30;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
 "Cn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12163,9 +11591,49 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"Cr" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "Cs" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/bridgecheck)
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/item/weapon/paper/monitorkey,
+/obj/item/sticky_pad/random,
+/obj/effect/floor_decal/corner/yellow/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"Cv" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
+"Cx" = (
+/obj/machinery/uniform_vendor{
+	icon_state = "uniform";
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "CD" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -12179,6 +11647,17 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/airlock)
+"CE" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "CH" = (
 /obj/structure/sign/directions/bridge{
 	dir = 8;
@@ -12192,14 +11671,35 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
+"CJ" = (
+/obj/structure/sign/warning/secure_area{
+	icon_state = "securearea";
+	dir = 1
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/ce)
 "CN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftport)
 "CO" = (
 /turf/simulated/wall/r_wall/hull,
 /area/aux_eva)
+"CP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
 "CU" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12208,12 +11708,42 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/monotile,
 /area/maintenance/bridge/aftport)
 "CV" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"CW" = (
+/obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/item/weapon/material/ashtray/bronze,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"CX" = (
+/obj/structure/bed/chair/padded/green{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"CZ" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridgehallway";
+	name = "Bridge Interior Hallway Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/bridge/hallway/port)
 "Db" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Head"
@@ -12247,76 +11777,30 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Dd" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "De" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/structure/flora/pottedplant/bamboo,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"Df" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/stamp/ce,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"Dg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/sol{
-	name = "XO's Quarters";
-	secured_wires = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
-"Dh" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/structure/sign/dedicationplaque{
-	desc = "S.E.V. Torch - Mako Class - Sol Expeditionary Corps Registry 95519 - Shiva Fleet Yards, Mars - First Vessel To Bear The Name - Launched 2560 - Sol Central Government - 'Never was anything great achieved without danger.' The protective housing of the plaque has been sunken into the floor.";
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
-"Dj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Disciplinary Board Room Maintenance Access"
+/area/bridge/storage)
+"Dg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/disciplinary_board_room)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "Dq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack{
@@ -12348,39 +11832,106 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Dr" = (
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"Dw" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"DJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Dt" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aux_eva)
+"Du" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/obj/structure/table/rack,
+/obj/item/weapon/aicard,
+/obj/item/weapon/pinpointer,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"Dw" = (
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Dx" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "co_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/co)
+"DE" = (
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/bridge/storage)
+"DH" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"DI" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "DN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/bridge/aft)
+"DQ" = (
+/obj/structure/bed/chair/comfy/captain{
+	icon_state = "capchair_preview";
+	dir = 4;
+	color = "#666666"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "DR" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/head)
+"DY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"DZ" = (
+/obj/structure/flora/pottedplant/tall,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
 "Eb" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "Shield Generator - Bridge Deck"
@@ -12401,66 +11952,33 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "Ed" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Executive Officer - Office"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Ee" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"Ef" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/secure_closet/cos,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "Eh" = (
-/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue{
-	dir = 6
+	dir = 1
 	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 38;
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 16
-	},
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"Ej" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = -34
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/area/bridge/hallway/starboard)
 "El" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12482,11 +12000,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"Ey" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -35
+"En" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"Ey" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
@@ -12494,11 +12014,11 @@
 	},
 /obj/machinery/light,
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/maintenance/bridge/aftport)
 "Ez" = (
@@ -12526,39 +12046,60 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
-"EN" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "CMO"
-	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"EX" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
-"Fb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Starboard";
+"EJ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
 	dir = 1
 	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"EN" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/closet/secure_closet/CMO_torch,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/sign/goldenplaque/medical{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/item/weapon/storage/belt/medical,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"EV" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"Fb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow/half,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "Fc" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -12587,110 +12128,144 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/airlock)
-"Fd" = (
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
+"Fe" = (
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"Fe" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Ff" = (
+/obj/structure/closet/secure_closet/cos,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/recharger/wallcharger{
+	dir = 4;
+	icon_state = "wrecharger0";
+	pixel_x = -23;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"Fg" = (
+/obj/structure/bed/chair/comfy/captain{
+	icon_state = "capchair_preview";
+	dir = 4;
+	color = "#666666"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"Ff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
+"Fh" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"Fg" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/bridge/storage)
+/area/maintenance/bridge/foreport)
 "Fi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "Fj" = (
+/obj/machinery/computer/rdservercontrol{
+	icon_state = "computer";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Fl" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
+"Fn" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "bottom-center";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"Fn" = (
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
 "Fp" = (
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
+"Fy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "Fz" = (
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"FE" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"FG" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "XO"
+	},
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/structure/table/woodentable_reinforced/mahogany/walnut,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
 "FK" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
-"FW" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+"FL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
-/obj/structure/reagent_dispensers/water_cooler{
-	icon_state = "water_cooler";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Gb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Port"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -12702,75 +12277,51 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/head)
-"Gd" = (
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
 "Ge" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/item/weapon/pen,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "Gf" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/obj/item/weapon/stamp/cos,
-/obj/item/device/flashlight/lamp/green{
-	dir = 2;
-	pixel_x = 10;
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "Gg" = (
-/obj/machinery/hologram/holopad/longrange,
-/obj/effect/landmark{
-	name = "lightsout"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"Gh" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 38;
-	pixel_y = 0
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/item/weapon/pen/blue,
-/obj/item/weapon/pen/red,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -16
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"Gh" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "Gi" = (
 /obj/random/closet,
 /obj/random/maintenance/solgov,
@@ -12778,15 +12329,82 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
 "Gj" = (
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Gk" = (
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"Gn" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"Gr" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc/super{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/area/bridge/storage)
+"Gs" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"Gy" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cl)
 "GI" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -12799,129 +12417,106 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"GW" = (
-/obj/structure/hygiene/shower{
-	icon_state = "shower";
-	dir = 4
+"GU" = (
+/obj/structure/displaycase,
+/obj/item/weapon/gun/projectile/revolver/medium/captain{
+	pixel_y = -3
 	},
-/obj/item/weapon/soap/deluxe,
-/obj/item/weapon/bikehorn/rubberducky,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
-"GX" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"GY" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Quarters"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"GZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"Ha" = (
-/obj/machinery/door/airlock/sol{
-	name = "CO's Quarters";
-	secured_wires = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/co)
-"Hb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"GV" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
 	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/xo)
-"Hc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"Hd" = (
-/obj/machinery/papershredder,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/cable/green,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"He" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
-"Hf" = (
-/obj/machinery/button/remote/blast_door{
-	id = "cap_window";
-	name = "CO's Quarters shutter control";
-	pixel_x = -24;
-	pixel_y = 6
+/area/bridge)
+"GW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"GX" = (
+/obj/machinery/vending/wallmed1{
+	pixel_x = 0;
+	pixel_y = 32;
+	products = list(/obj/item/stack/medical/bruise_pack = 6, /obj/item/stack/medical/ointment = 6, /obj/item/weapon/reagent_containers/pill/paracetamol = 8, /obj/item/weapon/storage/med_pouch/trauma = 4, /obj/item/weapon/storage/med_pouch/burn = 2, /obj/item/weapon/storage/med_pouch/oxyloss = 2, /obj/item/weapon/storage/med_pouch/toxin = 2)
 	},
-/obj/item/weapon/storage/photo_album{
-	pixel_y = -10
+/obj/machinery/computer/mecha,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"GY" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
-/obj/item/device/camera,
-/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/modular_computer/console/preset/command,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"GZ" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/machinery/computer/robotics,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"Hb" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/area/crew_quarters/heads/office/cl)
+"Hc" = (
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"He" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cl)
+"Hf" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "Hg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -12944,131 +12539,176 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "Hh" = (
-/obj/structure/flora/pottedplant/orientaltree,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
 "Hi" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"Hm" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/power/apc/high{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "Ho" = (
+/obj/machinery/door/airlock/sol{
+	id_tag = "hopdoor";
+	name = "Executive Officer";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "co_windows"
-	},
-/turf/simulated/floor/plating,
-/area/bridge/hallway/starboard)
-"Hp" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "co_windows"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
-"Hq" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "co_windows"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/xo)
+"Hp" = (
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge entry star";
+	name = "Bridge Starboard Lockdown Window Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
+/area/crew_quarters/heads/office/xo)
 "Hs" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bridge entry star";
+	name = "Starboard Bridge Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/bridge/hallway/starboard)
+"Ht" = (
+/obj/item/weapon/soap/deluxe,
+/obj/item/weapon/bikehorn/rubberducky,
+/obj/structure/hygiene/shower{
+	icon_state = "shower";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
+"Hu" = (
+/obj/effect/floor_decal/corner/blue,
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"Hu" = (
-/obj/effect/wallframe_spawn/reinforced,
+"Hv" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/bridge)
-"Hx" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -8;
-	pixel_y = 24
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder/blue,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"HA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
+"Hx" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"Hz" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "HC" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"HD" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
-/obj/item/weapon/storage/secure/briefcase{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HE" = (
@@ -13079,151 +12719,150 @@
 /turf/simulated/wall/r_wall/hull,
 /area/bridge)
 "HF" = (
+/obj/item/modular_computer/console/preset/dock,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"HH" = (
-/obj/structure/window/reinforced{
+"HG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor3";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"HH" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-top-left";
+	icon_state = "top-left"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/bridge)
+"HI" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
 /area/bridge)
 "HK" = (
-/obj/machinery/computer/ship/helm{
-	icon_state = "computer";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"HN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"HO" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/flashlight,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/overmap/ship/torch,
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HP" = (
+/obj/item/modular_computer/console/preset/supply{
+	icon_state = "console";
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "HS" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"HT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Bridge"
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Bridge";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_x = 30;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HU" = (
-/obj/machinery/computer/mecha{
-	icon_state = "computer";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"HW" = (
 /obj/structure/table/glass,
-/obj/item/weapon/book/manual/sol_sop,
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = -38
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Bridge"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"HX" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Port";
-	dir = 1
+"HW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/closet/walllocker/emerglocker/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"HY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"Ia" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"HX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/sol{
+	id_tag = "portbridgedoor";
+	name = "Bridge";
+	secured_wires = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
+/area/bridge)
+"HY" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "Ib" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -13237,422 +12876,269 @@
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
 "Ic" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
+/obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "Id" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/r_wall/hull,
-/area/bridge/storage)
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "Ie" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall/hull,
 /area/bridge)
 "If" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/bridge)
-"Ig" = (
-/obj/structure/table/steel,
-/obj/random/cash,
-/obj/random/cash,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random_multi/single_item/boombox,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Ih" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/secure_closet/bridgeofficer,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Ii" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Ij" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"Ik" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "sea_windows"
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/sea)
-"Il" = (
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Im" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"In" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/bridge/storage)
-"Io" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/box/PDAs{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/ids,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Ip" = (
-/obj/machinery/door/airlock/vault/bolted{
-	id_tag = "bridgesafedoor";
-	name = "Bridge Safe Room"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/safe_room/bridge)
-"Iq" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
+/obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 8
-	},
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"Ir" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"Is" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"It" = (
-/obj/structure/closet/crate,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/powercell,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"Iu" = (
-/obj/structure/closet/hydrant{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"Iv" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"Iw" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"Ix" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6;
-	icon_state = "intact"
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"Iy" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"Iz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"IA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"IB" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Safe Room Atmospherics"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"IC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"ID" = (
-/obj/structure/closet/medical_wall/filled{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/random/firstaid,
-/obj/random/firstaid,
-/obj/random/medical,
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"IE" = (
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/safe_room/bridge)
-"IF" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/sea)
-"IG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/structure/closet/crate/freezer/rations,
-/obj/random/drinkbottle,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"IH" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"II" = (
-/obj/machinery/computer/ship/navigation{
-	icon_state = "computer";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"Ig" = (
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
+"Ih" = (
+/obj/item/weapon/stamp/co,
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
+"Ii" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
+"Ik" = (
+/obj/machinery/button/remote/airlock{
+	name = "safe room door-control";
+	pixel_x = -25;
+	pixel_y = 0;
+	id = "bridge_safe_exterior";
+	specialfunctions = 4
+	},
+/obj/machinery/access_button/airlock_exterior{
+	name = "Exterior access button";
+	pixel_x = -26;
+	pixel_y = 9;
+	master_tag = "bridge_safe"
+	},
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "bridge_safe";
+	name = "Interior access button";
+	pixel_x = -26;
+	pixel_y = -9
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	icon_state = "techfloororange_edges";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"In" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
+"Io" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/co)
+"Ip" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"Iq" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/military_law,
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"Is" = (
+/obj/structure/bed/chair/padded/blue,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"Iv" = (
+/obj/machinery/door/airlock/sol{
+	name = "CO's Quarters";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"Iz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "CO - Quarters"
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"IA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"IB" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/military_law,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"IE" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "SEA"
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Senior Enlisted Advisor's Desk";
+	departmentType = 6;
+	name = "Senior Enlisted Advisor RC";
+	pixel_x = 0;
+	pixel_y = -34
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"IF" = (
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"IG" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"IH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "IJ" = (
 /obj/effect/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -13661,6 +13147,19 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"IK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/bridge/fore)
 "IL" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -13673,36 +13172,80 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
+"IN" = (
+/obj/structure/flora/pottedplant/smallcactus{
+	desc = "This is a small cactus. Its needles are sharp. It seems neglected, as if no one loves it."
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/effect/floor_decal/corner/yellow/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"IO" = (
+/obj/structure/bed/chair/comfy/green,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "IT" = (
-/obj/structure/closet,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/item/device/taperecorder,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
+/obj/structure/table/glass,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/item/weapon/folder/envelope/blanks,
+/obj/item/sticky_pad/random,
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "csodoor";
+	name = "CSO's Office Door Control";
+	pixel_x = 28;
+	pixel_y = 28;
+	req_access = list("ACCESS_RESEARCH_DIRECTOR")
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "IW" = (
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_storage_unit/atmos/alt/sol,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"Jb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Fore Port";
-	dir = 8
+"IY" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
+/obj/item/sticky_pad/random,
+/obj/item/device/destTagger,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/obj/effect/catwalk_plated,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Jc" = (
 /obj/machinery/power/apc{
@@ -13723,31 +13266,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shield/bridge)
-"Jd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
 "Je" = (
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/cobed)
-"Jf" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/structure/filingcabinet,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "Jg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -13765,58 +13287,60 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "Jh" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/storage/secure/briefcase/nukedisk,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "Ji" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "Jj" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/structure/bed/chair/padded/green{
+	icon_state = "chair_preview";
+	dir = 1
 	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "Jo" = (
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
-"Jr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Jp" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
+/area/maintenance/bridge/forestarboard)
+"Js" = (
+/obj/structure/lattice,
+/obj/machinery/light/navigation/delay2,
+/turf/space,
+/area/space)
 "Jt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "JA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13833,55 +13357,46 @@
 	},
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
-"JD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"JB" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
 	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "JE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
+"JF" = (
+/obj/structure/grille,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "JG" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"JK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"JP" = (
-/turf/simulated/wall/prepainted,
-/area/crew_quarters/heads/office/rd)
 "JT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -13889,36 +13404,48 @@
 "JV" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
+"JX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"Ka" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cl)
+"Kb" = (
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = -6
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/rd)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/airlock)
 "Kd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Ke" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"Ke" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "Kf" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
-/obj/item/weapon/storage/medical_lolli_jar,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "Kg" = (
@@ -13939,28 +13466,31 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/turret_protected/ai_outer_chamber)
 "Kh" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aicard,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/weapon/pinpointer,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
+/obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/matches,
+/obj/random/smokes,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "Kj" = (
-/obj/item/device/radio/intercom{
+/obj/effect/floor_decal/corner/b_green/diagonal{
+	tag = "icon-corner_white_diagonal (EAST)";
+	icon_state = "corner_white_diagonal";
+	dir = 4
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Science Officer - Office";
 	dir = 8;
-	pixel_x = 21
+	network = list("Command","Research")
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "Km" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -13981,19 +13511,96 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"Kq" = (
+/obj/structure/closet/secure_closet/CO,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
+"Ks" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Kt" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-bottom-left";
+	icon_state = "bottom-left"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "Ku" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atm{
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"Kv" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cos)
-"Kx" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"KB" = (
+/obj/structure/largecrate,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"KC" = (
+/obj/structure/flora/pottedplant/bamboo,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"KG" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "KH" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -14016,43 +13623,40 @@
 "KP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/folder/white{
-	pixel_y = 10
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = -24
 	},
-/obj/item/weapon/pen,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/random/clipboard,
+/obj/item/weapon/stamp/cmo,
+/obj/item/device/radio{
+	frequency = 1487;
+	name = "medbay emergency radio link"
 	},
-/obj/machinery/light,
-/obj/item/sticky_pad/random,
+/obj/machinery/button/remote/airlock{
+	name = "CMO's Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = -5;
+	pixel_y = -35;
+	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER");
+	id = "cmodoor"
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 7;
+	pixel_y = -34;
+	id = "cmo_windows";
+	range = 11
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"KR" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+"KX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/open,
-/area/maintenance/bridge/foreport)
-"KU" = (
-/obj/structure/lattice,
-/obj/machinery/light/navigation,
-/turf/space,
-/area/space)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "KZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning,
+/obj/random/plushie/large,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "La" = (
@@ -14069,76 +13673,31 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "Lb" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Science Officer - Office";
-	dir = 8;
-	network = list("Command","Research")
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/item/device/paicard,
-/obj/structure/table/glass,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/nt,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"Lc" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"Ld" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Le" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "hop_office_desk";
-	name = "XO Office Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 1
-	},
+/area/bridge/disciplinary_board_room)
+"Ld" = (
+/obj/item/weapon/stool/padded,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"Lf" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"Le" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/cl)
 "Lg" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -14165,21 +13724,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "Lh" = (
-/obj/structure/table/glass,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/item/weapon/stamp/rd,
-/obj/item/weapon/pen,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "Li" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -14210,22 +13762,27 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"Lp" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
-	},
+"Lk" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"Ll" = (
+/obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Conference Room";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"Lp" = (
+/obj/structure/sign/warning/secure_area,
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/cos)
 "Lr" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14247,19 +13804,95 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
+"Lt" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"Lv" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (WEST)";
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/item/weapon/book/manual/nt_regs,
+/obj/item/weapon/stamp/rd,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Lw" = (
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry port";
+	name = "Port Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = -42;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry star";
+	name = "Starboard Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = -24;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridgehallway";
+	name = "Bridge Internal Hallway Lockdown Control";
+	pixel_x = 25;
+	pixel_y = -33;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "heads_meeting";
+	name = "Bridge Meeting Room Shutters Control";
+	pixel_x = 39;
+	pixel_y = -33;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"LJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "LM" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "LN" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
+/obj/structure/table/woodentable/mahogany,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
+"LP" = (
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "Ma" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -14268,18 +13901,15 @@
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
 "Mb" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/vehicle/bike/gyroscooter,
-/obj/effect/floor_decal/corner/b_green/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
-	icon_state = "corner_white_diagonal";
+/obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "Mc" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
@@ -14302,73 +13932,34 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
-"Md" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
-	pixel_x = 3;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
+"Mf" = (
+/obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/item/weapon/folder/envelope/captain,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"Mh" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "top-left";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
-"Me" = (
-/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"Mi" = (
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge sensors";
-	name = "Bridge Sensor Shroud Control"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
-"Mf" = (
-/obj/structure/closet/secure_closet/bridgeofficer,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Mg" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"Mh" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/item/weapon/folder/envelope/blanks,
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"Mi" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 36;
-	pixel_y = 0
-	},
-/obj/random/action_figure,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/cobed)
 "Mj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14384,6 +13975,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"Mn" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief of Security's Desk";
+	departmentType = 5;
+	name = "Chief of Security RC";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
 "Mq" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 2;
@@ -14398,42 +14006,59 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "Mr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Aft";
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"Mt" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/weapon/book/manual/nt_regs,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "Mw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
+"Mz" = (
+/turf/simulated/wall/r_wall/hull,
+/area/crew_quarters/heads/office/co)
+"MA" = (
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
+"MB" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 25
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "MD" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"MF" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
 "MU" = (
 /obj/machinery/light{
 	dir = 4
@@ -14444,22 +14069,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
-"Nb" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Science Officer's Desk";
-	departmentType = 5;
-	name = "Chief Science Officer RC";
-	pixel_x = -2;
-	pixel_y = -30
-	},
+"MV" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Nb" = (
+/obj/structure/bed/chair/comfy/captain{
+	icon_state = "capchair_preview";
+	dir = 1;
+	color = "#666666"
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
 "Nc" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -14479,58 +14109,79 @@
 /area/aquila/airlock)
 "Nd" = (
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/blue/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cl)
 "Ne" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Nf" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/cobed)
-"Nf" = (
-/obj/machinery/light,
-/obj/structure/closet/secure_closet/bridgeofficer,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "Ng" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge sensors";
-	name = "Sensor Shroud"
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "captaindoor";
+	name = "Aft Office Door Control";
+	pixel_x = 6;
+	pixel_y = 24
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/bridge)
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "captaindoorfore";
+	name = "Fore Office Door Control";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "CO"
+	},
+/obj/machinery/button/windowtint{
+	id = "co_windows";
+	pixel_x = 6;
+	pixel_y = 33
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "CO's Office Window Blast Door Control";
+	pixel_x = -6;
+	pixel_y = 33;
+	id = "cap_window"
+	},
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "Nh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
 	pixel_y = -24
 	},
-/obj/machinery/light,
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "Ni" = (
@@ -14544,26 +14195,29 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shield/bridge)
-"Nj" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
 "Nk" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/xo)
-"Nm" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 4
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/co)
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"Nn" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/packet/tea,
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/teacup,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
 "Np" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -14573,6 +14227,13 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"Nr" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	icon_state = "map_off";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Ns" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -14585,37 +14246,117 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"NH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"Nt" = (
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (SOUTHWEST)";
+	icon_state = "corner_white";
+	dir = 6
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Nv" = (
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Nw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"ND" = (
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/item/weapon/storage/secure/briefcase/nukedisk,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"NE" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
-"NV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/area/security/bridgecheck)
+"NH" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/xo)
+"NJ" = (
+/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge";
+	dir = 1
+	},
+/obj/item/weapon/book/manual/sol_sop,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"NL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"NM" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"NN" = (
+/obj/item/weapon/tableflag,
+/obj/machinery/camera/network/command{
+	c_tag = "CO - Office"
+	},
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "NW" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -14644,60 +14385,62 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "Od" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"Oe" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/captain,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/cobed)
-"Of" = (
-/obj/item/modular_computer/console/preset/command,
-/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"Og" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge entry port";
-	name = "Port Bridge Blast Doors";
-	opacity = 0
+/area/crew_quarters/heads/office/xo)
+"Oe" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_x = 30;
+	pixel_y = 0
 	},
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Og" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/port)
-"Oh" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Oi" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -14711,12 +14454,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "Oj" = (
-/obj/machinery/light_switch{
-	pixel_x = 6;
-	pixel_y = -24
+/obj/machinery/computer/rdconsole{
+	icon_state = "computer";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "Ok" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14727,50 +14470,115 @@
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
 "Ol" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Bridge Conference Room";
+	sortType = "Bridge Conference Room"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"Os" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/area/bridge/hallway/port)
+"Om" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/security{
+	c_tag = "Checkpoint - Bridge";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 8
 	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"Os" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Ov" = (
-/obj/structure/table/steel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "cosdoor";
-	name = "Office Door Control";
-	pixel_x = -12;
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
+"Ow" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"OD" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"OE" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cl)
+"OH" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "OK" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
-"OQ" = (
-/obj/structure/railing/mapped,
+"OM" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"OO" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair/comfy/teal{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"OS" = (
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
+/area/maintenance/bridge/forestarboard)
 "OX" = (
 /obj/machinery/shipsensors,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -14815,46 +14623,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)
-"Pd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
 "Pe" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"Pf" = (
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"Pg" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge entry port";
-	name = "Port Bridge Blast Doors";
-	opacity = 0
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14862,30 +14631,67 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/airlock/multi_tile/glass/command{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"Pf" = (
+/obj/random/maintenance/solgov,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"Pg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/vault/bolted{
 	autoset_access = 0;
-	dir = 8;
-	id_tag = "portbridgeaccess";
-	name = "Bridge Access";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
+	id_tag = "bridgesafe_front";
+	name = "Auxillary Safe Room Door"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/port)
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/bridge/fore)
 "Pi" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/disciplinary_board_room)
-"Pj" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Pt" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"Py" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"PB" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "bridge_safe_sensor";
+	master_tag = "bridge_safe";
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 2;
+	frequency = 1379;
+	id_tag = "bridge_safe_pump"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14904,9 +14710,18 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
+"PF" = (
+/obj/structure/sign/double/icarus/solgovflag/right{
+	dir = 4;
+	icon_state = "solgovflag-right";
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "PP" = (
 /obj/machinery/firealarm{
 	dir = 4;
+	layer = 3.3;
 	pixel_x = 26
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -14916,6 +14731,34 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/medical)
+"PQ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14949,62 +14792,84 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/aux_eva)
 "Qd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
 	},
-/obj/item/weapon/storage/box/donut,
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "hop_office_desk";
+	name = "Queue Desk Privacy Shutter";
+	pixel_x = 24;
+	pixel_y = -6;
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "hop_office";
+	name = "XO Desk Privacy Shutter";
+	pixel_x = 24;
+	pixel_y = 6;
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/xo)
 "Qe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/b_green{
+	tag = "icon-corner_white (WEST)";
+	icon_state = "corner_white";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Qf" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1;
+	target_pressure = 200
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 1
 	},
-/obj/item/weapon/pen,
-/obj/item/weapon/stamp/sea,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
 "Qg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "center";
+	dir = 4
+	},
+/obj/structure/bed/chair,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "Qh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack{
@@ -15041,12 +14906,66 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Qj" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Disciplinary Board Room";
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Qp" = (
+/obj/machinery/door/airlock/sol{
+	id_tag = "captaindoorfore";
+	name = "Commanding Officer";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"Qq" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"Qt" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/area/bridge/hallway/port)
+"Qv" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "Qz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15080,16 +14999,88 @@
 /turf/simulated/wall/titanium,
 /area/aquila/storage)
 "QN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"QQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/button/remote/airlock{
+	id = "bridgestorage_exit";
+	name = "Emergency Exit door-control";
+	pixel_x = 25;
+	pixel_y = 0;
+	req_access = list("ACCESS_BRIDGE");
+	specialfunctions = 4
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"QS" = (
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/weapon/pen/green,
+/obj/item/weapon/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/book/manual/solgov_law,
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"QW" = (
+/obj/machinery/computer/ship/engines{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"QX" = (
+/obj/item/device/flashlight/lamp/green,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "hopdoor";
+	name = "XO's Office Door Control";
+	pixel_x = -5;
+	pixel_y = 38;
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 8;
+	pixel_y = 39;
+	id = "xo_windows"
+	},
+/obj/structure/table/woodentable_reinforced/mahogany/walnut,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"QY" = (
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"Ra" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "Rb" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Infirmary"
@@ -15101,49 +15092,37 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/medical)
-"Rc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/half,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "Rd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "Re" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Rf" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/item/weapon/pen,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "Rg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow{
@@ -15197,23 +15176,64 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Rj" = (
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/book/manual/military_law,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/corner/b_green/diagonal{
+	tag = "icon-corner_white_diagonal (EAST)";
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/machinery/button/windowtint{
+	id = "rd_windows";
+	pixel_x = 6;
+	pixel_y = -24;
+	range = 11
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Rl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
+"Rq" = (
+/obj/machinery/computer/ship/helm{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"Rs" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/megaphone,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "Rx" = (
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_outer_chamber)
@@ -15229,25 +15249,109 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"RC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"RD" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/reagent_dispensers/water_cooler{
+	icon_state = "water_cooler";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
+"RE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "RH" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
+"RK" = (
+/obj/structure/bed/chair/padded/beige{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"RQ" = (
+/obj/vehicle/bike/gyroscooter,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "RT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "sea_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/sea)
+"RU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
 	},
-/obj/machinery/power/apc/high{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"RV" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "cap_window";
+	name = "CO's Quarters Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/co)
 "Sb" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Storage"
@@ -15266,57 +15370,45 @@
 /turf/simulated/floor/tiled/monotile,
 /area/aquila/storage)
 "Sc" = (
-/obj/machinery/power/apc/high{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
 	},
-/obj/structure/cable/green,
-/obj/item/modular_computer/console/preset/sysadmin{
-	icon_state = "console";
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
 "Sd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Se" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/cobed)
-"Sf" = (
-/obj/item/weapon/pen/blue{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/weapon/pen/red{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/weapon/reagent_containers/food/drinks/coffeecup/NT{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/obj/item/weapon/folder/envelope/blanks,
-/obj/item/weapon/pen/green,
-/obj/item/documents/nanotrasen,
-/obj/effect/floor_decal/corner/b_green/diagonal,
 /obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/tiled/dark,
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
+"Se" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Sf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -15341,14 +15433,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/bridge/aft)
 "Sh" = (
-/obj/machinery/camera/network/command{
-	c_tag = "EVA- Command";
-	dir = 2
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -15357,30 +15441,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"Si" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
+"Sj" = (
+/obj/structure/flora/pottedplant/unusual,
+/obj/effect/floor_decal/corner/b_green/diagonal{
+	tag = "icon-corner_white_diagonal (EAST)";
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/structure/sign/double/icarus/solgovflag/left{
-	pixel_y = 32
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Sn" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
-"Sj" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
+/area/bridge/meeting_room)
 "So" = (
 /obj/machinery/alarm{
 	frequency = 1439;
@@ -15390,33 +15474,6 @@
 /obj/machinery/cryopod,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/passenger)
-"Sq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"Sw" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
 "SA" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -15430,9 +15487,76 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
-"SF" = (
-/turf/simulated/open,
-/area/maintenance/bridge/forestarboard)
+"SB" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/device/taperecorder,
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
+"SE" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"SG" = (
+/obj/machinery/papershredder,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"SJ" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"SL" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/effect/floor_decal/spline/plain/brown{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/obj/item/weapon/material/ashtray/bronze,
+/obj/item/weapon/flame/lighter/zippo/random,
+/obj/random/smokes,
+/obj/structure/sign/warning/smoking{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"SM" = (
+/obj/structure/table/woodentable/mahogany,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
 "SN" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -15445,9 +15569,40 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/medical)
+"SU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"SV" = (
+/obj/machinery/door/airlock/civilian{
+	autoset_access = 0;
+	name = "Head"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
 "Ta" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -15503,44 +15658,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/auxsolarbridge)
-"Td" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/book/manual/military_law,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
 "Te" = (
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "Tf" = (
-/obj/item/weapon/pen/blue{
-	pixel_x = -5;
-	pixel_y = -1
+/obj/structure/table/woodentable_reinforced/walnut/maple,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
 	},
-/obj/item/weapon/pen/red{
-	pixel_x = -1;
-	pixel_y = 3
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/flame/lighter/zippo/random,
+/obj/random/smokes,
+/obj/structure/sign/warning/smoking{
+	pixel_x = 0;
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/obj/item/weapon/folder/envelope/rep,
-/obj/item/weapon/pen/green,
-/obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room/deliberation)
 "Tg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -15577,37 +15714,59 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA- Command";
+	dir = 2
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "Ti" = (
-/obj/structure/sign/double/icarus/solgovflag/right{
-	pixel_y = 32
+/obj/structure/closet/secure_closet/RD,
+/obj/effect/floor_decal/corner/research/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/structure/bed/chair/comfy/blue,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Tk" = (
+/turf/simulated/wall/prepainted,
+/area/bridge/disciplinary_board_room/deliberation)
+"Tl" = (
 /turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
-"Tj" = (
-/obj/machinery/door/airlock/sol{
-	name = "Disciplinary Board Room";
-	secured_wires = 0
+/area/bridge/storage)
+"Tm" = (
+/obj/structure/closet/secure_closet/bodyguard,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"Tn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"To" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"Tx" = (
+/obj/machinery/atmospherics/tvalve/mirrored/bypass{
+	icon_state = "map_tvalvem1";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Tz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -15619,6 +15778,61 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"TA" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/bridge/forestarboard)
+"TB" = (
+/turf/simulated/floor/reinforced/airless,
+/area/bridge/storage)
+"TI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"TK" = (
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/bed/chair/comfy/blue,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"TM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge - Stairs";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"TP" = (
+/obj/structure/curtain/open/bed,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "TQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -15634,6 +15848,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"TV" = (
+/obj/structure/closet/secure_closet/liaison,
+/obj/machinery/camera/network/command{
+	c_tag = "Corporate Liaison - Backroom";
+	dir = 8;
+	network = list("Command")
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "TX" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room)
@@ -15652,51 +15875,51 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/maintenance)
 "Uc" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/computer/account_database,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Ud" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/sticky_pad/random,
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Uf" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/machinery/photocopier/faxmachine{
+	anchored = 1;
+	department = "Corporate Liasion"
 	},
 /obj/structure/table/woodentable_reinforced/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/machinery/button/remote/airlock{
+	name = "CL's Rear Office Door Bolt Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = 6;
+	pixel_y = 26;
+	req_access = list("ACCESS_TORCH_CORPORATE_LIAISON");
+	id = "liaisondoor2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/remote/airlock{
+	name = "CL's Rear Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = -5;
+	pixel_y = 26;
+	req_access = list("ACCESS_TORCH_CORPORATE_LIAISON");
+	id = "liaisondoor2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 1;
+	pixel_y = 37
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
+"Ud" = (
+/obj/structure/bed/chair/office/comfy/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
+"Uf" = (
+/obj/structure/bed/chair/padded/beige,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room/deliberation)
 "Ug" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external{
@@ -15745,25 +15968,61 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Ui" = (
-/obj/structure/bed/chair/comfy/captain,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/research/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
-"Uj" = (
+/obj/structure/sign/ecplaque{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Uk" = (
+/obj/structure/sign/warning/detailed{
+	name = "\improper SECURE AREA"
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/bridge/hallway/starboard)
+"Un" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/button/remote/blast_door{
+	name = "Bridge Window Lockdown Control";
+	pixel_x = -30;
+	pixel_y = 0;
+	id = "bridge blast"
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/flashlight,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"Uo" = (
+/obj/structure/bed/chair/padded/green,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Up" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atm{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "Ut" = (
 /obj/effect/landmark{
@@ -15771,34 +16030,95 @@
 	},
 /turf/space,
 /area/space)
-"UG" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/bridge/foreport)
-"UP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"UT" = (
+"Uu" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
+"Uy" = (
 /obj/structure/table/glass,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 6
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/weapon/reagent_containers/food/drinks/coffeecup/SCG{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/item/device/paicard,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"UC" = (
+/obj/structure/closet/firecloset,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"UE" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
+"UG" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/maintenance/bridge/foreport)
+"UH" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/prefab/hand_teleporter,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"UL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 9
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"UN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
+/area/bridge/meeting_room)
 "UU" = (
 /obj/effect/shuttle_landmark/ert/deck5,
 /turf/space,
@@ -15816,20 +16136,14 @@
 /turf/simulated/floor/airless,
 /area/aquila/medical)
 "UX" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
 "UY" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
-/area/bridge)
+/obj/item/modular_computer/console/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "Vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -15853,60 +16167,33 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
 "Vc" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"Vd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/heads/office/xo)
 "Ve" = (
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "hop_office_desk";
-	name = "Desk Privacy Shutter";
-	pixel_x = 24;
-	pixel_y = -6
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/camera{
+	pixel_x = 3;
+	pixel_y = -4
 	},
-/obj/machinery/button/windowtint{
-	id = "xo_windows";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"Vf" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "center-left";
 	dir = 4
 	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"Vf" = (
-/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/item/weapon/book/manual/nt_regs,
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHEAST)";
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "Vg" = (
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
@@ -15929,61 +16216,129 @@
 /area/aquila/airlock)
 "Vh" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/sign/goldenplaque/medical{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "Vi" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
 	},
-/obj/structure/sign/double/icarus/solgovflag/left{
-	pixel_y = 32
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Science Officer's Desk";
+	departmentType = 5;
+	name = "Chief Science Officer RC";
+	pixel_x = 0;
+	pixel_y = 30
 	},
-/obj/structure/bed/chair/comfy/blue,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/item/weapon/folder/nt,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "Vj" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHWEST)";
+	icon_state = "corner_white";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Vn" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "Vs" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
+"Vw" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "heads_meeting";
+	name = "Bridge Meeting Room Shutters Control";
+	pixel_x = 39;
+	pixel_y = 31;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridgehallway";
+	name = "Bridge Internal Hallway Lockdown Control";
+	pixel_x = 25;
+	pixel_y = 31;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry star";
+	name = "Starboard Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = 40;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry port";
+	name = "Port Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = 22;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "VB" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"VD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"VF" = (
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/obj/structure/table/woodentable/mahogany,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "VG" = (
 /obj/structure/sign/warning/secure_area{
 	icon_state = "securearea";
@@ -15996,34 +16351,78 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"VY" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 4
+"VM" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/sea)
-"Wa" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/random/maintenance/solgov/clean,
-/obj/structure/closet/secure_closet{
-	name = "Security Equipment Locker";
-	req_access = list("ACCESS_SECURITY")
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"VN" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_port"
 	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	icon_state = "wrecharger0";
-	pixel_x = 23;
-	pixel_y = -3
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"VP" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
+"VW" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/captain,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
+"VY" = (
+/obj/machinery/button/remote/airlock{
+	name = "safe room door-control";
+	pixel_x = 25;
+	pixel_y = -1;
+	id = "bridgesafe_front";
+	specialfunctions = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	icon_state = "techfloororange_edges";
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1379;
+	id_tag = "bridge_safe_pump_out_internal"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"Wa" = (
+/obj/structure/bed/chair/padded/red{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
@@ -16055,45 +16454,59 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
 "Wc" = (
-/obj/item/modular_computer/console/preset/medical,
+/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = 38
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 6;
+	pixel_y = 20
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/obj/random/snack,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "Wd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/item/weapon/book/manual/military_law,
-/obj/item/weapon/folder/blue,
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "hopdoor";
-	name = "Office Door Control";
-	pixel_x = -12;
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"We" = (
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable/mahogany,
-/turf/simulated/floor/carpet/blue2,
-/area/bridge/meeting_room)
-"Wf" = (
 /obj/item/modular_computer/console/preset/command{
 	icon_state = "console";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/b_green/diagonal,
 /obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/button/remote/airlock{
+	name = "CL's Front Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = 27;
+	pixel_y = -7;
+	req_access = list("ACCESS_TORCH_CORPORATE_LIAISON");
+	id = "liaisondoor"
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 25;
+	pixel_y = 7;
+	id = "cl_windows"
+	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
+"We" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/papershredder,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -16116,67 +16529,52 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "Wh" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Bridge";
-	dir = 1
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/half,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
 "Wi" = (
-/obj/structure/sign/double/icarus/solgovflag/right{
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Science Officer's Office - Torch"
+	},
+/obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
-"Wj" = (
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"Wr" = (
+/obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Ws" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"Wv" = (
+/obj/structure/closet/secure_closet/bridgeofficer,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "Ww" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
-"WI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/co)
 "WK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -16186,18 +16584,85 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"WM" = (
+"WL" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"WS" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"WX" = (
 /obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/area/maintenance/bridge/foreport)
+"WY" = (
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/simulated/wall/prepainted,
+/area/bridge/meeting_room)
+"Xa" = (
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/machinery/power/apc/high{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/closet/medical_wall/filled{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/medical,
+/obj/random/drinkbottle,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
 "Xb" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -16214,44 +16679,24 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
 "Xc" = (
-/obj/item/modular_computer/console/preset/security,
+/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/random/single{
+	icon = 'icons/obj/drinks.dmi';
+	icon_state = "cola";
+	name = "randomly spawned cola";
+	spawn_nothing_percentage = 50;
+	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"Xd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/co)
 "Xe" = (
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
-"Xf" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
-	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sgr)
 "Xg" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -16299,21 +16744,13 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/fore)
-"Xk" = (
-/obj/item/modular_computer/console/preset/command,
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Xp" = (
 /obj/structure/sign/solgov,
 /obj/effect/paint/hull,
@@ -16340,17 +16777,42 @@
 "Xr" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/bridge/forestarboard)
-"Xz" = (
-/turf/simulated/wall/r_wall/hull,
-/area/crew_quarters/heads/cobed)
-"XC" = (
+"Xx" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/door/airlock/medical{
+	id_tag = "cmodoor";
+	name = "Chief Medical Officer";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"Xz" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/guncabinet/PPE,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"XB" = (
+/obj/structure/bed/chair/comfy/captain,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"XC" = (
+/obj/effect/floor_decal/corner/blue,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -16372,6 +16834,53 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
+"XN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"XO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"XQ" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge sensors";
+	name = "Sensor Shroud"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/bridge/storage)
+"XW" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
 "Yb" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -16381,55 +16890,93 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
-"Yc" = (
-/obj/machinery/papershredder,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
 "Yd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
 "Ye" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -3
-	},
-/obj/structure/table/woodentable/mahogany,
-/turf/simulated/floor/carpet/blue2,
-/area/bridge/meeting_room)
-"Yf" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
-	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"Yg" = (
-/obj/machinery/papershredder,
-/obj/structure/sign/ecplaque{
-	pixel_y = 30
-	},
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/photocopier,
+/obj/machinery/button/remote/blast_door{
+	id = "bridgehallway";
+	name = "Bridge Internal Hallway Lockdown Control";
+	pixel_x = -38;
+	pixel_y = 7;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "heads_meeting";
+	name = "Bridge Meeting Room Shutters Control";
+	pixel_x = -26;
+	pixel_y = 7;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = -24;
+	pixel_y = -7;
+	id = "meeting_windows"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
+"Yf" = (
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
+"Yg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Bridge Storage";
+	sortType = "Bridge Storage"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "Yh" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -16443,67 +16990,173 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"Yi" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
 "Yj" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Yy" = (
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/rd)
-"YC" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 1
+"Yk" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cl)
-"YD" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/bridge/aftport)
-"YI" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
-"YQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"Yz" = (
+/obj/structure/flora/pottedplant/orientaltree,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"YA" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/wood/mahogany,
+/area/crew_quarters/heads/office/xo)
+"YC" = (
+/obj/machinery/door/airlock/sol{
+	id_tag = "repdoor";
+	name = "SolGov Representative";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
+"YF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"YI" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/bridge/forestarboard)
+"YJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"YK" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"YL" = (
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/open,
+/area/maintenance/bridge/forestarboard)
+"YN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disciplinary Board Room Maintenance Access"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
+"YR" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/aft)
+"YS" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/aft)
 "YW" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/machinery/light,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "south bump";
@@ -16512,6 +17165,17 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"YX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/vault/bolted{
+	autoset_access = 0;
+	id_tag = "bridgestorage_exit";
+	name = "Emergency Exit";
+	req_access = list("ACCESS_BRIDGE")
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "YY" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16531,56 +17195,70 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Zc" = (
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/noticeboard{
-	pixel_y = 30
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
-"Zd" = (
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/weapon/stamp/nt,
+/obj/item/weapon/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/pen/green,
+/obj/item/weapon/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/coffeecup/NT{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"Ze" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/co)
-"Ze" = (
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/blue,
-/obj/structure/table/woodentable/mahogany,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "Zf" = (
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
+/obj/structure/table/woodentable/walnut,
+/obj/structure/sign/double/icarus/solgovflag/left{
+	dir = 1;
+	icon_state = "solgovflag-left";
+	pixel_y = -32
 	},
-/obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	anchored = 1;
-	department = "Corporate Liasion"
+/obj/item/weapon/stamp/solgov,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
 	},
-/obj/item/weapon/book/manual/nt_regs,
-/obj/effect/floor_decal/corner/b_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cl)
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "Zg" = (
-/obj/structure/bed/chair/comfy/captain{
-	color = "#666666";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/scglogo{
-	tag = "icon-center-left";
-	icon_state = "center-left"
+	tag = "icon-center-right";
+	icon_state = "center-right"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -16591,17 +17269,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Zi" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/floor_decal/corner/research/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 8
 	},
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
 "Zj" = (
 /obj/structure/hygiene/sink{
 	icon_state = "sink";
@@ -16620,11 +17302,35 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/aquila/head)
+"Zs" = (
+/obj/machinery/computer/account_database,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"Zx" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/stamp/ce,
+/obj/effect/floor_decal/corner/yellow/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
 "Zy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -28
@@ -16648,6 +17354,69 @@
 "ZD" = (
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/rd)
+"ZH" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "co_windows"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"ZJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"ZM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"ZN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bridge entry star";
+	name = "Starboard Bridge Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/multi_tile/glass/command{
+	autoset_access = 0;
+	dir = 8;
+	id_tag = "starboardbridgeaccess";
+	name = "Bridge Access";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/bridge/hallway/starboard)
 "ZQ" = (
 /obj/random/closet,
 /obj/random/maintenance/solgov/clean,
@@ -16655,21 +17424,21 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
-"ZW" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+"ZR" = (
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"ZT" = (
+/obj/structure/dogbed,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/obj/random/plushie,
+/mob/living/simple_animal/corgi/Ian,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
 "ZX" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/structure/bed/chair/padded/teal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 
@@ -23418,16 +24187,18 @@ aa
 aa
 aa
 aa
-af
-af
-af
-af
-af
-af
-af
-af
-af
-af
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+pe
 aa
 aa
 aa
@@ -23443,20 +24214,18 @@ aa
 aa
 aa
 aa
+pe
 aa
 aa
 aa
 aa
-tg
-tg
-tg
-tg
-tg
-tg
-tg
-tg
-tg
-tg
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -23619,6 +24388,7 @@ aa
 aa
 aa
 aa
+aa
 af
 af
 af
@@ -23629,25 +24399,25 @@ af
 af
 af
 af
-af
-af
+aa
+ae
 aa
 aa
 aa
 aa
 aa
+Js
+aa
+aa
+aa
+Js
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-BC
-aa
-aa
-aa
-aa
+ae
+qA
 tg
 tg
 tg
@@ -23658,8 +24428,7 @@ tg
 tg
 tg
 tg
-tg
-tg
+aa
 aa
 aa
 aa
@@ -23820,6 +24589,7 @@ aa
 aa
 aa
 aa
+aa
 af
 af
 af
@@ -23832,16 +24602,13 @@ af
 af
 af
 af
-af
+oA
 aa
 aa
 aa
 aa
-KU
 aa
-aa
-aa
-aa
+hH
 aa
 aa
 aa
@@ -23850,6 +24617,8 @@ aa
 aa
 aa
 aa
+aa
+ae
 tg
 tg
 tg
@@ -23862,7 +24631,7 @@ tg
 tg
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -24021,51 +24790,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
 af
 af
-ax
-aJ
-aJ
-aJ
-aJ
-aJ
-aJ
-aJ
-ek
-Lc
+af
+af
+af
+af
+af
+af
+af
+af
+af
 fu
-aa
-aa
-aa
-ae
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ae
-aa
+XQ
+XQ
+wM
+Hz
+SE
+Aw
+wM
+AB
+mc
+Aw
+KG
+Hz
+mc
 aa
 aa
 sx
-Mg
-tQ
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-xw
 tg
 tg
 tg
 tg
+uy
+uy
+uy
+uy
+uy
+uy
+tg
+tg
+tg
+aa
 aa
 aa
 aa
@@ -24223,51 +24992,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
 af
-ai
-ay
-YI
-ci
+VB
+yc
+VB
 cR
-Xr
-Xr
-Xr
-Xr
-Xr
-af
-ad
-ad
-aa
-aa
-ae
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ae
-aa
-aa
-ad
-ad
-tg
-UG
+YX
+QQ
+TP
+LJ
+LP
+NL
+DE
+TB
+sm
+HE
+Ra
+CE
+BE
+QW
+Rq
+GV
+Un
+By
+FE
+HE
+BI
+RV
+Mz
+Yz
+PF
 ux
-vc
-oB
-oB
-oB
-Ji
-oB
-xx
-xE
+An
+uy
+Kq
+Cl
+UH
+Av
+uy
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -24425,51 +25194,51 @@ aa
 aa
 aa
 aa
-af
-af
-af
-YI
-ay
-YI
-aK
-aK
-aK
-zE
-zE
-zE
-zE
-Xz
-ed
-eM
 aa
+af
+af
+KB
+VB
+OS
+QY
+er
+qO
+qO
+qO
+Gr
+rz
+Xz
+Fp
+eM
+DE
 Ie
 nf
 If
-HE
+lt
 vg
 zg
-If
-HE
+zN
+VM
+TK
+cV
 Ie
-nf
-Bg
 Ng
 Id
 th
-Fp
-qO
-qO
-qO
-ti
-ti
-ti
-ti
-oB
+OM
+Pt
+yS
+Py
+uy
+VW
+MA
+EJ
+DQ
 xx
-xF
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -24627,51 +25396,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
-af
-YI
-ay
-at
-aK
-GW
-bH
-zE
+XB
+VB
+zq
+aj
+qs
+UC
+qO
 aY
 dE
 Jh
 Hf
 bf
 ee
-aa
-ef
+Wv
+eP
 Wc
 Af
-jt
-ks
+hn
+hn
 HK
-HN
-HO
-Af
+hn
+hn
+SJ
 HU
-ef
+eP
 UY
 Fg
 Ig
-Il
+OM
 tR
 Mf
-qO
-It
+CW
+uy
 UX
-Iy
-ti
-oB
-xx
-oB
+MA
+lu
+mT
+ND
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -24829,51 +25598,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
-af
-YI
-ay
-bG
-aK
-Oi
-bI
-ck
-GX
-cT
-cT
+DI
+VB
+zq
+FL
+GW
+aj
+qO
+zC
+dE
+XO
 eN
 Ke
-Xz
-Xz
+Ks
+TI
 eP
 Xc
-iG
-UT
-kt
+HC
+jw
+kw
 lm
-ll
-Me
-ov
+kw
+nH
+HC
 pq
 eP
-qO
-qO
+NN
+Fl
 Ih
-Im
-tS
+OM
+Pt
 Nf
-qO
-Iu
+Nf
+uy
 Iz
 IG
-ti
-xa
-xx
-oB
+Cr
+CV
+zP
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -25031,51 +25800,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
-af
-YI
-ay
-Au
-aK
-aK
-zE
-zE
-GY
-dG
-CV
-dG
+aj
+VB
+zq
+Nr
+Tx
+bI
+qO
+GX
+cT
+Tl
+jA
 Je
 Ne
-Je
-eP
+Jh
+HI
 aZ
 XC
-hn
-hn
+kw
+Fy
 Gg
-hn
-hn
+Am
+kw
 HS
 Sc
-eP
+ZH
 qP
 rI
 fv
 In
 tT
 uB
-qO
+tT
 Iv
 IA
 IH
-ti
-xb
-xx
-oB
+DY
+dG
+SG
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -25233,51 +26002,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
-af
-YI
-ay
-aL
-bo
-Xr
-zE
-cU
-GZ
+TA
+VB
+zq
+Wr
+NM
+Bd
+qO
+GY
 Hc
-dG
+MV
 De
 Mi
 Oe
 Se
-eP
+lL
 Hx
-HC
-jw
+EV
+Vw
 HH
 Ch
-HH
-nH
-HC
+Kt
+Lw
+fN
 HW
-eP
+Qp
 qQ
 rJ
 Ii
 Io
 Kh
 uC
-qO
-ti
+GU
+uy
 IB
-ti
-ti
-ti
-xx
-xG
+To
+KC
+dG
+Cx
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -25435,51 +26204,51 @@ aa
 aa
 aa
 aa
+aa
 af
 af
-af
-ak
-ay
+at
+VB
 aL
-aj
-Xr
-zE
-cn
-cW
-Hd
-eo
-aK
-aK
-aK
-aK
+bo
+bt
+Jp
+qO
+GZ
+Rs
+Kv
+Du
+qO
+qO
+yM
 eP
 hV
-UP
+eP
 jy
-fH
+vf
 lo
-II
-jy
-VD
+yh
+NJ
+eP
 HX
 eP
-qO
+Dx
 rK
-qO
-qO
-qO
-qO
-vh
-Iw
-IC
-vN
-wv
-ti
-xx
-Ca
+bq
+bq
+bq
+bq
+bq
+uy
+uy
+uy
+uy
+SV
+uy
+uy
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -25637,23 +26406,23 @@ aa
 aa
 aa
 aa
-af
+aa
 af
 af
 al
 aA
 al
-al
-bq
-co
-co
-Ha
-co
-co
-bq
-Hm
+aO
+aO
+aO
+aO
+aO
+aO
+aO
+aO
+aO
 fP
-gA
+fS
 Hu
 hW
 iI
@@ -25664,24 +26433,24 @@ qh
 HP
 ox
 HY
-Hu
+yY
 Ic
 rL
 RT
-ti
+vm
 tW
 Iq
-vi
-Ix
-ID
-ti
-ti
-ti
-xy
-xc
+sB
+sB
+sB
+sB
+Rl
+jc
+bH
+aK
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -25839,30 +26608,30 @@ aa
 aa
 aa
 aa
-af
+aa
 af
 af
 am
 ay
-zq
-aj
-bq
-bM
-cp
-cX
-dI
-aB
-bq
-fw
+JF
+aO
+sC
+Bs
+qa
+aO
+sl
+si
+VF
+aO
 fQ
 gB
 ho
 hX
 iJ
 jz
-vf
+dT
 dh
-yh
+IY
 nJ
 oy
 pr
@@ -25870,20 +26639,20 @@ qj
 qS
 rM
 sy
-ti
+En
 tX
-Ir
+En
 vj
 vO
 ww
-vN
-wv
-ti
-xx
-Kx
+sB
+Oi
+lT
+Ht
+aK
 tg
 tg
-tg
+aa
 aa
 aa
 aa
@@ -26044,31 +26813,31 @@ aa
 af
 af
 af
-Au
-da
-jD
-ZW
-bq
-bN
-cq
-Td
-WI
-eq
-bq
+YI
+VB
+JF
+aO
+Zs
+co
+cp
+aO
+dI
+aB
+za
 fx
 fR
 gC
 hp
 Eh
-HD
-Bh
+eP
+AH
 yf
-nh
+eP
+VN
 zh
-Dh
-HT
+eP
 Gh
-hp
+Qt
 qT
 rN
 sz
@@ -26078,11 +26847,11 @@ Is
 vk
 vP
 IE
-tk
-ti
-ti
-xx
-Kx
+sB
+aK
+aK
+aK
+aK
 tg
 tg
 tg
@@ -26247,44 +27016,44 @@ af
 af
 af
 an
-JK
+VB
 xN
-SF
+aO
 fz
-bO
-Md
-cZ
-dJ
-Ce
-bq
-bQ
+bN
+cq
+aO
+aO
+eq
+aO
+yg
 fS
-gD
-hq
-hq
-hq
-hq
-hq
-lq
-hq
-hq
-hq
-hq
-hq
+gB
+lQ
+hX
+cl
+KX
+KX
+CZ
+OD
+OD
+bK
+pr
+Yk
 qU
 rO
-Ij
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-xI
+sB
+ZR
+vZ
+uG
+Nn
+Ck
+mz
+sB
 xc
-Jr
-xH
+xc
+xc
+xc
 tg
 tg
 tg
@@ -26449,33 +27218,33 @@ af
 af
 af
 aj
-JK
+VB
 xN
-SF
-bq
-Vc
-Fd
+aO
+en
+bO
+bO
 Od
-Xd
-eQ
-Hh
-Ho
-fT
+dJ
+Ce
+ZT
+bQ
+fS
 gE
-hq
+JB
 Yg
 iK
+YK
+YK
 jB
 kx
-lr
-hZ
-nL
-FW
+kx
+Ol
 pt
-hq
+Bu
 qV
 rP
-sz
+sB
 tm
 tZ
 uE
@@ -26483,10 +27252,10 @@ vl
 vQ
 wx
 sB
-vM
+xc
 Ji
 KZ
-KR
+Ma
 tg
 tg
 tg
@@ -26651,43 +27420,43 @@ af
 af
 af
 ao
-JK
+VB
 xN
-SF
-bq
+aO
+RK
 bd
-Gd
-Od
+Vc
+dR
 Yd
-es
-eR
-Hp
+eQ
+Hh
+Ho
 fU
 gF
+PQ
 hq
-HA
 rt
-Te
-zf
-zf
-zf
-Te
-Ol
-Ia
+yd
+Hv
+WY
+bP
+ab
+ta
 hq
+AP
 qW
 rQ
-sB
-sB
-ua
-uF
-Of
-vR
-wy
-sB
-vM
-OQ
-KZ
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+vc
+rT
 Ma
 tg
 tg
@@ -26853,43 +27622,43 @@ af
 af
 af
 aj
-JK
+VB
 xN
-SF
-bq
+aO
+QX
 dd
-xd
-Pd
-Zd
-et
-eS
-fy
+bO
+iB
+oz
+zT
+oI
+Hp
 fV
 gG
 hr
-ia
-rt
-Xe
+hq
+MB
+Qv
 We
 Ye
 Ze
-Ah
-Ol
-pu
+Ll
+BF
+hq
 qk
 qX
 rR
 Ik
 to
 ub
-uG
+Tn
 Pf
 vS
 wz
-sB
-vM
-xc
-KZ
+Xa
+ti
+oB
+oB
 Ma
 tg
 tg
@@ -27054,44 +27823,44 @@ ad
 af
 af
 af
-YI
-JK
-xN
-SF
-bq
+aj
+VB
+YL
+aO
+rC
 Ad
-zd
+bO
 Qd
 be
 NH
 eT
-Hq
-fT
+aO
+Uk
 Hs
-hq
+ZN
 ib
-rt
-Te
-Xg
-Xg
-Xg
-Te
-Ol
+WS
+Lt
+ew
+Gk
+ew
+DH
+dF
 pv
-hq
+dO
 qY
 rS
-Ik
+PB
 tp
 uc
 uH
 Qf
 vT
 wA
-sB
+nK
 xe
-xc
-KZ
+Cj
+WX
 Ma
 tg
 tg
@@ -27256,42 +28025,42 @@ ad
 af
 af
 af
-YI
-WM
-al
-al
-bq
-bq
-bq
-bq
-bq
-ev
-bq
-Nm
-ng
+aj
+VB
+aj
+aO
+FG
+YA
+WL
+aO
+aO
+et
+eS
+aO
+eU
 qg
-hs
-hs
+Ow
+Vn
 iM
-jE
-kB
-kB
-kB
-nO
-iM
-hs
-hs
+Te
+zf
+zf
+zf
+Te
+BV
+oJ
+dQ
 Og
 Pg
 VY
-sB
+to
 ud
 uI
 vp
 vU
 IF
-sB
-xc
+yL
+ti
 xc
 xy
 xc
@@ -27458,45 +28227,45 @@ ad
 af
 af
 af
-YI
-ay
-al
+aj
+VB
+Xr
 ba
-WK
-xS
-xT
-ab
+aO
+kA
+kV
+ba
 Ta
 Os
-jO
-eU
-fY
+lx
+jR
+bT
 gI
 hu
 jO
-Ta
-Sq
-Ta
+UN
+Xe
+Ax
 LN
-Ta
-Sq
-Ta
-jO
+SM
+Ah
+hZ
+bX
 br
 ra
-rU
-sD
-jO
-ue
-Sq
-xS
-yd
-ye
-AR
-ba
-xc
-xx
-oB
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+UG
+Fh
+XW
+xE
 tg
 tg
 tg
@@ -27661,44 +28430,44 @@ af
 af
 af
 VB
-aC
-aN
+VB
+Xr
 bb
 bs
 bU
-cw
+xT
 df
-dN
-ex
+lx
+bT
 QN
-fA
-fZ
+jR
+bT
 gJ
 hv
 id
+UN
+Te
+Xg
+Xg
+Xg
+Te
 iN
-jG
-kD
-lv
-mD
-nP
-iN
-pw
+id
 ql
 rb
 rV
-sE
-Bb
-uf
+jR
+WK
+xS
 uK
 Jb
-vV
+AR
 wB
-wX
-Rc
-xp
-xz
+fB
+xb
 oB
+xz
+xF
 tg
 tg
 tg
@@ -27864,42 +28633,42 @@ af
 af
 ap
 aD
-aO
-aO
-aO
-aO
+IK
+UL
+eK
+Up
 Nk
 dg
-aO
-aO
+YF
+YF
 eV
-fB
-ga
+XN
+cG
 gK
 hw
-ie
-ie
+hs
+dM
 jH
-ie
-ie
-mE
-nQ
-mE
-mE
+Sn
+zD
+JX
+jH
+Qq
+hs
 Ku
 rc
-rW
-sJ
-sJ
-sJ
-mM
-sJ
-sJ
-sJ
-sJ
-xc
-xc
-xj
+cG
+XN
+Gn
+ZM
+Nk
+cF
+AX
+RE
+IK
+UE
+UE
+lW
 oB
 tg
 tg
@@ -28066,42 +28835,42 @@ af
 af
 aq
 aE
-aO
-db
+sJ
+sJ
 dc
 bV
-Bd
+sJ
 Nd
 He
-aO
-Ee
+Ka
+sJ
 Le
 Pe
 gL
-hx
-if
-iO
-jI
-Df
 ie
-mF
-Ef
-Oh
-px
-qm
+hs
+hs
+hs
+hs
+hs
+hs
+hs
+hs
+hs
+mE
 rd
-rX
-sG
+sf
+sP
 ts
 ug
-uL
-vr
-vW
-wC
-sJ
-xb
-xq
-xA
+sL
+sL
+sL
+sL
+sL
+oB
+oB
+xj
 xJ
 tg
 tg
@@ -28268,7 +29037,7 @@ af
 af
 YI
 aE
-aO
+sJ
 gb
 fc
 Dg
@@ -28277,20 +29046,20 @@ Rd
 Be
 ey
 Fe
-fD
+OE
 Qe
 gM
-hy
+hx
 ig
 iP
 Bf
 kF
-ie
+mE
 mG
 Ff
 oD
 py
-qn
+qm
 re
 rY
 sH
@@ -28300,7 +29069,7 @@ uM
 Rf
 vX
 wD
-sJ
+sL
 NW
 NW
 gP
@@ -28470,24 +29239,24 @@ af
 af
 ar
 aE
-aO
+sJ
 Hb
 gc
-bV
+OH
 Dd
 Sd
 we
-aO
+Nw
 eY
-fD
+Nv
 gd
 gO
 hz
 ih
-iQ
+CP
 Cf
 Nh
-ie
+mE
 mH
 Gf
 nU
@@ -28502,7 +29271,7 @@ uN
 Sf
 vY
 wE
-sJ
+sL
 JG
 GI
 BG
@@ -28672,24 +29441,24 @@ af
 af
 as
 aE
-aO
+sJ
 bc
-aO
-bV
+Uo
+Mt
 Ed
 Ud
 ze
 ez
 eZ
-fD
+Gy
 xU
 xX
-hz
+dp
 ii
 iR
-jL
+iQ
 kH
-ie
+mE
 mI
 Ov
 oF
@@ -28702,9 +29471,9 @@ tv
 uj
 uO
 vu
-Wf
+vY
 Zf
-sJ
+sL
 JG
 Ma
 Xq
@@ -28874,16 +29643,16 @@ af
 af
 at
 aE
-aO
-aO
-aO
+sJ
+sJ
+sJ
 Uc
-Jd
+Dd
 Wd
 Ae
-aO
-eZ
-fD
+ZJ
+qR
+sJ
 xV
 Fb
 hA
@@ -28891,22 +29660,22 @@ ij
 iS
 jM
 kI
-ie
+mE
 mJ
 nV
 oG
 pB
 qq
 xZ
-sb
-sJ
-sJ
-sJ
-sJ
-sJ
-sJ
-sJ
-sJ
+hu
+sL
+DZ
+qB
+SL
+gv
+uz
+QS
+sL
 JG
 Ma
 Xq
@@ -29078,37 +29847,37 @@ JT
 aE
 VB
 VB
-aO
-Yc
+sJ
+sJ
 ve
-Vd
-Be
-ey
-fa
-fD
+sJ
+sJ
+HG
+sJ
+sJ
 xW
 gQ
-gl
-gl
-gl
-gl
+ie
+IN
+Zx
+AZ
 Cs
-Cs
-Cs
-Cs
-Cs
-Cs
-qr
+mE
+Gs
+Mn
+kE
+fF
+mE
 ya
 yb
 VG
-tw
-uk
-uP
-vv
-Xf
-cg
 sL
+uk
+sL
+vv
+vv
+vv
+vv
 xh
 Ma
 Xq
@@ -29280,37 +30049,37 @@ af
 aF
 aP
 bg
-aO
+dk
 Zc
 Kd
 dn
 BB
 eA
 fb
-fE
-ge
+dk
+ga
 gR
-fD
-ik
-iT
-jN
-Cs
-lw
-mK
-Jf
-Lf
-pC
+CJ
+ie
+ie
+ie
+ie
+mE
+mE
+mE
+mE
+mE
 Lp
-DJ
-sc
-sM
+rd
+ga
+sL
 tx
 ul
-uQ
+sL
 Tf
 wb
 wH
-sL
+Tk
 xi
 xr
 xB
@@ -29482,37 +30251,37 @@ af
 af
 aj
 bh
-aO
+dk
 kd
 Ld
-de
+dn
 Ve
-aO
+IO
 Ge
-fB
+dk
 gf
-NV
+gM
 fD
 il
 iU
-bT
+TM
 mC
 AI
 qw
-qw
-qw
+YJ
+Om
 Wh
-Cs
+yR
 Gb
 Aq
-sN
+sL
 ty
 um
-uR
+sL
 Uf
 wc
 wI
-sL
+Tk
 Lr
 vs
 tg
@@ -29684,37 +30453,37 @@ af
 af
 al
 bi
-aO
-aO
-aO
-aO
-aO
-aO
-Pi
-Pi
+dk
+zp
+Tm
+TV
+nN
+zS
+CX
+dk
 Re
-gK
+xX
 CH
 im
 iV
+nM
 VL
-Sw
-Xk
-qw
-qw
-qw
+bT
+NE
+Uu
+gT
 pE
-Cs
-rj
+mA
+rg
 se
-sO
+sL
 tz
 un
-uS
+sL
 vy
 wd
 wJ
-sL
+Tk
 xj
 xs
 tg
@@ -29886,16 +30655,16 @@ gz
 gz
 aQ
 bx
-TX
-Si
-Yi
-gj
-yj
-Ej
-Nj
-TX
-Uj
-Wj
+sT
+sT
+sT
+sT
+sT
+sT
+sT
+Kb
+xW
+xX
 Mq
 im
 Jt
@@ -29906,17 +30675,17 @@ mN
 nZ
 Wa
 pF
-dH
+mN
 rg
-YQ
-sP
-sL
-sL
-sL
-sL
-sL
-sL
-sL
+yb
+Pi
+Pi
+Pi
+Pi
+Tk
+nI
+Tk
+Tk
 xk
 xc
 tg
@@ -30088,37 +30857,37 @@ gz
 gz
 cb
 bx
-TX
+sT
 Ti
 Zi
 hj
-hj
+RQ
 Fj
 Oj
-TX
+sT
 uJ
 zo
 gl
 La
 iX
-jR
-Cs
-MF
+Lk
+gl
+gl
 mO
 oK
-Cs
+zM
 pG
-Cs
+yW
 rk
-sf
-sQ
+qz
+TX
 tA
 uo
 uT
 Lh
 Yf
 gg
-sT
+TX
 xl
 xt
 CN
@@ -30290,37 +31059,37 @@ gz
 gz
 fd
 gh
-TX
+sT
 Ui
 bj
 nj
 Aj
 Gj
-Pj
-Tj
+ZD
+sQ
 Vj
 Xj
 Tz
 hE
 iY
 jS
-Mr
+RU
 lB
-mP
+Mr
 ob
-Tz
-hE
+vx
+zY
 qt
 rl
-sg
-sR
+hu
+TX
 tB
 up
 uU
 Mh
 wf
 wL
-sT
+TX
 xl
 xt
 CN
@@ -30492,14 +31261,14 @@ gz
 gz
 cc
 bz
-TX
+sT
 Vi
 cj
-hj
-hj
-hj
+Nt
+Uy
+Ao
 Qj
-TX
+cS
 gk
 Yj
 hF
@@ -30510,9 +31279,9 @@ kK
 lC
 mQ
 oc
+bJ
 hF
-pH
-JD
+RC
 rm
 sh
 sS
@@ -30522,7 +31291,7 @@ Qg
 Vf
 wg
 Nb
-sT
+TX
 xl
 CN
 CN
@@ -30694,14 +31463,14 @@ gz
 gz
 cd
 bz
-TX
+sT
 Wi
-dj
-dj
-dj
+Lv
+AE
+fl
 Jj
 Rj
-Pi
+sT
 gl
 gl
 hC
@@ -30710,21 +31479,21 @@ uV
 in
 kL
 lD
-mR
+kL
 lA
+Xx
 kJ
+fW
+Cv
 pI
-qu
-kJ
-kJ
 kJ
 tD
 lS
 Fn
-Fn
+rA
 wh
 wN
-sT
+TX
 xm
 CN
 CN
@@ -30896,14 +31665,14 @@ gz
 gz
 aR
 bz
-TX
-TX
+sT
+sT
 IT
 tj
-Jo
+BR
 Kj
 Sj
-Pi
+sT
 gm
 gm
 gm
@@ -30921,12 +31690,12 @@ rn
 yw
 kJ
 tE
-ZD
+dj
 uW
 Lb
 Mb
-wO
-sT
+Jo
+YN
 xl
 CN
 CN
@@ -31099,13 +31868,13 @@ gz
 aS
 bz
 bm
-yV
-TX
-TX
-Dj
-TX
-Pi
-Pi
+ag
+sT
+sT
+sT
+sT
+sT
+sT
 gm
 gm
 gm
@@ -31113,22 +31882,22 @@ gm
 gm
 jV
 SN
-nb
+YR
 yZ
 of
 oP
 ZX
-Bn
 Kf
+OO
 KP
 kJ
-sT
-sT
-sT
-sT
-sT
-sT
-sT
+SB
+RD
+TX
+TX
+TX
+TX
+TX
 xn
 CN
 CN
@@ -31306,7 +32075,7 @@ cc
 jx
 MD
 bm
-ag
+yV
 fI
 gm
 gm
@@ -31315,8 +32084,8 @@ gm
 gm
 jV
 SN
-nb
-yZ
+YS
+VP
 og
 ly
 pL
@@ -31324,9 +32093,9 @@ qx
 rp
 nG
 kJ
-ju
-Yy
-JP
+TX
+TX
+TX
 vE
 vE
 wP
@@ -31508,7 +32277,7 @@ aG
 aT
 MD
 zW
-ag
+yV
 fI
 gm
 gm
@@ -32335,7 +33104,7 @@ on
 on
 on
 on
-YD
+on
 uY
 Pc
 wn
@@ -32534,10 +33303,10 @@ Qh
 Xh
 di
 qi
+Bp
 yi
 Ci
 on
-YD
 uY
 vI
 wo
@@ -32736,10 +33505,10 @@ Rh
 Yh
 Yh
 TQ
+SU
 Rz
 YW
 CO
-CN
 dV
 vJ
 wp
@@ -32938,10 +33707,10 @@ oW
 Zh
 hi
 pR
+yD
 Fi
-EX
+Dt
 CO
-CN
 dV
 dV
 wq
@@ -33141,9 +33910,9 @@ pQ
 pQ
 QE
 Ai
+Ai
 Zy
 CO
-CN
 dV
 dV
 Tc
@@ -33342,10 +34111,10 @@ Th
 Dq
 Uh
 bk
+zz
 Bi
 IW
 CO
-CN
 dV
 dV
 ws
@@ -33547,7 +34316,7 @@ CO
 CO
 CO
 CO
-CN
+CO
 dV
 ad
 wt

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -744,6 +744,11 @@
 	name = "\improper Command - CL's Office"
 	req_access = list(access_liaison)
 
+/area/crew_quarters/heads/office/cl/backroom
+	icon_state = "heads_cl"
+	name = "\improper Command - CL's Backroom"
+	req_access = list(access_liaison)
+
 /area/crew_quarters/heads/office/sgr
 	icon_state = "heads_sr"
 	name = "\improper Command - SCGR's Office"
@@ -1244,6 +1249,10 @@
 
 /area/bridge/disciplinary_board_room
 	name = "\improper Disciplinary Board Room"
+	sound_env = SMALL_ENCLOSED
+
+/area/bridge/disciplinary_board_room/deliberation
+	name = "\improper Deliberation Room"
 	sound_env = SMALL_ENCLOSED
 
 /area/crew_quarters/heads


### PR DESCRIPTION
:cl: Albens
maptweak: Bridge Deck has undergone a refit. 
/:cl:

Bridge deck has been Refit.

<details><summary>Expanded Details.</summary>
<p>

I've refit Bridge Deck, touching the Head's Offices, the Secpoint, Bridge Safe Room, Aux EVA, Bridge Fore Maintenance, Disciplinary room, and of course, Bridge Itself.

Fancy new Desks for the CO and XO have been added.

Two new Areas, the CL's backroom, and Deliberation Room.

The Bridge Combined Arms Locker, and the Bridge Safe Room Firearm locker have had their inventories mostly retained, but shuffled into two Lockers.
I did trade 2 small eguns for 1 large Egun + belt. This was done to reflect the Bridge staffing levels, and I believe it might alleviate an Escalation of Force issue, caused by having a deficiency in "Suitable" firearms for Command and Command Support. 

In Short: Command has _just_ enough full sized Eguns on Bridge that they shouldn't feel the need to run to Earm to grab more.

Bridge Storage now has two lockers: Combined Arms Cabinet, and Bridge PPE Cabinet.

Bridge Safe Room is now drastically smaller, and unfit for Habitation for long periods of time, using my THERA Concept. 

There's an Atmospheric Support station in Bridge-Deck Fore Starboard Maintenance. It's like those dual-Pressure tanks that exist currently, but less useless. Engineering can set them up further if they want.

Bridge has been designed to minimize the two dominant Meta-strategies. 

Emagging onto a Locked-down Bridge now must be done through some of the Secured, Bolted Emergency Exits, or the Safe Room Auxiliary Door. This adds time, in the form of both Hacking and acquiring Tools.

Thermite-ing into a Command-level locker now takes marginally more time. The XO's locker is hard to get at discreetly, while the CO and SEA's locker require you to breach a regular wall, and then an R-wall. This adds time.

These two measures should hopefully reduce the occurrence of, and introduce some risk into the _lolEmag_ and _lolThermite_ Metas.

The Disciplinary Board Room now has a Deliberation Sub-Room. No more awkward whispering at the Officer's desk.

The CL's office now contains a backroom. Due to the lack of actual function to the CL as a job, I've used the LPA and some creative door/tint/light controls to give multi-function to the CL's office, designed to create a power imbalance between the CL and their "prey".

Personal Offices have had their disposals, photocopiers, and shredders removed, re-added on a case-by-case basis.
These served to clutter offices, and their function was extremely limited. The disposals where largely used for bombings or by mailing mistakes.

Bridge Storage and Bridge Meeting Room are now the only valid mailing locations on Bridge Deck. Trust me, you won't miss personal office disposals bins. 

Aux EVA has been expanded Port, adding in one more row of suits; a Command and Security Voidsuit have been added, to reflect updated staffing numbers.

A locked-down Bridge presents a fortress like-appearance, but has vulnerabilities all the same. 

If I remember any more changes, I'll update this!

Special thanks to:
Orelbon, Eckles, Sabira, Norodo, Mattatlas, Ondra, Sweedle, SierraKomodo, Xaytan, Fre3bie, BlueNexus, Lonefly, QuestioningMark, Flying_loulou, Roland410, and any others I forgot.
</p>
</details>
<!-- 
