### PR TITLE
Removes the vat-grown blanks from Petrov

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -10351,7 +10351,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
 "xV" = (
-/obj/structure/closet/crate/secure/biohazard/blanks,
+/obj/structure/closet/crate/secure/biohazard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
 	alarm_id = "petrov2";
@@ -13534,7 +13534,7 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/equipment)
 "JA" = (
-/obj/structure/closet/crate/secure/biohazard/blanks,
+/obj/structure/closet/crate/secure/biohazard,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/custodial)
 "JB" = (
@@ -15515,7 +15515,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "QR" = (
-/obj/structure/closet/crate/secure/biohazard/blanks,
+/obj/structure/closet/crate/secure/biohazard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	layer = 2.4;

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -4058,7 +4058,6 @@
 	pixel_x = 3;
 	pixel_y = 0
 	},
-/obj/item/weapon/folder/envelope/blanks,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
 "ke" = (


### PR DESCRIPTION
Admins mentioned wanting this removed in #staffcoach, and I'm personally tired of the constant 'I found clones this is morally bad revolt!' meme.

:cl:
del: Vat-grown blanks have been removed from the SRV Petrov.
/:cl: