### PR TITLE
Uplink Description Update and Bugfixes

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -6,91 +6,107 @@
 	category = /datum/uplink_category/ammunition
 
 /datum/uplink_item/item/ammo/holdout
-	name = "Holdout Pistol Magazine"
+	name = "Small Magazine"
+	desc = "A magazine for small pistols. Contains 8 rounds."
 	item_cost = 3
 	path = /obj/item/ammo_magazine/pistol/small
 
 /datum/uplink_item/item/ammo/holdout_speedloader
-	name = "Holdout Revolver Speedloader"
+	name = "Small Speedloader"
+	desc = "A speedloader for small revolvers. Contains 6 rounds."
 	item_cost = 3
 	path = /obj/item/ammo_magazine/speedloader/small
 
 /datum/uplink_item/item/ammo/darts
-	name = "Darts"
+	name = "Dart Cartridge"
+	desc = "A small cartridge for a gas-powered dart gun. Contains 5 hollow darts."
 	path = /obj/item/ammo_magazine/chemdart
 
 /datum/uplink_item/item/ammo/speedloader
-	name = "Revolver Speedloader"
+	name = "Standard Speedloader"
+	desc = "A speedloader for standard revolvers. Contains 6 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/speedloader
 
 /datum/uplink_item/item/ammo/rifle
-	name = "Assault Rifle Magazine"
+	name = "Rifle Magazine"
+	desc = "A magazine for assault rifles. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo
-	name = "Sniper Shells"
+	name = "Ammobox of Sniper Rounds"
+	desc = "A container of rounds for the anti-materiel rifle. Contains 7 rounds."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/sniperammo
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo/apds
-	name = "Sniper APDS Shells"
+	name = "Ammobox of APDS Sniper Rounds"
+	desc = "A container of armor piercing rounds for the anti-materiel rifle. Contains 3 rounds."
 	item_cost = 12
 	path = /obj/item/weapon/storage/box/ammo/sniperammo/apds
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/shotgun_shells
-	name = "Shotgun Shells box"
+	name = "Ammobox of Shotgun Shells"
+	desc = "An ammobox with 2 sets of shell holders. Contains 8 buckshot shells total."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/shotgunshells
 
 /datum/uplink_item/item/ammo/shotgun_slugs
-	name = "Shotgun Slugs box"
+	name = "Ammobox of Shotgun Slugs"
+	desc = "An ammobox with 2 sets of shell holders. Contains 8 slugs total."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/shotgunammo
 
 /datum/uplink_item/item/ammo/machine_pistol
-	name = "Machine Pistol Magazine"
+	name = "Standard Stick Magazine"
+	desc = "A magazine for standard machine pistols. Contains 16 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/machine_pistol
 
 /datum/uplink_item/item/ammo/smg
-	name = "SMG Magazine"
+	name = "Standard Box Magazine"
+	desc = "A magazine for standard SMGs. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/smg
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol
-	name = "Pistol Magazine"
-	item_cost = 6
-	path = /obj/item/ammo_magazine/pistol
+	name = "Standard Doublestack Magazine"
+	desc = "A magazine for standard military pistols. Contains 15 rounds."
+	item_cost = 9
+	path = /obj/item/ammo_magazine/pistol/double
 
 /datum/uplink_item/item/ammo/magnum
 	name = "Magnum Magazine"
+	desc = "A magazine for magnum pistols. Contains 7 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/magnum
 
 /datum/uplink_item/item/ammo/speedloader_magnum
 	name = "Magnum Speedloader"
+	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/speedloader/magnum
 
 /datum/uplink_item/item/ammo/flechette
 	name = "Flechette Rifle Magazine"
+	desc = "A  rifle magazine loaded with flechette rounds. Contains 9 rounds."
 	item_cost = 8
 	path = /obj/item/weapon/magnetic_ammo
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol_emp
-	name = "Pistol EMP Ammmo Box (10 rounds)"
-	item_cost = 6
+	name = "Standard EMP Ammo Box"
+	desc = "A box of EMP ammo for standard pistols. Contains 15 rounds."
+	item_cost = 8
 	path = /obj/item/ammo_magazine/box/emp/pistol
 
 /datum/uplink_item/item/ammo/holdout_emp
-	name = "Small Pistol EMP Ammmo Box (10 rounds)"
-	desc = "EMP ammo for holdout pistols and revolvers."
+	name = "Small EMP Ammo Box"
+	desc = "A box of EMP ammo for small pistols and revolvers. Contains 8 rounds."
 	item_cost = 6
 	path = /obj/item/ammo_magazine/box/emp/smallpistol

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -6,91 +6,107 @@
 	category = /datum/uplink_category/ammunition
 
 /datum/uplink_item/item/ammo/holdout
-	name = "Holdout Pistol Magazine"
+	name = "7mm Magazine"
+	desc = "A magazine for pocket-sized pistols. Contains 8 rounds."
 	item_cost = 3
 	path = /obj/item/ammo_magazine/pistol/small
 
 /datum/uplink_item/item/ammo/holdout_speedloader
-	name = "Holdout Revolver Speedloader"
+	name = "7mm Speedloader"
+	desc = "A speedloader for pocket-sized revolvers. Contains 6 rounds."
 	item_cost = 3
 	path = /obj/item/ammo_magazine/speedloader/small
 
 /datum/uplink_item/item/ammo/darts
-	name = "Darts"
+	name = "Dart Cartridge"
+	desc = "A small cartridge for a gas-powered dart gun. Contains 5 hollow darts."
 	path = /obj/item/ammo_magazine/chemdart
 
 /datum/uplink_item/item/ammo/speedloader
-	name = "Revolver Speedloader"
+	name = "10mm Speedloader"
+	desc = "A speedloader for standard revolvers. Contains 6 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/speedloader
 
 /datum/uplink_item/item/ammo/rifle
-	name = "Assault Rifle Magazine"
+	name = "7mmR Magazine"
+	desc = "A magazine for assault rifles. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo
-	name = "Sniper Shells"
+	name = "Ammobox of 15mmR Sniper Rounds"
+	desc = "An ammobox of rounds for the anti-materiel rifle. Contains 7 rounds."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/sniperammo
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo/apds
-	name = "Sniper APDS Shells"
+	name = "Ammobox of 15mmR APDS Rounds"
+	desc = "An ammobox of armor piercing rounds for the anti-materiel rifle. Contains 3 rounds."
 	item_cost = 12
 	path = /obj/item/weapon/storage/box/ammo/sniperammo/apds
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/shotgun_shells
-	name = "Shotgun Shells box"
+	name = "Ammobox of Shotgun Shells"
+	desc = "An ammobox with 2 sets of shell holders. Contains 8 buckshot shells total."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/shotgunshells
 
 /datum/uplink_item/item/ammo/shotgun_slugs
-	name = "Shotgun Slugs box"
+	name = "Ammobox of Shotgun Slugs"
+	desc = "An ammobox with 2 sets of shell holders. Contains 8 slugs total."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/ammo/shotgunammo
 
 /datum/uplink_item/item/ammo/machine_pistol
-	name = "Machine Pistol Magazine"
+	name = "10mm Stick Magazine"
+	desc = "A magazine for machine pistols. Contains 16 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/machine_pistol
 
 /datum/uplink_item/item/ammo/smg
-	name = "SMG Magazine"
+	name = "10mm Box Magazine"
+	desc = "A magazine for SMGs. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/smg
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol
-	name = "Pistol Magazine"
-	item_cost = 6
-	path = /obj/item/ammo_magazine/pistol
+	name = "10mm Doublestack Magazine"
+	desc = "A magazine for military pistols. Contains 15 rounds."
+	item_cost = 9
+	path = /obj/item/ammo_magazine/pistol/double
 
 /datum/uplink_item/item/ammo/magnum
-	name = "Magnum Magazine"
+	name = "15mm Magazine"
+	desc = "A magazine for high-caliber pistols. Contains 7 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/magnum
 
 /datum/uplink_item/item/ammo/speedloader_magnum
-	name = "Magnum Speedloader"
+	name = "15mm Speedloader"
+	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/speedloader/magnum
 
 /datum/uplink_item/item/ammo/flechette
 	name = "Flechette Rifle Magazine"
+	desc = "A magazine loaded with flechette rounds. Contains 9 rounds."
 	item_cost = 8
 	path = /obj/item/weapon/magnetic_ammo
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol_emp
-	name = "Pistol EMP Ammmo Box (10 rounds)"
-	item_cost = 6
+	name = "10mm EMP Ammo Box"
+	desc = "A box of EMP ammo for standard pistols. Contains 15 loose rounds."
+	item_cost = 8
 	path = /obj/item/ammo_magazine/box/emp/pistol
 
 /datum/uplink_item/item/ammo/holdout_emp
-	name = "Small Pistol EMP Ammmo Box (10 rounds)"
-	desc = "EMP ammo for holdout pistols and revolvers."
+	name = "7mm EMP Ammo Box"
+	desc = "A box of EMP ammo for pocket-sized pistols and revolvers. Contains 8 loose rounds."
 	item_cost = 6
 	path = /obj/item/ammo_magazine/box/emp/smallpistol

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -28,7 +28,7 @@
 **************/
 /datum/uplink_item/item/badassery/random_one
 	name = "Random Item"
-	desc = "Buys you a random item for at least 1TC. Careful: No upper price cap!"
+	desc = "Buys you a random item for at least 1 TC. Be careful, this can spend any amount of telecrystals!"
 	item_cost = 1
 
 /datum/uplink_item/item/badassery/random_one/buy(var/obj/item/device/uplink/U, var/mob/user)
@@ -72,7 +72,7 @@
 /datum/uplink_item/item/badassery/surplus/New()
 	..()
 	antag_roles = list(MODE_MERCENARY)
-	desc = "A crate containing [item_worth] telecrystal\s worth of surplus leftovers."
+	desc = "A crate containing [item_worth] telecrystal\s worth of surplus leftovers. If you can find some help to pay for it, you might strike gold."
 
 /datum/uplink_item/item/badassery/surplus/get_goods(var/obj/item/device/uplink/U, var/loc)
 	var/obj/structure/largecrate/C = new(loc)

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -6,6 +6,7 @@
 
 /datum/uplink_item/item/tools/toolbox
 	name = "Fully Loaded Toolbox"
+	desc = "A hefty toolbox filled with all the equipment you need to get past any construction or electrical issues. Instructions and materials not included."
 	item_cost = 8
 	path = /obj/item/weapon/storage/toolbox/syndicate
 
@@ -13,47 +14,56 @@
 	name = "Operations Funding"
 	item_cost = 8
 	path = /obj/item/weapon/storage/secure/briefcase/money
-	desc = "A briefcase with 10,000 untraceable thalers for funding your sneaky activities."
+	desc = "A briefcase with 10,000 untraceable thalers. Makes a great bribe if they're willing to take you up on your offer."
 
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"
-	desc = "Comes with all you need to fake paperwork. Assumes you have passed basic writing lessons."
+	desc = "Comes with everything you need to fake paperwork, assuming you know how to forge the required documents."
 	item_cost = 16
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/clerical
 
 /datum/uplink_item/item/tools/plastique
-	name = "C-4 (Destroys walls)"
+	name = "C-4"
+	desc = "Set this on a wall to put a hole exactly where you need it."
 	item_cost = 16
 	path = /obj/item/weapon/plastique
 
 /datum/uplink_item/item/tools/heavy_armor
 	name = "Heavy Armor Vest and Helmet"
+	desc = "This satchel holds a combat helmet and fully equipped plate carrier. Suit up, and strap in, things are about to get hectic."
 	item_cost = 16
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/armor
 
 /datum/uplink_item/item/tools/encryptionkey_radio
 	name = "Encrypted Radio Channel Key"
+	desc = "This headset encryption key will allow you to eavesdrop on all available department channels, as well as speak on a hidden, encrypted radio channel. Use a screwdriver on your headset to exchange keys."
 	item_cost = 1
 	path = /obj/item/device/encryptionkey/syndicate
 
 /datum/uplink_item/item/tools/shield_diffuser
 	name = "Handheld Shield Diffuser"
+	desc = "A small device used to disrupt energy barriers, and allow passage through them."
 	item_cost = 16
 	path = /obj/item/weapon/shield_diffuser
 
 /datum/uplink_item/item/tools/suit_sensor_mobile
 	name = "Suit Sensor Jamming Device"
-	desc = "This device will affect suit sensor data using method and radius defined by the user."
+	desc = "This tiny device can temporarily change the sensor levels or report random or false readings on any suit sensors in your vicinity. The range at which this device operates can be toggled as well. All of these options drain the internal battery."
 	item_cost = 20
 	path = /obj/item/device/suit_sensor_jammer
 
 /datum/uplink_item/item/tools/encryptionkey_binary
 	name = "Binary Translator Key"
+	desc = "This headset encryption key will allow you to both listen and speak on the binary channel that synthetics and AI have access to. Remember this is not normal access, and will alert the AI. Use a screwdriver on your headset to exchange keys."
 	item_cost = 20
 	path = /obj/item/device/encryptionkey/binary
 
 /datum/uplink_item/item/tools/emag
 	name = "Cryptographic Sequencer"
+	desc = "An electromagnetic card capable of scrambling electronics to either subvert them into serving you, \
+			or giving you access to things you normally can't. Doors can be opened with this card \
+			even if you aren't normally able to, but will destroy them in the proccess. This card can have its appearance changed \
+			like any other chameleon item."
 	item_cost = 24
 	path = /obj/item/weapon/card/emag
 
@@ -61,32 +71,37 @@
 	name = "Door Hacking Tool"
 	item_cost = 24
 	path = /obj/item/device/multitool/hacktool
-	desc = "Appears and functions as a standard multitool until the mode is toggled by applying a screwdriver appropriately. \
-			When in hacking mode this device will grant full access to any standard airlock within 20 to 40 seconds. \
-			This device will also be able to immediately access the last 6 to 8 hacked airlocks."
+	desc = "Appears and functions as a standard multitool until a screwdriver is used to toggle it. \
+			While in hacking mode, this device will grant full access to any airlock in 20 to 40 seconds. \
+			This device will be able to  continously reaccess the last 6 to 8  airlocks it was used on."
 
 /datum/uplink_item/item/tools/space_suit
-	name = "Space Suit"
+	name = "Voidsuit and Tactical Mask"
+	desc = "A satchel containing a non-regulation voidsuit, voidsuit helmet, tactical mask, and oxygen tank. Conceal your identity, while also not dying in space."
 	item_cost = 28
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/space
 
 /datum/uplink_item/item/tools/thermal
 	name = "Thermal Imaging Glasses"
+	desc = "A pair of meson goggles that have been modified to instead show synthetics or living creatures, through thermal imaging."
 	item_cost = 24
 	path = /obj/item/clothing/glasses/thermal/syndi
 
 /datum/uplink_item/item/tools/flashdark
 	name = "Flashdark"
+	desc = "A device similar to a flash light that absorbs the surrounding light, casting a shadowy, black mass."
 	item_cost = 32
 	path = /obj/item/device/flashlight/flashdark
 
 /datum/uplink_item/item/tools/powersink
 	name = "Powersink (DANGER!)"
+	desc = "A device, that when bolted down to an exposed wire, spikes the surrounding electrical systems, draining power at an alarming rate. Use with caution, as this will be extremely noticable to anyone monitoring the power systems."
 	item_cost = 40
 	path = /obj/item/device/powersink
 
 /datum/uplink_item/item/tools/teleporter
 	name = "Teleporter Circuit Board"
+	desc = "A circuit board that can be used to create a teleporter console, able to lock onto detected teleportation beacons. Requires a projector and teleporter hub nearby to work."
 	item_cost = 40
 	path = /obj/item/weapon/circuitboard/teleporter
 
@@ -96,16 +111,19 @@
 
 /datum/uplink_item/item/tools/ai_module
 	name = "Hacked AI Upload Module"
+	desc = "A module that can be used anonymously add a singular, top level law to an active AI. All you need to do is write in the law and insert it into any available AI Upload Console."
 	item_cost = 52
 	path = /obj/item/weapon/aiModule/syndicate
 
 /datum/uplink_item/item/tools/supply_beacon
 	name = "Hacked Supply Beacon (DANGER!)"
+	desc = "Wrench this large beacon onto an exposed power cable, in order to activate it. This will call in a drop pod to the target location, containing a random assortment of (possibly useful) items. The ship's computer system will announce when this pod is enroute."
 	item_cost = 52
 	path = /obj/item/supply_beacon
 
 /datum/uplink_item/item/tools/camera_mask
 	name = "Camera MIU"
+	desc = "Wearing this mask allows you to remotely view any cameras you currently have access to. Take the mask off to stop viewing."
 	item_cost = 60
 	antag_costs = list(MODE_MERCENARY = 30)
 	path = /obj/item/clothing/mask/ai
@@ -114,11 +132,11 @@
 	name = "Radio Interceptor"
 	item_cost = 30
 	path = /obj/item/device/radio/intercept
-	desc = "A radio that can intercept secure radio channels. Doesn't fit in pockets."
-	
+	desc = "A reciever-like device that can intercept secure radio channels. This item is too big to fit into your pockets."
+
 /datum/uplink_item/item/tools/ttv
 	name = "Binary Gas Bomb"
 	item_cost = 30
 	path = /obj/effect/spawner/newbomb/traitor
-	desc = "A remote-activated phoron-oxygen bomb assembly with built-in signaler. \
+	desc = "A remote-activated phoron-oxygen bomb assembly with an included signaler. \
 			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -60,7 +60,7 @@
 /datum/uplink_item/item/tools/encryptionkey_binary
 	name = "Binary Translator Key"
 	desc = "This headset encryption key will allow you to both listen and speak on the binary channel that \
-	synthetics and AI have access to. Remember this is not normal access, and will alert the AI. \
+	synthetics and AI have access to. Remember, non-synths don't normally have access to this channel, so talking in it will raise suspicion. \
 	Use a screwdriver on your headset to exchange keys."
 	item_cost = 20
 	path = /obj/item/device/encryptionkey/binary

--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -6,6 +6,7 @@
 
 /datum/uplink_item/item/grenades/anti_photon
 	name = "1x Photon Disruption Grenade"
+	desc = "An experimental device for temporarily removing light in a limited area for a small amount of time."
 	item_cost = 4
 	path = /obj/item/weapon/grenade/anti_photon
 
@@ -16,6 +17,7 @@
 
 /datum/uplink_item/item/grenades/smoke
 	name = "1x Smoke Grenade"
+	desc = "A grenade that will erupt into a vision obscuring cloud of smoke. Makes for great getaways!"
 	item_cost = 4
 	path = /obj/item/weapon/grenade/smokebomb
 
@@ -26,6 +28,7 @@
 
 /datum/uplink_item/item/grenades/emp
 	name = "1x EMP Grenade"
+	desc = "A grenade that will send electronics into a frenzy, or possibly fry them altogether. The timer is adjustable with a screwdriver."
 	item_cost = 8
 	path = /obj/item/weapon/grenade/empgrenade
 

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -6,36 +6,43 @@
 
 /datum/uplink_item/item/hardsuit_modules/thermal
 	name = "\improper Thermal Scanner"
+	desc = "A module capable of giving vision of synthetic or living creatures, through thermal imaging."
 	item_cost = 16
 	path = /obj/item/rig_module/vision/thermal
 
 /datum/uplink_item/item/hardsuit_modules/energy_net
 	name = "\improper Net Projector"
+	desc = "A module capable of creating an energy net device that can be thrown in order to capture targets like the prey they are."
 	item_cost = 20
 	path = /obj/item/rig_module/fabricator/energy_net
 
 /datum/uplink_item/item/hardsuit_modules/ewar_voice
 	name = "\improper Electrowarfare Suite and Voice Synthesiser"
+	desc = "Includes two modules that, once installed and activated, are capable of masking your voice and disrupting the AI from tracking you."
 	item_cost = 24
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/ewar_voice
 
 /datum/uplink_item/item/hardsuit_modules/maneuvering_jets
 	name = "\improper Maneuvering Jets"
+	desc = "A module capable of giving your suit an active thrust system, so that you can maneuver in zero gravity."
 	item_cost = 32
 	path = /obj/item/rig_module/maneuvering_jets
 
 /datum/uplink_item/item/hardsuit_modules/egun
 	name = "\improper Mounted Energy Gun"
+	desc = "A module that drains your power reserves in order to fire an arm mounted energy gun."
 	item_cost = 48
 	path = /obj/item/rig_module/mounted/egun
 
 /datum/uplink_item/item/hardsuit_modules/power_sink
 	name = "\improper Power Sink"
+	desc = "A module capable of recharging your suit's power reserves, by tapping into an exposed, live wire."
 	item_cost = 48
 	path = /obj/item/rig_module/power_sink
 
 /datum/uplink_item/item/hardsuit_modules/laser_canon
 	name = "\improper Mounted Laser Cannon"
+	desc = "A module capable of draining your suit's power reserves in order to fire a shoulder mounted laser cannon."
 	item_cost = 64
 	path = /obj/item/rig_module/mounted/lcannon
 	antag_roles = list(MODE_MERCENARY)

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -6,22 +6,28 @@
 
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
+	desc = "A gas-powered dart gun capable of delivering chemical payloads across short distances. \
+			Uses a unique cartridge loaded with hollow darts."
 	item_cost = 20
 	path = /obj/item/weapon/gun/projectile/dartgun
 
 /datum/uplink_item/item/visible_weapons/crossbow
 	name = "Energy Crossbow"
+	desc = "A self-recharging, almost silent weapon employed by stealth operatives."
 	item_cost = 24
 	path = /obj/item/weapon/gun/energy/crossbow
 
 /datum/uplink_item/item/visible_weapons/energy_sword
 	name = "Energy Sword"
+	desc = "A hilt, that when activated, creates a solid beam of pure energy in the form of a sword. \
+			Able to slice through people like butter!"
 	item_cost = 32
 	path = /obj/item/weapon/melee/energy/sword
 
 /datum/uplink_item/item/visible_weapons/silenced
-	name = "Silenced Holdout Pistol"
-	desc = "Holdout pistol with silencer kit and ammunition."
+	name = "Small Silenced Pistol"
+	desc = "A kit with a pocket-sized holdout pistol, silencer, and an extra magazine. \
+			Attaching the silencer will make it to big to conceal in your pocket."
 	item_cost = 32
 	path = /obj/item/weapon/storage/box/syndie_kit/silenced
 
@@ -38,41 +44,47 @@
 
 /datum/uplink_item/item/visible_weapons/energy_gun
 	name = "Energy Gun"
+	desc = "A energy based sidearm with three different lethality settings."
 	item_cost = 32
 	path = /obj/item/weapon/gun/energy/gun
 
 /datum/uplink_item/item/visible_weapons/revolver
-	name = "Revolver"
-	desc = "Magnum revolver, with ammunition."
+	name = "Magnum Revolver"
+	desc = "A high-caliber revolver. Includes an extra speedloader of ammo."
 	item_cost = 56
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
 
 /datum/uplink_item/item/visible_weapons/grenade_launcher
 	name = "Grenade Launcher"
+	desc = "A pump action grenade launcher loaded with a random assortment of grenades"
 	item_cost = 60
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/gun/launcher/grenade/loaded
 
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
 /datum/uplink_item/item/visible_weapons/submachinegun
-	name = "Submachine Gun"
+	name = "Standard Submachine Gun"
+	desc = "A quick-firing weapon with three togglable fire modes."
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
+	desc = "A common rifle with three togglable fire modes."
 	item_cost = 60
 	path = /obj/item/weapon/gun/projectile/automatic/assault_rifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/advanced_energy_gun
 	name = "Advanced Energy Gun"
+	desc = "A highly experimental heavy energy weapon, with three different lethality settings."
 	item_cost = 60
 	path = /obj/item/weapon/gun/energy/gun/nuclear
 
 /datum/uplink_item/item/visible_weapons/heavysniper
-	name = "Anti-materiel Rifle with ammunition"
+	name = "Anti-materiel Sniper Rifle"
+	desc = "A secure briefcase that contains an immensely powerful penetrating rifle, as well as seven extra sniper rounds."
 	item_cost = 68
 	path = /obj/item/weapon/storage/secure/briefcase/heavysniper
 	antag_roles = list(MODE_MERCENARY)
@@ -86,56 +98,68 @@
 */
 
 /datum/uplink_item/item/visible_weapons/machine_pistol
-	name = "Machine Pistol"
+	name = "Standard Machine Pistol"
+	desc = "A high rate of fire weapon in a smaller form factor, able to sling standard ammunition almost as quick as a submachine gun."
 	item_cost = 45
 	path = /obj/item/weapon/gun/projectile/automatic/machine_pistol
 
 /datum/uplink_item/item/visible_weapons/combat_shotgun
 	name = "Combat Shotgun"
+	desc = "A high compacity, pump-action shotgun regularly used for repelling boarding parties in close range scenarios."
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/sawnoff
 	name = "Sawnoff Shotgun"
+	desc = "A shortened double-barrel shotgun, able to fire either one, or both, barrels at once."
 	item_cost = 45
 	path = /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn
 
 /datum/uplink_item/item/visible_weapons/deagle
 	name = "Magnum Pistol"
+	desc = "A high-caliber pistol that uses 15mm ammunition."
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/pistol/magnum_pistol
 
 /datum/uplink_item/item/visible_weapons/sigsauer
-	name = "Military Pistol"
+	name = "Standard Military Pistol"
+	desc = "A regularly used and reliable weapon that is standard issue in the Navy."
 	item_cost = 40
 	path = /obj/item/weapon/gun/projectile/pistol/military/alt
 
 /datum/uplink_item/item/visible_weapons/detective_revolver
-	name = "Holdout Revolver"
+	name = "Small Revolver"
+	desc = "A pocket-sized holdout revolver. Easily concealable.."
 	item_cost = 24
 	path = /obj/item/weapon/gun/projectile/revolver/holdout
 
 /datum/uplink_item/item/visible_weapons/pulserifle
 	name = "Pulse Rifle"
+	desc = "A triple burst, heavy laser rifle, with a large battery compacity."
 	item_cost = 68
 	path = /obj/item/weapon/gun/energy/pulse_rifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/flechetterifle
 	name = "Flechette Rifle"
+	desc = "A railgun with two togglable fire modes, able to launch flechette ammunition at incredible speeds."
 	item_cost = 60
 	path = /obj/item/weapon/gun/magnetic/railgun/flechette
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/railgun // Like a semi-auto AMR
 	name = "Railgun"
+	desc = "An anti-armour magnetic launching system fed by a high-capacity matter cartridge, \
+			capable of firing slugs at intense speeds."
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/gun/magnetic/railgun
 
 /datum/uplink_item/item/visible_weapons/railguntcc // Only slightly better than the normal railgun; but cooler looking
 	name = "Advanced Railgun"
+	desc = "A modified prototype of the original railgun implement, this time boring slugs out of steel rods loaded into the chamber, \
+			now with even MORE stopping power."
 	antag_roles = list(MODE_MERCENARY)
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
 	path = /obj/item/weapon/gun/magnetic/railgun/tcc

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -6,22 +6,25 @@
 
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
+	desc = "A gas-powered dart gun capable of delivering chemical payloads across short distances. Uses a unique cartridge loaded with hollow darts."
 	item_cost = 20
 	path = /obj/item/weapon/gun/projectile/dartgun
 
 /datum/uplink_item/item/visible_weapons/crossbow
 	name = "Energy Crossbow"
+	desc = "A self-recharging, almost silent weapon employed by stealth operatives."
 	item_cost = 24
 	path = /obj/item/weapon/gun/energy/crossbow
 
 /datum/uplink_item/item/visible_weapons/energy_sword
 	name = "Energy Sword"
+	desc = "A hilt, that when activated, creates a solid beam of pure energy in the form of a sword.Able to slice through people like butter!"
 	item_cost = 32
 	path = /obj/item/weapon/melee/energy/sword
 
 /datum/uplink_item/item/visible_weapons/silenced
 	name = "Silenced Holdout Pistol"
-	desc = "Holdout pistol with silencer kit and ammunition."
+	desc = "A kit with a pocket-sized pistol, silencer, and an extra 7mm magazine. Attaching the silencer will make it to big to conceal in your pocket."
 	item_cost = 32
 	path = /obj/item/weapon/storage/box/syndie_kit/silenced
 
@@ -38,17 +41,19 @@
 
 /datum/uplink_item/item/visible_weapons/energy_gun
 	name = "Energy Gun"
+	desc = "A energy based sidearm with three different lethality settings."
 	item_cost = 32
 	path = /obj/item/weapon/gun/energy/gun
 
 /datum/uplink_item/item/visible_weapons/revolver
-	name = "Revolver"
-	desc = "Magnum revolver, with ammunition."
+	name = "Magnum Revolver"
+	desc = "A high-caliber revolver. Includes an extra speedloader of 15mm ammo."
 	item_cost = 56
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
 
 /datum/uplink_item/item/visible_weapons/grenade_launcher
 	name = "Grenade Launcher"
+	desc = "A pump action grenade launcher loaded with a random assortment of grenades"
 	item_cost = 60
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/gun/launcher/grenade/loaded
@@ -56,23 +61,27 @@
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
 /datum/uplink_item/item/visible_weapons/submachinegun
 	name = "Submachine Gun"
+	desc = "A quick-firing gun with three togglable fire modes, that uses 10mm ammunition."
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/automatic/merc_smg
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
+	desc = "A standard rifle with three togglable fire modes, that uses 7mmR ammunition."
 	item_cost = 60
 	path = /obj/item/weapon/gun/projectile/automatic/assault_rifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/advanced_energy_gun
 	name = "Advanced Energy Gun"
+	desc = "A highly experimental heavy energy weapon, with three different lethality settings."
 	item_cost = 60
 	path = /obj/item/weapon/gun/energy/gun/nuclear
 
 /datum/uplink_item/item/visible_weapons/heavysniper
-	name = "Anti-materiel Rifle with ammunition"
+	name = "Anti-materiel Rifle"
+	desc = "A secure briefcase that contains an immensely powerful penetrating rifle, as well as seven extra 15mmR rounds."
 	item_cost = 68
 	path = /obj/item/weapon/storage/secure/briefcase/heavysniper
 	antag_roles = list(MODE_MERCENARY)
@@ -87,55 +96,65 @@
 
 /datum/uplink_item/item/visible_weapons/machine_pistol
 	name = "Machine Pistol"
+	desc = "A high rate of fire weapon, able to sling 10mm ammunition almost as quick as a submachine gun."
 	item_cost = 45
 	path = /obj/item/weapon/gun/projectile/automatic/machine_pistol
 
 /datum/uplink_item/item/visible_weapons/combat_shotgun
 	name = "Combat Shotgun"
+	desc = "A high compacity, pump-action shotgun regularly used for repelling boarding parties in close range scenarios."
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/shotgun/pump/combat
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/sawnoff
 	name = "Sawnoff Shotgun"
+	desc = "A shortened double-barrel shotgun, able to fire either one, or both, barrels at once."
 	item_cost = 45
 	path = /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn
 
 /datum/uplink_item/item/visible_weapons/deagle
 	name = "Magnum Pistol"
+	desc = "A high-caliber pistol that uses 15mm ammunition."
 	item_cost = 52
 	path = /obj/item/weapon/gun/projectile/pistol/magnum_pistol
 
 /datum/uplink_item/item/visible_weapons/sigsauer
 	name = "Military Pistol"
+	desc = "A Navy issued sidearm that uses 10mm ammunition."
 	item_cost = 40
 	path = /obj/item/weapon/gun/projectile/pistol/military/alt
 
 /datum/uplink_item/item/visible_weapons/detective_revolver
 	name = "Holdout Revolver"
+	desc = "A pocket-sized revolver that uses 7mm ammunition."
 	item_cost = 24
 	path = /obj/item/weapon/gun/projectile/revolver/holdout
 
 /datum/uplink_item/item/visible_weapons/pulserifle
 	name = "Pulse Rifle"
+	desc = "A triple burst, heavy laser rifle, with a large battery compacity."
 	item_cost = 68
 	path = /obj/item/weapon/gun/energy/pulse_rifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/flechetterifle
 	name = "Flechette Rifle"
+	desc = "A railgun with two togglable fire modes, able to launch flechette ammunition at incredible speeds."
 	item_cost = 60
 	path = /obj/item/weapon/gun/magnetic/railgun/flechette
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/railgun // Like a semi-auto AMR
 	name = "Railgun"
+	desc = "An anti-armour magnetic launching system fed by a high-capacity matter cartridge, capable of firing slugs at intense speeds."
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/gun/magnetic/railgun
 
 /datum/uplink_item/item/visible_weapons/railguntcc // Only slightly better than the normal railgun; but cooler looking
 	name = "Advanced Railgun"
+	desc = "A modified prototype of the original railgun implement, this time boring slugs out of steel rods loaded into the chamber, now with even MORE stopping power."
 	antag_roles = list(MODE_MERCENARY)
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
 	path = /obj/item/weapon/gun/magnetic/railgun/tcc

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -27,7 +27,7 @@
 /datum/uplink_item/item/visible_weapons/silenced
 	name = "Small Silenced Pistol"
 	desc = "A kit with a pocket-sized holdout pistol, silencer, and an extra magazine. \
-			Attaching the silencer will make it to big to conceal in your pocket."
+			Attaching the silencer will make it too big to conceal in your pocket."
 	item_cost = 32
 	path = /obj/item/weapon/storage/box/syndie_kit/silenced
 

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -35,7 +35,7 @@
 	activatable with an emotive trigger. You will have access to it, as long as it is still inside of you."
 
 /datum/uplink_item/item/implants/imp_imprinting
-	name = "Neural Subjugation Implant"
+	name = "Neural Imprinting Implant"
 	desc = "An implant able to be used on someone who is under the influence of Mindbreaker Toxin to give them a \
 	set of law-like instructions to follow. This kit contains a dose of Mindbreaker Toxin."
 	item_cost = 20

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -6,16 +6,19 @@
 
 /datum/uplink_item/item/implants/imp_freedom
 	name = "Freedom Implant"
+	desc = "An implant with an emotive trigger that can break you free of restraints. Show Security who has the real upperhand!"
 	item_cost = 24
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
 
 /datum/uplink_item/item/implants/imp_compress
 	name = "Compressed Matter Implant"
+	desc = "An implant with an emotive trigger used to hide a handheld item in your body. Activating it materializes the item in your hand."
 	item_cost = 32
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_compress
 
 /datum/uplink_item/item/implants/imp_explosive
 	name = "Explosive Implant (DANGER!)"
+	desc = "An explosive impant activated with a vocal trigger or radio signal. Use the included pad to adjust the settings before implanting."
 	item_cost = 40
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
 
@@ -26,10 +29,10 @@
 /datum/uplink_item/item/implants/imp_uplink/New()
 	..()
 	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
-	desc = "Contains [IMPLANT_TELECRYSTAL_AMOUNT(DEFAULT_TELECRYSTAL_AMOUNT)] Telecrystal\s"
+	desc = "This implant holds an uplink containing [IMPLANT_TELECRYSTAL_AMOUNT(DEFAULT_TELECRYSTAL_AMOUNT)] telecrystals, activatable with an emotive trigger. You will have access to it, as long as it is still inside of you."
 
 /datum/uplink_item/item/implants/imp_imprinting
-	name = "Neural Imprinting Implant"
-	desc = "Use on someone who is under influence of Mindbreaker to give them laws-like set of instructions. Kit comes with a dose of mindbreaker."
+	name = "Neural Subjugation Implant"
+	desc = "An implant able to be used on someone who is under the influence of Mindbreaker Toxin to give them a law-like set of instructions to follow. This kit contains a dose of Mindbreaker Toxin."
 	item_cost = 20
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_imprinting

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -6,15 +6,18 @@
 
 /datum/uplink_item/item/medical/sinpockets
 	name = "Box of Sin-Pockets"
+	desc = "A box of filled dough pockets. Great for a quick meal when you're hiding from Security. Instructions included on the box."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/sinpockets
 
 /datum/uplink_item/item/medical/surgery
-	name = "Surgery kit"
+	name = "Surgery Kit"
+	desc = "Contains all the tools needed for on the spot surgery, assuming you actually know what you're doing with them. Floor sterilization not included."
 	item_cost = 40
 	path = /obj/item/weapon/storage/firstaid/surgery
 
 /datum/uplink_item/item/medical/combat
-	name = "Combat medical kit"
+	name = "Combat Medical Kit"
+	desc = "Contains most medicines you need to recover from injuries and illnesses, all in a convenient pill form. Splints for broken bones also included!"
 	item_cost = 48
 	path = /obj/item/weapon/storage/firstaid/combat

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -6,31 +6,31 @@
 
 /datum/uplink_item/item/services/fake_ion_storm
 	name = "Ion Storm Announcement"
-	desc = "Interferes with ion sensors."
+	desc = "A single-use device, that when activated, fakes an announcement, so people think all their electronic readings are wrong."
 	item_cost = 8
 	path = /obj/item/device/uplink_service/fake_ion_storm
 
 /datum/uplink_item/item/services/suit_sensor_garble
 	name = "Complete Suit Sensor Jamming"
-	desc = "Garbles all suit sensor data for 10 minutes."
+	desc = "A single-use device, that when activated, garbles all suit sensor data for 10 minutes."
 	item_cost = 16
 	path = /obj/item/device/uplink_service/jamming/garble
 
 /datum/uplink_item/item/services/fake_rad_storm
 	name = "Radiation Storm Announcement"
-	desc = "Interferes with radiation sensors."
+	desc = "A single-use device, that when activated, fakes an announcement, so people run to the tunnels in fear of being irradiated! "
 	item_cost = 24
 	path = /obj/item/device/uplink_service/fake_rad_storm
 
 /datum/uplink_item/item/services/fake_crew_annoncement
 	name = "Crew Arrival Announcement and Records"
-	desc = "Creates a fake crew arrival announcement as well as fake crew records, using your current appearance (including held items!) and worn id card. Prepare well!"
+	desc = "A single-use device, that when activated, creates a fake crew arrival announcement as well as fake crew records, using your current appearance (including held items!) and worn id card. Prepare well!"
 	item_cost = 16
 	path = /obj/item/device/uplink_service/fake_crew_announcement
 
 /datum/uplink_item/item/services/suit_sensor_shutdown
 	name = "Complete Suit Sensor Shutdown"
-	desc = "Completely disables all suit sensors for 10 minutes."
+	desc = "A single-use device, that when activated, completely disables all suit sensors for 10 minutes."
 	item_cost = 40
 	path = /obj/item/device/uplink_service/jamming
 

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -6,38 +6,43 @@
 
 /datum/uplink_item/item/stealth_items/syndigaloshes
 	name = "No-Slip Shoes"
+	desc = "These shoes have a non-slip grip on them, so those pesky janitors can't ruin your operations!"
 	item_cost = 4
 	path = /obj/item/clothing/shoes/syndigaloshes
 
 /datum/uplink_item/item/stealth_items/spy
 	name = "Bug Kit"
-	desc = "For when you want to conduct voyeurism from afar."
+	desc = "For when you want to conduct voyeurism from afar. Comes with 6 bugs to plant, and a monitoring device to pair them with."
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/spy
 
 /datum/uplink_item/item/stealth_items/id
 	name = "Agent ID card"
+	desc = "A unique ID card that is completely configurable. Scan another ID card with it to clone its access capabilities."
 	item_cost = 12
 	path = /obj/item/weapon/card/id/syndicate
 
 /datum/uplink_item/item/stealth_items/chameleon_kit
 	name = "Chameleon Kit"
-	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
+	desc = "Comes with a full set of appearance changing clothing you need to impersonate most people.  Accessories, backpack, and gun included!"
 	item_cost = 20
 	path = /obj/item/weapon/storage/backpack/chameleon/sydie_kit
 
 /datum/uplink_item/item/stealth_items/voice
-	name = "Chameleon Mask/Voice Changer"
+	name = "Modified Gas Mask"
+	desc = "A fully functioning gas mask that is able to conceal your face and has a built in voice modulator, so you can become a true shadow operative!"
 	item_cost = 20
 	path = /obj/item/clothing/mask/chameleon/voice
 
 /datum/uplink_item/item/stealth_items/chameleon_projector
-	name = "Chameleon-Projector"
+	name = "Chameleon Projector"
+	desc = "Use this to scan a small, portable object in order to disguise yourself as said object."
 	item_cost = 32
 	path = /obj/item/device/chameleon
 
 /datum/uplink_item/item/stealth_items/sneakies
 	name = "Sneakies"
+	desc = "A fashionable pair of polished dress shoes. The soles are made in a way so that any tracks you leave look like they are traveling the opposite direction."
 	item_cost = 4
 	path = /obj/item/clothing/shoes/laceup/sneakies
 

--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -10,28 +10,31 @@
 	path = /obj/item/weapon/soap/syndie
 
 /datum/uplink_item/item/stealthy_weapons/cigarette_kit
-	name = "Cigarette Kit"
-	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xMindBreaker, 1xTricordrazine. Avoid mixing them up."
+	name = "Box of Tricky Cigarettes"
+	desc = "A box with some 'special' packs in the following order: 2x Flashes, 2x Smokes, 1x MindBreaker Toxin, and 1x Tricordrazine. Try not to mix them up!"
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/cigarette
 
 /datum/uplink_item/item/stealthy_weapons/concealed_cane
 	name = "Concealed Cane Sword"
+	desc = "A cane used by a true gentlemen, especially ones with sharp intentions."
 	item_cost = 8
 	path = /obj/item/weapon/cane/concealed
 
 /datum/uplink_item/item/stealthy_weapons/random_toxin
-	name = "Random Toxin - Beaker"
-	desc = "An apple will not be enough to keep the doctor away after this."
+	name = "Random Toxin Vial"
+	desc = "Contains one of an assortment of nasty toxins, with a single syringe included. Don't worry, its labeled. "
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/toxin
 
 /datum/uplink_item/item/stealthy_weapons/sleepy
 	name = "Sleepy Pen"
+	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be out like a light."
 	item_cost = 20
 	path = /obj/item/weapon/pen/reagent/sleepy
 
 /datum/uplink_item/item/stealthy_weapons/syringegun
 	name = "Disguised Syringe Gun"
+	desc = "A syringe gun disguised as an electronic cigarette with 4 darts included in the box. Chemicals not included!"
 	item_cost = 10
 	path = /obj/item/weapon/storage/box/syndie_kit/syringegun

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -9,27 +9,33 @@
 	return new /obj/item/stack/telecrystal(loc, cost(U.uses, U))
 
 /datum/uplink_item/item/telecrystal/one
-	name = "Telecrystal - 01"
+	name = "1x Telecrystal"
+	desc = "Remove 1 telecrystal from this uplink."
 	item_cost = 1
 
 /datum/uplink_item/item/telecrystal/five
-	name = "Telecrystals - 05"
+	name = "5x Telecrystals"
+	desc = "Remove 5 telecrystals from this uplink."
 	item_cost = 5
 
 /datum/uplink_item/item/telecrystal/ten
-	name = "Telecrystals - 10"
+	name = "10x Telecrystals"
+	desc = "Remove 10 telecrystals from this uplink."
 	item_cost = 10
 
 /datum/uplink_item/item/telecrystal/twentyfive
-	name = "Telecrystals - 25"
+	name = "25x Telecrystals"
+	desc = "Remove 25 telecrystals from this uplink."
 	item_cost = 25
 
 /datum/uplink_item/item/telecrystal/fifty
-	name = "Telecrystals - 50"
+	name = "50x Telecrystals"
+	desc = "Remove 50 telecrystals from this uplink."
 	item_cost = 50
 
 /datum/uplink_item/item/telecrystal/all
-	name = "Telecrystals - Empty Uplink"
+	name = "Empty Uplink"
+	desc = "Completely empties this uplink of all remaining telecrystals."
 
 /datum/uplink_item/item/telecrystal/all/cost(var/telecrystals, obj/item/device/uplink/U)
 	return max(1, telecrystals)

--- a/code/datums/uplink/uplink_categories.dm
+++ b/code/datums/uplink/uplink_categories.dm
@@ -16,34 +16,34 @@
 	name = "Ammunition"
 
 /datum/uplink_category/grenades
-	name = "Grenades and Thrown Objects"
+	name = "Grenades"
 
 /datum/uplink_category/visible_weapons
-	name = "Highly Visible and Dangerous Weapons"
+	name = "Loud & Dangerous Weaponry"
 
 /datum/uplink_category/stealthy_weapons
-	name = "Stealthy and Inconspicuous Weapons"
+	name = "Disguised & Inconspicuous Weaponry"
 
 /datum/uplink_category/stealth_items
