### PR TITLE
Bridge window oversight, Adds airlock braces, Door buttons, and No smoking signs.

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -43,6 +43,15 @@
 /obj/effect/floor_decal/solarpanel,
 /turf/simulated/floor/reinforced/airless,
 /area/solar/bridge)
+"ai" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/uniform_vendor,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "aj" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
@@ -301,6 +310,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
+"aN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "aO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
@@ -408,11 +434,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
-"aY" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/uniform_vendor,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
 "aZ" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
@@ -1153,6 +1174,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "cV" = (
@@ -1240,6 +1262,23 @@
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
+	},
+/obj/structure/flora/pottedplant/deskleaf{
+	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
+	},
+/obj/machinery/button/remote/airlock{
+	id = "meetingstarboard";
+	name = "Bridge Meeting Starboard Door Control";
+	pixel_x = 34;
+	pixel_y = 6;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/airlock{
+	id = "meetingport";
+	name = "Bridge Meeting Port Door Control";
+	pixel_x = 34;
+	pixel_y = -6;
+	req_access = list("ACCESS_BRIDGE")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
@@ -1496,6 +1535,11 @@
 /obj/machinery/camera/network/command{
 	c_tag = "Executive Officer - Quarters"
 	},
+/obj/structure/sign/warning/nosmoking_1{
+	desc = "";
+	pixel_x = 0;
+	pixel_y = 26
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
 "dJ" = (
@@ -1586,9 +1630,6 @@
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
-	},
-/obj/structure/flora/pottedplant/deskleaf{
-	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3818,11 +3859,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/item/weapon/storage/secure/briefcase{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "jz" = (
@@ -5384,6 +5420,11 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mH" = (
@@ -6536,10 +6577,6 @@
 "pq" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
-	pixel_y = -32
-	},
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -7253,11 +7290,6 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/co)
@@ -7542,6 +7574,7 @@
 /area/crew_quarters/heads/office/cmo)
 "rt" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "meetingstarboard";
 	name = "Conference Room"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -7688,11 +7721,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -7809,6 +7837,10 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "rP" = (
@@ -8258,6 +8290,7 @@
 /area/aquila/maintenance)
 "ta" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "meetingport";
 	name = "Conference Room"
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -8439,7 +8472,7 @@
 	},
 /obj/random/drinkbottle,
 /obj/structure/sign/warning/nosmoking_1{
-	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
+	desc = "";
 	pixel_x = 0;
 	pixel_y = 26
 	},
@@ -9208,6 +9241,11 @@
 /obj/item/weapon/folder/white,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
 "vn" = (
@@ -10025,6 +10063,9 @@
 	id_tag = "bridgesafe_back";
 	name = "Emergency Exit"
 	},
+/obj/item/weapon/airlock_brace{
+	req_access = list("ACCESS_BRIDGE")
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
 "xg" = (
@@ -10649,10 +10690,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
@@ -10793,6 +10833,11 @@
 /obj/random/coin,
 /obj/random/firstaid,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/sign/warning/nosmoking_1{
+	desc = "";
+	pixel_x = 0;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "zD" = (
@@ -11265,6 +11310,11 @@
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "Bi" = (
@@ -11316,6 +11366,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/weapon/storage/secure/briefcase{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "BB" = (
@@ -12025,6 +12080,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
+"Ev" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "Ey" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -12216,6 +12284,11 @@
 	pixel_y = 0
 	},
 /obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Fn" = (
@@ -12854,6 +12927,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 0;
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -13816,10 +13893,6 @@
 "Ll" = (
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Conference Room";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "Lp" = (
@@ -14389,11 +14462,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "NM" = (
@@ -14404,10 +14472,12 @@
 /area/maintenance/bridge/forestarboard)
 "NN" = (
 /obj/item/weapon/tableflag,
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Office"
-	},
 /obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "NW" = (
@@ -14510,6 +14580,11 @@
 /obj/machinery/computer/rdconsole{
 	icon_state = "computer";
 	dir = 4
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/rd)
@@ -14710,6 +14785,9 @@
 	name = "Auxillary Safe Room Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/item/weapon/airlock_brace{
+	req_access = list("ACCESS_BRIDGE")
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/fore)
 "Pi" = (
@@ -16198,6 +16276,9 @@
 "UY" = (
 /obj/item/modular_computer/console/preset/command,
 /obj/item/modular_computer/tablet/lease/preset/command,
+/obj/machinery/camera/network/command{
+	c_tag = "CO - Office"
+	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Vb" = (
@@ -16447,7 +16528,7 @@
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/captain,
 /obj/structure/sign/warning/nosmoking_1{
-	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
+	desc = "";
 	pixel_x = 0;
 	pixel_y = 26
 	},
@@ -16993,6 +17074,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Conference Room";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "Yf" = (
@@ -17233,6 +17318,9 @@
 	autoset_access = 0;
 	id_tag = "bridgestorage_exit";
 	name = "Emergency Exit";
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/item/weapon/airlock_brace{
 	req_access = list("ACCESS_BRIDGE")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -17494,6 +17582,11 @@
 	dir = 9
 	},
 /obj/random/plushie,
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 4;
+	pixel_x = -37
+	},
 /mob/living/simple_animal/corgi/Ian,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
@@ -25467,7 +25560,7 @@ aj
 qs
 UC
 qO
-aY
+ai
 dE
 Jh
 Hf
@@ -25686,7 +25779,7 @@ kw
 nH
 HC
 pq
-eP
+ZH
 NN
 Fl
 Ih
@@ -25888,7 +25981,7 @@ Am
 kw
 HS
 Sc
-ZH
+Qp
 qP
 rI
 fv
@@ -26090,7 +26183,7 @@ Kt
 Lw
 fN
 HW
-Qp
+eP
 qQ
 rJ
 Ii
@@ -29728,7 +29821,7 @@ oG
 pB
 qq
 xZ
-hu
+aN
 sL
 DZ
 qB
@@ -30118,7 +30211,7 @@ BB
 eA
 fb
 dk
-ga
+Ev
 gR
 CJ
 ie


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixed oversight involving CO's window allowing the bridge to be listened in on when tinted.

Added Airlock braces to the Emergency Exits and Aux Safe room door. Intended to deter their use as maint doors, adds in a greater time delay.

Adds in Bridge Meeting Room door buttons. Both because it's nice, and because there's wallspace.

Adds in NO SMOKING signs to offices which are of average size and don't contain doubled atmospheric scrubbers/pumps, and are more of a badge of position (Ie XO/CMO) and not a primary work space.

The criteria for SMOKING signs are doubled atmospheric scrubbers/pumps, and offices that are a Primary work space (IE SCGR/CL) or special areas (CO Office, Deliberation, Meeting room).

Unfucks the snowflake NO SMOKING sign that was probably from Engineering?

Adds in a wall Charger, some fire extinguisher cabinets. 

I don't think I missed anything.