### PR TITLE
Make gun sprites not go away for higher than 100% charge

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -107,10 +107,11 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 		var/ratio = power_supply.percent()
 
 		//make sure that rounding down will not give us the empty state even if we have charge for a shot left.
+		// Also make sure cells adminbussed with higher-than-max charge don't break sprites
 		if(power_supply.charge < charge_cost)
 			ratio = 0
 		else
-			ratio = max(round(ratio, 25), 25)
+			ratio = Clamp(round(ratio, 25), 25, 100)
 
 		if(modifystate)
 			icon_state = "[modifystate][ratio]"


### PR DESCRIPTION
Fixes an issue I came across the other day where an adminbussed power cell caused an energy gun sprite to break.

:cl:
fix: Energy guns no longer become invisible if cell charge exceeds cell capacity due to adminbus.
/:cl: