### PR TITLE
Genericise rotate() on obj

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 
 #define OBJ_FLAG_ANCHORABLE              0x0001 // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE             0x0002 // Conducts electricity. (metal etc.)
+#define OBJ_FLAG_ROTATABLE               0x0004 // Can be rotated with alt-click
 
 #define MOB_FLAG_HOLY_BAD                0x001  // If this mob is allergic to holiness
 

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -6,10 +6,11 @@
 	name = "computer frame"
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "0"
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
+	obj_flags = OBJ_FLAG_ROTATABLE
+
 	var/state = 0
 	var/obj/item/weapon/circuitboard/circuit = null
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
-//	weight = 1.0E8
 
 /obj/structure/computerframe/attackby(obj/item/P as obj, mob/user as mob)
 	switch(state)
@@ -115,15 +116,7 @@
 				B.set_dir(src.dir)
 				qdel(src)
 
-/obj/structure/computerframe/verb/rotate()
-	set category = "Object"
-	set name = "Rotate Computer Frame"
-	set src in oview(1)
-
-	if (!Adjacent(usr) || usr.incapacitated() || src.state != 0)
+/obj/structure/computerframe/rotate(mob/user)
+	if(state != 0)
 		return
-
-	src.set_dir(turn(src.dir, 90))
-
-/obj/structure/computerframe/AltClick()
-	rotate()
+	..()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/machines/floodlight.dmi'
 	icon_state = "flood00"
 	density = 1
+	obj_flags = OBJ_FLAG_ROTATABLE
 	var/on = 0
 	var/obj/item/weapon/cell/cell = null
 	var/use = 200 // 200W light
@@ -135,24 +136,3 @@
 				cell = W
 				to_chat(user, "You insert the power cell.")
 	update_icon()
-
-/obj/machinery/floodlight/verb/rotate()
-	set name = "Rotate Light"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr || !Adjacent(usr))
-		return
-
-	if(usr.stat == DEAD)
-		if(!round_is_spooky())
-			to_chat(src, "<span class='warning'>The veil is not thin enough for you to do that.</span>")
-			return
-	else if(usr.incapacitated())
-		return
-
-	src.set_dir(turn(src.dir, 90))
-	return
-
-/obj/machinery/floodlight/AltClick()
-	rotate()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -306,17 +306,8 @@ Buildable meters
 	else
 		return ..()
 
-// rotate the pipe item clockwise
-
-/obj/item/pipe/verb/rotate()
-	set category = "Object"
-	set name = "Rotate Pipe"
-	set src in view(1)
-
-	if (usr.stat || usr.restrained() || !Adjacent(usr) || usr.incapacitated())
-		return
-
-	src.set_dir(turn(src.dir, -90))
+/obj/item/pipe/rotate(mob/user)
+	..()
 
 	if (pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
 		if(dir==2)
@@ -325,11 +316,7 @@ Buildable meters
 			set_dir(4)
 	else if (pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
 		set_dir(2)
-	//src.pipe_set_dir(get_pipe_dir())
 	return
-
-/obj/item/pipe/AltClick()
-	rotate()
 
 /obj/item/pipe/Move()
 	..()
@@ -423,7 +410,7 @@ Buildable meters
 			return 0
 
 /obj/item/pipe/attack_self(mob/user as mob)
-	return rotate()
+	return rotate(user)
 
 /obj/item/pipe/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -10,7 +10,7 @@
 	layer = BELOW_OBJ_LAYER
 	anchored = 1
 	density = 1
-	obj_flags = OBJ_FLAG_ANCHORABLE
+	obj_flags = OBJ_FLAG_ANCHORABLE | OBJ_FLAG_ROTATABLE
 	clicksound = "button"
 	clickvol = 40
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -414,33 +414,11 @@
 	item_state = "lamp"
 	on = 0
 	w_class = ITEM_SIZE_LARGE
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_ROTATABLE
 
 	flashlight_max_bright = 1
 	flashlight_inner_range = 3
 	flashlight_outer_range = 7
-
-
-/obj/item/device/flashlight/floodlamp/verb/rotate()
-	set name = "Rotate Light"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr || !Adjacent(usr))
-		return
-
-	if(usr.stat == DEAD)
-		if(!round_is_spooky())
-			to_chat(src, "<span class='warning'>The veil is not thin enough for you to do that.</span>")
-			return
-	else if(usr.incapacitated())
-		return
-
-	src.set_dir(turn(src.dir, 90))
-	return
-
-/obj/item/device/flashlight/floodlamp/AltClick()
-	rotate()
 
 /obj/item/device/flashlight/lamp/floodlamp/green
 	icon_state = "greenfloodlamp"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,13 +1,12 @@
 /obj
 	layer = OBJ_LAYER
+	animate_movement = 2
 
 	var/obj_flags
 
-	//Used to store information about the contents of the object.
-	var/list/matter
+	var/list/matter //Used to store information about the contents of the object.
 	var/w_class // Size of the object.
 	var/unacidable = 0 //universal "unacidabliness" var, here so you can use it in any obj.
-	animate_movement = 2
 	var/throwforce = 1
 	var/sharp = 0		// whether this object cuts
 	var/edge = 0		// whether this object is more likely to dismember
@@ -164,3 +163,25 @@
 
 /obj/proc/can_embed()
 	return is_sharp(src)
+
+/obj/AltClick(mob/user)
+	if(obj_flags & OBJ_FLAG_ROTATABLE)
+		rotate(user)
+	..()
+	
+/obj/examine(mob/user)
+	. = ..(user)
+	if(. && (obj_flags & OBJ_FLAG_ROTATABLE))
+		to_chat(user, "<span class='subtle'>Can be rotated with alt-click.</span>")
+
+/obj/proc/rotate(mob/user)
+	if(!CanPhysicallyInteract(user))
+		to_chat(user, SPAN_NOTICE("You can't interact with \the [src] right now!"))
+		return
+
+	if(anchored)
+		to_chat(user, SPAN_NOTICE("\The [src] is secured to the floor!"))
+		return 
+
+	set_dir(turn(dir, 90))
+	update_icon() 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -2,13 +2,14 @@
 	name = "railing"
 	desc = "A simple bar railing designed to protect against careless trespass."
 	icon = 'icons/obj/railing.dmi'
+	icon_state = "railing0-1"
 	density = 1
 	throwpass = 1
 	layer = 5.2
 	climb_speed_mult = 0.25
 	anchored = FALSE
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CLIMBABLE
-	icon_state = "railing0-1"
+	obj_flags = OBJ_FLAG_ROTATABLE
 
 	var/broken =    FALSE
 	var/health =    70
@@ -154,35 +155,6 @@
 						pix_offset_y = 32
 				overlays += image(icon, "mcorneroverlay[density]", pixel_x = pix_offset_x, pixel_y = pix_offset_y)
 
-/obj/structure/railing/verb/rotate()
-	set name = "Rotate Railing Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.incapacitated())
-		return 0
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>It is fastened to the floor and cannot be rotated.</span>")
-		return 0
-
-	set_dir(turn(dir, 90))
-	update_icon()
-
-/obj/structure/railing/verb/revrotate()
-	set name = "Rotate Railing Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.incapacitated())
-		return 0
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>It is fastened to the floor and cannot be rotated.</span>")
-		return 0
-
-	set_dir(turn(dir, -90))
-	update_icon()
 
 /obj/structure/railing/verb/flip() // This will help push railing to remote places, such as open space turfs
 	set name = "Flip Railing"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -6,6 +6,8 @@
 	base_icon = "chair"
 	buckle_dir = 0
 	buckle_lying = 0 //force people to sit up in chairs when buckled
+	obj_flags = OBJ_FLAG_ROTATABLE
+	
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 
 /obj/structure/bed/chair/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -25,11 +27,11 @@
 		SK.master = E
 		qdel(src)
 
-/obj/structure/bed/chair/attack_tk(mob/user as mob)
+/obj/structure/bed/chair/attack_tk(mob/user)
 	if(buckled_mob)
 		..()
 	else
-		rotate()
+		rotate(user)
 	return
 
 /obj/structure/bed/chair/post_buckle_mob()
@@ -86,27 +88,6 @@
 	..()
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
-
-/obj/structure/bed/chair/AltClick()
-	rotate()
-
-/obj/structure/bed/chair/verb/rotate()
-	set name = "Rotate Chair"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr || !Adjacent(usr))
-		return
-
-	if(usr.stat == DEAD)
-		if(!round_is_spooky())
-			to_chat(src, "<span class='warning'>The veil is not thin enough for you to do that.</span>")
-			return
-	else if(usr.incapacitated())
-		return
-
-	src.set_dir(turn(src.dir, 90))
-	return
 
 /obj/structure/bed/chair/padded/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_CARPET)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -288,7 +288,6 @@
 			if(health <= 7)
 				set_anchored(FALSE)
 				step(src, get_dir(user, src))
-				update_verbs()
 		else
 			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		..()
@@ -318,36 +317,17 @@
 	if(reinf_material) damage *= 0.5
 	take_damage(damage)
 
-/obj/structure/window/proc/rotate()
-	set name = "Rotate Window Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
+/obj/structure/window/rotate(mob/user)
+	if(!CanPhysicallyInteract(user))
+		to_chat(user, SPAN_NOTICE("You can't interact with \the [src] right now!"))
+		return
 
-	if(usr.incapacitated())
-		return 0
-
-	if(anchored)
-		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
-		return 0
+	if (anchored)
+		to_chat(user, SPAN_NOTICE("\The [src] is secured to the floor!"))
+		return 
 
 	update_nearby_tiles(need_rebuild=1) //Compel updates before
 	set_dir(turn(dir, 90))
-	update_nearby_tiles(need_rebuild=1)
-
-/obj/structure/window/proc/revrotate()
-	set name = "Rotate Window Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.incapacitated())
-		return 0
-
-	if(anchored)
-		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
-		return 0
-
-	update_nearby_tiles(need_rebuild=1) //Compel updates before
-	set_dir(turn(dir, 270))
 	update_nearby_tiles(need_rebuild=1)
 
 /obj/structure/window/Move()
@@ -367,7 +347,6 @@
 	if(anchored == new_anchored)
 		return
 	anchored = new_anchored
-	update_verbs()
 	update_connections(1)
 	update_nearby_icons()
 
@@ -376,15 +355,6 @@
 	update_icon()
 	for(var/obj/structure/window/W in orange(src, 1))
 		W.update_icon()
-
-//Updates the availabiliy of the rotation verbs
-/obj/structure/window/proc/update_verbs()
-	if(anchored)
-		verbs -= /obj/structure/window/proc/rotate
-		verbs -= /obj/structure/window/proc/revrotate
-	else
-		verbs += /obj/structure/window/proc/rotate
-		verbs += /obj/structure/window/proc/revrotate
 
 // Visually connect with every type of window as long as it's full-tile.
 /obj/structure/window/can_visually_connect()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -6,14 +6,12 @@
 	icon_state = "infrared"
 	origin_tech = list(TECH_MAGNET = 2)
 	matter = list(MATERIAL_STEEL = 1000, MATERIAL_GLASS = 500, MATERIAL_WASTE = 100)
-
 	wires = WIRE_PULSE
-
 	secured = 0
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_ROTATABLE
 
 	var/on = 0
 	var/visible = 0
-
 	var/list/beams
 	var/list/seen_turfs
 	var/datum/proximity_trigger/line/proximity_trigger
@@ -92,13 +90,6 @@
 
 	if(usr)
 		attack_self(usr)
-
-/obj/item/device/assembly/infra/verb/rotate()//This could likely be better
-	set name = "Rotate Infrared Laser"
-	set category = "Object"
-	set src in usr
-
-	set_dir(turn(dir, 90))
 
 /obj/item/device/assembly/infra/proc/on_beam_entered(var/atom/enterer)
 	if(enterer == src)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -300,6 +300,8 @@
 	name = "mining drill brace"
 	desc = "A machinery brace for an industrial drill. It looks easily two feet thick."
 	icon_state = "mining_brace"
+	obj_flags = OBJ_FLAG_ROTATABLE
+
 	var/obj/machinery/mining/drill/connected
 
 /obj/machinery/mining/brace/New()
@@ -365,25 +367,7 @@
 	connected.check_supports()
 	connected = null
 
