### PR TITLE
Add camera to Charon power compartment

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11863,6 +11863,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/camera/network/exploration_shuttle{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "Ds" = (


### PR DESCRIPTION
The old Charon prior to the remap had a camera in this room.

:cl:
map: The Charon power compartment has a camera again.
/:cl: