### PR TITLE
Robustify Rig Flash

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -35,13 +35,13 @@
 
 //attack_as_weapon
 /obj/item/device/flash/attack(mob/living/M, mob/living/user, var/target_zone)
-	if(!user || !M)	return	//sanity
+	if(!user || !M)	return 0 //sanity
 	admin_attack_log(user, M, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
 
-	if(!clown_check(user))	return
+	if(!clown_check(user))	return 0
 	if(broken)
 		to_chat(user, "<span class='warning'>\The [src] is broken.</span>")
-		return
+		return 0
 
 	flash_recharge()
 
@@ -54,11 +54,11 @@
 				broken = 1
 				to_chat(user, "<span class='warning'>The bulb has burnt out!</span>")
 				icon_state = "[initial(icon_state)]_burnt"
-				return
+				return 0
 			times_used++
 		else	//can only use it 5 times a minute
 			to_chat(user, "<span class='warning'>*click* *click*</span>")
-			return
+			return 0
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
@@ -126,17 +126,17 @@
 			user.visible_message("<span class='notice'>[user] overloads [M]'s sensors with \the [src]!</span>")
 	else
 		user.visible_message("<span class='notice'>[user] fails to blind [M] with \the [src]!</span>")
-	return
+	return 1
 
 
 
 
 /obj/item/device/flash/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
-	if(!user || !clown_check(user)) 	return
+	if(!user || !clown_check(user)) 	return 0
 
 	if(broken)
 		user.show_message("<span class='warning'>The [src.name] is broken</span>", 2)
-		return
+		return 0
 
 	flash_recharge()
 
@@ -148,11 +148,11 @@
 				broken = 1
 				to_chat(user, "<span class='warning'>The bulb has burnt out!</span>")
 				icon_state = "[initial(icon_state)]_burnt"
-				return
+				return 0
 			times_used++
 		else	//can only use it  5 times a minute
 			user.show_message("<span class='warning'>*click* *click*</span>", 2)
-			return
+			return 0
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[initial(icon_state)]_on", src)
@@ -175,7 +175,7 @@
 				M.flash_eyes()
 				M.eye_blurry += 2
 
-	return
+	return 1
 
 /obj/item/device/flash/emp_act(severity)
 	if(broken)	return

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -17,8 +17,21 @@
 	name = "mounted flash"
 	desc = "You are the law."
 	icon_state = "flash"
+	
+	selectable = 0
+	toggleable = 1
+	activates_on_touch = 1
+	module_cooldown = 0
+	usable = 1
+	active_power_cost = 100
+	use_power_cost = 18000 //10 Whr
+
+	engage_string = "Flash"
+	activate_string = "Activate Flash Module"
+	deactivate_string = "Deactivate Flash Module"
+
 	interface_name = "mounted flash"
-	interface_desc = "Disorientates your target by blinding them with a bright light."
+	interface_desc = "Disorientates your target by blinding them with this intense palm-mounted light."
 	device = /obj/item/device/flash
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 
@@ -26,6 +39,46 @@
 	name = "advanced mounted flash"
 	device = /obj/item/device/flash/advanced
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 3, TECH_ENGINEERING = 5)
+
+/obj/item/rig_module/device/flash/installed()
+	. = ..()
+	if(!holder.glove_type)//gives select option for gloveless suits, why even use rig at this point
+		selectable = 1
+		activates_on_touch = 0
+		toggleable = 0
+	else
+		selectable = 0
+		activates_on_touch = 1
+		toggleable = 1
+
+/obj/item/rig_module/device/flash/engage(atom/target)
+	if(!check() || !device)
+		return 0
+
+	if(!holder.cell.check_charge(use_power_cost * CELLRATE))
+		to_chat(holder.wearer,"<span class='warning'>Not enough stored power.</span>")
+		return 0
+
+	if(!target)
+		if(device.attack_self(holder.wearer))
+			holder.cell.use(use_power_cost * CELLRATE)
+		return 1
+
+	if(!target.Adjacent(holder.wearer) || !ismob(target))
+		return 0
+
+	var/resolved = target.attackby(device,holder.wearer)
+	if(resolved)
+		holder.cell.use(use_power_cost * CELLRATE)
+	return resolved
+
+/obj/item/rig_module/device/flash/activate()
+	if(active || !check())
+		return
+
+	to_chat(holder.wearer, SPAN_NOTICE("Your hardsuit gauntlets heat up and lock into place, ready to be used."))
+	playsound(src.loc, 'sound/items/goggles_charge.ogg', 20, 1)
+	active = 1
 
 /obj/item/rig_module/grenade_launcher
 	name = "mounted grenade launcher"


### PR DESCRIPTION
🆑
tweak: Hardsuit flash module now flashes on unarmed attacks.
tweak: Hardsuit flash module now has has a function to activate the flash without targeting anything.
tweak: Hardsuit flash now has a higher energy cost of 10 Whr per use.
/🆑
Okay, rig flash now flashes on unarmed attack if it doesn't flash, it'll do the default attack instead. 
In other words it lets you pick up the item now or hug/disarm/grab/hurt people if your flash is on cooldown instead.
Easier to use for cqc spams click battles, (totally not first hand experience from fighting a carp)
Also has a "Flash" button which just activates the flash like normal.