### PR TITLE
Adds ability to scan overmap objects with scanner console

### DIFF
--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 		var/datum/map_template/ruin/ruin = R
 		if(ruin.id in GLOB.banned_ruin_ids)
 			ruins -= ruin //remove all prohibited ids from the candidate list; used to forbit global duplicates.
-
+	var/list/spawned_ruins = list()
 //Each iteration needs to either place a ruin or strictly decrease either the budget or ruins.len (or break).
 	while(budget > 0)
 		// Pick a ruin
@@ -59,6 +59,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 			log_world("Ruin \"[ruin.name]\" placed at ([T.x], [T.y], [T.z])")
 
 			load_ruin(T, ruin)
+			spawned_ruins += ruin
 			if(ruin.cost >= 0)
 				budget -= ruin.cost
 			if(!(ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
@@ -68,6 +69,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 						ruins -= ruin //Remove all ruins with the same id if we don't allow duplicates
 				GLOB.banned_ruin_ids += ruin.id //and ban them globally too
 			break
+	return spawned_ruins
 
 proc/load_ruin(turf/central_turf, datum/map_template/template)
 	if(!template)

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -37,6 +37,7 @@
 	var/ruin_tags_blacklist
 	var/features_budget = 4
 	var/list/possible_features = list()
+	var/list/spawned_features
 
 /obj/effect/overmap/sector/exoplanet/New(nloc, max_x, max_y)
 	if(!GLOB.using_map.use_overmap)
@@ -162,7 +163,7 @@
 				new map_type(null,1,1,zlevel,maxx,maxy,0,1,1)
 
 /obj/effect/overmap/sector/exoplanet/proc/generate_features()
-	seedRuins(map_z, features_budget, /area/exoplanet, possible_features, maxx, maxy)
+	spawned_features = seedRuins(map_z, features_budget, /area/exoplanet, possible_features, maxx, maxy)
 
 /obj/effect/overmap/sector/exoplanet/proc/get_biostuff(var/datum/random_map/noise/exoplanet/random_map)
 	if(!istype(random_map))
@@ -325,6 +326,38 @@
 	var/list/badgases = gas_data.gases.Copy()
 	badgases -= atmosphere.gas
 	badgas = pick(badgases)
+
+/obj/effect/overmap/sector/exoplanet/get_scan_data(mob/user)
+	. = ..()
+	var/list/extra_data = list("<hr>")
+	if(atmosphere)
+		if(user.skill_check(SKILL_SCIENCE, SKILL_EXPERT))
+			var/list/gases = list()
+			for(var/g in atmosphere.gas)
+				if(atmosphere.gas[g] > atmosphere.total_moles * 0.05)
+					gases += gas_data.name[g]
+			extra_data += "Atmosphere composition: [english_list(gases)]"
+			var/inaccuracy = rand(8,12)/10
+			extra_data += "Atmosphere pressure [atmosphere.return_pressure()*inaccuracy] kPa, temperature [atmosphere.temperature*inaccuracy] K"
+		else if(user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
+			extra_data += "Atmosphere present"
+		extra_data += "<hr>"
+
+	if(seeds.len && user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
+		extra_data += "Xenoflora detected"
+
+	if(animals.len && user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
+		extra_data += "Life traces detected"
+
+	if(LAZYLEN(spawned_features) && user.skill_check(SKILL_SCIENCE, SKILL_ADEPT))
+		var/ruin_num = 0
+		for(var/datum/map_template/ruin/exoplanet/R in spawned_features)
+			if(!(R.ruin_tags & RUIN_NATURAL))
+				ruin_num++
+		if(ruin_num)
+			extra_data += "<hr>[ruin_num] possible artificial structure\s detected."
+
+	. += jointext(extra_data, "<br>")
 
 /area/exoplanet
 	name = "\improper Planetary surface"

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -47,6 +47,9 @@
 //This is called later in the init order by SSshuttle to populate sector objects. Importantly for subtypes, shuttles will be created by then.
 /obj/effect/overmap/proc/populate_sector_objects()
 
+/obj/effect/overmap/proc/get_scan_data(mob/user)
+	return desc
+
 /obj/effect/overmap/proc/get_areas()
 	return get_filtered_areas(list(/proc/area_belongs_to_zlevels = map_z))
 

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -53,6 +53,16 @@
 			data["status"] = "VACUUM SEAL BROKEN"
 		else
 			data["status"] = "OK"
+		var/list/contacts = list()
+		for(var/obj/effect/overmap/O in view(7,linked))
+			if(linked == O)
+				continue
+			var/bearing = round(90 - Atan2(O.x - linked.x, O.y - linked.y),5)
+			if(bearing < 0)
+				bearing += 360
+			contacts.Add(list(list("name"=O.name, "ref"="\ref[O]", "bearing"=bearing)))
+		if(contacts.len)
+			data["contacts"] = contacts
 	else
 		data["status"] = "MISSING"
 		data["range"] = "N/A"
@@ -133,6 +143,13 @@
 		if (href_list["toggle"])
 			sensors.toggle()
 			return TOPIC_REFRESH
+
+	if (href_list["scan"])
+		var/obj/effect/overmap/O = locate(href_list["scan"])
+		if(istype(O) && !QDELETED(O) && (O in view(7,linked)))
+			playsound(loc, "sound/machines/dotprinter.ogg", 30, 1)
+			new/obj/item/weapon/paper/(get_turf(src), O.get_scan_data(user), "paper (Sensor Scan - [O])")
+		return TOPIC_HANDLED
 
 /obj/machinery/computer/ship/sensors/CouldNotUseTopic(mob/user)
 	unlook(user)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -51,6 +51,11 @@
 /obj/effect/overmap/ship/proc/is_still()
 	return !MOVING(speed[1]) && !MOVING(speed[2])
 
+/obj/effect/overmap/ship/get_scan_data(mob/user)
+	. = ..()
+	if(!is_still())
+		. += "<br>Heading: [dir2angle(get_heading())], speed [get_speed() * 1000]"
+
 //Projected acceleration based on information from engines
 /obj/effect/overmap/ship/proc/get_acceleration()
 	return round(get_total_thrust()/vessel_mass, SHIP_MOVE_RESOLUTION)

--- a/nano/templates/shipsensors.tmpl
+++ b/nano/templates/shipsensors.tmpl
@@ -68,6 +68,21 @@
 		</div>
 	</div>
 </div>
+<h4>Sensor contacts</h4>
+<div class='block'>
+{{if data.contacts}}
+	<table>
+	{{for data.contacts}}
+	<tr>
+	<div class='item'>
+		<td>{{:helper.link('Scan', 'search' ,{ 'scan' : value.ref }, null, null)}}</td>
+		<td><span class='white'>{{:value.name}}</span>, bearing {{:value.bearing}}</td>
+	</div>
+	</tr>
+	{{/for}}
+	</table>
+{{/if}}
+</div>
 {{if data.status == 'MISSING'}}
 	<div class='item'>
 		{{:helper.link('Link up with the sensor suite', 'gear', { 'link' : 1 }, data.status == 'MISSING' ? null : 'disabled', null)}}


### PR DESCRIPTION
Need to 'see' them, e.g. they should be lit up.
By default just returns the description.
For ships, returns heading and speed if they're moving.

For planets, output depends on Science skill.
No skill - just description.
Basic skill - binary yes/no on atmosphere, flora/fauna presence
Trained - number of non-natural ruins detected
Experienced - atmosphere composition, pressure and temperature

Output at full skill

![](https://i.imgur.com/Otbkvbc.png)

:cl: Chinsky
rscadd: Can now scan overmap things with sensor console. By default just shows site description.
rscadd: For ships, shows heading and speed, if ship is moving.
rscadd: For planets output depends on Science skill - atmosphere / plantlife / wildlife presence (Basic), number of non-natural ruins (Trained), compoisition / temp / pressure of atmosphere (Expert).
/:cl: