### PR TITLE
Tweak bonus blob attacks

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -152,4 +152,10 @@
 // Used to easily change research colour in case of ???
 #define COLOR_RESEARCH COLOR_PURPLE_GRAY
 
+//Blob colors
+#define BLOB_COLOR_CORE      "#c96e28"
+#define BLOB_COLOR_SHIELD    "#9ed659"
+#define BLOB_COLOR_RAV       "#d65f42"
+#define BLOB_COLOR_PULS      "#b5ff5b"
+
 #define RANDOM_RGB rgb(rand(0,255), rand(0,255), rand(0,255))

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -1,10 +1,10 @@
 /obj/effect/blob
-	name = "ravaging mass"
+	name = "pulsating mass"
 	desc = "A pulsating mass of interwoven tendrils."
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob"
 	light_outer_range = 2
-	light_color = "#b5ff5b"
+	light_color = BLOB_COLOR_PULS
 	density = 1
 	opacity = 1
 	anchored = 1
@@ -13,7 +13,6 @@
 	plane = BLOB_PLANE
 	layer = BLOB_SHIELD_LAYER
 
-	var/blob_may_process = 1
 	var/maxHealth = 30
 	var/health
 	var/regen_rate = 5
@@ -23,9 +22,10 @@
 	var/expandType = /obj/effect/blob
 	var/secondary_core_growth_chance = 5 //% chance to grow a secondary blob core instead of whatever was suposed to grown. Secondary cores are considerably weaker, but still nasty.
 	var/damage_min = 20
-	var/damage_max = 40
+	var/damage_max = 35
 	var/pruned = FALSE
 	var/product = /obj/item/weapon/blob_tendril
+	var/attack_freq = 3 //see proc/attempt_attack; lower is more often, min 1
 
 /obj/effect/blob/New(loc)
 	health = maxHealth
@@ -57,7 +57,7 @@
 		icon_state = "blob_damaged"
 
 /obj/effect/blob/Process(wait, times_fired)
-	if(times_fired % 2)
+	if(times_fired % attack_freq)
 		return
 	attempt_attack(GLOB.alldirs)
 
@@ -112,8 +112,7 @@
 		return
 	var/obj/mecha/M = locate() in T
 	if(M)
-		M.visible_message("<span class='danger'>The blob attacks \the [M]!</span>")
-		M.take_damage(40)
+		attack_mech(M)
 		return
 	var/obj/machinery/camera/CA = locate() in T
 	if(CA)
@@ -148,9 +147,15 @@
 	if(!L)
 		return
 	var/blob_damage = pick(BRUTE, BURN)
-	L.visible_message("<span class='danger'>A tendril flies out from \the [src] and smashes into \the [L]!</span>", "<span class='danger'>A tendril flies out from \the [src] and smashes into you!</span>")
+	L.visible_message(SPAN_DANGER("A tendril flies out from \the [src] and smashes into \the [L]!"), SPAN_DANGER("A tendril flies out from \the [src] and smashes into you!"))
 	playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)
 	L.apply_damage(rand(damage_min, damage_max), blob_damage, used_weapon = "blob tendril")
+
+/obj/effect/blob/proc/attack_mech(var/obj/mecha/mech)
+	if(!mech)
+		return
+	mech.visible_message(SPAN_DANGER("A tendril flies out from \the [src] and slams into \the [mech]!"))
+	mech.take_damage(rand(damage_min, damage_max))
 
 /obj/effect/blob/proc/attempt_attack(var/list/dirs)
 	var/attackDir = pick(dirs)
@@ -159,6 +164,8 @@
 		if(victim.stat == DEAD)
 			continue
 		attack_living(victim)
+	for(var/obj/mecha/mech in T)
+		attack_mech(mech)
 
 /obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
@@ -209,14 +216,17 @@
 	brute_resist = 1
 	fire_resist = 4
 	regen_rate = 2
-
-	layer = BLOB_CORE_LAYER
-
 	damage_min = 30
 	damage_max = 40
 	expandType = /obj/effect/blob/shield
 	product = /obj/item/weapon/blob_tendril/core
+	attack_freq = 4
+	light_color = BLOB_COLOR_CORE
+
+	layer = BLOB_CORE_LAYER
+
 	var/growth_range = 10 // Maximal distance for new blob pieces from this core.
+	var/blob_may_process = 1
 
 // Rough icon state changes that reflect the core's health
 /obj/effect/blob/core/on_update_icon()
@@ -263,9 +273,13 @@
 	name = "shielding mass"
 	desc = "A pulsating mass of interwoven tendrils. These seem particularly robust, but not quite as active."
 	icon_state = "blob_idle"
-	maxHealth = 60
-	damage_min = 20
-	damage_max = 35
+	maxHealth = 100
+	damage_min = 16
+	damage_max = 28
+	attack_freq = 5
+	expandType = /obj/effect/blob/ravaging
+	light_color = BLOB_COLOR_SHIELD
+
 
 /obj/effect/blob/shield/New()
 	..()
@@ -286,6 +300,14 @@
 
 /obj/effect/blob/shield/CanPass(var/atom/movable/mover, var/turf/target, var/height = 0, var/air_group = 0)
 	return !density
+
+/obj/effect/blob/ravaging
+	name = "ravaging mass"
+	desc = "A mass of interwoven tendrils. They thrash around haphazardly at anything in reach."
+	damage_min = 35
+	damage_max = 45
+	attack_freq = 2
+	light_color = BLOB_COLOR_RAV
 
 //produce
 /obj/item/weapon/blob_tendril
@@ -323,7 +345,7 @@
 	if(is_tendril && prob(50))
 		force--
 		if(force <= 0)
-			visible_message("<span class='notice'>\The [src] crumbles apart!</span>")
+			visible_message(SPAN_NOTICE("\The [src] crumbles apart!"))
 			user.drop_from_inventory(src)
 			new /obj/effect/decal/cleanable/ash(src.loc)
 			qdel(src)


### PR DESCRIPTION
:cl:
tweak: All types of blob will now launch bonus attacks less often overall, and will attack more or less often depending on their type.
rscadd: Added the 'ravaging mass', which forms an offensive line around the shield blob spawned by the cores. This type attacks most often and most potently of all the blob types.
tweak: The base type (which makes up the bulk of the blob) formerly known as 'ravaging mass' is now 'pulsating mass', and has had its maximum damage potential reduced.
tweak: Reduced damage potential of the shielding mass. Increased hit points.
tweak: Mecha are now valid targets for the blob's bonus attacks.
/:cl:

COR = core | SH = shield | RA = ravaging | PU = pulsing
![](https://i.imgur.com/RJ6ghiL.png)
COR = high damage, low frequency
SH = low damage, very low frequency (engage at melee)
RA = high damage, high frequency (engage at range)
PU = standard (engage at melee)