### PR TITLE
Fix for grabs.

### DIFF
--- a/code/game/gamemodes/godmode/god_altar.dm
+++ b/code/game/gamemodes/godmode/god_altar.dm
@@ -23,7 +23,7 @@
 			G.affecting.dropInto(loc)
 			G.affecting.Weaken(1)
 			user.visible_message("<span class='warning'>\The [user] throws \the [G.affecting] onto \the [src]!</span>")
-			user.drop_from_inventory(G)
+			qdel(G)
 	else ..()
 
 /obj/structure/deity/altar/Process()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -62,8 +62,7 @@
 		if(!G.force_danger())
 			to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
 			return
-		if(!user.unEquip(W))
-			return
+		qdel(G)
 		move_into_gibber(user,G.affecting)
 	else if(istype(W, /obj/item/organ))
 		if(!user.unEquip(W))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -207,20 +207,23 @@
 			to_chat(user, "<span class='notice'>You try to use your hand, but realize it is no longer attached!</span>")
 			return
 
-	var/old_loc = src.loc
+	var/old_loc = loc
 
-	src.pickup(user)
-	if (istype(src.loc, /obj/item/weapon/storage))
-		var/obj/item/weapon/storage/S = src.loc
+	pickup(user)
+	if (istype(loc, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = loc
 		S.remove_from_storage(src)
 
-	src.throwing = 0
-	if (src.loc == user)
+	throwing = 0
+	if (loc == user)
 		if(!user.unEquip(src))
 			return
 	else
-		if(isliving(src.loc))
+		if(isliving(loc))
 			return
+
+	if(QDELETED(src))
+		return // Unequipping changes our state, so must check here.
 
 	if(user.put_in_active_hand(src))
 		if (isturf(old_loc))
@@ -233,7 +236,6 @@
 		else if(randpixel == 0)
 			pixel_x = 0
 			pixel_y = 0
-	return
 
 /obj/item/attack_ai(mob/user as mob)
 	if (istype(src.loc, /obj/item/weapon/robot_module))

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -21,7 +21,7 @@
 	if(istype(thing, /obj/item/grab))
 		var/obj/item/grab/G = thing
 		if(enter_bath(G.affecting))
-			user.unEquip(G)
+			qdel(G)
 		return
 	. = ..()
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -1,6 +1,7 @@
 
 /obj/item/grab
 	name = "grab"
+	canremove = 0
 
 	var/mob/living/carbon/human/affecting = null
 	var/mob/living/carbon/human/assailant = null


### PR DESCRIPTION
Closes #25630. Should also close all grab-related runtimes, as this potentially fixes many of them.

Honestly shocked that grabs don't set `canremove` already, as that means various random interactions may yank them away from the user. However, it's possible that this will break other interactions using `unEquip` on grabs instead of `qdel`, which is the preferred way of dropping a grab. I caught the most obvious uses.

Also resolves the underlying deletion issue in inventory code.