### PR TITLE
Fatigues for Fleet Pilot

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -390,7 +390,6 @@
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
-						 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command

--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -359,6 +359,7 @@
 	utility_extra = list(/obj/item/clothing/head/beret/solgov/fleet/exploration,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 
@@ -389,6 +390,7 @@
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+						 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -174,7 +174,7 @@
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet)
 
 /obj/item/clothing/under/solgov/utility/fleet/combat/exploration
-    starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/fleet)
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/fleet)
 
 /obj/item/clothing/under/solgov/utility/fleet/officer
 	name = "fleet officer's coveralls"

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -173,6 +173,9 @@
 /obj/item/clothing/under/solgov/utility/fleet/combat/command
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet)
 
+/obj/item/clothing/under/solgov/utility/fleet/combat/exploration
+    starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/fleet)
+
 /obj/item/clothing/under/solgov/utility/fleet/officer
 	name = "fleet officer's coveralls"
 	desc = "Alternative utility uniform of the SCG Fleet, for officers."


### PR DESCRIPTION
:cl: NewOriginalSchwann
tweak: Fatigues have been added to the Fleet pilot's uniform vendor under utility.
/:cl:
The pilot still spawns in coveralls, so this just serves as alternate fluff for pilots who want it since the exploration fatigues look _really_ good.
![GLORIOUS FATIGUES](https://user-images.githubusercontent.com/45934768/58141182-77a2f500-7c10-11e9-99e5-1771f46e3fe0.png)
 This is my first PR so I apologize if I've horribly butchered the code or unintentionally cause somebody's computer to explode.