### PR TITLE
Overmap antagonists

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -37,6 +37,8 @@ var/global/list/additional_antag_types = list()
 
 	var/waittime_l = 60 SECONDS				 // Lower bound on time before start of shift report
 	var/waittime_h = 180 SECONDS		     // Upper bounds on time before start of shift report
+	
+	var/datum/map_template/overmap_template = null // Antagonist spawn areas for overmap. Default to none.
 
 	//Format: list(start_animation = duration, hit_animation, miss_animation). null means animation is skipped.
 	var/cinematic_icon_states = list(
@@ -202,6 +204,9 @@ var/global/list/additional_antag_types = list()
 			EMajor.delay_modifier = event_delay_mod_major
 
 /datum/game_mode/proc/pre_setup()
+	if(istype(overmap_template)) //spawn relevant overmap template if defined
+		overmap_template.load_new_z()
+		report_progress("Loaded gamemode away site [overmap_template]!")
 	for(var/datum/antagonist/antag in antag_templates)
 		antag.update_current_antag_max(src)
 		antag.build_candidate_list(src) //compile a list of all eligible candidates

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -13,4 +13,5 @@
 		colony of sizable population and considerable wealth causes it to often be the target of various \
 		attempts of robbery, fraud and other malicious actions."
 	end_on_antag_death = FALSE
+	overmap_template = /datum/map_template/gamemode_site/heist_base
 	antag_tags = list(MODE_RAIDER)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -23,6 +23,7 @@ var/list/nuke_disks = list()
 		"summary_nukewin",
 		"summary_nukefail"
 	)
+	overmap_template = /datum/map_template/gamemode_site/heist_base
 
 //checks if L has a nuke disk on their person
 /datum/game_mode/nuclear/proc/check_mob(mob/living/L)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -23,7 +23,7 @@ var/list/nuke_disks = list()
 		"summary_nukewin",
 		"summary_nukefail"
 	)
-	overmap_template = /datum/map_template/gamemode_site/heist_base
+	overmap_template = /datum/map_template/gamemode_site/nuclear_base
 
 //checks if L has a nuke disk on their person
 /datum/game_mode/nuclear/proc/check_mob(mob/living/L)

--- a/maps/gamemode/gamemode_sites.dm
+++ b/maps/gamemode/gamemode_sites.dm
@@ -1,0 +1,2 @@
+/datum/map_template/gamemode_site
+	prefix = "maps/gamemode/"

--- a/maps/gamemode/heist/heist_base.dm
+++ b/maps/gamemode/heist/heist_base.dm
@@ -1,0 +1,13 @@
+#include "heist_base_areas.dm"
+
+/obj/effect/overmap/sector/heist_base
+	name = "asteroid base"
+	desc = "A large asteroid emitting faint traces of sub-space activity."
+	icon_state = "meteor2"
+	known = 0
+
+/datum/map_template/gamemode_site/heist_base
+	name = "asteroid base"
+	id = "awaysite_heist_hideout"
+	description = "Just another large asteroid."
+	suffixes = list("heist/heist_base.dmm")

--- a/maps/gamemode/nuclear/nuclear_base.dm
+++ b/maps/gamemode/nuclear/nuclear_base.dm
@@ -1,0 +1,13 @@
+#include "nuclear_base_areas.dm"
+
+/obj/effect/overmap/sector/nuclear_base
+	name = "asteroid base"
+	desc = "A large asteroid emitting faint traces of sub-space activity."
+	icon_state = "meteor1"
+	known = 0
+
+/datum/map_template/gamemode_site/nuclear_base
+	name = "asteroid base"
+	id = "awaysite_nuclear_hideout"
+	description = "Just another large asteroid."
+	suffixes = list("nuclearn/nuclear_base.dmm")


### PR DESCRIPTION
This PR will modify certain antagonists/gamemodes to utilise the overmap system instead of relying on the admin Z to house antags. At the moment all sectors will spawn looking like other overmap hazards and not appear on sensors to give antags the upper hand. Shuttles will also be able to cloak to remain hidden if desired.

- [X] Create overmap template spawn system within gamemode
- [ ] Port shuttle cloaking to overmap shuttle system
- [ ] Move merc/raider/ninja/wizard bases off of admin Z onto their own landmark maps
- [ ] Have antag shuttles not require fuel
- [ ] Look at code while not on web editor
- [ ] Test spawns working correctly
- [ ] Test sensors not picking up landmarks
- [ ] Test range checks on flying to Torch