### PR TITLE
Reduce flying borg speed

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -4,7 +4,7 @@
 	icon_state = "drone-standard"
 	module_category = ROBOT_MODULE_TYPE_FLYING
 	dismantle_type = /obj/item/robot_parts/robot_suit/flyer
-	speed = -2 // nyoom
+	speed = -1 // nyoom
 	power_efficiency = 0.75
 
 	// They are not very heavy or strong.


### PR DESCRIPTION
Current default flying borg speed is a bit obnoxious and results in traitor borgs being incredibly frustrating to deal with. Flying borg default speed is now the same as a regular borg with a VTEC module. Flying borgs with a VTEC module will be as fast as the old default flying borg speed.

NOTE: Due to bugs and poorly coded checks, flying borgs with this change won't be able to receive VTEC upgrades unless #25593 is also merged.

:cl:
tweak: Flying borg speed has been reduced one level. Flying borg default speed is now the same as a regular borg with a VTEC module. Flying borgs with a VTEC module will be as fast as the old default flying borg speed.
/:cl: