### PR TITLE
Helm interface tweak

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -139,7 +139,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 		ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 		if (!ui)
-			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 560, 545)
+			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 565, 545)
 			ui.set_initial_data(data)
 			ui.open()
 			ui.set_auto_update(1)

--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -2,158 +2,158 @@
 
 
 <div style="float:left;width:45%;">
-		<div class='block' style="height:180px;">
-				<h3>Flight data</h3> 
-			<div class='item'>
-				<div class="itemLabelWider">
-					ETA to next grid:
-				</div>
-				<div style="float:right">
-					{{:data.ETAnext}}
-				</div>
+	<fieldset style="min-height:180px;background-color: #202020;">
+		<legend style="text-align:center">Flight data</legend> 
+		<div class='item'>
+			<div class="itemLabelWider">
+				ETA to next grid:
 			</div>
-			<div class='item'>
-				<div class="itemLabelWider">
-					Speed:
-				</div>
-				<div style="float:right">
-					{{:data.speed}} Gm/h
-				</div>
-			</div>
-			<div class='item'>
-				<div class="itemLabelWider">
-					Acceleration:
-				</div>
-				<div style="float:right">
-					{{:data.accel}} Gm/h
-				</div>
-			</div>
-			<div class='item'>
-				<div class="itemLabelWider">
-					Heading:
-				</div>
-				<div style="float:right">
-					{{:data.heading}}&deg;
-				</div>
-			</div> 
-			<div class='item'>
-				<div class="itemLabelWider">
-					Acceleration limiter:
-				</div>
-				<div style="float:right">
-					{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}} Gm/h
-				</div>
-			</div> 
-		</div>
-		</div>
-		
-		<div style="float:left;width:25%">
-		<div class='block' style="height:180px;">
-			<h3>Manual control</h3>
-			<div class='item'>
-				<div class='item'>
-					{{:helper.link('', 'triangle-1-nw', { 'move' : 9 }, data.canburn ? null : 'disabled', null)}}
-					{{:helper.link('', 'triangle-1-n', { 'move' : 1 }, data.canburn ? null : 'disabled', null)}}
-					{{:helper.link('', 'triangle-1-ne', { 'move' : 5 }, data.canburn ? null : 'disabled', null)}}
-				</div>
-				<div class='item'>
-					{{:helper.link('', 'triangle-1-w', { 'move' : 8 }, data.canburn ? null : 'disabled', null)}}
-					{{:helper.link('', 'circle-close', { 'brake' : 1 }, data.canburn ? null : 'disabled', null)}}
-					{{:helper.link('', 'triangle-1-e', { 'move' : 4 }, data.canburn ? null : 'disabled', null)}}
-				</div>
-				<div class='item'>
-					{{:helper.link('', 'triangle-1-sw', { 'move' : 10 }, data.canburn ? null : 'disabled', null)}}
-					{{:helper.link('', 'triangle-1-s', { 'move' : 2 }, data.canburn ? null : 'disabled', null)}}
-					{{:helper.link('', 'triangle-1-se', { 'move' : 6 }, data.canburn ? null : 'disabled', null)}}
-				</div>
-		
-				<div class='item'>
-					<span class='white'>Direct control</span>
-					<br>
-					{{:helper.link(data.manual_control ? 'Engaged' : 'Disengaged', 'shuffle', { 'manual' : 1 }, null, data.manual_control ? 'selected' : null)}}
-				</div>
+			<div style="float:right">
+				{{:data.ETAnext}}
 			</div>
 		</div>
-		</div>
-		
-		<div style="float:left;width:30%">
-		<div class='block' style="height:180px;">
-			<h3>Autopilot</h3>
-			<div class='item'>
-				<div class="itemLabelWide">
-					Target:
-				</div>
-				<div class="itemContent">
-					{{if data.dest}}
-						{{:helper.link(data.d_x, null, { 'setx' : 1 }, null, null)}} {{:helper.link(data.d_y, null, { 'sety' : 1 }, null, null)}}
-					{{else}}
-						{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
-					{{/if}}
-				</div>
-			</div> 
-			<div class='item'>
-				<div class="itemLabelWide">
-					Speed limit:
-				</div>
-				<div class="itemContent">
-					{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}} Gm/h
-				</div>
-			</div> 
-			<div class="item">
-				{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
+		<div class='item'>
+			<div class="itemLabelWider">
+				Speed:
+			</div>
+			<div style="float:right">
+				{{:data.speed}} Gm/h
 			</div>
 		</div>
+		<div class='item'>
+			<div class="itemLabelWider">
+				Acceleration:
+			</div>
+			<div style="float:right">
+				{{:data.accel}} Gm/h
+			</div>
 		</div>
-		
-		<div class='block' style='clear: both;'>
-			<h3>Navigation data</h3>
-			<div class='item'>
-				<div class="itemLabel">
-					Location:
-				</div>
-				<div class="itemContent">
-						{{:data.sector}}
-				</div>
+		<div class='item'>
+			<div class="itemLabelWider">
+				Heading:
 			</div>
-			<div class='item'>
-				<div class="itemLabel">
-					Coordinates:
-				</div>
-				<div class="itemContent">
-					{{:data.s_x}} : {{:data.s_y}}
-				</div>
+			<div style="float:right">
+				{{:data.heading}}&deg;
 			</div>
-			<div class='item'>
-				<div class="itemLabel">
-					Scan data:
-				</div>
-				<div class="itemContent">
-					{{:data.sector_info}}
-				</div>
+		</div> 
+		<div class='item'>
+			<div class="itemLabelWider">
+				Acceleration limiter:
 			</div>
-			<div class='item'>
-				<div class="itemLabel">
-					Status:
-				</div>
-				<div class="itemContent">
-					{{:data.landed}}
-				</div>
+			<div style="float:right">
+				{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}} Gm/h
 			</div>
-			<div class='item'>
-				{{:helper.link('Save current position', 'disk', { 'add' : 'current' }, null)}}
-				{{:helper.link('Add new entry', 'document', { 'add' : 'new' }, null)}}
-			</div>
-			<div class='statusDisplay'>
-			<table style="width:100%">
-			<tr><th style="width:40%">Name<th>Coordinates<th>Actions
-			{{for data.locations}}
-				<tr class="candystripe"><td>{{:value.name}}
-				<td>{{:value.x}} : {{:value.y}}
-				<td>{{:helper.link('Plot course', 'arrowreturnthick-1-e', { 'x' : value.x, 'y' : value.y }, null, null)}}
-				{{:helper.link('Remove', 'close', { 'remove' : value.reference }, null, null)}}
-			{{/for}}
-			</table>
+		</div> 
+	</fieldset>
+</div>
+	
+<div style="float:left;width:25%">
+<fieldset style="min-height:180px;background-color: #202020;">
+	<legend style="text-align:center">Manual control</legend>
+	<div class='item'>
+		<div class='item'>
+			{{:helper.link('', 'triangle-1-nw', { 'move' : 9 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'triangle-1-n', { 'move' : 1 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'triangle-1-ne', { 'move' : 5 }, data.canburn ? null : 'disabled', null)}}
 		</div>
+		<div class='item'>
+			{{:helper.link('', 'triangle-1-w', { 'move' : 8 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'circle-close', { 'brake' : 1 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'triangle-1-e', { 'move' : 4 }, data.canburn ? null : 'disabled', null)}}
 		</div>
-		
-		
+		<div class='item'>
+			{{:helper.link('', 'triangle-1-sw', { 'move' : 10 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'triangle-1-s', { 'move' : 2 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'triangle-1-se', { 'move' : 6 }, data.canburn ? null : 'disabled', null)}}
+		</div>
+
+		<div class='item'>
+			<span class='white'>Direct control</span>
+			<br>
+			{{:helper.link(data.manual_control ? 'Engaged' : 'Disengaged', 'shuffle', { 'manual' : 1 }, null, data.manual_control ? 'selected' : null)}}
+		</div>
+	</div>
+</fieldset>
+</div>
+	
+<div style="float:left;width:30%">
+<fieldset style="min-height:180px;background-color: #202020;">
+	<legend style="text-align:center">Autopilot</legend>
+	<div class='item'>
+		<div class="itemLabelWide">
+			Target:
+		</div>
+		<div class="itemContent">
+			{{if data.dest}}
+				{{:helper.link(data.d_x, null, { 'setx' : 1 }, null, null)}} {{:helper.link(data.d_y, null, { 'sety' : 1 }, null, null)}}
+			{{else}}
+				{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
+			{{/if}}
+		</div>
+	</div> 
+	<div class='item'>
+		<div class="itemLabelWide">
+			Speed limit:
+		</div>
+		<div class="itemContent">
+			{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}} Gm/h
+		</div>
+	</div> 
+	<div class="item">
+		{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
+	</div>
+</fieldset>
+</div>
+	
+	<div class='block' style='clear: both;'>
+		<h3>Navigation data</h3>
+		<div class='item'>
+			<div class="itemLabel">
+				Location:
+			</div>
+			<div class="itemContent">
+					{{:data.sector}}
+			</div>
+		</div>
+		<div class='item'>
+			<div class="itemLabel">
+				Coordinates:
+			</div>
+			<div class="itemContent">
+				{{:data.s_x}} : {{:data.s_y}}
+			</div>
+		</div>
+		<div class='item'>
+			<div class="itemLabel">
+				Scan data:
+			</div>
+			<div class="itemContent">
+				{{:data.sector_info}}
+			</div>
+		</div>
+		<div class='item'>
+			<div class="itemLabel">
+				Status:
+			</div>
+			<div class="itemContent">
+				{{:data.landed}}
+			</div>
+		</div>
+		<div class='item'>
+			{{:helper.link('Save current position', 'disk', { 'add' : 'current' }, null)}}
+			{{:helper.link('Add new entry', 'document', { 'add' : 'new' }, null)}}
+		</div>
+		<div class='statusDisplay'>
+		<table style="width:100%">
+		<tr><th style="width:40%">Name<th>Coordinates<th>Actions
+		{{for data.locations}}
+			<tr class="candystripe"><td>{{:value.name}}
+			<td>{{:value.x}} : {{:value.y}}
+			<td>{{:helper.link('Plot course', 'arrowreturnthick-1-e', { 'x' : value.x, 'y' : value.y }, null, null)}}
+			{{:helper.link('Remove', 'close', { 'remove' : value.reference }, null, null)}}
+		{{/for}}
+		</table>
+	</div>
+	</div>
+	
+	


### PR DESCRIPTION

![](https://i.imgur.com/lCrts27.png)

![](https://i.imgur.com/PshDmYR.png)
Using thise new fancy tag I found instead of blocks, to save space on block titles (now they're part of the border)
Also using min-height instead of height so it will try to use more space if it needs/can
Should fix #25609

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->