### PR TITLE
Xilvuxix Tweaks 4

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -82,7 +82,7 @@
 
 //tell the docking port to start getting ready for docking - e.g. pressurize
 /datum/computer/file/embedded_program/docking/airlock/prepare_for_docking()
-	airlock_program.begin_cycle_in()
+	airlock_program.begin_dock_cycle()
 
 //are we ready for docking?
 /datum/computer/file/embedded_program/docking/airlock/ready_for_docking()

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -281,6 +281,12 @@
 	playsound(master, 'sound/machines/warning-buzzer.ogg', 50)
 	shutAlarm()
 
+/datum/computer/file/embedded_program/airlock/proc/begin_dock_cycle()
+	state = STATE_IDLE
+	target_state = TARGET_INOPEN
+	playsound(master, 'sound/machines/warning-buzzer.ogg', 50)
+	shutAlarm()
+
 /datum/computer/file/embedded_program/airlock/proc/begin_cycle_out()
 	state = STATE_IDLE
 	target_state = TARGET_OUTOPEN

--- a/maps/away/skrellscoutship/skrellscoutship-1.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-1.dmm
@@ -109,10 +109,6 @@
 "ar" = (
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/medbay)
-"as" = (
-/obj/effect/paint/sun,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/kitchen)
 "at" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/accessory/storage/black_vest,
@@ -195,13 +191,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/medbay)
-"aH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/skrell,
-/area/ship/skrellscoutship/hangar)
 "aI" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/hangar)
 "aJ" = (
@@ -227,8 +220,6 @@
 	target_temperature = 313.15;
 	temperature = 313.15
 	},
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "aL" = (
@@ -263,9 +254,6 @@
 "aQ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
@@ -313,9 +301,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
 "aY" = (
@@ -422,30 +408,20 @@
 /turf/simulated/floor/plating,
 /area/ship/skrellscoutshuttle)
 "bi" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1292;
-	id_tag = "xil_shuttle_outer";
-	locked = 0
-	},
-/obj/machinery/door/blast/regular/open{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	id = "xil_shuttle";
-	name = "Blast Doors"
-	},
-/obj/machinery/access_button/airlock_exterior{
 	frequency = 1292;
-	master_tag = "xil_shuttle";
-	pixel_x = 32;
-	pixel_y = -4
+	id_tag = "xil_shuttle_dock_pump_out_internal"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock";
+	pixel_x = 20;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
 /turf/simulated/floor/plating,
-/area/ship/skrellscoutshuttle)
+/area/ship/skrellscoutship/hangar)
 "bj" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -474,16 +450,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/medbay)
-"bn" = (
-/obj/machinery/door/airlock/glass/atmos{
-	name = "Hangar"
-	},
-/obj/machinery/door/firedoor/autoset,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/skrell,
-/area/ship/skrellscoutship/hangar)
 "bo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -496,26 +462,13 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass/atmos{
-	name = "Hangar"
+	name = "Shuttle Dock"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/hangar)
-"bp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	req_access = list("ACCESS_SKRELLSCOUT");
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	target_temperature = 313.15;
-	temperature = 313.15
-	},
-/turf/simulated/floor/tiled/skrell,
-/area/ship/skrellscoutship/crew/hallway/d2)
 "bq" = (
 /obj/structure/bed/chair/shuttle{
 	tag = "icon-shuttle_chair_preview (NORTH)";
@@ -574,6 +527,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -945,6 +901,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1292;
+	master_tag = "xil_shuttle_dock";
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/hangar)
 "cp" = (
@@ -1059,10 +1021,6 @@
 /obj/item/clothing/accessory/storage/black_vest,
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/quarters)
-"cC" = (
-/obj/effect/paint/blue,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/command/armory)
 "cD" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1292;
@@ -1261,6 +1219,7 @@
 	frequency = 1292;
 	id_tag = "xil_shuttle";
 	pixel_y = -24;
+	req_access = list("ACCESS_SKRELLSCOUT");
 	tag_exterior_sensor = "xil_shuttle_sensor_external"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1272,7 +1231,12 @@
 /area/ship/skrellscoutshuttle)
 "de" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/skrell,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_pump"
+	},
+/turf/simulated/floor/plating,
 /area/ship/skrellscoutship/hangar)
 "df" = (
 /obj/structure/cable{
@@ -1364,10 +1328,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
-"dq" = (
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/turf/simulated/floor/tiled/skrell/green,
-/area/ship/skrellscoutship/maintenance/atmos)
 "ds" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -1390,9 +1350,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/alarm{
 	req_access = list("ACCESS_SKRELLSCOUT");
 	dir = 8;
@@ -1402,6 +1359,9 @@
 	temperature = 313.15
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -1425,13 +1385,12 @@
 /obj/item/weapon/melee/energy/machete,
 /obj/item/weapon/melee/energy/machete,
 /obj/item/weapon/melee/energy/machete,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/command/armory)
 "dx" = (
-/obj/machinery/door/airlock/glass/atmos{
-	name = "Atmospherics"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
@@ -1528,7 +1487,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/skrell,
@@ -1635,12 +1594,6 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/command/armory)
-"dU" = (
-/obj/effect/wingrille_spawn/reinforced_phoron,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/tiled/skrell/green,
-/area/ship/skrellscoutship/maintenance/atmos)
 "dV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1675,14 +1628,19 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
 "dY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
+	},
+/obj/machinery/power/apc/critical{
+	req_access = list("ACCESS_SKRELLSCOUT");
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
@@ -1707,10 +1665,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/command/armory)
-"ec" = (
-/obj/effect/paint/expeditionary,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/quarters)
 "ed" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1732,8 +1686,9 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
 "ef" = (
-/obj/effect/paint/green,
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "eg" = (
 /obj/machinery/power/terminal{
@@ -1784,11 +1739,10 @@
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "el" = (
-/obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "en" = (
@@ -2043,11 +1997,6 @@
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "eW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/pipedispenser,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
@@ -2163,19 +2112,6 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
 "fr" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/machinery/power/apc/critical{
-	req_access = list("ACCESS_SKRELLSCOUT");
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
@@ -2358,6 +2294,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
 "fU" = (
@@ -2366,6 +2305,17 @@
 	},
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutshuttle)
+"fY" = (
+/obj/machinery/door/airlock/external/glass/bolted{
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_inner"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/hangar)
 "he" = (
 /obj/machinery/door/firedoor/autoset,
 /turf/simulated/floor/tiled/skrell,
@@ -2373,14 +2323,18 @@
 "hk" = (
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
-"hO" = (
-/obj/effect/paint/sun,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/medbay)
 "jf" = (
 /obj/structure/table/woodentable/ebony,
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/quarters)
+"jC" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/skrell/green,
+/area/ship/skrellscoutship/maintenance/atmos)
 "jI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2406,16 +2360,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
-"mo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/skrell,
-/area/ship/skrellscoutship/hangar)
-"mp" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/skrell/green,
-/area/ship/skrellscoutship/maintenance/atmos)
 "mI" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -2432,6 +2376,9 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
+"oS" = (
+/turf/simulated/floor/tiled/skrell/green,
+/area/ship/skrellscoutship/maintenance/atmos)
 "ph" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/glasses/square,
@@ -2473,6 +2420,10 @@
 /obj/item/device/scanner/gas,
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutshuttle)
+"qX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/hangar)
 "rq" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood,
@@ -2578,12 +2529,29 @@
 	},
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/command/armory)
-"wA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+"yj" = (
+/obj/machinery/door/firedoor/autoset,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1;
-	level = 2
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/hangar)
+"yk" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_pump_out_external"
+	},
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/hangar)
+"yC" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
+/turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/hangar)
 "yX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2613,6 +2581,25 @@
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship,
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/quarters)
+"Ch" = (
+/obj/effect/shuttle_landmark/skrellscoutshuttle/start,
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "xil_shuttle_dock";
+	pixel_x = -24;
+	pixel_y = 10;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
+/obj/machinery/door/airlock/external/glass/bolted{
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_outer"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "xil_airlock";
+	name = "Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/ship/skrellscoutship/hangar)
 "CE" = (
 /obj/effect/paint/silver,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -2665,6 +2652,21 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/skrellscoutship/command/armory)
+"Fv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/autoset,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "xil_bridge";
+	name = "Blast Doors"
+	},
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/hangar)
 "FK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/skrell/white,
@@ -2702,8 +2704,12 @@
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/crew/kitchen)
 "Jq" = (
-/obj/effect/shuttle_landmark/skrellscoutshuttle/start,
-/turf/simulated/floor/tiled/skrell,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_pump_out_internal"
+	},
+/turf/simulated/floor/plating,
 /area/ship/skrellscoutship/hangar)
 "Jx" = (
 /obj/structure/cable{
@@ -2717,17 +2723,29 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
-"LD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+"Lz" = (
+/obj/machinery/airlock_sensor{
+	id_tag = "xil_shuttle_dock_sensor";
+	pixel_y = 22
 	},
-/turf/simulated/floor/tiled/skrell,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_pump"
+	},
+/turf/simulated/floor/plating,
 /area/ship/skrellscoutship/hangar)
 "LY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/skrell/green,
+/area/ship/skrellscoutship/maintenance/atmos)
+"Mz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "MJ" = (
@@ -2771,10 +2789,12 @@
 	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/quarters)
-"PB" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
+"Pw" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/maintenance/atmos)
 "PZ" = (
@@ -2792,6 +2812,13 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/medbay)
+"Rh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/hangar)
 "Rn" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
@@ -2806,6 +2833,11 @@
 /obj/item/weapon/storage/box/lights/tubes,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
+"Ss" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/skrell/green,
+/area/ship/skrellscoutship/maintenance/atmos)
 "Tf" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -2828,6 +2860,19 @@
 	},
 /turf/simulated/wall/r_titanium,
 /area/ship/skrellscoutshuttle)
+"UB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	icon_state = "map_connector";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/hangar)
 "UQ" = (
 /obj/item/weapon/melee/baton/loaded,
 /obj/item/weapon/melee/baton/loaded,
@@ -2845,6 +2890,27 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
+"VH" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1292;
+	id_tag = "xil_shuttle_outer";
+	locked = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "xil_shuttle";
+	name = "Blast Doors"
+	},
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1292;
+	master_tag = "xil_shuttle";
+	pixel_x = 32;
+	pixel_y = -4;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/floor/plating,
+/area/ship/skrellscoutshuttle)
 "VM" = (
 /obj/structure/bed/chair/padded/red{
 	icon_state = "chair_preview";
@@ -2860,6 +2926,11 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/command/armory)
+"Xc" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/wall/r_wall,
+/area/ship/skrellscoutship/hangar)
 "Xd" = (
 /obj/machinery/shipsensors/weak,
 /turf/simulated/floor/tiled/skrell/red,
@@ -2875,6 +2946,18 @@
 /obj/machinery/door/firedoor/autoset,
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
+"XA" = (
+/obj/machinery/airlock_sensor{
+	id_tag = "xil_shuttle_dock_sensor_external";
+	pixel_x = -20
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1292;
+	id_tag = "xil_shuttle_dock_pump_out_external"
+	},
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/hangar)
 "Yh" = (
 /obj/machinery/door/airlock/glass{
 	name = "EVA"
@@ -2887,9 +2970,16 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/hangar)
 "Zp" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/hangar)
+/obj/machinery/alarm{
+	req_access = list("ACCESS_SKRELLSCOUT");
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	target_temperature = 313.15;
+	temperature = 313.15
+	},
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutship/crew/hallway/d2)
 "Zr" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2898,7 +2988,7 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d2)
 "ZE" = (
-/obj/effect/paint/green,
+/obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/robotics)
 "ZO" = (
@@ -7963,7 +8053,7 @@ cU
 dj
 dE
 fk
-as
+IK
 Dj
 Dj
 Dj
@@ -8075,7 +8165,7 @@ aa
 ab
 ab
 bg
-hO
+ab
 cs
 cF
 cF
@@ -8085,7 +8175,7 @@ cO
 vz
 dn
 fm
-as
+IK
 eo
 TE
 en
@@ -8197,7 +8287,7 @@ ab
 ab
 aB
 bb
-hO
+ab
 bF
 cF
 cF
@@ -8207,7 +8297,7 @@ cP
 cF
 sa
 fo
-as
+IK
 TE
 TE
 TE
@@ -8319,7 +8409,7 @@ ab
 av
 ar
 bb
-hO
+ab
 bz
 cF
 bO
@@ -8329,7 +8419,7 @@ cX
 cY
 dF
 cy
-as
+IK
 dB
 ep
 eK
@@ -8441,17 +8531,17 @@ ab
 aw
 aC
 bm
-hO
-as
-as
-as
+ab
+IK
+IK
+IK
 cJ
-as
-as
-as
-as
+IK
+IK
+IK
+IK
 fx
-as
+IK
 dH
 eq
 Jx
@@ -8942,11 +9032,11 @@ fc
 ZE
 TE
 cd
-cC
-cC
-cC
+Xb
+Xb
+Xb
 Yh
-cC
+Xb
 Xb
 aa
 aa
@@ -9064,7 +9154,7 @@ fy
 ZE
 pt
 fg
-cC
+Xb
 vi
 ey
 dA
@@ -9186,7 +9276,7 @@ fz
 ZE
 eo
 yX
-cC
+Xb
 PZ
 dA
 eu
@@ -9430,7 +9520,7 @@ fB
 ZE
 TE
 Zr
-cC
+Xb
 dT
 jI
 eQ
@@ -9662,7 +9752,7 @@ ad
 ai
 aP
 aX
-bc
+cw
 bv
 bc
 cg
@@ -9674,7 +9764,7 @@ bc
 dZ
 eC
 dQ
-cC
+Xb
 dw
 kB
 eT
@@ -9782,9 +9872,9 @@ ae
 Pn
 Hb
 am
-ec
+vZ
 aQ
-bp
+bN
 by
 bN
 ch
@@ -9904,21 +9994,21 @@ BW
 BW
 BW
 BW
-ec
-bn
+vZ
+ee
 Zp
-Zp
-Zp
-Zp
-Zp
-Zp
+TE
+TE
+aU
+aU
+aU
 bo
 aU
 ci
 ee
 df
 TE
-cC
+Xb
 eg
 ex
 fb
@@ -10025,22 +10115,22 @@ vZ
 vZ
 vZ
 vZ
+vZ
+vZ
+Dj
+Dj
+Dj
+Dj
 aU
-aU
-LD
-mo
-wA
-aH
-aI
-aI
-aI
+Yp
+Rh
 bw
 aU
 eP
-ef
+Rn
 do
-ef
-ef
+Rn
+Rn
 Rn
 Xb
 Xb
@@ -10147,15 +10237,15 @@ an
 an
 an
 vZ
+bH
+bs
+bs
+bs
+bs
+bH
 aU
-aH
-bH
-bs
-bs
-bs
-bs
-bH
-Yp
+aU
+qX
 dG
 aU
 dK
@@ -10268,8 +10358,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 bH
 ca
@@ -10278,6 +10366,8 @@ bL
 fU
 bH
 bH
+aU
+aI
 dJ
 aU
 bA
@@ -10390,8 +10480,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 ag
 bq
@@ -10400,13 +10488,15 @@ bT
 bW
 cT
 dc
+Fv
+UB
 co
 aU
 LY
 ei
 ef
-ef
-ef
+Mz
+jC
 Rn
 aa
 aa
@@ -10512,8 +10602,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 ap
 bD
@@ -10522,12 +10610,14 @@ bH
 cq
 cz
 bH
-aI
+aU
+yj
+fY
 aU
 vc
 ej
-ef
-el
+Ss
+eH
 el
 Rn
 aa
@@ -10634,8 +10724,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 aq
 bD
@@ -10644,13 +10732,15 @@ CE
 cD
 dd
 Up
+aU
+Lz
 de
 aU
 CJ
 dM
-ef
-mp
-PB
+Ss
+eH
+eV
 Rn
 aa
 aa
@@ -10756,8 +10846,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 aW
 Da
@@ -10765,14 +10853,16 @@ bt
 bh
 dR
 sk
+VH
+Ch
 bi
 Jq
 aU
 dN
 ek
-dq
-mp
-eV
+Ss
+eH
+Pw
 Rn
 aa
 aa
@@ -10878,8 +10968,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 qD
 bG
@@ -10888,7 +10976,9 @@ CV
 dR
 sk
 pO
-aI
+aU
+yC
+Xc
 aU
 dP
 dp
@@ -11000,8 +11090,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 bH
 bH
 bH
@@ -11010,11 +11098,13 @@ bH
 bH
 OY
 pO
-aI
+aa
+yk
+XA
 aU
 aK
-eG
-dU
+oS
+ef
 eS
 eV
 Rn
@@ -11122,8 +11212,6 @@ aa
 aa
 aa
 aa
-aa
-aU
 Xd
 bD
 bH
@@ -11132,7 +11220,9 @@ bS
 bH
 Ik
 fK
-aI
+aa
+aa
+aa
 aU
 fG
 Rn
@@ -11245,17 +11335,17 @@ aa
 aa
 aa
 aa
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 dS
 aa
 aa

--- a/maps/away/skrellscoutship/skrellscoutship-2.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-2.dmm
@@ -165,8 +165,8 @@
 /turf/simulated/floor/plating,
 /area/ship/skrellscoutship/dock)
 "ax" = (
-/obj/effect/paint/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/maintenance/power)
 "ay" = (
@@ -267,10 +267,6 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/dock)
-"aK" = (
-/obj/effect/paint/expeditionary,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/fit)
 "aL" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -337,10 +333,6 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/dock)
-"aS" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/command/bridge)
 "aT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -405,14 +397,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/fit)
-"bb" = (
-/obj/effect/paint/expeditionary,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/toilets)
 "bd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -511,12 +495,6 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d1)
-"bn" = (
-/obj/effect/paint/expeditionary,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/toilets)
 "bo" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/skrell/orange,
@@ -1611,7 +1589,7 @@
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/paint/green,
+/obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/maintenance/power)
 "dq" = (
@@ -1758,10 +1736,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/rec)
-"sB" = (
-/obj/effect/paint/sun,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/rec)
 "td" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -1769,10 +1743,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/rec)
-"uC" = (
-/obj/effect/paint/green,
-/turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/maintenance/power)
 "uX" = (
 /obj/machinery/door/firedoor/autoset,
 /obj/structure/cable{
@@ -1832,10 +1802,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/crew/fit)
-"BA" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/skrellscoutship/solars)
 "BU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1918,11 +1884,6 @@
 "Mg" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/rec)
-"MG" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor/autoset,
-/turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/rec)
 "NS" = (
 /turf/simulated/open,
@@ -6984,13 +6945,13 @@ aa
 wb
 wb
 wb
-sB
+Mg
 bj
 Rb
 wz
 HT
 rz
-sB
+Mg
 ah
 ah
 ah
@@ -7106,7 +7067,7 @@ Bz
 wb
 yh
 pi
-MG
+Mg
 bk
 nH
 td
@@ -7225,16 +7186,16 @@ aa
 Bz
 Bz
 bo
-aK
+Bz
 iX
 aq
-sB
+Mg
 bl
-sB
+Mg
 Rr
-sB
+Mg
 qi
-sB
+Mg
 bW
 SD
 YL
@@ -7347,10 +7308,10 @@ Bz
 Bz
 bo
 FP
-aK
+Bz
 Uk
-bb
-bn
+wb
+wb
 YX
 Gn
 ca
@@ -7469,7 +7430,7 @@ Bz
 FP
 FP
 bx
-aK
+Bz
 BU
 PL
 at
@@ -7478,11 +7439,11 @@ oP
 at
 PL
 bK
-uC
-uC
-uC
-uC
-uC
+bP
+bP
+bP
+bP
+bP
 cE
 cD
 ah
@@ -7593,19 +7554,19 @@ xw
 by
 ae
 oO
-aS
-aS
+aW
+aW
 aU
 aU
-aS
-aS
+aW
+aW
 bK
-uC
+bP
 cz
 co
 cu
-uC
-uC
+bP
+bP
 cH
 ah
 ah
@@ -7713,14 +7674,14 @@ aB
 be
 bq
 bz
-aK
+Bz
 uX
-aS
+aW
 bs
 bO
 wS
 nU
-aS
+aW
 do
 cg
 ci
@@ -7831,20 +7792,20 @@ aa
 aa
 Bz
 Bz
-aK
-aK
-aK
+Bz
+Bz
+Bz
 bg
-aK
+Bz
 oO
-aS
+aW
 bt
 bu
 bY
 cd
-aS
+aW
 bN
-uC
+bP
 cj
 bZ
 cw
@@ -7959,19 +7920,19 @@ oU
 bC
 bE
 aZ
-aS
+aW
 ds
 Lg
 bS
 cf
-aS
+aW
 dr
-uC
+bP
 ck
-uC
+bP
 cy
-uC
-uC
+bP
+bP
 cH
 bQ
 Gb
@@ -8088,12 +8049,12 @@ bU
 cb
 ce
 bG
-uC
+bP
 cl
 ax
 ch
-uC
-uC
+bP
+bP
 cK
 TF
 OH
@@ -8322,7 +8283,7 @@ aL
 aO
 vb
 ac
-BA
+ac
 ai
 am
 am
@@ -9418,7 +9379,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 aj
@@ -9540,7 +9501,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 aj
@@ -9662,7 +9623,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 ak
@@ -9784,7 +9745,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 aj
@@ -9906,7 +9867,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 aj
@@ -10028,7 +9989,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 aj
@@ -10150,7 +10111,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 aj
@@ -10272,7 +10233,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ag
 al
@@ -10394,7 +10355,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 ac
 ac
 ac

--- a/maps/away/skrellscoutship/skrellscoutship_areas.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_areas.dm
@@ -46,7 +46,7 @@
 	icon_state = "entry_1"
 
 /area/ship/skrellscoutship/hangar
-	name = "\improper Hangar"
+	name = "\improper Shuttle Dock"
 	icon_state = "auxstorage"
 
 /area/ship/skrellscoutship/robotics

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -51,6 +51,7 @@
 		/area/ship/skrellscoutship/command/armory, /area/ship/skrellscoutship/crew/rec
 		)
 	defer_initialisation = TRUE
