### PR TITLE
Operation Lizard Hotbox (Heat comfort spam)

### DIFF
--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -58,7 +58,7 @@
 
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/claw
 
-	heat_discomfort_level = 295
+	heat_discomfort_level = 320
 	heat_discomfort_strings = list(
 		"You feel soothingly warm.",
 		"You feel the heat sink into your bones.",


### PR DESCRIPTION
Because being told you're "soothingly warm" while the interface says you're nearly freezing to death is weird.

:cl: Draxtheros
   tweak: Raised the temperature at which Unathi begin to receive "warmth" messages.
/:cl: