### PR TITLE
no default language ident on radios

### DIFF
--- a/code/__defines/languages.dm
+++ b/code/__defines/languages.dm
@@ -13,26 +13,30 @@
 #define LANGUAGE_SPACER         "Spacer"
 
 //Alien
-#define LANGUAGE_EAL            "Encoded Audio Language"
-#define LANGUAGE_UNATHI_SINTA   "Sinta'unathi"
-#define LANGUAGE_UNATHI_YEOSA   "Yeosa'unathi"
-#define LANGUAGE_SKRELLIAN      "Skrellian"
-#define LANGUAGE_ROOTLOCAL      "Local Rootspeak"
-#define LANGUAGE_ROOTGLOBAL     "Global Rootspeak"
-#define LANGUAGE_ADHERENT       "Protocol"
-#define LANGUAGE_VOX            "Vox-pidgin"
-#define LANGUAGE_NABBER         "Serpentid"
+#define LANGUAGE_EAL               "Encoded Audio Language"
+#define LANGUAGE_UNATHI_SINTA      "Sinta'unathi"
+#define LANGUAGE_UNATHI_YEOSA      "Yeosa'unathi"
+#define LANGUAGE_SKRELLIAN         "Skrellian"
+#define LANGUAGE_ROOTLOCAL         "Local Rootspeak"
+#define LANGUAGE_ROOTGLOBAL        "Global Rootspeak"
+#define LANGUAGE_ADHERENT          "Protocol"
+#define LANGUAGE_VOX               "Vox-pidgin"
+#define LANGUAGE_NABBER            "Serpentid"
 
 //Antag
-#define LANGUAGE_XENOPHAGE      "Xenophage"
-#define LANGUAGE_XENOPHAGE_HIVE "Hivemind"
-#define LANGUAGE_CULT           "Cult"
-#define LANGUAGE_CULT_GLOBAL    "Occult"
-#define LANGUAGE_ALIUM          "Alium"
+#define LANGUAGE_XENOPHAGE         "Xenophage"
+#define LANGUAGE_XENOPHAGE_GLOBAL  "Hivemind"
+#define LANGUAGE_CULT              "Cult"
+#define LANGUAGE_CULT_GLOBAL       "Occult"
+#define LANGUAGE_ALIUM             "Alium"
 
 //Other
-#define LANGUAGE_PRIMITIVE      "Primitive"
-#define LANGUAGE_SIGN           "Sign Language"
+#define LANGUAGE_PRIMITIVE         "Primitive"
+#define LANGUAGE_SIGN              "Sign Language"
+#define LANGUAGE_ROBOT_GLOBAL      "Robot Talk"
+#define LANGUAGE_DRONE_GLOBAL      "Drone Talk"
+#define LANGUAGE_CHANGELING_GLOBAL "Changeling"
+#define LANGUAGE_BORER_GLOBAL      "Cortical Link"
 
 // Language flags.
 #define WHITELISTED  1   // Language is available if the speaker is whitelisted.

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -56,7 +56,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	if(!mind.changeling)	mind.changeling = new /datum/changeling(gender)
 
 	verbs += /datum/changeling/proc/EvolutionMenu
-	add_language("Changeling")
+	add_language(LANGUAGE_CHANGELING_GLOBAL)
 
 	var/lesser_form = !ishuman(src)
 
@@ -132,7 +132,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		languages += language
 
 	//This isn't strictly necessary but just to be safe...
-	add_language("Changeling")
+	add_language(LANGUAGE_CHANGELING_GLOBAL)
 
 	return
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -49,10 +49,10 @@
 /obj/item/device/radio/headset/handle_message_mode(mob/living/M as mob, message, channel)
 	if (channel == "special")
 		if (translate_binary)
-			var/datum/language/binary = all_languages["Robot Talk"]
+			var/datum/language/binary = all_languages[LANGUAGE_ROBOT_GLOBAL]
 			binary.broadcast(M, message)
 		if (translate_hive)
-			var/datum/language/hivemind = all_languages["Hivemind"]
+			var/datum/language/hivemind = all_languages[LANGUAGE_XENOPHAGE_GLOBAL]
 			hivemind.broadcast(M, message)
 		return null
 

--- a/code/modules/culture_descriptor/culture/cultures_hidden.dm
+++ b/code/modules/culture_descriptor/culture/cultures_hidden.dm
@@ -40,7 +40,7 @@
 	name = CULTURE_XENOPHAGE_D
 	language = LANGUAGE_XENOPHAGE
 	default_language = LANGUAGE_XENOPHAGE
-	additional_langs = list(LANGUAGE_XENOPHAGE_HIVE)
+	additional_langs = list(LANGUAGE_XENOPHAGE_GLOBAL)
 	var/caste_name = "drone"
 	var/caste_number = 0
 

--- a/code/modules/culture_descriptor/faction/factions_xenophage.dm
+++ b/code/modules/culture_descriptor/faction/factions_xenophage.dm
@@ -2,10 +2,9 @@
 	name = FACTION_XENOPHAGE
 	language = LANGUAGE_XENOPHAGE
 	default_language = LANGUAGE_XENOPHAGE
-	additional_langs = list(LANGUAGE_XENOPHAGE_HIVE)
+	additional_langs = list(LANGUAGE_XENOPHAGE_GLOBAL)
 	description = "Skree!"
 	mob_faction = "xenophage"
-	additional_langs = list("Hivemind")
 	secondary_langs = null
 	economic_power = 0
 	hidden = TRUE

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -202,25 +202,28 @@
 		track = "([ghost_follow_link(speaker, src)]) [speaker_name]"
 
 	var/formatted
-	if(language)
-		if(!say_understands(speaker,language)) //Check if we understand the message. If so, add the language name after the verb. Don't do this for Galactic Common.
-			formatted = language.format_message_radio(message, verb)
-		else
-			var/nverb = null
-			switch(src.get_preference_value(/datum/client_preference/language_display))
-				if(GLOB.PREF_FULL) // Full language name
-					nverb = "[verb] in [language.name]"
-				if(GLOB.PREF_SHORTHAND) //Shorthand codes
-					nverb = "[verb] ([language.shorthand])"
-				if(GLOB.PREF_OFF)//Regular output
-					nverb = verb
-			formatted = language.format_message_radio(message, nverb)
+	if (language)
+		var/nverb = verb
+		if (say_understands(speaker, language))
+			var/skip = FALSE
+			if (isliving(src))
+				var/mob/living/L = src
+				skip = L.default_language == language
+			if (!skip)
+				switch(src.get_preference_value(/datum/client_preference/language_display))
+					if (GLOB.PREF_FULL)
+						nverb = "[verb] in [language.name]"
+					if(GLOB.PREF_SHORTHAND)
+						nverb = "[verb] ([language.shorthand])"
+					if(GLOB.PREF_OFF)
+						nverb = verb
+		formatted = language.format_message_radio(message, nverb)
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>"
 	if(sdisabilities & DEAF || ear_deaf)
 		var/mob/living/carbon/human/H = src
 		if(istype(H) && H.has_headset_in_ears() && prob(20))
-			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")
+			to_chat(src, SPAN_WARNING("You feel your headset vibrate but can hear nothing from it!"))
 	else
 		on_hear_radio(part_a, speaker_name, track, part_b, part_c, formatted)
 

--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -12,7 +12,7 @@
 	shorthand = "Xeno"
 
 /datum/language/xenos
-	name = LANGUAGE_XENOPHAGE_HIVE
+	name = LANGUAGE_XENOPHAGE_GLOBAL
 	desc = "Xenophages have the strange ability to commune over a psychic hivemind."
 	speech_verb = "hisses"
 	ask_verb = "hisses"
@@ -33,7 +33,7 @@
 	return 0
 
 /datum/language/ling
-	name = "Changeling"
+	name = LANGUAGE_CHANGELING_GLOBAL
 	desc = "Although they are normally wary and suspicious of each other, changelings can commune over a distance."
 	speech_verb = "says"
 	colour = "changeling"
@@ -49,7 +49,7 @@
 		..(speaker,message)
 
 /datum/language/corticalborer
-	name = "Cortical Link"
+	name = LANGUAGE_BORER_GLOBAL
 	desc = "Cortical borers possess a strange link between their tiny minds."
 	speech_verb = "sings"
 	ask_verb = "sings"

--- a/code/modules/mob/language/human/misc/gutter.dm
+++ b/code/modules/mob/language/human/misc/gutter.dm
@@ -1,5 +1,5 @@
 /datum/language/gutter
-	name = "Gutter"
+	name = LANGUAGE_GUTTER
 	desc = "This crude pidgin tongue developed on Pluto during its busier days. Nowadays it serves as a trade language for criminal elements and those who wish they were ones."
 	speech_verb = "growls"
 	colour = "rough"

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -1,5 +1,5 @@
 /datum/language/binary
-	name = "Robot Talk"
+	name = LANGUAGE_ROBOT_GLOBAL
 	desc = "Most human facilities support free-use communications protocols and routing hubs for synthetic use."
 	colour = "say_quote"
 	speech_verb = "states"
@@ -53,7 +53,7 @@
 		R.cell_use_power(C.active_usage)
 
 /datum/language/binary/drone
-	name = "Drone Talk"
+	name = LANGUAGE_DRONE_GLOBAL
 	desc = "A heavily encoded damage control coordination stream."
 	speech_verb = "transmits"
 	ask_verb = "transmits"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -8,7 +8,7 @@
 	health = 100
 	maxHealth = 100
 	mob_size = 4
-	species_language = "Xenophage"
+	species_language = LANGUAGE_XENOPHAGE
 
 	var/dead_icon
 	var/language

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -4,7 +4,7 @@
 
 	speak_emote = list("hisses")
 	icon_state = "larva"
-	language = "Hivemind"
+	language = LANGUAGE_XENOPHAGE_GLOBAL
 	maxHealth = 25
 	health = 25
 
@@ -18,7 +18,7 @@
 /mob/living/carbon/alien/larva/New()
 	..()
 	time_of_birth = world.time
-	add_language("Xenophage") //Bonus language.
+	add_language(LANGUAGE_XENOPHAGE) //Bonus language.
 	internal_organs |= new /obj/item/organ/internal/xeno/hivenode(src)
 	create_reagents(100)
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -147,7 +147,7 @@ var/list/ai_verbs_default = list(
 		add_ai_verbs(src)
 
 	//Languages
-	add_language("Robot Talk", 1)
+	add_language(LANGUAGE_ROBOT_GLOBAL, 1)
 	add_language(LANGUAGE_EAL, 1)
 	add_language(LANGUAGE_HUMAN_EURO, 1)
 	add_language(LANGUAGE_HUMAN_ARABIC, 1)

--- a/code/modules/mob/living/silicon/posi_brainmob.dm
+++ b/code/modules/mob/living/silicon/posi_brainmob.dm
@@ -16,7 +16,7 @@
 	reagents = new/datum/reagents(1000, src)
 	if(istype(loc, /obj/item/organ/internal/posibrain))
 		container = loc
-	add_language("Robot Talk")
+	add_language(LANGUAGE_ROBOT_GLOBAL)
 	..()
 
 /mob/living/silicon/sil_brainmob/Destroy()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -66,10 +66,10 @@ var/list/mob_hat_cache = list()
 	. = ..()
 
 	verbs += /mob/living/proc/hide
-	remove_language("Robot Talk")
-	add_language("Robot Talk", 0)
-	add_language("Drone Talk", 1)
-	default_language = all_languages["Drone Talk"]
+	remove_language(LANGUAGE_ROBOT_GLOBAL)
+	add_language(LANGUAGE_ROBOT_GLOBAL, 0)
+	add_language(LANGUAGE_DRONE_GLOBAL, 1)
+	default_language = all_languages[LANGUAGE_DRONE_GLOBAL]
 	// NO BRAIN.
 	mmi = null
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
@@ -32,8 +32,8 @@
 	silicon_radio = new /obj/item/device/radio/headset/heads/ai_integrated(src)
 	//silicon_radio.recalculateChannels()
 
-	add_language("Drone Talk", 1)
-	add_language("Robot Talk", 1)
+	add_language(LANGUAGE_DRONE_GLOBAL, 1)
+	add_language(LANGUAGE_ROBOT_GLOBAL, 1)
 	default_language = controlling_ai.default_language
 
 	stat = CONSCIOUS
@@ -106,7 +106,7 @@
 	QDEL_NULL(silicon_radio)
 	silicon_radio = drone_silicon_radio
 	drone_silicon_radio = null
-	default_language = all_languages["Drone Talk"]
+	default_language = all_languages[LANGUAGE_DRONE_GLOBAL]
 
 	verbs -= /mob/living/silicon/robot/drone/proc/release_ai_control_verb
 	full_law_reset()

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -14,7 +14,7 @@
 			return emote(copytext(message,2))
 
 		if(copytext(message,1,2) == ";")
-			var/datum/language/L = all_languages["Drone Talk"]
+			var/datum/language/L = all_languages[LANGUAGE_DRONE_GLOBAL]
 			if(istype(L))
 				return L.broadcast(src,trim(copytext(message,2)))
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -107,7 +107,7 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	add_language("Robot Talk", 1)
+	add_language(LANGUAGE_ROBOT_GLOBAL, 1)
 	add_language(LANGUAGE_EAL, 1)
 
 	wires = new(src)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -53,7 +53,7 @@
 /mob/living/simple_animal/borer/New(atom/newloc, var/gen=1)
 	..(newloc)
 
-	add_language("Cortical Link")
+	add_language(LANGUAGE_BORER_GLOBAL)
 	verbs += /mob/living/proc/ventcrawl
 	verbs += /mob/living/proc/hide
 
@@ -123,7 +123,7 @@
 
 	controlling = 0
 
-	host.remove_language("Cortical Link")
+	host.remove_language(LANGUAGE_BORER_GLOBAL)
 	host.verbs -= /mob/living/carbon/proc/release_control
 	host.verbs -= /mob/living/carbon/proc/punish_host
 	host.verbs -= /mob/living/carbon/proc/spawn_larvae

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_INIT(borer_reagent_types_by_name, setup_borer_reagents())
 
 	to_chat(src, "<span class = 'danger'>You settle into the empty brainpan and begin to expand, fusing inextricably with the dead flesh of [H].</span>")
 
-	H.add_language("Cortical Link")
+	H.add_language(LANGUAGE_BORER_GLOBAL)
 
 	if(host.stat == 2)
 		H.verbs |= /mob/living/carbon/human/proc/jumpstart
@@ -302,7 +302,7 @@ GLOBAL_LIST_INIT(borer_reagent_types_by_name, setup_borer_reagents())
 
 			to_chat(src, "<span class='danger'>You plunge your probosci deep into the cortex of the host brain, interfacing directly with their nervous system.</span>")
 			to_chat(host, "<span class='danger'>You feel a strange shifting sensation behind your eyes as an alien consciousness displaces yours.</span>")
-			host.add_language("Cortical Link")
+			host.add_language(LANGUAGE_BORER_GLOBAL)
 
 			// host -> brain
 			var/h2b_id = host.computer_id

--- a/code/modules/organs/internal/species/xenophage.dm
+++ b/code/modules/organs/internal/species/xenophage.dm
@@ -86,7 +86,7 @@
 	if(owner && ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		to_chat(H, "<span class='alium'>You feel your connection to the hivemind fray and fade away...</span>")
-		H.remove_language("Hivemind")
+		H.remove_language(LANGUAGE_XENOPHAGE_GLOBAL)
 		if(H.mind && H.species.get_bodytype(H) != "Xenophage")
 			GLOB.xenomorphs.remove_antagonist(H.mind)
 	..(user)
@@ -96,7 +96,7 @@
 
 	if(owner && ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.add_language("Hivemind")
+		H.add_language(LANGUAGE_XENOPHAGE_GLOBAL)
 		if(H.mind && H.species.get_bodytype(H) != "Xenophage")
 			to_chat(H, "<span class='alium'>You feel a sense of pressure as a vast intelligence meshes with your thoughts...</span>")
 			GLOB.xenomorphs.add_antagonist_mind(H.mind,1, GLOB.xenomorphs.faction_role_text, GLOB.xenomorphs.faction_welcome)


### PR DESCRIPTION
:cl:
tweak: Radio messages no longer show language identifiers if the language is the same as your default.
/:cl:

In `hear_say.dm`

The rest of it is finishing replacing inline language name strings with the language name defines.