### PR TITLE
Override chair rotate()

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -84,6 +84,14 @@
 				stool_cache[cache_key] = I
 			overlays |= stool_cache[cache_key]
 
+/obj/structure/bed/chair/rotate(mob/user)
+	if(!CanPhysicallyInteract(user))
+		to_chat(user, SPAN_NOTICE("You can't interact with \the [src] right now!"))
+		return
+
+	set_dir(turn(dir, 90))
+	update_icon() 
+
 /obj/structure/bed/chair/set_dir()
 	..()
 	if(buckled_mob)


### PR DESCRIPTION
Forgot that there were a lot of anchored chairs. Overrides the base rotate() to skip checking anchored

Fixes #25694