### PR TITLE
Coveralls for fleet security (as utility extra)

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -104,7 +104,8 @@
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
-						 /obj/item/clothing/gloves/thick/duty/solgov/sec)
+						 /obj/item/clothing/gloves/thick/duty/solgov/sec,
+						 /obj/item/clothing/under/solgov/utility/fleet/security)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/combat/security
 
 /decl/hierarchy/mil_uniform/fleet/sec/noncom


### PR DESCRIPTION
:cl: Flying_loulou
tweak: Security coveralls are now also available for all fleet security personnel (via the uniform vendor, under utility extra).
/:cl:

Gives access to the coveralls to security fleeties, via the uniform vendor, utility extras.