### PR TITLE
Add `gigameters/hour` and `degrees` labels to helm and navigation readouts

### DIFF
--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -17,7 +17,7 @@
 					Speed:
 				</div>
 				<div style="float:right">
-					{{:data.speed}}
+					{{:data.speed}} Gm/h
 				</div>
 			</div>
 			<div class='item'>
@@ -25,7 +25,7 @@
 					Acceleration:
 				</div>
 				<div style="float:right">
-					{{:data.accel}}
+					{{:data.accel}} Gm/h
 				</div>
 			</div>
 			<div class='item'>
@@ -33,7 +33,7 @@
 					Heading:
 				</div>
 				<div style="float:right">
-					{{:data.heading}}
+					{{:data.heading}}&deg;
 				</div>
 			</div> 
 			<div class='item'>
@@ -41,7 +41,7 @@
 					Acceleration limiter:
 				</div>
 				<div style="float:right">
-					{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}}
+					{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}} Gm/h
 				</div>
 			</div> 
 		</div>
@@ -96,7 +96,7 @@
 					Speed limit:
 				</div>
 				<div class="itemContent">
-					{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}}
+					{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}} Gm/h
 				</div>
 			</div> 
 			<div class="item">

--- a/nano/templates/nav.tmpl
+++ b/nano/templates/nav.tmpl
@@ -36,7 +36,7 @@
 				<span class='average'>Speed:</span>
 			</div>
 			<div style="float:right">
-				{{:data.speed}}
+				{{:data.speed}} Gm/h
 			</div>
 		</div>
 		<div class='item'>
@@ -44,7 +44,7 @@
 				<span class='average'>Acceleration:</span>
 			</div>
 			<div style="float:right">
-				{{:data.accel}}
+				{{:data.accel}} Gm/h
 			</div>
 		</div>
 		<div class='item'>
@@ -52,7 +52,7 @@
 				<span class='average'>Heading:</span>
 			</div>
 			<div style="float:right">
-				{{:data.heading}}
+				{{:data.heading}}&deg;
 			</div>
 		</div> 
 	</div>


### PR DESCRIPTION
Now everyone can agree on what to call speed units.
<img width="201" alt="GFneSE9ryQ" src="https://user-images.githubusercontent.com/11140088/57746155-c38bf200-7684-11e9-9a4f-02886564b387.png">
<img width="191" alt="MVZLj37yAN" src="https://user-images.githubusercontent.com/11140088/57746157-c38bf200-7684-11e9-92a5-b31a583f61e5.png">

:cl:
tweak: Helm and navigation consoles now show 'gigameters/hour' for speed and acceleration.
/:cl: