### PR TITLE
Generic area change helper and related cleanup.

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -133,10 +133,9 @@
 		var/turf/target = translation[source]
 
 		if(target)
-			//update area first so that area/Entered() will be called with the correct area when atoms are moved
 			if(base_area)
-				source.loc.contents.Add(target)
-				base_area.contents.Add(source)
+				ChangeArea(target, get_area(source))
+				ChangeArea(source, base_area)
 			transport_turf_contents(source, target)
 
 	//change the old turfs

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -452,13 +452,13 @@
 						R.module_active = null
 					if(R.module_state_1 == R.module.emag)
 						R.module_state_1 = null
-						R.contents -= R.module.emag
+						R.module.emag.forceMove(null)
 					else if(R.module_state_2 == R.module.emag)
 						R.module_state_2 = null
-						R.contents -= R.module.emag
+						R.module.emag.forceMove(null)
 					else if(R.module_state_3 == R.module.emag)
 						R.module_state_3 = null
-						R.contents -= R.module.emag
+						R.module.emag.forceMove(null)
 					log_admin("[key_name_admin(usr)] has unemag'ed [R].")
 
 			if("unemagcyborgs")
@@ -471,13 +471,13 @@
 								R.module_active = null
 							if(R.module_state_1 == R.module.emag)
 								R.module_state_1 = null
-								R.contents -= R.module.emag
+								R.module.emag.forceMove(null)
 							else if(R.module_state_2 == R.module.emag)
 								R.module_state_2 = null
-								R.contents -= R.module.emag
+								R.module.emag.forceMove(null)
 							else if(R.module_state_3 == R.module.emag)
 								R.module_state_3 = null
-								R.contents -= R.module.emag
+								R.module.emag.forceMove(null)
 					log_admin("[key_name_admin(usr)] has unemag'ed [ai]'s Cyborgs.")
 
 	else if (href_list["common"])

--- a/code/datums/observation/dir_set.dm
+++ b/code/datums/observation/dir_set.dm
@@ -36,6 +36,6 @@ GLOBAL_DATUM_INIT(dir_set_event, /decl/observ/dir_set, new)
 	if(GLOB.dir_set_event.has_listeners(am))
 		GLOB.dir_set_event.register(src, am, /atom/proc/recursive_dir_set)
 
-/atom/movable/Exited(var/atom/movable/am, atom/old_loc)
+/atom/movable/Exited(var/atom/movable/am, atom/new_loc)
 	. = ..()
 	GLOB.dir_set_event.unregister(src, am, /atom/proc/recursive_dir_set)

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -34,7 +34,7 @@ GLOBAL_DATUM_INIT(moved_event, /decl/observ/moved, new)
 	if(GLOB.moved_event.has_listeners(am))
 		GLOB.moved_event.register(src, am, /atom/movable/proc/recursive_move)
 
-/atom/movable/Exited(var/atom/movable/am, atom/old_loc)
+/atom/movable/Exited(var/atom/movable/am, atom/new_loc)
 	. = ..()
 	GLOB.moved_event.unregister(src, am, /atom/movable/proc/recursive_move)
 

--- a/code/datums/outfits/horror_killers.dm
+++ b/code/datums/outfits/horror_killers.dm
@@ -55,9 +55,9 @@
 	for(var/obj/item/briefcase_item in sec_briefcase)
 		qdel(briefcase_item)
 	for(var/i=3, i>0, i--)
-		sec_briefcase.contents += new /obj/item/weapon/spacecash/bundle/c1000
-	sec_briefcase.contents += new /obj/item/weapon/gun/energy/crossbow
-	sec_briefcase.contents += new /obj/item/weapon/gun/projectile/revolver
-	sec_briefcase.contents += new /obj/item/ammo_magazine/speedloader/magnum
-	sec_briefcase.contents += new /obj/item/weapon/plastique
+		new /obj/item/weapon/spacecash/bundle/c1000(sec_briefcase)
+	new /obj/item/weapon/gun/energy/crossbow(sec_briefcase)
+	new /obj/item/weapon/gun/projectile/revolver(sec_briefcase)
+	new /obj/item/ammo_magazine/speedloader/magnum(sec_briefcase)
+	new /obj/item/weapon/plastique(sec_briefcase)
 	H.equip_to_slot_or_del(sec_briefcase, slot_l_hand)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,6 +32,17 @@
 		power_environ = 0
 	power_change()		// all machines set to current power level, also updates lighting icon
 
+// Changes the area of T to A. Do not do this manually.
+// Area is expected to be a non-null instance.
+/proc/ChangeArea(var/turf/T, var/area/A)
+	if(!istype(A))
+		CRASH("Area change attempt failed: invalid area supplied.")
+	var/old_area = get_area(T)
+	if(old_area == A)
+		return
+	A.contents.Add(T)
+	A.Entered(T, old_area)
+
 /area/proc/get_contents()
 	return contents
 
@@ -304,4 +315,3 @@ var/list/mob/living/forced_ambiance_list = new
 
 /area/proc/has_turfs()
 	return !!(locate(/turf) in src)
-

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -37,10 +37,12 @@
 /proc/ChangeArea(var/turf/T, var/area/A)
 	if(!istype(A))
 		CRASH("Area change attempt failed: invalid area supplied.")
-	var/old_area = get_area(T)
+	var/area/old_area = get_area(T)
 	if(old_area == A)
 		return
 	A.contents.Add(T)
+	if(old_area)
+		old_area.Exited(T, A)
 	A.Entered(T, old_area)
 
 /area/proc/get_contents()

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -64,13 +64,10 @@
 			return
 
 	user.set_machine(src)
-	var/loc = src.loc
-	if (istype(loc, /turf))
-		loc = loc:loc
-	if (!istype(loc, /area))
-		to_chat(user, text("Turret badly positioned - loc.loc is [].", loc))
+
+	var/area/area = get_area(src)
+	if(!area || isturf(loc))
 		return
-	var/area/area = loc
 	var/t = "<TT><B>AI Liquid Dispenser</B> ([area.name])<HR>"
 
 	if(src.locked && (!istype(user, /mob/living/silicon)))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -41,8 +41,8 @@
 
 
 /obj/machinery/atmospherics/unary/cryo_cell/Destroy()
-	var/turf/T = loc
-	T.contents += contents
+	for(var/atom/movable/A in src)
+		A.dropInto(loc)
 	if(beaker)
 		beaker.forceMove(get_step(loc, SOUTH)) //Beaker is carefully ejected from the wreckage of the cryotube
 		beaker = null

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -155,7 +155,8 @@ move an amendment</a> to the drawing, or <a href='?src=\ref[src];action=delete_a
 
 
 /obj/item/blueprints/proc/move_turfs_to_area(var/list/turf/turfs, var/area/A)
-	A.contents.Add(turfs)
+	for(var/T in turfs)
+		ChangeArea(T, A)
 
 /obj/item/blueprints/proc/edit_area()
 	var/area/A = get_area()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -41,10 +41,9 @@
 	return INITIALIZE_HINT_LATELOAD // oh no! we need to switch to being a different kind of turf!
 
 /turf/space/LateInitialize()
-	// We alter area type before the turf to ensure the turf-change-event-propagation is handled as expected.
 	if(GLOB.using_map.base_floor_area)
 		var/area/new_area = locate(GLOB.using_map.base_floor_area) || new GLOB.using_map.base_floor_area
-		new_area.contents.Add(src)
+		ChangeArea(src, new_area)
 	ChangeTurf(GLOB.using_map.base_floor_type)
 
 // override for space turfs, since they should never hide anything

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -91,7 +91,7 @@
 			output += "&nbsp;&nbsp;[filter]: [f.len]<br>"
 			for (var/device in f)
 				if (isobj(device))
-					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device] ([device:x],[device:y],[device:z] in area [get_area(device:loc)])<br>"
+					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device] ([device:x],[device:y],[device:z] in area [get_area(device)])<br>"
 				else
 					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device]<br>"
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -83,7 +83,6 @@
 		return
 
 	for (var/obj/item/weapon/ore/O in contents)
-		contents -= O
 		O.dropInto(loc)
 	to_chat(usr, "<span class='notice'>You empty the ore box</span>")
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -26,9 +26,8 @@
 			sight_mode &= ~module_state_1:sight_mode
 		if (client)
 			client.screen -= module_state_1
-		contents -= module_state_1
+		module_state_1.forceMove(module)
 		module_active = null
-		module_state_1:loc = module //So it can be used again later
 		module_state_1 = null
 		inv1.icon_state = "inv1"
 	else if(module_state_2 == module_active)
@@ -36,9 +35,8 @@
 			sight_mode &= ~module_state_2:sight_mode
 		if (client)
 			client.screen -= module_state_2
-		contents -= module_state_2
+		module_state_2.forceMove(module)
 		module_active = null
-		module_state_2:loc = module
 		module_state_2 = null
 		inv2.icon_state = "inv2"
 	else if(module_state_3 == module_active)
@@ -46,9 +44,8 @@
 			sight_mode &= ~module_state_3:sight_mode
 		if (client)
 			client.screen -= module_state_3
-		contents -= module_state_3
+		module_state_3.forceMove(module)
 		module_active = null
-		module_state_3:loc = module
 		module_state_3 = null
 		inv3.icon_state = "inv3"
 	update_icon()
@@ -61,8 +58,7 @@
 			sight_mode &= ~module_state_1:sight_mode
 		if (client)
 			client.screen -= module_state_1
-		contents -= module_state_1
-		module_state_1:loc = module
+		module_state_1.forceMove(module)
 		module_state_1 = null
 		inv1.icon_state = "inv1"
 	if(module_state_2)
@@ -70,8 +66,7 @@
 			sight_mode &= ~module_state_2:sight_mode
 		if (client)
 			client.screen -= module_state_2
-		contents -= module_state_2
-		module_state_2:loc = module
+		module_state_2.forceMove(module)
 		module_state_2 = null
 		inv2.icon_state = "inv2"
 	if(module_state_3)
@@ -79,8 +74,7 @@
 			sight_mode &= ~module_state_3:sight_mode
 		if (client)
 			client.screen -= module_state_3
-		contents -= module_state_3
-		module_state_3:loc = module
+		module_state_3.forceMove(module)
 		module_state_3 = null
 		inv3.icon_state = "inv3"
 	update_icon()
@@ -226,21 +220,21 @@
 		module_state_1 = O
 		O.hud_layerise()
 		O.screen_loc = inv1.screen_loc
-		contents += O
+		O.forceMove(src)
 		if(istype(module_state_1,/obj/item/borg/sight))
 			sight_mode |= module_state_1:sight_mode
 	else if(!module_state_2)
 		module_state_2 = O
 		O.hud_layerise()
 		O.screen_loc = inv2.screen_loc
-		contents += O
+		O.forceMove(src)
 		if(istype(module_state_2,/obj/item/borg/sight))
 			sight_mode |= module_state_2:sight_mode
 	else if(!module_state_3)
 		module_state_3 = O
 		O.hud_layerise()
 		O.screen_loc = inv3.screen_loc
-		contents += O
+		O.forceMove(src)
 		if(istype(module_state_3,/obj/item/borg/sight))
 			sight_mode |= module_state_3:sight_mode
 	else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -44,10 +44,10 @@
 
 //3 Modules can be activated at any one time.
 	var/obj/item/weapon/robot_module/module = null
-	var/module_active = null
-	var/module_state_1 = null
-	var/module_state_2 = null
-	var/module_state_3 = null
+	var/obj/item/module_active
+	var/obj/item/module_state_1
+	var/obj/item/module_state_2
+	var/obj/item/module_state_3
 
 	silicon_camera = /obj/item/device/camera/siliconcam/robot_camera
 	silicon_radio = /obj/item/device/radio/borg
@@ -830,19 +830,19 @@
 		if(!module_state_1)
 			module_state_1 = O
 			O.hud_layerise()
-			contents += O
+			O.forceMove(src)
 			if(istype(module_state_1,/obj/item/borg/sight))
 				sight_mode |= module_state_1:sight_mode
 		else if(!module_state_2)
 			module_state_2 = O
 			O.hud_layerise()
-			contents += O
+			O.forceMove(src)
 			if(istype(module_state_2,/obj/item/borg/sight))
 				sight_mode |= module_state_2:sight_mode
 		else if(!module_state_3)
 			module_state_3 = O
 			O.hud_layerise()
-			contents += O
+			O.forceMove(src)
 			if(istype(module_state_3,/obj/item/borg/sight))
 				sight_mode |= module_state_3:sight_mode
 		else
@@ -855,13 +855,13 @@
 		if(activated(O))
 			if(module_state_1 == O)
 				module_state_1 = null
-				contents -= O
+				O.forceMove(null)
 			else if(module_state_2 == O)
 				module_state_2 = null
-				contents -= O
+				O.forceMove(null)
 			else if(module_state_3 == O)
 				module_state_3 = null
-				contents -= O
+				O.forceMove(null)
 			else
 				to_chat(src, "Module isn't activated.")
 		else

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -257,7 +257,7 @@
 	if(target == start)
 		return
 
-	var/obj/item/projectile/A = new projectiletype(user:loc)
+	var/obj/item/projectile/A = new projectiletype(get_turf(user))
 	playsound(user, projectilesound, 100, 1)
 	if(!A)	return
 	var/def_zone = get_exposed_defense_zone(target)

--- a/code/modules/overmap/exoplanets/theme.dm
+++ b/code/modules/overmap/exoplanets/theme.dm
@@ -28,7 +28,7 @@
 
 /datum/random_map/automata/cave_system/mountains/get_additional_spawns(value, var/turf/simulated/mineral/T)
 	T.color = rock_color
-	if(planetary_area)	
-		planetary_area.contents.Add(T)
+	if(planetary_area)
+		ChangeArea(T, planetary_area)
 		if(istype(T))
 			T.mined_turf = planetary_area.base_turf

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -24,8 +24,7 @@
 			//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
 			set_light(E.lightlevel, 0.1, 2)
 			if(E.planetary_area && istype(loc, world.area))
-				E.planetary_area.contents.Add(src)
-				E.planetary_area.Entered(src)
+				ChangeArea(src, E.planetary_area)
 	..()
 
 /turf/simulated/floor/exoplanet/attackby(obj/item/C, mob/user)
@@ -137,7 +136,7 @@
 	if(!istype(E))
 		return
 	if(E.planetary_area && istype(loc, world.area))
-		E.planetary_area.contents.Add(src)
+		ChangeArea(src, E.planetary_area)
 	var/new_x = A.x
 	var/new_y = A.y
 	if(x <= TRANSITIONEDGE)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -120,17 +120,14 @@
 	testing("Building overmap...")
 	world.maxz++
 	GLOB.using_map.overmap_z = world.maxz
-	var/list/turfs = list()
+	var/area/overmap/A = new
 	for (var/square in block(locate(1,1,GLOB.using_map.overmap_z), locate(GLOB.using_map.overmap_size,GLOB.using_map.overmap_size,GLOB.using_map.overmap_z)))
 		var/turf/T = square
 		if(T.x == GLOB.using_map.overmap_size || T.y == GLOB.using_map.overmap_size)
 			T = T.ChangeTurf(/turf/unsimulated/map/edge)
 		else
-			T = T.ChangeTurf(/turf/unsimulated/map/)
-		turfs += T
-
-	var/area/overmap/A = new
-	A.contents.Add(turfs)
+			T = T.ChangeTurf(/turf/unsimulated/map)
+		ChangeArea(T, A)
 
 	GLOB.using_map.sealed_levels |= GLOB.using_map.overmap_z
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -164,7 +164,7 @@
 
 			to_chat(user, "<span class='warning'>You slip \the [W] inside \the [src].</span>")
 			add_fingerprint(user)
-			contents += W
+			W.forceMove(src)
 			return
 
 		if (has_edge(W))

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -164,11 +164,10 @@
 				if(tx >= ux && tx <= ex && ty >= uy && ty <= ey)
 					floor_turfs += checking
 
-		// Do this area stuff before placing machinery or anything else. Otherwise it will potentially change areas without properly updating listeners.
 		var/area_path = areas_to_use[az]
-		for(var/thing in floor_turfs)
-			new area_path(thing)
-		var/area/A = locate(area_path)
+		var/area/A = locate(area_path) || new area_path()
+		for(var/T in floor_turfs)
+			ChangeArea(T, A)
 		cfloor.set_area_ref("\ref[A]")
 
 		// Place exterior doors.

--- a/code/modules/xenoarcheaology/finds/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/fossils.dm
@@ -31,15 +31,16 @@
 /obj/item/weapon/fossil/skull/horned
 	icon_state = "hskull"
 
-/obj/item/weapon/fossil/skull/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/fossil/skull/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W,/obj/item/weapon/fossil/bone))
+		if(!user.canUnEquip(W))
+			return
+		var/mob/M = get_holder_of_type(src, /mob)
+		if(M && !M.unEquip(src))
+			return
 		var/obj/o = new /obj/skeleton(get_turf(src))
-		var/a = new /obj/item/weapon/fossil/bone
-		var/b = new src.type
-		o.contents.Add(a)
-		o.contents.Add(b)
-		qdel(W)
-		qdel(src)
+		user.unEquip(W, o)
+		forceMove(o)
 
 /obj/skeleton
 	name = "Incomplete skeleton"
@@ -55,12 +56,10 @@
 	src.breq = rand(6)+3
 	src.desc = "An incomplete skeleton, looks like it could use [src.breq-src.bnum] more bones."
 
-/obj/skeleton/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/skeleton/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W,/obj/item/weapon/fossil/bone))
-		if(!bstate)
+		if(!bstate && user.unEquip(W, src))
 			bnum++
-			src.contents.Add(new/obj/item/weapon/fossil/bone)
-			qdel(W)
 			if(bnum==breq)
 				usr = user
 				icon_state = "skel"


### PR DESCRIPTION
Adds `ChangeArea`, my best guess at good practices when changing the area of a turf. At any rate it centralizes most area changes to this proc, so if my best guess is bad it can be fixed.

All area changes that I could find now go through this, with the exception of the map reader (which I think is incorrect to change but am not sure) and the swapmap library (which is unmaintained, but should also likely not go through this). This may be incomplete, as they are relatively hard to find. Turbolifts were doing something particularly bad relative to the other stuff I touch, so are most likely to have noticeable effects.

After this, the following syntax should not be used outside of dmm manipulation:
```
new /area([not null first argument])
area.contents.Add(turfs)
area.contents += turfs
area.contents -= turfs
```
The last three should not be used on any atoms, not just areas, and all uses I could find were removed. Also all uses of `:loc`. I'm aware that this superficially touches a lot of borg inventory code which is awful, but fixing it is not by goal here.

Note that this is not particularly well-tested. Most likely effects would be fixing (or breaking) power stuff.