### PR TITLE
Fix invisidrone

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -122,7 +122,7 @@
 
 	if(R.silicon_radio)
 		R.silicon_radio.recalculateChannels()
-	R.choose_icon(0, R.set_module_sprites(list("Default" = "robot")))
+	R.choose_icon(0, R.set_module_sprites(list("Default" = initial(R.icon_state))))
 
 /obj/item/weapon/robot_module/Destroy()
 	QDEL_NULL_LIST(equipment)


### PR DESCRIPTION
:cl: WezYo
bugfix: resetting a flying drone will no longer make it invisible
/:cl:

Issue was the icon_state was reverting back to the original value for a robot, which is `default`, but the intended sprite for flying drones was called `drone-standard`. Passing the initial(R.icon_state) will correctly set the icon if its a flying bot or a regular bot.

Fixes #25649