### PR TITLE
Non hotkey mode binds for move-up/down moved to Numpad+/-

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -395,10 +395,10 @@ macro "macro"
 		name = "F12"
 		command = "F12"
 	elem 
-		name = "CTRL+,"
+		name = "CTRL+Add"
 		command = "move-upwards"
 	elem 
-		name = "CTRL+."
+		name = "CTRL+Subtract"
 		command = "move-down"
 
 macro "hotkeymode"
@@ -806,10 +806,10 @@ macro "borgmacro"
 		name = "F12"
 		command = "F12"
 	elem 
-		name = "CTRL+,"
+		name = "CTRL+Add"
 		command = "move-upwards"
 	elem 
-		name = "CTRL+."
+		name = "CTRL+Subtract"
 		command = "move-down"
 
 


### PR DESCRIPTION
Certain keyboard layouts had issues with non hotkey-mode `CTRL+,`/`.` for move-up/down. Moved to `CTRL+Numpad_Add` and `CTRL+Numpad_Substract`
🆑
bugfix: In non hotkey-mode, move-up/down have been moved to CTRL+Numpad_Add/Numpad_Substract to fix issues with some keyboard layouts.
/🆑