### PR TITLE
Fixes atmos machine processing.

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -125,13 +125,17 @@ Class Procs:
 	. = ..()
 
 /obj/machinery/Process()
-	if(LAZYLEN(processing_parts))
+	if((. = process_parts()))
+		return
+	return PROCESS_KILL // Only process if you need to.
+
+/obj/machinery/proc/process_parts()
+	. = processing_parts
+	if(.)
 		for(var/thing in processing_parts)
 			var/obj/item/weapon/stock_parts/part = thing
 			if(part.machine_process(src) == PROCESS_KILL)
 				part.stop_processing()
-	else
-		return PROCESS_KILL // Only process if you need to.
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -103,7 +103,7 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 	return node.pipe_color
 
 /obj/machinery/atmospherics/Process()
-	. = ..()
+	..() // do not return process kill by default
 	last_flow_rate = 0
 	last_power_draw = 0
 

--- a/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
+++ b/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
@@ -273,7 +273,7 @@
 		src.set_dir(turn(src.dir, 90))
 
 /obj/machinery/power/turbinemotor/Process()
-	..()
+	process_parts()
 	updateConnection()
 	if(!turbine || !anchored || stat & (BROKEN))
 		return

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -66,7 +66,7 @@ Thus, the two variables affect pump operation are set in New():
 	update_underlays()
 
 /obj/machinery/atmospherics/binary/pump/Process()
-	..()
+	process_parts()
 	last_power_draw = 0
 	last_flow_rate = 0
 

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -61,7 +61,7 @@
 	return
 
 /obj/machinery/atmospherics/omni/Process()
-	..()
+	process_parts()
 	last_power_draw = 0
 	last_flow_rate = 0
 

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -177,6 +177,10 @@
 	else
 		src.go_to_side()
 
+/obj/machinery/atmospherics/tvalve/Process()
+	..()
+	return PROCESS_KILL
+
 /obj/machinery/atmospherics/tvalve/atmos_init()
 	..()
 	var/node1_dir

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -135,6 +135,10 @@
 	else
 		src.open()
 
+/obj/machinery/atmospherics/valve/Process()
+	..()
+	return PROCESS_KILL
+
 /obj/machinery/atmospherics/valve/atmos_init()
 	..()
 	normalize_dir()


### PR DESCRIPTION
Forgot that they do crazy shit with their Process calls. This ensures that legacy return of `PROCESS_KILL` is preserved, but `process_parts` is always called. Will need further improvements later to make it actually process if parts need processing, but for now this should be fine due to how their power usage works.