### PR TITLE
Adds subtle visible messages to emag effects

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -319,9 +319,9 @@
 		available_chemicals |= upgrade2_chemicals
 
 
-/obj/machinery/sleeper/emag_act(var/remaining_charges, var/mob/user)
+/obj/machinery/sleeper/emag_act(var/remaining_charges, var/mob/user, var/emag_source)
 	emagged = !emagged
-	to_chat(user, "<span class='danger'>You [emagged ? "disable" : "enable"] \the [src]'s chemical synthesis safety checks.</span>")
+	user.visible_message(SPAN_WARNING("[user] swipes a card through \the [src]. The panel flashes [emagged ? "green" : "red"] then beeps quietly."), SPAN_DANGER("You [emagged ? "disable" : "enable"] \the [src]'s chemical synthesis safety checks with \the [emag_source]. The panel flashes [emagged ? "green" : "red"] then beeps quietly."), "You hear a quiet beep.", 1)
 
 	if (emagged)
 		available_chemicals |= antag_chemicals

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -12,7 +12,7 @@
 
 /obj/structure/AIcore/emag_act(var/remaining_charges, var/mob/user, var/emag_source)
 	if(!authorized)
-		to_chat(user, "<span class='warning'>You swipe [emag_source] at [src] and jury rig it into the systems of [GLOB.using_map.full_name]!</span>")
+		user.visible_message(SPAN_WARNING("[user] swipes a card through \the [src]. The screen briefly flashes static then beeps quietly."), SPAN_DANGER("You swipe \the [emag_source] at [src] and jury rig it into the systems of [GLOB.using_map.full_name]! The screen briefly flashes static and emits a quiet beep."), "You hear a soft beep.", 1)
 		authorized = 1
 		return 1
 	. = ..()


### PR DESCRIPTION
Proof of concept pending community feedback. If I go through with this, I'll be adding this to every instance of `emag_act()`. PLEASE read this fully before you start ping spamming me in #feedback.

Adds visible messages to emag actions that more or less come down to `User swipes a card on the thing. The thing does something abnormal`. These messages are only visible if you're close by - Same range are is required to fully hear a whisper.

This is to provide a level of 'I saw you do something' beyond just seeing someone have an ID in their hand for a brief moment, while not outing an antag just because someone happened to be on the same screen but on the other side of the room.

May add a beep sound effect that has the same range limitations since the emote does mention a beep - Probably using the PDA beep sound effect to help reduce the potential for meta.