### PR TITLE
Uplink Descriptions Update and Small Bugfixes

### DIFF
--- a/ammunition.dm
+++ b/ammunition.dm
@@ -1,0 +1,112 @@
+/*************
+* Ammunition *
+*************/
+/datum/uplink_item/item/ammo
+	item_cost = 4
+	category = /datum/uplink_category/ammunition
+
+/datum/uplink_item/item/ammo/holdout
+	name = "7mm Magazine"
+	desc = "A magazine for pocket-sized pistols. Contains 8 rounds."
+	item_cost = 3
+	path = /obj/item/ammo_magazine/pistol/small
+
+/datum/uplink_item/item/ammo/holdout_speedloader
+	name = "7mm Speedloader"
+	desc = "A speedloader for pocket-sized revolvers. Contains 6 rounds."
+	item_cost = 3
+	path = /obj/item/ammo_magazine/speedloader/small
+
+/datum/uplink_item/item/ammo/darts
+	name = "Dart Cartridge"
+	desc = "A small cartridge for a gas-powered dart gun. Contains 5 hollow darts."
+	path = /obj/item/ammo_magazine/chemdart
+
+/datum/uplink_item/item/ammo/speedloader
+	name = "10mm Speedloader"
+	desc = "A speedloader for standard revolvers. Contains 6 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/speedloader
+
+/datum/uplink_item/item/ammo/rifle
+	name = "7mmR Magazine"
+	desc = "A magazine for assault rifles. Contains 20 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/rifle
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/ammo/sniperammo
+	name = "Ammobox of 15mmR Sniper Rounds"
+	desc = "An ammobox of rounds for the anti-materiel rifle. Contains 7 rounds."
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/ammo/sniperammo
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/ammo/sniperammo/apds
+	name = "Ammobox of 15mmR APDS Rounds"
+	desc = "An ammobox of armor piercing rounds for the anti-materiel rifle. Contains 3 rounds."
+	item_cost = 12
+	path = /obj/item/weapon/storage/box/ammo/sniperammo/apds
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/ammo/shotgun_shells
+	name = "Ammobox of Shotgun Shells"
+	desc = "An ammobox with 2 sets of shell holders. Contains 8 buckshot shells total."
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/ammo/shotgunshells
+
+/datum/uplink_item/item/ammo/shotgun_slugs
+	name = "Ammobox of Shotgun Slugs"
+	desc = "An ammobox with 2 sets of shell holders. Contains 8 slugs total."
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/ammo/shotgunammo
+
+/datum/uplink_item/item/ammo/machine_pistol
+	name = "10mm Stick Magazine"
+	desc = "A magazine for machine pistols. Contains 16 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/machine_pistol
+
+/datum/uplink_item/item/ammo/smg
+	name = "10mm Box Magazine"
+	desc = "A magazine for SMGs. Contains 20 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/smg
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/ammo/pistol
+	name = "10mm Doublestack Magazine"
+	desc = "A magazine for military pistols. Contains 15 rounds."
+	item_cost = 9
+	path = /obj/item/ammo_magazine/pistol/double
+
+/datum/uplink_item/item/ammo/magnum
+	name = "15mm Magazine"
+	desc = "A magazine for high-caliber pistols. Contains 7 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/magnum
+
+/datum/uplink_item/item/ammo/speedloader_magnum
+	name = "15mm Speedloader"
+	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/speedloader/magnum
+
+/datum/uplink_item/item/ammo/flechette
+	name = "Flechette Rifle Magazine"
+	desc = "A magazine loaded with flechette rounds. Contains 9 rounds."
+	item_cost = 8
+	path = /obj/item/weapon/magnetic_ammo
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/ammo/pistol_emp
+	name = "10mm EMP Ammo Box"
+	desc = "A box of EMP ammo for standard pistols. Contains 15 loose rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/box/emp/pistol
+
+/datum/uplink_item/item/ammo/holdout_emp
+	name = "7mm EMP Ammo Box"
+	desc = "A box of EMP ammo for pocket-sized pistols and revolvers. Contains 8 loose rounds."
+	item_cost = 6
+	path = /obj/item/ammo_magazine/box/emp/smallpistol

--- a/badassery.dm
+++ b/badassery.dm
@@ -1,0 +1,91 @@
+/************
+* Badassery *
+************/
+/datum/uplink_item/item/badassery
+	category = /datum/uplink_category/badassery
+
+/datum/uplink_item/item/badassery/balloon
+	name = "For showing that You Are The BOSS (Useless Balloon)"
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	path = /obj/item/toy/balloon
+
+/datum/uplink_item/item/badassery/balloon/corporate
+	name = "For showing that you love the company SOO much (Useless Balloon)"
+	path = /obj/item/toy/balloon/nanotrasen
+
+/datum/uplink_item/item/badassery/balloon/random
+	name = "For showing 'Whatevah~' (Useless Balloon)"
+	desc = "Randomly selects a ballon for you!"
+	path = /obj/item/toy/balloon
+
+/datum/uplink_item/item/badassery/balloon/random/get_goods(var/obj/item/device/uplink/U, var/loc)
+	var/balloon_type = pick(typesof(path))
+	var/obj/item/I = new balloon_type(loc)
+	return I
+
+/**************
+* Random Item *
+**************/
+/datum/uplink_item/item/badassery/random_one
+	name = "Random Item"
+	desc = "Buys you a random item for at least 1 TC. Be careful, this can spend any amount of telecrystals!"
+	item_cost = 1
+
+/datum/uplink_item/item/badassery/random_one/buy(var/obj/item/device/uplink/U, var/mob/user)
+	var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/default)
+	var/datum/uplink_item/item = uplink_selection.get_random_item(U.uses, U)
+	return item && item.buy(U, user)
+
+/datum/uplink_item/item/badassery/random_one/can_buy(obj/item/device/uplink/U)
+	return U.uses
+
+/datum/uplink_item/item/badassery/random_many
+	name = "Random Items"
+	desc = "Buys you as many random items as you can afford. Convenient packaging NOT included!"
+
+/datum/uplink_item/item/badassery/random_many/cost(var/telecrystals, obj/item/device/uplink/U)
+	return max(1, telecrystals)
+
+/datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/device/uplink/U, var/loc)
+	var/list/bought_items = list()
+	for(var/datum/uplink_item/UI in get_random_uplink_items(U, U.uses, loc))
+		UI.purchase_log(U)
+		var/obj/item/I = UI.get_goods(U, loc)
+		if(istype(I))
+			bought_items += I
+
+	return bought_items
+
+/datum/uplink_item/item/badassery/random_many/purchase_log(obj/item/device/uplink/U)
+	SSstatistics.add_field_details("traitor_uplink_items_bought", "[src]")
+	log_and_message_admins("used \the [U.loc] to buy \a [src]")
+
+/****************
+* Surplus Crate *
+****************/
+/datum/uplink_item/item/badassery/surplus
+	name = "\improper Surplus Crate"
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT * 4
+	var/item_worth = DEFAULT_TELECRYSTAL_AMOUNT * 6
+	var/icon
+
+/datum/uplink_item/item/badassery/surplus/New()
+	..()
+	antag_roles = list(MODE_MERCENARY)
+	desc = "A crate containing [item_worth] telecrystal\s worth of surplus leftovers. If you can find some help to pay for it, you might strike gold."
+
+/datum/uplink_item/item/badassery/surplus/get_goods(var/obj/item/device/uplink/U, var/loc)
+	var/obj/structure/largecrate/C = new(loc)
+	var/random_items = get_random_uplink_items(U, item_worth, C)
+	for(var/datum/uplink_item/I in random_items)
+		I.purchase_log(U)
+		I.get_goods(U, C)
+
+	return C
+
+/datum/uplink_item/item/badassery/surplus/log_icon()
+	if(!icon)
+		var/obj/structure/largecrate/C = /obj/structure/largecrate
+		icon = image(initial(C.icon), initial(C.icon_state))
+
+	return "\icon[icon]"

--- a/boxes.dm
+++ b/boxes.dm
@@ -1,0 +1,300 @@
+/obj/item/ammo_magazine/speedloader
+	name = "speed loader"
+	desc = "A speed loader for revolvers."
+	icon_state = "spdloader"
+	caliber = CALIBER_PISTOL
+	ammo_type = /obj/item/ammo_casing/pistol
+	matter = list(MATERIAL_STEEL = 1260)
+	max_ammo = 6
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/speedloader/rubber
+	labels = list("rubber")
+	ammo_type = /obj/item/ammo_casing/pistol/rubber
+
+/obj/item/ammo_magazine/speedloader/magnum
+	icon_state = "spdloader_magnum"
+	caliber = CALIBER_PISTOL_MAGNUM
+	ammo_type = /obj/item/ammo_casing/pistol/magnum
+	matter = list(MATERIAL_STEEL = 1440)
+	max_ammo = 6
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/speedloader/small
+	name = "speed loader"
+	icon_state = "spdloader_small"
+	caliber = CALIBER_PISTOL_SMALL
+	ammo_type = /obj/item/ammo_casing/pistol/small
+	matter = list(MATERIAL_STEEL = 1060)
+	max_ammo = 6
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/shotholder
+	name = "shotgun slug holder"
+	desc = "A convenient pouch that holds 12 gauge shells."
+	icon_state = "shotholder"
+	caliber = CALIBER_SHOTGUN
+	ammo_type = /obj/item/ammo_casing/shotgun
+	matter = list(MATERIAL_STEEL = 1440)
+	max_ammo = 4
+	multiple_sprites = 1
+	var/marking_color
+
+/obj/item/ammo_magazine/shotholder/on_update_icon()
+	..()
+	overlays.Cut()
+	if(marking_color)
+		var/image/I = image(icon, "shotholder-marking")
+		I.color = marking_color
+		overlays += I
+	
+/obj/item/ammo_magazine/shotholder/shell
+	name = "shotgun shell holder"
+	ammo_type = /obj/item/ammo_casing/shotgun/pellet
+	marking_color = COLOR_RED_GRAY
+
+/obj/item/ammo_magazine/shotholder/beanbag
+	name = "beanbag shell holder"
+	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	matter = list(MATERIAL_STEEL = 720)
+	marking_color = COLOR_PAKISTAN_GREEN
+
+/obj/item/ammo_magazine/shotholder/flash
+	name = "illumination shell holder"
+	ammo_type = /obj/item/ammo_casing/shotgun/flash
+	matter = list(MATERIAL_STEEL = 360, MATERIAL_GLASS = 360)
+	marking_color = COLOR_PALE_YELLOW
+
+/obj/item/ammo_magazine/shotholder/stun
+	name = "stun shell holder"
+	ammo_type = /obj/item/ammo_casing/shotgun/stunshell
+	matter = list(MATERIAL_STEEL = 1440, MATERIAL_GLASS = 2880)
+	marking_color = COLOR_MUZZLE_FLASH
+
+/obj/item/ammo_magazine/shotholder/empty
+	name = "shotgun ammunition holder"
+	matter = list(MATERIAL_STEEL = 250)
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/machine_pistol
+	name = "stick magazine"
+	icon_state = "machine_pistol"
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/ammo_casing/pistol
+	matter = list(MATERIAL_STEEL = 1200)
+	caliber = CALIBER_PISTOL
+	max_ammo = 16
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/machine_pistol/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/smg_top
+	name = "top mounted magazine"
+	icon_state = "smg_top"
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/ammo_casing/pistol/small
+	matter = list(MATERIAL_STEEL = 1200)
+	caliber = CALIBER_PISTOL_SMALL
+	max_ammo = 20
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/smg_top/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/smg_top/rubber
+	labels = list("rubber")
+	ammo_type = /obj/item/ammo_casing/pistol/small/rubber
+
+/obj/item/ammo_magazine/smg_top/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/pistol/small/practice
+
+/obj/item/ammo_magazine/smg
+	name = "box magazine"
+	icon_state = "smg"
+	origin_tech = list(TECH_COMBAT = 2)
+	mag_type = MAGAZINE
+	caliber = CALIBER_PISTOL
+	matter = list(MATERIAL_STEEL = 1500)
+	ammo_type = /obj/item/ammo_casing/pistol
+	max_ammo = 20
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/smg/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/pistol
+	name = "pistol magazine"
+	icon_state = "pistol"
+	origin_tech = list(TECH_COMBAT = 2)
+	mag_type = MAGAZINE
+	caliber = CALIBER_PISTOL
+	matter = list(MATERIAL_STEEL = 750)
+	ammo_type = /obj/item/ammo_casing/pistol
+	max_ammo = 10
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/pistol/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/pistol/rubber
+	labels = list("rubber")
+	ammo_type = /obj/item/ammo_casing/pistol/rubber
+
+/obj/item/ammo_magazine/pistol/double
+	name = "doublestack pistol magazine"
+	icon_state = "pistol"
+	matter = list(MATERIAL_STEEL = 1050)
+	max_ammo = 15
+
+/obj/item/ammo_magazine/pistol/double/rubber
+	labels = list("rubber")
+	ammo_type = /obj/item/ammo_casing/pistol/rubber
+
+/obj/item/ammo_magazine/pistol/double/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/pistol/practice
+
+/obj/item/ammo_magazine/pistol/small
+	icon_state = "holdout"
+	matter = list(MATERIAL_STEEL = 480)
+	caliber = CALIBER_PISTOL_SMALL
+	ammo_type = /obj/item/ammo_casing/pistol/small
+	max_ammo = 8
+
+/obj/item/ammo_magazine/pistol/small/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/magnum
+	name = "magazine"
+	icon_state = "magnum"
+	origin_tech = list(TECH_COMBAT = 2)
+	mag_type = MAGAZINE
+	caliber = CALIBER_PISTOL_MAGNUM
+	matter = list(MATERIAL_STEEL = 1680)
+	ammo_type = /obj/item/ammo_casing/pistol/magnum
+	max_ammo = 7
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/magnum/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/box/smallpistol
+	name = "ammunition box"
+	icon_state = "smallpistol"
+	origin_tech = list(TECH_COMBAT = 2)
+	matter = list(MATERIAL_STEEL = 1800)
+	caliber = CALIBER_PISTOL_SMALL
+	ammo_type = /obj/item/ammo_casing/pistol/small
+	max_ammo = 30
+
+/obj/item/ammo_magazine/box/pistol
+	name = "ammunition box"
+	icon_state = "smallpistol"
+	origin_tech = list(TECH_COMBAT = 2)
+	caliber = CALIBER_PISTOL
+	matter = list(MATERIAL_STEEL = 2250)
+	ammo_type = /obj/item/ammo_casing/pistol
+	max_ammo = 30
+
+/obj/item/ammo_magazine/box/pistol/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/pistol/throwback
+	name = "pistol magazine"
+	caliber = CALIBER_PISTOL_ANTIQUE
+	ammo_type = /obj/item/ammo_casing/pistol/throwback
+
+/obj/item/ammo_magazine/box/emp/pistol
+	name = "ammunition box"
+	desc = "A box containing loose rounds of 10mm EMP ammo."
+	labels = list("haywire")
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/ammo_casing/pistol/emp
+	caliber = CALIBER_PISTOL
+	max_ammo = 15
+
+/obj/item/ammo_magazine/box/emp/smallpistol
+	name = "ammunition box"
+	desc = "A box containing loose rounds of 7mm EMP ammo."
+	labels = list("haywire")
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/ammo_casing/pistol/small/emp
+	caliber = CALIBER_PISTOL_SMALL
+	max_ammo = 8
+
+/obj/item/ammo_magazine/proto_smg
+	name = "submachine gun magazine"
+	icon_state = CALIBER_PISTOL_FLECHETTE
+	origin_tech = list(TECH_COMBAT = 4)
+	mag_type = MAGAZINE
+	caliber = CALIBER_PISTOL_FLECHETTE
+	matter = list(MATERIAL_STEEL = 2000)
+	ammo_type = /obj/item/ammo_casing/flechette
+	max_ammo = 40
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/gyrojet
+	name = "microrocket magazine"
+	icon_state = "gyrojet"
+	mag_type = MAGAZINE
+	caliber = CALIBER_GYROJET
+	ammo_type = /obj/item/ammo_casing/gyrojet
+	multiple_sprites = 1
+	max_ammo = 4
+
+/obj/item/ammo_magazine/gyrojet/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/box/machinegun
+	name = "magazine box"
+	icon_state = "machinegun"
+	origin_tech = list(TECH_COMBAT = 2)
+	mag_type = MAGAZINE
+	caliber = CALIBER_RIFLE
+	matter = list(MATERIAL_STEEL = 4500)
+	ammo_type = /obj/item/ammo_casing/rifle
+	max_ammo = 50
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/box/machinegun/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/rifle
+	name = "assault rifle magazine"
+	icon_state = "assault_rifle"
+	mag_type = MAGAZINE
+	caliber = CALIBER_RIFLE
+	matter = list(MATERIAL_STEEL = 1800)
+	ammo_type = /obj/item/ammo_casing/rifle
+	max_ammo = 20
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/mil_rifle
+	name = "assault rifle magazine"
+	icon_state = "bullup"
+	origin_tech = list(TECH_COMBAT = 2)
+	mag_type = MAGAZINE
+	caliber = CALIBER_RIFLE_MILITARY
+	matter = list(MATERIAL_STEEL = 1800)
+	ammo_type = /obj/item/ammo_casing/rifle/military
+	max_ammo = 15 //if we lived in a world where normal mags had 30 rounds, this would be a 20 round mag
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/mil_rifle/empty
+	initial_ammo = 0
+
+/obj/item/ammo_magazine/mil_rifle/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/rifle/military/practice
+
+/obj/item/ammo_magazine/caps
+	name = "speed loader"
+	desc = "A cheap plastic speed loader for some kind of revolver."
+	icon_state = "T38"
+	caliber = CALIBER_CAPS
+	ammo_type = /obj/item/ammo_casing/cap
+	matter = list(MATERIAL_STEEL = 600)
+	max_ammo = 7
+	multiple_sprites = 1

--- a/bullets.dm
+++ b/bullets.dm
@@ -1,0 +1,194 @@
+
+/obj/item/ammo_casing/pistol
+	desc = "A pistol bullet casing."
+	caliber = CALIBER_PISTOL
+	projectile_type = /obj/item/projectile/bullet/pistol
+	icon_state = "pistolcasing"
+	spent_icon = "pistolcasing-spent"
+
+/obj/item/ammo_casing/pistol/rubber
+	desc = "A rubber pistol bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/rubber
+	icon_state = "pistolcasing_r"
+
+/obj/item/ammo_casing/pistol/practice
+	desc = "A practice pistol bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/practice
+	icon_state = "pistolcasing_p"
+
+/obj/item/ammo_casing/pistol/small
+	desc = "A small pistol bullet casing."
+	caliber = CALIBER_PISTOL_SMALL
+	projectile_type = /obj/item/projectile/bullet/pistol
+	icon_state = "smallcasing"
+	spent_icon = "smallcasing-spent"
+
+/obj/item/ammo_casing/pistol/small/rubber
+	desc = "A small pistol rubber bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/rubber
+	icon_state = "pistolcasing_r"
+
+/obj/item/ammo_casing/pistol/small/practice
+	desc = "A small pistol practice bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/practice
+	icon_state = "pistolcasing_p"
+
+/obj/item/ammo_casing/pistol/magnum
+	desc = "A high-power pistol bullet casing."
+	caliber = CALIBER_PISTOL_MAGNUM
+	projectile_type = /obj/item/projectile/bullet/pistol/strong
+	icon_state = "magnumcasing"
+	spent_icon = "magnumcasing-spent"
+
+/obj/item/ammo_casing/pistol/throwback
+	desc = "An antique pistol bullet casing. Somewhere between 9 and 11 mm in caliber."
+	caliber = CALIBER_PISTOL_ANTIQUE
+
+/obj/item/ammo_casing/gyrojet
+	desc = "A minirocket casing."
+	caliber = CALIBER_GYROJET
+	projectile_type = /obj/item/projectile/bullet/gyro
+	icon_state = "lcasing"
+	spent_icon = "lcasing-spent"
+
+/obj/item/ammo_casing/flechette
+	desc = "A flechette casing."
+	caliber = CALIBER_PISTOL_FLECHETTE
+	projectile_type = /obj/item/projectile/bullet/flechette
+	icon_state = "flechette-casing"
+	spent_icon = "flechette-casing-spent"
+
+/obj/item/ammo_casing/shotgun
+	name = "shotgun slug"
+	desc = "A shotgun slug."
+	icon_state = "slshell"
+	spent_icon = "slshell-spent"
+	caliber = CALIBER_SHOTGUN
+	projectile_type = /obj/item/projectile/bullet/shotgun
+	matter = list(MATERIAL_STEEL = 360)
+	fall_sounds = list('sound/weapons/guns/shotgun_fall.ogg')
+
+/obj/item/ammo_casing/shotgun/pellet
+	name = "shotgun shell"
+	desc = "A shotshell."
+	icon_state = "gshell"
+	spent_icon = "gshell-spent"
+	projectile_type = /obj/item/projectile/bullet/pellet/shotgun
+	matter = list(MATERIAL_STEEL = 360)
+
+/obj/item/ammo_casing/shotgun/blank
+	name = "shotgun shell"
+	desc = "A blank shell."
+	icon_state = "blshell"
+	spent_icon = "blshell-spent"
+	projectile_type = /obj/item/projectile/bullet/blank
+	matter = list(MATERIAL_STEEL = 90)
+
+/obj/item/ammo_casing/shotgun/practice
+	name = "shotgun shell"
+	desc = "A practice shell."
+	icon_state = "pshell"
+	spent_icon = "pshell-spent"
+	projectile_type = /obj/item/projectile/bullet/shotgun/practice
+	matter = list(MATERIAL_STEEL = 90)
+
+/obj/item/ammo_casing/shotgun/beanbag
+	name = "beanbag shell"
+	desc = "A beanbag shell."
+	icon_state = "bshell"
+	spent_icon = "bshell-spent"
+	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag
+	matter = list(MATERIAL_STEEL = 180)
+
+//Can stun in one hit if aimed at the head, but
+//is blocked by clothing that stops tasers and is vulnerable to EMP
+/obj/item/ammo_casing/shotgun/stunshell
+	name = "stun shell"
+	desc = "A taser cartridge."
+	icon_state = "stunshell"
+	spent_icon = "stunshell-spent"
+	projectile_type = /obj/item/projectile/energy/electrode/stunshot
+	leaves_residue = 0
+	matter = list(MATERIAL_STEEL = 360, MATERIAL_GLASS = 720)
+
+/obj/item/ammo_casing/shotgun/stunshell/emp_act(severity)
+	if(prob(100/severity)) BB = null
+	update_icon()
+
+//Does not stun, only blinds, but has area of effect.
+/obj/item/ammo_casing/shotgun/flash
+	name = "flash shell"
+	desc = "A chemical shell used to signal distress or provide illumination."
+	icon_state = "fshell"
+	spent_icon = "fshell-spent"
+	projectile_type = /obj/item/projectile/energy/flash/flare
+	matter = list(MATERIAL_STEEL = 90, MATERIAL_GLASS = 90)
+
+/obj/item/ammo_casing/rifle
+	desc = "A rifle bullet casing."
+	caliber = CALIBER_RIFLE
+	projectile_type = /obj/item/projectile/bullet/rifle
+	icon_state = "riflecasing"
+	spent_icon = "riflecasing-spent"
+
+/obj/item/ammo_casing/shell
+	name = "shell casing"
+	desc = "An antimaterial shell casing."
+	icon_state = "lcasing"
+	spent_icon = "lcasing-spent"
+	caliber = CALIBER_ANTIMATERIAL
+	projectile_type = /obj/item/projectile/bullet/rifle/shell
+	matter = list(MATERIAL_STEEL = 1250)
+
+/obj/item/ammo_casing/shell/apds
+	name = "\improper APDS shell casing"
+	desc = "An Armour Piercing Discarding Sabot shell."
+	projectile_type = /obj/item/projectile/bullet/rifle/shell/apds
+
+/obj/item/ammo_casing/rifle/military
+	desc = "A military rifle bullet casing."
+	caliber = CALIBER_RIFLE_MILITARY
+	projectile_type = /obj/item/projectile/bullet/rifle/military
+	icon_state = "rifle_mil"
+	spent_icon = "rifle_mil-spent"
+
+/obj/item/ammo_casing/rifle/military/practice
+	desc = "A military rifle practice bullet casing."
+	projectile_type = /obj/item/projectile/bullet/rifle/military/practice
+	icon_state = "rifle_mil_p"
+
+/obj/item/ammo_casing/rocket
+	name = "rocket shell"
+	desc = "A high explosive designed to be fired from a launcher."
+	icon_state = "rocketshell"
+	projectile_type = /obj/item/missile
+	caliber = "rocket"
+
+/obj/item/ammo_casing/cap
+	name = "cap"
+	desc = "A cap for children toys."
+	caliber = CALIBER_CAPS
+	color = "#ff0000"
+	projectile_type = /obj/item/projectile/bullet/pistol/cap
+
+// EMP ammo.
+/obj/item/ammo_casing/pistol/emp
+	name = "haywire round"
+	desc = "A pistol bullet casing fitted with a single-use ion pulse generator."
+	projectile_type = /obj/item/projectile/ion/small
+	icon_state = "pistolcasing_h"
+	matter = list(MATERIAL_STEEL = 130, MATERIAL_URANIUM = 100)
+
+/obj/item/ammo_casing/pistol/small/emp
+	name = "small haywire round"
+	desc = "A small bullet casing fitted with a single-use ion pulse generator."
+	projectile_type = /obj/item/projectile/ion/tiny
+	icon_state = "smallcasing_h"
+
+/obj/item/ammo_casing/shotgun/emp
+	name = "haywire slug"
+	desc = "A 12-gauge shotgun slug fitted with a single-use ion pulse generator."
+	icon_state = "empshell"
+	spent_icon = "empshell-spent"
+	projectile_type  = /obj/item/projectile/ion
+	matter = list(MATERIAL_STEEL = 260, MATERIAL_URANIUM = 200)

--- a/devices and tools.dm
+++ b/devices and tools.dm
@@ -1,0 +1,142 @@
+/********************
+* Devices and Tools *
+********************/
+/datum/uplink_item/item/tools
+	category = /datum/uplink_category/tools
+
+/datum/uplink_item/item/tools/toolbox
+	name = "Fully Loaded Toolbox"
+	desc = "A hefty toolbox filled with all the equipment you need to get past any construction or electrical issues. Instructions and materials not included."
+	item_cost = 8
+	path = /obj/item/weapon/storage/toolbox/syndicate
+
+/datum/uplink_item/item/tools/money
+	name = "Operations Funding"
+	item_cost = 8
+	path = /obj/item/weapon/storage/secure/briefcase/money
+	desc = "A briefcase with 10,000 untraceable thalers. Makes a great bribe if they're willing to take you up on your offer."
+
+/datum/uplink_item/item/tools/clerical
+	name = "Morphic Clerical Kit"
+	desc = "Comes with everything you need to fake paperwork, assuming you know how to forge the required documents."
+	item_cost = 16
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/clerical
+
+/datum/uplink_item/item/tools/plastique
+	name = "C-4"
+	desc = "Set this on a wall to put a hole exactly where you need it."
+	item_cost = 16
+	path = /obj/item/weapon/plastique
+
+/datum/uplink_item/item/tools/heavy_armor
+	name = "Heavy Armor Vest and Helmet"
+	desc = "This satchel holds a combat helmet and fully equipped plate carrier. Suit up, and strap in, things are about to get hectic."
+	item_cost = 16
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
+
+/datum/uplink_item/item/tools/encryptionkey_radio
+	name = "Encrypted Radio Channel Key"
+	desc = "This headset encryption key will allow you to eavesdrop on all available department channels, as well as speak on a hidden, encrypted radio channel. Use a screwdriver on your headset to exchange keys."
+	item_cost = 1
+	path = /obj/item/device/encryptionkey/syndicate
+
+/datum/uplink_item/item/tools/shield_diffuser
+	name = "Handheld Shield Diffuser"
+	desc = "A small device used to disrupt energy barriers, and allow passage through them."
+	item_cost = 16
+	path = /obj/item/weapon/shield_diffuser
+
+/datum/uplink_item/item/tools/suit_sensor_mobile
+	name = "Suit Sensor Jamming Device"
+	desc = "This tiny device can temporarily change the sensor levels or report random or false readings on any suit sensors in your vicinity. The range at which this device operates can be toggled as well. All of these options drain the internal battery."
+	item_cost = 20
+	path = /obj/item/device/suit_sensor_jammer
+
+/datum/uplink_item/item/tools/encryptionkey_binary
+	name = "Binary Translator Key"
+	desc = "This headset encryption key will allow you to both listen and speak on the binary channel that synthetics and AI have access to. Remember this is not normal access, and will alert the AI. Use a screwdriver on your headset to exchange keys."
+	item_cost = 20
+	path = /obj/item/device/encryptionkey/binary
+
+/datum/uplink_item/item/tools/emag
+	name = "Cryptographic Sequencer"
+	desc = "An electromagnetic card capable of scrambling electronics to either subvert them into serving you, \
+			or giving you access to things you normally can't. Doors can be opened with this card \
+			even if you aren't normally able to, but will destroy them in the proccess. This card can have its appearance changed \
+			like any other chameleon item."
+	item_cost = 24
+	path = /obj/item/weapon/card/emag
+
+/datum/uplink_item/item/tools/hacking_tool
+	name = "Door Hacking Tool"
+	item_cost = 24
+	path = /obj/item/device/multitool/hacktool
+	desc = "Appears and functions as a standard multitool until a screwdriver is used to toggle it. \
+			While in hacking mode, this device will grant full access to any airlock in 20 to 40 seconds. \
+			This device will be able to  continously reaccess the last 6 to 8  airlocks it was used on."
+
+/datum/uplink_item/item/tools/space_suit
+	name = "Voidsuit and Tactical Mask"
+	desc = "A satchel containing a non-regulation voidsuit, voidsuit helmet, tactical mask, and oxygen tank. Conceal your identity, while also not dying in space."
+	item_cost = 28
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/space
+
+/datum/uplink_item/item/tools/thermal
+	name = "Thermal Imaging Glasses"
+	desc = "A pair of meson goggles that have been modified to instead show synthetics or living creatures, through thermal imaging."
+	item_cost = 24
+	path = /obj/item/clothing/glasses/thermal/syndi
+
+/datum/uplink_item/item/tools/flashdark
+	name = "Flashdark"
+	desc = "A device similar to a flash light that absorbs the surrounding light, casting a shadowy, black mass."
+	item_cost = 32
+	path = /obj/item/device/flashlight/flashdark
+
+/datum/uplink_item/item/tools/powersink
+	name = "Powersink (DANGER!)"
+	desc = "A device, that when bolted down to an exposed wire, spikes the surrounding electrical systems, draining power at an alarming rate. Use with caution, as this will be extremely noticable to anyone monitoring the power systems."
+	item_cost = 40
+	path = /obj/item/device/powersink
+
+/datum/uplink_item/item/tools/teleporter
+	name = "Teleporter Circuit Board"
+	desc = "A circuit board that can be used to create a teleporter console, able to lock onto detected teleportation beacons. Requires a projector and teleporter hub nearby to work."
+	item_cost = 40
+	path = /obj/item/weapon/circuitboard/teleporter
+
+/datum/uplink_item/item/tools/teleporter/New()
+	..()
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/tools/ai_module
+	name = "Hacked AI Upload Module"
+	desc = "A module that can be used anonymously add a singular, top level law to an active AI. All you need to do is write in the law and insert it into any available AI Upload Console."
+	item_cost = 52
+	path = /obj/item/weapon/aiModule/syndicate
+
+/datum/uplink_item/item/tools/supply_beacon
+	name = "Hacked Supply Beacon (DANGER!)"
+	desc = "Wrench this large beacon onto an exposed power cable, in order to activate it. This will call in a drop pod to the target location, containing a random assortment of (possibly useful) items. The ship's computer system will announce when this pod is enroute."
+	item_cost = 52
+	path = /obj/item/supply_beacon
+
+/datum/uplink_item/item/tools/camera_mask
+	name = "Camera MIU"
+	desc = "Wearing this mask allows you to remotely view any cameras you currently have access to. Take the mask off to stop viewing."
+	item_cost = 60
+	antag_costs = list(MODE_MERCENARY = 30)
+	path = /obj/item/clothing/mask/ai
+
+/datum/uplink_item/item/tools/interceptor
+	name = "Radio Interceptor"
+	item_cost = 30
+	path = /obj/item/device/radio/intercept
+	desc = "A reciever-like device that can intercept secure radio channels. This item is too big to fit into your pockets."
+
+/datum/uplink_item/item/tools/ttv
+	name = "Binary Gas Bomb"
+	item_cost = 30
+	path = /obj/effect/spawner/newbomb/traitor
+	desc = "A remote-activated phoron-oxygen bomb assembly with an included signaler. \
+			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"

--- a/grenades.dm
+++ b/grenades.dm
@@ -1,0 +1,84 @@
+/***********
+* Grenades *
+************/
+/datum/uplink_item/item/grenades
+	category = /datum/uplink_category/grenades
+
+/datum/uplink_item/item/grenades/anti_photon
+	name = "1x Photon Disruption Grenade"
+	desc = "An experimental device for temporarily removing light in a limited area for a small amount of time."
+	item_cost = 4
+	path = /obj/item/weapon/grenade/anti_photon
+
+/datum/uplink_item/item/grenades/anti_photons
+	name = "5x Photon Disruption Grenades"
+	item_cost = 16
+	path = /obj/item/weapon/storage/box/anti_photons
+
+/datum/uplink_item/item/grenades/smoke
+	name = "1x Smoke Grenade"
+	desc = "A grenade that will erupt into a vision obscuring cloud of smoke. Makes for great getaways!"
+	item_cost = 4
+	path = /obj/item/weapon/grenade/smokebomb
+
+/datum/uplink_item/item/grenades/smokes
+	name = "5x Smoke Grenades"
+	item_cost = 16
+	path = /obj/item/weapon/storage/box/smokes
+
+/datum/uplink_item/item/grenades/emp
+	name = "1x EMP Grenade"
+	desc = "A grenade that will send electronics into a frenzy, or possibly fry them altogether. The timer is adjustable with a screwdriver."
+	item_cost = 8
+	path = /obj/item/weapon/grenade/empgrenade
+
+/datum/uplink_item/item/grenades/emps
+	name = "5x EMP Grenades"
+	item_cost = 24
+	path = /obj/item/weapon/storage/box/emps
+
+/datum/uplink_item/item/grenades/frag_high_yield
+	name = "Fragmentation Bomb"
+	item_cost = 24
+	antag_roles = list(MODE_MERCENARY) // yeah maybe regular traitors shouldn't be able to get these
+	path = /obj/item/weapon/grenade/frag/high_yield
+
+/datum/uplink_item/item/grenades/fragshell
+	name = "1x Fragmentation Shell"
+	desc = "Weaker than standard fragmentation grenades, these devices can be fired from a grenade launcher."
+	item_cost = 10
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/grenade/frag/shell
+
+/datum/uplink_item/item/grenades/fragshells
+	name = "5x Fragmentation Shells"
+	desc = "Weaker than standard fragmentation grenades, these devices can be fired from a grenade launcher."
+	item_cost = 40
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/storage/box/fragshells
+
+/datum/uplink_item/item/grenades/frag
+	name = "1x Fragmentation Grenade"
+	item_cost = 10
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/grenade/frag
+
+/datum/uplink_item/item/grenades/frags
+	name = "5x Fragmentation Grenades"
+	item_cost = 40
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/storage/box/frags
+
+/datum/uplink_item/item/grenades/supermatter
+	name = "1x Supermatter Grenade"
+	desc = "This grenade contains a small supermatter shard which will delaminate upon activation and pull in nearby objects, irradiate lifeforms, and eventually explode."
+	item_cost = 15
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/grenade/supermatter
+
+/datum/uplink_item/item/grenades/supermatters
+	name = "5x Supermatter Grenades"
+	desc = "These grenades contains a small supermatter shard which will delaminate upon activation and pull in nearby objects, irradiate lifeforms, and eventually explode."
+	item_cost = 60
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/storage/box/supermatters

--- a/hardsuit_modules.dm
+++ b/hardsuit_modules.dm
@@ -1,0 +1,48 @@
+/*******************
+* Hardsuit Modules *
+*******************/
+/datum/uplink_item/item/hardsuit_modules
+	category = /datum/uplink_category/hardsuit_modules
+
+/datum/uplink_item/item/hardsuit_modules/thermal
+	name = "\improper Thermal Scanner"
+	desc = "A module capable of giving vision of synthetic or living creatures, through thermal imaging."
+	item_cost = 16
+	path = /obj/item/rig_module/vision/thermal
+
+/datum/uplink_item/item/hardsuit_modules/energy_net
+	name = "\improper Net Projector"
+	desc = "A module capable of creating an energy net device that can be thrown in order to capture targets like the prey they are."
+	item_cost = 20
+	path = /obj/item/rig_module/fabricator/energy_net
+
+/datum/uplink_item/item/hardsuit_modules/ewar_voice
+	name = "\improper Electrowarfare Suite and Voice Synthesiser"
+	desc = "Includes two modules that, once installed and activated, are capable of masking your voice and disrupting the AI from tracking you."
+	item_cost = 24
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/ewar_voice
+
+/datum/uplink_item/item/hardsuit_modules/maneuvering_jets
+	name = "\improper Maneuvering Jets"
+	desc = "A module capable of giving your suit an active thrust system, so that you can maneuver in zero gravity."
+	item_cost = 32
+	path = /obj/item/rig_module/maneuvering_jets
+
+/datum/uplink_item/item/hardsuit_modules/egun
+	name = "\improper Mounted Energy Gun"
+	desc = "A module that drains your power reserves in order to fire an arm mounted energy gun."
+	item_cost = 48
+	path = /obj/item/rig_module/mounted/egun
+
+/datum/uplink_item/item/hardsuit_modules/power_sink
+	name = "\improper Power Sink"
+	desc = "A module capable of recharging your suit's power reserves, by tapping into an exposed, live wire."
+	item_cost = 48
+	path = /obj/item/rig_module/power_sink
+
+/datum/uplink_item/item/hardsuit_modules/laser_canon
+	name = "\improper Mounted Laser Cannon"
+	desc = "A module capable of draining your suit's power reserves in order to fire a shoulder mounted laser cannon."
+	item_cost = 64
+	path = /obj/item/rig_module/mounted/lcannon
+	antag_roles = list(MODE_MERCENARY)

--- a/highly_visible_and_dangerous_weapons.dm
+++ b/highly_visible_and_dangerous_weapons.dm
@@ -1,0 +1,165 @@
+/***************************************
+* Highly Visible and Dangerous Weapons *
+***************************************/
+/datum/uplink_item/item/visible_weapons
+	category = /datum/uplink_category/visible_weapons
+
+/datum/uplink_item/item/visible_weapons/dartgun
+	name = "Dart Gun"
+	desc = "A gas-powered dart gun capable of delivering chemical payloads across short distances. Uses a unique cartridge loaded with hollow darts."
+	item_cost = 20
+	path = /obj/item/weapon/gun/projectile/dartgun
+
+/datum/uplink_item/item/visible_weapons/crossbow
+	name = "Energy Crossbow"
+	desc = "A self-recharging, almost silent weapon employed by stealth operatives."
+	item_cost = 24
+	path = /obj/item/weapon/gun/energy/crossbow
+
+/datum/uplink_item/item/visible_weapons/energy_sword
+	name = "Energy Sword"
+	desc = "A hilt, that when activated, creates a solid beam of pure energy in the form of a sword.Able to slice through people like butter!"
+	item_cost = 32
+	path = /obj/item/weapon/melee/energy/sword
+
+/datum/uplink_item/item/visible_weapons/silenced
+	name = "Silenced Holdout Pistol"
+	desc = "A kit with a pocket-sized pistol, silencer, and an extra 7mm magazine. Attaching the silencer will make it to big to conceal in your pocket."
+	item_cost = 32
+	path = /obj/item/weapon/storage/box/syndie_kit/silenced
+
+/datum/uplink_item/item/badassery/money_cannon
+	name = "Modified Money Cannon"
+	item_cost = 48
+	path = /obj/item/weapon/gun/launcher/money/hacked
+	desc = "Too much money? Not enough screaming? Try the Money Cannon."
+
+/datum/uplink_item/item/visible_weapons/riggedlaser
+	name = "Exosuit (APLU) Rigged Laser"
+	item_cost = 32
+	path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/riggedlaser
+
+/datum/uplink_item/item/visible_weapons/energy_gun
+	name = "Energy Gun"
+	desc = "A energy based sidearm with three different lethality settings."
+	item_cost = 32
+	path = /obj/item/weapon/gun/energy/gun
+
+/datum/uplink_item/item/visible_weapons/revolver
+	name = "Magnum Revolver"
+	desc = "A high-caliber revolver. Includes an extra speedloader of 15mm ammo."
+	item_cost = 56
+	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
+
+/datum/uplink_item/item/visible_weapons/grenade_launcher
+	name = "Grenade Launcher"
+	desc = "A pump action grenade launcher loaded with a random assortment of grenades"
+	item_cost = 60
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/gun/launcher/grenade/loaded
+
+//These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
+/datum/uplink_item/item/visible_weapons/submachinegun
+	name = "Submachine Gun"
+	desc = "A quick-firing gun with three togglable fire modes, that uses 10mm ammunition."
+	item_cost = 52
+	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/visible_weapons/assaultrifle
+	name = "Assault Rifle"
+	desc = "A standard rifle with three togglable fire modes, that uses 7mmR ammunition."
+	item_cost = 60
+	path = /obj/item/weapon/gun/projectile/automatic/assault_rifle
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/visible_weapons/advanced_energy_gun
+	name = "Advanced Energy Gun"
+	desc = "A highly experimental heavy energy weapon, with three different lethality settings."
+	item_cost = 60
+	path = /obj/item/weapon/gun/energy/gun/nuclear
+
+/datum/uplink_item/item/visible_weapons/heavysniper
+	name = "Anti-materiel Rifle"
+	desc = "A secure briefcase that contains an immensely powerful penetrating rifle, as well as seven extra 15mmR rounds."
+	item_cost = 68
+	path = /obj/item/weapon/storage/secure/briefcase/heavysniper
+	antag_roles = list(MODE_MERCENARY)
+
+/*
+/datum/uplink_item/item/visible_weapons/psi_amp
+	name = "Cerebroenergetic Psionic Amplifier"
+	item_cost = 50
+	path = /obj/item/clothing/head/helmet/space/psi_amp/lesser
+	desc = "A powerful, illegal psi-amp. Boosts latent psi-faculties to extremely high levels."
+*/
+
+/datum/uplink_item/item/visible_weapons/machine_pistol
+	name = "Machine Pistol"
+	desc = "A high rate of fire weapon, able to sling 10mm ammunition almost as quick as a submachine gun."
+	item_cost = 45
+	path = /obj/item/weapon/gun/projectile/automatic/machine_pistol
+
+/datum/uplink_item/item/visible_weapons/combat_shotgun
+	name = "Combat Shotgun"
+	desc = "A high compacity, pump-action shotgun regularly used for repelling boarding parties in close range scenarios."
+	item_cost = 52
+	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/visible_weapons/sawnoff
+	name = "Sawnoff Shotgun"
+	desc = "A shortened double-barrel shotgun, able to fire either one, or both, barrels at once."
+	item_cost = 45
+	path = /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn
+
+/datum/uplink_item/item/visible_weapons/deagle
+	name = "Magnum Pistol"
+	desc = "A high-caliber pistol that uses 15mm ammunition."
+	item_cost = 52
+	path = /obj/item/weapon/gun/projectile/pistol/magnum_pistol
+
+/datum/uplink_item/item/visible_weapons/sigsauer
+	name = "Military Pistol"
+	desc = "A Navy issued sidearm that uses 10mm ammunition."
+	item_cost = 40
+	path = /obj/item/weapon/gun/projectile/pistol/military/alt
+
+/datum/uplink_item/item/visible_weapons/detective_revolver
+	name = "Holdout Revolver"
+	desc = "A pocket-sized revolver that uses 7mm ammunition."
+	item_cost = 24
+	path = /obj/item/weapon/gun/projectile/revolver/holdout
+
+/datum/uplink_item/item/visible_weapons/pulserifle
+	name = "Pulse Rifle"
+	desc = "A triple burst, heavy laser rifle, with a large battery compacity."
+	item_cost = 68
+	path = /obj/item/weapon/gun/energy/pulse_rifle
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/visible_weapons/flechetterifle
+	name = "Flechette Rifle"
+	desc = "A railgun with two togglable fire modes, able to launch flechette ammunition at incredible speeds."
+	item_cost = 60
+	path = /obj/item/weapon/gun/magnetic/railgun/flechette
+	antag_roles = list(MODE_MERCENARY)
+
+/datum/uplink_item/item/visible_weapons/railgun // Like a semi-auto AMR
+	name = "Railgun"
+	desc = "An anti-armour magnetic launching system fed by a high-capacity matter cartridge, capable of firing slugs at intense speeds."
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6
+	antag_roles = list(MODE_MERCENARY)
+	path = /obj/item/weapon/gun/magnetic/railgun
+
+/datum/uplink_item/item/visible_weapons/railguntcc // Only slightly better than the normal railgun; but cooler looking
+	name = "Advanced Railgun"
+	desc = "A modified prototype of the original railgun implement, this time boring slugs out of steel rods loaded into the chamber, now with even MORE stopping power."
+	antag_roles = list(MODE_MERCENARY)
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	path = /obj/item/weapon/gun/magnetic/railgun/tcc
+
+/datum/uplink_item/item/visible_weapons/harpoonbomb
+	name = "Explosive Harpoon"
+	item_cost = 12
+	path = /obj/item/weapon/material/harpoon/bomb

--- a/implants.dm
+++ b/implants.dm
@@ -1,0 +1,38 @@
+/***********
+* Implants *
+***********/
+/datum/uplink_item/item/implants
+	category = /datum/uplink_category/implants
+
+/datum/uplink_item/item/implants/imp_freedom
+	name = "Freedom Implant"
+	desc = "An implant with an emotive trigger that can break you free of restraints. Show Security who has the real upperhand!"
+	item_cost = 24
+	path = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
+
+/datum/uplink_item/item/implants/imp_compress
+	name = "Compressed Matter Implant"
+	desc = "An implant with an emotive trigger used to hide a handheld item in your body. Activating it materializes the item in your hand."
+	item_cost = 32
+	path = /obj/item/weapon/storage/box/syndie_kit/imp_compress
+
+/datum/uplink_item/item/implants/imp_explosive
+	name = "Explosive Implant (DANGER!)"
+	desc = "An explosive impant activated with a vocal trigger or radio signal. Use the included pad to adjust the settings before implanting."
+	item_cost = 40
+	path = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
+
+/datum/uplink_item/item/implants/imp_uplink
+	name = "Uplink Implant"
+	path = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
+
+/datum/uplink_item/item/implants/imp_uplink/New()
+	..()
+	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
+	desc = "This implant holds an uplink containing [IMPLANT_TELECRYSTAL_AMOUNT(DEFAULT_TELECRYSTAL_AMOUNT)] telecrystals, activatable with an emotive trigger. You will have access to it, as long as it is still inside of you."
+
+/datum/uplink_item/item/implants/imp_imprinting
+	name = "Neural Subjugation Implant"
+	desc = "An implant able to be used on someone who is under the influence of Mindbreaker Toxin to give them a law-like set of instructions to follow. This kit contains a dose of Mindbreaker Toxin."
+	item_cost = 20
+	path = /obj/item/weapon/storage/box/syndie_kit/imp_imprinting

--- a/medical.dm
+++ b/medical.dm
@@ -1,0 +1,23 @@
+/**********
+* Medical *
+**********/
+/datum/uplink_item/item/medical
+	category = /datum/uplink_category/medical
+
+/datum/uplink_item/item/medical/sinpockets
+	name = "Box of Sin-Pockets"
+	desc = "A box of filled dough pockets. Great for a quick meal when you're hiding from Security. Instructions included on the box."
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/sinpockets
+
+/datum/uplink_item/item/medical/surgery
+	name = "Surgery Kit"
+	desc = "Contains all the tools needed for on the spot surgery, assuming you actually know what you're doing with them. Floor sterilization not included."
+	item_cost = 40
+	path = /obj/item/weapon/storage/firstaid/surgery
+
+/datum/uplink_item/item/medical/combat
+	name = "Combat Medical Kit"
+	desc = "Contains most medicines you need to recover from injuries and illnesses, all in a convenient pill form. Splints for broken bones also included!"
+	item_cost = 48
+	path = /obj/item/weapon/storage/firstaid/combat

--- a/services.dm
+++ b/services.dm
@@ -1,0 +1,244 @@
+/***********
+* Services *
+************/
+/datum/uplink_item/item/services
+	category = /datum/uplink_category/services
+
+/datum/uplink_item/item/services/fake_ion_storm
+	name = "Ion Storm Announcement"
+	desc = "A single-use device, that when activated, fakes an announcement, so people think all their electronic readings are wrong."
+	item_cost = 8
+	path = /obj/item/device/uplink_service/fake_ion_storm
+
+/datum/uplink_item/item/services/suit_sensor_garble
+	name = "Complete Suit Sensor Jamming"
+	desc = "A single-use device, that when activated, garbles all suit sensor data for 10 minutes."
+	item_cost = 16
+	path = /obj/item/device/uplink_service/jamming/garble
+
+/datum/uplink_item/item/services/fake_rad_storm
+	name = "Radiation Storm Announcement"
+	desc = "A single-use device, that when activated, fakes an announcement, so people run to the tunnels in fear of being irradiated! "
+	item_cost = 24
+	path = /obj/item/device/uplink_service/fake_rad_storm
+
+/datum/uplink_item/item/services/fake_crew_annoncement
+	name = "Crew Arrival Announcement and Records"
+	desc = "A single-use device, that when activated, creates a fake crew arrival announcement as well as fake crew records, using your current appearance (including held items!) and worn id card. Prepare well!"
+	item_cost = 16
+	path = /obj/item/device/uplink_service/fake_crew_announcement
+
+/datum/uplink_item/item/services/suit_sensor_shutdown
+	name = "Complete Suit Sensor Shutdown"
+	desc = "A single-use device, that when activated, completely disables all suit sensors for 10 minutes."
+	item_cost = 40
+	path = /obj/item/device/uplink_service/jamming
+
+/datum/uplink_item/item/services/fake_update_annoncement
+	item_cost = 40
+	path = /obj/item/device/uplink_service/fake_update_announcement
+
+/datum/uplink_item/item/services/fake_update_annoncement/New()
+	..()
+	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
+
+	spawn(2)
+		name = "[command_name()] Update Announcement"
+		desc = "Causes a falsified [command_name()] Update."
+
+/***************
+* Service Item *
+***************/
+
+#define AWAITING_ACTIVATION 0
+#define CURRENTLY_ACTIVE 1
+#define HAS_BEEN_ACTIVATED 2
+
+/obj/item/device/uplink_service
+	name = "tiny device"
+	desc = "Press button to activate. Can be done once and only once."
+	w_class = ITEM_SIZE_TINY
+	icon_state = "sflash"
+	var/state = AWAITING_ACTIVATION
+	var/service_label = "Unnamed Service"
+	var/service_duration = 0 SECONDS
+
+/obj/item/device/uplink_service/Destroy()
+	if(state == CURRENTLY_ACTIVE)
+		deactivate()
+	. = ..()
+
+/obj/item/device/uplink_service/examine(var/user)
+	. = ..(user, 1)
+	if(.)
+		switch(state)
+			if(AWAITING_ACTIVATION)
+				to_chat(user, "It is labeled '[service_label]' and appears to be awaiting activation.")
+			if(CURRENTLY_ACTIVE)
+				to_chat(user, "It is labeled '[service_label]' and appears to be active.")
+			if(HAS_BEEN_ACTIVATED)
+				to_chat(user, "It is labeled '[service_label]' and appears to be permanently disabled.")
+
+/obj/item/device/uplink_service/attack_self(var/mob/user)
+	if(state != AWAITING_ACTIVATION)
+		to_chat(user, "<span class='warning'>\The [src] won't activate again.</span>")
+		return
+	if(!(user.z in GLOB.using_map.station_levels))
+		to_chat(user, SPAN_WARNING("You are too far away from \the [GLOB.using_map.name] to make use of this service."))
+		return
+	if(!enable())
+		return
+	state = CURRENTLY_ACTIVE
+	update_icon()
+	user.visible_message("<span class='notice'>\The [user] activates \the [src].</span>", "<span class='notice'>You activate \the [src].</span>")
+	log_and_message_admins("has activated the service '[service_label]'", user)
+
+	if(service_duration)
+		addtimer(CALLBACK(src,/obj/item/device/uplink_service/proc/deactivate), service_duration)
+	else
+		deactivate()
+
+/obj/item/device/uplink_service/proc/deactivate()
+	if(state != CURRENTLY_ACTIVE)
+		return
+	disable()
+	state = HAS_BEEN_ACTIVATED
+	update_icon()
+	playsound(loc, "sparks", 50, 1)
+	visible_message("<span class='warning'>\The [src] shuts down with a spark.</span>")
+
+/obj/item/device/uplink_service/on_update_icon()
+	switch(state)
+		if(AWAITING_ACTIVATION)
+			icon_state = initial(icon_state)
+		if(CURRENTLY_ACTIVE)
+			icon_state = "flash_on"
+		if(HAS_BEEN_ACTIVATED)
+			icon_state = "flash_burnt"
+
+/obj/item/device/uplink_service/proc/enable(var/mob/user = usr)
+	return TRUE
+
+/obj/item/device/uplink_service/proc/disable(var/mob/user = usr)
+	return
+
+/*****************
+* Sensor Jamming *
+*****************/
+/obj/item/device/uplink_service/jamming
+	service_duration = 10 MINUTES
+	service_label = "Suit Sensor Shutdown"
+	var/suit_sensor_jammer_method/ssjm = /suit_sensor_jammer_method/cap_off
+
+/obj/item/device/uplink_service/jamming/New()
+	..()
+	ssjm = new ssjm()
+
+/obj/item/device/uplink_service/jamming/Destroy()
+	qdel(ssjm)
+	ssjm = null
+	. = ..()
+
+/obj/item/device/uplink_service/jamming/enable(var/mob/user = usr)
+	ssjm.enable()
+	. = ..()
+
+/obj/item/device/uplink_service/jamming/disable(var/mob/user = usr)
+	ssjm.disable()
+
+/obj/item/device/uplink_service/jamming/garble
+	service_label = "Suit Sensor Garble"
+	ssjm = /suit_sensor_jammer_method/random/moderate
+
+/*****************
+* Fake Ion storm *
+*****************/
+/obj/item/device/uplink_service/fake_ion_storm
+	service_label = "Ion Storm Announcement"
+
+/obj/item/device/uplink_service/fake_ion_storm/enable(var/mob/user = usr)
+	ion_storm_announcement()
+	. = ..()
+
+/*****************
+* Fake Rad storm *
+*****************/
+/obj/item/device/uplink_service/fake_rad_storm
+	service_label = "Radiation Storm Announcement"
+
+/obj/item/device/uplink_service/fake_rad_storm/enable(var/mob/user = usr)
+	var/datum/event_meta/EM = new(EVENT_LEVEL_MUNDANE, "Fake Radiation Storm", add_to_queue = 0)
+	new/datum/event/radiation_storm/syndicate(EM)
+	. = ..()
+
+/***************************
+* Fake CentCom Annoncement *
+***************************/
+/obj/item/device/uplink_service/fake_update_announcement
+	service_label = "Update Announcement"
+
+/obj/item/device/uplink_service/fake_update_announcement/enable(var/mob/user = usr)
+	var/title = sanitize(input(user, "Enter your announcement title.", "Announcement Title") as null|text)
+	if(!title)
+		return
+	var/message = sanitize(input(user, "Enter your announcement message.", "Announcement Title") as null|text)
+	if(!message)
+		return
+
+	if(CanUseTopic(user, GLOB.hands_state) != STATUS_INTERACTIVE)
+		return FALSE
+	command_announcement.Announce(message, title, msg_sanitized = 1)
+	return TRUE
+
+/*********************************
+* Fake Crew Records/Announcement *
+*********************************/
+/obj/item/device/uplink_service/fake_crew_announcement
+	service_label = "Crew Arrival Announcement and Records"
+
+#define COPY_VALUE(KEY) new_record.set_##KEY(random_record.get_##KEY())
+
+/obj/item/device/uplink_service/fake_crew_announcement/enable(var/mob/user = usr)
+
+	var/datum/computer_file/report/crew_record/random_record
+	var/obj/item/weapon/card/id/I = user.GetIdCard()
+	if(GLOB.all_crew_records.len)
+		random_record = pick(GLOB.all_crew_records)
+	var/datum/computer_file/report/crew_record/new_record = CreateModularRecord(user)
+	if(I)
+		new_record.set_name(I.registered_name)
+		new_record.set_formal_name("[I.formal_name_prefix][I.registered_name][I.formal_name_suffix]")
+		new_record.set_sex(I.sex)
+		new_record.set_age(I.age)
+		new_record.set_job(I.assignment)
+		new_record.set_fingerprint(I.fingerprint_hash)
+		new_record.set_bloodtype(I.blood_type)
+		new_record.set_dna(I.dna_hash)
+		if(I.military_branch)
+			new_record.set_branch(I.military_branch.name)
+			if(I.military_rank)
+				new_record.set_rank(I.military_rank.name)
+				new_record.set_formal_name("[I.registered_name][I.formal_name_suffix]") // Rank replaces formal name prefix in real manifest entries
+	if(random_record)
+		COPY_VALUE(faction)
+		COPY_VALUE(religion)
+		COPY_VALUE(homeSystem)
+		COPY_VALUE(fingerprint)
+		COPY_VALUE(dna)
+		COPY_VALUE(bloodtype)
+	var/datum/job/job = SSjobs.get_by_title(new_record.get_job())
+	if(job)
+		var/skills = list()
+		for(var/decl/hierarchy/skill/S in GLOB.skills)
+			var/level = job.min_skill[S.type]
+			if(prob(10))
+				level = min(rand(1,3), job.max_skill[S.type])
+			if(level > SKILL_NONE)
+				skills += "[S.name], [S.levels[level]]"
+		new_record.set_skillset(jointext(skills,"\n"))
+
+	if(istype(job) && job.announced)
+		AnnounceArrivalSimple(new_record.get_name(), new_record.get_job(), "has completed cryogenic revival", get_announcement_frequency(job))
+	. = ..()
+
+#undef COPY_VALUE

