### PR TITLE
Psionics changes.

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -539,7 +539,7 @@ SUBSYSTEM_DEF(jobs)
 			W.buckled_mob = H
 			W.add_fingerprint(H)
 
-	to_chat(H, "<B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title ? alt_title : rank].</B>")
+	to_chat(H, "<font size = 3><B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title ? alt_title : rank].</B></font>")
 
 	if(job.supervisors)
 		to_chat(H, "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -51,6 +51,7 @@
 	var/list/species_branch_rank_cache_ = list()
 	var/list/psi_faculties                // Starting psi faculties, if any.
 	var/psi_latency_chance = 0            // Chance of an additional psi latency, if any.
+	var/give_psionic_implant_on_join = TRUE // If psionic, will be implanted for control.
 
 	var/required_language
 
@@ -85,7 +86,17 @@
 			H.set_psi_rank(psi, psi_faculties[psi], take_larger = TRUE, defer_update = TRUE)
 	if(H.psi)
 		H.psi.update()
-		H.give_psi_implant()
+		if(give_psionic_implant_on_join)
+			var/obj/item/weapon/implant/psi_control/imp = new
+			imp.implanted(H)
+			imp.forceMove(H)
+			imp.imp_in = H
+			imp.implanted = TRUE
+			var/obj/item/organ/external/affected = H.get_organ(BP_HEAD)
+			if(affected)
+				affected.implants += imp
+				imp.part = affected
+			to_chat(H, SPAN_DANGER("As a registered psionic, you are fitted with a psi-dampening control implant. Using psi-power while the implant is active will result in neural shocks and your violation being reported."))
 
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)
 	if(outfit) . = outfit.equip(H, title, alt_title)

--- a/code/modules/goals/goal_mob.dm
+++ b/code/modules/goals/goal_mob.dm
@@ -30,16 +30,16 @@
 
 	to_chat(src, "<hr>")
 	if(LAZYLEN(mind.goals))
-		to_chat(src, SPAN_NOTICE("<b>This round, you have the following personal goals:</b><br>[jointext(mind.summarize_goals(show_success, allow_modification, mind.current), "<br>")]"))
+		to_chat(src, SPAN_NOTICE("<font size = 3><b>This round, you have the following personal goals:</b></font><br>[jointext(mind.summarize_goals(show_success, allow_modification, mind.current), "<br>")]"))
 	else
-		to_chat(src, SPAN_NOTICE("<b>You have no personal goals this round.</b>"))
+		to_chat(src, SPAN_NOTICE("<font size = 3><b>You have no personal goals this round.</b></font>"))
 	if(allow_modification && LAZYLEN(mind.goals) < 5)
 		to_chat(src, SPAN_NOTICE("<a href='?src=\ref[mind];add_goal=1;add_goal_caller=\ref[mind.current]'>Add Random Goal</a>"))
 	if(dept)
 		if(LAZYLEN(dept.goals))
-			to_chat(src, SPAN_NOTICE("<br><b>This round, [dept.name] has the following departmental goals:</b><br>[jointext(dept.summarize_goals(show_success), "<br>")]"))
+			to_chat(src, SPAN_NOTICE("<br><br><font size = 3><b>This round, [dept.name] has the following departmental goals:</b></font><br>[jointext(dept.summarize_goals(show_success), "<br>")]"))
 		else
-			to_chat(src, SPAN_NOTICE("<br><b>[dept.name] has no departmental goals this round.</b>"))
+			to_chat(src, SPAN_NOTICE("<br><br><font size = 3><b>[dept.name] has no departmental goals this round.</b></font>"))
 
 	if(LAZYLEN(mind.goals))
 		to_chat(mind.current, SPAN_NOTICE("<br><br>You can check your round goals with the <b>Show Goals</b> verb."))

--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -45,9 +45,6 @@
 	aura_image.pixel_y = -64
 	aura_image.mouse_opacity = 0
 	aura_image.appearance_flags = 0
-	var/matrix/M = matrix()
-	M.Scale(-5)
-	aura_image.transform = M
 
 	START_PROCESSING(SSpsi, src)
 

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -157,12 +157,13 @@
 			// Heal organ damage.
 			for(var/obj/item/organ/I in H.internal_organs)
 
-				if(BP_IS_ROBOTIC(I))
+				if(BP_IS_ROBOTIC(I) || BP_IS_CRYSTAL(I))
 					continue
 
 				if(I.damage > 0 && spend_power(heal_rate))
 					I.damage = max(I.damage - heal_rate, 0)
-					to_chat(H, SPAN_NOTICE("Your innards itch as your autoredactive faculty mends your [I.name]."))
+					if(prob(10))
+						to_chat(H, SPAN_NOTICE("Your innards itch as your autoredactive faculty mends your [I.name]."))
 					return
 
 			// Heal broken bones.
@@ -193,8 +194,9 @@
 						for(var/datum/wound/W in E.wounds)
 
 							if(W.bleeding() && spend_power(heal_rate))
-								to_chat(H, SPAN_NOTICE("Your autoredactive faculty knits together severed veins, stemming the bleeding from your [E.name]."))
+								to_chat(H, SPAN_NOTICE("Your autoredactive faculty knits together severed veins, stemming the bleeding from \a [W.desc] on your [E.name]."))
 								W.bleed_timer = 0
+								W.clamped = TRUE
 								E.status &= ~ORGAN_BLEEDING
 								return
 
@@ -202,12 +204,14 @@
 	if(heal_poison)
 
 		if(owner.radiation && spend_power(heal_rate))
-			to_chat(owner, SPAN_NOTICE("Your autoredactive faculty repairs some of the radiation damage to your body."))
+			if(prob(10))
+				to_chat(owner, SPAN_NOTICE("Your autoredactive faculty repairs some of the radiation damage to your body."))
 			owner.radiation = max(0, owner.radiation - heal_rate)
 			return
 
 		if(owner.getCloneLoss() && spend_power(heal_rate))
-			to_chat(owner, SPAN_NOTICE("Your autoredactive faculty stitches together some of your mangled DNA."))
+			if(prob(10))
+				to_chat(owner, SPAN_NOTICE("Your autoredactive faculty stitches together some of your mangled DNA."))
 			owner.adjustCloneLoss(-heal_rate)
 			return
 
@@ -216,4 +220,5 @@
 		owner.adjustBruteLoss(-(heal_rate))
 		owner.adjustFireLoss(-(heal_rate))
 		owner.adjustOxyLoss(-(heal_rate))
-		to_chat(owner, SPAN_NOTICE("Your skin crawls as your autoredactive faculty heals your body."))
+		if(prob(10))
+			to_chat(owner, SPAN_NOTICE("Your skin crawls as your autoredactive faculty heals your body."))

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -162,7 +162,7 @@
 
 				if(I.damage > 0 && spend_power(heal_rate))
 					I.damage = max(I.damage - heal_rate, 0)
-					if(prob(10))
+					if(prob(25))
 						to_chat(H, SPAN_NOTICE("Your innards itch as your autoredactive faculty mends your [I.name]."))
 					return
 
@@ -204,13 +204,13 @@
 	if(heal_poison)
 
 		if(owner.radiation && spend_power(heal_rate))
-			if(prob(10))
+			if(prob(25))
 				to_chat(owner, SPAN_NOTICE("Your autoredactive faculty repairs some of the radiation damage to your body."))
 			owner.radiation = max(0, owner.radiation - heal_rate)
 			return
 
 		if(owner.getCloneLoss() && spend_power(heal_rate))
-			if(prob(10))
+			if(prob(25))
 				to_chat(owner, SPAN_NOTICE("Your autoredactive faculty stitches together some of your mangled DNA."))
 			owner.adjustCloneLoss(-heal_rate)
 			return
@@ -220,5 +220,5 @@
 		owner.adjustBruteLoss(-(heal_rate))
 		owner.adjustFireLoss(-(heal_rate))
 		owner.adjustOxyLoss(-(heal_rate))
-		if(prob(10))
+		if(prob(25))
 			to_chat(owner, SPAN_NOTICE("Your skin crawls as your autoredactive faculty heals your body."))

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -4,6 +4,7 @@
 
 	var/last_rating = rating
 	var/highest_faculty
+	var/highest_rank = 0
 	var/combined_rank = 0
 	for(var/faculty in ranks)
 		var/check_rank = get_rank(faculty)
@@ -14,14 +15,19 @@
 				ranks -= faculty
 			LAZYREMOVE(latencies, faculty)
 		combined_rank += check_rank
-		if(!highest_faculty || get_rank(highest_faculty) < check_rank)
+		if(!highest_faculty || highest_rank < check_rank)
 			highest_faculty = faculty
+			highest_rank = check_rank
 
 	UNSETEMPTY(latencies)
 
 	if(force || last_rating != ceil(combined_rank/ranks.len))
-		rebuild_power_cache = TRUE
-		if(combined_rank > 0)
+		if(highest_rank <= 1)
+			if(highest_rank == 0)
+				qdel(src)
+			return
+		else
+			rebuild_power_cache = TRUE
 			sound_to(owner, 'sound/effects/psi/power_unlock.ogg')
 			rating = ceil(combined_rank/ranks.len)
 			cost_modifier = 1
@@ -52,12 +58,11 @@
 					aura_color = "#33cc33"
 				else if(highest_faculty == PSI_ENERGISTICS)
 					aura_color = "#cccc33"
-		else
-			qdel(src)
 
 	if(!announced && owner && owner.client && !QDELETED(src))
 		announced = TRUE
-		owner.announce_psionics()
+		to_chat(owner, SPAN_NOTICE("<font size = 3>You are <b>psionic</b>, touched by powers beyond understanding.</font>"))
+		to_chat(owner, SPAN_NOTICE("<b>Shift-left-click your Psi icon</b> on the bottom right to <b>view a summary of how to use them</b>, or <b>left click</b> it to <b>suppress or unsuppress</b> your psionics. Beware: overusing your gifts can have <b>deadly consequences</b>."))
 
 /datum/psi_complexus/Process()
 

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -61,8 +61,10 @@
 
 	if(!announced && owner && owner.client && !QDELETED(src))
 		announced = TRUE
+		to_chat(owner, "<hr>")
 		to_chat(owner, SPAN_NOTICE("<font size = 3>You are <b>psionic</b>, touched by powers beyond understanding.</font>"))
 		to_chat(owner, SPAN_NOTICE("<b>Shift-left-click your Psi icon</b> on the bottom right to <b>view a summary of how to use them</b>, or <b>left click</b> it to <b>suppress or unsuppress</b> your psionics. Beware: overusing your gifts can have <b>deadly consequences</b>."))
+		to_chat(owner, "<hr>")
 
 /datum/psi_complexus/Process()
 

--- a/code/modules/psionics/equipment/foundation_implanter.dm
+++ b/code/modules/psionics/equipment/foundation_implanter.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implanter/psi
-	name = "\improper Foundation implanter"
-	desc = "An implant gun customized to interact with psi dampeners. Property of the Cuchulain Foundation."
+	name = "psi-null implanter"
+	desc = "An implant gun customized to interact with psi dampeners."
 	var/implanter_mode = PSI_IMPLANT_AUTOMATIC
 
 /obj/item/weapon/implanter/psi/attack_self(var/mob/user)

--- a/code/modules/psionics/equipment/foundation_weapon.dm
+++ b/code/modules/psionics/equipment/foundation_weapon.dm
@@ -10,7 +10,7 @@
 
 /obj/item/weapon/storage/briefcase/foundation
 	name = "\improper Foundation briefcase"
-	desc = "A handsome black leather briefcase embossed with the Cuchulain Foundation logo."
+	desc = "A handsome black leather briefcase embossed with a stylized radio telescope."
 	icon_state = "fbriefcase"
 	item_state = "fbriefcase"
 

--- a/code/modules/psionics/equipment/psimeter.dm
+++ b/code/modules/psionics/equipment/psimeter.dm
@@ -1,6 +1,6 @@
 /obj/machinery/psi_meter
 	name = "psi-meter"
-	desc = "A bulky, rather outdated psi-meter for conducting assays of psi-operants. The rear casing is stamped with a large Cuchulain Foundation logo."
+	desc = "A bulky psi-meter for conducting assays of psi-operants."
 	icon = 'icons/obj/machines/psimeter.dmi'
 	icon_state = "meter_on"
 	use_power = 2
@@ -31,7 +31,7 @@
 	if(LAZYLEN(last_assay))
 		dat = last_assay
 	else
-		dat += "<h2>Cuchulain Foundation Mark I Psi-Meter</h2><hr><table border = 1 width = 100%><tr><td colspan = 2><b>Candidates</b></td></tr>"
+		dat += "<h2>TELESTO Mark I Psi-Meter</h2><hr><table border = 1 width = 100%><tr><td colspan = 2><b>Candidates</b></td></tr>"
 		var/found
 		for(var/mob/living/H in range(1, src))
 			found = TRUE

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -53,6 +53,41 @@
 			M.confused = rand(3,8)
 		return TRUE
 
