### PR TITLE
More Hardsuit tweaks and fixes

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -219,6 +219,7 @@
 	name = "mounted plasma cutter"
 	desc = "A forearm-mounted plasma cutter."
 	icon_state = "plasmacutter"
+	usable = 0
 
 	suit_overlay_active = "plasmacutter"
 
@@ -233,24 +234,10 @@
 	if(!check() || !gun)
 		return 0
 
-	if(!target)
-		playsound(src.loc, 'sound/weapons/guns/selector.ogg', 50, 1)
-		if(!active)
-			active=1
-			to_chat(holder.wearer, "<span class='notice'>\The [src] is now set to close range mode.</span>")
-		else
-			active=0
-			to_chat(holder.wearer, "<span class='notice'>\The [src] is now set to firing mode.</span>")
-		return
-
-	if(!active)
+	if(holder.wearer.a_intent == I_HURT || !target.Adjacent(holder.wearer))
 		gun.Fire(target,holder.wearer)
 		return 1
 	else
-		var/turf/T = get_turf(target)
-		if(istype(T) && !target.Adjacent(holder.wearer))
-			return 0
-
 		var/resolved = target.attackby(gun,holder.wearer)
 		if(!resolved && gun && target)
 			gun.afterattack(target,holder.wearer,1)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -17,6 +17,7 @@
 
 	var/damage = 0
 	var/obj/item/weapon/rig/holder
+	var/list/banned_modules = list()
 
 	var/module_cooldown = 10
 	var/next_use = 0
@@ -223,13 +224,11 @@
 	if(!check())
 		return 0
 
-	for (var/obj/item/rig_module/M in holder.installed_modules)
-		if(M.selectable)
-			if(M.suit_overlay_inactive)
-				M.suit_overlay = M.suit_overlay_inactive
-			else
-				M.suit_overlay = null
-			holder.update_icon()
+	if(holder.selected_module)
+		if(holder.selected_module.suit_overlay_inactive)
+			holder.selected_module.suit_overlay = holder.selected_module.suit_overlay_inactive
+		else
+			holder.selected_module.suit_overlay = null
 
 	holder.selected_module = src
 	if(suit_overlay_active)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -121,8 +121,7 @@
 		device.attack_self(holder.wearer)
 		return 1
 
-	var/turf/T = get_turf(target)
-	if(istype(T) && !target.Adjacent(holder.wearer))
+	if(!target.Adjacent(holder.wearer))
 		return 0
 
 	var/resolved = target.attackby(device,holder.wearer)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -402,7 +402,8 @@
 			malfunction()
 
 		for(var/obj/item/rig_module/module in installed_modules)
-			cell.use(module.Process() * CELLRATE)
+			if(!cell.checked_use(module.Process() * CELLRATE))
+				module.deactivate()//turns off modules when your cell is dry
 
 //offline should not change outside this proc
 /obj/item/weapon/rig/proc/update_offline()
@@ -605,7 +606,10 @@
 				if("engage")
 					module.engage()
 				if("select")
-					module.select()
+					if(selected_module == module)
+						deselect_module()
+					else
+						module.select()
 				if("select_charge_type")
 					module.charge_selected = href_list["charge_type"]
 		return 1
@@ -746,6 +750,14 @@
 	if(wearer)
 		wearer.wearing_rig = null
 		wearer = null
+
+/obj/item/weapon/rig/proc/deselect_module()
+	if(selected_module.suit_overlay_inactive)
+		selected_module.suit_overlay = selected_module.suit_overlay_inactive
+	else
+		selected_module.suit_overlay = null
+	selected_module = null
+	update_icon()
 
 //Todo
 /obj/item/weapon/rig/proc/malfunction()

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -5,9 +5,6 @@
 	if(electrified != 0)
 		if(shock(user)) //Handles removing charge from the cell, as well. No need to do that here.
 			return
-	if(is_type_in_list(W,banned_modules))
-		to_chat(user, "<span class='danger'>\The [src] cannot mount this type of module.</span>")
-		return
 
 	// Pass repair items on to the chestpiece.
 	if(chest && (istype(W,/obj/item/stack/material) || isWelder(W)))
@@ -80,14 +77,26 @@
 					to_chat(user, "<span class='danger'>You can't install a hardsuit module while the suit is being worn.</span>")
 					return 1
 
+			if(is_type_in_list(W,banned_modules))
+				to_chat(user, SPAN_DANGER("\The [src] cannot mount this type of module."))
+				return 1
+
+			var/obj/item/rig_module/mod = W
+
 			if(!installed_modules) installed_modules = list()
 			if(installed_modules.len)
 				for(var/obj/item/rig_module/installed_mod in installed_modules)
-					if(!installed_mod.redundant && istype(installed_mod,W))
+					if(is_type_in_list(installed_mod,mod.banned_modules))
+						to_chat(user, SPAN_DANGER("\The [installed_mod] is incompatible with this module."))
+						return 1
+					if(installed_mod.banned_modules.len)
+						if(is_type_in_list(W,installed_mod.banned_modules))
+							to_chat(user, SPAN_DANGER("\The [installed_mod] is incompatible with this module."))
+							return 1
+					if(!installed_mod.redundant && installed_mod.type == W.type)
 						to_chat(user, "The hardsuit already has a module of that class installed.")
 						return 1
 
-			var/obj/item/rig_module/mod = W
 			to_chat(user, "You begin installing \the [mod] into \the [src].")
 			if(!do_after(user,40,src))
 				return

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -217,15 +217,8 @@
 	var/obj/item/rig_module/module = input("Which module do you wish to select?") as null|anything in selectable
 
 	if(!istype(module))
-		selected_module = null
+		deselect_module()
 		to_chat(usr, "<font color='blue'><b>Primary system is now: deselected.</b></font>")
-		for (var/obj/item/rig_module/M in installed_modules)//removes all selectable module icons
-			if(M.selectable)
-				if(M.suit_overlay_inactive)
-					M.suit_overlay = M.suit_overlay_inactive
-				else
-					M.suit_overlay = null
-				update_icon()
 		return
 
 	module.select()


### PR DESCRIPTION
🆑
tweak: Hardsuit modules can now be deselected by pressing select again.
tweak: Hardsuit plasma cutter automatically do object interaction if they're adjacent. They will now also always fire on harm intent.
/🆑

I'm back at it again, gonna keep on polishing it until it shines.

- Plasma cutter module is more usable now.
- Allow hardsuit to deselect modules easier and more intuitively, so you can stop shoving that plasma cutter gun into peoples' faces.
- Hardsuit will now automatically turn off modules if they can't power them. So no more jetpack, cooler or stealth module lasting forever with no power
- Allow hardsuits modules to ban installing other modules. So you can't stack flash with an advance flash or grenade launcher with a ninja grenade launcher.