### PR TITLE
Add light armor for flying borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -75,6 +75,13 @@
 	external_type = /obj/item/robot_parts/robot_component/armour
 	max_damage = 150
 
+// LIGHT ARMOUR
+// Same as armour, but for flying borgs - Less protection.
+/datum/robot_component/armour/light
+	name = "light armour plating"
+	external_type = /obj/item/robot_parts/robot_component/armour/light
+	max_damage = 75
+
 // ACTUATOR
 // Enables movement.
 // Uses no power when idle. Uses 200J for each tile the cyborg moves.
@@ -226,6 +233,9 @@
 	name = "armour plating"
 	icon_state = "armor"
 	icon_state_broken = "armor_broken"
+
+/obj/item/robot_parts/robot_component/armour/light
+	name = "light-weight armour plating"
 
 /obj/item/robot_parts/robot_component/camera
 	name = "camera"

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -20,6 +20,7 @@
 	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
 	components["camera"] =         new/datum/robot_component/camera(src)
 	components["comms"] =          new/datum/robot_component/binary_communication(src)
+	components["armour"] =         new/datum/robot_component/armour/light(src)
 
 /mob/living/silicon/robot/flying/Life()
 	. = ..()

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -103,6 +103,14 @@
 	id = "armour"
 	build_path = /obj/item/robot_parts/robot_component/armour
 
+/datum/design/item/mechfab/robot/component/armour/light
+	name = "Light-weight armour plating"
+	id = "light_armour"
+	build_path = /obj/item/robot_parts/robot_component/armour/light
+	// Half the armor, half the cost
+	time = 10
+	materials = list(MATERIAL_STEEL = 2500)
+
 /datum/design/item/mechfab/ripley
 	category = "Ripley"
 


### PR DESCRIPTION
Adds a new light-weight variant of borg armor, that flying borgs spawn with and can use. Currently provides half the armor, uses half the materials, and takes half the build time of regular armor. Has the unintended side effect of also being usable on regular borgs if a roboticist wants to be an arse, or is really that short on materials.

This will require a wiki update when completed and merged to provide notes on light vs regular armor, and what to use for flying vs regular borgs.

TODO:
 - [X] Light armor item
 - [X] Fabricator entry

:cl:
add: Flying borgs now have light-weight armor, providing half the armor value of a regular borg's armor. Light-weight armor can be printed from fabricators for half the cost of regular armor, and can also be applied to regular borgs (Not that you'd ever want to do this.)
/:cl: