### PR TITLE
Changes way shuttle (jump) fuel is displayed

### DIFF
--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -6,23 +6,22 @@
 /obj/machinery/computer/shuttle_control/explore/get_ui_data(var/datum/shuttle/autodock/overmap/shuttle)
 	. = ..()
 	if(istype(shuttle))
-		var/fuel_pressure = 0
-		var/fuel_max_pressure = 0
+		var/total_gas = 0
 		for(var/obj/structure/fuel_port/FP in shuttle.fuel_ports) //loop through fuel ports
 			var/obj/item/weapon/tank/fuel_tank = locate() in FP
 			if(fuel_tank)
-				fuel_pressure += fuel_tank.air_contents.return_pressure()
-				fuel_max_pressure += 1013
+				total_gas += fuel_tank.air_contents.total_moles
 
-		if(fuel_max_pressure == 0) fuel_max_pressure = 1
+		var/fuel_span = "good"
+		if(total_gas < shuttle.fuel_consumption * 2)
+			fuel_span = "bad"
 
 		. += list(
 			"destination_name" = shuttle.get_destination_name(),
 			"can_pick" = shuttle.moving_status == SHUTTLE_IDLE,
-			"fuel_port_present" = shuttle.fuel_consumption? 1 : 0,
-			"fuel_pressure" = fuel_pressure,
-			"fuel_max_pressure" = fuel_max_pressure,
-			"fuel_pressure_status" = (fuel_pressure/fuel_max_pressure > 0.2)? "good" : "bad"
+			"fuel_usage" = shuttle.fuel_consumption * 100,
+			"remaining_fuel" = round(total_gas, 0.01) * 100,
+			"fuel_span" = fuel_span
 		)
 
 /obj/machinery/computer/shuttle_control/explore/handle_topic_href(var/datum/shuttle/autodock/overmap/shuttle, var/list/href_list)	

--- a/nano/templates/shuttle_control_console_exploration.tmpl
+++ b/nano/templates/shuttle_control_console_exploration.tmpl
@@ -61,15 +61,22 @@
 		{{:helper.link('Choose Destination', 'arrowreturn-1-s', {'pick' : '1'}, data.can_pick ? null : 'disabled' , null)}}
 	</div>
 </div>
-<div class="item" style="padding-top: 10px">
-	<div class="itemLabel">
-		Fuel Tank Pressure:
+{{if data.fuel_usage}}
+	<div class="item" style="padding-top: 10px">
+		<div class="itemLabel">
+			Est. Delta-V Budget:
+		</div>
+		<div class="itemContent">
+			<span class='{{:data.fuel_span}}'>{{:data.remaining_fuel}} m/s</span>
+		</div>
+		<div class="itemLabel">
+			Avg. Delta-V Per Maneuver:
+		</div>
+		<div class="itemContent">
+			 {{:data.fuel_usage}} m/s
+		</div>
 	</div>
-	<div class="itemContent">
-		{{:data.fuel_port_present ? helper.displayBar(data.fuel_pressure, 0, data.fuel_max_pressure, data.fuel_pressure_status) : ''}}
-		{{:data.fuel_port_present ? data.fuel_pressure : '<i>This shuttle\'s ionic propulsion does not require fuel.</i>'}}{{:data.fuel_port_present ? ' kPa' : ''}}
-	</div>
-</div>
+{{/if}}
 <h3>Shuttle Control</h3>
 <div class="item" style="padding-top: 10px">
 	<div class="item">


### PR DESCRIPTION
Instead of gas pressure it now shows bullshit 'Delta-V', which is just gas moles count multiplied by 100 for prettiness.

Reasoning is that moles is ACTUAL gauge of fuel, pressure is misleading.
Also displaying usage per jump, so you can actually tell if you're going to strand yourself or no.

:cl: Chinsky
tweak: Shuttles now display their fuel in Delta-V rather than pressure gauge. They also show Delta-V used per move, so you can actually gauge how many jumps you have left on your fuel.
/:cl:

![](https://i.imgur.com/UDe7RyW.png)