-/obj/machinery/mining/brace/verb/rotate()
-	set name = "Rotate"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!CanPhysicallyInteract(usr))
-		return
-
-	if (src.anchored)
-		to_chat(usr, "It is anchored in place!")
-		return 0
-
-	src.set_dir(turn(src.dir, 90))
-	return 1
-
 /obj/machinery/mining/brace/default_deconstruction_crowbar(var/mob/user, var/obj/item/weapon/crowbar/C)
 	if(connected)
 		disconnect()
 	..()
-
-/obj/machinery/mining/brace/AltClick()
-	rotate()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -32,20 +32,6 @@
 	anchored = 1
 	state = 2
 
-/obj/machinery/power/emitter/verb/rotate()
-	set name = "Rotate"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.incapacitated())
-		return
-
-	if (src.anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.set_dir(turn(src.dir, 90))
-	return 1
-
 /obj/machinery/power/emitter/Initialize()
 	. = ..()
 	if(state == 2 && anchored)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -65,6 +65,8 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	icon_state = "none"
 	anchored = 0
 	density = 1
+	obj_flags = OBJ_FLAG_ROTATABLE
+
 	var/obj/machinery/particle_accelerator/control_box/master = null
 	var/construction_state = 0
 	var/reference = null
@@ -87,29 +89,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 /obj/structure/particle_accelerator/on_update_icon()
 	..()
 	return
-
-
-/obj/structure/particle_accelerator/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.set_dir(turn(src.dir, 270))
-	return 1
-
-/obj/structure/particle_accelerator/verb/rotateccw()
-	set name = "Rotate Counter Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.set_dir(turn(src.dir, 90))
-	return 1
 
 /obj/structure/particle_accelerator/examine(mob/user)
 	switch(src.construction_state)
@@ -266,29 +245,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	var/powered = null
 	var/strength = 0
 	var/desc_holder = null
-
-
-/obj/machinery/particle_accelerator/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.set_dir(turn(src.dir, 270))
-	return 1
-
-/obj/machinery/particle_accelerator/verb/rotateccw()
-	set name = "Rotate Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if (src.anchored || usr:stat)
-		to_chat(usr, "It is fastened to the floor!")
-		return 0
-	src.set_dir(turn(src.dir, 90))
-	return 1
 
 /obj/machinery/particle_accelerator/on_update_icon()
 	return

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -24,10 +24,8 @@
 
 /obj/structure/disposalconstruct/proc/update_verbs()
 	if(anchored)
-		verbs -= /obj/structure/disposalconstruct/proc/rotate
 		verbs -= /obj/structure/disposalconstruct/proc/flip
 	else
-		verbs += /obj/structure/disposalconstruct/proc/rotate
 		verbs += /obj/structure/disposalconstruct/proc/flip
 
 // update iconstate and dpdir due to dir and type
@@ -113,26 +111,6 @@
 /obj/structure/disposalconstruct/hide(var/intact)
 	set_invisibility((intact && level==1) ? 101: 0)	// hide if floor is intact
 	update()
-
-
-// flip and rotate verbs
-/obj/structure/disposalconstruct/proc/rotate()
-	set category = "Object"
-	set name = "Rotate Pipe"
-	set src in view(1)
-
-	if(usr.stat || usr.restrained() || !Adjacent(usr) || usr.incapacitated())
-		return
-
-	if(anchored)
-		to_chat(usr, "You must unfasten the pipe before rotating it.")
-		return
-
-	set_dir(turn(dir, -90))
-	update()
-
-/obj/structure/disposalconstruct/AltClick()
-	rotate()
 
 /obj/structure/disposalconstruct/proc/flip()
 	set category = "Object"


### PR DESCRIPTION
:cl:
tweak: Many objects that were previously rotatable with a verb are now rotated using alt-click. Any such object will report in examine that it can be rotated.
tweak: You can now rotate vending machines with alt-click.
/:cl:

Adding rotation with alt-click in most cases is now simply the case of adding the relevant flag (`OBJ_FLAG_ROTATABLE`). In some cases like pipes and windows and where things are in more than 90 degree increments, an override is required.

By default the standard `obj/rotate` checks if the user can physically interact and if the object is anchored.