--- a/sniper.dm
+++ b/sniper.dm
@@ -1,0 +1,79 @@
+/obj/item/weapon/gun/projectile/heavysniper
+	name = "anti-materiel rifle"
+	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to be used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 15 mmR shells."
+	icon = 'icons/obj/guns/heavysniper.dmi'
+	icon_state = "heavysniper"
+	item_state = "heavysniper" //sort of placeholder
+	w_class = ITEM_SIZE_HUGE
+	force = 10
+	slot_flags = SLOT_BACK
+	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 2, TECH_ILLEGAL = 8)
+	caliber = CALIBER_ANTIMATERIAL
+	screen_shake = 2 //extra kickback
+	handle_casings = HOLD_CASINGS
+	load_method = SINGLE_CASING
+	max_shells = 1
+	ammo_type = /obj/item/ammo_casing/shell
+	one_hand_penalty = 6
+	accuracy = -2
+	bulk = 8
+	scoped_accuracy = 8 //increased accuracy over the LWAP because only one shot
+	scope_zoom = 2
+	var/bolt_open = 0
+	wielded_item_state = "heavysniper-wielded" //sort of placeholder
+	load_sound = 'sound/weapons/guns/interaction/rifle_load.ogg'
+	fire_delay = 12
+
+/obj/item/weapon/gun/projectile/heavysniper/on_update_icon()
+	..()
+	if(bolt_open)
+		icon_state = "heavysniper-open"
+	else
+		icon_state = "heavysniper"
+
+/obj/item/weapon/gun/projectile/heavysniper/handle_post_fire(mob/user, atom/target, var/pointblank=0, var/reflex=0)
+	..()
+	if(user && user.skill_check(SKILL_WEAPONS, SKILL_PROF))
+		to_chat(user, "<span class='notice'>You work the bolt open with a reflexive motion, ejecting [chambered]!</span>")
+		unload_shell()
+
+/obj/item/weapon/gun/projectile/heavysniper/proc/unload_shell()
+	if(chambered)
+		if(!bolt_open)
+			playsound(src.loc, 'sound/weapons/guns/interaction/rifle_boltback.ogg', 50, 1)
+			bolt_open = 1
+		chambered.dropInto(src.loc)
+		loaded -= chambered
+		chambered = null
+
+/obj/item/weapon/gun/projectile/heavysniper/attack_self(mob/user as mob)
+	bolt_open = !bolt_open
+	if(bolt_open)
+		if(chambered)
+			to_chat(user, "<span class='notice'>You work the bolt open, ejecting [chambered]!</span>")
+			unload_shell()
+		else
+			to_chat(user, "<span class='notice'>You work the bolt open.</span>")
+	else
+		to_chat(user, "<span class='notice'>You work the bolt closed.</span>")
+		playsound(src.loc, 'sound/weapons/guns/interaction/rifle_boltforward.ogg', 50, 1)
+		bolt_open = 0
+	add_fingerprint(user)
+	update_icon()
+
+/obj/item/weapon/gun/projectile/heavysniper/special_check(mob/user)
+	if(bolt_open)
+		to_chat(user, "<span class='warning'>You can't fire [src] while the bolt is open!</span>")
+		return 0
+	return ..()
+
+/obj/item/weapon/gun/projectile/heavysniper/load_ammo(var/obj/item/A, mob/user)
+	if(!bolt_open)
+		return
+	..()
+
+/obj/item/weapon/gun/projectile/heavysniper/unload_ammo(mob/user, var/allow_dump=1)
+	if(!bolt_open)
+		return
+	..()
+

--- a/stealth_and_camouflage_items.dm
+++ b/stealth_and_camouflage_items.dm
@@ -1,0 +1,53 @@
+/*******************************
+* Stealth and Camouflage Items *
+*******************************/
+/datum/uplink_item/item/stealth_items
+	category = /datum/uplink_category/stealth_items
+
+/datum/uplink_item/item/stealth_items/syndigaloshes
+	name = "No-Slip Shoes"
+	desc = "These shoes have a non-slip grip on them, so those pesky janitors can't ruin your operations!"
+	item_cost = 4
+	path = /obj/item/clothing/shoes/syndigaloshes
+
+/datum/uplink_item/item/stealth_items/spy
+	name = "Bug Kit"
+	desc = "For when you want to conduct voyeurism from afar. Comes with 6 bugs to plant, and a monitoring device to pair them with."
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/syndie_kit/spy
+
+/datum/uplink_item/item/stealth_items/id
+	name = "Agent ID card"
+	desc = "A unique ID card that is completely configurable. Scan another ID card with it to clone its access capabilities."
+	item_cost = 12
+	path = /obj/item/weapon/card/id/syndicate
+
+/datum/uplink_item/item/stealth_items/chameleon_kit
+	name = "Chameleon Kit"
+	desc = "Comes with a full set of appearance changing clothing you need to impersonate most people.  Accessories, backpack, and gun included!"
+	item_cost = 20
+	path = /obj/item/weapon/storage/backpack/chameleon/sydie_kit
+
+/datum/uplink_item/item/stealth_items/voice
+	name = "Modified Gas Mask"
+	desc = "A fully functioning gas mask that is able to conceal your face and has a built in voice modulator, so you can become a true shadow operative!"
+	item_cost = 20
+	path = /obj/item/clothing/mask/chameleon/voice
+
+/datum/uplink_item/item/stealth_items/chameleon_projector
+	name = "Chameleon Projector"
+	desc = "Use this to scan a small, portable object in order to disguise yourself as said object."
+	item_cost = 32
+	path = /obj/item/device/chameleon
+
+/datum/uplink_item/item/stealth_items/sneakies
+	name = "Sneakies"
+	desc = "A fashionable pair of polished dress shoes. The soles are made in a way so that any tracks you leave look like they are traveling the opposite direction."
+	item_cost = 4
+	path = /obj/item/clothing/shoes/laceup/sneakies
+
+/datum/uplink_item/item/stealth_items/smuggler_satchel
+	name = "Smuggler's Satchel"
+	desc = "This satchel is thin enough to be hidden in the gap between plating and tiling, great for stashing your stolen goods. Comes with a crowbar and a floor tile inside."
+	item_cost = 20
+	path = /obj/item/weapon/storage/backpack/satchel/flat

--- a/stealthy_and_inconspicuous_weapons.dm
+++ b/stealthy_and_inconspicuous_weapons.dm
@@ -1,0 +1,40 @@
+/*************************************
+* Stealthy and Inconspicuous Weapons *
+*************************************/
+/datum/uplink_item/item/stealthy_weapons
+	category = /datum/uplink_category/stealthy_weapons
+
+/datum/uplink_item/item/stealthy_weapons/soap
+	name = "Subversive Soap"
+	item_cost = 1
+	path = /obj/item/weapon/soap/syndie
+
+/datum/uplink_item/item/stealthy_weapons/cigarette_kit
+	name = "Box of Tricky Cigarettes"
+	desc = "A box with some 'special' packs in the following order: 2x Flashes, 2x Smokes, 1x MindBreaker Toxin, and 1x Tricordrazine. Try not to mix them up!"
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/syndie_kit/cigarette
+
+/datum/uplink_item/item/stealthy_weapons/concealed_cane
+	name = "Concealed Cane Sword"
+	desc = "A cane used by a true gentlemen, especially ones with sharp intentions."
+	item_cost = 8
+	path = /obj/item/weapon/cane/concealed
+
+/datum/uplink_item/item/stealthy_weapons/random_toxin
+	name = "Random Toxin Vial"
+	desc = "Contains one of an assortment of nasty toxins, with a single syringe included. Don't worry, its labeled. "
+	item_cost = 8
+	path = /obj/item/weapon/storage/box/syndie_kit/toxin
+
+/datum/uplink_item/item/stealthy_weapons/sleepy
+	name = "Sleepy Pen"
+	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be out like a light."
+	item_cost = 20
+	path = /obj/item/weapon/pen/reagent/sleepy
+
+/datum/uplink_item/item/stealthy_weapons/syringegun
+	name = "Disguised Syringe Gun"
+	desc = "A syringe gun disguised as an electronic cigarette with 4 darts included in the box. Chemicals not included!"
+	item_cost = 10
+	path = /obj/item/weapon/storage/box/syndie_kit/syringegun

--- a/telecrystals.dm
+++ b/telecrystals.dm
@@ -1,0 +1,41 @@
+/***************
+* Telecrystals *
+***************/
+/datum/uplink_item/item/telecrystal
+	category = /datum/uplink_category/telecrystals
+	desc = "Acquire the uplink crystals in pure form."
+
+/datum/uplink_item/item/telecrystal/get_goods(var/obj/item/device/uplink/U, var/loc)
+	return new /obj/item/stack/telecrystal(loc, cost(U.uses, U))
+
+/datum/uplink_item/item/telecrystal/one
+	name = "1x Telecrystal"
+	desc = "Remove 1 telecrystal from this uplink."
+	item_cost = 1
+
+/datum/uplink_item/item/telecrystal/five
+	name = "5x Telecrystals"
+	desc = "Remove 5 telecrystals from this uplink."
+	item_cost = 5
+
+/datum/uplink_item/item/telecrystal/ten
+	name = "10x Telecrystals"
+	desc = "Remove 10 telecrystals from this uplink."
+	item_cost = 10
+
+/datum/uplink_item/item/telecrystal/twentyfive
+	name = "25x Telecrystals"
+	desc = "Remove 25 telecrystals from this uplink."
+	item_cost = 25
+
+/datum/uplink_item/item/telecrystal/fifty
+	name = "50x Telecrystals"
+	desc = "Remove 50 telecrystals from this uplink."
+	item_cost = 50
+
+/datum/uplink_item/item/telecrystal/all
+	name = "Empty Uplink"
+	desc = "Completely empties this uplink of all remaining telecrystals."
+
+/datum/uplink_item/item/telecrystal/all/cost(var/telecrystals, obj/item/device/uplink/U)
+	return max(1, telecrystals)

--- a/uplink.tmpl
+++ b/uplink.tmpl
@@ -1,0 +1,89 @@
+
+<!-- 
+Title: Syndicate Uplink, uses some javascript to change nanoUI up a bit.
+Used In File(s): \code\game\objects\items\devices\uplinks.dm
+ -->
+{{:helper.syndicateMode()}}
+<H2><span class="white">{{:data.welcome}}</span></H2>
+<br>
+<div class="item">
+	<div class="itemLabelNarrow">
+		<b>Functions</b>:
+	</div>
+	<div class="itemContent">
+		{{:helper.link('Request Items', 'gear', {'menu' : 0}, null, 'fixedLeftWider')}}
+		{{:helper.link('Exploitable Information', 'gear', {'menu' : 2}, null, 'fixedLeftWider')}}
+		{{:helper.link('Return', 'arrowreturn-1-w', {'return' : 1}, null, 'fixedLeft')}}
+		{{:helper.link('Close', 'gear', {'lock' : "1"}, null, 'fixedLeft')}}
+	</div>
+</div>
+<br>
+
+{{if data.menu == 0 || data.menu == 1}}
+	<div class="item">
+		<div class="itemLabel">
+			<b>Telecrystals</b>:
+		</div>
+		<div class="itemContent">
+			{{:data.crystals}}
+		</div>
+	</div>
+
+	{{if data.discount_amount < 100}}
+		<div class="item">
+			<div class="itemLabel">
+				<b>Currently discounted</b>:
+			</div>
+			<div class="itemContent">
+				{{:data.discount_category}}<br>{{:data.discount_name}}<br>{{:data.discount_amount}}% off. Offer will expire at: {{:data.offer_expiry}}
+			</div>
+		</div>
+	{{/if}}
+{{/if}}
+
+{{if data.menu == 0}}
+	<H2>Categories:</H2>
+	{{for data.categories}}
+		<div class="item">
+			{{:helper.link(value.name, 'gear', {'menu' : 1, 'category' : value.ref})}}
+		</div>
+	{{/for}}
+{{else data.menu == 1}}
+    <H2><span class="white">Request items:</span></H2>
+    <span class="white"><i>Each item costs a number of tele-crystals as indicated by the number following their name.</i></span>
+	
+	{{for data.items}}
+		<div class="item">
+			{{:helper.link(value.name, 'gear', {'buy_item' : value.ref}, value.can_buy ? null : 'disabled')}} - <span class="white">{{:value.cost}}</span>
+		</div>
+		<div class="item">
+			{{:value.description}}
+		</div>
+    {{/for}}
+{{else data.menu == 2}}
+    <H2><span class="white">Information Record List:</span></H2>
+    <br>
+    <div class="item">
+        Select a Record
+    </div>
+    <br>
+    {{for data.exploit_records}}
+        <div class="item">
+             {{:helper.link(value.Name, value.exploit ? 'gear' : 'document', {'menu' : 21, 'id' : value.id}, null, value.exploit ? 'redButton' : null)}}
+        </div>
+    {{/for}}
+{{else data.menu == 21}}
+    <H2><span class="white">Information Record:</span></H2>
+    <br>
+    <div class="statusDisplayRecords">
+        <div class="item">
+            <div class="itemContent" style="width: 100%;">
+                {{if data.exploit_exists == 1}}
+					{{for data.exploit.fields}}
+                  	  <span class="good">{{:value.name}}:		</span> <span class="average">{{:value.value}}</span><br>
+					{{/for}}
+                {{/if}}
+            </div>
+        </div>
+    </div>
+{{/if}}

--- a/uplink_categories.dm
+++ b/uplink_categories.dm
@@ -1,0 +1,49 @@
+/datum/uplink_category
+	var/name = ""
+	var/list/datum/uplink_item/items
+
+/datum/uplink_category/New()
+	..()
+	items = list()
+
+/datum/uplink_category/proc/can_view(obj/item/device/uplink/U)
+	for(var/datum/uplink_item/item in items)
+		if(item.can_view(U))
+			return 1
+	return 0
+
+/datum/uplink_category/ammunition
+	name = "Ammunition"
+
+/datum/uplink_category/grenades
+	name = "Grenades"
+
+/datum/uplink_category/visible_weapons
+	name = "Loud & Dangerous Weaponry"
+
+/datum/uplink_category/stealthy_weapons
+	name = "Disguised & Inconspicuous Weaponry"
+
+/datum/uplink_category/stealth_items
+	name = "Stealth & Camouflage Accessories"
+
+/datum/uplink_category/tools
+	name = "Devices & Tools"
+
+/datum/uplink_category/implants
+	name = "Implants"
+
+/datum/uplink_category/medical
+	name = "Medical & Food"
+
+/datum/uplink_category/hardsuit_modules
+	name = "Hardsuit Modules"
+
+/datum/uplink_category/services
+	name = "Jamming & Announcements"
+
+/datum/uplink_category/badassery
+	name = "Badassery"
+
+/datum/uplink_category/telecrystals
+	name = "Telecrystal Materialization"

--- a/uplink_items.dm
+++ b/uplink_items.dm
@@ -1,0 +1,164 @@
+var/datum/uplink/uplink = new()
+
+/datum/uplink
+	var/list/items_assoc
+	var/list/datum/uplink_item/items
+	var/list/datum/uplink_category/categories
+
+/datum/uplink/New()
+	items_assoc = list()
+	items = init_subtypes(/datum/uplink_item)
+	categories = init_subtypes(/datum/uplink_category)
+	categories = dd_sortedObjectList(categories)
+
+	for(var/datum/uplink_item/item in items)
+		if(!item.name)
+			items -= item
+			continue
+
+		items_assoc[item.type] = item
+
+		for(var/datum/uplink_category/category in categories)
+			if(item.category == category.type)
+				category.items += item
+				item.category = category
+
+	for(var/datum/uplink_category/category in categories)
+		category.items = dd_sortedObjectList(category.items)
+
+/datum/uplink_item
+	var/name
+	var/desc
+	var/item_cost = 0
+	var/list/antag_costs = list()			// Allows specific antag roles to purchase at a different cost
+	var/datum/uplink_category/category		// Item category
+	var/list/datum/antagonist/antag_roles = list("Exclude", MODE_DEITY)	// Antag roles this item is displayed to. If empty, display to all. If it includes 'Exclude", anybody except this role can view it
+
+/datum/uplink_item/item
+	var/path = null
+
+/datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
+	var/extra_args = extra_args(user)
+	if(!extra_args)
+		return
+
+	if(!can_buy(U))
+		return
+
+	var/cost = cost(U.uses, U)
+
+	var/goods = get_goods(U, get_turf(user), user, extra_args)
+	if(!goods)
+		return
+
+	purchase_log(U, user, cost)
+	U.uses -= cost
+	U.used_TC += cost
+	return goods
+
+// Any additional arguments you wish to send to the get_goods
+/datum/uplink_item/proc/extra_args(var/mob/user)
+	return 1
+
+/datum/uplink_item/proc/can_buy(obj/item/device/uplink/U)
+	if(cost(U.uses, U) > U.uses)
+		return 0
+
+	return can_view(U)
+
+/datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
+	// Making the assumption that if no uplink was supplied, then we don't care about antag roles
+	if(!U || !antag_roles.len)
+		return 1
+
+	// With no owner, there's no need to check antag status.
+	if(!U.uplink_owner)
+		return 0
+
+	for(var/antag_role in antag_roles)
+		if(antag_role == "Exclude")
+			continue
+		var/datum/antagonist/antag = GLOB.all_antag_types_[antag_role]
+		if(antag.is_antagonist(U.uplink_owner))
+			return !("Exclude" in antag_roles)
+	return ("Exclude" in antag_roles)
+
+/datum/uplink_item/proc/cost(var/telecrystals, obj/item/device/uplink/U)
+	. = item_cost
+	if(U && U.uplink_owner)
+		for(var/antag_role in antag_costs)
+			var/datum/antagonist/antag = GLOB.all_antag_types_[antag_role]
+			if(antag.is_antagonist(U.uplink_owner))
+				. = min(antag_costs[antag_role], .)
+	return max(1, U ?  U.get_item_cost(src, .) : .)
+
+/datum/uplink_item/proc/name()
+	return name
+
+/datum/uplink_item/proc/description()
+	return desc
+
+// get_goods does not necessarily return physical objects, it is simply a way to acquire the uplink item without paying
+/datum/uplink_item/proc/get_goods(var/obj/item/device/uplink/U, var/loc)
+	return 0
+
+/datum/uplink_item/proc/log_icon()
+	return
+
+/datum/uplink_item/proc/purchase_log(obj/item/device/uplink/U, var/mob/user, var/cost)
+	SSstatistics.add_field_details("traitor_uplink_items_bought", "[src]")
+	log_and_message_admins("used \the [U.loc] to buy \a [src]")
+	if(user)
+		uplink_purchase_repository.add_entry(user.mind, src, cost)
+
+datum/uplink_item/dd_SortValue()
+	return cost(INFINITY, null)
+
+/********************************
+*                           	*
+*	Physical Uplink Entries		*
+*                           	*
+********************************/
+/datum/uplink_item/item/buy(var/obj/item/device/uplink/U, var/mob/user)
+	var/obj/item/I = ..()
+	if(!I)
+		return
+
+	if(istype(I, /list))
+		var/list/L = I
+		if(L.len) I = L[1]
+
+	if(istype(I) && ishuman(user))
+		var/mob/living/carbon/human/A = user
+		A.put_in_any_hand_if_possible(I)
+	return I
+
+/datum/uplink_item/item/get_goods(var/obj/item/device/uplink/U, var/loc)
+	var/obj/item/I = new path(loc)
+	return I
+
+/datum/uplink_item/item/description()
+	if(!desc)
+		// Fallback description
+		var/obj/temp = src.path
+		desc = initial(temp.desc)
+	return ..()
+
+/datum/uplink_item/item/log_icon()
+	var/obj/I = path
+	return "\icon[I]"
+
+/****************
+* Support procs *
+****************/
+/proc/get_random_uplink_items(var/obj/item/device/uplink/U, var/remaining_TC, var/loc)
+	var/list/bought_items = list()
+	while(remaining_TC)
+		var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/default)
+		var/datum/uplink_item/I = uplink_selection.get_random_item(remaining_TC, U, bought_items)
+		if(!I)
+			break
+		bought_items += I
+		remaining_TC -= I.cost(remaining_TC, U)
+
+	return bought_items

--- a/uplink_sources.dm
+++ b/uplink_sources.dm
@@ -1,0 +1,139 @@
+#define NO_GUARANTEE_NO_EXTRA_COST_DESC(X) "Installs an uplink into " + X + " if, and only if, found on your person. Has no TC cost."
+
+#define SETUP_FAILED TRUE
+
+GLOBAL_LIST_INIT(default_uplink_source_priority, list(
+	/decl/uplink_source/pda,
+	/decl/uplink_source/radio,
+	/decl/uplink_source/unit))
+
+/decl/uplink_source
+	var/name
+	var/desc
+
+/decl/uplink_source/proc/setup_uplink_source(var/mob/M, var/amount)
+	return SETUP_FAILED
+
+/decl/uplink_source/pda
+	name = "PDA"
+	desc = NO_GUARANTEE_NO_EXTRA_COST_DESC("a PDA")
+
+/decl/uplink_source/pda/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/modular_computer/pda/P = find_in_mob(M, /obj/item/modular_computer/pda)
+	if(!P || !P.hard_drive)
+		return SETUP_FAILED
+
+	var/pda_pass = "[rand(100,999)] [pick(GLOB.greek_letters)]"
+	var/obj/item/device/uplink/T = new(P, M.mind, amount)
+	P.hidden_uplink = T
+	var/datum/computer_file/program/uplink/program = new(pda_pass)
+	if(!P.hard_drive.try_store_file(program))
+		P.hard_drive.remove_file(P.hard_drive.find_file_by_name(program.filename))	//Maybe it already has a fake copy.
+	if(!P.hard_drive.try_store_file(program))
+		return SETUP_FAILED	//Not enough space or other issues.
+	P.hard_drive.store_file(program)
+	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [P.name]. Simply enter the code \"[pda_pass]\" in your new program to unlock its hidden features.</span>")
+	M.mind.store_memory("<B>Uplink passcode:</B> [pda_pass] ([P.name]).")
+
+/decl/uplink_source/radio
+	name = "Radio"
+	desc = NO_GUARANTEE_NO_EXTRA_COST_DESC("a radio")
+
+/decl/uplink_source/radio/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/device/radio/R = find_in_mob(M, /obj/item/device/radio)
+	if(!R)
+		return SETUP_FAILED
+
+	var/freq = PUBLIC_LOW_FREQ
+	var/list/freqlist = list()
+	while (freq <= PUBLIC_HIGH_FREQ)
+		if (freq < 1451 || freq > PUB_FREQ)
+			freqlist += freq
+		freq += 2
+		if ((freq % 2) == 0)
+			freq += 1
+
+	freq = freqlist[rand(1, freqlist.len)]
+	var/obj/item/device/uplink/T = new(R, M.mind, amount)
+	R.hidden_uplink = T
+	R.traitor_frequency = freq
+	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [R.name]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features.</span>")
+	M.mind.store_memory("<B>Radio Freq:</B> [format_frequency(freq)] ([R.name]).")
+
+/decl/uplink_source/implant
+	name = "Implant"
+	desc = "Teleports an uplink implant into your head. Costs at least half the initial TC amount."
+
+/decl/uplink_source/implant/setup_uplink_source(var/mob/living/carbon/human/H, var/amount)
+	if(!istype(H))
+		return SETUP_FAILED
+
+	var/obj/item/organ/external/head = H.organs_by_name[BP_HEAD]
+	if(!head)
+		return SETUP_FAILED
+
+	var/obj/item/weapon/implant/uplink/U = new(H, IMPLANT_TELECRYSTAL_AMOUNT(amount))
+	U.imp_in = H
+	U.implanted = TRUE
+	U.part = head
+	head.implants += U
+
+	U.implanted(H) // This proc handles the installation feedback
+
+/decl/uplink_source/unit
+	name = "Uplink Unit"
+	desc = "Teleports an uplink unit to your location. Costs 10% of the initial TC amount."
+
+/decl/uplink_source/unit/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/device/radio/uplink/U = new(M, M.mind, round(amount * 0.9))
+	put_on_mob(M, U, "\A [U]")
+
+/decl/uplink_source/telecrystals
+	name = "Telecrystals"
+	desc = "Get your telecrystals in pure form, without the means to trade them for goods."
+
+/decl/uplink_source/telecrystals/setup_uplink_source(var/mob/M, var/amount)
+	var/obj/item/stack/telecrystal/TC = new(M, amount)
+	put_on_mob(M, TC, "[amount] telecrystal\s")
+
+/decl/uplink_source/proc/find_in_mob(var/mob/M, var/type)
+	for(var/item in M.get_equipped_items(TRUE))
+		if(!istype(item, type))
+			continue
+		var/obj/item/I = item
+		if(!I.hidden_uplink)
+			return I
+
+/decl/uplink_source/proc/put_on_mob(var/mob/M, var/atom/movable/AM, var/text)
+	var/obj/O = M.equip_to_storage(AM)
+	if(O)
+		to_chat(M, "<span class='notice'>[text] can be found in your [O.name].</span>")
+	else if(M.put_in_hands(AM))
+		to_chat(M, "<span class='notice'>[text] appear in your hands.</span>")
+	else
+		AM.dropInto(M.loc)
+		to_chat(M, "<span class='notice'>[text] appear at your location.</span>")
+
+/proc/setup_uplink_source(var/mob/M, var/amount = DEFAULT_TELECRYSTAL_AMOUNT)
+	if(!istype(M) || !M.mind)
+		return FALSE
+
+	var/list/priority_order
+	if(M.client && M.client.prefs)
+		priority_order = M.client.prefs.uplink_sources
+
+	if(!priority_order || !priority_order.len)
+		priority_order = list()
+		for(var/entry in GLOB.default_uplink_source_priority)
+			priority_order += decls_repository.get_decl(entry)
+
+	for(var/entry in priority_order)
+		var/decl/uplink_source/US = entry
+		if(US.setup_uplink_source(M, amount) != SETUP_FAILED)
+			return TRUE
+
+	to_chat(M, "<span class='warning'>Either by choice or circumstance you will be without an uplink.</span>")
+	return FALSE
+
+#undef NO_GUARANTEE_NO_EXTRA_COST_DESC
+#undef SETUP_FAILED


### PR DESCRIPTION
Made all of the purchasable items more descriptive in the uplink menus, so everyone (mostly newer traitors) can have more informed decisions.

TODO

- [x]  Fix anti-materiel rifle description to show correct caliber
- [x]  Rename SMG magazine to better fit naming convention in purchase menu
- [x] Increase10mm EMP ammo box to contain 15 rounds. This is a full magazine worth of the only 10mm pistol traitors can purchase and increase price to compensate
- [x] Increase 7mm EMP ammo box to contain 8 rounds. This is a full magazine worth of the base holdout pistol
- [x] Fix the 7mm EMP ammo box spawning the wrong caliber 

- [ ] Fix the trick cigarettes as they currently DO NOT seem to have the reagents react after lighting them. (I tried to take care of this, but it was a little over my head)

examples shown here - [ https://imgur.com/a/z5blkOY](url) 

@comma mentioned he removed the calibers of bullets, so if it is not wanted I can redo it.

This is my first attempt at contributing, so please feel free to leave criticism or suggestions.


:cl:
tweak: Item descriptions in the traitor uplink menus have been adjusted so that new recruits actually understand what they are buying.
tweak: EMP ammo boxes purchased from the uplink should now have enough ammo to refill a magazine.
bugfix: 7mm EMP ammo boxes now have the correct sized rounds in them.
/:cl: