### PR TITLE
adds antag language on changer species change

### DIFF
--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -14,6 +14,10 @@
 		return
 
 	set_species(new_species)
+	var/datum/antagonist/antag = player_is_antag(src)
+	if (antag && antag.required_language)
+		add_language(antag.required_language)
+		set_default_language(all_languages[antag.required_language])
 	reset_hair()
 	return 1
 


### PR DESCRIPTION
:cl:
tweak: Changing species with the changer re-adds languages required by the user's antagonist type.
/:cl:
