### PR TITLE
Rig module Tweaks and quick fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -979,6 +979,8 @@ About the new airlock wires panel:
 		cut_verb = "cutting"
 		cut_sound = 'sound/items/Welder.ogg'
 	else if(istype(item,/obj/item/weapon/gun/energy/plasmacutter)) //They could probably just shoot them out, but who cares!
+		var/obj/item/weapon/gun/energy/plasmacutter/cutter = item
+		cutter.slice(user)
 		cut_verb = "cutting"
 		cut_sound = 'sound/items/Welder.ogg'
 		cut_delay *= 0.66

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -118,7 +118,7 @@
 /obj/item/weapon/storage/proc/can_be_inserted(obj/item/W, mob/user, stop_messages = 0)
 	if(!istype(W)) return //Not an item
 
-	if(user && user.isEquipped(W) && !user.canUnEquip(W))
+	if(user && !user.canUnEquip(W))
 		return 0
 
 	if(src.loc == W)

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -269,9 +269,14 @@
 			return 0
 		if(isWelder(W))
 			var/obj/item/weapon/weldingtool/WT = W
-			if(WT.isOn())
-				slice_into_parts(WT, user)
+			if(WT.remove_fuel(0,user))
+				slice_into_parts(user)
 				return
+		if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+			var/obj/item/weapon/gun/energy/plasmacutter/cutter = W
+			cutter.slice(user)
+			slice_into_parts(W, user)
+			return
 		if(istype(W, /obj/item/weapon/storage/laundry_basket) && W.contents.len)
 			var/obj/item/weapon/storage/laundry_basket/LB = W
 			var/turf/T = get_turf(src)
@@ -315,13 +320,10 @@
 	else
 		src.attack_hand(user)
 
-/obj/structure/closet/proc/slice_into_parts(obj/item/weapon/weldingtool/WT, mob/user)
-	if(!WT.remove_fuel(0,user))
-		to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-		return
+/obj/structure/closet/proc/slice_into_parts(obj/W, mob/user)
 	new /obj/item/stack/material/steel(src.loc, 2)
-	user.visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", \
-						 "<span class='notice'>You have cut \the [src] apart with \the [WT].</span>", \
+	user.visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [W].</span>", \
+						 "<span class='notice'>You have cut \the [src] apart with \the [W].</span>", \
 						 "You hear welding.")
 	qdel(src)
 

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -19,12 +19,12 @@
 	icon_state = "flash"
 	interface_name = "mounted flash"
 	interface_desc = "Disorientates your target by blinding them with a bright light."
-	device_type = /obj/item/device/flash
+	device = /obj/item/device/flash
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 
 /obj/item/rig_module/device/flash/advanced
 	name = "advanced mounted flash"
-	device_type = /obj/item/device/flash/advanced
+	device = /obj/item/device/flash/advanced
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 
 /obj/item/rig_module/grenade_launcher
@@ -160,6 +160,7 @@
 	. = ..()
 	if(ispath(gun))
 		gun = new gun(src)
+		gun.canremove = 0
 
 /obj/item/rig_module/mounted/engage(atom/target)
 

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -23,7 +23,6 @@
 	toggleable = 0
 	disruptive = 0
 
-	var/device_type
 	var/obj/item/device
 
 /obj/item/rig_module/device/healthscanner
@@ -36,7 +35,7 @@
 	usable = 1
 	use_power_cost = 200
 	origin_tech = list(TECH_MAGNET = 3, TECH_BIO = 3, TECH_ENGINEERING = 5)
-	device_type = /obj/item/device/scanner/health
+	device = /obj/item/device/scanner/health
 
 /obj/item/rig_module/device/defib
 	name = "mounted defibrillator"
@@ -47,7 +46,7 @@
 	interface_desc = "A prototype defibrillator, palm-mounted for ease of use."
 
 	use_power_cost = 0//Already handled by defib, but it's 150 Wh, normal defib takes 100
-	device_type = /obj/item/weapon/shockpaddles/rig
+	device = /obj/item/weapon/shockpaddles/rig
 
 /obj/item/rig_module/device/drill
 	name = "hardsuit mounted drill"
@@ -60,7 +59,7 @@
 	use_power_cost = 3600 //2 Wh per use
 	module_cooldown = 0
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 6)
-	device_type = /obj/item/weapon/pickaxe/diamonddrill
+	device = /obj/item/weapon/pickaxe/diamonddrill
 
 /obj/item/rig_module/device/anomaly_scanner
 	name = "anomaly scanner module"
@@ -72,7 +71,7 @@
 	use_power_cost = 200
 	usable = 1
 	selectable = 0
-	device_type = /obj/item/device/ano_scanner
+	device = /obj/item/device/ano_scanner
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MAGNET = 4, TECH_ENGINEERING = 6)
 
 /obj/item/rig_module/device/orescanner
@@ -86,7 +85,7 @@
 	usable = 1
 	toggleable = 1
 	use_power_cost = 200
-	device_type = /obj/item/device/scanner/mining
+	device = /obj/item/device/scanner/mining
 	origin_tech = list(TECH_MATERIAL = 4, TECH_MAGNET = 4, TECH_ENGINEERING = 6)
 
 /obj/item/rig_module/device/orescanner/activate()
@@ -106,11 +105,13 @@
 	engage_string = "Configure RCD"
 	use_power_cost = 300
 	origin_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 5, TECH_ENGINEERING = 7)
-	device_type = /obj/item/weapon/rcd/mounted
+	device = /obj/item/weapon/rcd/mounted
 
 /obj/item/rig_module/device/Initialize()
 	. = ..()
-	if(device_type) device = new device_type(src)
+	if(ispath(device))
+		device = new device(src)
+		device.canremove = 0
 
 /obj/item/rig_module/device/engage(atom/target)
 	if(!..() || !device)
@@ -147,11 +148,11 @@
 
 	charges = list(
 		list("dexalin plus",  "dexalin plus",  /datum/reagent/dexalinp,          80),
-		list("dylovene",    "dylovene",    /datum/reagent/dylovene,          80),
+		list("inaprovaline",  "inaprovaline",  /datum/reagent/inaprovaline,      80),
+		list("dylovene",      "dylovene",      /datum/reagent/dylovene,          80),
 		list("hyronalin",     "hyronalin",     /datum/reagent/hyronalin,         80),
-		list("spaceacillin",   "spaceacillin",   /datum/reagent/spaceacillin,      80),
-		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          80),
-		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     80)
+		list("spaceacillin",  "spaceacillin",  /datum/reagent/spaceacillin,      80),
+		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          80)
 		)
 
 	var/max_reagent_volume = 80 //Used when refilling.
@@ -162,13 +163,13 @@
 	//just over a syringe worth of each. Want more? Go refill. Gives the ninja another reason to have to show their face.
 	charges = list(
 		list("dexalin plus",  "dexalin plus",  /datum/reagent/dexalinp,          20),
-		list("dylovene",    "dylovene",    /datum/reagent/dylovene,          20),
+		list("inaprovaline",  "inaprovaline",  /datum/reagent/inaprovaline,      20),
+		list("dylovene",      "dylovene",      /datum/reagent/dylovene,          20),
 		list("glucose",       "glucose",       /datum/reagent/nutriment/glucose, 80),
 		list("hyronalin",     "hyronalin",     /datum/reagent/hyronalin,         20),
-		list("radium",        "radium",        /datum/reagent/radium,            20),
-		list("spaceacillin",   "spaceacillin",   /datum/reagent/spaceacillin,      20),
-		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          20),
-		list("tricordrazine", "tricordrazine", /datum/reagent/tricordrazine,     20)
+		list("dermaline",     "dermaline",     /datum/reagent/dermaline,         20),
+		list("spaceacillin",  "spaceacillin",  /datum/reagent/spaceacillin,      20),
+		list("tramadol",      "tramadol",      /datum/reagent/tramadol,          20)
 		)
 
 /obj/item/rig_module/chem_dispenser/accepts_item(var/obj/item/input_item, var/mob/living/user)
@@ -407,7 +408,7 @@
 	use_power_cost = 200
 	usable = 1
 	selectable = 0
-	device_type = /obj/item/weapon/paper_bin
+	device = /obj/item/weapon/paper_bin
 
 /obj/item/rig_module/device/paperdispenser/engage(atom/target)
 
@@ -426,7 +427,7 @@
 	interface_desc = "Signatures with style(tm)."
 	engage_string = "Change color"
 	usable = 1
-	device_type = /obj/item/weapon/pen/multi
+	device = /obj/item/weapon/pen/multi
 
 /obj/item/rig_module/device/stamp
 	name = "mounted internal affairs stamp"
@@ -465,7 +466,7 @@
 	interface_name = "mounted matter decompiler"
 	interface_desc = "Eats trash like no one's business."
 	origin_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 5)
-	device_type = /obj/item/weapon/matter_decompiler
+	device = /obj/item/weapon/matter_decompiler
 
 /obj/item/rig_module/cooling_unit
 	name = "mounted cooling unit"

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -235,7 +235,7 @@
 	boot_type = /obj/item/clothing/shoes/magboots/rig/medical
 	glove_type = /obj/item/clothing/gloves/rig/medical
 
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/scanner/health,/obj/item/stack/medical,/obj/item/roller )
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/scanner/health,/obj/item/stack/medical,/obj/item/roller,/obj/item/auto_cpr)
 
 	req_access = list(access_medical_equip)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -212,7 +212,7 @@ var/list/slot_equipment_priority = list( \
 	if(!I) //If there's nothing to drop, the drop is automatically successful.
 		return 1
 	var/slot = get_inventory_slot(I)
-	if(!slot)
+	if(!slot && !istype(I.loc, /obj/item/rig_module))
 		return 1 //already unequipped, so success
 	return I.mob_can_unequip(src, slot)
 


### PR DESCRIPTION
🆑
rscadd: Plasma cutter can now deconstruct closet.
tweak: Hardsuit chemical dispenser now has inaprovaline instead of tricordrazine.
tweak: Rescue rig can now have auto-compressor hooked on the suit storage slot.
tweak: Ninja's chemical dispenser now has dermaline instead of radium, no more radioactive super powers today.
bugfix: Hardsuit module item will no longer be put into bags or closets.
/🆑 
Fix this shit.
https://i.imgur.com/nBDAHNt.gif
Fixed being able to pull guns and items out of rig module and into bags or closets
Buff the rig chemical dispenser by changing it have to inaprov instead of tricord.
Added some more plasma cutter interactions, also add sparks to cutting an airlock open. forgot that bit
Change radium to dermaline for ninja dispenser
also removed an unnecessary device_type var for device modules