### PR TITLE
Fixes NanoUI "To BYOND Cache" script

### DIFF
--- a/nano/To BYOND Cache.bat
+++ b/nano/To BYOND Cache.bat
@@ -1,4 +1,6 @@
-copy css\* "%USERPROFILE%\Documents\BYOND\cache" /y
-copy images\* "%USERPROFILE%\Documents\BYOND\cache" /y
-copy js\* "%USERPROFILE%\Documents\BYOND\cache" /y
-copy templates\* "%USERPROFILE%\Documents\BYOND\cache" /y
+for /D %%i in ("%USERPROFILE%\Documents\BYOND\cache\*") do ( 
+	copy css\* %%i /y
+	copy images\* %%i /y
+	copy js\* %%i /y
+	copy templates\* %%i /y
+)


### PR DESCRIPTION
It was broken by a BYOND update that changed the way cache folder works. I fixed it.