-	name = "Stealth and Camouflage Items"
+	name = "Stealth & Camouflage Accessories"
 
 /datum/uplink_category/tools
-	name = "Devices and Tools"
+	name = "Devices & Tools"
 
 /datum/uplink_category/implants
 	name = "Implants"
 
 /datum/uplink_category/medical
-	name = "Medical"
+	name = "Medical & Food"
 
 /datum/uplink_category/hardsuit_modules
 	name = "Hardsuit Modules"
 
 /datum/uplink_category/services
-	name = "Services"
+	name = "Jamming & Announcements"
 
 /datum/uplink_category/badassery
 	name = "Badassery"
 
 /datum/uplink_category/telecrystals
-	name = "Telecrystals"
+	name = "Telecrystal Materialization"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -47,7 +47,7 @@
 		var/image/I = image(icon, "shotholder-marking")
 		I.color = marking_color
 		overlays += I
-	
+
 /obj/item/ammo_magazine/shotholder/shell
 	name = "shotgun shell holder"
 	ammo_type = /obj/item/ammo_casing/shotgun/pellet
@@ -111,7 +111,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol/small/practice
 
 /obj/item/ammo_magazine/smg
-	name = "submachine gun magazine"
+	name = "box magazine"
 	icon_state = "smg"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
@@ -207,14 +207,22 @@
 	ammo_type = /obj/item/ammo_casing/pistol/throwback
 
 /obj/item/ammo_magazine/box/emp/pistol
+	name = "ammunition box"
+	desc = "A box containing loose rounds of standard EMP ammo."
 	labels = list("haywire")
+	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/pistol/emp
 	caliber = CALIBER_PISTOL
+	max_ammo = 15
 
 /obj/item/ammo_magazine/box/emp/smallpistol
+	name = "ammunition box"
+	desc = "A box containing loose rounds of small EMP ammo."
 	labels = list("haywire")
-	ammo_type = /obj/item/ammo_casing/pistol/emp/small
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/ammo_casing/pistol/small/emp
 	caliber = CALIBER_PISTOL_SMALL
+	max_ammo = 8
 
 /obj/item/ammo_magazine/proto_smg
 	name = "submachine gun magazine"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -210,7 +210,6 @@
 	name = "ammunition box"
 	desc = "A box containing loose rounds of standard EMP ammo."
 	labels = list("haywire")
-	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/pistol/emp
 	caliber = CALIBER_PISTOL
 	max_ammo = 15
@@ -219,7 +218,6 @@
 	name = "ammunition box"
 	desc = "A box containing loose rounds of small EMP ammo."
 	labels = list("haywire")
-	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/pistol/small/emp
 	caliber = CALIBER_PISTOL_SMALL
 	max_ammo = 8

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -111,7 +111,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol/small/practice
 
 /obj/item/ammo_magazine/smg
-	name = "submachine gun magazine"
+	name = "box magazine"
 	icon_state = "smg"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
@@ -207,14 +207,22 @@
 	ammo_type = /obj/item/ammo_casing/pistol/throwback
 
 /obj/item/ammo_magazine/box/emp/pistol
+	name = "ammunition box"
+	desc = "A box containing loose rounds of 10mm EMP ammo."
 	labels = list("haywire")
+	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/pistol/emp
 	caliber = CALIBER_PISTOL
+	max_ammo = 15
 
 /obj/item/ammo_magazine/box/emp/smallpistol
+	name = "ammunition box"
+	desc = "A box containing loose rounds of 7mm EMP ammo."
 	labels = list("haywire")
-	ammo_type = /obj/item/ammo_casing/pistol/emp/small
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/ammo_casing/pistol/small/emp
 	caliber = CALIBER_PISTOL_SMALL
+	max_ammo = 8
 
 /obj/item/ammo_magazine/proto_smg
 	name = "submachine gun magazine"

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -179,7 +179,7 @@
 	icon_state = "pistolcasing_h"
 	matter = list(MATERIAL_STEEL = 130, MATERIAL_URANIUM = 100)
 
-/obj/item/ammo_casing/pistol/emp/small
+/obj/item/ammo_casing/pistol/small/emp
 	name = "small haywire round"
 	desc = "A small bullet casing fitted with a single-use ion pulse generator."
 	projectile_type = /obj/item/projectile/ion/tiny

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/heavysniper
 	name = "anti-materiel rifle"
-	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 14.5mm shells."
+	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to be used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease."
 	icon = 'icons/obj/guns/heavysniper.dmi'
 	icon_state = "heavysniper"
 	item_state = "heavysniper" //sort of placeholder

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/heavysniper
 	name = "anti-materiel rifle"
-	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 14.5mm shells."
+	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to be used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 15 mmR shells."
 	icon = 'icons/obj/guns/heavysniper.dmi'
 	icon_state = "heavysniper"
 	item_state = "heavysniper" //sort of placeholder

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -22,7 +22,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 {{if data.menu == 0 || data.menu == 1}}
 	<div class="item">
 		<div class="itemLabel">
-			<b>Tele-Crystals</b>:
+			<b>Telecrystals</b>:
 		</div>
 		<div class="itemContent">
 			{{:data.crystals}}


### PR DESCRIPTION
Made all of the purchasable items more descriptive in the uplink menus, so everyone (mostly newer traitors) can have more informed decisions.

TODO

- [x] Fix anti-materiel rifle description to show correct caliber
- [x] Rename SMG magazine to better fit naming convention in purchase menu
- [x] Increase 10mm EMP ammo box to contain 15 rounds. This is a full magazine worth of the only 10mm pistol traitors can purchas. Increase price to compensate
- [x] Increase 7mm EMP ammo box to contain 8 rounds. This is a full magazine worth of the base holdout pistol
- [x] Fix the 7mm EMP ammo box spawning the wrong caliber
- [x] changed the 10mm magazine purchase to be a doublestack magazine, as the military pistol only accepts the doublestack. price increased to compensate. 

examples shown here - [https://imgur.com/a/z5blkOY](url)

@comma mentioned he removed the calibers of bullets from descriptions, so if it is not wanted I can redo it.

This is my first attempt at contributing, so please feel free to leave criticism or suggestions.

:cl: Kamiztheman
tweak: Item descriptions in the traitor uplink menus have been adjusted so that new recruits actually understand what they are buying.
tweak: EMP ammo boxes purchased from the uplink should now have enough ammo to refill a magazine.
bugfix: 7mm EMP ammo boxes now contain and can store the correct caliber rounds.
/:cl: