### PR TITLE
Removes rounding for movement delay from items.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -48,7 +48,7 @@
 					else
 						item_slowdown = item_slowdown - species.strength - size_mod
 				total_item_slowdown += max(item_slowdown, 0)
-		tally += round(total_item_slowdown)
+		tally += total_item_slowdown
 
 		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/E = get_organ(organ_name)


### PR DESCRIPTION
:cl:
tweak: Movement delay handling from items has been tweaked slightly to give more fine-grained effects.
/:cl:

Not sure what the argument in favor of rounding is, but this should help with balancing.