### PR TITLE
Fix access flags for research access area/deck 1 security checkpoint windoors

### DIFF
--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -943,6 +943,7 @@
 /area/rnd/entry
 	name = "\improper Research and Development Access"
 	icon_state = "decontamination"
+	req_access = list()
 
 /area/rnd/locker
 	name = "\improper Research Locker Room"


### PR DESCRIPTION
It's a publicly accessible hallway, so there's no point to it having an access restriction. This effectively only the access flags for the windoors in the security checkpoint.

 - Fixes #25494

:cl:
bugfix: Deck 1 security checkpoint windoors have the correct access flags now.
/:cl: