### PR TITLE
Decouples embedded object damage from move delay.

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -224,6 +224,7 @@
 // Finally.. the last of the mob movement junk
 /datum/movement_handler/mob/movement/DoMove(var/direction, var/mob/mover)
 	. = MOVEMENT_HANDLED
+
 	if(mob.moving)
 		return
 
@@ -248,6 +249,9 @@
 	for (var/obj/item/grab/G in mob.grabbed_by)
 		G.adjust_position()
 
+	//Moving with objects stuck in you can cause bad times.
+	if(get_turf(mob) != old_turf)
+		mob.handle_embedded_and_stomach_objects()
 	mob.moving = 0
 
 /datum/movement_handler/mob/movement/MayMove(var/mob/mover)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -932,13 +932,16 @@
 				return 1
 	return 0
 
-/mob/living/carbon/human/proc/handle_embedded_and_stomach_objects()
-	for(var/obj/item/organ/external/organ in src.organs)
-		if(organ.splinted)
-			continue
-		for(var/obj/item/O in organ.implants)
-			if(!istype(O,/obj/item/weapon/implant) && O.w_class > 1 && prob(5)) //Moving with things stuck in you could be bad.
-				jossle_internal_object(organ, O)
+/mob/living/carbon/human/handle_embedded_and_stomach_objects()
+
+	if(embedded_flag)
+		for(var/obj/item/organ/external/organ in organs)
+			if(organ.splinted)
+				continue
+			for(var/obj/item/O in organ.implants)
+				if(!istype(O,/obj/item/weapon/implant) && O.w_class > 1 && prob(5)) //Moving with things stuck in you could be bad.
+					jostle_internal_object(organ, O)
+
 	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
 	if(stomach && stomach.contents.len)
 		for(var/obj/item/O in stomach.contents)
@@ -950,9 +953,9 @@
 					if(parent)
 						parent.embed(O)
 				else
-					jossle_internal_object(parent, O)
+					jostle_internal_object(parent, O)
 
-/mob/living/carbon/human/proc/jossle_internal_object(var/obj/item/organ/external/organ, var/obj/item/O)
+/mob/living/carbon/human/proc/jostle_internal_object(var/obj/item/organ/external/organ, var/obj/item/O)
 	// All kinds of embedded objects cause bleeding.
 	if(!organ.can_feel_pain())
 		to_chat(src, SPAN_DANGER("You feel [O] moving inside your [organ.name]."))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -11,10 +11,6 @@
 			tally -= 2
 		tally -= 1
 
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
-	if(embedded_flag || (stomach && stomach.contents.len))
-		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
-
 	if(CE_SPEEDBOOST in chem_effects)
 		tally -= chem_effects[CE_SPEEDBOOST]
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1119,3 +1119,6 @@
 
 /mob/proc/get_footstep(var/footstep_type)
 	return
+
+/mob/proc/handle_embedded_and_stomach_objects()
+	return


### PR DESCRIPTION
As far as I can tell this is 1:1 with the old behavior. Pulling doesn't invoke `movement_delay()` as far as I know, and this code prevents grabs and pulls from invoking the jostle proc.