### PR TITLE
Add pill bottles to autolathes

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -323,6 +323,11 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	path = /obj/item/weapon/implanter
 	category = "Medical"
 
+/datum/autolathe/recipe/pill_bottle
+	name = "pill bottle"
+	path = /obj/item/weapon/storage/pill_bottle
+	category = "Medical"
+
 /datum/autolathe/recipe/syringegun_ammo
 	name = "syringe gun cartridge"
 	path = /obj/item/weapon/syringe_cartridge

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -180,6 +180,7 @@
 	allow_quick_gather = 1
 	use_to_pickup = 1
 	use_sound = 'sound/effects/storage/pillbottle.ogg'
+	matter = list(MATERIAL_PLASTIC = 250)
 	var/wrapper_color
 	var/label
 


### PR DESCRIPTION
- Pill bottle cost is based on the cost of a glass vial.

May add more recipes if people send me usable ideas before this gets approved+merged.

:cl:
add: Pill bottles can now be printed at autolathes
/:cl: