### PR TITLE
Fix being muted while incapacitated with radio set to broadcast

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -255,16 +255,18 @@
 
 	if(speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) return 0
 
-	// Sedation chemical effect should prevent radio use (Chloral and Soporific)
-	var/mob/living/carbon/C = M
-	if ((istype(C)) && (C.chem_effects[CE_SEDATE] || C.incapacitated(INCAPACITATION_DISRUPTED)))
-		to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
-		return 0
-	if((istype(C)) && C.radio_interrupt_cooldown > world.time)
-		to_chat(M, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
-		return 0
+	if (!broadcasting)
+		// Sedation chemical effect should prevent radio use (Chloral and Soporific)
+		var/mob/living/carbon/C = M
+		if ((istype(C)) && (C.chem_effects[CE_SEDATE] || C.incapacitated(INCAPACITATION_DISRUPTED)))
+			to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
+			return 0
+		
+		if((istype(C)) && C.radio_interrupt_cooldown > world.time)
+			to_chat(M, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
+			return 0
 
-	if(istype(M)) M.trigger_aiming(TARGET_CAN_RADIO)
+		if(istype(M)) M.trigger_aiming(TARGET_CAN_RADIO)
 
 	//  Uncommenting this. To the above comment:
 	// 	The permacell radios aren't suppose to be able to transmit, this isn't a bug and this "fix" is just making radio wires useless. -Giacom


### PR DESCRIPTION
Also fixes triggering aiming when talking normally with a radio set to broadcast

:cl:
fix: Being incapacitated no longer affects talking and radio use if the radio's microphone is set to on.
fix: Talking normally with a nearby radio set to on will no longer trigger aim-mode shooting.
/:cl: