### PR TITLE
Makes Three Eye possible to make

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2263,7 +2263,7 @@
 	result = /datum/reagent/three_eye
 	result_amount = 2
 	mix_message = "The surface of the oily, iridescent liquid twitches like a living thing."
-	minimum_temperature = 100 CELSIUS
+	minimum_temperature = 40 CELSIUS
 	reaction_sound = 'sound/effects/psi/power_used.ogg'
 	hidden_from_codex = TRUE
 


### PR DESCRIPTION
Right now, there's no way to make Three Eye. Why?
Carptoxin, used as a catalyst, turns into denatured toxin way below the target temp before it can be used for the reaction.
Blood, one of the components, coagulates way below the target temp before it can be used for the reaction.
This lowers target temperature, so, you know, you can actually make this.