### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -13,8 +13,7 @@ The following conduct may result in a warning being logged against your account:
 	* The same rule applies to sprite, sound, or map contributions, though there the definition of "technical" will be interpreted rather broadly.
 	* The following are exempt from this rule: 
 		* The PR's author(s).
-		* Developers discussing what changes would be needed for the PR to attain approval.
-		* Other staff members with the right to approve or veto the pull request.
+		* Developers, or other staff members with the right to approve or veto the pull request.
 	* Emote reactions to pull requests are exempt. Comments on issue reports are exempt so long as they remain on topic.
 * Issuing commits, editing wiki pages, commenting, or opening bug reports in bad faith.
 	* The Head Developer and Developers are obligated to assume good faith until evidence otherwise surfaces.
@@ -48,7 +47,7 @@ Warnings expire in six months from the date of warning.
 ## Developer Responsibilities
 The Head Developer has the responsiblity to:
 * Clarify the standards of acceptable behaviour
-* Handle the appeals process for all issued ban
+* Handle the appeals process for all issued bans
 
 All Developers have the responsibility to:
 * Take appropriate and fair corrective action in response to any instances of unacceptable behaviour
@@ -58,7 +57,7 @@ All Developers have the right to:
 * Remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct
 * Issue warnings in accordance with the Code of Conduct (except in the cases elaborated in the second section of the Rules category, which require conference with the Head Developer)
 * Temporarily ban any contributor from Discord development channels for behaviour not aligned to this Code of Conduct, for a period up to three days
-    * Any such ban issued will be accompanied by a warning, and should be logged
+    * Any such ban issued will be accompanied by a warning, and will be logged
 
 ## Enforcement
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the Head Developer on Discord. The Head Developer will review and investigate all complaints, and will respond in a way that they deem appropriate to the circumstances. The Head Developer is obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
People are already using this wording to come up with excuses to complain about developer comments so lets quash this immediately

As written before this, random 'other staff' have more flexible rules in commenting than actual developers