### PR TITLE
Helm console reshuffle

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -13,10 +13,12 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	var/dx		//desitnation
 	var/dy		//coordinates
 	var/speedlimit = 1/(45 SECONDS) //top speed for autopilot
+	var/accellimit = 10 //manual limiter for acceleration
 
 /obj/machinery/computer/ship/helm/Initialize()
 	. = ..()
 	get_known_sectors()
+	speedlimit = round(speedlimit)
 
 /obj/machinery/computer/ship/helm/attempt_hook_up(obj/effect/overmap/ship/sector)
 	if(!(. = ..()))
@@ -46,7 +48,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		else
 			var/brake_path = linked.get_brake_path()
 			var/direction = get_dir(linked.loc, T)
-			var/acceleration = linked.get_acceleration()
+			var/acceleration = min(linked.get_acceleration(), accellimit)
 			var/speed = linked.get_speed()
 			var/heading = linked.get_heading()
 
@@ -64,7 +66,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 /obj/machinery/computer/ship/helm/relaymove(var/mob/user, direction)
 	if(manual_control && linked)
-		linked.relaymove(user,direction)
+		if(prob(user.skill_fail_chance(SKILL_PILOT, 50, linked.skill_needed, factor = 1)))
+			direction = turn(direction,pick(90,-90))
+		linked.relaymove(user, direction, accellimit)
 		return 1
 
 /obj/machinery/computer/ship/helm/check_eye(var/mob/user as mob)
@@ -102,11 +106,12 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		data["d_x"] = dx
 		data["d_y"] = dy
 		data["speedlimit"] = speedlimit ? speedlimit*1000 : "None"
-		data["accel"] = round(linked.get_acceleration()*1000, 0.01)
+		data["accel"] = min(round(linked.get_acceleration()*1000, 0.01),accellimit)
 		data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
 		data["autopilot"] = autopilot
 		data["manual_control"] = manual_control
 		data["canburn"] = linked.can_burn()
+		data["accellimit"] = accellimit
 
 		var/speed = round(linked.get_speed()*1000, 0.01)
 		if(linked.get_speed() < SHIP_SPEED_SLOW)
@@ -134,7 +139,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 		ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 		if (!ui)
-			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 400, 630)
+			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 560, 545)
 			ui.set_initial_data(data)
 			ui.open()
 			ui.set_auto_update(1)
@@ -204,12 +209,16 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		var/newlimit = input("Input new speed limit for autopilot (0 to disable)", "Autopilot speed limit", speedlimit*1000) as num|null
 		if(newlimit)
 			speedlimit = Clamp(newlimit/1000, 0, 100)
+	if (href_list["accellimit"])
+		var/newlimit = input("Input new acceleration limit", "Acceleration limit", accellimit) as num|null
+		if(newlimit)
+			accellimit = max(newlimit, 0)
 
 	if (href_list["move"])
 		var/ndir = text2num(href_list["move"])
 		if(prob(user.skill_fail_chance(SKILL_PILOT, 50, linked.skill_needed, factor = 1)))
 			ndir = turn(ndir,pick(90,-90))
-		linked.relaymove(user, ndir)
+		linked.relaymove(user, ndir, accellimit)
 
 	if (href_list["brake"])
 		linked.decelerate()

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -45,8 +45,8 @@
 	SSshuttle.ships -= src
 	. = ..()
 
-/obj/effect/overmap/ship/relaymove(mob/user, direction)
-	accelerate(direction)
+/obj/effect/overmap/ship/relaymove(mob/user, direction, accel_limit)
+	accelerate(direction, accel_limit)
 
 /obj/effect/overmap/ship/proc/is_still()
 	return !MOVING(speed[1]) && !MOVING(speed[2])
@@ -112,18 +112,18 @@
 			adjust_speed(0, -SIGN(speed[2]) * min(get_burn_acceleration(),abs(speed[2])))
 		last_burn = world.time
 
-/obj/effect/overmap/ship/proc/accelerate(direction)
+/obj/effect/overmap/ship/proc/accelerate(direction, accel_limit)
 	if(can_burn())
 		last_burn = world.time
-
+		var/acceleration = min(get_burn_acceleration(), accel_limit)
 		if(direction & EAST)
-			adjust_speed(get_burn_acceleration(), 0)
+			adjust_speed(acceleration, 0)
 		if(direction & WEST)
-			adjust_speed(-get_burn_acceleration(), 0)
+			adjust_speed(-acceleration, 0)
 		if(direction & NORTH)
-			adjust_speed(0, get_burn_acceleration())
+			adjust_speed(0, acceleration)
 		if(direction & SOUTH)
-			adjust_speed(0, -get_burn_acceleration())
+			adjust_speed(0, -acceleration)
 
 /obj/effect/overmap/ship/Process()
 	if(!halted && !is_still())

--- a/html/changelogs/chinsky - limit.yml
+++ b/html/changelogs/chinsky - limit.yml
@@ -1,0 +1,5 @@
+author: Chinsky
+delete-after: True
+changes: 
+  - tweak: "Helm console layout changed, mostly to prevent sector descriptions shifting movement keys down at WRONG FUCKIGN MOMENT."
+  - rscadd: "Added acceleration limiter to helm console. Hard value vs engine thruster's percentage. Doesn't affect fuel usage, use engine limiters for that."

--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -1,134 +1,159 @@
 
-<div style="float:left;width:50%">
-	<h3>Sector information</h3> 
-	<div class='block'>
-		{{:data.sector}}
-		<br>
-		<span class='average'>Coordinates:</span> {{:data.s_x}} : {{:data.s_y}}
-		<br>
-		<span class='average'>Additional information:</span> {{:data.sector_info}}
-		<br>
-		<span class='average'>Status:</span> {{:data.landed}}
-	</div>
-</div>
-
-<div style="float:right;width:50%">
-	<h3>Flight data</h3> 
-	<div class='block'>
-		<div class='item'>
-			<div class="itemLabel">
-				<span class='average'>ETA to next grid:</span>
-			</div>
-			<div style="float:right">
-				{{:data.ETAnext}}
-			</div>
-		</div>
-		<div class='item'>
-			<div class="itemLabel">
-				<span class='average'>Speed:</span>
-			</div>
-			<div style="float:right">
-				{{:data.speed}}
-			</div>
-		</div>
-		<div class='item'>
-			<div class="itemLabel">
-				<span class='average'>Acceleration:</span>
-			</div>
-			<div style="float:right">
-				{{:data.accel}}
-			</div>
-		</div>
-		<div class='item'>
-			<div class="itemLabel">
-				<span class='average'>Heading:</span>
-			</div>
-			<div style="float:right">
-				{{:data.heading}}
-			</div>
-		</div> 
-	</div>
-</div>
 
 
-<h3>Manual control</h3>
-<div class='block'>
-	<div class='item'>
-		<div class="itemLabel">
+<div style="float:left;width:45%;">
+		<div class='block' style="height:180px;">
+				<h3>Flight data</h3> 
 			<div class='item'>
-				{{:helper.link('', 'triangle-1-nw', { 'move' : 9 }, data.canburn ? null : 'disabled', null)}}
-				{{:helper.link('', 'triangle-1-n', { 'move' : 1 }, data.canburn ? null : 'disabled', null)}}
-				{{:helper.link('', 'triangle-1-ne', { 'move' : 5 }, data.canburn ? null : 'disabled', null)}}
+				<div class="itemLabelWider">
+					ETA to next grid:
+				</div>
+				<div style="float:right">
+					{{:data.ETAnext}}
+				</div>
 			</div>
 			<div class='item'>
-				{{:helper.link('', 'triangle-1-w', { 'move' : 8 }, data.canburn ? null : 'disabled', null)}}
-				{{:helper.link('', 'circle-close', { 'brake' : 1 }, data.canburn ? null : 'disabled', null)}}
-				{{:helper.link('', 'triangle-1-e', { 'move' : 4 }, data.canburn ? null : 'disabled', null)}}
+				<div class="itemLabelWider">
+					Speed:
+				</div>
+				<div style="float:right">
+					{{:data.speed}}
+				</div>
 			</div>
 			<div class='item'>
-				{{:helper.link('', 'triangle-1-sw', { 'move' : 10 }, data.canburn ? null : 'disabled', null)}}
-				{{:helper.link('', 'triangle-1-s', { 'move' : 2 }, data.canburn ? null : 'disabled', null)}}
-				{{:helper.link('', 'triangle-1-se', { 'move' : 6 }, data.canburn ? null : 'disabled', null)}}
+				<div class="itemLabelWider">
+					Acceleration:
+				</div>
+				<div style="float:right">
+					{{:data.accel}}
+				</div>
 			</div>
-		</div>
-
-		<div class="itemContent">
 			<div class='item'>
-				<span class='white'>Direct control</span>
-				{{:helper.link(data.manual_control ? 'Engaged' : 'Disengaged', 'shuffle', { 'manual' : 1 }, null, data.manual_control ? 'selected' : null)}}
+				<div class="itemLabelWider">
+					Heading:
+				</div>
+				<div style="float:right">
+					{{:data.heading}}
+				</div>
+			</div> 
+			<div class='item'>
+				<div class="itemLabelWider">
+					Acceleration limiter:
+				</div>
+				<div style="float:right">
+					{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}}
+				</div>
+			</div> 
+		</div>
+		</div>
+		
+		<div style="float:left;width:25%">
+		<div class='block' style="height:180px;">
+			<h3>Manual control</h3>
+			<div class='item'>
+				<div class='item'>
+					{{:helper.link('', 'triangle-1-nw', { 'move' : 9 }, data.canburn ? null : 'disabled', null)}}
+					{{:helper.link('', 'triangle-1-n', { 'move' : 1 }, data.canburn ? null : 'disabled', null)}}
+					{{:helper.link('', 'triangle-1-ne', { 'move' : 5 }, data.canburn ? null : 'disabled', null)}}
+				</div>
+				<div class='item'>
+					{{:helper.link('', 'triangle-1-w', { 'move' : 8 }, data.canburn ? null : 'disabled', null)}}
+					{{:helper.link('', 'circle-close', { 'brake' : 1 }, data.canburn ? null : 'disabled', null)}}
+					{{:helper.link('', 'triangle-1-e', { 'move' : 4 }, data.canburn ? null : 'disabled', null)}}
+				</div>
+				<div class='item'>
+					{{:helper.link('', 'triangle-1-sw', { 'move' : 10 }, data.canburn ? null : 'disabled', null)}}
+					{{:helper.link('', 'triangle-1-s', { 'move' : 2 }, data.canburn ? null : 'disabled', null)}}
+					{{:helper.link('', 'triangle-1-se', { 'move' : 6 }, data.canburn ? null : 'disabled', null)}}
+				</div>
+		
+				<div class='item'>
+					<span class='white'>Direct control</span>
+					<br>
+					{{:helper.link(data.manual_control ? 'Engaged' : 'Disengaged', 'shuffle', { 'manual' : 1 }, null, data.manual_control ? 'selected' : null)}}
+				</div>
 			</div>
 		</div>
-	</div>
-</div>
-
-<div class='item'>
-	<div class="itemLabel">
-		<h3>Autopilot</h3>
-	</div>
-	<div class="itemContent" style="padding-top: 10px;">
-		{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
-	</div>
-</div> 
-<div class='block'>
-	<div class='item'>
-		<div style="float:left;width:45%">
-			<span class='white'>Target coordinates:</span>
 		</div>
-		<div style="float:left;width:20%">
-			{{if data.dest}}
-				{{:helper.link(data.d_x, null, { 'setx' : 1 }, null, null)}} {{:helper.link(data.d_y, null, { 'sety' : 1 }, null, null)}}
-			{{else}}
-				{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
-			{{/if}}
+		
+		<div style="float:left;width:30%">
+		<div class='block' style="height:180px;">
+			<h3>Autopilot</h3>
+			<div class='item'>
+				<div class="itemLabelWide">
+					Target:
+				</div>
+				<div class="itemContent">
+					{{if data.dest}}
+						{{:helper.link(data.d_x, null, { 'setx' : 1 }, null, null)}} {{:helper.link(data.d_y, null, { 'sety' : 1 }, null, null)}}
+					{{else}}
+						{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
+					{{/if}}
+				</div>
+			</div> 
+			<div class='item'>
+				<div class="itemLabelWide">
+					Speed limit:
+				</div>
+				<div class="itemContent">
+					{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}}
+				</div>
+			</div> 
+			<div class="item">
+				{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
+			</div>
 		</div>
-	</div> 
-	<div class='item'>
-		<div style="float:left;width:45%">
-			<span class='white'>Maximum speed:</span>
 		</div>
-		<div style="float:left;width:20%">
-			{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}}
+		
+		<div class='block' style='clear: both;'>
+			<h3>Navigation data</h3>
+			<div class='item'>
+				<div class="itemLabel">
+					Location:
+				</div>
+				<div class="itemContent">
+						{{:data.sector}}
+				</div>
+			</div>
+			<div class='item'>
+				<div class="itemLabel">
+					Coordinates:
+				</div>
+				<div class="itemContent">
+					{{:data.s_x}} : {{:data.s_y}}
+				</div>
+			</div>
+			<div class='item'>
+				<div class="itemLabel">
+					Scan data:
+				</div>
+				<div class="itemContent">
+					{{:data.sector_info}}
+				</div>
+			</div>
+			<div class='item'>
+				<div class="itemLabel">
+					Status:
+				</div>
+				<div class="itemContent">
+					{{:data.landed}}
+				</div>
+			</div>
+			<div class='item'>
+				{{:helper.link('Save current position', 'disk', { 'add' : 'current' }, null)}}
+				{{:helper.link('Add new entry', 'document', { 'add' : 'new' }, null)}}
+			</div>
+			<div class='statusDisplay'>
+			<table style="width:100%">
+			<tr><th style="width:40%">Name<th>Coordinates<th>Actions
+			{{for data.locations}}
+				<tr class="candystripe"><td>{{:value.name}}
+				<td>{{:value.x}} : {{:value.y}}
+				<td>{{:helper.link('Plot course', 'arrowreturnthick-1-e', { 'x' : value.x, 'y' : value.y }, null, null)}}
+				{{:helper.link('Remove', 'close', { 'remove' : value.reference }, null, null)}}
+			{{/for}}
+			</table>
 		</div>
-	</div> 
-</div>
-
-<h3>Navigation data</h3>
-<div class='item'>
-	{{:helper.link('Save current position', 'disk', { 'add' : 'current' }, null)}}
-	{{:helper.link('Add new entry', 'document', { 'add' : 'new' }, null)}}
-</div>
-
-<div class='statusDisplay'>
-	{{if data.locations}}
-		{{for data.locations}}
-		  <div class='item'>
-				<span class='average'>{{:value.name}}:</span>
-				<span class='white'>{{:value.x}} : {{:value.y}}</span>
-		  </div>
-		  <div class='item'>
-			{{:helper.link('Plot course', 'arrowreturnthick-1-e', { 'x' : value.x, 'y' : value.y }, null, null)}}
-			{{:helper.link('Remove entry', 'close', { 'remove' : value.reference }, null, null)}}
-		  </div>
-		{{/for}}
-	{{/if}}
-</div>	
+		</div>
+		
+		


### PR DESCRIPTION
Changes layout to prevent suddenly appearing sector descs shifting movement keys down, which resulted in accidental click on wrong movement dir.

Adds acceleration limiter, hard value instead of percentage like engine thrust limiter is. It doesn't affect fuel usage, use engine limiters for that.

Also fixes manual ship movemnt via relaymove bypassing skill reqs woops

![](https://i.imgur.com/3BN7Ar5.png)
