### PR TITLE
Add non-expanding attacks to blobs

### DIFF
--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -6,6 +6,8 @@
 	randpixel = 8
 	force = 1
 	throwforce = 1
+	force_divisor = 0.1
+	thrown_force_divisor = 0.1
 	w_class = 1
 	slot_flags = SLOT_EARS
 	var/string_colour


### PR DESCRIPTION
:cl:
rscadd: Blobs will now additionally attempt to attack a random nearby tile, even if they aren't expanding to that tile. The core nucleus itself is particularly aggressive.
tweak: Material coins are no longer effective weapons.
/:cl: