### PR TITLE
Further grab fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -440,7 +440,7 @@ var/list/global/slot_flags_enumeration = list(
 		return 0
 	return 1
 
-/obj/item/proc/can_be_dropped(mob/M)
+/obj/item/proc/can_be_dropped_by_client(mob/M)
 	return M.canUnEquip(src)
 
 /obj/item/verb/verb_pickup()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -440,6 +440,9 @@ var/list/global/slot_flags_enumeration = list(
 		return 0
 	return 1
 
+/obj/item/proc/can_be_dropped(mob/M)
+	return M.canUnEquip(src)
+
 /obj/item/verb/verb_pickup()
 	set src in oview(1)
 	set category = "Object"

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -87,6 +87,10 @@
 	if(!QDELETED(src))
 		qdel(src)
 
+/obj/item/grab/can_be_dropped(mob/M)
+	if(M == assailant)
+		return TRUE
+
 /obj/item/grab/Destroy()
 	if(affecting)
 		GLOB.dismembered_event.unregister(affecting, src)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -87,7 +87,7 @@
 	if(!QDELETED(src))
 		qdel(src)
 
-/obj/item/grab/can_be_dropped(mob/M)
+/obj/item/grab/can_be_dropped_by_client(mob/M)
 	if(M == assailant)
 		return TRUE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -106,9 +106,9 @@
 /client/verb/drop_item()
 	set hidden = 1
 	if(!isrobot(mob) && mob.stat == CONSCIOUS && isturf(mob.loc))
-		return mob.unequip_item()
-	return
-
+		var/obj/item/I = mob.get_active_hand()
+		if(I && I.can_be_dropped(mob))
+			mob.drop_item()
 
 //This proc should never be overridden elsewhere at /atom/movable to keep directions sane.
 /atom/movable/Move(newloc, direct)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -107,7 +107,7 @@
 	set hidden = 1
 	if(!isrobot(mob) && mob.stat == CONSCIOUS && isturf(mob.loc))
 		var/obj/item/I = mob.get_active_hand()
-		if(I && I.can_be_dropped(mob))
+		if(I && I.can_be_dropped_by_client(mob))
 			mob.drop_item()
 
 //This proc should never be overridden elsewhere at /atom/movable to keep directions sane.


### PR DESCRIPTION
Basically lets unequip checks use custom checks; makes grabs override q-verb drop handling to actually drop.

Maybe this isn't worth it and should just set canremove to true again, idk.