### PR TITLE
Make cleanable decals qdel in space

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -10,6 +10,8 @@
 
 /obj/effect/decal/cleanable/Initialize()
 	. = ..()
+	if(isspace(loc))
+		return INITIALIZE_HINT_QDEL
 	hud_overlay = new /image/hud_overlay('icons/obj/hud_tile.dmi', src, "caution")
 	hud_overlay.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 
@@ -24,6 +26,7 @@
 /obj/effect/decal/cleanable/Destroy()
 	SSpersistence.forget_value(src, /datum/persistent/filth)
 	. = ..()
+
 /obj/effect/decal/cleanable/water_act(var/depth)
 	..()
 	qdel(src)


### PR DESCRIPTION
All cleanable decals will fail to spawn in space now

Not sure why there are two `cleanable/Initialize()` but I added it to the first one

Closes https://github.com/Baystation12/Baystation12/issues/25616