### PR TITLE
Adjusts vagrant stun times

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -105,8 +105,8 @@
 	if(ishuman(.))
 		var/mob/living/carbon/human/H = .
 		if(gripping == H)
-			H.Weaken(3)
-			H.Stun(3)
+			H.Weaken(2)
+			H.Stun(2)
 			return
 		//This line ensures there's always a reasonable chance of grabbing, while still
 		//Factoring in health
@@ -114,8 +114,8 @@
 			gripping = H
 			cloaked = 0
 			update_icon()
-			H.Weaken(3)
-			H.Stun(3)
+			H.Weaken(2)
+			H.Stun(2)
 			H.visible_message("<span class='danger'>\the [src] latches onto \the [H], pulsating!</span>")
 			if(carried && length(gripping.virus2) == 0)
 				infect_virus2(gripping, carried, 1)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Should mean you can get up faster after they let you go, and give you more time to kill or run from them.