+/decl/psionic_power/coercion/mindread
+	name =            "Mindread"
+	cost =            6
+	cooldown =        80
+	use_melee =       TRUE
+	min_rank =        PSI_RANK_OPERANT
+	associated_intent = I_HELP
+	use_description = "Target the head and click on a living subject while on help intent to attempt to read their mind."
+
+/decl/psionic_power/coercion/mindread/invoke(var/mob/living/user, var/mob/living/target)
+	if(!isliving(target) || !istype(target) || user.zone_sel.selecting != BP_HEAD)
+		return FALSE
+	. = ..()
+	if(.)
+		if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
+			to_chat(user, SPAN_WARNING("\The [target]'s soul has departed."))
+			return TRUE
+			
+		var/question =  input("Say something?","Mindread") as null|text
+		if(do_after(user, 20))
+			var/started_mindread = world.time
+			user.visible_message(SPAN_NOTICE("<i>\The [user] places their hand over \the [target]'s temple...</i>"))
+			if(question)
+				to_chat(target, SPAN_NOTICE("You hear echoes in your mind, <i>[question]</i>"))
+			var/question_header = (question) ? question : "What thoughts fly through your head?"
+			var/answer =  input(target, question_header,"Mindread") as null|text
+			if(world.time > started_mindread + 10 SECONDS)
+				to_chat(user, SPAN_NOTICE("You hear nothing.."))
+			else if(answer)
+				to_chat(user, SPAN_NOTICE("You hear the depths of \the [target]'s mind, <i>[answer]</i>"))
+				return TRUE									
+			if(answer)
+				to_chat(target, SPAN_NOTICE("Your thoughts return to you. It seems you were too slow."))
+		return TRUE
+
 /decl/psionic_power/coercion/agony
 	name =          "Agony"
 	cost =          8

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -171,26 +171,26 @@
 		GLOB.thralls.add_antagonist(target.mind, new_controller = user)
 		return TRUE
 
-/decl/psionic_power/coercion/probe
-	name =            "Probe"
+/decl/psionic_power/coercion/assay
+	name =            "Assay"
 	cost =            15
 	cooldown =        100
 	use_grab =        TRUE
-	min_rank =        PSI_RANK_GRANDMASTER
-	use_description = "Grab a victim, target the head, then use the grab on them while on disarm intent, in order to perform a deep coercive-redactive probe of their innermost secrets."
+	min_rank =        PSI_RANK_OPERANT
+	use_description = "Grab a patient, target the head, then use the grab on them while on disarm intent, in order to perform a deep coercive-redactive probe of their psionic potential."
 
-/decl/psionic_power/coercion/probe/invoke(var/mob/living/user, var/mob/living/target)
+/decl/psionic_power/coercion/assay/invoke(var/mob/living/user, var/mob/living/target)
 	if(user.zone_sel.selecting != BP_HEAD)
 		return FALSE
 	. = ..()
 	if(.)
-		user.visible_message("<span class='danger'><i>\The [user] grips the head of \the [target] in both hands...</i></span>")
-		to_chat(user, "<span class='warning'>You plunge your mentality into that of \the [target]...</span>")
-		to_chat(target, "<span class='danger'>Your persona is scrutinized by the psychic lens of \the [user]. They are trying to read your mind!</span>")
-		if(!do_after(user, target.stat == CONSCIOUS ? 50 : 25, target, 0, 1))
+		user.visible_message(SPAN_WARNING("\The [user] holds the head of \the [target] in both hands..."))
+		to_chat(user, SPAN_NOTICE("You insinuate your mentality into that of \the [target]..."))
+		to_chat(target, SPAN_WARNING("Your persona is being probed by the psychic lens of \the [user]."))
+		if(!do_after(user, (target.stat == CONSCIOUS ? 50 : 25), target, 0, 1))
 			user.psi.backblast(rand(5,10))
 			return TRUE
-		to_chat(user, "<span class='notice'>You retreat from \the [target], holding your new knowledge close.</span>")
-		to_chat(target, "<span class='danger'>Your mental complexus is laid bare to judgement of \the [user].</span>")
+		to_chat(user, SPAN_NOTICE("You retreat from \the [target], holding your new knowledge close."))
+		to_chat(target, SPAN_DANGER("Your mental complexus is laid bare to judgement of \the [user]."))
 		target.show_psi_assay(user)
 		return TRUE

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -27,10 +27,10 @@
 	use_ranged =     TRUE
 	use_melee =      TRUE
 	min_rank =       PSI_RANK_OPERANT
-	use_description = "Target the head, eyes or mouth on disarm intent and click anywhere to use a radial attack that blinds, deafens and disorients everyone near you."
+	use_description = "Target the eyes or mouth on disarm intent and click anywhere to use a radial attack that blinds, deafens and disorients everyone near you."
 
 /decl/psionic_power/coercion/blindstrike/invoke(var/mob/living/user, var/mob/living/target)
-	if(user.zone_sel.selecting != BP_HEAD && user.zone_sel.selecting != BP_MOUTH && user.zone_sel.selecting != BP_EYES)
+	if(user.zone_sel.selecting != BP_MOUTH && user.zone_sel.selecting != BP_EYES)
 		return FALSE
 	. = ..()
 	if(.)
@@ -54,39 +54,39 @@
 		return TRUE
 
 /decl/psionic_power/coercion/mindread
-	name =            "Mindread"
+	name =            "Read Mind"
 	cost =            6
 	cooldown =        80
 	use_melee =       TRUE
 	min_rank =        PSI_RANK_OPERANT
-	associated_intent = I_HELP
-	use_description = "Target the head and click on a living subject while on help intent to attempt to read their mind."
+	use_description = "Target the head on disarm intent at melee range to attempt to read a victim's surface thoughts."
 
 /decl/psionic_power/coercion/mindread/invoke(var/mob/living/user, var/mob/living/target)
 	if(!isliving(target) || !istype(target) || user.zone_sel.selecting != BP_HEAD)
 		return FALSE
 	. = ..()
-	if(.)
-		if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
-			to_chat(user, SPAN_WARNING("\The [target]'s soul has departed."))
-			return TRUE
-			
-		var/question =  input("Say something?","Mindread") as null|text
-		if(do_after(user, 20))
-			var/started_mindread = world.time
-			user.visible_message(SPAN_NOTICE("<i>\The [user] places their hand over \the [target]'s temple...</i>"))
-			if(question)
-				to_chat(target, SPAN_NOTICE("You hear echoes in your mind, <i>[question]</i>"))
-			var/question_header = (question) ? question : "What thoughts fly through your head?"
-			var/answer =  input(target, question_header,"Mindread") as null|text
-			if(world.time > started_mindread + 10 SECONDS)
-				to_chat(user, SPAN_NOTICE("You hear nothing.."))
-			else if(answer)
-				to_chat(user, SPAN_NOTICE("You hear the depths of \the [target]'s mind, <i>[answer]</i>"))
-				return TRUE									
-			if(answer)
-				to_chat(target, SPAN_NOTICE("Your thoughts return to you. It seems you were too slow."))
+	if(!.)
+		return
+
+	if(target.stat == DEAD || (target.status_flags & FAKEDEATH) || !target.client)
+		to_chat(user, SPAN_WARNING("\The [target] is in no state for a mind-ream."))
 		return TRUE
+			
+	user.visible_message(SPAN_WARNING("\The [user] touches \the [target]'s temple..."))
+	var/question =  input(user, "Say something?", "Read Mind", "Penny for your thoughts?") as null|text
+	if(!question || user.incapacitated() || !do_after(user, 20))
+		return TRUE
+
+	var/started_mindread = world.time
+	to_chat(user, SPAN_NOTICE("<b>You dip your mentality into the surface layer of \the [target]'s mind, seeking an answer: <i>[question]</i></b>"))
+	to_chat(target, SPAN_NOTICE("<b>Your mind is compelled to answer: <i>[question]</i></b>"))
+
+	var/answer =  input(target, question, "Read Mind") as null|text
+	if(!answer || world.time > started_mindread + 25 SECONDS || user.stat != CONSCIOUS || target.stat == DEAD)
+		to_chat(user, SPAN_NOTICE("<b>You receive nothing useful from \the [target].</b>"))
+	else
+		to_chat(user, SPAN_NOTICE("<b>You skim thoughts from the surface of \the [target]'s mind: <i>[answer]</i></b>"))
+	return TRUE
 
 /decl/psionic_power/coercion/agony
 	name =          "Agony"
@@ -143,10 +143,10 @@
 	cooldown =      200
 	use_grab =      TRUE
 	min_rank =      PSI_RANK_PARAMOUNT
-	use_description = "Grab a victim, target the head, then use the grab on them while on disarm intent, in order to convert them into a loyal mind-slave. The process takes some time, and failure is punished harshly."
+	use_description = "Grab a victim, target the eyes, then use the grab on them while on disarm intent, in order to convert them into a loyal mind-slave. The process takes some time, and failure is punished harshly."
 
 /decl/psionic_power/coercion/mindslave/invoke(var/mob/living/user, var/mob/living/target)
-	if(!istype(target) || user.zone_sel.selecting != BP_HEAD)
+	if(!istype(target) || user.zone_sel.selecting != BP_EYES)
 		return FALSE
 	. = ..()
 	if(.)
@@ -176,10 +176,10 @@
 	cooldown =        100
 	use_grab =        TRUE
 	min_rank =        PSI_RANK_GRANDMASTER
-	use_description = "Grab a victim, target the eyes, then use the grab on them while on disarm intent, in order to perform a deep coercive-redactive probe of their innermost secrets."
+	use_description = "Grab a victim, target the head, then use the grab on them while on disarm intent, in order to perform a deep coercive-redactive probe of their innermost secrets."
 
 /decl/psionic_power/coercion/probe/invoke(var/mob/living/user, var/mob/living/target)
