### PR TITLE
shoe storage & hobbling & cuffs tweaks

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ITEM_FLAG_IS_BELT                0x0800 // Items that can be worn on the belt slot, even with no undersuit equipped
 #define ITEM_FLAG_SILENT                 0x1000 // sneaky shoes
 #define ITEM_FLAG_NOCUFFS                0x2000 // Gloves that have this flag prevent cuffs being applied
+#define ITEM_FLAG_CAN_HIDE_IN_SHOES      0x4000 // Items that can be hidden in shoes that permit it
 
 // Flags for pass_flags.
 #define PASS_FLAG_TABLE  0x1

--- a/code/game/gamemodes/wizard/servant_items/champion.dm
+++ b/code/game/gamemodes/wizard/servant_items/champion.dm
@@ -28,7 +28,6 @@
 	icon_state = "medievalboots"
 	force = 5
 	armor = list(melee = 45, bullet = 10, laser = 5, energy = 15, bomb = 30, bio = 0, rad = 0)
-	can_hold_knife = 0
 
 /obj/item/weapon/excalibur
 	name = "champion's blade"

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -4,6 +4,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "handcuff"
+	health = 0
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
 	throwforce = 5
@@ -18,7 +19,14 @@
 	var/cuff_sound = 'sound/weapons/handcuffs.ogg'
 	var/cuff_type = "handcuffs"
 
-
+/obj/item/weapon/handcuffs/examine(mob/user)
+	if (!(. = ..()))
+		return
+	if (health)
+		var display = health / initial(health) * 100
+		if (display > 66)
+			return
+		to_chat(user, SPAN_WARNING("They look [display < 33 ? "badly ": ""]damaged."))
 
 /obj/item/weapon/handcuffs/get_icon_state(mob/user_mob, slot)
 	if(slot == slot_handcuffed_str)
@@ -134,6 +142,7 @@ var/last_chew = 0
 	cuff_sound = 'sound/weapons/cablecuff.ogg'
 	cuff_type = "cable restraints"
 	elastic = 1
+	health = 75
 
 /obj/item/weapon/handcuffs/cable/red
 	color = COLOR_MAROON
@@ -181,3 +190,4 @@ var/last_chew = 0
 	icon = 'icons/obj/bureaucracy.dmi'
 	breakouttime = 200
 	cuff_type = "duct tape"
+	health = 50

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -13,6 +13,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	sharp = TRUE
 	edge = TRUE
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/weapon/material/knife/attack(mob/living/carbon/M, mob/living/carbon/user, target_zone)
 	if(!istype(M))

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -16,6 +16,7 @@
 	default_material = MATERIAL_GLASS
 	unbreakable = 1 //It's already broken.
 	drops_debris = 0
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/weapon/material/shard/set_material(var/new_material)
 	..(new_material)

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -56,39 +56,6 @@
 /obj/item/clothing/shoes/orange
 	name = "orange shoes"
 	icon_state = "orange"
-	force = 0 //nerf brig shoe throwing
-	throwforce = 0
-	desc = "A pair of flimsy, cheap shoes. The soles have been made of a soft rubber."
-	var/obj/item/weapon/handcuffs/chained = null
-
-/obj/item/clothing/shoes/orange/proc/attach_cuffs(var/obj/item/weapon/handcuffs/cuffs, mob/user as mob)
-	if (src.chained) return
-
-	if(!user.unequip_item())
-		return
-	cuffs.forceMove(src)
-	src.chained = cuffs
-	src.slowdown_per_slot[slot_shoes] += 15
-	src.icon_state = "orange1"
-
-/obj/item/clothing/shoes/orange/proc/remove_cuffs(mob/user as mob)
-	if (!src.chained) return
-
-	user.put_in_hands(src.chained)
-	src.chained.add_fingerprint(user)
-
-	src.slowdown_per_slot[slot_shoes] -= 15
-	src.icon_state = "orange"
-	src.chained = null
-
-/obj/item/clothing/shoes/orange/attack_self(mob/user as mob)
-	..()
-	remove_cuffs(user)
-
-/obj/item/clothing/shoes/orange/attackby(H as obj, mob/user as mob)
-	..()
-	if (istype(H, /obj/item/weapon/handcuffs))
-		attach_cuffs(H, user)
 
 /obj/item/clothing/shoes/flats
 	name = "flats"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -4,7 +4,6 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
 	item_flags = ITEM_FLAG_NOSLIP
-	can_hold_knife = 1
 	species_restricted = null
 
 /obj/item/clothing/shoes/galoshes/Initialize()
@@ -19,7 +18,6 @@
 	force = 3
 	armor = list(melee = 30, bullet = 10, laser = 10, energy = 15, bomb = 20, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
 	cold_protection = FEET
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 
@@ -37,7 +35,6 @@
 	item_state = "workboots"
 	armor = list(melee = 40, bullet = 0, laser = 0, energy = 15, bomb = 20, bio = 0, rad = 20)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
 
 /obj/item/clothing/shoes/workboots/toeless
 	name = "toe-less workboots"

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -3,7 +3,6 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
-	can_hold_knife = 1
 	species_restricted = null
 	force = 3
 	overshoes = 1

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -13,6 +13,7 @@
 /obj/item/clothing/shoes/mime
 	name = "mime shoes"
 	icon_state = "mime"
+	can_add_cuffs = FALSE
 
 /obj/item/clothing/shoes/swat
 	name = "\improper SWAT boots"
@@ -22,7 +23,6 @@
 	armor = list(melee = 80, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10, rad = 0)
 	item_flags = ITEM_FLAG_NOSLIP
 	siemens_coefficient = 0.6
-	can_hold_knife = 1
 
 /obj/item/clothing/shoes/combat //Basically SWAT shoes combined with galoshes.
 	name = "combat boots"
@@ -32,7 +32,6 @@
 	armor = list(melee = 80, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10, rad = 0)
 	item_flags = ITEM_FLAG_NOSLIP
 	siemens_coefficient = 0.6
-	can_hold_knife = 1
 
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
@@ -46,7 +45,6 @@
 	force = 3
 	armor = list(melee = 30, bullet = 10, laser = 10, energy = 15, bomb = 20, bio = 10, rad = 0)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
 
 /obj/item/clothing/shoes/desertboots
 	name = "desert boots"
@@ -55,7 +53,6 @@
 	force = 3
 	armor = list(melee = 30, bullet = 10, laser = 10, energy = 15, bomb = 20, bio = 10, rad = 0)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
 
 /obj/item/clothing/shoes/dutyboots
 	name = "duty boots"
@@ -63,7 +60,6 @@
 	icon_state = "duty"
 	armor = list(melee = 40, bullet = 0, laser = 0, energy = 15, bomb = 20, bio = 0, rad = 20)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
 
 /obj/item/clothing/shoes/tactical
 	name = "tactical boots"
@@ -72,12 +68,13 @@
 	force = 3
 	armor = list(melee = 40, bullet = 30, laser = 40,energy = 25, bomb = 50, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
-	can_hold_knife = 1
 
 /obj/item/clothing/shoes/dress
 	name = "dress shoes"
 	desc = "The height of fashion, and they're pre-polished!"
 	icon_state = "laceups"
+	can_add_hidden_item = FALSE
+	can_add_cuffs = FALSE
 
 /obj/item/clothing/shoes/dress/white
 	name = "white dress shoes"
@@ -90,8 +87,9 @@
 	icon_state = "wizard"
 	species_restricted = null
 	body_parts_covered = 0
-
 	wizard_garb = 1
+	can_add_hidden_item = FALSE
+	can_add_cuffs = FALSE
 
 /obj/item/clothing/shoes/sandal/marisa
 	desc = "A pair of magic, black shoes."
@@ -107,6 +105,7 @@
 	force = 0
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
+	can_add_hidden_item = FALSE
 
 /obj/item/clothing/shoes/clown_shoes/New()
 	..()
@@ -149,19 +148,21 @@
 	force = 0
 	species_restricted = null
 	w_class = ITEM_SIZE_SMALL
+	can_add_hidden_item = FALSE
+	can_add_cuffs = FALSE
 
-/obj/item/clothing/shoes/slippers_worn
+/obj/item/clothing/shoes/slippers/worn
 	name = "worn bunny slippers"
 	desc = "Fluffy..."
 	icon_state = "slippers_worn"
 	item_state = "slippers_worn"
-	force = 0
-	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/shoes/laceup
 	name = "laceup shoes"
 	desc = "The height of fashion, and they're pre-polished!"
 	icon_state = "laceups"
+	can_add_hidden_item = FALSE
+	can_add_cuffs = FALSE
 
 /obj/item/clothing/shoes/swimmingfins
 	desc = "Help you swim good."
@@ -169,6 +170,8 @@
 	icon_state = "flippers"
 	item_flags = ITEM_FLAG_NOSLIP
 	species_restricted = null
+	can_add_hidden_item = FALSE
+	can_add_cuffs = FALSE
 
 /obj/item/clothing/shoes/swimmingfins/New()
 	..()
@@ -189,7 +192,7 @@
 	name = "high heels"
 	icon_state = "heels"
 	desc = "A pair of colourable high heels."
-	can_hold_knife = 1
+	can_add_cuffs = FALSE
 
 /obj/item/clothing/shoes/heels/black
 	name = "black high heels"

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -61,9 +61,21 @@
 	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
 		if(!handcuffed || buckled)
 			return
+		if (handcuffed.health) // Improvised cuffs can break because their health is > 0
+			handcuffed.health = handcuffed.health - initial(handcuffed.health) / 2
+			if (handcuffed.health < 1)
+				visible_message(
+					SPAN_DANGER("\The [src] manages to remove \the [handcuffed], breaking them!"),
+					SPAN_NOTICE("You successfully remove \the [handcuffed], breaking them!")
+				)
+				QDEL_NULL(handcuffed)
+				if(buckled && buckled.buckle_require_restraints)
+					buckled.unbuckle_mob()
+				update_inv_handcuffed()
+				return
 		visible_message(
-			"<span class='danger'>\The [src] manages to remove \the [handcuffed]!</span>",
-			"<span class='notice'>You successfully remove \the [handcuffed].</span>"
+			SPAN_WARNING("\The [src] manages to remove \the [handcuffed]!"),
+			SPAN_NOTICE("You successfully remove \the [handcuffed]!")
 			)
 		drop_from_inventory(handcuffed)
 


### PR DESCRIPTION
:cl:
tweak: Improvised cuffs break if resisted out of a few times.
tweak: Cuffs and improvised cuffs can now be attached to most shoes, hobbling them. Improvised cuffs break if the wearer moves enough.
tweak: Knives can be stored in more kinds of shoe.
/:cl:

Shoe storage is limited to just knives and shards to keep parity with existing behavior. I'll add other stuff in another PR to keep this clean.