### PR TITLE
Misc bridge tweaks

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -43,14 +43,39 @@
 /obj/effect/floor_decal/solarpanel,
 /turf/simulated/floor/reinforced/airless,
 /area/solar/bridge)
+"ai" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "aj" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"ak" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/papershredder,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "al" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/forestarboard)
 "am" = (
-/obj/random/torchcloset,
+/obj/random/closet,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
@@ -142,6 +167,28 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/bridge)
+"ax" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "ay" = (
 /obj/structure/catwalk,
 /obj/structure/grille/broken,
@@ -190,6 +237,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"aC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "aD" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -260,6 +329,23 @@
 /obj/effect/floor_decal/solarpanel,
 /turf/simulated/floor/reinforced/airless,
 /area/solar/bridge)
+"aJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "aK" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/cobed)
@@ -282,6 +368,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
+"aN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "aO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
@@ -526,11 +632,24 @@
 /obj/machinery/suit_storage_unit/command,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
+"bl" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/sticky_pad/random,
+/obj/item/weapon/book/manual/nt_regs,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "bm" = (
-/obj/random/torchcloset,
+/obj/random/closet,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/aftstarboard)
+"bn" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/structure/flora/pottedplant/deskleaf{
+	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -538,9 +657,71 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"bp" = (
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/weapon/stamp/nt,
+/obj/item/weapon/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/pen/green,
+/obj/item/weapon/pen/red{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/corp,
+/obj/item/weapon/storage/box/large/union_cards,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
 "bq" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/co)
+"br" = (
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/documents/nanotrasen,
+/obj/item/weapon/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/item/weapon/folder/envelope/blanks,
+/obj/item/weapon/material/clipboard,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"bs" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "bt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -553,6 +734,51 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"bu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor3";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"bv" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"bw" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
 "bx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -568,6 +794,33 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
+"by" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"bz" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/weapon/material/ashtray/plastic,
+/obj/item/weapon/storage/fancy/cigar,
+/obj/item/weapon/flame/lighter/zippo/bronze,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
+"bA" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Corporate Liaison - Office";
+	dir = 8;
+	network = list("Command")
+	},
+/obj/item/weapon/storage/box/donut,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl)
 "bB" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -603,6 +856,32 @@
 	},
 /turf/simulated/floor/airless,
 /area/solar/bridge)
+"bF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/primary/bridge/fore)
+"bG" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/large,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
 "bH" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -638,14 +917,46 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "bK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"bL" = (
+/obj/machinery/door/airlock/research{
+	id_tag = "liaisondoor";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/office/cl)
+"bM" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
+/area/bridge/hallway/starboard)
 "bN" = (
 /obj/effect/floor_decal/spline/plain/beige{
 	icon_state = "spline_plain";
@@ -688,6 +999,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/xo)
+"bR" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/storage/box/cups,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"bS" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Entry Starboard"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "bT" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -712,6 +1052,12 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cl)
+"bW" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/hallway/starboard)
 "bX" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -734,6 +1080,50 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
+"bY" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"bZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"ca" = (
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "cb" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -780,12 +1170,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
+"cg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "ch" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Bridge Substation Bypass"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
+"ci" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "cj" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -805,12 +1220,50 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/bridgecheck)
 "cl" = (
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cn" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
@@ -840,6 +1293,256 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"cr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cs" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/item/device/radio/beacon,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
+"ct" = (
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cx" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cy" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = 38
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 6;
+	pixel_y = 20
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/red,
+/obj/item/weapon/pen/blue,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"cz" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/flashlight,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"cA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/sign/warning/nosmoking_1{
+	icon_state = "nosmoking";
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = -34
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
+"cE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Bridge Storage";
+	sort_type = "Bridge Storage"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "cF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1083,6 +1786,22 @@
 /obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
+"cU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "cV" = (
 /obj/item/modular_computer/console/preset/sysadmin{
 	icon_state = "console";
@@ -1098,31 +1817,123 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"cW" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Conference Room Starboard";
+	dir = 2
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"cX" = (
+/obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/item/weapon/book/manual/solgov_law,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"cY" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/book/manual/sol_sop,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"cZ" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/hand_labeler,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
+"da" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/structure/flora/pottedplant/smallcactus{
+	desc = "This is a small cactus. Its needles are sharp. It seems neglected, as if no one loves it."
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"db" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "dc" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/door/airlock/research{
-	id_tag = "liaisondoor2";
-	name = "Corporate Liaison";
-	secured_wires = 1
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/starboard)
 "dd" = (
 /obj/item/weapon/pen,
 /obj/item/weapon/stamp/xo,
 /obj/structure/table/woodentable_reinforced/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
+"de" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 25
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "df" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1138,23 +1949,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "dg" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -1223,12 +2027,31 @@
 "dk" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cl/backroom)
+"dl" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dm" = (
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_foyer)
 "dn" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
+"do" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dp" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -1243,6 +2066,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/ce)
+"dq" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dr" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -1395,22 +2233,54 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "dF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/weapon/rcd,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "CE's Equipment Storage"
 	},
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
 "dG" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"dH" = (
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge - Stairs";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/vending/cola{
+	dir = 4;
+	icon_state = "Cola_Machine"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/bridge/fore)
 "dI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{
@@ -1435,6 +2305,72 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
+"dK" = (
+/obj/structure/table/woodentable/walnut,
+/obj/random/clipboard,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
+"dL" = (
+/obj/structure/closet/secure_closet/engineering_chief_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/crew_quarters/heads/office/ce)
+"dM" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
+"dN" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Engineer - Office";
+	dir = 1;
+	network = list("Command","Engineering")
+	},
+/obj/machinery/button/remote/airlock{
+	name = "CE's Office Door Control";
+	desc = "A remote control-switch for the office door.";
+	pixel_x = 0;
+	pixel_y = -27;
+	req_access = list("ACCESS_CHIEF_ENGINEER");
+	id = "cedoor"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/office/ce)
+"dO" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/red/half,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
+"dP" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/folder/blue,
+/turf/simulated/floor/carpet/blue2,
+/area/bridge/meeting_room)
+"dQ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -1448,6 +2384,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
+"dS" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge Conference Room";
+	departmentType = 5;
+	name = "Bridge Conference Room";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dT" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue{
@@ -1463,9 +2413,50 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"dU" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/button/remote/blast_door{
+	name = "Bridge Window Lockdown Control";
+	pixel_x = -30;
+	pixel_y = 0;
+	id = "bridge blast"
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/item/weapon/storage/box/donut,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "dV" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarbridge)
+"dW" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge";
+	dir = 1
+	},
+/obj/item/weapon/book/manual/sol_sop,
+/obj/item/weapon/book/manual/solgov_law,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"dX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "dY" = (
 /turf/simulated/wall/r_wall/hull,
 /area/shield/bridge)
@@ -1493,6 +2484,15 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/cockpit)
+"ed" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "ee" = (
 /obj/structure/closet/secure_closet/bridgeofficer,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1503,6 +2503,21 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
+"ef" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Bridge Conference Room";
+	sort_type = "Bridge Conference Room"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "eg" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -1526,6 +2541,34 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/hull,
 /area/turret_protected/ai_outer_chamber)
+"ek" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"el" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "em" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -1548,6 +2591,21 @@
 /obj/structure/flora/pottedplant/fern,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
+"eo" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"ep" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "eq" = (
 /obj/machinery/door/airlock/sol{
 	name = "XO's Quarters";
@@ -1573,6 +2631,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
+"es" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "et" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -1596,6 +2669,77 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
+"eu" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/toy/figure/secofficer{
+	desc = "A 'Space Life' brand Security Officer action figure. This one seems rather old. A small heart is sewn into the armor vest."
+	},
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/heads/office/cos)
+"ev" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/keycard_auth/torch{
+	pixel_x = 0;
+	pixel_y = -38
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/red,
+/obj/item/weapon/pen/blue,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"ew" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/flashlight,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
+"ex" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -1622,6 +2766,75 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
+"eB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"eC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 2;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"eD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"eE" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "eF" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1636,6 +2849,17 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
+"eG" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
 "eH" = (
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
@@ -1649,23 +2873,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
 "eK" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Conference Room Port";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/meeting_room)
+"eL" = (
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "eM" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -1685,6 +2914,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
+"eO" = (
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "eP" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge)
@@ -1705,6 +2942,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
+"eR" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge/meeting_room)
 "eS" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -1754,25 +3007,57 @@
 /area/hallway/primary/bridge/fore)
 "eV" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/bed/chair/padded/blue{
+	icon_state = "chair_preview";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "eW" = (
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/carpet/blue2,
-/area/bridge/meeting_room)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"eX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "eY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1784,25 +3069,51 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"fb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
-"fc" = (
+"fa" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/office/cl/backroom)
+"fc" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fd" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -1926,6 +3237,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
+"fo" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fp" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -1980,12 +3305,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/co)
+"fw" = (
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fx" = (
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -7
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
+"fy" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fz" = (
 /obj/effect/floor_decal/spline/plain/beige{
 	icon_state = "spline_plain";
@@ -2004,13 +3347,69 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"fA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fB" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/fore)
+"fC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"fE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fF" = (
 /obj/structure/flora/pottedplant/smelly{
 	desc = "This is some kind of tropical plant. It reeks of rotten eggs. This one has a hand-painted Nametag on the rim. It reads 'Steve'"
@@ -2023,6 +3422,52 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
+"fG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor{
+	command = null;
+	id_tag = "bridge_safe_exterior_sensor";
+	master_tag = "bridge_safe";
+	pixel_x = 26;
+	pixel_y = -35
+	},
+/obj/machinery/computer/guestpass{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fH" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 8;
+	name = "CE's Equipment Storage"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/item/weapon/rig/ce/equipped,
+/turf/simulated/floor/tiled/monotile,
+/area/aux_eva)
 "fI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
@@ -2050,6 +3495,31 @@
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
+"fM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
 "fN" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -2083,73 +3553,98 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
 "fP" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fQ" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/weapon/storage/box/cups,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fR" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Entry Starboard"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fS" = (
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fU" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"fV" = (
-/obj/machinery/atmospherics/valve/shutoff{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fR" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fS" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Entry Port";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/hallway/port)
+"fU" = (
 /obj/effect/floor_decal/industrial/shutoff{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	icon_state = "corner_white";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
+/area/bridge/hallway/port)
+"fV" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/prefab/hand_teleporter,
+/obj/item/toy/torchmodel,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
 "fW" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -2172,6 +3667,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/medical)
+"fY" = (
+/obj/effect/floor_decal/corner/red/half,
+/obj/machinery/vending/coffee{
+	dir = 4;
+	icon_state = "coffee"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/fore)
 "ga" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -2185,18 +3688,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"gb" = (
-/obj/structure/flora/pottedplant/large,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
-	pixel_y = 20
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "gc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2428,56 +3919,6 @@
 "gz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftstarboard)
-"gB" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gC" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gE" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gF" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"gG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "gJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2488,20 +3929,6 @@
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
-"gK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/item/device/radio/beacon,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "gL" = (
 /obj/machinery/door/firedoor/border_only,
@@ -2702,48 +4129,9 @@
 "hn" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"ho" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"hp" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "hq" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/meeting_room)
-"hr" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "hs" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/meeting_room)
@@ -2991,44 +4379,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"hW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"hX" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"hZ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "id" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -3291,11 +4641,6 @@
 "iE" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/turret_protected/ai)
-"iG" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "iI" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -3320,42 +4665,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"iK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
-"iM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"iN" = (
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "iP" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
@@ -3867,27 +5176,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/aquila/head)
-"kd" = (
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/item/documents/nanotrasen,
-/obj/item/weapon/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 0
-	},
-/obj/item/weapon/folder/envelope/blanks,
-/obj/item/weapon/material/clipboard,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
 "ke" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4098,22 +5386,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/xo)
-"kF" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 4;
-	name = "CE's Equipment Storage"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/weapon/rig/ce/equipped,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
 "kI" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -4737,21 +6009,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/aft)
-"lQ" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "lR" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
@@ -5138,26 +6395,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/aquila/medical)
-"my" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Engineer - Office";
-	dir = 1;
-	network = list("Command","Engineering")
-	},
-/obj/structure/closet/secure_closet/engineering_chief_torch,
-/obj/machinery/button/remote/airlock{
-	name = "CE's Office Door Control";
-	desc = "A remote control-switch for the office door.";
-	pixel_x = 0;
-	pixel_y = -27;
-	req_access = list("ACCESS_CHIEF_ENGINEER");
-	id = "cedoor"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
 "mz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -5199,20 +6436,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/bridgecheck)
-"mC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red/half,
-/obj/machinery/vending/cola{
-	icon_state = "Cola_Machine";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "mE" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/cos)
@@ -5460,15 +6683,6 @@
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"ng" = (
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "ni" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/camera/network/aquila{
@@ -6114,25 +7328,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/cos)
-"oG" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 26;
-	pixel_y = 0
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/item/toy/figure/secofficer{
-	desc = "A 'Space Life' brand Security Officer action figure. This one seems rather old. A small heart is sewn into the armor vest."
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/heads/office/cos)
 "oI" = (
 /obj/machinery/light_switch{
 	pixel_x = 23;
@@ -6397,51 +7592,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
-"pq" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen/red,
-/obj/item/weapon/pen,
-/obj/item/weapon/pen/blue,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
-"pr" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"pt" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -6825,40 +7975,6 @@
 /obj/item/weapon/rig/command/science/equipped,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"qj" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"qk" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "qm" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall/prepainted,
@@ -7125,108 +8241,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"qS" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"qT" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"qU" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"qV" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"qW" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"qX" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/airlock_sensor{
-	command = null;
-	id_tag = "bridge_safe_exterior_sensor";
-	master_tag = "bridge_safe";
-	pixel_x = 26;
-	pixel_y = -35
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "qY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7621,75 +8635,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/co)
-"rL" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rM" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rN" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rO" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
-"rP" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "rQ" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -7782,13 +8727,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"sb" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/hallway/starboard)
 "se" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8212,15 +9150,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"tk" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "tm" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -8975,20 +9904,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shield/bridge)
-"ve" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Corporate Liaison";
-	secured_wires = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "vf" = (
 /obj/effect/floor_decal/scglogo{
 	tag = "icon-top-center";
@@ -9882,21 +10797,6 @@
 "xc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/foreport)
-"xd" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "xe" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -10052,7 +10952,7 @@
 /area/maintenance/bridge/aftport)
 "xo" = (
 /obj/random/maintenance/solgov,
-/obj/random/torchcloset,
+/obj/random/closet,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -10524,7 +11424,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
 "yV" = (
-/obj/random/torchcloset,
+/obj/random/closet,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
@@ -10533,27 +11433,6 @@
 "yW" = (
 /turf/simulated/wall/prepainted,
 /area/security/bridgecheck)
-"yY" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "yZ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -10582,14 +11461,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
-"ze" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/weapon/material/ashtray/plastic,
-/obj/item/weapon/flame/lighter/random,
-/obj/random/smokes,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl)
 "zf" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -10698,16 +11569,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"zD" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "zF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10858,20 +11719,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
-"Ae" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Corporate Liaison - Office";
-	dir = 8;
-	network = list("Command")
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl)
 "Af" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -11000,12 +11847,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/bridge)
-"Ax" = (
-/obj/structure/table/woodentable/walnut,
-/obj/random/clipboard,
-/obj/item/weapon/folder/blue,
-/turf/simulated/floor/carpet/blue2,
-/area/bridge/meeting_room)
 "Ay" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -11111,30 +11952,6 @@
 "AN" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
-"AP" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/hallway/port)
 "AR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -11195,50 +12012,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"Be" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
-"Bf" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/rcd,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "CE's Equipment Storage"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
-"Bi" = (
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/engineering/alt/sol,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
-"Bn" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "Bp" = (
 /obj/effect/floor_decal/corner/red/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -11256,24 +12029,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"Bu" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Bw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11291,16 +12046,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"By" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "BB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/button/remote/airlock{
@@ -11333,26 +12078,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"BF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "BG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11407,19 +12132,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"BV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "BW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -11690,17 +12402,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
-"CL" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "CN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftport)
@@ -11982,25 +12683,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
-"Eh" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/sign/warning/nosmoking_1{
-	icon_state = "nosmoking";
-	dir = 1;
-	pixel_x = 2;
-	pixel_y = -34
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "El" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12096,24 +12778,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"EL" = (
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Stairs";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "EM" = (
 /obj/structure/sign/warning/detailed,
 /turf/simulated/wall/r_wall/prepainted,
@@ -12191,13 +12855,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/airlock)
-"Fe" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "Ff" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -12263,34 +12920,6 @@
 "Fp" = (
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
-"Ft" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/folder/white{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder/blue{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
-"Fv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "Fy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12421,28 +13050,8 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Gh" = (
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Gi" = (
-/obj/random/torchcloset,
+/obj/random/closet,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/tiled/techfloor,
@@ -12469,11 +13078,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"Gq" = (
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "Gr" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -12601,20 +13205,6 @@
 /obj/machinery/computer/robotics,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Hb" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "Hc" = (
 /obj/structure/bed/chair/padded/blue{
 	icon_state = "chair_preview";
@@ -12775,23 +13365,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
-"Hu" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "Hv" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "meeting_windows"
@@ -12934,22 +13507,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"HU" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = -38
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "HW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12988,24 +13545,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"HY" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Ia" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -13031,18 +13570,6 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
-"Ic" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Id" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13236,14 +13763,6 @@
 /obj/item/weapon/book/manual/military_law,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"ID" = (
-/obj/effect/floor_decal/corner/red/half,
-/obj/machinery/vending/coffee{
-	icon_state = "coffee";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
 "IE" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -13337,19 +13856,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/secure_storage)
-"IN" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile,
-/area/crew_quarters/heads/office/ce)
 "IO" = (
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/carpet,
@@ -13519,28 +14025,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
-"JB" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "JE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -13566,26 +14050,6 @@
 "JV" = (
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
-"JX" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/structure/sign/ecplaque{
-	pixel_x = 29
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
-"JY" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/book/manual/sol_sop,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/meeting_room)
 "Ka" = (
 /obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -13764,21 +14228,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"KK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
 "KN" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -14166,11 +14615,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"Mt" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/weapon/book/manual/nt_regs,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl)
 "Mw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14183,39 +14627,6 @@
 "MA" = (
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
-"MB" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 25
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "MD" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -14332,22 +14743,6 @@
 /obj/structure/table/woodentable_reinforced/ebony/walnut,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
-"Nh" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/smallcactus{
-	desc = "This is a small cactus. Its needles are sharp. It seems neglected, as if no one loves it."
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/office/ce)
 "Ni" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Bridge Deck Shield Generator"
@@ -14419,22 +14814,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"Nv" = (
-/obj/machinery/door/airlock/research{
-	id_tag = "liaisondoor";
-	name = "Corporate Liaison";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/office/cl)
 "Nw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
@@ -14475,18 +14854,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
-"NJ" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge";
-	dir = 1
-	},
-/obj/item/weapon/book/manual/sol_sop,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "NL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
@@ -14661,18 +15028,6 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/aquila/maintenance)
-"Ol" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Bridge Conference Room";
-	sort_type = "Bridge Conference Room"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Om" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -14716,11 +15071,6 @@
 	id = "cl_windows"
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/heads/office/cl)
-"OH" = (
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
 "OK" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -14787,6 +15137,7 @@
 /obj/machinery/power/smes/buildable{
 	capacity = 1e+007;
 	charge = 0;
+	dir = 4;
 	RCon_tag = "Solar - Bridge"
 	},
 /obj/item/device/radio/intercom{
@@ -14919,22 +15270,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/medical)
-"PQ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "Qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15096,19 +15431,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"Qn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Entry Port";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Qp" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "captaindoorfore";
@@ -15118,30 +15440,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"Qt" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Qv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16188,45 +16486,10 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/starboard)
-"Un" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/button/remote/blast_door{
-	name = "Bridge Window Lockdown Control";
-	pixel_x = -30;
-	pixel_y = 0;
-	id = "bridge blast"
-	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/flashlight,
-/obj/machinery/light/spot{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "Uo" = (
 /obj/structure/bed/chair/padded/green,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"Up" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "Ut" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -16273,19 +16536,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
-"UH" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
-	dir = 1
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/prefab/hand_teleporter,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/heads/cobed)
 "UL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16303,17 +16553,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"UN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "UU" = (
 /obj/effect/shuttle_landmark/ert/deck5,
 /turf/space,
@@ -16549,18 +16788,6 @@
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"VM" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "VN" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "bridge_port"
@@ -16651,23 +16878,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
-"Wc" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/keycard_auth/torch{
-	pixel_x = 0;
-	pixel_y = 38
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 6;
-	pixel_y = 20
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -8;
-	pixel_y = 20
-	},
-/obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "Wd" = (
 /obj/item/modular_computer/console/preset/command{
 	icon_state = "console";
@@ -16799,27 +17009,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
-"WS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Conference Room";
-	dir = 2
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "WX" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -16887,22 +17076,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/maintenance)
-"Xc" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/snack,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge)
 "Xe" = (
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/carpet/blue2,
@@ -17011,10 +17184,6 @@
 "Xz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/guncabinet/PPE,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Storage";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "XB" = (
@@ -17188,29 +17357,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"Yg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Bridge Storage";
-	sort_type = "Bridge Storage"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/starboard)
 "Yh" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -17243,23 +17389,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Yk" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	icon_state = "corner_white_diagonal";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/hallway/port)
 "Yz" = (
 /obj/structure/flora/pottedplant/orientaltree,
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -17301,17 +17430,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
-"YF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
 "YI" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
@@ -17429,31 +17547,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/aquila/maintenance)
-"Zc" = (
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/weapon/stamp/nt,
-/obj/item/weapon/pen/blue{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/weapon/pen/green,
-/obj/item/weapon/pen/red{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/NT{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/office/cl/backroom)
 "Ze" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25235,8 +25328,8 @@ BE
 QW
 Rq
 GV
-Un
-By
+dU
+CE
 FE
 HE
 BI
@@ -25249,7 +25342,7 @@ An
 uy
 Kq
 Cl
-UH
+fV
 Av
 uy
 uy
@@ -25437,7 +25530,7 @@ lt
 vg
 zg
 zN
-VM
+lt
 TK
 cV
 Ie
@@ -25633,7 +25726,7 @@ bf
 ee
 Wv
 eP
-Wc
+cy
 Af
 hn
 hn
@@ -25641,7 +25734,7 @@ HK
 hn
 hn
 SJ
-HU
+ev
 eP
 UY
 Fg
@@ -25835,7 +25928,7 @@ Ke
 Ks
 TI
 eP
-Xc
+cz
 HC
 jw
 kw
@@ -25843,7 +25936,7 @@ lm
 kw
 nH
 HC
-pq
+ew
 XR
 NN
 Fl
@@ -26447,7 +26540,7 @@ jy
 vf
 lo
 yh
-NJ
+dW
 eP
 HX
 eP
@@ -26640,10 +26733,10 @@ aO
 aO
 aO
 aO
-fP
-fS
-Hu
-hW
+bM
+ci
+ct
+cA
 iI
 HF
 qf
@@ -26651,10 +26744,10 @@ Zg
 qh
 HP
 ox
-HY
-yY
-Ic
-rL
+ex
+eV
+fo
+fM
 RT
 vm
 tW
@@ -26842,10 +26935,10 @@ sl
 si
 VF
 aO
-fQ
-gB
-ho
-hX
+bR
+cl
+cu
+cB
 iJ
 jz
 dT
@@ -26853,10 +26946,10 @@ dh
 IY
 nJ
 oy
-pr
-qj
-qS
-rM
+eB
+eW
+fw
+fP
 sy
 En
 tX
@@ -27044,10 +27137,10 @@ dI
 aB
 za
 fx
-fR
-gB
-hp
-Eh
+bS
+cl
+cv
+cC
 eP
 AH
 yf
@@ -27055,10 +27148,10 @@ eP
 VN
 zh
 eP
-Gh
-Qt
-qT
-rN
+eC
+eX
+fy
+fQ
 sz
 Ip
 kv
@@ -27246,21 +27339,21 @@ aO
 eq
 aO
 yg
-sb
-gC
-lQ
-hX
+bW
 cl
+cw
+cD
+db
 KX
 KX
 CZ
 OD
 OD
-bK
-pr
-Yk
-qU
-rO
+ed
+eD
+fa
+fA
+fR
 sB
 ZR
 vZ
@@ -27448,21 +27541,21 @@ dJ
 Ce
 ZT
 bQ
-fS
-gE
-JB
-Yg
-iK
+bY
+cm
+cx
+cE
+dc
 YK
 YK
 jB
 kx
 kx
-Ol
-pt
-Bu
-qV
-rP
+ef
+eE
+fc
+fC
+fS
 sB
 tm
 tZ
@@ -27650,9 +27743,9 @@ Yd
 eQ
 Hh
 Ho
-fU
-gF
-PQ
+bZ
+cn
+hq
 hq
 rt
 yd
@@ -27662,9 +27755,9 @@ bP
 ab
 ta
 hq
-AP
-qW
-Qn
+hq
+fE
+fT
 rQ
 ti
 ti
@@ -27852,21 +27945,21 @@ oz
 zT
 oI
 Hp
-fV
-gG
-hr
+ca
+cr
 hq
-MB
+cU
+de
 Qv
 We
 Ye
 Ze
 DH
-BF
+ek
+eG
 hq
-qk
-qX
-ng
+fG
+fU
 rR
 Ik
 to
@@ -28057,15 +28150,15 @@ EM
 Uk
 Hs
 hs
-hq
-WS
+cW
+dg
 Te
 zf
 zf
 zf
 Te
-dF
-hq
+el
+eK
 hs
 qY
 AJ
@@ -28259,15 +28352,15 @@ aO
 eU
 qg
 Vn
-Gq
-iM
+cX
+dl
 Xe
-Ax
-eW
+dK
+dP
 LN
 Ah
-BV
-tk
+eo
+eL
 oJ
 Og
 Vl
@@ -28461,15 +28554,15 @@ jR
 BY
 ra
 jO
-iG
-UN
+cY
+do
 Te
 Xg
 Xg
 Xg
 Te
-hZ
-Ft
+ep
+eO
 bX
 GD
 Ap
@@ -28663,15 +28756,15 @@ jR
 Lf
 gJ
 id
-CL
-xd
+cZ
+dq
 jH
 Sn
-zD
-JX
-jH
-iN
-JY
+dQ
+dS
+dX
+es
+eR
 id
 rb
 rV
@@ -28854,16 +28947,16 @@ ap
 aD
 QK
 UL
-eK
-Up
-Fv
-dg
-YF
-YF
-eV
-Bn
-KK
-gK
+ax
+aN
+bs
+bv
+bw
+bw
+bF
+bK
+cg
+cs
 hs
 hs
 hs
@@ -29056,7 +29149,7 @@ aq
 aE
 sJ
 sJ
-dc
+aC
 bV
 sJ
 Nd
@@ -29069,8 +29162,8 @@ gL
 hx
 ig
 iP
-Bf
-kF
+dF
+dL
 mE
 mG
 Ff
@@ -29257,14 +29350,14 @@ af
 YI
 aE
 sJ
-gb
-fc
+ai
+aJ
 Dg
 Cd
 Rd
-Be
+by
 ey
-Fe
+bG
 OE
 Qe
 Ga
@@ -29272,7 +29365,7 @@ hz
 ih
 CP
 Cf
-Nh
+dM
 mE
 mH
 Gf
@@ -29459,22 +29552,22 @@ af
 ar
 aE
 sJ
-Hb
+ak
 gc
-OH
+bl
 Dd
 Sd
 we
 Nw
 eY
-Nv
+bL
 gd
 gO
 dp
 ii
 Ia
 iR
-my
+dN
 mE
 mI
 oF
@@ -29663,10 +29756,10 @@ aE
 sJ
 bc
 Uo
-Mt
+bn
 Ed
 Ud
-ze
+bz
 ez
 eZ
 Gy
@@ -29868,21 +29961,21 @@ sJ
 Uc
 Dd
 Wd
-Ae
+bA
 ZJ
 qR
 sJ
 xV
 Fb
 ie
-IN
+da
 Zx
 AZ
 Cs
 mE
 mJ
 Mn
-oG
+eu
 fF
 mE
 xZ
@@ -30068,7 +30161,7 @@ VB
 VB
 sJ
 sJ
-ve
+bu
 sJ
 sJ
 HG
@@ -30269,7 +30362,7 @@ aF
 aP
 bg
 dk
-Zc
+bp
 Kd
 dn
 BB
@@ -30281,8 +30374,8 @@ Rp
 fD
 Pd
 BX
-EL
-ID
+dH
+fY
 zV
 kX
 eF
@@ -30471,7 +30564,7 @@ af
 aj
 bh
 dk
-kd
+br
 Ld
 dn
 Ve
@@ -30484,7 +30577,7 @@ fD
 il
 iU
 TM
-mC
+dO
 AI
 qw
 YJ
@@ -33522,8 +33615,8 @@ Qh
 Xh
 di
 qi
-Bp
 yi
+Bp
 Ci
 on
 uY
@@ -33724,10 +33817,10 @@ Rh
 Yh
 Yh
 TQ
-SU
 Rz
+SU
 YW
-CO
+on
 dV
 vJ
 wp
@@ -33929,7 +34022,7 @@ pR
 yD
 Fi
 Dt
-CO
+on
 dV
 dV
 wq
@@ -34131,7 +34224,7 @@ QE
 Ai
 Ai
 Zy
-CO
+on
 dV
 dV
 Tc
@@ -34329,11 +34422,11 @@ on
 Th
 Dq
 Uh
+fH
 bk
 zz
-Bi
 IW
-CO
+on
 dV
 dV
 ws


### PR DESCRIPTION
🆑
maptweak: Moved the CE's suit to the bridge EVA storage.
maptweak: Made the conference room a tad bit bigger and moved items around, gave it a request console.
maptweak: Removed one console on each side of the bridge and added tables instead, gave another emergency toolbox, donut box, coffee mug, and a shortwave.
maptweak: Gave the CL a box of cigars, bronze zippo, union card box, and made the backroom properly boltable by the button.
maptweak: Added disposals to the CL office.
maptweak: Shuffled around the contents of the CE's office.
maptweak: Gave the CO a Torch ship model.
/🆑
Decided that I should open one of these as these are !!HOT!! and I didn't agree with all the recent changes fully anyways.
Mostly moved minor stuff around, and added some, the diff shows better than words.