+	knockdown = FALSE
 	flags = SHUTTLE_FLAGS_PROCESS
 	skill_needed = SKILL_NONE
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/torch
@@ -64,7 +65,7 @@
 	warmup_time = 5
 	current_location = "nav_skrellscoutsh_dock"
 	range = 2
-	current_dock_target = "xil_shuttle"
+	dock_target = "xil_shuttle"
 	shuttle_area = /area/ship/skrellscoutshuttle
 	defer_initialisation = TRUE
 	flags = SHUTTLE_FLAGS_PROCESS
@@ -77,6 +78,7 @@
 	landmark_tag = "nav_skrellscoutsh_dock"
 	base_area = /area/ship/skrellscoutship/hangar
 	base_turf = /turf/simulated/floor/tiled/skrell
+	docking_controller = "xil_shuttle_dock"
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 	
 /obj/effect/shuttle_landmark/skrellscoutshuttle/altdock


### PR DESCRIPTION
Changes hangar to a docking port, removes stray sensor array, beefs up air supply and adds binoculars.

Also unifies wall colors, it seemed strange after a few rounds to see the different colored walls while exterior facing walls were all the same.

![](https://i.imgur.com/AAzPa3F.png)

:cl:
:maptweak: Xilvuxix shuttle now lives in a dock, not a hangar
:tweak: Xilvuxix air supply increased, binoculars added
:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->