### PR TITLE
Removes Jungle Boots from Fleet Med Tech

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -171,7 +171,6 @@
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 						 /obj/item/clothing/head/soft/solgov/fleet,
 						 /obj/item/clothing/under/solgov/utility/fleet/combat/medical,
-						 /obj/item/clothing/shoes/jungleboots,
 						 /obj/item/clothing/gloves/thick/duty/solgov/med)
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/medical
 


### PR DESCRIPTION
This is being done because the Jungle boots are not part of fleet gear. They only exist as a result of an ancient holdover from when Field Medic could wear a marine uniform. They aren't meant to have them. 

:cl:
rscdel: Removed inappropriate boots from Fleet EMT.
/:cl: