### PR TITLE
Adds planet habitability class

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -248,3 +248,8 @@
 
 //Lying animation
 #define ANIM_LYING_TIME 2
+
+//Planet habitability class
+#define HABITABILITY_IDEAL  1
+#define HABITABILITY_OKAY  2
+#define HABITABILITY_BAD  3

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -9,6 +9,9 @@
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 	features_budget = 6
 
+/obj/effect/overmap/sector/exoplanet/barren/generate_habitability()
+	return HABITABILITY_BAD
+
 /obj/effect/overmap/sector/exoplanet/barren/generate_atmosphere()
 	..()
 	atmosphere.remove_ratio(0.9)

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -7,6 +7,9 @@
 	map_generators = list(/datum/random_map/noise/exoplanet/chlorine, /datum/random_map/noise/ore/poor)
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 
+/obj/effect/overmap/sector/exoplanet/chlorine/generate_habitability()
+	return HABITABILITY_BAD
+
 /obj/effect/overmap/sector/exoplanet/chlorine/generate_map()
 	if(prob(50))
 		lightlevel = rand(7,10)/10 //It could be night.

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -14,7 +14,11 @@
 /obj/effect/overmap/sector/exoplanet/desert/generate_atmosphere()
 	..()
 	if(atmosphere)
-		atmosphere.temperature = T20C + rand(20, 100)
+		var/limit = 1000
+		if(habitability_class <= HABITABILITY_OKAY)
+			var/datum/species/human/H = /datum/species/human
+			limit = initial(H.heat_level_1) - rand(1,10)
+		atmosphere.temperature = min(T20C + rand(20, 100), limit)
 		atmosphere.update_values()
 
 /obj/effect/overmap/sector/exoplanet/desert/adapt_seed(var/datum/seed/S)

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -9,7 +9,11 @@
 /obj/effect/overmap/sector/exoplanet/snow/generate_atmosphere()
 	..()
 	if(atmosphere)
-		atmosphere.temperature = T0C - rand(10, 100)
+		var/limit = 0
+		if(habitability_class <= HABITABILITY_OKAY)
+			var/datum/species/human/H = /datum/species/human
+			limit = initial(H.cold_level_1) + rand(1,10)
+		atmosphere.temperature = max(T0C - rand(10, 100), limit)
 		atmosphere.update_values()
 
 /datum/random_map/noise/exoplanet/snow

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -8,6 +8,9 @@
 	map_generators = list(/datum/random_map/automata/cave_system/mountains/volcanic, /datum/random_map/noise/exoplanet/volcanic, /datum/random_map/noise/ore/filthy_rich)
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 
+/obj/effect/overmap/sector/exoplanet/volcanic/generate_habitability()
+	return HABITABILITY_BAD
+	
 /obj/effect/overmap/sector/exoplanet/volcanic/generate_atmosphere()
 	..()
 	if(atmosphere)


### PR DESCRIPTION
It decides how bad atmos are
1 - Perfect breathable
2 - Enough oxygen but has other gases, temps are not too extreme
3 - Free for all

Not all types of planets can be above 3 (e.g. volcanic and chlorine)
Around half would be bearable (1-2)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->