### PR TITLE
Thruster Volume changes + Overmap Tweaks + Charon changes

### DIFF
--- a/code/__defines/overmap.dm
+++ b/code/__defines/overmap.dm
@@ -3,5 +3,5 @@
 #define SHIP_SIZE_LARGE	3
 
 //multipliers for max_speed to find 'slow' and 'fast' speeds for the ship
-#define SHIP_SPEED_SLOW  1/(40 SECONDS) 
-#define SHIP_SPEED_FAST  1/(5 SECONDS)
+#define SHIP_SPEED_SLOW  1/(40 SECONDS)
+#define SHIP_SPEED_FAST  3/(20 SECONDS)// 15 speed

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -1118,8 +1118,11 @@
 	initialize_directions = SOUTH
 	density = 1
 
-/obj/machinery/atmospherics/pipe/tank/Initialize()
+/obj/machinery/atmospherics/pipe/tank/air/New()
+	..()
 	icon_state = "air"
+
+/obj/machinery/atmospherics/pipe/tank/Initialize()
 	initialize_directions = dir
 	. = ..()
 

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -45,7 +45,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "engines_control.tmpl", "[linked.name] Engines Control", 380, 530)
+		ui = new(user, src, ui_key, "engines_control.tmpl", "[linked.name] Engines Control", 390, 530)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -51,7 +51,7 @@
 	var/on = 1
 	var/datum/ship_engine/gas_thruster/controller
 	var/thrust_limit = 1	//Value between 1 and 0 to limit the resulting thrust
-	var/moles_per_burn = 5
+	var/volume_per_burn = 20 //litres
 
 /obj/machinery/atmospherics/unary/engine/Initialize()
 	. = ..()
@@ -70,7 +70,7 @@
 		.+= "Insufficient fuel for a burn."
 
 	.+= "Propellant total mass: [round(air_contents.get_mass(),0.01)] kg."
-	.+= "Propellant used per burn: [round(air_contents.specific_mass() * moles_per_burn * thrust_limit,0.01)] kg."
+	.+= "Propellant used per burn: [round(air_contents.get_mass() * volume_per_burn * thrust_limit / air_contents.volume,0.01)] kg."
 	.+= "Propellant pressure: [round(air_contents.return_pressure()/1000,0.1)] MPa."
 	. = jointext(.,"<br>")
 
@@ -78,12 +78,12 @@
 	return on && powered()
 
 /obj/machinery/atmospherics/unary/engine/proc/check_fuel()
-	return air_contents.total_moles > moles_per_burn * thrust_limit
+	return air_contents.total_moles > 5 // minimum fuel usage is five moles, for EXTREMELY hot mix or super low pressure
 
 /obj/machinery/atmospherics/unary/engine/proc/get_thrust()
 	if(!is_on() || !check_fuel())
 		return 0
-	var/used_part = moles_per_burn/air_contents.get_total_moles() * thrust_limit
+	var/used_part = volume_per_burn * thrust_limit / air_contents.volume
 	. = calculate_thrust(air_contents, used_part)
 	return
 
@@ -95,7 +95,7 @@
 		on = !on
 		return 0
 	var/exhaust_dir = reverse_direction(dir)
-	var/datum/gas_mixture/removed = air_contents.remove(moles_per_burn * thrust_limit)
+	var/datum/gas_mixture/removed = air_contents.remove_ratio(volume_per_burn * thrust_limit / air_contents.volume)
 	. = calculate_thrust(removed)
 	playsound(loc, 'sound/machines/thruster.ogg', 100 * thrust_limit, 0, world.view * 4, 0.1)
 	var/turf/T = get_step(src,exhaust_dir)
@@ -104,7 +104,7 @@
 		new/obj/effect/engine_exhaust(T, exhaust_dir, air_contents.check_combustability() && air_contents.temperature >= PHORON_MINIMUM_BURN_TEMPERATURE)
 
 /obj/machinery/atmospherics/unary/engine/proc/calculate_thrust(datum/gas_mixture/propellant, used_part = 1)
-	return round(sqrt(propellant.get_mass() * used_part * air_contents.return_pressure()/100),0.1)
+	return round(sqrt(propellant.get_mass() * used_part * sqrt(air_contents.return_pressure()/200)),0.1)
 
 //Exhaust effect
 /obj/effect/engine_exhaust

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -98,6 +98,8 @@
 	var/datum/gas_mixture/removed = air_contents.remove_ratio(volume_per_burn * thrust_limit / air_contents.volume)
 	. = calculate_thrust(removed)
 	playsound(loc, 'sound/machines/thruster.ogg', 100 * thrust_limit, 0, world.view * 4, 0.1)
+	if(network)
+		network.update = 1
 	var/turf/T = get_step(src,exhaust_dir)
 	if(T)
 		T.assume_air(removed)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -62,6 +62,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "al" = (
@@ -497,6 +498,7 @@
 	},
 /obj/machinery/camera/network/exploration_shuttle,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -535,7 +537,7 @@
 	frequency = 1431;
 	id_tag = "guppy_shuttle_outer";
 	name = "Guppy External Access";
-	req_access = list("ACCESS_TORCH_GUP")
+	req_access = list()
 	},
 /obj/machinery/shield_diffuser,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -600,7 +602,8 @@
 	id = "guppy_hatch";
 	name = "Rear Hatch Control";
 	pixel_x = 0;
-	pixel_y = -32
+	pixel_y = -32;
+	req_access = list("ACCESS_TORCH_GUP")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -805,7 +808,7 @@
 	frequency = 1431;
 	id_tag = "guppy_shuttle_outer";
 	name = "Guppy External Access";
-	req_access = list("ACCESS_TORCH_GUP")
+	req_access = list()
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -813,7 +816,7 @@
 "cg" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/valve/open{
-	layer = 6;
+	layer = 5.1;
 	open = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -1040,9 +1043,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
+"cC" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "cD" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crew Area"
@@ -1542,7 +1555,8 @@
 	id = "guppy_hatch";
 	name = "Rear Hatch Control";
 	pixel_x = 32;
-	pixel_y = -32
+	pixel_y = -32;
+	req_access = list("ACCESS_TORCH_GUP")
 	},
 /obj/machinery/hologram/holopad/longrange,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1816,12 +1830,14 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "dT" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+	dir = 4;
+	layer = 5.1;
+	start_pressure = 1013.25
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "dU" = (
 /obj/machinery/meter,
@@ -1835,33 +1851,39 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "dV" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "dW" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
-	},
 /obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "dY" = (
@@ -1894,31 +1916,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/supply{
-	icon_state = "map-supply";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "eb" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/handrai,
 /obj/random_multi/single_item/boombox,
 /obj/machinery/firealarm{
 	dir = 2;
@@ -1928,6 +1940,17 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 0;
+	rcon_setting = 2
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -1956,12 +1979,16 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "eh" = (
 /obj/structure/cable/cyan{
@@ -1969,19 +1996,26 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "ei" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	layer = 2.4;
+	level = 2
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -2031,11 +2065,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
@@ -2049,32 +2078,45 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "en" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
 /obj/machinery/power/terminal{
 	icon_state = "term";
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "eq" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "er" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/infirmary)
 "es" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2111,6 +2153,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "ew" = (
@@ -2123,10 +2166,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "ez" = (
@@ -2194,12 +2235,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
 "eE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "eF" = (
@@ -2216,6 +2253,16 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"eP" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "eQ" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -2334,6 +2381,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fc" = (
+/obj/effect/paint/hull,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/atmos)
 "fd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -2445,7 +2500,10 @@
 /area/exploration_shuttle/cargo)
 "fp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	icon_state = "map";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "fq" = (
@@ -2502,11 +2560,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "fy" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
@@ -2517,6 +2570,11 @@
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/hull,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "fz" = (
@@ -2606,7 +2664,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/valve/open,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "fM" = (
@@ -2823,6 +2881,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/compressed_gas,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5;
+	icon_state = "intact"
+	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "gt" = (
@@ -2878,6 +2940,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -4201,6 +4264,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/shuttlefuel)
 "jT" = (
@@ -4227,6 +4291,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/shuttlefuel)
 "jV" = (
@@ -4238,6 +4303,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/shuttlefuel)
 "jW" = (
@@ -4458,6 +4524,7 @@
 	pixel_y = 0;
 	req_access = newlist()
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "ky" = (
@@ -4705,6 +4772,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
 "kZ" = (
@@ -4724,6 +4792,11 @@
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 1;
+	name = "CO2 to Charon";
+	unlocked = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
@@ -4765,6 +4838,11 @@
 /obj/structure/handrai{
 	icon_state = "handrail";
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -5078,6 +5156,13 @@
 /obj/random/coin,
 /turf/simulated/floor/tiled,
 /area/quartermaster/hangar)
+"ma" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "mb" = (
 /obj/machinery/mineral/unloading_machine{
 	input_turf = 2;
@@ -5136,6 +5221,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -5233,6 +5319,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"mr" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/hangar{
+	icon_state = "camera";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "ms" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -7387,6 +7482,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -8569,6 +8665,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"sD" = (
+/obj/effect/paint/hull,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/atmos)
 "sI" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -10324,6 +10428,7 @@
 /obj/structure/closet/crate/secure/biohazard/blanks,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -10579,6 +10684,20 @@
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/rnd)
+"yE" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
+	dir = 1;
+	frequency = 1331;
+	id_tag = "calypso_cargo_pump"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration_shuttle/cargo)
 "yG" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11025,12 +11144,11 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/equipment)
 "Ar" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "As" = (
 /obj/structure/cable/cyan{
@@ -11733,6 +11851,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -11859,15 +11978,9 @@
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "Ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12523,6 +12636,14 @@
 	},
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
+"Ge" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "Gh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -13220,6 +13341,15 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/equipment)
+"IE" = (
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "IF" = (
 /obj/machinery/computer/shuttle_control{
 	dir = 4;
@@ -13342,11 +13472,12 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
 "Ja" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "Jc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -13523,6 +13654,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -13716,7 +13848,9 @@
 /area/shuttle/petrov/custodial)
 "Ko" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -13745,19 +13879,17 @@
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Charon"
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/cyan{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "Kz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
@@ -13765,6 +13897,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "KA" = (
@@ -13790,6 +13923,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
+"KG" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "KI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -14539,9 +14677,10 @@
 	icon_state = "handrail";
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "Np" = (
@@ -14677,6 +14816,17 @@
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
+"NM" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/hangar{
+	icon_state = "camera";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "NO" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -15004,6 +15154,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "OZ" = (
@@ -15036,6 +15190,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/analysis)
+"Pj" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "Pm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -15133,13 +15295,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "PA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/pipedispenser/orderable,
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -15230,6 +15389,7 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -16542,22 +16702,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
 "Vb" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 0;
-	rcon_setting = 2
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	layer = 2.4;
 	level = 2
+	},
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -16786,6 +16938,16 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/toxins)
+"VR" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
 "VT" = (
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
@@ -16842,6 +17004,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"Wb" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration_shuttle/cargo)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17139,6 +17310,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"Xy" = (
+/obj/effect/paint/hull,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	name = "Fuel Port pump"
+	},
+/turf/simulated/wall/titanium,
+/area/exploration_shuttle/atmos)
 "Xz" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -17765,6 +17944,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/alarm{
+	alarm_id = "petrov2";
 	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
@@ -33332,19 +33512,19 @@ oM
 zf
 aX
 aX
-aX
-aX
+Pj
+KG
 kx
 ev
-aX
-aX
-aX
-oM
-kU
-aX
-aX
-aX
-aX
+KG
+KG
+KG
+mr
+cC
+KG
+KG
+KG
+Ge
 lQ
 lM
 jZ
@@ -33531,7 +33711,7 @@ eU
 Ho
 Ho
 Ho
-Ho
+VR
 Ho
 Ho
 Ho
@@ -33546,7 +33726,7 @@ Ho
 Ho
 Ho
 hT
-aX
+ma
 lV
 lS
 pF
@@ -33736,7 +33916,7 @@ bi
 bi
 bi
 bi
-bi
+IE
 bi
 bi
 Gz
@@ -33748,7 +33928,7 @@ QJ
 bi
 bi
 fS
-aX
+ma
 UH
 lW
 pF
@@ -33938,7 +34118,7 @@ dc
 dv
 ew
 ew
-ew
+Xy
 ew
 ew
 dK
@@ -33950,7 +34130,7 @@ dK
 gx
 bi
 fS
-aX
+ma
 UH
 kD
 lS
@@ -34138,7 +34318,7 @@ bh
 cJ
 dd
 cJ
-ew
+sD
 dT
 eg
 Ja
@@ -34152,7 +34332,7 @@ xu
 gx
 gy
 fS
-aX
+ma
 UH
 kD
 pF
@@ -34340,7 +34520,7 @@ bh
 cK
 de
 dw
-ew
+fc
 dU
 eh
 eq
@@ -34354,7 +34534,7 @@ Zg
 gi
 gz
 fS
-aX
+ma
 lX
 pF
 lT
@@ -34556,7 +34736,7 @@ ak
 gj
 gz
 fS
-aX
+ma
 lR
 lN
 lF
@@ -34752,13 +34932,13 @@ ez
 dK
 Id
 eZ
-fq
-Mu
+yE
+Wb
 Kz
 gx
 gy
 fS
-oO
+NM
 gO
 gO
 gO
@@ -34960,7 +35140,7 @@ RU
 gl
 Ow
 fS
-aX
+eP
 jR
 jT
 jR

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -62,7 +62,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "al" = (
@@ -1043,19 +1042,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
-"cC" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/light/spot{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "cD" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crew Area"
@@ -1551,13 +1540,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "dp" = (
-/obj/machinery/button/remote/blast_door{
-	id = "guppy_hatch";
-	name = "Rear Hatch Control";
-	pixel_x = 32;
-	pixel_y = -32;
-	req_access = list("ACCESS_TORCH_GUP")
-	},
 /obj/machinery/hologram/holopad/longrange,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/yellow{
@@ -1764,6 +1746,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "guppy_hatch";
+	name = "Rear Hatch Control";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_access = list("ACCESS_TORCH_GUP")
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "dK" = (
@@ -1830,13 +1819,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "dT" = (
+/obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 4;
-	layer = 5.1;
 	start_pressure = 1013.25
 	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "dU" = (
@@ -1851,7 +1838,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1872,6 +1859,9 @@
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "dW" = (
@@ -1984,10 +1974,6 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9;
-	icon_state = "intact"
-	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "eh" = (
@@ -1996,8 +1982,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2008,14 +1996,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	layer = 2.4;
 	level = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -2070,16 +2058,16 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-6";
-	d1 = 2;
-	d2 = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -2153,7 +2141,6 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "ew" = (
@@ -2253,16 +2240,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"eP" = (
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "eQ" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -2381,14 +2358,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"fc" = (
-/obj/effect/paint/hull,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact";
-	dir = 10
-	},
-/turf/simulated/wall/titanium,
-/area/exploration_shuttle/atmos)
 "fd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -2500,10 +2469,7 @@
 /area/exploration_shuttle/cargo)
 "fp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	icon_state = "map";
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "fq" = (
@@ -2664,7 +2630,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/atmospherics/valve/open,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "fM" = (
@@ -2881,10 +2847,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/compressed_gas,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5;
-	icon_state = "intact"
-	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "gt" = (
@@ -4264,7 +4226,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/shuttlefuel)
 "jT" = (
@@ -4291,7 +4252,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/shuttlefuel)
 "jV" = (
@@ -4303,7 +4263,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/shuttlefuel)
 "jW" = (
@@ -4524,7 +4483,6 @@
 	pixel_y = 0;
 	req_access = newlist()
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "ky" = (
@@ -4772,7 +4730,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
 "kZ" = (
@@ -4792,11 +4749,6 @@
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 1;
-	name = "CO2 to Charon";
-	unlocked = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
@@ -4823,11 +4775,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/shuttlefuel)
 "le" = (
-/obj/structure/cable/cyan{
-	icon_state = "0-9";
-	d1 = 2;
-	d2 = 8
-	},
 /obj/machinery/power/apc/shuttle/charon{
 	icon_state = "apc0";
 	dir = 4
@@ -4843,6 +4790,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -5156,13 +5107,6 @@
 /obj/random/coin,
 /turf/simulated/floor/tiled,
 /area/quartermaster/hangar)
-"ma" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "mb" = (
 /obj/machinery/mineral/unloading_machine{
 	input_turf = 2;
@@ -5319,15 +5263,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"mr" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	icon_state = "camera";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "ms" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -8665,14 +8600,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"sD" = (
-/obj/effect/paint/hull,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/exploration_shuttle/atmos)
 "sI" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -10467,6 +10394,10 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/fore)
+"yb" = (
+/obj/effect/shuttle_landmark/ninja/hanger,
+/turf/space,
+/area/space)
 "yc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -10684,20 +10615,6 @@
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/rnd)
-"yE" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	controlled = 0;
-	dir = 1;
-	frequency = 1331;
-	id_tag = "calypso_cargo_pump"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact";
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/exploration_shuttle/cargo)
 "yG" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -10918,6 +10835,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/isolation)
+"zr" = (
+/obj/effect/shuttle_landmark/merc/hanger,
+/turf/space,
+/area/space)
 "zs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -10963,6 +10884,10 @@
 "zC" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/security)
+"zD" = (
+/obj/effect/shuttle_landmark/ert/hanger,
+/turf/space,
+/area/space)
 "zH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
@@ -11980,6 +11905,10 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow,
+/obj/machinery/camera/network/exploration_shuttle{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "Ds" = (
@@ -12636,14 +12565,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
-"Ge" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "Gh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -13341,15 +13262,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/equipment)
-"IE" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "IF" = (
 /obj/machinery/computer/shuttle_control{
 	dir = 4;
@@ -13897,7 +13809,9 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "KA" = (
@@ -13923,11 +13837,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
-"KG" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "KI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -14816,17 +14725,6 @@
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
-"NM" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	icon_state = "camera";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "NO" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -15154,10 +15052,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact";
-	dir = 10
-	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "OZ" = (
@@ -15190,14 +15084,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/analysis)
-"Pj" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "Pm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -15295,11 +15181,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "PA" = (
-/obj/machinery/pipedispenser/orderable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/machinery/pipedispenser,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "PC" = (
@@ -15412,6 +15298,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"Qh" = (
+/obj/effect/shuttle_landmark/skipjack/hanger,
+/turf/space,
+/area/space)
 "Qi" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/paint/silver,
@@ -16711,6 +16601,11 @@
 	icon_state = "handrail";
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "Ve" = (
@@ -16938,16 +16833,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/toxins)
-"VR" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
 "VT" = (
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
@@ -17004,15 +16889,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Wb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/exploration_shuttle/cargo)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17310,14 +17186,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Xy" = (
-/obj/effect/paint/hull,
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	name = "Fuel Port pump"
-	},
-/turf/simulated/wall/titanium,
-/area/exploration_shuttle/atmos)
 "Xz" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -24823,7 +24691,7 @@ aa
 aa
 aa
 aa
-aa
+yb
 aa
 aa
 aa
@@ -33512,19 +33380,19 @@ oM
 zf
 aX
 aX
-Pj
-KG
+aX
+aX
 kx
 ev
-KG
-KG
-KG
-mr
-cC
-KG
-KG
-KG
-Ge
+aX
+aX
+aX
+oM
+kU
+aX
+aX
+aX
+aX
 lQ
 lM
 jZ
@@ -33711,7 +33579,7 @@ eU
 Ho
 Ho
 Ho
-VR
+Ho
 Ho
 Ho
 Ho
@@ -33726,7 +33594,7 @@ Ho
 Ho
 Ho
 hT
-ma
+aX
 lV
 lS
 pF
@@ -33877,7 +33745,7 @@ aa
 aa
 aa
 aa
-aa
+Qh
 aa
 aa
 aa
@@ -33916,7 +33784,7 @@ bi
 bi
 bi
 bi
-IE
+bi
 bi
 bi
 Gz
@@ -33928,7 +33796,7 @@ QJ
 bi
 bi
 fS
-ma
+aX
 UH
 lW
 pF
@@ -34118,7 +33986,7 @@ dc
 dv
 ew
 ew
-Xy
+ew
 ew
 ew
 dK
@@ -34130,7 +33998,7 @@ dK
 gx
 bi
 fS
-ma
+aX
 UH
 kD
 lS
@@ -34318,7 +34186,7 @@ bh
 cJ
 dd
 cJ
-sD
+ew
 dT
 eg
 Ja
@@ -34332,7 +34200,7 @@ xu
 gx
 gy
 fS
-ma
+aX
 UH
 kD
 pF
@@ -34520,7 +34388,7 @@ bh
 cK
 de
 dw
-fc
+ew
 dU
 eh
 eq
@@ -34534,7 +34402,7 @@ Zg
 gi
 gz
 fS
-ma
+aX
 lX
 pF
 lT
@@ -34736,7 +34604,7 @@ ak
 gj
 gz
 fS
-ma
+aX
 lR
 lN
 lF
@@ -34889,7 +34757,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 aa
@@ -34932,13 +34800,13 @@ ez
 dK
 Id
 eZ
-yE
-Wb
+fq
+Mu
 Kz
 gx
 gy
 fS
-NM
+oO
 gO
 gO
 gO
@@ -35140,7 +35008,7 @@ RU
 gl
 Ow
 fS
-eP
+aX
 jR
 jT
 jR
@@ -43445,7 +43313,7 @@ aa
 aa
 aa
 aa
-aa
+zD
 aa
 aa
 aa
@@ -48828,7 +48696,7 @@ aa
 aa
 aa
 aa
-aa
+zr
 aa
 aa
 aa

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -14,34 +14,59 @@
 	)
 
 	initial_generic_waypoints = list(
-		"nav_merc_deck1",
-		"nav_merc_deck2",
-		"nav_merc_deck3",
-		"nav_merc_deck4",
+		//start Bridge Deck
 		"nav_merc_deck5",
-		"nav_ert_deck1",
-		"nav_ert_deck2",
-		"nav_ert_deck3",
-		"nav_ert_deck4",
+		"nav_ninja_deck5",
+		"nav_skipjack_deck5",
 		"nav_ert_deck5",
-		"nav_deck1_calypso",
-		"nav_deck2_calypso",
-		"nav_deck3_calypso",
-		"nav_deck4_calypso",
 		"nav_bridge_calypso",
-		"nav_deck1_guppy",
-		"nav_deck2_guppy",
-		"nav_deck3_guppy",
-		"nav_deck4_guppy",
 		"nav_bridge_guppy",
-		"nav_deck1_aquila",
-		"nav_deck2_aquila",
-		"nav_deck3_aquila",
-		"nav_deck4_aquila",
 		"nav_bridge_aquila",
+
+		//start First Deck
+		"nav_merc_deck1",
+		"nav_ninja_deck1",
+		"nav_skipjack_deck1",
+		"nav_ert_deck4",
+		"nav_deck4_calypso",
+		"nav_deck4_guppy",
+		"nav_deck4_aquila",
+
+		//start Second Deck
+		"nav_merc_deck2",
+		"nav_ninja_deck2",
+		"nav_skipjack_deck2",
+		"nav_ert_deck3",
+		"nav_deck3_calypso",
+		"nav_deck3_guppy",
+		"nav_deck3_aquila",
+
+		//start Third Deck
+		"nav_merc_deck3",
+		"nav_ninja_deck3",
+		"nav_skipjack_deck3",
+		"nav_ert_deck2",
+		"nav_deck2_calypso",
+		"nav_deck2_guppy",
+		"nav_deck2_aquila",
+		
+		//start Forth Deck
+		"nav_merc_deck4",
+		"nav_ninja_deck4",
+		"nav_skipjack_deck4",
+		"nav_ert_deck1",
+		"nav_deck1_calypso",
+		"nav_deck1_guppy",
+		"nav_deck1_aquila",
+
+		//start Hanger Deck
+		"nav_merc_hanger",
+		"nav_ninja_hanger",
+		"nav_skipjack_hanger",
+		"nav_ert_hanger",
+
 		"nav_skrellscoutsh_altdock",
 		"nav_ert_dock"
-		
 	)
 
 /obj/effect/overmap/ship/landable/exploration_shuttle

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -66,9 +66,9 @@
 /obj/effect/overmap/ship/landable/guppy
 	name = "Guppy"
 	shuttle = "Guppy"
-	max_speed = 1/(10 SECONDS)
+	max_speed = 1/(5 SECONDS)
 	burn_delay = 2 SECONDS
-	vessel_mass = 2000
+	vessel_mass = 2500 //very inefficient pod
 	fore_dir = SOUTH
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -212,6 +212,7 @@
 		"nav_ninja_deck3",
 		"nav_ninja_deck4",
 		"nav_ninja_deck5",
+		"nav_ninja_hanger",
 		"nav_away_6",
 		"nav_derelict_5",
 		"nav_cluster_6",
@@ -239,6 +240,10 @@
 /obj/effect/shuttle_landmark/ninja/internim
 	name = "In transit"
 	landmark_tag = "nav_ninja_transition"
+
+/obj/effect/shuttle_landmark/ninja/hanger
+	name = "West of Hanger Deck"
+	landmark_tag = "nav_ninja_hanger"
 
 /obj/effect/shuttle_landmark/ninja/deck1
 	name = "South of First Deck"
@@ -334,6 +339,7 @@
 		"nav_merc_deck3",
 		"nav_merc_deck4",
 		"nav_merc_deck5",
+		"nav_merc_hanger",
 		"nav_away_5",
 		"nav_derelict_6",
 		"nav_cluster_5",
@@ -370,6 +376,10 @@
 	landmark_tag = "nav_merc_dock"
 	docking_controller = "nuke_shuttle_dock_airlock"
 
+/obj/effect/shuttle_landmark/merc/hanger
+	name = "Northeast of Hanger Deck"
+	landmark_tag = "nav_merc_hanger"
+
 /obj/effect/shuttle_landmark/merc/deck1
 	name = "Northeast of First Deck"
 	landmark_tag = "nav_merc_deck1"
@@ -401,6 +411,7 @@
 		"nav_skipjack_deck3",
 		"nav_skipjack_deck4",
 		"nav_skipjack_deck5",
+		"nav_skipjack_hanger",
 		"nav_away_7",
 		"nav_derelict_7",
 		"nav_cluster_7",
@@ -437,6 +448,10 @@
 	landmark_tag = "nav_skipjack_dock"
 	docking_controller = "skipjack_shuttle_dock_airlock"
 
+/obj/effect/shuttle_landmark/skipjack/hanger
+	name = "North of Hanger Deck"
+	landmark_tag = "nav_skipjack_hanger"
+
 /obj/effect/shuttle_landmark/skipjack/deck1
 	name = "Northwest of First Deck"
 	landmark_tag = "nav_skipjack_deck1"
@@ -468,6 +483,7 @@
 		"nav_ert_deck3",
 		"nav_ert_deck4",
 		"nav_ert_deck5",
+		"nav_ert_hanger",
 		"nav_away_4",
 		"nav_derelict_4",
 		"nav_cluster_4",
@@ -503,6 +519,10 @@
 	name = "Docking Port"
 	landmark_tag = "nav_ert_dock"
 	docking_controller = "rescue_shuttle_dock_airlock"
+
+/obj/effect/shuttle_landmark/ert/hanger
+	name =  "Southeast of Hanger deck"
+	landmark_tag = "nav_ert_hanger"
 
 /obj/effect/shuttle_landmark/ert/deck1
 	name =  "Southwest of Fourth deck"
@@ -584,19 +604,19 @@
 	base_turf = /turf/simulated/floor/plating
 
 /obj/effect/shuttle_landmark/torch/deck1/exploration_shuttle
-	name = "Space near Deck Four"
+	name = "Space near Forth Deck"
 	landmark_tag = "nav_deck1_calypso"
 
 /obj/effect/shuttle_landmark/torch/deck2/exploration_shuttle
-	name = "Space near Deck Three"
+	name = "Space near Third Deck"
 	landmark_tag = "nav_deck2_calypso"
 
 /obj/effect/shuttle_landmark/torch/deck3/exploration_shuttle
-	name = "Space near Deck Two"
+	name = "Space near Second Deck"
 	landmark_tag = "nav_deck3_calypso"
 
 /obj/effect/shuttle_landmark/torch/deck4/exploration_shuttle
-	name = "Space near Deck One"
+	name = "Space near First Deck"
 	landmark_tag = "nav_deck4_calypso"
 
 /obj/effect/shuttle_landmark/torch/deck5/exploration_shuttle
@@ -630,19 +650,19 @@
 	base_turf = /turf/simulated/floor/plating
 
 /obj/effect/shuttle_landmark/torch/deck1/guppy
-	name = "Space near Deck Four"
+	name = "Space near Forth Deck"
 	landmark_tag = "nav_deck1_guppy"
 
 /obj/effect/shuttle_landmark/torch/deck2/guppy
-	name = "Space near Deck Three"
+	name = "Space near Third Deck"
 	landmark_tag = "nav_deck2_guppy"
 
 /obj/effect/shuttle_landmark/torch/deck3/guppy
-	name = "Space near Deck Two"
+	name = "Space near Second Deck"
 	landmark_tag = "nav_deck3_guppy"
 
 /obj/effect/shuttle_landmark/torch/deck4/guppy
-	name = "Space near Deck One"
+	name = "Space near First Deck"
 	landmark_tag = "nav_deck4_guppy"
 
 /obj/effect/shuttle_landmark/torch/deck5/guppy
@@ -672,19 +692,19 @@
 	base_turf = /turf/simulated/floor/reinforced/airless
 
 /obj/effect/shuttle_landmark/torch/deck1/aquila
-	name = "Space near Deck Four"
+	name = "Space near Forth Deck"
 	landmark_tag = "nav_deck1_aquila"
 
 /obj/effect/shuttle_landmark/torch/deck2/aquila
-	name = "Space near Deck Three"
+	name = "Space near Third Deck"
 	landmark_tag = "nav_deck2_aquila"
 
 /obj/effect/shuttle_landmark/torch/deck3/aquila
-	name = "Space near Deck Two"
+	name = "Space near Second Deck"
 	landmark_tag = "nav_deck3_aquila"
 
 /obj/effect/shuttle_landmark/torch/deck4/aquila
-	name = "Space near Deck One"
+	name = "Space near First Deck"
 	landmark_tag = "nav_deck4_aquila"
 
 /obj/effect/shuttle_landmark/torch/deck5/aquila

--- a/nano/templates/engines_control.tmpl
+++ b/nano/templates/engines_control.tmpl
@@ -13,7 +13,7 @@
 	</div>
 	<div class='item'>
 		<div class="itemLabel">
-			<span class='average'>Thrust limit:</span>
+			<span class='average'>Volume limit:</span>
 		</div>
 		<div class="itemContent">
 			{{:helper.link('', 'circle-plus', { 'global_limit' : 0.1}, null, null)}}
@@ -69,7 +69,7 @@
 			  </div>
 			  <div class='item'>
 				<div class="itemLabel">
-					<span class='average'>Thrust limit:</span>
+					<span class='average'>Volume limit:</span>
 				</div>
 				<div class="itemContent">
 					{{:helper.link('', 'circle-plus', { 'limit' : 0.1, 'engine' : value.eng_reference }, null, null)}}
@@ -97,7 +97,7 @@
 					<div class="itemLabel">
 						<span class='average'>Thrust:</span>
 						<br>
-						<span class='average'>Thrust limit:</span>
+						<span class='average'>Volume:</span>
 					</div>
 					<div class="itemContent">
 						<span class='white'>{{:value.eng_thrust}}</span>

--- a/nano/templates/engines_control.tmpl
+++ b/nano/templates/engines_control.tmpl
@@ -97,7 +97,7 @@
 					<div class="itemLabel">
 						<span class='average'>Thrust:</span>
 						<br>
-						<span class='average'>Volume:</span>
+						<span class='average'>Volume limit:</span>
 					</div>
 					<div class="itemContent">
 						<span class='white'>{{:value.eng_thrust}}</span>


### PR DESCRIPTION
🆑
tweak: Overmap Fast speed is now reduced from 20 to 15, this applies to dodging meteors in shuttles at experienced/master levels.
tweak: Gas thrusters for overmap travel, will now calculate thrust and fuel consumption by volume. Lower volume limit from the engine control for more fuel efficiency.
tweak: Guppy's mass and max speed has been increased.
maptweak: Charon's atmospheric and electric compartment has be reworked to accommodate for the fuel consumption.
maptweak: There are now shuttle navpoints on the hanger deck. 
/🆑

Thrusters will now calculate thrust based on volume instead of a fixed number moles.
Thrust is now (roughly) calculate as root(Moles x molar mass x root(pressure)), where moles is taken from a volume of gas, instead of being arbitrary.
Basically not much has change front end, you'll still get a similar range of thrust in most circumstances
except there's more dynamic fuel consumption based on pressure/how dense the air is
And thrust is now also based on how dense the air is (molar volume). Which means you can go really fast if you freeze your gas lol.
This change would enable more complex mechanic to play with,
like varying fuel consumption and fuel efficiency and thrust calculations,
instead of just heat the gas until the pressure is high

While I was there, I fixed a small bug where the thrusters doesnt update its gas network, causing it to get stuck.

Changed Thrust limit to Volume limit on the engine console.

Increased both the Guppy's mass and max speed

Reduced Overmap fast speed to 15

Added some more shuttle Nav point on the hanger deck, reorganised the order shuttle navpoint, so it's less of a cluster fuck.

Add a co2 pressure tank to the charon for extra fuel reserve, they now have enough fuel on round start. (Reverted the fuel pump idea I had before)
Got #25591. Hopefully this way I can avoid the merge conflict

While I was mapping I also changed the guppy's door access to none, similar to the charon for ease of use from other departments. Cargo hatch is now locked to guppy access.

Reworked Charon
![dreammaker_6eFHBF1lHN](https://user-images.githubusercontent.com/43085828/57977644-fb59b780-7a3f-11e9-97bb-c2b33101143c.png)