### PR TITLE
Bridge deck tweaks & fixes

### DIFF
--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -145,6 +145,7 @@
 
 /obj/structure/closet/secure_closet/guncabinet/PPE
 	name = "Bridge PPE cabinet"
+	req_access = list(list(access_armory,access_emergency_armory,access_hos,access_hop,access_ce,access_cmo,access_rd,access_senadv))
 
 /obj/structure/closet/secure_closet/guncabinet/PPE/WillContain()
 	return list(

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -311,9 +311,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "aO" = (
@@ -2139,9 +2137,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"fB" = (
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/bridge/fore)
 "fD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -2970,6 +2965,7 @@
 	name = "Chief Engineer";
 	secured_wires = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "hA" = (
@@ -3873,6 +3869,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/port)
 "jH" = (
@@ -4447,6 +4444,10 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge Hallway - Aft";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "kV" = (
@@ -6276,6 +6277,9 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "COS"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "oF" = (
@@ -6388,10 +6392,6 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 20
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Medical Officer - Office";
-	network = list("Command","Medical")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -6696,6 +6696,11 @@
 	icon_state = "nosmoking";
 	dir = 4;
 	pixel_x = -37
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Medical Officer - Office";
+	dir = 4;
+	network = list("Command","Security")
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -7101,6 +7106,7 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/pen/blue,
 /obj/random/clipboard,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qw" = (
@@ -7129,6 +7135,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/cookie,
 /obj/item/weapon/reagent_containers/food/snacks/cookie,
 /obj/item/weapon/storage/lunchbox/cat,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "qy" = (
@@ -7755,6 +7762,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/co)
 "rL" = (
@@ -8360,14 +8368,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/rd)
+"tl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/maintenance/bridge/foreport)
 "tm" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
 /obj/structure/flora/pottedplant/unusual,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
@@ -9787,15 +9809,15 @@
 	name = "plastic table frame"
 	},
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/item/toy/bosunwhistle,
 /obj/item/sticky_pad/random,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32;
 	pixel_y = 0
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
@@ -10572,11 +10594,10 @@
 "yw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
-/obj/item/sticky_pad/random,
-/obj/item/weapon/storage/box/cups,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
-/obj/item/weapon/reagent_containers/food/drinks/ice,
 /obj/machinery/light,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer's Office - Torch"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "yy" = (
@@ -10853,6 +10874,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/security/bridgecheck)
 "zN" = (
@@ -11149,6 +11171,20 @@
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/rd)
+"AF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "AH" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "bridge_starboard"
@@ -11399,6 +11435,10 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "BG" = (
@@ -11765,7 +11805,7 @@
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/bridge/aftport)
+/area/hallway/primary/bridge/aft)
 "CV" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -11797,6 +11837,7 @@
 	opacity = 0
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/port)
 "Db" = (
@@ -12075,11 +12116,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "Ey" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
 /obj/machinery/light,
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -12088,7 +12124,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/bridge/aftport)
+/area/hallway/primary/bridge/aft)
 "Ez" = (
 /obj/effect/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -13254,7 +13290,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/bridge/fore)
+/area/maintenance/bridge/forestarboard)
 "IL" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -13542,6 +13578,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
 /obj/item/weapon/storage/medical_lolli_jar,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "Kg" = (
@@ -13740,14 +13777,12 @@
 	id = "cmo_windows";
 	range = 11
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer's Office - Torch"
-	},
 /obj/item/weapon/stamp/cmo,
 /obj/item/device/radio{
 	frequency = 1487;
 	name = "medbay emergency radio link"
 	},
+/obj/item/weapon/storage/box/cups,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "KX" = (
@@ -14161,6 +14196,17 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"MH" = (
+/obj/structure/bed/chair/comfy/blue{
+	icon_state = "comfychair_preview";
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "CO - Office Port";
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/co)
 "MU" = (
 /obj/machinery/light{
 	dir = 4
@@ -14901,6 +14947,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/aux_eva)
 "Qd" = (
@@ -15042,6 +15089,10 @@
 	},
 /obj/structure/noticeboard{
 	pixel_x = 32
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
@@ -15704,6 +15755,7 @@
 	autoset_access = 0;
 	name = "Head"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "Ta" = (
@@ -16258,7 +16310,7 @@
 /obj/item/modular_computer/console/preset/command,
 /obj/item/modular_computer/tablet/lease/preset/command,
 /obj/machinery/camera/network/command{
-	c_tag = "CO - Office"
+	c_tag = "CO - Office Starboard"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
@@ -16457,13 +16509,6 @@
 /obj/item/sticky_pad/random,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"VG" = (
-/obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 1
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/heads/office/sgr)
 "VL" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -25770,7 +25815,7 @@ Ih
 OM
 Pt
 Nf
-Nf
+MH
 uy
 Iz
 IG
@@ -28601,7 +28646,7 @@ uK
 Jb
 AR
 wB
-fB
+xc
 xb
 oB
 xz
@@ -28803,7 +28848,7 @@ Nk
 cF
 AX
 RE
-IK
+tl
 UE
 UE
 lW
@@ -30007,8 +30052,8 @@ kE
 fF
 mE
 ya
-yb
-VG
+AF
+sL
 sL
 uk
 sL


### PR DESCRIPTION
Various changes and fixes to the existing bridge map.

- SEA office intercom moved to be accessible while sitting at the desk
- Fixed a section of bridge aft hallway using maintenance tags
- Fixed inconsistent hallway vs maintenance tags used on maintenance hatches
- Rearranges fax machine and table items in the CMO's office (The corner of the table is no longer inaccessible)
- Fixed inconsistent access flags for the PEE closet
- Removed redundant alarms and re-arranged wall items to fix overlapping issues
- Added lights in areas that were dark
- Added a second light switch to the meeting room

:cl:
map: The bridge deck has received some minor tweaks and fixes. See https://github.com/Baystation12/Baystation12/pull/25628 for details. Notable changes below:
map: CMO's office fax machine no longer blocks access to part of the table
map: Meeting room now has a fire alarm
map: Additional cameras were added to CO's office and aft hallway to fix blindspots
map: Fire doors were added to doors and windoors that were missing them
map: PPE closet access flags now match the sidearm closet
/:cl: