### PR TITLE
changes construct darkness aura

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -256,7 +256,7 @@
 	eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	eye_glow.layer = EYE_GLOW_LAYER
 	overlays += eye_glow
-	set_light(-1.5, 0.1, 3, l_color = "#ffffff")
+	set_light(-2, 0.1, 1.5, l_color = "#ffffff")
 
 ////////////////HUD//////////////////////
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -256,7 +256,7 @@
 	eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	eye_glow.layer = EYE_GLOW_LAYER
 	overlays += eye_glow
-	set_light(-10, 0.1, 3, l_color = "#ffffff")
+	set_light(-1.5, 0.1, 3, l_color = "#ffffff")
 
 ////////////////HUD//////////////////////
 


### PR DESCRIPTION
Apparently, it got changed when every light source was transferred to the new system. Everything was considered to be "too dark" and got brightened up, everything except constructs, probably.
If anyone knows how to do this better, do it better, please.

Image:
Top one is after this change, bottom is before.
![image](https://user-images.githubusercontent.com/20609424/58695503-cd6d5f00-83bf-11e9-8d7b-51b0551e7acc.png)
