### PR TITLE
Fixes pipes missing on the Xilvuxix

### DIFF
--- a/maps/away/skrellscoutship/skrellscoutship-1.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-1.dmm
@@ -309,6 +309,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/medical/torch{
+	dir = 1;
 	density = 0;
 	pixel_y = -32;
 	req_access = list("ACCESS_SKRELLSCOUT")
@@ -876,7 +877,9 @@
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutshuttle)
 "cl" = (
-/obj/machinery/seed_storage/garden,
+/obj/machinery/seed_storage/garden{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/kitchen)
 "cm" = (
@@ -945,7 +948,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/dinnerware{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/crew/kitchen)
 "cu" = (
@@ -1009,6 +1014,7 @@
 /area/ship/skrellscoutshuttle)
 "cA" = (
 /obj/machinery/vending/hydronutrients{
+	dir = 1;
 	categories = 3
 	},
 /turf/simulated/floor/tiled/skrell/orange,

--- a/maps/away/skrellscoutship/skrellscoutship-2.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-2.dmm
@@ -1648,6 +1648,12 @@
 	},
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/toilets)
+"lV" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall/r_wall,
+/area/ship/skrellscoutship/crew/toilets)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/skrell/orange,
@@ -1822,6 +1828,14 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/dock)
+"Cl" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall/r_wall,
+/area/ship/skrellscoutship/crew/toilets)
 "Cr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1967,9 +1981,6 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/crew/hallway/d1)
 "Uk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Bathroom";
 	req_access = newlist()
@@ -7310,8 +7321,8 @@ bo
 FP
 Bz
 Uk
-wb
-wb
+Cl
+lV
 YX
 Gn
 ca


### PR DESCRIPTION
It's important when you delete things that you readd things that you need.

Places pipes that were accidentally deleted off of the second level when changing the paints over.

Also corrects directions on the vending machines on the Xilvuxix

Something something pipes under walls is a sin something something