### PR TITLE
Bridge Deck Tweaks

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3,19 +3,12 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Command Hallway - Center Fore Staboard";
-	dir = 4;
-	network = list("Bridge")
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "ac" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -176,8 +169,11 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "aA" = (
@@ -186,14 +182,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "aB" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/hop,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
@@ -208,10 +201,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -228,9 +217,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -245,10 +231,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -306,7 +288,6 @@
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -369,8 +350,6 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "aW" = (
@@ -417,9 +396,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "aZ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -439,6 +415,11 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "bc" = (
@@ -448,15 +429,16 @@
 /obj/structure/sign/warning/smoking{
 	pixel_x = 26
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "bd" = (
-/obj/structure/bed/chair/padded/beige{
-	icon_state = "chair_preview";
+/obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/mahogany,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "be" = (
 /obj/item/modular_computer/console/preset/command,
@@ -481,10 +463,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -498,9 +476,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -524,9 +499,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -536,13 +508,17 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/bridge/forestarboard)
 "bj" = (
-/obj/effect/floor_decal/corner/b_green,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "bk" = (
 /obj/effect/floor_decal/corner/white/full,
@@ -555,78 +531,29 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
-"bn" = (
-/turf/simulated/floor/reinforced/airless,
-/area/bridge/storage)
 "bo" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "bq" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/co)
-"br" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"bt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"bs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/meter,
+/obj/machinery/light/small{
+	icon_state = "bulb1";
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"bx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/aftstarboard)
-"by" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge";
-	dir = 1
-	},
-/obj/item/weapon/book/manual/sol_sop,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"bz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/area/maintenance/bridge/forestarboard)
+"bx" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -642,10 +569,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "bB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -680,71 +603,90 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/bridge)
-"bF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/maintenance/bridge/foreport)
 "bH" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
+"bI" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "bJ" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"bK" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"bM" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
+/area/bridge/hallway/port)
 "bN" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"bO" = (
 /obj/effect/floor_decal/spline/plain/beige{
 	icon_state = "spline_plain";
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"bO" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
 "bP" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
+"bQ" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "ce_windows"
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge entry star";
+	name = "Bridge Starboard Lockdown Window Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/ce)
-"bQ" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4
-	},
-/turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "bT" = (
 /turf/simulated/floor/tiled,
@@ -771,19 +713,27 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cl)
 "bX" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "cap_window";
-	name = "CO's Quarters Shutters"
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
+/area/bridge/meeting_room)
 "cb" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -799,7 +749,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
 "ce" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -838,31 +787,38 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
 "cj" = (
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 10
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"cp" = (
-/obj/structure/bed/chair/comfy/beige{
+"ck" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/bridgecheck)
+"cl" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
-	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"co" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"cq" = (
-/obj/structure/table/woodentable/mahogany,
+"cp" = (
+/obj/structure/table/woodentable/walnut,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
 	pixel_x = -5;
 	pixel_y = 5
@@ -873,38 +829,56 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"cu" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "heads_meeting";
-	name = "Meeting Room Window Shutters";
-	opacity = 0
+"cq" = (
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 8
 	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"cF" = (
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Fore Port";
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/bridge/meeting_room)
-"cD" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/area/hallway/primary/bridge/fore)
+"cG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j1s";
+	name = "Chief of Security";
+	sortType = "Chief of Security"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "cH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -917,7 +891,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "cI" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -1075,35 +1048,56 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "cS" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/research{
+	id_tag = "csodoor";
+	name = "Chief Science Officer";
+	secured_wires = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/spline/plain/beige{
-	icon_state = "spline_plain";
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/rd)
+"cT" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/cash,
+/obj/random/cash,
+/obj/random_multi/single_item/boombox,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"cV" = (
+/obj/item/modular_computer/console/preset/sysadmin{
+	icon_state = "console";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"cT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"cW" = (
-/obj/machinery/firealarm{
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/power/apc/super/critical{
 	dir = 2;
-	pixel_y = 24
+	is_critical = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/machinery/computer/robotics,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
+/area/bridge)
 "dc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -1124,18 +1118,25 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "dd" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/item/weapon/pen,
 /obj/item/weapon/stamp/xo,
-/obj/structure/table/woodentable_reinforced/mahogany/walnut,
-/turf/simulated/floor/wood/mahogany,
+/obj/structure/table/woodentable_reinforced/walnut,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
-"de" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Command Hallway - Center Fore Staboard";
+	dir = 4;
+	network = list("Bridge")
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "dg" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1147,7 +1148,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -1164,21 +1164,21 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/obj/structure/flora/pottedplant/deskleaf{
-	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
+/obj/machinery/photocopier/faxmachine{
+	department = "Bridge"
 	},
 /obj/machinery/button/remote/airlock{
-	id = "meetingstarboard";
+	id = "meetindstarboard";
 	name = "Bridge Meeting Starboard Door Control";
 	pixel_x = 34;
-	pixel_y = 6;
+	pixel_y = -6;
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/machinery/button/remote/airlock{
 	id = "meetingport";
 	name = "Bridge Meeting Port Door Control";
 	pixel_x = 34;
-	pixel_y = -6;
+	pixel_y = 6;
 	req_access = list("ACCESS_BRIDGE")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -1221,39 +1221,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "dk" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/random/clipboard,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/cl/backroom)
 "dm" = (
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_foyer)
 "dn" = (
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
 "dp" = (
-/obj/structure/sign/double/icarus/solgovflag/right{
-	dir = 4;
-	icon_state = "solgovflag-right";
-	pixel_x = -32
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "ce_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/ce)
 "dr" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -1268,7 +1257,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "ds" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -1407,65 +1395,74 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "dF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
-/area/aux_eva)
+/area/bridge/meeting_room)
 "dG" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "dI" = (
-/obj/structure/flora/pottedplant/shoot,
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/camera/network/command{
+	c_tag = "Executive Officer - Quarters"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"dN" = (
+"dJ" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"dP" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"dQ" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 26;
-	pixel_y = 0
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"dR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"dR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"dT" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/flora/pottedplant/deskleaf{
+	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "dV" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarbridge)
@@ -1529,52 +1526,54 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_outer_chamber)
-"eo" = (
+"em" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/flashlight/lamp{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/cos)
+"en" = (
 /obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+	pixel_y = 24
 	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/camera/network/command{
+	c_tag = "Executive Officer - Office"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/flora/pottedplant/fern,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
 "eq" = (
+/obj/machinery/door/airlock/sol{
+	name = "XO's Quarters";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
-"es" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+"er" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "et" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"ev" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/door/firedoor/border_only,
@@ -1623,31 +1622,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
-"eD" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"eE" = (
-/obj/structure/bed/chair/padded/green{
-	icon_state = "chair_preview";
-	dir = 1
+"eF" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHEAST)";
-	icon_state = "corner_white";
-	dir = 5
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/closet/secure_closet{
+	name = "Security Equipment Locker";
+	req_access = list("ACCESS_SECURITY")
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
 "eH" = (
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
@@ -1661,27 +1649,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
 "eK" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"eL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/area/hallway/primary/bridge/fore)
 "eM" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -1705,48 +1689,39 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge)
 "eQ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
-"eR" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "eS" = (
-/obj/machinery/light_switch{
-	pixel_x = 23;
-	pixel_y = -23
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/machinery/papershredder,
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
+	id = "hop_office_desk";
+	name = "XO Queue Privacy Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/xo)
 "eT" = (
 /obj/structure/cable/green{
@@ -1758,13 +1733,31 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
+"eU" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "eV" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -1777,18 +1770,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "eW" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
+/obj/structure/table/woodentable/walnut,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
 "eY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1860,10 +1844,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
 "fg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -1880,10 +1860,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "fh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -1922,6 +1898,11 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"fl" = (
+/obj/structure/table/glass,
+/obj/random/clipboard,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
 "fm" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -2005,24 +1986,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
-"fy" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "xo_windows"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge entry star";
-	name = "Bridge Starboard Lockdown Window Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/xo)
 "fz" = (
 /obj/effect/floor_decal/spline/plain/beige{
 	icon_state = "spline_plain";
@@ -2042,22 +2005,24 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
 "fB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "fD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"fF" = (
+/obj/structure/flora/pottedplant/smelly{
+	desc = "This is some kind of tropical plant. It reeks of rotten eggs. This one has a hand-painted Nametag on the rim. It reads 'Steve'"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
 "fI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
@@ -2085,6 +2050,23 @@
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
+"fN" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "fO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -2133,30 +2115,51 @@
 /area/bridge/hallway/starboard)
 "fS" = (
 /obj/effect/floor_decal/corner/blue,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fT" = (
-/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
 "fU" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
 "fV" = (
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
+"fW" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
 "fX" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -2177,6 +2180,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "gb" = (
@@ -2207,25 +2213,7 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"ge" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "gf" = (
 /obj/structure/cable/green{
@@ -2263,9 +2251,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -2409,6 +2394,28 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_outer_chamber)
+"gv" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "repdoor";
+	name = "SCGR's Office Door Control";
+	pixel_x = 27;
+	pixel_y = 5;
+	req_access = list("ACCESS_TORCH_REPRESENTATIVE")
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 25;
+	pixel_y = -6;
+	id = "sgr_windows";
+	range = 11
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "gw" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
@@ -2420,7 +2427,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"gD" = (
+"gC" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
@@ -2445,14 +2452,14 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
@@ -2466,20 +2473,6 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"gI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "gJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2487,33 +2480,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "gK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/item/device/radio/beacon,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gL" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2521,6 +2507,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "gM" = (
@@ -2537,13 +2526,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/yellow{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gP" = (
@@ -2568,22 +2555,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
-"gQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Starboard";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "gR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment{
@@ -2598,6 +2569,12 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"gT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
 "gV" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external{
@@ -2710,13 +2687,12 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "hj" = (
-/obj/machinery/hologram/holopad/longrange,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/vehicle/bike/gyroscooter,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "hn" = (
 /turf/simulated/floor/tiled/dark,
@@ -2747,16 +2723,19 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
@@ -2773,40 +2752,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"hv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"hw" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/machinery/atm{
-	pixel_x = 32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+	icon_state = "corner_white";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -2835,6 +2782,7 @@
 	name = "Chief Engineer";
 	secured_wires = 1
 	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
@@ -2848,19 +2796,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/ce)
-"hB" = (
-/obj/structure/flora/pottedplant/bamboo,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
 "hC" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
@@ -2890,11 +2825,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "hH" = (
-/obj/structure/sign/warning/high_voltage{
-	pixel_y = -6
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Exterior";
+	dir = 8
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/rd)
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "hI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
@@ -3026,25 +2963,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
-"hT" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "hV" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/sol{
@@ -3100,33 +3018,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"hY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "hZ" = (
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"ib" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "id" = (
 /obj/machinery/door/blast/shutters{
@@ -3153,7 +3049,6 @@
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
 	},
-/obj/item/weapon/book/manual/sol_sop,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/folder,
@@ -3170,6 +3065,11 @@
 	pixel_x = -24;
 	pixel_y = -6
 	},
+/obj/item/weapon/paper/monitorkey,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "ih" = (
@@ -3182,6 +3082,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "ii" = (
@@ -3198,17 +3099,10 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "il" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "im" = (
 /obj/structure/railing/mapped,
@@ -3367,6 +3261,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/passenger)
+"iB" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain/beige{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
 "iC" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -3382,24 +3286,11 @@
 "iE" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/turret_protected/ai)
-"iH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+"iG" = (
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "iI" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -3437,20 +3328,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
-"iL" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/reagent_dispensers/water_cooler{
-	icon_state = "water_cooler";
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
 "iM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -3460,19 +3337,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "iN" = (
-/obj/random/trash,
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "iP" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "CE"
-	},
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
 	icon_state = "wrecharger0";
@@ -3480,10 +3359,12 @@
 	pixel_y = -3
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"iQ" = (
-/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "iR" = (
 /obj/machinery/hologram/holopad,
@@ -3500,29 +3381,23 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "iU" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3540,7 +3415,7 @@
 	icon_state = "warning";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "iX" = (
 /obj/machinery/door/firedoor/border_only,
@@ -3605,6 +3480,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
+"jc" = (
+/obj/structure/drain,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
 "je" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -3639,11 +3518,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
-"ji" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/aftport)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3753,6 +3627,11 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/item/weapon/storage/secure/briefcase{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "jz" = (
@@ -3781,15 +3660,43 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"jA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "jB" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridgehallway";
+	name = "Bridge Interior Hallway Shutters";
+	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/hallway/port)
+"jD" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "jH" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -3832,25 +3739,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"jP" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/modular_computer/console/preset/security,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "jR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "jS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jT" = (
@@ -3897,7 +3796,6 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
 "jX" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -3981,6 +3879,8 @@
 	pixel_x = 3;
 	pixel_y = 0
 	},
+/obj/item/weapon/folder/envelope/blanks,
+/obj/item/weapon/material/clipboard,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
 "ke" = (
@@ -4153,14 +4053,46 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
-"kA" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
+"kw" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
+"kx" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"kA" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
+	id = "hop_office";
+	name = "XO Office Privacy Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/xo)
 "kF" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -4177,37 +4109,14 @@
 /obj/item/weapon/rig/ce/equipped,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
-"kH" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Engineer - Office";
-	dir = 1;
-	network = list("Command","Engineering")
-	},
-/obj/structure/closet/secure_closet/engineering_chief_torch,
-/obj/machinery/button/remote/airlock{
-	name = "CE's Office Door Control";
-	desc = "A remote control-switch for the office door.";
-	pixel_x = 0;
-	pixel_y = -27;
-	req_access = list("ACCESS_CHIEF_ENGINEER");
-	id = "cedoor"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
 "kI" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/toy/desk/newtoncradle,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/toy/desk/newtoncradle,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "kJ" = (
@@ -4244,7 +4153,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "kO" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -4259,10 +4167,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "kP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue/half{
+	icon_state = "bordercolorhalf";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
@@ -4318,12 +4228,23 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge Hallway - Aft";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
+"kV" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 1;
+	dir = 4;
+	icon_state = "shutter1";
+	id = "hop_office";
+	name = "XO Office Privacy Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/xo)
 "kW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
@@ -4342,6 +4263,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
+"kX" = (
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
 "kY" = (
 /obj/machinery/teleport/hub,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4568,34 +4506,44 @@
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
 "lq" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridgehallway";
-	name = "Bridge Interior Hallway Shutters";
-	opacity = 0
-	},
+/obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/port)
-"lr" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridgehallway";
-	name = "Bridge Interior Hallway Shutters";
-	opacity = 0
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/port)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"lt" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"lu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"lx" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "ly" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
@@ -4605,17 +4553,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"lz" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "lA" = (
 /obj/structure/sign/warning/high_voltage{
 	icon_state = "shock";
@@ -4638,6 +4575,10 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "lC" = (
@@ -4658,6 +4599,12 @@
 	dir = 4
 	},
 /obj/item/device/radio/beacon,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j1s";
+	name = "Chief Medical Officer";
+	sortType = "Chief Medical Officer"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "lD" = (
@@ -4673,6 +4620,9 @@
 	dir = 4
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "lE" = (
@@ -4692,6 +4642,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "lH" = (
@@ -4705,8 +4658,27 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
+"lL" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/bridge)
 "lN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -4760,6 +4732,21 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/aft)
+"lQ" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "lR" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
@@ -4796,6 +4783,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"lT" = (
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
+"lW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
 "lX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -4809,18 +4819,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
-"lY" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4862,6 +4860,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
+"mc" = (
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "md" = (
 /obj/machinery/teleport/station,
 /obj/structure/sign/kiddieplaque{
@@ -5051,9 +5060,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
-"mr" = (
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
 "ms" = (
 /obj/machinery/camera/all/command{
 	c_tag = "AI Core - Auxiliary Access";
@@ -5127,28 +5133,78 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
-"mB" = (
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
+"my" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Engineer - Office";
+	dir = 1;
+	network = list("Command","Engineering")
+	},
+/obj/structure/closet/secure_closet/engineering_chief_torch,
+/obj/machinery/button/remote/airlock{
+	name = "CE's Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = 0;
+	pixel_y = -27;
+	req_access = list("ACCESS_CHIEF_ENGINEER");
+	id = "cedoor"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
+"mz" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/weapon/stamp/sea,
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "seaforedoor";
+	name = "SEA's Office Door Control";
+	pixel_x = -6;
+	pixel_y = -25;
+	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 9;
+	pixel_y = -24;
+	id = "sea_windows"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
+"mA" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
-/area/bridge/storage)
+/area/security/bridgecheck)
 "mC" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/vending/coffee{
-	icon_state = "coffee";
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/red/half,
+/obj/machinery/vending/cola{
+	icon_state = "Cola_Machine";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
@@ -5156,19 +5212,14 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cos)
 "mG" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/device/radio,
-/obj/item/weapon/crowbar/prybar,
-/obj/item/device/binoculars,
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
+/obj/machinery/papershredder,
+/obj/machinery/recharger/wallcharger{
 	dir = 4;
-	pixel_x = -37
+	icon_state = "wrecharger0";
+	pixel_x = -23;
+	pixel_y = -3
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mH" = (
@@ -5182,9 +5233,17 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mI" = (
+/obj/structure/closet/secure_closet/cos,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/camera/network/command{
 	c_tag = "Head of Security - Office";
 	network = list("Command","Security")
@@ -5197,44 +5256,25 @@
 	req_access = list("ACCESS_HEAD_OF_SECURITY");
 	id = "cosdoor"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "mJ" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
-/obj/item/weapon/stamp/cos,
-/obj/item/toy/figure/secofficer{
-	desc = "A 'Space Life' brand Security Officer action figure. This one seems rather old. A small heart is sewn into the armor vest."
+/obj/machinery/photocopier/faxmachine{
+	department = "COS"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
-"mL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "bridge_safe_sensor";
-	master_tag = "bridge_safe";
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
-	frequency = 1379;
-	id_tag = "bridge_safe_pump"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
 "mN" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -5258,12 +5298,6 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/bridgecheck)
-"mP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "mQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5271,6 +5305,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/blue,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "mS" = (
@@ -5288,20 +5323,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "mT" = (
-/obj/structure/flora/pottedplant/smallcactus{
-	desc = "This is a small cactus. Its needles are sharp. It seems neglected, as if no one loves it."
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
+/obj/structure/table/woodentable/walnut,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "mV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -5351,11 +5375,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "mZ" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/corner/blue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "na" = (
@@ -5366,6 +5389,10 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge Hallway - Aft";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5382,6 +5409,9 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "nc" = (
@@ -5426,14 +5456,14 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "ng" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "ni" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/camera/network/aquila{
@@ -5454,18 +5484,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "nj" = (
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "nk" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5750,7 +5770,6 @@
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
 	},
-/obj/item/weapon/book/manual/sol_sop,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/folder,
@@ -5770,6 +5789,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"nI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/sol{
+	name = "Deliberation Room";
+	secured_wires = 0
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room/deliberation)
 "nJ" = (
 /obj/item/modular_computer/console/preset/command{
 	icon_state = "console";
@@ -5800,42 +5838,44 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "nK" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/item/device/flashlight/lamp,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"nS" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
-	},
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
-"nT" = (
-/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/remote/airlock{
+	id = "bridgesafe_back";
+	name = "Emergency Exit door-control";
+	pixel_x = 25;
+	pixel_y = -25;
+	specialfunctions = 4
 	},
-/turf/simulated/floor/plating,
-/area/bridge)
+/obj/effect/floor_decal/techfloor/orange,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"nM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"nN" = (
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "nU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5843,6 +5883,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "nV" = (
@@ -5852,36 +5896,6 @@
 /obj/structure/bed/chair/comfy/red,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
-"nW" = (
-/obj/item/weapon/tableflag,
-/obj/structure/table/woodentable_reinforced/ebony/walnut,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/crew_quarters/heads/office/co)
-"nY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "nZ" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -5906,9 +5920,6 @@
 /obj/effect/floor_decal/corner/red/half{
 	icon_state = "bordercolorhalf";
 	dir = 4
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
@@ -5942,13 +5953,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"od" = (
-/obj/structure/catwalk,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
 "oe" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -6056,18 +6063,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
-"ow" = (
-/obj/structure/flora/pottedplant/large,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "ox" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -6089,21 +6084,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
+"oz" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"oA" = (
+/obj/structure/lattice,
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Exterior - Starboard";
+	dir = 2
+	},
+/turf/space,
+/area/space)
 "oB" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
-"oD" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "COS"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
 "oF" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6113,39 +6113,59 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/toy/figure/secofficer{
+	desc = "A 'Space Life' brand Security Officer action figure. This one seems rather old. A small heart is sewn into the armor vest."
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
-"oH" = (
+"oI" = (
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/papershredder,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"oJ" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
+	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "xo_windows"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 1;
-	dir = 4;
-	icon_state = "shutter1";
-	id = "hop_office";
-	name = "XO Office Privacy Shutters";
-	opacity = 1
-	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/xo)
-"oI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
+/area/bridge/meeting_room)
 "oK" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -6193,16 +6213,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"oQ" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
 "oR" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/flora/pottedplant/overgrown,
@@ -6215,13 +6225,19 @@
 	dir = 8;
 	pixel_x = 20
 	},
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Medical Officer - Office";
+	network = list("Command","Medical")
+	},
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "oS" = (
-/turf/simulated/floor/plating,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
 "oT" = (
 /obj/structure/disposalpipe/segment,
@@ -6250,44 +6266,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"oX" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/weapon/stamp/sea,
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "seaforedoor";
-	name = "SEA's Office Door Control";
-	pixel_x = -6;
-	pixel_y = -25;
-	req_access = list("ACCESS_TORCH_SENIOR_ADVISOR")
-	},
-/obj/machinery/button/windowtint{
-	pixel_x = 9;
-	pixel_y = -24;
-	id = "sea_windows"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/sea)
-"oY" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/effect/floor_decal/spline/plain/brown{
-	icon_state = "spline_plain";
-	dir = 1
-	},
-/obj/item/weapon/material/ashtray/bronze,
-/obj/item/weapon/flame/lighter/zippo/random,
-/obj/random/smokes,
-/obj/structure/sign/warning/smoking{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/sgr)
 "oZ" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/radio,
@@ -6329,6 +6307,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
+"pe" = (
+/obj/structure/lattice,
+/obj/machinery/light/navigation/delay5,
+/turf/space,
+/area/space)
 "pf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6454,15 +6437,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"pv" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/meeting_room)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
 	},
-/obj/item/weapon/book/manual/sol_sop,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/folder,
@@ -6479,6 +6457,10 @@
 	pixel_x = -24;
 	pixel_y = -6
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "pz" = (
@@ -6491,6 +6473,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
 "pA" = (
@@ -6514,7 +6497,6 @@
 	icon_state = "console";
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "pF" = (
@@ -6535,31 +6517,20 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/bridgecheck)
+"pI" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
 "pJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Medical Officer - Office";
-	dir = 4;
-	network = list("Command","Security")
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"pK" = (
-/obj/machinery/papershredder,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
 "pL" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/hologram/holopad,
@@ -6568,44 +6539,13 @@
 /area/crew_quarters/heads/office/cmo)
 "pM" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"pO" = (
-/obj/item/device/flashlight/lamp/green,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "hopdoor";
-	name = "XO's Office Door Control";
-	pixel_x = -5;
-	pixel_y = 38;
-	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
-	},
-/obj/machinery/button/windowtint{
-	pixel_x = 8;
-	pixel_y = 39;
-	id = "xo_windows"
-	},
-/obj/structure/table/woodentable_reinforced/mahogany/walnut,
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
-"pP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "pQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -6756,6 +6696,13 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
+"qa" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6821,6 +6768,11 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -6889,30 +6841,19 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/emcloset,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"ql" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "qm" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall/prepainted,
@@ -6936,6 +6877,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "qp" = (
@@ -6962,6 +6904,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cos)
+"qs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "qt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6969,14 +6917,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "qu" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cmo_windows"
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qv" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -6985,25 +6940,18 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/pen/blue,
 /obj/random/clipboard,
-/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qw" = (
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 8
 	},
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
 "qx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -7014,32 +6962,35 @@
 /obj/item/weapon/reagent_containers/food/snacks/cookie,
 /obj/item/weapon/reagent_containers/food/snacks/cookie,
 /obj/item/weapon/storage/lunchbox/cat,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"qy" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+"qz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"qC" = (
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"qA" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Exterior - Port";
+	dir = 1
 	},
-/obj/structure/bed/chair/comfy/green,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/space,
+/area/space)
+"qB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
 "qD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/crew,
@@ -7074,11 +7025,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
-"qG" = (
-/obj/structure/lattice,
-/obj/machinery/light/navigation/delay5,
-/turf/space,
-/area/space)
+"qH" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/maintenance/bridge/aftport)
 "qI" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -7154,8 +7103,23 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/command{
+	c_tag = "CO - Office Port"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/co)
+"qR" = (
+/obj/structure/flora/pottedplant/large,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "qS" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	icon_state = "corner_white_diagonal";
@@ -7222,12 +7186,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 10
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Entry Port";
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
@@ -7248,6 +7211,15 @@
 	pixel_x = 26;
 	pixel_y = -35
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "qY" = (
@@ -7266,18 +7238,16 @@
 	name = "Port Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/multi_tile/glass/command{
-	autoset_access = 0;
-	dir = 8;
-	id_tag = "portbridgeaccess";
-	name = "Bridge Access";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner/blue/three_quarters,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/port)
 "ra" = (
@@ -7298,16 +7268,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "rc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -7320,6 +7292,14 @@
 	dir = 1
 	},
 /obj/item/device/radio/beacon,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "rd" = (
@@ -7334,25 +7314,33 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "re" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"rj" = (
+"rf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"rg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -7397,8 +7385,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -7409,32 +7398,16 @@
 	dir = 4
 	},
 /obj/item/modular_computer/tablet/lease/preset/command,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "rp" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"rq" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	id_tag = "liaisondoor3";
-	name = "Corporate Liaison";
-	secured_wires = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "rt" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "meetingstarboard";
-	name = "Conference Room"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7446,6 +7419,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	id_tag = "meetingport";
+	name = "Conference Room"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
@@ -7501,16 +7478,40 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
+"rz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"rA" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-center-left";
+	icon_state = "bottom-left";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/disciplinary_board_room)
 "rC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/item/toy/torchmodel,
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/random_multi/single_item/runtime,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
 "rE" = (
 /obj/structure/table/standard,
 /obj/item/weapon/defibrillator/loaded,
@@ -7613,7 +7614,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/co)
 "rL" = (
@@ -7668,25 +7668,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "rO" = (
-/obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "rP" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -28;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
@@ -7716,31 +7711,19 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/bridge)
 "rT" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/power/apc/super{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
+/obj/structure/closet/toolcloset,
+/obj/random/action_figure,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/powercell,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
 "rV" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -7750,25 +7733,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"rZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -7778,6 +7744,19 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"rZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "sa" = (
@@ -7791,10 +7770,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/blue{
@@ -7803,20 +7778,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "sb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/effect/floor_decal/corner/blue,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/hallway/starboard)
 "se" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7858,17 +7825,38 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "si" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/hop,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"sl" = (
+/obj/structure/flora/pottedplant/shoot,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"sm" = (
+/obj/machinery/shipsensors,
+/turf/simulated/floor/reinforced/airless,
+/area/bridge/storage)
 "sn" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Secure Storage"
@@ -7896,18 +7884,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
-"sp" = (
-/obj/effect/floor_decal/scglogo{
-	tag = "icon-bottom-left";
-	icon_state = "bottom-left"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "st" = (
 /obj/structure/hygiene/sink{
 	icon_state = "sink";
@@ -7998,23 +7974,12 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/sea)
 "sC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/military_law,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "sH" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -8060,6 +8025,7 @@
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "rd_windows"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/rd)
 "sS" = (
@@ -8135,21 +8101,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
-"sZ" = (
-/obj/structure/displaycase,
-/obj/item/weapon/gun/projectile/revolver/medium/captain{
-	pixel_y = -3
+"ta" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/sign/ecplaque{
-	pixel_x = 29
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light,
-/obj/structure/sign/warning/smoking{
-	pixel_x = 0;
-	pixel_y = -26
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
+/obj/machinery/door/airlock/command{
+	id_tag = "meetingstarboard";
+	name = "Conference Room"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "tb" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -8237,32 +8205,24 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"tk" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "tm" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
 /obj/structure/flora/pottedplant/unusual,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
-"tn" = (
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
 "to" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -8277,10 +8237,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
-"tq" = (
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
 "ts" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -8297,16 +8253,11 @@
 /area/crew_quarters/heads/office/sgr)
 "tt" = (
 /obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tu" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tv" = (
@@ -8314,10 +8265,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -8345,7 +8292,7 @@
 	},
 /obj/random/drinkbottle,
 /obj/structure/sign/warning/nosmoking_1{
-	desc = "";
+	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
 	pixel_x = 0;
 	pixel_y = 26
 	},
@@ -8422,29 +8369,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"tF" = (
-/obj/effect/floor_decal/corner/white/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/command,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
-"tG" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "tH" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -8618,11 +8542,18 @@
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "sgr_windows"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/sgr)
 "uh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
@@ -8809,6 +8740,14 @@
 "uy" = (
 /turf/simulated/wall/walnut,
 /area/crew_quarters/heads/cobed)
+"uz" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/flashlight/lamp/green,
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "uB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8842,15 +8781,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
-"uD" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8;
-	pixel_x = 4;
-	pixel_y = -6
-	},
-/turf/simulated/wall/prepainted,
-/area/bridge/meeting_room)
 "uE" = (
 /obj/structure/bed/chair/padded/blue,
 /obj/structure/sign/double/icarus/solgovflag/left{
@@ -8894,6 +8824,10 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -9027,11 +8961,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"vc" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/foreport)
 "vd" = (
 /obj/machinery/power/shield_generator,
 /obj/structure/cable/green{
@@ -9053,7 +8982,7 @@
 	name = "Corporate Liaison";
 	secured_wires = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "vf" = (
 /obj/effect/floor_decal/scglogo{
@@ -9130,6 +9059,21 @@
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
+"vm" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/material/clipboard,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/sea)
 "vn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -9157,13 +9101,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
-"vt" = (
-/obj/structure/sign/dedicationplaque{
-	desc = "S.E.V. Torch - Mako Class - Sol Expeditionary Corps Registry 95519 - Shiva Fleet Yards, Mars - First Vessel To Bear The Name - Launched 2302 - Sol Central Government - 'Never was anything great achieved without danger.'";
-	pixel_x = 0
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/storage)
 "vu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9180,12 +9117,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/disciplinary_board_room/deliberation)
 "vx" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "vy" = (
 /obj/structure/table/woodentable_reinforced/walnut/maple,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -9286,9 +9226,9 @@
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
@@ -9343,6 +9283,12 @@
 "vY" = (
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
+"vZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
 "wb" = (
 /obj/structure/bed/chair/padded/beige{
 	icon_state = "chair_preview";
@@ -9392,7 +9338,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
 "wf" = (
-/obj/structure/table/steel_reinforced,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -9415,10 +9360,10 @@
 	},
 /obj/item/weapon/reagent_containers/food/drinks/glass2/square,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+/obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "wg" = (
-/obj/structure/table/steel_reinforced,
 /obj/item/weapon/tableflag{
 	pixel_x = 4
 	},
@@ -9438,23 +9383,19 @@
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "wh" = (
-/obj/structure/table/steel_reinforced,
 /obj/item/weapon/book/manual/military_law,
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 10
 	},
 /obj/item/weapon/reagent_containers/food/drinks/glass2/square,
+/obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"wi" = (
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/aftport)
 "wj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -9692,10 +9633,7 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
 "wz" = (
@@ -9732,6 +9670,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"wC" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/item/weapon/stamp/cos,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
 "wD" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/photocopier/faxmachine{
@@ -9817,6 +9765,20 @@
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
+"wM" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "wN" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -9915,6 +9877,21 @@
 "xc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/foreport)
+"xd" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "xe" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -10111,14 +10088,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
-"xu" = (
-/obj/machinery/hologram/holopad/longrange,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "xv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10237,12 +10206,6 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"xM" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "xN" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -10372,22 +10335,10 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"ya" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Port"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "yb" = (
 /obj/structure/cable/green{
@@ -10395,14 +10346,27 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"yc" = (
+/obj/structure/catwalk,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"yd" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "yf" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "bridge_starboard"
@@ -10415,16 +10379,12 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "yg" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4
 	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
-/obj/random/drinkbottle,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/xo)
 "yh" = (
 /obj/effect/floor_decal/scglogo{
 	tag = "icon-bottom-center";
@@ -10459,19 +10419,31 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
-"yu" = (
-/obj/structure/bed/chair/padded/green{
-	icon_state = "chair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
 "yw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
+/obj/item/sticky_pad/random,
+/obj/item/weapon/storage/box/cups,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
 /obj/machinery/light,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer's Office - Torch"
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/button/remote/airlock{
+	name = "CMO's Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = -5;
+	pixel_y = -35;
+	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER");
+	id = "cmodoor"
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 7;
+	pixel_y = -34;
+	id = "cmo_windows";
+	range = 11
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -10494,74 +10466,89 @@
 /obj/effect/shuttle_landmark/ninja/deck5,
 /turf/space,
 /area/space)
-"yE" = (
-/obj/effect/floor_decal/corner/blue{
+"yD" = (
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"yL" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/structure/fireaxecabinet{
+	pixel_x = 32
+	},
+/obj/item/weapon/deck/cards,
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
 	dir = 6
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/safe_room/bridge)
+"yM" = (
+/obj/structure/sign/dedicationplaque{
+	desc = "S.E.V. Torch - Mako Class - Sol Expeditionary Corps Registry 95519 - Shiva Fleet Yards, Mars - First Vessel To Bear The Name - Launched 2302 - Sol Central Government - 'Never was anything great achieved without danger.'";
+	pixel_x = 0
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+/turf/simulated/wall/r_wall/prepainted,
+/area/bridge/storage)
+"yR" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"yG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
+"yS" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 25
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"yV" = (
+/obj/random/closet,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/bridge/aftstarboard)
+"yW" = (
+/turf/simulated/wall/prepainted,
+/area/security/bridgecheck)
+"yY" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"yK" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
-/area/bridge/storage)
-"yO" = (
-/obj/machinery/computer/ship/helm{
-	icon_state = "computer";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"yV" = (
-/turf/simulated/wall/prepainted,
-/area/maintenance/bridge/aftstarboard)
-"yX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
+/area/bridge/hallway/port)
 "yZ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -10574,6 +10561,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
+"za" = (
+/obj/structure/closet/secure_closet/XO,
+/obj/random/drinkbottle,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "zb" = (
 /obj/effect/shuttle_landmark/torch/deck5/guppy,
 /turf/space,
@@ -10623,30 +10615,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "zh" = (
+/obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "bridge_port"
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"zi" = (
-/obj/machinery/uniform_vendor{
-	icon_state = "uniform";
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
 "zo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10657,8 +10632,33 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 4;
+	icon_state = "pipe-j2s";
+	name = "Chief Science Officer";
+	sortType = "Chief Science Officer"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"zp" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = 36;
+	pixel_y = 0
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "zq" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -10666,88 +10666,106 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"zr" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/button/remote/airlock{
-	id = "bridgesafe_back";
-	name = "Emergency Exit door-control";
-	pixel_x = 25;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
-/obj/effect/floor_decal/techfloor/orange,
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/safe_room/bridge)
-"zu" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "heads_meeting";
-	name = "Meeting Room Window Shutters";
-	opacity = 0
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
 "zz" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge Exterior";
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/space,
-/area/space)
-"zE" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
+/obj/effect/floor_decal/corner/white/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"zG" = (
-/obj/effect/floor_decal/corner/red/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/security/alt,
+/obj/machinery/suit_storage_unit/command,
 /obj/machinery/light{
 	icon_state = "tube1";
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"zK" = (
-/obj/structure/table/woodentable/mahogany,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+"zC" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/PDAs{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/item/weapon/pen,
-/turf/simulated/floor/carpet/blue2,
+/obj/item/weapon/storage/box/ids,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/random/coin,
+/obj/random/firstaid,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"zD" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"zO" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
+"zF" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"zM" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 8;
+	name = "Security Checkpoint"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
+"zN" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
+"zP" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/folder/blue,
+/obj/machinery/light,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "zQ" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -10756,62 +10774,54 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
-"zT" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
+"zS" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"zT" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"zU" = (
-/obj/structure/closet/secure_closet/XO,
-/turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"zV" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
 "zW" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
 "zY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
 	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Stairs";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"zZ" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/door/airlock/medical{
-	id_tag = "cmodoor";
-	name = "Chief Medical Officer";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
 "Ab" = (
 /obj/effect/shuttle_landmark/merc/deck5,
 /turf/space,
@@ -10837,11 +10847,11 @@
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
 "Ad" = (
-/obj/structure/bed/chair/comfy/beige{
-	icon_state = "comfychair_preview";
+/obj/structure/bed/chair/office/comfy/blue{
+	icon_state = "comfyofficechair_preview";
 	dir = 8
 	},
-/turf/simulated/floor/wood/mahogany,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "Ae" = (
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -10895,21 +10905,55 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Aj" = (
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
+"Am" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"An" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/machinery/light,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"Ao" = (
+/obj/structure/bed/chair/padded/green{
+	icon_state = "chair_preview";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"Ap" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Aq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10933,79 +10977,159 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Av" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/rocks,
+/obj/random/drinkbottle,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"Aw" = (
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 8
+	},
+/turf/simulated/wall/r_wall/hull,
+/area/bridge)
 "Ax" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
-/obj/item/weapon/deck/cards,
-/obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/safe_room/bridge)
+/obj/structure/table/woodentable/walnut,
+/obj/random/clipboard,
+/obj/item/weapon/folder/blue,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
 "Ay" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/corner/red/half,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"AE" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
-"AH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"AI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/vending/cola{
-	icon_state = "Cola_Machine";
+"AA" = (
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"AB" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"AE" = (
+/obj/structure/bed/chair/comfy/green,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"AH" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_starboard"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"AI" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_checkpoint_shutters";
+	name = "Bridge Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/security/bridgecheck)
+"AJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bridge entry port";
+	name = "Port Bridge Blast Doors";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/door/airlock/multi_tile/glass/command{
+	autoset_access = 0;
+	dir = 8;
+	id_tag = "portbridgeaccess";
+	name = "Bridge Access";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/bridge/hallway/port)
 "AN" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
+"AP" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/hallway/port)
 "AR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -11015,16 +11139,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"AS" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "co_windows"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
 "AU" = (
 /obj/effect/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -11033,25 +11147,37 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
-"AV" = (
-/turf/simulated/wall/r_wall/hull,
-/area/crew_quarters/heads/office/co)
 "AX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/small{
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"AZ" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
 	dir = 8
 	},
-/obj/machinery/button/remote/airlock{
-	id = "bridgestorage_exit";
-	name = "Emergency Exit door-control";
-	pixel_x = 25;
-	pixel_y = 0;
-	req_access = list("ACCESS_BRIDGE");
-	specialfunctions = 4
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 6;
+	name = "Chief Engineer RC";
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
 "Bc" = (
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Aquila"
@@ -11059,6 +11185,11 @@
 /obj/structure/cable/cyan,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
+"Bd" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Be" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11072,9 +11203,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/weapon/rcd,
 /obj/item/weapon/rcd_ammo,
@@ -11083,122 +11211,19 @@
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "CE's Equipment Storage"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
-"Bh" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "bridge_starboard"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "Bi" = (
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_storage_unit/engineering/alt/sol,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"Bm" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "Bn" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/glass,
-/obj/item/weapon/storage/medical_lolli_jar,
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"Bo" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"Bq" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
-	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
-"Bs" = (
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"Bu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"Bw" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cmo_windows"
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cmo)
-"Bx" = (
-/obj/vehicle/bike/gyroscooter,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"By" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -11206,23 +11231,71 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
-"BA" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"Bp" = (
+/obj/effect/floor_decal/corner/red/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/security/alt,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"Bs" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"Bu" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"Bw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Starboard";
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/primary/bridge/fore)
+"By" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "BB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/button/remote/airlock{
@@ -11240,6 +11313,41 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
+"BE" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/button/remote/blast_door{
+	name = "Bridge Window Lockdown Control";
+	pixel_x = -30;
+	pixel_y = 0;
+	id = "bridge blast"
+	},
+/obj/item/weapon/storage/box/donut,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"BF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "BG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11263,26 +11371,7 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"BH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"BM" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"BO" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
-"BT" = (
+"BI" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -11291,20 +11380,41 @@
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
+	id = "cap_window";
+	name = "CO's Quarters Shutters"
 	},
 /turf/simulated/floor/plating,
-/area/bridge)
-"BV" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
+/area/crew_quarters/heads/office/co)
+"BO" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
+"BR" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
+/obj/item/weapon/pen,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/rd)
+"BV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "BW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -11320,6 +11430,33 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
+"BX" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"BY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Cb" = (
 /obj/effect/shuttle_landmark/torch/deck5/aquila,
 /turf/space,
@@ -11350,18 +11487,16 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "Ce" = (
-/obj/machinery/door/airlock/sol{
-	name = "XO's Quarters";
-	secured_wires = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "Cf" = (
 /obj/structure/cable/green{
@@ -11427,6 +11562,32 @@
 /obj/machinery/suit_storage_unit/medical/alt/sol,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"Ck" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"Cl" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "CO's Desk";
+	departmentType = 5;
+	name = "CO Request Console";
+	pixel_x = -30;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
 "Cn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11445,83 +11606,48 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
-"Cq" = (
-/obj/machinery/light/small{
-	dir = 1
+"Cr" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "Cs" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/item/weapon/paper/monitorkey,
-/obj/item/sticky_pad/random,
 /obj/effect/floor_decal/corner/yellow/mono,
+/obj/machinery/photocopier,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
-"Cu" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
+"Cv" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cmo_windows"
+	},
+/obj/structure/cable/green,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"CA" = (
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/cmo)
+"Cx" = (
+/obj/machinery/uniform_vendor{
+	icon_state = "uniform";
+	dir = 1
 	},
-/obj/item/weapon/pen/green,
-/obj/item/weapon/pen/red{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/weapon/pen/blue{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/weapon/book/manual/solgov_law,
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/sgr)
-"CC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/research{
-	id_tag = "csodoor";
-	name = "Chief Science Officer";
-	secured_wires = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "CD" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -11535,6 +11661,17 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/airlock)
+"CE" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "CH" = (
 /obj/structure/sign/directions/bridge{
 	dir = 8;
@@ -11548,27 +11685,42 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
+"CL" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "CN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftport)
 "CO" = (
 /turf/simulated/wall/r_wall/hull,
 /area/aux_eva)
-"CQ" = (
+"CP" = (
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "cap_window";
-	name = "CO's Quarters Shutters"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/co)
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
 "CU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11595,14 +11747,26 @@
 /obj/item/weapon/material/ashtray/bronze,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
-"Da" = (
-/obj/machinery/computer/ship/engines{
-	icon_state = "computer";
-	dir = 4
+"CX" = (
+/obj/structure/bed/chair/padded/green{
+	icon_state = "chair_preview";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"CZ" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridgehallway";
+	name = "Bridge Interior Hallway Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
+/area/bridge/hallway/port)
 "Db" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Head"
@@ -11655,47 +11819,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"Dh" = (
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "bridge_port"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
-"Dm" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"Dp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/obj/structure/table/rack,
-/obj/item/weapon/aicard,
-/obj/item/weapon/pinpointer,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/multitool,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
 "Dq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack{
@@ -11728,161 +11851,104 @@
 /area/aux_eva)
 "Dr" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Dt" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/captain,
-/obj/structure/sign/warning/nosmoking_1{
-	desc = "";
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/blue,
-/area/crew_quarters/heads/cobed)
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aux_eva)
 "Du" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
+/obj/structure/table/rack,
+/obj/item/weapon/aicard,
+/obj/item/weapon/pinpointer,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "Dw" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
-"Dy" = (
+"Dx" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "co_windows"
 	},
-/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
-"DF" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 8;
-	name = "Security Checkpoint"
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
+/area/crew_quarters/heads/office/co)
+"DE" = (
+/obj/structure/cable/green,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
-/area/security/bridgecheck)
-"DK" = (
-/obj/machinery/door/airlock/command{
-	id_tag = "meetingport";
-	name = "Conference Room"
+/area/bridge/storage)
+"DH" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
+"DI" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "DN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/bridge/aft)
+"DQ" = (
+/obj/structure/bed/chair/comfy/captain{
+	icon_state = "capchair_preview";
+	dir = 4;
+	color = "#666666"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "DR" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/head)
-"DT" = (
-/obj/effect/floor_decal/corner/blue{
+"DY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"DY" = (
-/obj/structure/largecrate,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "DZ" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
+/obj/structure/flora/pottedplant/tall,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/device/paicard,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/sgr)
 "Eb" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "Shield Generator - Bridge Deck"
@@ -11911,11 +11977,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
-"Eg" = (
-/obj/structure/lattice,
-/obj/machinery/light/navigation/delay2,
-/turf/space,
-/area/space)
 "Eh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
@@ -11954,39 +12015,40 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"Es" = (
+"En" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"Eu" = (
+/area/crew_quarters/heads/office/sea)
+"Eq" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/corner/red/mono,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/table/rack,
+/obj/item/device/binoculars,
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Security";
+	departmentType = 5;
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
 "Ey" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -12022,67 +12084,67 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
-"EK" = (
+"EJ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"EL" = (
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge - Stairs";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"EM" = (
+/obj/structure/sign/warning/detailed,
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/xo)
+"EN" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/sign/goldenplaque/medical{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"EP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/closet/secure_closet/CMO_torch,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"EV" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"EN" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/closet/secure_closet/CMO_torch,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/structure/sign/goldenplaque/medical{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/item/weapon/storage/belt/medical,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"ES" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aux_eva)
-"ET" = (
-/obj/structure/drain,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
-"EZ" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/item/device/taperecorder,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
-"Fa" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -12132,14 +12194,11 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "Ff" = (
-/obj/structure/closet/secure_closet/cos,
+/obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	dir = 4;
-	icon_state = "wrecharger0";
-	pixel_x = -23;
-	pixel_y = -3
-	},
+/obj/item/device/radio,
+/obj/item/weapon/crowbar/prybar,
+/obj/item/device/binoculars,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "Fg" = (
@@ -12165,8 +12224,26 @@
 	icon_state = "computer";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"Fl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "Fn" = (
 /obj/effect/floor_decal/scglogo{
 	tag = "icon-center-left";
@@ -12178,106 +12255,121 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"Fo" = (
-/obj/structure/flora/pottedplant/orientaltree,
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
 "Fp" = (
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
-"Fs" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
+"Ft" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/folder/white{
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder/blue{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"Fv" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Fu" = (
-/obj/structure/bed/chair/comfy/green,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
-"Fx" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "Fy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"Fz" = (
+/turf/simulated/open,
+/area/maintenance/bridge/foreport)
+"FE" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"FG" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "XO"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/structure/table/woodentable_reinforced/mahogany/walnut,
-/turf/simulated/floor/wood/mahogany,
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
-"Fz" = (
-/turf/simulated/open,
-/area/maintenance/bridge/foreport)
-"FF" = (
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
+"FK" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/airlock)
+"FL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/bridge)
-"FI" = (
+/area/maintenance/bridge/forestarboard)
+"FS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
-"FK" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
-"FM" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Port"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"FV" = (
-/obj/machinery/atmospherics/tvalve/mirrored/bypass{
-	icon_state = "map_tvalvem1";
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"Ga" = (
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j1s";
+	name = "Chief Engineer";
+	sortType = "Chief Engineer"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Gb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -12299,10 +12391,6 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/head)
-"Gd" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
 "Ge" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -12355,138 +12443,64 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
 "Gj" = (
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"Gk" = (
-/obj/item/modular_computer/console/preset/sysadmin{
-	icon_state = "console";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/power/apc/super/critical{
-	dir = 2;
-	is_critical = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"Gm" = (
-/obj/structure/bed/chair/padded/green,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "Gn" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	icon_state = "map_off";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"Gp" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"Gs" = (
-/obj/structure/cable/green,
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
-"Gw" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"Gx" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Bridge";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/half{
-	icon_state = "bordercolorhalf";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
-"Gz" = (
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (SOUTHWEST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"GA" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief of Security's Desk";
-	departmentType = 5;
-	name = "Chief of Security RC";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"Gq" = (
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"GC" = (
+/area/bridge/meeting_room)
+"Gr" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/power/apc/super{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Gs" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"Gy" = (
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -12496,17 +12510,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cl)
-"GF" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/b_green{
-	tag = "icon-corner_white (WEST)";
-	icon_state = "corner_white";
-	dir = 8
+"GD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/weapon/book/manual/nt_regs,
-/obj/item/weapon/stamp/rd,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "GI" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -12519,65 +12541,35 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"GL" = (
-/obj/structure/sign/warning/detailed{
-	name = "\improper SECURE AREA"
+"GU" = (
+/obj/structure/displaycase,
+/obj/item/weapon/gun/projectile/revolver/medium/captain{
+	pixel_y = -3
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/hallway/starboard)
-"GQ" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
 	},
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/folder/white,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/sea)
-"GS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/light,
+/obj/structure/sign/warning/smoking{
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/sgr)
-"GW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/area/crew_quarters/heads/office/co)
+"GV" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"GW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "GX" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/box/PDAs{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/ids,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/random/coin,
-/obj/random/firstaid,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/sign/warning/nosmoking_1{
-	desc = "";
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"GY" = (
 /obj/machinery/vending/wallmed1{
 	pixel_x = 0;
 	pixel_y = 32;
@@ -12586,11 +12578,22 @@
 /obj/machinery/computer/mecha,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"GZ" = (
+"GY" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
 /obj/item/modular_computer/console/preset/command,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"GZ" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/machinery/computer/robotics,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "Hb" = (
@@ -12604,6 +12607,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "Hc" = (
@@ -12617,19 +12621,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Hd" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/megaphone,
-/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "He" = (
 /obj/structure/cable/green{
@@ -12677,17 +12668,19 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "Hh" = (
-/obj/structure/dogbed,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/random/plushie,
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/mob/living/simple_animal/corgi/Ian,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "Hi" = (
@@ -12695,24 +12688,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
 "Ho" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "xo_windows"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge entry star";
-	name = "Bridge Starboard Lockdown Window Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/xo)
-"Hp" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "hopdoor";
 	name = "Executive Officer";
@@ -12739,12 +12714,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
-"Hr" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 4
+"Hp" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "xo_windows"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge entry star";
+	name = "Bridge Starboard Lockdown Window Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/xo)
 "Hs" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12761,21 +12748,28 @@
 	name = "Starboard Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/door/airlock/multi_tile/glass/command{
+	autoset_access = 0;
+	dir = 8;
+	id_tag = "starboardbridgeaccess";
+	name = "Bridge Access";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/starboard)
 "Ht" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/woodentable/walnut,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/item/weapon/soap/deluxe,
+/obj/item/weapon/bikehorn/rubberducky,
+/obj/structure/hygiene/shower{
+	icon_state = "shower";
+	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
 "Hu" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/structure/bed/chair/padded/blue{
@@ -12787,13 +12781,23 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
+"Hv" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/meeting_room)
 "Hx" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -12818,6 +12822,21 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/bridge)
+"Hz" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
 /area/bridge)
 "HC" = (
 /obj/structure/cable/green{
@@ -12846,6 +12865,21 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"HG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor3";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "HH" = (
 /obj/effect/floor_decal/scglogo{
 	tag = "icon-top-left";
@@ -12858,23 +12892,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"HI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass/command{
+	name = "Bridge Storage"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "HK" = (
 /obj/effect/overmap/ship/torch,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"HM" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/pen,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
 "HP" = (
 /obj/item/modular_computer/console/preset/supply{
 	icon_state = "console";
@@ -12902,7 +12930,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HU" = (
-/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/keycard_auth/torch{
 	pixel_x = 0;
@@ -12912,14 +12939,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Bridge"
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"HV" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cl/backroom)
 "HW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12976,6 +13001,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
+"Ia" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/stamp/ce,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
 "Ib" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -13122,10 +13160,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light_switch{
-	pixel_x = 23;
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "Iq" = (
@@ -13197,6 +13231,14 @@
 /obj/item/weapon/book/manual/military_law,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"ID" = (
+/obj/effect/floor_decal/corner/red/half,
+/obj/machinery/vending/coffee{
+	icon_state = "coffee";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "IE" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -13265,6 +13307,19 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/secure_storage)
+"IK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/bridge/fore)
 "IL" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -13277,28 +13332,23 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
-"IM" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
+"IN" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "repdoor";
-	name = "SCGR's Office Door Control";
-	pixel_x = 27;
-	pixel_y = 5;
-	req_access = list("ACCESS_TORCH_REPRESENTATIVE")
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
-/obj/machinery/button/windowtint{
-	pixel_x = 25;
-	pixel_y = -6;
-	id = "sgr_windows";
-	range = 11
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/sgr)
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"IO" = (
+/obj/structure/bed/chair/comfy/green,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "IT" = (
 /obj/structure/table/glass,
 /obj/machinery/keycard_auth/torch{
@@ -13318,7 +13368,11 @@
 	pixel_y = 28;
 	req_access = list("ACCESS_RESEARCH_DIRECTOR")
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research/half{
+	icon_state = "bordercolorhalf";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "IW" = (
 /obj/effect/floor_decal/corner/yellow/full,
@@ -13326,6 +13380,21 @@
 /obj/machinery/suit_storage_unit/atmos/alt/sol,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"IY" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/item/sticky_pad/random,
+/obj/item/device/destTagger,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13394,22 +13463,24 @@
 	icon_state = "chair_preview";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/research{
-	tag = "icon-corner_white (NORTHWEST)";
-	icon_state = "corner_white";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"Jn" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/bridgecheck)
 "Jo" = (
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
+"Jp" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"Js" = (
+/obj/structure/lattice,
+/obj/machinery/light/navigation/delay2,
+/turf/space,
+/area/space)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13426,17 +13497,8 @@
 	icon_state = "warning";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"Jz" = (
-/obj/machinery/door/airlock/sol{
-	id_tag = "captaindoorfore";
-	name = "Commanding Officer";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "JA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13453,20 +13515,27 @@
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
 "JB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"JD" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "JE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -13474,60 +13543,17 @@
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
 "JF" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/structure/grille,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "heads_meeting";
-	name = "Bridge Meeting Room Shutters Control";
-	pixel_x = 39;
-	pixel_y = 31;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridgehallway";
-	name = "Bridge Internal Hallway Lockdown Control";
-	pixel_x = 25;
-	pixel_y = 31;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge entry star";
-	name = "Starboard Bridge Entrance Lockdown Control";
-	pixel_x = 32;
-	pixel_y = 40;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge entry port";
-	name = "Port Bridge Entrance Lockdown Control";
-	pixel_x = 32;
-	pixel_y = 22;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "JG" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"JO" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "JT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -13536,24 +13562,38 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
 "JX" = (
-/obj/structure/grille,
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"JY" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/book/manual/sol_sop,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"Ka" = (
+/obj/structure/cable/green,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"JZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/area/crew_quarters/heads/office/cl)
+"Kb" = (
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = -6
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/heads/office/rd)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/paint/hull,
@@ -13573,10 +13613,8 @@
 /area/bridge/storage)
 "Kf" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/comfy/teal{
-	icon_state = "comfychair_preview";
-	dir = 1
-	},
+/obj/structure/table/glass,
+/obj/item/weapon/storage/medical_lolli_jar,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "Kg" = (
@@ -13610,25 +13648,14 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
 "Kj" = (
-/obj/effect/floor_decal/corner/b_green/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
 /obj/machinery/camera/network/command{
 	c_tag = "Chief Science Officer - Office";
 	dir = 8;
 	network = list("Command","Research")
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"Kl" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 1
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/ce)
 "Km" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -13649,62 +13676,82 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
-"Ko" = (
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual/solgov_law,
-/obj/item/weapon/book/manual/sol_sop,
-/obj/item/weapon/book/manual/military_law,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"Ku" = (
-/obj/machinery/alarm{
-	pixel_y = 24
+"Kq" = (
+/obj/structure/closet/secure_closet/CO,
+/obj/structure/noticeboard{
+	pixel_y = 30
 	},
-/obj/machinery/atm{
-	pixel_x = 32
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
+"Ks" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Kt" = (
+/obj/effect/floor_decal/scglogo{
+	tag = "icon-bottom-left";
+	icon_state = "bottom-left"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"Kv" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"KB" = (
+/obj/structure/largecrate,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"KC" = (
+/obj/structure/flora/pottedplant/bamboo,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"KG" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"Kw" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
-/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
 /turf/simulated/floor/plating,
-/area/bridge/meeting_room)
-"KB" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/computer/ship/navigation{
-	icon_state = "computer";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
 /area/bridge)
-"KG" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
 "KH" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13712,6 +13759,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"KK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "KN" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -13723,32 +13785,22 @@
 "KP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/button/remote/airlock{
-	name = "CMO's Office Door Control";
-	desc = "A remote control-switch for the office door.";
-	pixel_x = -5;
-	pixel_y = -35;
-	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER");
-	id = "cmodoor"
-	},
-/obj/machinery/button/windowtint{
-	pixel_x = 7;
-	pixel_y = -34;
-	id = "cmo_windows";
-	range = 11
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer's Office - Torch"
 	},
 /obj/item/weapon/stamp/cmo,
 /obj/item/device/radio{
 	frequency = 1487;
 	name = "medbay emergency radio link"
 	},
-/obj/item/weapon/storage/box/cups,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"KX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "KZ" = (
 /obj/random/plushie/large,
 /turf/simulated/floor/plating,
@@ -13792,6 +13844,15 @@
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cl)
+"Lf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "Lg" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -13856,27 +13917,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"Ll" = (
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
-"Lo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_hallway_shutters";
-	name = "Bridge Deck Hallway Shutters";
-	opacity = 0
+"Lk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/mono,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"Lp" = (
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/cos)
+"Ll" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "Lr" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13898,100 +13953,96 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
-"Lt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Lv" = (
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/nt_regs,
+/obj/item/weapon/stamp/rd,
+/obj/effect/floor_decal/corner/research{
+	tag = "icon-corner_white (NORTHEAST)";
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"Lw" = (
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry port";
+	name = "Port Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = -42;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry star";
+	name = "Starboard Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = -24;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridgehallway";
+	name = "Bridge Internal Hallway Lockdown Control";
+	pixel_x = 25;
+	pixel_y = -33;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "heads_meeting";
+	name = "Bridge Meeting Room Shutters Control";
+	pixel_x = 39;
+	pixel_y = -33;
+	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"Lu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"Lw" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/prefab/hand_teleporter,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"Ly" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/sol{
-	name = "Deliberation Room";
-	secured_wires = 0
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room/deliberation)
-"LE" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/button/remote/blast_door{
-	name = "Bridge Window Lockdown Control";
-	pixel_x = -30;
-	pixel_y = 0;
-	id = "bridge blast"
-	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/flashlight,
-/obj/machinery/light/spot{
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"LJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"LF" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "LM" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "LN" = (
-/obj/structure/table/woodentable/mahogany,
+/obj/structure/table/woodentable/walnut,
 /obj/item/weapon/material/ashtray/glass,
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
-"LU" = (
-/obj/machinery/door/airlock/civilian{
-	autoset_access = 0;
-	name = "Head"
+"LP" = (
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"LQ" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
 "Ma" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -14031,17 +14082,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
-"Md" = (
-/obj/effect/floor_decal/spline/plain/beige{
-	icon_state = "spline_plain";
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/beige{
-	icon_state = "comfychair_preview";
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
 "Mf" = (
 /obj/structure/table/woodentable_reinforced/walnut/maple,
 /obj/item/weapon/folder/envelope/captain,
@@ -14072,7 +14112,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "Mj" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -14086,37 +14125,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"Ml" = (
-/obj/machinery/light{
-	dir = 1
+"Mn" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/item/toy/torchmodel,
-/obj/structure/table/woodentable_reinforced/mahogany/walnut,
-/obj/random_multi/single_item/runtime,
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
-"Mo" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 36;
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief of Security's Desk";
+	departmentType = 5;
+	name = "Chief of Security RC";
+	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
 "Mq" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 2;
@@ -14134,35 +14159,62 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"Mt" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/weapon/book/manual/nt_regs,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "Mw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
+"Mz" = (
+/turf/simulated/wall/r_wall/hull,
+/area/crew_quarters/heads/office/co)
+"MA" = (
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
+"MB" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 25
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "MD" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"MH" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/pawn,
-/obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
-"MQ" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
 "MU" = (
 /obj/machinery/light{
 	dir = 4
@@ -14173,18 +14225,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
-"MY" = (
-/obj/structure/catwalk,
+"MV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
 "Nb" = (
 /obj/structure/bed/chair/comfy/captain{
 	icon_state = "capchair_preview";
@@ -14286,6 +14338,9 @@
 	icon_state = "warning";
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/smallcactus{
+	desc = "This is a small cactus. Its needles are sharp. It seems neglected, as if no one loves it."
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "Ni" = (
@@ -14314,6 +14369,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"Nn" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/pawn,
+/obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
 "Np" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -14323,6 +14386,13 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
+"Nr" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	icon_state = "map_off";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Ns" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -14336,38 +14406,41 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Nt" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "heads_meeting";
-	name = "Meeting Room Window Shutters";
-	opacity = 0
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"Nv" = (
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Nw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
-"Ny" = (
-/turf/simulated/wall/prepainted,
-/area/security/bridgecheck)
-"NH" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/bed/chair/comfy/beige{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/xo)
-"NK" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"ND" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/alarm{
 	dir = 1;
@@ -14377,21 +14450,69 @@
 /obj/item/weapon/storage/secure/briefcase/nukedisk,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"NO" = (
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "xo_windows"
+"NE" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	secured_wires = 1
 	},
-/obj/machinery/door/blast/shutters{
-	density = 1;
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"NH" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/xo)
+"NJ" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge";
+	dir = 1
+	},
+/obj/item/weapon/book/manual/sol_sop,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"NL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
 	dir = 4;
-	icon_state = "shutter1";
-	id = "hop_office";
-	name = "XO Office Privacy Shutters";
-	opacity = 1
+	pixel_x = -37
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"NM" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/xo)
+/area/maintenance/bridge/forestarboard)
+"NN" = (
+/obj/item/weapon/tableflag,
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/office/co)
 "NW" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -14399,37 +14520,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
-"NY" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 25
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/smoking{
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "Ob" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crew Area"
@@ -14494,6 +14584,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
+"Of" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "Og" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14504,6 +14612,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -14524,12 +14645,7 @@
 	icon_state = "computer";
 	dir = 4
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 4;
-	pixel_x = -37
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Ok" = (
 /obj/structure/cable{
@@ -14552,80 +14668,37 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"On" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Om" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"Op" = (
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/structure/table/woodentable/mahogany,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"Or" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "CO's Desk";
-	departmentType = 5;
-	name = "CO Request Console";
-	pixel_x = -30;
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blue,
-/area/crew_quarters/heads/cobed)
-"Ou" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/open,
-/area/maintenance/bridge/forestarboard)
-"Ov" = (
 /turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/cos)
-"Ox" = (
-/obj/structure/curtain/open/bed,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
+/area/security/bridgecheck)
+"Os" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"Oz" = (
+/obj/structure/sign/warning/smoking{
+	icon_state = "smoking";
+	dir = 8
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/bridge/meeting_room)
 "OD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"OH" = (
-/obj/structure/closet/secure_closet/bodyguard,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
-"OI" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"OE" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -14634,17 +14707,42 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "cl_windows"
+	},
 /turf/simulated/floor/plating,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/office/cl)
+"OH" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "OK" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftport)
-"OP" = (
-/obj/structure/closet/secure_closet/bridgeofficer,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
+"OM" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"OO" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair/comfy/teal{
+	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "OS" = (
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1";
@@ -14697,25 +14795,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)
 "Pd" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
 	},
-/obj/effect/floor_decal/spline/plain/beige{
-	icon_state = "spline_plain";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "Pe" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -14745,83 +14839,43 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/fore)
-"Ph" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl)
 "Pi" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/disciplinary_board_room)
-"Pk" = (
-/obj/structure/closet/toolcloset,
-/obj/random/action_figure,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/powercell,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"Pl" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Executive Officer - Office"
-	},
-/obj/structure/disposalpipe/segment{
+"Pt" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"Py" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
 	dir = 4
 	},
-/obj/structure/flora/pottedplant/fern,
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
-"Pm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/camera/network/command{
+	c_tag = "CO - Office Starboard";
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"PB" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"Po" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/airlock_sensor{
+	id_tag = "bridge_safe_sensor";
+	master_tag = "bridge_safe";
+	pixel_y = 22
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Pr" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass/command{
-	name = "Bridge Storage"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 2;
+	frequency = 1379;
+	id_tag = "bridge_safe_pump"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"Py" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14840,36 +14894,14 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
-"PI" = (
-/obj/structure/flora/pottedplant/tall,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 23;
-	pixel_y = 24
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 1
+"PF" = (
+/obj/structure/sign/double/icarus/solgovflag/right{
+	dir = 4;
+	icon_state = "solgovflag-right";
+	pixel_x = -32
 	},
 /turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/sgr)
-"PJ" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/sea)
+/area/crew_quarters/heads/office/co)
 "PP" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -14883,6 +14915,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/medical)
+"PQ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14966,6 +15014,11 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Qf" = (
@@ -15012,10 +15065,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "Qi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -15038,28 +15087,71 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"Qk" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
-"Qr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/area/crew_quarters/heads/office/rd)
+"Qn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Entry Port";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"Qp" = (
+/obj/machinery/door/airlock/sol{
+	id_tag = "captaindoorfore";
+	name = "Commanding Officer";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "Qt" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"Qv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "Qz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15075,25 +15167,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
-"QA" = (
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/bridge)
-"QB" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "QE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -15107,6 +15180,18 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/passenger)
+"QK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/bridge/fore)
 "QL" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
@@ -15117,20 +15202,87 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"QR" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+"QQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/button/remote/airlock{
+	id = "bridgestorage_exit";
+	name = "Emergency Exit door-control";
+	pixel_x = 25;
+	pixel_y = 0;
+	req_access = list("ACCESS_BRIDGE");
+	specialfunctions = 4
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cl_windows"
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"QS" = (
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/weapon/pen/green,
+/obj/item/weapon/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/book/manual/solgov_law,
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
+"QW" = (
+/obj/machinery/computer/ship/engines{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"QX" = (
+/obj/item/device/flashlight/lamp/green,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the office door.";
+	id = "hopdoor";
+	name = "XO's Office Door Control";
+	pixel_x = -5;
+	pixel_y = 38;
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
+	},
+/obj/machinery/button/windowtint{
+	pixel_x = 8;
+	pixel_y = 39;
+	id = "xo_windows"
+	},
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
+"QY" = (
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cl)
+/area/maintenance/bridge/forestarboard)
+"Ra" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "Rb" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Infirmary"
@@ -15213,10 +15365,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Ri" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -15237,11 +15385,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Rj" = (
-/obj/effect/floor_decal/corner/b_green/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
 /obj/machinery/button/windowtint{
 	id = "rd_windows";
 	pixel_x = 6;
@@ -15252,43 +15395,58 @@
 	pixel_x = -6;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"Rn" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/random/cash,
-/obj/random/cash,
-/obj/random_multi/single_item/boombox,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"Rl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
+"Rp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"Rq" = (
+/obj/machinery/computer/ship/helm{
+	icon_state = "computer";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"Rr" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"Rs" = (
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/megaphone,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "Rx" = (
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_outer_chamber)
-"Ry" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disciplinary Board Room Maintenance Access"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/disciplinary_board_room)
 "Rz" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -15301,100 +15459,76 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"RA" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "meeting_windows"
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
 "RC" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/item/weapon/pen,
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "RD" = (
-/obj/machinery/computer/account_database,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
-	pixel_y = 24
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"RF" = (
-/obj/structure/bed/chair/comfy/captain{
-	icon_state = "capchair_preview";
-	dir = 4;
-	color = "#666666"
+/obj/structure/reagent_dispensers/water_cooler{
+	icon_state = "water_cooler";
+	dir = 8
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
+"RE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "RH" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
-"RJ" = (
-/obj/machinery/door/airlock/research{
-	id_tag = "liaisondoor";
-	name = "Corporate Liaison";
-	secured_wires = 1
+"RK" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
-"RM" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/light,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
-"RN" = (
-/obj/structure/closet/firecloset,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
-"RR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"RS" = (
-/obj/effect/floor_decal/scglogo{
-	tag = "icon-center-left";
-	icon_state = "bottom-left";
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
+"RQ" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/disciplinary_board_room)
+/obj/structure/flora/pottedplant/unusual,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/rd)
 "RT" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -15406,33 +15540,31 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/sea)
 "RU" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/device/flashlight/lamp/green,
-/obj/structure/noticeboard{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/sgr)
-"RZ" = (
-/obj/structure/closet/secure_closet/CO,
-/obj/structure/noticeboard{
-	pixel_y = 30
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"RV" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/carpet/blue,
-/area/crew_quarters/heads/cobed)
-"Sa" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "cap_window";
+	name = "CO's Quarters Shutters"
 	},
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/office/co)
 "Sb" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Storage"
@@ -15450,16 +15582,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/aquila/storage)
-"Sc" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "Sd" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/device/flashlight/lamp,
@@ -15526,39 +15648,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Sj" = (
-/obj/structure/flora/pottedplant/unusual,
-/obj/effect/floor_decal/corner/b_green/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"Sk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Sn" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "So" = (
 /obj/machinery/alarm{
 	frequency = 1439;
@@ -15568,45 +15679,6 @@
 /obj/machinery/cryopod,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/passenger)
-"Sp" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"St" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "co_windows"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
-"Sx" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 26;
-	pixel_y = 0
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/item/weapon/stamp/ce,
-/obj/effect/floor_decal/corner/yellow/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"Sy" = (
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cmo_windows"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cmo)
 "SA" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -15620,63 +15692,114 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
-"SD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+"SB" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/device/taperecorder,
+/obj/effect/floor_decal/corner/blue/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
 "SE" = (
-/obj/structure/closet/secure_closet/liaison,
-/obj/machinery/camera/network/command{
-	c_tag = "Corporate Liaison - Backroom";
-	dir = 8;
-	network = list("Command")
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
-"SH" = (
-/turf/simulated/floor/carpet/blue,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"SG" = (
+/obj/machinery/papershredder,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"SJ" = (
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"SL" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/effect/floor_decal/spline/plain/brown{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/obj/item/weapon/material/ashtray/bronze,
+/obj/item/weapon/flame/lighter/zippo/random,
+/obj/random/smokes,
+/obj/structure/sign/warning/smoking{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/crew_quarters/heads/office/sgr)
 "SN" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
-"SP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bridgecheck)
 "SQ" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/aquila/medical)
-"SV" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+"SU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"SV" = (
+/obj/machinery/door/airlock/civilian{
+	autoset_access = 0;
+	name = "Head"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/heads/cobed)
 "Ta" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -15796,35 +15919,72 @@
 /area/aux_eva)
 "Ti" = (
 /obj/structure/closet/secure_closet/RD,
-/obj/effect/floor_decal/corner/research/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Tl" = (
-/obj/effect/floor_decal/corner/blue{
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"Tm" = (
+/obj/structure/closet/secure_closet/bodyguard,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"Tn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	icon_state = "tube1";
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/safe_room/bridge)
+"To" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"Tx" = (
+/obj/machinery/atmospherics/tvalve/mirrored/bypass{
+	icon_state = "map_tvalvem1";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"Tz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "bridge_hallway_shutters";
+	name = "Bridge Deck Hallway Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"TA" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/bridge/forestarboard)
+"TB" = (
+/turf/simulated/floor/reinforced/airless,
+/area/bridge/storage)
+"TI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"Tn" = (
+/area/bridge/storage)
+"TK" = (
 /obj/effect/floor_decal/corner/blue/three_quarters,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15844,86 +16004,23 @@
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Tz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_hallway_shutters";
-	name = "Bridge Deck Hallway Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"TD" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge sensors";
-	name = "Sensor Shroud"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/bridge/storage)
-"TG" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/weapon/storage/secure/briefcase{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/secure/briefcase,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"TK" = (
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
-"TN" = (
-/obj/machinery/button/remote/blast_door{
-	id = "bridge entry port";
-	name = "Port Bridge Entrance Lockdown Control";
-	pixel_x = 32;
-	pixel_y = -42;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridge entry star";
-	name = "Starboard Bridge Entrance Lockdown Control";
-	pixel_x = 32;
-	pixel_y = -24;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "bridgehallway";
-	name = "Bridge Internal Hallway Lockdown Control";
-	pixel_x = 25;
-	pixel_y = -33;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "heads_meeting";
-	name = "Bridge Meeting Room Shutters Control";
-	pixel_x = 39;
-	pixel_y = -33;
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+"TM" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"TP" = (
+/obj/structure/curtain/open/bed,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "TQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -15939,26 +16036,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"TT" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+"TV" = (
+/obj/structure/closet/secure_closet/liaison,
+/obj/machinery/camera/network/command{
+	c_tag = "Corporate Liaison - Backroom";
+	dir = 8;
+	network = list("Command")
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "TX" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room)
-"TZ" = (
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "Ub" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Engineering"
@@ -16067,93 +16156,160 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Ui" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/research/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
-	},
 /obj/structure/sign/ecplaque{
 	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/research/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Uk" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "bridge entry star";
+	name = "Starboard Bridge Blast Doors";
+	opacity = 0
 	},
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/folder/blue,
-/obj/machinery/light,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"Ul" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/starboard)
+"Un" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/button/remote/blast_door{
+	name = "Bridge Window Lockdown Control";
+	pixel_x = -30;
+	pixel_y = 0;
+	id = "bridge blast"
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/flashlight,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "Uo" = (
-/obj/structure/table/woodentable/mahogany,
-/obj/random/clipboard,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/carpet/blue2,
-/area/bridge/meeting_room)
+/obj/structure/bed/chair/padded/green,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"Up" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "Ut" = (
 /obj/effect/landmark{
 	name = "carpspawn"
 	},
 /turf/space,
 /area/space)
-"Uw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/vault/bolted{
-	autoset_access = 0;
-	id_tag = "bridgestorage_exit";
-	name = "Emergency Exit";
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/item/weapon/airlock_brace{
-	req_access = list("ACCESS_BRIDGE")
-	},
+"Uu" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/storage)
-"UD" = (
+/area/security/bridgecheck)
+"Uy" = (
+/obj/structure/table/glass,
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "xo_windows"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/door/blast/shutters{
-	density = 1;
-	dir = 4;
-	icon_state = "shutter1";
-	id = "hop_office_desk";
-	name = "XO Queue Privacy Shutters";
-	opacity = 1
-	},
+/obj/item/device/paicard,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"UA" = (
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"UC" = (
+/obj/structure/closet/firecloset,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/xo)
-"UG" = (
-/turf/simulated/wall/r_wall/prepainted,
+/area/maintenance/bridge/forestarboard)
+"UE" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
+"UH" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/prefab/hand_teleporter,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"UL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"UN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "UU" = (
 /obj/effect/shuttle_landmark/ert/deck5,
 /turf/space,
@@ -16177,9 +16333,6 @@
 "UY" = (
 /obj/item/modular_computer/console/preset/command,
 /obj/item/modular_computer/tablet/lease/preset/command,
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Office Starboard"
-	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Vb" = (
@@ -16205,7 +16358,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
 "Vc" = (
-/turf/simulated/floor/wood/mahogany,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "Ve" = (
 /obj/structure/table/woodentable/walnut,
@@ -16253,11 +16407,10 @@
 /area/aquila/airlock)
 "Vh" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
 /obj/random_multi/single_item/runtime,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "Vi" = (
@@ -16270,7 +16423,6 @@
 /obj/item/weapon/folder/nt,
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/folder/white,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Chief Science Officer's Desk";
@@ -16280,7 +16432,8 @@
 	pixel_y = 30
 	},
 /obj/item/weapon/folder/nt,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Vj" = (
 /obj/structure/cable/green{
@@ -16294,49 +16447,38 @@
 	icon_state = "corner_white";
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Vk" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/structure/sign/ecplaque{
-	pixel_x = 29
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "Vl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Vp" = (
+"Vn" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "heads_meeting";
+	name = "Meeting Room Window Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Fore Port";
-	dir = 8
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "meeting_windows"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/bridge/meeting_room)
 "Vs" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
@@ -16344,74 +16486,106 @@
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
 "Vw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge entry port";
-	name = "Port Bridge Blast Doors";
-	opacity = 0
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/port)
-"Vz" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/button/remote/blast_door{
-	name = "Bridge Window Lockdown Control";
-	pixel_x = -30;
-	pixel_y = 0;
-	id = "bridge blast"
+	id = "heads_meeting";
+	name = "Bridge Meeting Room Shutters Control";
+	pixel_x = 39;
+	pixel_y = 31;
+	req_access = list("ACCESS_BRIDGE")
 	},
-/obj/item/weapon/storage/box/donut,
-/obj/machinery/light/spot{
-	dir = 8
+/obj/machinery/button/remote/blast_door{
+	id = "bridgehallway";
+	name = "Bridge Internal Hallway Lockdown Control";
+	pixel_x = 25;
+	pixel_y = 31;
+	req_access = list("ACCESS_BRIDGE")
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry star";
+	name = "Starboard Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = 40;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "bridge entry port";
+	name = "Port Bridge Entrance Lockdown Control";
+	pixel_x = 32;
+	pixel_y = 22;
+	req_access = list("ACCESS_BRIDGE")
+	},
+/turf/simulated/floor/tiled/dark,
 /area/bridge)
 "VB" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"VJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+"VF" = (
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/bridge)
-"VK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
+/obj/structure/table/woodentable/walnut,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
 "VL" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"VR" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge Exterior - Port";
-	dir = 1
+"VM" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/turf/space,
-/area/space)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"VN" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "bridge_port"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"VP" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/aft)
+"VW" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/captain,
+/turf/simulated/floor/carpet/blue,
+/area/crew_quarters/heads/cobed)
 "VY" = (
 /obj/machinery/button/remote/airlock{
 	name = "safe room door-control";
@@ -16474,7 +16648,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
 "Wc" = (
-/obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/keycard_auth/torch{
 	pixel_x = 0;
@@ -16488,7 +16661,7 @@
 	pixel_x = -8;
 	pixel_y = 20
 	},
-/obj/random/snack,
+/obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "Wd" = (
@@ -16513,8 +16686,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
 "We" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/papershredder,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -16525,7 +16696,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -16549,20 +16723,16 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/aquila/airlock)
 "Wh" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red/half{
 	icon_state = "bordercolorhalf";
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
@@ -16574,48 +16744,103 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"Wl" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
+"Wj" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Checkpoint - Bridge";
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/bridgecheck)
+"Wr" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
+"Ws" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
+"Wv" = (
+/obj/structure/closet/secure_closet/bridgeofficer,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
+"Ww" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
+"WK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"WL" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
+"WS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Conference Room";
+	dir = 2
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"Wn" = (
-/obj/structure/cable/green,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "cl_windows"
+/area/bridge/meeting_room)
+"WX" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cl)
-"Ws" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
-"Ww" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
-"Wx" = (
+/area/maintenance/bridge/foreport)
+"WY" = (
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/simulated/wall/prepainted,
+/area/bridge/meeting_room)
+"Xa" = (
 /obj/structure/bed/chair/padded/blue{
 	icon_state = "chair_preview";
 	dir = 4
@@ -16643,126 +16868,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
-"Wz" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
-"WC" = (
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 8
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Office Port";
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
-"WE" = (
-/obj/structure/bed/chair/padded/beige{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood/mahogany,
-/area/crew_quarters/heads/office/xo)
-"WF" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/book/manual/nt_regs,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl)
-"WI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Executive Officer - Quarters"
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	desc = "";
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/xo)
-"WJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_x = 3;
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable_reinforced/ebony/walnut,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/crew_quarters/heads/office/co)
-"WK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"WL" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"WW" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"WY" = (
-/obj/structure/bed/chair/comfy/captain,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
 "Xb" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -16791,21 +16896,9 @@
 	spawn_nothing_percentage = 50;
 	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
 	},
+/obj/random/snack,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"Xd" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
 "Xe" = (
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/carpet/blue2,
@@ -16890,80 +16983,35 @@
 "Xr" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/bridge/forestarboard)
-"Xu" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+"Xx" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/door/airlock/medical{
+	id_tag = "cmodoor";
+	name = "Chief Medical Officer";
+	secured_wires = 1
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"Xv" = (
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 6;
-	name = "Chief Engineer RC";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"Xx" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/item/sticky_pad/random,
-/obj/item/device/destTagger,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 "Xz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/guncabinet/PPE,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"XA" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_ridged,
+"XB" = (
+/obj/structure/bed/chair/comfy/captain,
+/turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "XC" = (
 /obj/effect/floor_decal/corner/blue,
@@ -16973,13 +17021,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge)
-"XE" = (
-/obj/item/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "XI" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -16999,67 +17040,69 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"XL" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/foreport)
-"XV" = (
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
-"XZ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+"XN" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"Ya" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"XO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/storage)
+"XQ" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "bridge sensors";
+	name = "Sensor Shroud"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/bridge/storage)
+"XR" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "co_windows"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
+"XW" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/foreport)
 "Yb" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -17086,8 +17129,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "Ye" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/photocopier,
 /obj/machinery/button/remote/blast_door{
 	id = "bridgehallway";
 	name = "Bridge Internal Hallway Lockdown Control";
@@ -17112,11 +17153,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Conference Room";
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "Yf" = (
 /obj/effect/floor_decal/corner/blue/three_quarters,
@@ -17188,41 +17230,48 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/atm{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Yk" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	icon_state = "corner_white_diagonal";
+	dir = 4
+	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"Yo" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"Yq" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
-"Yx" = (
-/obj/structure/lattice,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge Exterior - Starboard";
-	dir = 2
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"Yz" = (
+/obj/structure/flora/pottedplant/orientaltree,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
 	},
-/turf/space,
-/area/space)
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
+"YA" = (
+/obj/item/modular_computer/console/preset/command{
+	icon_state = "console";
+	dir = 8
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/xo)
 "YC" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "repdoor";
@@ -17235,7 +17284,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -17246,102 +17294,115 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "YF" = (
-/obj/structure/flora/pottedplant/smelly{
-	desc = "This is some kind of tropical plant. It reeks of rotten eggs. This one has a hand-painted Nametag on the rim. It reads 'Steve'"
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
-"YH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge entry star";
-	name = "Starboard Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/multi_tile/glass/command{
-	autoset_access = 0;
-	dir = 8;
-	id_tag = "starboardbridgeaccess";
-	name = "Bridge Access";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"))
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/bridge/hallway/starboard)
-"YI" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/forestarboard)
-"YM" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"YO" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
-"YQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
-"YS" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"YI" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/bridge/forestarboard)
+"YJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/red/half{
+	icon_state = "bordercolorhalf";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bridgecheck)
+"YK" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"YL" = (
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/open,
+/area/maintenance/bridge/forestarboard)
+"YN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disciplinary Board Room Maintenance Access"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/disciplinary_board_room)
+"YR" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/aft)
+"YS" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/aft)
+"YW" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"YV" = (
-/obj/item/weapon/soap/deluxe,
-/obj/item/weapon/bikehorn/rubberducky,
-/obj/structure/hygiene/shower{
-	icon_state = "shower";
-	dir = 8
+"YX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/vault/bolted{
+	autoset_access = 0;
+	id_tag = "bridgestorage_exit";
+	name = "Emergency Exit";
+	req_access = list("ACCESS_BRIDGE")
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/heads/cobed)
+/obj/item/weapon/airlock_brace{
+	req_access = list("ACCESS_BRIDGE")
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/storage)
 "YY" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -17385,26 +17446,16 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
-"Zd" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/office/xo)
 "Ze" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "Zf" = (
 /obj/structure/table/woodentable/walnut,
@@ -17444,10 +17495,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Zi" = (
-/obj/effect/floor_decal/corner/research/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 8
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -17457,7 +17504,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/research/half{
+	icon_state = "bordercolorhalf";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Zj" = (
 /obj/structure/hygiene/sink{
@@ -17477,56 +17528,47 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/aquila/head)
-"Zn" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"Zr" = (
-/obj/structure/bed/chair/comfy/blue{
-	icon_state = "comfychair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/co)
 "Zs" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/machinery/computer/account_database,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1";
-	tag = "icon-railing0 (EAST)"
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/xo)
+"Zt" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
 "Zx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4;
-	icon_state = "map"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/machinery/meter,
-/obj/machinery/light/small{
-	icon_state = "bulb1";
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/machinery/photocopier/faxmachine{
+	department = "CE"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"Zy" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge/forestarboard)
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "ZA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17541,72 +17583,75 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
-"ZC" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "bridge_checkpoint_shutters";
-	name = "Bridge Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/security/bridgecheck)
 "ZD" = (
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/rd)
-"ZK" = (
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/rd)
+"ZI" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
+"ZJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"ZQ" = (
-/obj/random/closet,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/bridge/aftport)
-"ZX" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/padded/teal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/office/cmo)
-"ZY" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"ZM" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"ZR" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 23;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/sea)
+"ZT" = (
+/obj/structure/dogbed,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/random/plushie,
+/mob/living/simple_animal/corgi/Ian,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/office/xo)
+"ZX" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair/padded/teal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/office/cmo)
 
 (1,1,1) = {"
 aa
@@ -24364,7 +24409,7 @@ aa
 aa
 aa
 aa
-qG
+pe
 aa
 aa
 aa
@@ -24380,7 +24425,7 @@ aa
 aa
 aa
 aa
-qG
+pe
 aa
 aa
 aa
@@ -24572,18 +24617,18 @@ aa
 aa
 aa
 aa
-Eg
+Js
 aa
 aa
 aa
-Eg
+Js
 aa
 aa
 aa
 aa
 aa
 ae
-VR
+qA
 tg
 tg
 tg
@@ -24768,13 +24813,13 @@ af
 af
 af
 af
-Yx
+oA
 aa
 aa
 aa
 aa
 aa
-zz
+hH
 aa
 aa
 aa
@@ -24971,19 +25016,19 @@ af
 af
 af
 fu
-TD
-TD
-BT
-nT
-Gs
-QA
-BT
-FF
-TZ
-QA
-Wz
-nT
-TZ
+XQ
+XQ
+wM
+Hz
+SE
+Aw
+wM
+AB
+mc
+Aw
+KG
+Hz
+mc
 aa
 aa
 sx
@@ -25163,41 +25208,41 @@ af
 af
 af
 VB
-od
+yc
 VB
 cR
-Uw
-AX
-Ox
-RR
-Fs
-Bo
-mB
-bn
-yK
+YX
+QQ
+TP
+LJ
+LP
+NL
+DE
+TB
+sm
 HE
-jP
-zO
-Vz
-Da
-yO
-kA
-LE
-TG
-XE
+Ra
+CE
+BE
+QW
+Rq
+GV
+Un
+By
+FE
 HE
-bX
-CQ
-AV
-Fo
-dp
+BI
+RV
+Mz
+Yz
+PF
 ux
-RM
+An
 uy
-RZ
-Or
-Lw
-yg
+Kq
+Cl
+UH
+Av
 uy
 uy
 tg
@@ -25363,43 +25408,43 @@ aa
 aa
 af
 af
-DY
+KB
 VB
-Zs
 OS
-Lu
+QY
+er
 qO
 qO
 qO
-rT
-VK
+Gr
+rz
 Xz
 Fp
 eM
-mB
+DE
 Ie
 nf
 If
-eK
+lt
 vg
 zg
-lY
-JO
-Tn
-Gk
+zN
+VM
+TK
+cV
 Ie
 Ng
 Id
 th
-AE
-mr
-Zr
-XV
+OM
+Pt
+yS
+Py
 uy
-Dt
-SH
-KG
-RF
+VW
+MA
+EJ
+DQ
 xx
 uy
 tg
@@ -25565,12 +25610,12 @@ aa
 aa
 af
 af
-WY
+XB
 VB
 zq
 aj
-GW
-RN
+qs
+UC
 qO
 aY
 dE
@@ -25578,7 +25623,7 @@ Jh
 Hf
 bf
 ee
-OP
+Wv
 eP
 Wc
 Af
@@ -25587,22 +25632,22 @@ hn
 HK
 hn
 hn
-QB
+SJ
 HU
 eP
 UY
 Fg
 Ig
-AE
+OM
 tR
 Mf
 CW
 uy
 UX
-SH
-YM
-tq
-NK
+MA
+lu
+mT
+ND
 uy
 tg
 tg
@@ -25767,44 +25812,44 @@ aa
 aa
 af
 af
-eD
+DI
 VB
 zq
-eL
-Qr
+FL
+GW
 aj
 qO
-GX
+zC
 dE
-cT
+XO
 eN
 Ke
-bJ
-Po
+Ks
+TI
 eP
 Xc
 HC
 jw
-Fa
+kw
 lm
-Fa
+kw
 nH
 HC
 pq
-St
-nW
-WJ
+XR
+NN
+Fl
 Ih
-AE
-mr
+OM
+Pt
 Nf
-WC
+Nf
 uy
 Iz
 IG
-Hr
+Cr
 CV
-Uk
+zP
 uy
 tg
 tg
@@ -25972,28 +26017,28 @@ af
 aj
 VB
 zq
-Gn
-FV
-zE
+Nr
+Tx
+bI
 qO
-GY
-Rn
-TK
-oI
+GX
+cT
+Tl
+jA
 Je
 Ne
 Jh
-Yk
+HI
 aZ
 XC
-Fa
-tG
+kw
+Fy
 Gg
-KB
-Fa
+Am
+kw
 HS
-Sc
-Jz
+aZ
+Qp
 qP
 rI
 fv
@@ -26004,9 +26049,9 @@ tT
 Iv
 IA
 IH
-JZ
+DY
 dG
-pK
+SG
 uy
 tg
 tg
@@ -26171,29 +26216,29 @@ aa
 aa
 af
 af
-MQ
+TA
 VB
 zq
-bo
-dP
-Qt
+Wr
+NM
+Bd
 qO
-GZ
+GY
 Hc
-AH
+MV
 De
 Mi
 Oe
 Se
-Pr
+lL
 Hx
-hT
-JF
+EV
+Vw
 HH
 Ch
-sp
-TN
-XZ
+Kt
+Lw
+fN
 HW
 eP
 qQ
@@ -26202,13 +26247,13 @@ Ii
 Io
 Kh
 uC
-sZ
+GU
 uy
 IB
-YO
-hB
+To
+KC
 dG
-zi
+Cx
 uy
 tg
 tg
@@ -26376,17 +26421,17 @@ af
 at
 VB
 aL
-OD
-Zx
-Gp
+bo
+bt
+Jp
 qO
-cW
-Hd
-eo
-Dp
+GZ
+Rs
+Kv
+Du
 qO
 qO
-vt
+yM
 eP
 hV
 eP
@@ -26394,11 +26439,11 @@ jy
 vf
 lo
 yh
-by
+NJ
 eP
 HX
 eP
-AS
+Dx
 rK
 bq
 bq
@@ -26409,7 +26454,7 @@ uy
 uy
 uy
 uy
-LU
+SV
 uy
 uy
 tg
@@ -26588,7 +26633,7 @@ aO
 aO
 aO
 fP
-fT
+fS
 Hu
 hW
 iI
@@ -26599,19 +26644,19 @@ qh
 HP
 ox
 HY
-Tl
+yY
 Ic
 rL
 RT
-GQ
+vm
 tW
 Iq
 sB
 sB
 sB
 sB
-Cq
-ET
+Rl
+jc
 bH
 aK
 tg
@@ -26779,15 +26824,15 @@ af
 af
 am
 ay
-JX
+JF
 aO
-Ko
-bM
-cp
+sC
+Bs
+qa
 aO
-dI
-aB
-Op
+sl
+si
+VF
 aO
 fQ
 gB
@@ -26795,9 +26840,9 @@ ho
 hX
 iJ
 jz
-LF
+dT
 dh
-Xx
+IY
 nJ
 oy
 pr
@@ -26805,16 +26850,16 @@ qj
 qS
 rM
 sy
-Fx
+En
 tX
-Fx
+En
 vj
 vO
 ww
 sB
 Oi
-Ll
-YV
+lT
+Ht
 aK
 tg
 tg
@@ -26981,29 +27026,29 @@ af
 af
 YI
 VB
-JX
+JF
 aO
-RD
-bN
-cq
+Zs
+co
+cp
 aO
-WI
-eq
-zU
+dI
+aB
+za
 fx
 fR
 gB
 hp
 Eh
 eP
-Bh
+AH
 yf
 eP
+VN
 zh
-Dh
 eP
 Gh
-Wl
+Qt
 qT
 rN
 sz
@@ -27186,35 +27231,35 @@ VB
 xN
 aO
 fz
-bO
-Md
+bN
+cq
 aO
 aO
-Ce
+eq
 aO
-bQ
-fS
-gD
-Ul
+yg
+sb
+gC
+lQ
 hX
-Rr
-xM
-xM
-lq
-TT
-TT
-WL
+cl
+KX
+KX
+CZ
+OD
+OD
+bK
 pr
-Cu
+Yk
 qU
 rO
 sB
-Bs
-JB
+ZR
+vZ
 uG
-MH
-PJ
-oX
+Nn
+Ck
+mz
 sB
 xc
 xc
@@ -27387,27 +27432,27 @@ aj
 VB
 xN
 aO
-Pl
-Vc
-Vc
+en
+bO
+bO
 Od
-Xd
-eQ
-Hh
-Ho
-fT
+dJ
+Ce
+ZT
+bQ
+fS
 gE
-Dm
+JB
 Yg
 iK
+YK
+YK
 jB
-jB
-lr
-FM
-FM
+kx
+kx
 Ol
 pt
-Ya
+Bu
 qV
 rP
 sB
@@ -27589,28 +27634,29 @@ ao
 VB
 xN
 aO
-WE
+RK
 bd
-Gd
-cS
+Vc
+dR
 Yd
-es
-eR
-Hp
+eQ
+Hh
+Ho
 fU
 gF
-DT
+PQ
 hq
 rt
-oQ
-Kw
-uD
-OI
-RA
-DK
+yd
+Hv
+WY
+bP
+ab
+ta
 hq
-Xu
+AP
 qW
+Qn
 rQ
 ti
 ti
@@ -27621,8 +27667,7 @@ ti
 ti
 ti
 ti
-vc
-Pk
+rT
 Ma
 tg
 tg
@@ -27791,39 +27836,39 @@ aj
 VB
 xN
 aO
-pO
+QX
 dd
-Vc
-Pd
-Zd
-et
-eS
-fy
+bO
+iB
+oz
+zT
+oI
+Hp
 fV
 gG
 hr
 hq
-NY
-BM
+MB
+Qv
 We
 Ye
 Ze
-Sp
-ZK
+DH
+BF
 hq
 qk
 qX
+ng
 rR
 Ik
 to
 ub
-VJ
+Tn
 Pf
 vS
 wz
-Wx
+Xa
 ti
-oB
 oB
 Ma
 tg
@@ -27991,42 +28036,42 @@ af
 af
 aj
 VB
-Ou
+YL
 aO
-Ml
+rC
 Ad
-Vc
+bO
 Qd
 be
 NH
 eT
-aO
-GL
+EM
+Uk
 Hs
-YH
-ib
-Gw
-Yo
-Py
-xu
-Py
-vx
-Es
-pv
-Vw
+hs
+hq
+WS
+Te
+zf
+zf
+zf
+Te
+dF
+hq
+hs
 qY
+AJ
 rS
-mL
+PB
 tp
 uc
 uH
 Qf
 vT
 wA
-zr
+nK
 xe
-On
-XL
+WX
 Ma
 tg
 tg
@@ -28195,28 +28240,29 @@ aj
 VB
 aj
 aO
-Fy
-Bq
-nS
+FG
+YA
+WL
 aO
 aO
-ev
-UD
+et
+eS
 aO
-ng
+eU
 qg
-Vl
-zu
+Vn
+Gq
 iM
-Te
-zf
-zf
-zf
-Te
-BH
-cu
-Pm
+Xe
+Ax
+eW
+LN
+Ah
+BV
+tk
+oJ
 Og
+Vl
 Pg
 VY
 to
@@ -28225,9 +28271,8 @@ uI
 vp
 vU
 IF
-Ax
+yL
 ti
-xc
 xy
 xc
 tg
@@ -28396,29 +28441,30 @@ af
 aj
 VB
 Xr
-ba
 aO
-oH
-NO
+aO
+kA
+kV
 ba
-RC
 Ta
-dN
+Os
+lx
 jR
-bT
-gI
-hu
-jO
-pP
-Xe
-Uo
-LN
-zK
-Ah
-hZ
-Nt
-br
+BY
 ra
+jO
+iG
+UN
+Te
+Xg
+Xg
+Xg
+Te
+hZ
+Ft
+bX
+GD
+Ap
 ti
 ti
 ti
@@ -28428,9 +28474,8 @@ ti
 ti
 ti
 ti
-UG
-WW
-Du
+ti
+XW
 xE
 tg
 tg
@@ -28599,27 +28644,27 @@ VB
 VB
 Xr
 bb
-bs
+AR
 bU
 xT
-ab
-dN
+df
+lx
 bT
 QN
 jR
-bT
+Lf
 gJ
-hv
 id
-pP
-Te
-Xg
-Xg
-Xg
-Te
+CL
+xd
+jH
+Sn
+zD
+JX
+jH
 iN
+JY
 id
-ql
 rb
 rV
 jR
@@ -28629,7 +28674,7 @@ uK
 Jb
 AR
 wB
-xc
+fB
 xb
 oB
 xz
@@ -28799,42 +28844,42 @@ af
 af
 ap
 aD
-XA
-hY
-Zn
-Sk
-Nk
+QK
+UL
+eK
+Up
+Fv
 dg
-ZY
-ZY
+YF
+YF
 eV
-fB
-iH
+Bn
+KK
 gK
-hw
 hs
-yE
-jH
-Bm
-cD
-Vk
-jH
-Sa
 hs
-Ku
+hs
+Oz
+hs
+hs
+hs
+hs
+hs
+hs
+hs
 rc
-iH
-fB
-EK
-Eu
+cG
+XN
+Gn
+ZM
 Nk
-Vp
-SD
-sC
-bF
-MY
-MY
-Bu
+cF
+AX
+RE
+IK
+UE
+UE
+lW
 oB
 tg
 tg
@@ -29008,22 +29053,22 @@ bV
 sJ
 Nd
 He
-Wn
+Ka
 sJ
 Le
 Pe
 gL
-ie
-hs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
+hx
+ig
+iP
+Bf
+kF
 mE
+mG
+Ff
+lq
+py
+qm
 rd
 sf
 sP
@@ -29212,20 +29257,20 @@ Rd
 Be
 ey
 Fe
-QR
+OE
 Qe
-gM
-hx
-ig
-iP
-Bf
-kF
+Ga
+hz
+ih
+CP
+Cf
+Nh
 mE
-mG
-Ff
-oD
-py
-qm
+mH
+Gf
+nU
+pz
+qo
 re
 rY
 sH
@@ -29408,26 +29453,26 @@ aE
 sJ
 Hb
 gc
-Ph
+OH
 Dd
 Sd
 we
-yX
+Nw
 eY
-RJ
+Nv
 gd
 gO
-hz
-ih
-dR
-Cf
-Nh
+dp
+ii
+Ia
+iR
+my
 mE
-mH
-Gf
-nU
-pz
-qo
+mI
+oF
+em
+pA
+qp
 rf
 rZ
 sI
@@ -29609,27 +29654,27 @@ as
 aE
 sJ
 bc
-Gm
-WF
+Uo
+Mt
 Ed
 Ud
 ze
 ez
 eZ
-GC
+Gy
 xU
 xX
-bP
-ii
-iR
-iQ
-kH
+hA
+ij
+iS
+jM
+kI
 mE
-mI
-Ov
-oF
-pA
-qp
+Zt
+nV
+wC
+pB
+qq
 xY
 sa
 YC
@@ -29816,31 +29861,31 @@ Uc
 Dd
 Wd
 Ae
-FI
-ow
+ZJ
+qR
 sJ
 xV
 Fb
-hA
-ij
-iS
-jM
-kI
+ie
+IN
+Zx
+AZ
+Cs
 mE
 mJ
-nV
+Mn
 oG
-pB
-qq
+fF
+mE
 xZ
-sb
+hu
 sL
-PI
-GS
-oY
-IM
-RU
-CA
+DZ
+qB
+SL
+gv
+uz
+QS
 sL
 JG
 Ma
@@ -30018,24 +30063,24 @@ sJ
 ve
 sJ
 sJ
-rq
+HG
 sJ
 sJ
-xW
-gQ
+Gs
+gR
 ie
-mT
-Sx
-Xv
-Cs
+ie
+ie
+ie
+ie
 mE
-nK
-GA
-dQ
-YF
 mE
-ya
-yb
+mE
+mE
+mE
+mE
+rd
+ga
 sL
 sL
 uk
@@ -30215,29 +30260,29 @@ af
 aF
 aP
 bg
-HV
+dk
 Zc
 Kd
 dn
 BB
 eA
 fb
-HV
-ge
-gR
-Kl
-ie
-ie
-ie
-ie
-mE
-mE
-mE
-mE
-mE
-Lp
-rd
-ga
+dk
+xW
+Rp
+fD
+Pd
+BX
+EL
+ID
+zV
+kX
+eF
+Wj
+Eq
+ck
+FS
+yb
 sL
 tx
 ul
@@ -30417,27 +30462,27 @@ af
 af
 aj
 bh
-HV
+dk
 kd
 Ld
-de
+dn
 Ve
-Fu
+IO
 Ge
-HV
+dk
 gf
 gM
 fD
 il
 iU
-zY
+TM
 mC
 AI
 qw
-yG
-Gx
+YJ
+Om
 Wh
-By
+yR
 Gb
 Aq
 sL
@@ -30619,28 +30664,28 @@ af
 af
 al
 bi
-HV
-Mo
-OH
-SE
-tn
-Ht
-yu
-HV
+dk
+zp
+Tm
+TV
+nN
+zS
+CX
+dk
 Re
-xX
+Bw
 CH
 im
 iV
-si
+nM
 VL
-bT
-zT
-Jn
-SP
+NE
+UA
+Uu
+gT
 pE
-ZC
-rj
+mA
+rg
 se
 sL
 tz
@@ -30828,7 +30873,7 @@ sT
 sT
 sT
 sT
-hH
+Kb
 xW
 xX
 Mq
@@ -30836,20 +30881,20 @@ im
 Jt
 Dr
 Ay
-lz
 mN
+AA
 nZ
 Wa
 pF
 mN
-rj
-YQ
+rg
+yb
 Pi
 Pi
 Pi
 Pi
 vv
-Ly
+nI
 vv
 vv
 xk
@@ -31027,7 +31072,7 @@ sT
 Ti
 Zi
 hj
-Bx
+RQ
 Fj
 Oj
 sT
@@ -31036,16 +31081,16 @@ zo
 gl
 La
 iX
-Yq
+Lk
 gl
-gl
+ck
 mO
 oK
-DF
+zM
 pG
-Ny
+yW
 rk
-Lt
+qz
 TX
 tA
 uo
@@ -31239,15 +31284,15 @@ Tz
 hE
 iY
 jS
-Mr
+RU
 lB
-mP
+Mr
 ob
-rC
-Lo
+vx
+zY
 qt
 rl
-hu
+zF
 TX
 tB
 up
@@ -31426,15 +31471,15 @@ gz
 gz
 gz
 cc
-bz
+bx
 sT
 Vi
 cj
-Gz
-DZ
-eE
+Nt
+Uy
+Ao
 Qj
-CC
+cS
 gk
 Yj
 hF
@@ -31445,9 +31490,9 @@ kK
 lC
 mQ
 oc
-nY
-hF
-JD
+bJ
+Of
+RC
 rm
 sh
 sS
@@ -31628,12 +31673,12 @@ aa
 gz
 gz
 cd
-bz
+bx
 sT
 Wi
-GF
-qC
-dk
+Lv
+AE
+fl
 Jj
 Rj
 sT
@@ -31647,16 +31692,16 @@ kL
 lD
 kL
 lA
-zZ
+Xx
 kJ
-qu
-Bw
-Sy
+fW
+Cv
+pI
 kJ
 tD
 lS
 Fn
-RS
+rA
 wh
 wN
 TX
@@ -31830,12 +31875,12 @@ aa
 gz
 gz
 aR
-bz
+bx
 sT
 sT
 IT
 tj
-HM
+BR
 Kj
 Sj
 sT
@@ -31853,7 +31898,7 @@ oO
 pJ
 qv
 rn
-yw
+KP
 kJ
 tE
 dj
@@ -31861,7 +31906,7 @@ uW
 Lb
 Mb
 Jo
-Ry
+YN
 xl
 CN
 CN
@@ -32032,7 +32077,7 @@ aa
 gz
 gz
 aS
-bz
+bx
 bm
 ag
 sT
@@ -32048,17 +32093,17 @@ gm
 gm
 jV
 SN
-Dy
+YR
 yZ
 of
 oP
 ZX
-Bn
 Kf
-KP
+OO
+yw
 kJ
-EZ
-iL
+SB
+RD
 TX
 TX
 TX
@@ -32240,7 +32285,7 @@ KH
 cc
 jx
 MD
-bm
+MD
 yV
 fI
 gm
@@ -32250,13 +32295,13 @@ gm
 gm
 jV
 SN
-BA
-Qk
+YS
+VP
 og
 ly
 pL
 qx
-rp
+Ll
 nG
 kJ
 TX
@@ -32437,13 +32482,13 @@ dY
 dY
 dY
 gi
-bz
+bx
 Xi
 aG
 aT
 MD
+MD
 zW
-yV
 fI
 gm
 gm
@@ -32457,7 +32502,7 @@ mV
 kJ
 oR
 pM
-qy
+rp
 Vh
 EN
 kJ
@@ -32639,7 +32684,7 @@ dY
 Eb
 vd
 gi
-bz
+bx
 Ns
 cH
 dr
@@ -32658,10 +32703,10 @@ El
 mW
 kJ
 kJ
-kJ
-kJ
-kJ
-kJ
+jD
+ZI
+qu
+EP
 kJ
 Gi
 OK
@@ -32859,12 +32904,12 @@ SN
 nb
 mX
 Ey
-oh
-ZQ
-OK
-ji
-wi
-oh
+qH
+qH
+qH
+qH
+qH
+qH
 tH
 ut
 fO
@@ -33469,7 +33514,7 @@ Qh
 Xh
 di
 qi
-zG
+Bp
 yi
 Ci
 on
@@ -33671,9 +33716,9 @@ Rh
 Yh
 Yh
 TQ
-YS
+SU
 Rz
-eW
+YW
 CO
 dV
 vJ
@@ -33873,9 +33918,9 @@ oW
 Zh
 hi
 pR
-dF
+yD
 Fi
-ES
+Dt
 CO
 dV
 dV
@@ -34077,7 +34122,7 @@ pQ
 QE
 Ai
 Ai
-SV
+Zy
 CO
 dV
 dV
@@ -34277,7 +34322,7 @@ Th
 Dq
 Uh
 bk
-tF
+zz
 Bi
 IW
 CO
@@ -36703,7 +36748,7 @@ Ww
 Xb
 tc
 Cc
-BV
+LQ
 uw
 vL
 ad


### PR DESCRIPTION
🆑 Cakey
maptweak: adjusted the bridge deck slightly:
maptweak: straightened the outer hallways to be more convenient
maptweak: reorganised the meeting room to use its space better
maptweak: matched wood types accross all offices
maptweak: gave an extra console to the side-islands in the bridge
maptweak: reshuffled COS and CE office contents, added disposal chutes
maptweak: brought outer hallway decals in line with door marking standard
/🆑

https://forums.baystation12.net/threads/bridge-deck-tweaks.7974/

![image](https://user-images.githubusercontent.com/17550641/58366874-4d7f5a80-7ed0-11e9-9c05-f88dd41ad2fc.png)

Primary issues I wanted to fix with the current layout:
- crooked hallways
![image](https://user-images.githubusercontent.com/17550641/58379936-3a3cbf80-7fa2-11e9-999d-473ecaacf505.png)

- airlock funnel (closet misplaced in screenshot)
![image](https://user-images.githubusercontent.com/17550641/58379941-44f75480-7fa2-11e9-91c1-e58fdeff3b15.png)

- cornerdoors
![image](https://user-images.githubusercontent.com/17550641/58379956-6b1cf480-7fa2-11e9-98c6-8dfed092c81e.png)

- office layout improvements
![image](https://user-images.githubusercontent.com/17550641/58379958-7a03a700-7fa2-11e9-9dfa-cf3af46e5d7d.png)