-	if(user.zone_sel.selecting != BP_EYES)
+	if(user.zone_sel.selecting != BP_HEAD)
 		return FALSE
 	. = ..()
 	if(.)

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -26,7 +26,7 @@
 	cooldown =       120
 	use_ranged =     TRUE
 	use_melee =      TRUE
-	min_rank =       PSI_RANK_OPERANT
+	min_rank =       PSI_RANK_GRANDMASTER
 	use_description = "Target the eyes or mouth on disarm intent and click anywhere to use a radial attack that blinds, deafens and disorients everyone near you."
 
 /decl/psionic_power/coercion/blindstrike/invoke(var/mob/living/user, var/mob/living/target)
@@ -34,7 +34,8 @@
 		return FALSE
 	. = ..()
 	if(.)
-		to_chat(user, SPAN_DANGER("You open the gate and release a deafening psionic scream, striking at everyone near you with a blast of mental white noise!"))
+		user.visible_message(SPAN_DANGER("\The [user] suddenly throws back their head, as though screaming silently!"))
+		to_chat(user, SPAN_DANGER("You strike at all around you with a deafening psionic scream!"))
 		for(var/mob/living/M in orange(user, user.psi.get_rank(PSI_COERCION)))
 			if(M == user)
 				continue
@@ -46,7 +47,7 @@
 				var/mob/living/carbon/C = M
 				if(C.can_feel_pain())
 					M.emote("scream")
-			to_chat(M, SPAN_DANGER("Your senses are blasted into oblivion by a burst of mental static!"))
+			to_chat(M, SPAN_DANGER("Your senses are blasted into oblivion by a psionic scream!"))
 			M.flash_eyes()
 			M.eye_blind = max(M.eye_blind,3)
 			M.ear_deaf = max(M.ear_deaf,6)
@@ -114,7 +115,7 @@
 	cooldown =       100
 	use_melee =      TRUE
 	use_ranged =     TRUE
-	min_rank =       PSI_RANK_GRANDMASTER
+	min_rank =       PSI_RANK_OPERANT
 	use_description = "Target the arms or hands on disarm intent to use a ranged attack that may rip the weapons away from the target."
 
 /decl/psionic_power/coercion/spasm/invoke(var/mob/living/user, var/mob/living/carbon/human/target)

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -43,7 +43,7 @@
 	cooldown =        50
 	use_melee =       TRUE
 	min_rank =        PSI_RANK_MASTER
-	use_description = "Target a patient while on help intent at melee range to mend internal bleeding and broken bones."
+	use_description = "Target a patient while on help intent at melee range to mend a variety of maladies, such as bleeding or broken bones. Higher ranks in this faculty allow you to mend a wider range of problems."
 
 /decl/psionic_power/redaction/mend/invoke(var/mob/living/user, var/mob/living/carbon/human/target)
 	if(!istype(user) || !istype(target))
@@ -63,8 +63,9 @@
 		user.visible_message(SPAN_NOTICE("<i>\The [user] rests a hand on \the [target]'s [E.name]...</i>"))
 		to_chat(target, SPAN_NOTICE("A healing warmth suffuses you."))
 
+		var/redaction_rank = user.psi.get_rank(PSI_PSYCHOKINESIS)
 		var/pk_rank = user.psi.get_rank(PSI_PSYCHOKINESIS)
-		if(pk_rank >= 1)
+		if(pk_rank >= PSI_RANK_LATENT && redaction_rank >= PSI_RANK_MASTER)
 			var/removal_size = Clamp(5-pk_rank, 0, 5)
 			var/valid_objects = list()
 			for(var/thing in E.implants)
@@ -74,13 +75,23 @@
 			if(LAZYLEN(valid_objects))
 				var/removing = pick(valid_objects)
 				target.remove_implant(removing, TRUE)
-				to_chat(user, SPAN_NOTICE("You extend a tendril of psychokinetic force and carefully tease \the [removing] free of \the [E]."))
+				to_chat(user, SPAN_NOTICE("You extend a tendril of psychokinetic-redactive power and carefully tease \the [removing] free of \the [E]."))
 				return TRUE
 
-		if(E.status & ORGAN_ARTERY_CUT)
-			to_chat(user, SPAN_NOTICE("You painstakingly mend the torn veins in \the [E], stemming the internal bleeding."))
-			E.status &= ~ORGAN_ARTERY_CUT
-			return TRUE
+		if(redaction_rank >= PSI_RANK_MASTER)
+			if(E.status & ORGAN_ARTERY_CUT)
+				to_chat(user, SPAN_NOTICE("You painstakingly mend the torn veins in \the [E], stemming the internal bleeding."))
+				E.status &= ~ORGAN_ARTERY_CUT
+				return TRUE
+			if(E.status & ORGAN_TENDON_CUT)
+				to_chat(user, SPAN_NOTICE("You interleave and repair the severed tendon in \the [E]."))
+				E.status &= ~ORGAN_TENDON_CUT
+				return TRUE
+			if(E.status & ORGAN_BROKEN)
+				to_chat(user, SPAN_NOTICE("You coax shattered bones to come together and fuse, mending the break."))
+				E.status &= ~ORGAN_BROKEN
+				E.stage = 0
+				return TRUE
 
 		for(var/datum/wound/W in E.wounds)
 			if(W.bleeding() && W.wound_damage() <= W.bleed_threshold)
@@ -89,23 +100,13 @@
 				E.status &= ~ORGAN_BLEEDING
 				return TRUE
 
-		if(E.status & ORGAN_TENDON_CUT)
-			to_chat(user, SPAN_NOTICE("You interleave and repair the severed tendon in \the [E]."))
-			E.status &= ~ORGAN_TENDON_CUT
-			return TRUE
-
-		if(E.status & ORGAN_BROKEN)
-			to_chat(user, SPAN_NOTICE("You coax shattered bones to come together and fuse, mending the break."))
-			E.status &= ~ORGAN_BROKEN
-			E.stage = 0
-			return TRUE
-
-		for(var/obj/item/organ/internal/I in E.internal_organs)
-			if(!BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
-				to_chat(user, SPAN_NOTICE("You encourage the damaged tissue of \the [I] to repair itself."))
-				var/heal_rate = user.psi.get_rank(PSI_REDACTION)
-				I.damage = max(0, I.damage - rand(heal_rate,heal_rate*2))
-				return TRUE
+		if(redaction_rank >= PSI_RANK_GRANDMASTER)
+			for(var/obj/item/organ/internal/I in E.internal_organs)
+				if(!BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
+					to_chat(user, SPAN_NOTICE("You encourage the damaged tissue of \the [I] to repair itself."))
+					var/heal_rate = user.psi.get_rank(PSI_REDACTION)
+					I.damage = max(0, I.damage - rand(heal_rate,heal_rate*2))
+					return TRUE
 
 		to_chat(user, SPAN_NOTICE("You can find nothing within \the [target]'s [E.name] to mend."))
 		return FALSE

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -42,7 +42,7 @@
 	cost =            7
 	cooldown =        50
 	use_melee =       TRUE
-	min_rank =        PSI_RANK_MASTER
+	min_rank =        PSI_RANK_OPERANT
 	use_description = "Target a patient while on help intent at melee range to mend a variety of maladies, such as bleeding or broken bones. Higher ranks in this faculty allow you to mend a wider range of problems."
 
 /decl/psionic_power/redaction/mend/invoke(var/mob/living/user, var/mob/living/carbon/human/target)
@@ -97,6 +97,7 @@
 			if(W.bleeding() && W.wound_damage() <= W.bleed_threshold)
 				to_chat(user, SPAN_NOTICE("You knit together severed veins and broken flesh, stemming the bleeding."))
 				W.bleed_timer = 0
+				W.clamped = TRUE
 				E.status &= ~ORGAN_BLEEDING
 				return TRUE
 

--- a/code/modules/psionics/mob/mob.dm
+++ b/code/modules/psionics/mob/mob.dm
@@ -16,16 +16,3 @@
 	var/current_rank = psi.get_rank(faculty)
 	if(current_rank != rank && (!take_larger || current_rank < rank))
 		psi.set_rank(faculty, rank, defer_update, temporary)
-
-/mob/living/proc/announce_psionics()
-	if(client && psi)
-		to_chat(src, SPAN_NOTICE("<font size = 3>You are <b>psionic</b>, touched by powers beyond understanding.</font>"))
-
-		var/latent_only = TRUE
-		for(var/rank in psi.base_ranks)
-			if(psi.base_ranks[rank] > 1)
-				latent_only = FALSE
-		if(latent_only)
-			to_chat(src, SPAN_NOTICE("Your powers are <b>latent</b> and only debilitating trauma has a chance of making them available for use."))
-		else
-			to_chat(src, SPAN_NOTICE("Your powers are <b>operant</b>. <b>Shift-left-click your Psi icon</b> on the bottom right to <b>view a summary of how to use them</b>, or <b>left click</b> it to <b>suppress or unsuppress</b> your psionics. Beware: overusing your gifts can have <b>deadly consequences</b>."))

--- a/code/modules/psionics/mob/mob.dm
+++ b/code/modules/psionics/mob/mob.dm
@@ -29,16 +29,3 @@
 			to_chat(src, SPAN_NOTICE("Your powers are <b>latent</b> and only debilitating trauma has a chance of making them available for use."))
 		else
 			to_chat(src, SPAN_NOTICE("Your powers are <b>operant</b>. <b>Shift-left-click your Psi icon</b> on the bottom right to <b>view a summary of how to use them</b>, or <b>left click</b> it to <b>suppress or unsuppress</b> your psionics. Beware: overusing your gifts can have <b>deadly consequences</b>."))
-
-/mob/living/carbon/human/proc/give_psi_implant(var/silent = FALSE)
-	var/obj/item/weapon/implant/psi_control/imp = new()
-	imp.implanted(src)
-	imp.forceMove(src)
-	imp.imp_in = src
-	imp.implanted = 1
-	var/obj/item/organ/external/affected = get_organ(BP_HEAD)
-	if(affected)
-		affected.implants += imp
-		imp.part = affected
-	if(!silent)
-		to_chat(src, SPAN_DANGER("As a registered psionic, you are fitted with a psi-dampening control implant. Using psi-power while the implant is active will result in neural shocks and your violation being reported."))

--- a/code/modules/psionics/mob/mob_assay.dm
+++ b/code/modules/psionics/mob/mob_assay.dm
@@ -14,13 +14,14 @@
 	dat += "<h2>Summary</h2>"
 	dat += "<hr>"
 
-	if(psi && !(istype(machine) && psi.suppressed))
+	if(psi)
 
 		// Hi Warhammer 40k rating system, how are you?
 		// I hope you get along with the Galactic Milieu metapsychics.
 		var/use_rating
 		var/effective_rating = psi.rating
-		if(psi.suppressed) effective_rating = max(0, psi.rating-2)
+		if(effective_rating > 1 && psi.suppressed)
+			effective_rating = max(0, psi.rating-2)
 		var/rating_descriptor
 		if(mind && !psi.suppressed)
 			if(GLOB.paramounts.is_antagonist(mind))
@@ -51,7 +52,7 @@
 					rating_descriptor = "This indicates the presence of major psi capabilities of the Paramount Grandmaster rank or higher."
 				else
 					use_rating = "[effective_rating]-Lambda"
-					rating_descriptor = "This indicates the presence of low, sub-latent psi capabilities, or a lack thereof."
+					rating_descriptor = "This indicates the presence of trace latent psi capabilities."
 
 		dat += "[use_He_has] an overall psi rating of [use_rating].<br><i>[rating_descriptor]</i><hr>"
 

--- a/html/changelogs/mistakenot-psionics.yml
+++ b/html/changelogs/mistakenot-psionics.yml
@@ -1,0 +1,10 @@
+author: Unknown
+delete-after: True
+changes: 
+  - tweak: "The Mend psi-power now scales in effectiveness to your rank, and is available at lower ranks."
+  - tweak: "Autoredaction is now less buggy in regards to fixing bleeding, and somewhat less spammy when healing you."
+  - tweak: "Coercion now has Mind Read as a power. It prompts someone with a question that they are compelled to answer - RP tool only."
+  - tweak: "Blindstrike now has a visible tell when used."
+  - tweak: "Spasm, Agony and Blindstrike have been shuffled around within the Coercive tree."
+  - tweak: "Latent psionics will no longer be aware they are latent psionics."
+  - tweak: "The Probe power is now called Assay and has been moved to operant-rank."

--- a/html/changelogs/mistakenot-psionics.yml
+++ b/html/changelogs/mistakenot-psionics.yml
@@ -8,3 +8,4 @@ changes:
   - tweak: "Spasm, Agony and Blindstrike have been shuffled around within the Coercive tree."
   - tweak: "Latent psionics will no longer be aware they are latent psionics."
   - tweak: "The Probe power is now called Assay and has been moved to operant-rank."
+  - tweak: "Made some roundstart announcements bigger/easier to read."


### PR DESCRIPTION
This will be a collection of tweaks and adjustments to psionics, psionics powers, and how they interact with drugs and gear. I'm opening it as a draft sort of to keep my eye on it and have a place to stick minor tweaks made in the course of other projects without having to make a PR every time.

- Added Mind Read, thanks @CakeQ.
- Generalized Mend to be available earlier, but scale in effectiveness based on rank.
- Tweaked the trigger conditions for some of the Coercion powers (Probe and Mindslave)
- Made autoredaction and Mend more robust and less spammy when dealing with bleeding/repairs.
- Added a visible tell to Blindstrike.
- Shuffled around the ranks for other Coercive powers.
- Changed Probe to Assay, made it available at Operant.
- Made psi-dampeners spawn per job config.
- Hid latent psionic status from latent psionics.
- Tweaked the mechanical assay machine's ability to show latency.
- Other stuff probably.