### PR TITLE
Add percentages to shield generators

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
@@ -51,6 +51,7 @@
 		data["field_integrity"] = active.field_integrity()
 		data["max_energy"] = round(active.max_energy / 1000000, 0.1)
 		data["current_energy"] = round(active.current_energy / 1000000, 0.1)
+		data["percentage_energy"] = round(data["current_energy"] / data["max_energy"] * 100)
 		data["total_segments"] = active.field_segments ? active.field_segments.len : 0
 		data["functional_segments"] = active.damaged_segments ? data["total_segments"] - active.damaged_segments.len : data["total_segments"]
 		data["field_radius"] = active.field_radius

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -218,6 +218,7 @@
 	data["field_integrity"] = field_integrity()
 	data["max_energy"] = round(max_energy / 1000000, 0.1)
 	data["current_energy"] = round(current_energy / 1000000, 0.1)
+	data["percentage_energy"] = round(data["current_energy"] / data["max_energy"] * 100)
 	data["total_segments"] = field_segments ? field_segments.len : 0
 	data["functional_segments"] = damaged_segments ? data["total_segments"] - damaged_segments.len : data["total_segments"]
 	data["field_radius"] = field_radius

--- a/nano/templates/shieldgen.tmpl
+++ b/nano/templates/shieldgen.tmpl
@@ -27,7 +27,7 @@
 			Shield Capacity:
 		</div>
 		<div class="itemContent">
-			{{:data.current_energy}}/{{:data.max_energy}} MJ
+			{{:data.current_energy}}/{{:data.max_energy}} MJ ({{:data.percentage_energy}}%)
 		</div>
 	</div>
 	<div class="item">

--- a/nano/templates/shields_monitor.tmpl
+++ b/nano/templates/shields_monitor.tmpl
@@ -36,7 +36,7 @@
 				Shield Capacity:
 			</div>
 			<div class="itemContent">
-				{{:data.current_energy}}/{{:data.max_energy}} MJ
+				{{:data.current_energy}}/{{:data.max_energy}} MJ ({{:data.percentage_energy}}%)
 			</div>
 		</div>
 		<div class="item">


### PR DESCRIPTION
Adds capacitor percentages to both the Shield Generator UI and Shield Generator Monitor when a specific generator is opened.

<img width="251" alt="TCIgjhFdq2" src="https://user-images.githubusercontent.com/11140088/58279813-3156ae80-7d54-11e9-84d3-f459346eeb80.png">

<img width="201" alt="EQOHYovkRR" src="https://user-images.githubusercontent.com/11140088/58279816-34519f00-7d54-11e9-8663-23bcc3ae73ce.png">

:cl:
add: Shield generator and shield generator monitor UI now includes a capacity percentage.
/:cl: