### PR TITLE
Ghosts shouldn't be able to turn off antag pda program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -24,6 +24,10 @@
 	if(istype(computer) && istype(prog))
 		if(computer.hidden_uplink && prog.password)
 			if(prog.authenticated)
+				if(istype(user, /mob/observer/ghost))
+					var/mob/observer/ghost/G = user
+					if(!G.admin_ghosted)
+						return
 				if(alert(user, "Resume or close and secure?", name, "Resume", "Close") == "Resume")
 					computer.hidden_uplink.trigger(user)
 					return


### PR DESCRIPTION
:cl: BearKingKrug
bugfix: Ghosts can no longer close the traitor program on PDAs
/:cl:

Fixes #25358

I'm sure there's probably a more simple way to do this in less lines, still learning stuff. 