### PR TITLE
Deck 4 and 5 map fixes

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -286,10 +286,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/eva)
-"bd" = (
-/obj/effect/shuttle_landmark/ert/hanger,
-/turf/space,
-/area/space)
 "bf" = (
 /obj/machinery/light/spot{
 	pixel_y = 32
@@ -1553,6 +1549,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
+"dq" = (
+/obj/random_multi/single_item/runtime,
+/turf/simulated/floor/tiled,
+/area/quartermaster/exploration)
 "du" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -7265,6 +7265,7 @@
 /area/quartermaster/expedition/eva)
 "ql" = (
 /obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/quartermaster/expedition)
 "qm" = (
@@ -7366,15 +7367,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition)
 "qv" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/holofloor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "qw" = (
 /obj/effect/floor_decal/corner/mauve{
@@ -7423,6 +7426,9 @@
 	pixel_y = 23;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
+/obj/structure/sign/deck/fifth{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "qA" = (
@@ -7431,9 +7437,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/sign/deck/fifth{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "qB" = (
@@ -7510,6 +7513,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
@@ -8725,6 +8733,11 @@
 "te" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/sign/warning/compressed_gas{
+	dir = 8;
+	icon_state = "hikpa";
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/canister)
 "tf" = (
@@ -9704,10 +9717,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"vi" = (
-/obj/effect/shuttle_landmark/merc/hanger,
-/turf/space,
-/area/space)
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -10030,10 +10039,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/equipment)
-"wy" = (
-/obj/effect/shuttle_landmark/ninja/hanger,
-/turf/space,
-/area/space)
 "wz" = (
 /obj/machinery/door/airlock/research{
 	id_tag = null;
@@ -10206,6 +10211,11 @@
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
+	},
+/obj/structure/sign/deck/fifth{
+	dir = 4;
+	icon_state = "deck-5";
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -11495,17 +11505,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/custodial)
-"BW" = (
-/obj/structure/sign/warning/compressed_gas{
-	icon_state = "hikpa";
-	dir = 8
-	},
-/obj/structure/sign/warning/compressed_gas{
-	icon_state = "hikpa";
-	dir = 4
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/rnd/canister)
 "BX" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -12183,7 +12182,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "El" = (
 /obj/structure/table/standard,
@@ -12863,6 +12862,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"Hp" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/structure/sign/warning/compressed_gas{
+	dir = 4;
+	icon_state = "hikpa";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fifthdeck/aftstarboard)
 "Hr" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";
@@ -13213,6 +13224,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"Is" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/sign/warning/compressed_gas{
+	dir = 8;
+	icon_state = "hikpa";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "It" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -13321,10 +13346,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"IQ" = (
-/obj/effect/wallframe_spawn/no_grille,
-/turf/simulated/wall/prepainted,
-/area/quartermaster/expedition)
 "IR" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/light_switch{
@@ -13834,6 +13855,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
+"KF" = (
+/obj/effect/shuttle_landmark/merc/hanger,
+/turf/space,
+/area/space)
 "KI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -14340,6 +14365,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/security)
+"Ms" = (
+/obj/effect/shuttle_landmark/ninja/hanger,
+/turf/space,
+/area/space)
 "Mt" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -14522,6 +14551,10 @@
 /obj/effect/paint/silver,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/cockpit)
+"Nc" = (
+/obj/effect/shuttle_landmark/skipjack/hanger,
+/turf/space,
+/area/space)
 "Ne" = (
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
@@ -15021,10 +15054,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/rnd)
-"OV" = (
-/obj/random_multi/single_item/runtime,
-/turf/simulated/floor/tiled,
-/area/quartermaster/exploration)
 "OW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15150,6 +15179,10 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/hallwaya)
+"Pu" = (
+/obj/effect/shuttle_landmark/ert/hanger,
+/turf/space,
+/area/space)
 "Pv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/sign/directions/bridge{
@@ -15268,10 +15301,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
-"Qa" = (
-/obj/effect/shuttle_landmark/skipjack/hanger,
-/turf/space,
-/area/space)
 "Qd" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/bar)
@@ -24691,7 +24720,7 @@ aa
 aa
 aa
 aa
-wy
+Ms
 aa
 aa
 aa
@@ -32577,7 +32606,7 @@ oU
 iT
 hw
 kg
-OV
+dq
 ki
 kL
 hl
@@ -33745,7 +33774,7 @@ aa
 aa
 aa
 aa
-Qa
+Nc
 aa
 aa
 aa
@@ -39842,7 +39871,7 @@ qe
 qf
 qh
 Eg
-IQ
+ql
 qA
 un
 qG
@@ -41040,7 +41069,7 @@ aa
 ZG
 ZG
 TA
-jb
+Is
 hf
 An
 wk
@@ -42457,7 +42486,7 @@ aw
 ZA
 ZA
 tj
-BW
+ZA
 BC
 BC
 aa
@@ -42659,7 +42688,7 @@ WF
 HH
 hP
 BS
-Py
+Hp
 ZG
 ZG
 aa
@@ -43313,7 +43342,7 @@ aa
 aa
 aa
 aa
-bd
+Pu
 aa
 aa
 aa
@@ -48696,7 +48725,7 @@ aa
 aa
 aa
 aa
-vi
+KF
 aa
 aa
 aa

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -3129,6 +3129,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"kM" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/structure/ladder,
+/obj/effect/catwalk_plated,
+/obj/structure/sign/deck/fourth{
+	dir = 4;
+	icon_state = "deck-4";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/primary/fourthdeck/aft)
 "kN" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/fourthdeck/aft)
@@ -3174,10 +3187,6 @@
 /area/hallway/primary/fourthdeck/fore)
 "kX" = (
 /obj/structure/ladder/up,
-/obj/structure/sign/deck/fourth{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
@@ -7682,6 +7691,10 @@
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/green{
 	dir = 6
+	},
+/obj/structure/sign/deck/fourth{
+	dir = 8;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
@@ -37805,7 +37818,7 @@ UZ
 VL
 Wn
 Ym
-VA
+kM
 VA
 RD
 wa


### PR DESCRIPTION
just some quick map fixes.
Namely:
Removed a bulk head that was in the mining prep window.
Added a fire door to mining prep windows
shuffled the signs and air alarms around
Added extra signs on deck 4 and five make sure people really know where they are.