### PR TITLE
Fix attack_verb on swiss knives

### DIFF
--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -60,7 +60,7 @@
 		edge = initial(edge)
 		sharp = initial(sharp)
 		hitsound = initial(hitsound)
-		attack_verb = initial(attack_verb)
+		attack_verb = closed_attack_verbs
 		siemens_coefficient = initial(siemens_coefficient)
 	if(active_tool == SWISSKNF_CLOSED)
 		w_class = initial(w_class)


### PR DESCRIPTION
:cl: WezYo
bugfix: Attacking with swiss knives properly displays attack verb
/:cl:

initial doesn't work on lists, so we gotta grab the attack verbs from the parent for non-sharp attacks
Fixes #25756
Fixes #25744