### PR TITLE
Tweaks to giant spiders

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -46,7 +46,7 @@
 
 	//Breach thresholds, should ideally be inherited by most (if not all) voidsuits.
 	//With 0.2 resiliance, will reach 10 breach damage after 3 laser carbine blasts or 8 smg hits.
-	breach_threshold = 18
+	breach_threshold = 15
 	can_breach = 1
 
 	//Inbuilt devices.

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -262,7 +262,7 @@
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)
 	return
 
-/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message, var/environment_smash, var/damtype = BRUTE, var/armorcheck = "melee")
+/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message, var/environment_smash, var/damtype = BRUTE, var/armorcheck = "melee", dam_flags)
 
 	if(!damage || !istype(user))
 		return
@@ -272,7 +272,7 @@
 
 	var/dam_zone = pick(organs_by_name)
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
-	apply_damage(damage, damtype, affecting)
+	apply_damage(damage, damtype, affecting, dam_flags)
 	updatehealth()
 	return 1
 

--- a/code/modules/mob/living/simple_animal/aquatic/aquatic_carp.dm
+++ b/code/modules/mob/living/simple_animal/aquatic/aquatic_carp.dm
@@ -13,6 +13,7 @@
 	melee_damage_lower = 12
 	melee_damage_upper = 12
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/fish/carp
+	melee_damage_flags = DAM_SHARP
 
 /mob/living/simple_animal/hostile/retaliate/aquatic/carp/New()
 	..()

--- a/code/modules/mob/living/simple_animal/aquatic/aquatic_sharks.dm
+++ b/code/modules/mob/living/simple_animal/aquatic/aquatic_sharks.dm
@@ -13,6 +13,7 @@
 	break_stuff_probability = 15
 	faction = "sharks"
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/fish/shark
+	melee_damage_flags = DAM_SHARP
 
 /mob/living/simple_animal/hostile/aquatic/shark/huge
 	name = "gigacretoxyrhina"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -22,6 +22,7 @@
 	health = 60
 	melee_damage_lower = 20
 	melee_damage_upper = 30
+	melee_damage_flags = DAM_SHARP
 	can_escape = 1
 
 	//Space bears aren't affected by atmos.

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -20,6 +20,7 @@
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
 	pry_time = 10 SECONDS
+	melee_damage_flags = DAM_SHARP
 	pry_desc = "biting"
 
 	//Space carp aren't affected by atmos.

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -24,8 +24,9 @@
 	response_harm   = "pokes"
 	maxHealth = 125
 	health = 125
-	melee_damage_lower = 8
+	melee_damage_lower = 10
 	melee_damage_upper = 15
+	melee_damage_flags = DAM_SHARP
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
 	faction = "spiders"
@@ -181,6 +182,11 @@
 	if(isliving(.))
 		if(health < maxHealth)
 			health += (0.2 * rand(melee_damage_lower, melee_damage_upper)) //heal a bit on hit
+		if(ishuman(.))
+			var/mob/living/carbon/human/H = .
+			var/obj/item/clothing/suit/space/S = H.get_covering_equipped_item_by_zone(BP_CHEST)
+			if(istype(S) && !length(S.breaches))
+				return
 		var/mob/living/L = .
 		if(L.reagents)
 			L.reagents.add_reagent(poison_type, rand(0.5 * poison_per_bite, poison_per_bite))

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -13,6 +13,7 @@
 	maxHealth = 15
 	melee_damage_lower = 2
 	melee_damage_upper = 3
+	melee_damage_flags = DAM_SHARP|DAM_EDGE
 	attacktext = "clawed"
 	projectilesound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	projectiletype = /obj/item/projectile/hivebotbullet

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -5,6 +5,7 @@
 	var/attack_same = 0
 	var/ranged = 0
 	var/rapid = 0
+	var/melee_damage_flags //sharp, edge, etc
 	var/sa_accuracy = 85 //base chance to hit out of 100
 	var/projectiletype
 	var/projectilesound
@@ -139,7 +140,7 @@
 			visible_message("<span class='notice'>\The [src] misses its attack on \the [target_mob]!</span>")
 			return
 		var/mob/living/L = target_mob
-		L.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext,environment_smash,damtype,defense)
+		L.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext,environment_smash,damtype,defense,melee_damage_flags)
 		return L
 	if(istype(target_mob,/obj/mecha))
 		var/obj/mecha/M = target_mob
@@ -164,14 +165,7 @@
 	return L
 
 /mob/living/simple_animal/hostile/proc/get_accuracy()
-	var/accuracy_holder = sa_accuracy
-	if(eye_blind)
-		accuracy_holder -= 15
-	if(confused)
-		accuracy_holder -= 15
-	if(eye_blurry)
-		accuracy_holder -= 10
-	return Clamp(accuracy_holder, 0, 100)
+	return Clamp(sa_accuracy - melee_accuracy_mods(), 0, 100)
 
 /mob/living/simple_animal/hostile/death(gibbed, deathmessage, show_dead_message)
 	..(gibbed, deathmessage, show_dead_message)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -73,6 +73,7 @@
 	speed = 2
 	melee_damage_lower = 5
 	melee_damage_upper = 15
+	melee_damage_flags = DAM_SHARP
 	attacktext = "mauled"
 	cold_damage_per_tick = 0
 	speak_chance = 5
@@ -100,6 +101,7 @@
 	speed = 1
 	melee_damage_lower = 1
 	melee_damage_upper = 8
+	melee_damage_flags = DAM_SHARP
 	attacktext = "gouged"
 	cold_damage_per_tick = 0
 	speak_chance = 5
@@ -121,6 +123,7 @@
 	speed = 1
 	melee_damage_lower = 3
 	melee_damage_upper = 12
+	melee_damage_flags = DAM_SHARP
 	attacktext = "gouged"
 	cold_damage_per_tick = 0
 	speak_chance = 2

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -25,6 +25,7 @@
 	unsuitable_atmos_damage = 15
 	faction = "russian"
 	status_flags = CANPUSH
+	melee_damage_flags = DAM_SHARP|DAM_EDGE
 
 
 /mob/living/simple_animal/hostile/russian/ranged

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -24,6 +24,7 @@ Small, little HP, poisonous.
 	pass_flags = PASS_FLAG_TABLE
 	melee_damage_lower = 5
 	melee_damage_upper = 10
+	melee_damage_flags = DAM_SHARP
 	holder_type = /obj/item/weapon/holder/voxslug
 	faction = SPECIES_VOX
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -80,7 +80,12 @@
 	taste_description = "absolutely vile"
 	color = "#91d895"
 	target_organ = BP_LIVER
-	strength = 7
+	strength = 5
+
+/datum/reagent/toxin/venom/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(prob(volume*2))
+		M.confused = max(M.confused, 3)
+	..()
 
 /datum/reagent/toxin/chlorine
 	name = "Chlorine"


### PR DESCRIPTION
Hostile animals now can have sharp/edged attacks. Spiders attacks are sharp now.
Hostile animals now use base living melee accuracy modifiers instead of re-defining them. In effect it means being blind/confused affects them more now.

Giant spiders now need to breach a spacesuit first before injecting. Voidsuit breach threshold lowered a bit to spider's upper damage, so they have a chance to do so.

Venot strength lowered a bit, instead added confusion effect, fires more often the more poison is injected.

:cl: Chittersky
tweak: If you are wearing a voidsuit, spiders now need to breach it before injecting poison. On other hand, spiders now can breach voidsuits.
tweak: Spider venom's toxin damage is now slightly weaker, but can cause confusion.
/:cl:
