### PR TITLE
Re-add Spacer language color

### DIFF
--- a/code/modules/mob/language/human/misc/spacer.dm
+++ b/code/modules/mob/language/human/misc/spacer.dm
@@ -6,3 +6,4 @@
 	syllables = list("ada","zir","bian","ach","usk","ado","ich","cuan",
 					"iga","qing","le","que","ki","qaf","dei","eta")
 	partial_understanding = list(LANGUAGE_HUMAN_EURO = 66, LANGUAGE_HUMAN_IBERIAN = 55, LANGUAGE_HUMAN_CHINESE = 44, LANGUAGE_HUMAN_ARABIC = 44, LANGUAGE_HUMAN_INDIAN = 33, LANGUAGE_HUMAN_RUSSIAN = 33)
+	colour = "spacer"

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -106,6 +106,7 @@ h1.alert, h2.alert		{color: #000000;}
 .iberian				{color: #ff6600;}
 .russian				{color: #9c250b;}
 .arabic					{color: #128b11;}
+.spacer					{color: #9c660b;}
 
 .interface				{color: #330033;}
 


### PR DESCRIPTION
Gives spacer a text color again. It's a dark yellow-ish color, as the previous orange color is now taken by another human language.

:cl:
fix: Spacer now has a text color again. It's dark-yellow.
/:cl: