### PR TITLE
Reshuffles starting software a bit

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -39,7 +39,6 @@
 	..()
 	hard_drive.store_file(new/datum/computer_file/program/ntnetmonitor())
 	hard_drive.store_file(new/datum/computer_file/program/nttransfer())
-	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/aidiag())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())
@@ -54,7 +53,6 @@
 	..()
 	hard_drive.store_file(new/datum/computer_file/program/ntnetmonitor())
 	hard_drive.store_file(new/datum/computer_file/program/nttransfer())
-	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/aidiag())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())
@@ -70,13 +68,13 @@
 
 /obj/item/modular_computer/console/preset/command/install_default_programs()
 	..()
-	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/comm())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())
 	hard_drive.store_file(new/datum/computer_file/program/records())
 	hard_drive.store_file(new/datum/computer_file/program/wordprocessor())
 	hard_drive.store_file(new/datum/computer_file/program/docking())
+	hard_drive.store_file(new /datum/computer_file/program/reports())
 
 // Security
 /obj/item/modular_computer/console/preset/security/install_default_hardware()
@@ -94,7 +92,6 @@
 // Civilian
 /obj/item/modular_computer/console/preset/civilian/install_default_programs()
 	..()
-	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/nttransfer())
 	hard_drive.store_file(new/datum/computer_file/program/newsbrowser())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -13,7 +13,6 @@
 /obj/item/modular_computer/pda/install_default_programs()
 	..()
 
-	hard_drive.store_file(new /datum/computer_file/program/chatclient())
 	hard_drive.store_file(new /datum/computer_file/program/email_client())
 	hard_drive.store_file(new /datum/computer_file/program/crew_manifest())
 	hard_drive.store_file(new /datum/computer_file/program/wordprocessor())
@@ -42,6 +41,10 @@
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/reagent(src)
 
+/obj/item/modular_computer/pda/heads/install_default_programs()
+	..()
+	hard_drive.store_file(new /datum/computer_file/program/reports())
+
 /obj/item/modular_computer/pda/heads/hop/install_default_hardware()
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)
@@ -61,6 +64,10 @@
 /obj/item/modular_computer/pda/heads/rd/install_default_hardware()
 	..()
 	scanner = new /obj/item/weapon/computer_hardware/scanner/paper(src)
+
+/obj/item/modular_computer/pda/cargo/install_default_programs()
+	..()
+	hard_drive.store_file(new /datum/computer_file/program/reports())
 
 /obj/item/modular_computer/pda/cargo/install_default_hardware()
 	..()

--- a/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
@@ -51,7 +51,7 @@
 
 /obj/item/modular_computer/tablet/lease/preset/command/install_default_programs()
 	..()
-	hard_drive.store_file(new/datum/computer_file/program/chatclient())
+	hard_drive.store_file(new /datum/computer_file/program/reports())
 	hard_drive.store_file(new/datum/computer_file/program/camera_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/email_client())
 	hard_drive.store_file(new/datum/computer_file/program/records())


### PR DESCRIPTION
Removes NTIRC client from all loadouts. It's pretty useless AND takes up a lot of space.
Adds Reports program to command computers and heads/cargo PDAs.

Overall it should free up 6 GQ of space on PDAs.

:cl: Chinsky
tweak: NTIRC client no longer spawns by default, freeing up some space on PDAs and such.
tweak: Reports editor now spawns on Cargo and Command PDAs by default.
/:cl: