### PR TITLE
Alternative component processing implementation; component interaction framework.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3000,6 +3000,7 @@
 #include "code\unit_tests\integrated_circuits.dm"
 #include "code\unit_tests\job_tests.dm"
 #include "code\unit_tests\loadout_tests.dm"
+#include "code\unit_tests\machine_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
 #include "code\unit_tests\movement_tests.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -659,6 +659,7 @@
 #include "code\game\machinery\lightswitch.dm"
 #include "code\game\machinery\machinery.dm"
 #include "code\game\machinery\machinery_components.dm"
+#include "code\game\machinery\machinery_deconstruction.dm"
 #include "code\game\machinery\magnet.dm"
 #include "code\game\machinery\mass_driver.dm"
 #include "code\game\machinery\navbeacon.dm"

--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -40,6 +40,18 @@ if(Datum.is_processing) {\
 	}\
 }
 
+// For SSmachines, use these instead
+
+#define START_PROCESSING_MACHINE(machine, flag)\
+	var/obj/machinery/M = machine;\
+	M.processing_flags |= flag;\
+	START_PROCESSING(SSmachines, machine)
+
+#define STOP_PROCESSING_MACHINE(machine, flag)\
+	var/obj/machinery/M = machine;\
+	M.processing_flags &= ~flag;\
+	if(M.processing_flags == 0) STOP_PROCESSING(SSmachines, machine)
+
 //SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)
 
 //subsystem does not initialize.

--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -43,14 +43,12 @@ if(Datum.is_processing) {\
 // For SSmachines, use these instead
 
 #define START_PROCESSING_MACHINE(machine, flag)\
-	var/obj/machinery/M = machine;\
-	M.processing_flags |= flag;\
+	machine.processing_flags |= flag;\
 	START_PROCESSING(SSmachines, machine)
 
 #define STOP_PROCESSING_MACHINE(machine, flag)\
-	var/obj/machinery/M = machine;\
-	M.processing_flags &= ~flag;\
-	if(M.processing_flags == 0) STOP_PROCESSING(SSmachines, machine)
+	machine.processing_flags &= ~flag;\
+	if(machine.processing_flags == 0) STOP_PROCESSING(SSmachines, machine)
 
 //SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)
 

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -139,3 +139,7 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 #define PART_FLAG_LAZY_INIT   1 // Will defer init on stock parts until machine is destroyed or parts are otherwise queried.
 #define PART_FLAG_QDEL        2 // Will delete on uninstall
 #define PART_FLAG_HAND_REMOVE 4 // Can be removed by hand
+
+#define MACHINERY_PROCESS_SELF       1
+#define MACHINERY_PROCESS_COMPONENTS 2
+#define MACHINERY_PROCESS_ALL        (MACHINERY_PROCESS_SELF | MACHINERY_PROCESS_COMPONENTS)

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -143,3 +143,7 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 #define MACHINERY_PROCESS_SELF       1
 #define MACHINERY_PROCESS_COMPONENTS 2
 #define MACHINERY_PROCESS_ALL        (MACHINERY_PROCESS_SELF | MACHINERY_PROCESS_COMPONENTS)
+
+#define MCS_CHANGE   0 // Success
+#define MCS_CONTINUE 1 // Failed to change, silently
+#define MCS_BLOCK    2 // Failed to change, but action was performed

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -140,10 +140,12 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 #define PART_FLAG_QDEL        2 // Will delete on uninstall
 #define PART_FLAG_HAND_REMOVE 4 // Can be removed by hand
 
+// Machinery process flags, for use with START_PROCESSING_MACHINE
 #define MACHINERY_PROCESS_SELF       1
 #define MACHINERY_PROCESS_COMPONENTS 2
 #define MACHINERY_PROCESS_ALL        (MACHINERY_PROCESS_SELF | MACHINERY_PROCESS_COMPONENTS)
 
+// Machine construction state return values, for use with cannot_transition_to
 #define MCS_CHANGE   0 // Success
 #define MCS_CONTINUE 1 // Failed to change, silently
 #define MCS_BLOCK    2 // Failed to change, but action was performed

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -158,7 +158,7 @@ datum/controller/subsystem/machines/proc/setup_atmos_machinery(list/machines)
 	while(current_run.len)
 		var/obj/machinery/M = current_run[current_run.len]
 		current_run.len--
-		if(!QDELETED(M) && (M.Process(wait) == PROCESS_KILL))
+		if(!QDELETED(M) && (M.ProcessAll(wait) == PROCESS_KILL))
 			processing.Remove(M)
 			M.is_processing = null
 		if(MC_TICK_CHECK)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -118,7 +118,6 @@
 	return 0
 
 /obj/machinery/optable/Process()
-	..()
 	check_victim()
 
 /obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -7,6 +7,7 @@
 	anchored = 1.0
 	idle_power_usage = 1
 	active_power_usage = 5
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/suppressing = FALSE
 	var/mob/living/carbon/human/victim = null
@@ -42,13 +43,6 @@
 				src.set_density(0)
 
 /obj/machinery/optable/attackby(var/obj/item/O, var/mob/user)
-	if(default_deconstruction_screwdriver(user, O))
-		updateUsrDialog()
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
 	if (istype(O, /obj/item/grab))
 		var/obj/item/grab/G = O
 		if(iscarbon(G.affecting) && check_table(G.affecting))
@@ -60,7 +54,14 @@
 /obj/machinery/optable/attack_ai(var/mob/user)
 	attack_hand(user)
 
+/obj/machinery/optable/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
+		updateUsrDialog()
+
 /obj/machinery/optable/attack_hand(var/mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 
 	if(MUTATION_HULK in user.mutations)
 		visible_message("<span class='danger'>\The [usr] destroys \the [src]!</span>")

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -287,7 +287,8 @@
 		to_chat(user, "There's no suitable occupant in \the [src].")
 
 /obj/machinery/sleeper/RefreshParts()
-	var/T = total_component_rating_of_type(/obj/item/weapon/stock_parts/scanning_module)
+	..()
+	var/T = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/scanning_module), 1, 10)
 	T = max(T,1)
 	synth_modifier = 1/T
 	pump_speed = 2 + T

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -42,7 +42,6 @@
 
 
 /obj/machinery/sleeper/Process()
-	..()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -8,6 +8,7 @@
 	clicksound = 'sound/machines/buttonbeep.ogg'
 	clickvol = 30
 	base_type = /obj/machinery/sleeper
+	construct_state = /decl/machine_construction/default/panel_closed
 	var/mob/living/carbon/human/occupant = null
 	var/list/base_chemicals = list("Inaprovaline" = /datum/reagent/inaprovaline, "Soporific" = /datum/reagent/soporific, "Paracetamol" = /datum/reagent/paracetamol, "Dylovene" = /datum/reagent/dylovene, "Dexalin" = /datum/reagent/dexalin)
 	var/list/available_chemicals = list()
@@ -152,15 +153,13 @@
 /obj/machinery/sleeper/attack_ai(var/mob/user)
 	return attack_hand(user)
 
-/obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
-	if(default_deconstruction_screwdriver(user, I))
+/obj/machinery/sleeper/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
 		updateUsrDialog()
 		go_out()
-		return
-	if(default_deconstruction_crowbar(user, I))
-		return
-	if(default_part_replacement(user, I))
-		return
+
+/obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))
 		add_fingerprint(user)
 		if(!beaker)
@@ -170,9 +169,8 @@
 			user.visible_message("<span class='notice'>\The [user] adds \a [I] to \the [src].</span>", "<span class='notice'>You add \a [I] to \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>\The [src] has a beaker already.</span>")
-		return
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/sleeper/MouseDrop_T(var/mob/target, var/mob/user)
 	if(!CanMouseDrop(target, user))

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -150,8 +150,6 @@
 	update_icon()
 
 /obj/machinery/alarm/Process()
-	..()
-
 	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)
 		return
 
@@ -1026,8 +1024,6 @@ FIRE ALARM
 	return
 
 /obj/machinery/firealarm/Process()//Note: this processing was mostly phased out due to other code, and only runs when needed
-	..()
-
 	if(stat & (NOPOWER|BROKEN))
 		return
 
@@ -1038,7 +1034,7 @@ FIRE ALARM
 			src.alarm()
 			src.time = 0
 			src.timing = 0
-			STOP_PROCESSING(SSmachines, src)
+			STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		src.updateDialog()
 	last_process = world.timeofday
 
@@ -1106,7 +1102,7 @@ FIRE ALARM
 	else if (href_list["time"])
 		src.timing = text2num(href_list["time"])
 		last_process = world.timeofday
-		START_PROCESSING(SSmachines, src)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		. = TOPIC_REFRESH
 	else if (href_list["tp"])
 		var/tp = text2num(href_list["tp"])

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -1,6 +1,8 @@
 /obj/machinery/portable_atmospherics
 	name = "atmoalter"
 	use_power = POWER_USE_OFF
+	construct_state = /decl/machine_construction/default/panel_closed
+
 	var/datum/gas_mixture/air_contents = new
 
 	var/obj/machinery/atmospherics/portables_connector/connected_port
@@ -148,13 +150,6 @@
 	var/power_rating
 	var/power_losses
 	var/last_power_draw = 0
-
-/obj/machinery/portable_atmospherics/powered/attackby(obj/item/I, mob/user)
-	if(default_deconstruction_screwdriver(user, I))
-		return TRUE
-	if(default_deconstruction_crowbar(user, I))
-		return TRUE
-	return ..()
 
 /obj/machinery/portable_atmospherics/powered/power_change()
 	. = ..()

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -37,7 +37,6 @@
 		update_icon()
 
 /obj/machinery/portable_atmospherics/Process()
-	..()
 	if(!connected_port) //only react when pipe_network will ont it do it for you
 		//Allow for reactions
 		air_contents.react()

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -152,6 +152,7 @@
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge
 
 	uncreated_component_parts = list(/obj/item/weapon/stock_parts/power/apc)
+	maximum_component_parts = list(/obj/item/weapon/stock_parts = 12)
 	idle_power_usage = 500		//internal circuitry, friction losses and stuff
 	power_rating = 100000 //100 kW ~ 135 HP
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -126,6 +126,7 @@
 /obj/machinery/autolathe/cannot_transition_to(state_path)
 	if(busy)
 		return SPAN_NOTICE("You must wait for \the [src] to finish first.")
+	return ..()
 
 /obj/machinery/autolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -9,6 +9,7 @@
 	clicksound = "keyboard"
 	clickvol = 30
 	base_type = /obj/machinery/autolathe
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/list/machine_recipes
 	var/list/stored_material =  list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_GLASS = 0, MATERIAL_PLASTIC = 0)
@@ -114,20 +115,24 @@
 	popup.set_content(dat)
 	popup.open()
 
-/obj/machinery/autolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
+/obj/machinery/autolathe/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
+		updateUsrDialog()
 
+/obj/machinery/autolathe/components_are_accessible(path)
+	return !busy && ..()
+
+/obj/machinery/autolathe/cannot_transition_to(state_path)
+	if(busy)
+		return SPAN_NOTICE("You must wait for \the [src] to finish first.")
+
+/obj/machinery/autolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy. Please wait for completion of previous operation.</span>")
 		return
-
-	if(default_deconstruction_screwdriver(user, O))
-		updateUsrDialog()
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-
+	if(component_attackby(O, user))
+		return TRUE
 	if(stat)
 		return
 
@@ -197,7 +202,9 @@
 
 	updateUsrDialog()
 
-/obj/machinery/autolathe/attack_hand(mob/user as mob)
+/obj/machinery/autolathe/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	user.set_machine(src)
 	interact(user)
 

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -70,6 +70,7 @@
 /obj/machinery/biogenerator/cannot_transition_to(state_path)
 	if(processing)
 		return SPAN_NOTICE("You must turn \the [src] off first.")
+	return ..()
 
 /obj/machinery/biogenerator/attackby(var/obj/item/O, var/mob/user)
 	if((. = component_attackby(O, user)))

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -13,6 +13,7 @@
 	anchored = 1
 	idle_power_usage = 40
 	base_type = /obj/machinery/biogenerator
+	construct_state = /decl/machine_construction/default/panel_closed
 	var/processing = 0
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/points = 0
@@ -63,23 +64,29 @@
 		icon_state = "biogen-work"
 	return
 
-/obj/machinery/biogenerator/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
+/obj/machinery/biogenerator/components_are_accessible(path)
+	return !processing && ..()
+
+/obj/machinery/biogenerator/cannot_transition_to(state_path)
+	if(processing)
+		return SPAN_NOTICE("You must turn \the [src] off first.")
+
+/obj/machinery/biogenerator/attackby(var/obj/item/O, var/mob/user)
+	if((. = component_attackby(O, user)))
 		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
+	if(processing)
+		to_chat(user, "<span class='notice'>\The [src] is currently processing.</span>")
 	if(istype(O, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
 			to_chat(user, "<span class='notice'>]The [src] is already loaded.</span>")
+			return TRUE
 		else if(user.unEquip(O, src))
 			beaker = O
 			state = BG_READY
 			updateUsrDialog()
-	else if(processing)
-		to_chat(user, "<span class='notice'>\The [src] is currently processing.</span>")
-	else if(ingredients >= capacity)
+			return TRUE
+
+	if(ingredients >= capacity)
 		to_chat(user, "<span class='notice'>\The [src] is already full! Activate it.</span>")
 	else if(istype(O, /obj/item/weapon/storage/plants))
 		var/obj/item/weapon/storage/plants/P = O
@@ -170,6 +177,8 @@
 	return TOPIC_REFRESH
 
 /obj/machinery/biogenerator/attack_hand(mob/user as mob)
+	if((. = component_attack_hand(user)))
+		return
 	if(stat & (BROKEN|NOPOWER))
 		return
 	ui_interact(user)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -228,5 +228,5 @@
 
 /obj/machinery/biogenerator/RefreshParts()
 	..()
-	build_eff = total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator)
-	eat_eff = total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
+	build_eff = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator), 1, 10)
+	eat_eff = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 1, 10)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -43,7 +43,7 @@
 	print_delay += 10 * number_of_components(/obj/item/weapon/stock_parts/manipulator)
 	print_delay = max(0, print_delay)
 
-	max_stored_matter = 50 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
+	max_stored_matter = 50 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 20)
 	. = ..()
 
 /obj/machinery/organ_printer/components_are_accessible(path)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -52,6 +52,7 @@
 /obj/machinery/organ_printer/cannot_transition_to(path)
 	if(printing)
 		return SPAN_NOTICE("You must wait for \the [src] to finish printing first!")
+	return ..()
 
 /obj/machinery/organ_printer/attack_hand(mob/user, var/choice = null)
 	if(component_attack_hand(user))

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -11,6 +11,7 @@
 	density = 1
 	idle_power_usage = 40
 	active_power_usage = 300
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/stored_matter = 0
 	var/max_stored_matter = 0
@@ -20,15 +21,10 @@
 	// These should be subtypes of /obj/item/organ
 	var/list/products = list()
 
-/obj/machinery/organ_printer/attackby(var/obj/item/O, var/mob/user)
-	if(default_deconstruction_screwdriver(user, O))
+/obj/machinery/organ_printer/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
 		updateUsrDialog()
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-	return ..()
 
 /obj/machinery/organ_printer/on_update_icon()
 	overlays.Cut()
@@ -50,8 +46,16 @@
 	max_stored_matter = 50 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
 	. = ..()
 
-/obj/machinery/organ_printer/attack_hand(mob/user, var/choice = null)
+/obj/machinery/organ_printer/components_are_accessible(path)
+	return !printing && ..()
 
+/obj/machinery/organ_printer/cannot_transition_to(path)
+	if(printing)
+		return SPAN_NOTICE("You must wait for \the [src] to finish printing first!")
+
+/obj/machinery/organ_printer/attack_hand(mob/user, var/choice = null)
+	if(component_attack_hand(user))
+		return TRUE
 	if(printing || (stat & (BROKEN|NOPOWER)))
 		return
 

--- a/code/game/machinery/bluespacerelay.dm
+++ b/code/game/machinery/bluespacerelay.dm
@@ -6,19 +6,10 @@
 	anchored = 1
 	density = 1
 	idle_power_usage = 15000
+	construct_state = /decl/machine_construction/default/panel_closed
 
 /obj/machinery/bluespacerelay/on_update_icon()
 	if(stat & (BROKEN|NOPOWER))
 		icon_state = "[initial(icon_state)]_off"
 	else
 		icon_state = initial(icon_state)
-
-/obj/machinery/bluespacerelay/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-
-	..()

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -9,6 +9,7 @@
 	anchored = 1
 	idle_power_usage = 60
 	active_power_usage = 10000	//10 kW. It's a big all-body scanner.
+	construct_state = /decl/machine_construction/default/panel_closed
 
 /obj/machinery/bodyscanner/examine(mob/user)
 	. = ..()
@@ -57,20 +58,19 @@
 	update_icon()
 	SetName(initial(name))
 
+/obj/machinery/bodyscanner/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
+		updateUsrDialog()
+
 /obj/machinery/bodyscanner/attackby(obj/item/grab/normal/G, user as mob)
-	if(!istype(G))
-		if(default_deconstruction_screwdriver(user, G))
-			updateUsrDialog()
+	if(istype(G))
+		var/mob/M = G.affecting
+		if(!user_can_move_target_inside(M, user))
 			return
-		if(default_deconstruction_crowbar(user, G))
-			return
-		if(default_part_replacement(user, G))
-			return
-		return
-	var/mob/M = G.affecting
-	if(!user_can_move_target_inside(M, user))
-		return
-	qdel(G)
+		qdel(G)
+		return TRUE
+	return ..()
 
 /obj/machinery/bodyscanner/proc/user_can_move_target_inside(var/mob/target, var/mob/user)
 	if(!istype(user) || !istype(target))

--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -6,6 +6,7 @@
 	icon_state = "body_scannerconsole"
 	density = 0
 	anchored = 1
+	construct_state = /decl/machine_construction/default/panel_closed
 	var/list/display_tags = list()
 	var/list/connected_displays = list()
 	var/list/data = list()
@@ -137,14 +138,10 @@
 		data["pushEnabled"] = FALSE
 		return TOPIC_REFRESH
 
-/obj/machinery/body_scanconsole/attackby(var/obj/item/O, user as mob)
-	if(default_deconstruction_screwdriver(user, O))
+/obj/machinery/body_scanconsole/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
 		updateUsrDialog()
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
 
 /obj/machinery/body_scanconsole/proc/remove_display(var/obj/machinery/body_scan_display/display)
 	connected_displays -= display

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -116,16 +116,12 @@
 	return ..()
 
 /obj/machinery/camera/Process()
-	..()
 	if((stat & EMPED) && world.time >= affected_by_emp_until)
 		stat &= ~EMPED
 		cancelCameraAlarm()
 		update_icon()
 		update_coverage()
 	return internal_process()
-
-/obj/machinery/camera/proc/internal_process()
-	return
 
 /obj/machinery/camera/emp_act(severity)
 	if(!isEmpProof() && prob(100/severity))
@@ -137,7 +133,7 @@
 			triggerCameraAlarm()
 			update_icon()
 			update_coverage()
-			START_PROCESSING(SSmachines, src)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/machinery/camera/bullet_act(var/obj/item/projectile/P)
 	take_damage(P.get_structure_damage())

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -4,8 +4,7 @@
 	var/alarm_delay = 100 // Don't forget, there's another 10 seconds in queueAlarm()
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 
-/obj/machinery/camera/internal_process()
-	..()
+/obj/machinery/camera/proc/internal_process()
 	// motion camera event loop
 	if (stat & (EMPED|NOPOWER))
 		return

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -85,7 +85,7 @@
 /obj/machinery/camera/proc/upgradeMotion()
 	assembly.upgrades.Add(new /obj/item/device/assembly/prox_sensor(assembly))
 	setPowerUsage()
-	START_PROCESSING(SSmachines, src)
+	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	update_coverage()
 
 /obj/machinery/camera/proc/setPowerUsage()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -46,7 +46,7 @@
 				return
 			charging = W
 			set_power()
-			START_PROCESSING(SSmachines, src)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 			user.visible_message("[user] inserts a cell into the charger.", "You insert a cell into the charger.")
 			chargelevel = -1
 		queue_icon_update()
@@ -70,7 +70,7 @@
 		user.visible_message("[user] removes the cell from the charger.", "You remove the cell from the charger.")
 		chargelevel = -1
 		set_power()
-		STOP_PROCESSING(SSmachines, src)
+		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/machinery/cell_charger/attack_robot(mob/user)
 	if(Adjacent(user)) // Borgs can remove the cell if they are near enough

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -59,6 +59,5 @@
 	onclose(user, "op")
 
 /obj/machinery/computer/operating/Process()
-	..()
 	if(!inoperable())
 		updateDialog()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -143,7 +143,6 @@
 
 
 /obj/machinery/computer/pod/Process()
-	..()
 	if(inoperable())
 		return
 	if(timing)

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -49,19 +49,20 @@
 		return
 	. = ..()
 
-/obj/machinery/portable_atmospherics/cracker/Process()
-
+/obj/machinery/portable_atmospherics/cracker/power_change()
 	. = ..()
-
-	if(. == PROCESS_KILL)
-		return
-
-	if(stat & (BROKEN|NOPOWER))
-		if(use_power == POWER_USE_ACTIVE)
-			update_use_power(POWER_USE_IDLE)
+	if(. && (stat & NOPOWER))
+		update_use_power(POWER_USE_IDLE)
 		update_icon()
-		return
 
+/obj/machinery/portable_atmospherics/cracker/set_broken(new_state)
+	. = ..()
+	if(. && (stat & BROKEN))
+		update_use_power(POWER_USE_IDLE)
+		update_icon()
+
+/obj/machinery/portable_atmospherics/cracker/Process()
+	..()
 	if(use_power == POWER_USE_IDLE)
 		return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -10,6 +10,7 @@
 	interact_offline = 1
 	layer = ABOVE_HUMAN_LAYER
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/on = 0
 	idle_power_usage = 20
@@ -90,6 +91,8 @@
 		go_out()
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	ui_interact(user)
 
  /**
@@ -187,15 +190,14 @@
 		go_out()
 		return TOPIC_REFRESH
 
+/obj/machinery/atmospherics/unary/cryo_cell/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state))
+		updateUsrDialog()
 
 /obj/machinery/atmospherics/unary/cryo_cell/attackby(var/obj/G, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, G))
-		updateUsrDialog()
-		return
-	if(default_deconstruction_crowbar(user, G))
-		return
-	if(default_part_replacement(user, G))
-		return
+	if(component_attackby(G, user))
+		return TRUE
 	if(istype(G, /obj/item/weapon/reagent_containers/glass))
 		if(beaker)
 			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -301,7 +301,6 @@
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/machinery/cryopod/Process()
-	..()
 	if(occupant)
 		if(applies_stasis && iscarbon(occupant) && (world.time > time_entered + 20 SECONDS))
 			var/mob/living/carbon/C = occupant

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -9,7 +9,6 @@ obj/machinery/door/airlock
 	var/cur_command = null	//the command the door is currently attempting to complete
 
 obj/machinery/door/airlock/Process()
-	..()
 	if (arePowerSystemsOn())
 		execute_current_command()
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -56,8 +56,6 @@
 // if it's less than 0, open door, reset timer
 // update the door_timer window and the icon
 /obj/machinery/door_timer/Process()
-	..()
-
 	if(stat & (NOPOWER|BROKEN))	return
 	if(src.timing)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -100,7 +100,6 @@
 	. = ..()
 
 /obj/machinery/door/Process()
-	..()
 	if(close_door_at && world.time >= close_door_at)
 		if(autoclose)
 			close_door_at = next_close_time()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -287,8 +287,6 @@
 
 // CHECK PRESSURE
 /obj/machinery/door/firedoor/Process()
-	..()
-
 	if(density && next_process_time <= world.time)
 		next_process_time = world.time + 100		// 10 second delays between process updates
 		var/changed = 0

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -35,7 +35,6 @@
 		return program.receive_user_command(href_list["command"]) // Any further sanitization should be done in here.
 
 /obj/machinery/embedded_controller/Process()
-	..()
 	if(program)
 		program.process()
 

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -25,7 +25,6 @@
 	icon_state = "flood[open ? "o" : ""][open && cell ? "b" : ""]0[on]"
 
 /obj/machinery/floodlight/Process()
-	..()
 	if(!on)
 		return
 

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -87,7 +87,6 @@ var/list/floor_light_cache = list()
 		return
 
 /obj/machinery/floor_light/Process()
-	..()
 	var/need_update
 	if((!anchored || broken()) && on)
 		update_use_power(POWER_USE_OFF)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -304,7 +304,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 
 /obj/machinery/hologram/holopad/Process()
-	..()
 	for (var/mob/living/silicon/ai/master in masters)
 		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
 		if((stat & NOPOWER) || !active_ai)

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -35,8 +35,7 @@
 	ignite()
 
 /obj/machinery/igniter/Process()
-	..()
-	if(powered())
+	if(!(stat & NOPOWER))
 		var/turf/location = src.loc
 		if (isturf(location))
 			location.hotspot_expose(1000,500,1)
@@ -46,9 +45,9 @@
 	use_power_oneoff(50)
 	on = !on
 	if(on)
-		START_PROCESSING(SSmachines, src)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	else
-		STOP_PROCESSING(SSmachines, src)
+		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	update_icon()
 
 // Wall mounted remote-control igniter.

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -11,6 +11,7 @@
 	density = 1
 	anchored = 1
 	idle_power_usage = 5
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/on_icon						// Icon state used when cooking.
 	var/off_icon					// Icon state used when not cooking.
@@ -45,6 +46,11 @@
 /obj/machinery/cooker/components_are_accessible(path)
 	return !cooking && ..()
 
+/obj/machinery/cooker/cannot_transition_to(state_path, mob/user)
+	if(cooking)
+		return SPAN_NOTICE("Wait for \the [src] to finish first!")
+	return ..()
+
 /obj/machinery/cooker/attackby(var/obj/item/I, var/mob/user)
 	set waitfor = 0  //So that any remaining parts of calling proc don't have to wait for the long cooking time ahead.
 
@@ -52,10 +58,8 @@
 		to_chat(user, "<span class='warning'>\The [src] is running!</span>")
 		return
 
-	if(default_deconstruction_screwdriver(user, I))
-		return TRUE
-	if(default_deconstruction_crowbar(user, I))
-		return TRUE
+	if((. = component_attackby(I, user)))
+		return
 
 	if(!cook_type || (stat & (NOPOWER|BROKEN)))
 		to_chat(user, "<span class='warning'>\The [src] is not working.</span>")
@@ -214,7 +218,7 @@
 			selected_option = choice
 			to_chat(user, "<span class='notice'>You prepare \the [src] to make \a [selected_option].</span>")
 
-	..()
+	return ..()
 
 /obj/machinery/cooker/proc/cook_mob(var/mob/living/victim, var/mob/user)
 	return

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -7,6 +7,7 @@
 	density = 1
 	anchored = 1
 	req_access = list(access_kitchen,access_morgue)
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/operating = 0        //Is it on?
 	var/dirty = 0            // Does it need cleaning?
@@ -39,6 +40,8 @@
 	return
 
 /obj/machinery/gibber/attack_hand(mob/user as mob)
+	if((. = ..()))
+		return
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if(operating)
@@ -59,12 +62,14 @@
 /obj/machinery/gibber/components_are_accessible(path)
 	return !operating && ..()	
 
+/obj/machinery/gibber/cannot_transition_to(state_path, mob/user)
+	if(operating)
+		return SPAN_NOTICE("You must wait for \the [src] to finish operating first!")
+	return ..()	
+
 /obj/machinery/gibber/attackby(var/obj/item/W, var/mob/user)
 	if(!operating)
-		if(default_deconstruction_screwdriver(user, W))
-			return TRUE
-		if(default_deconstruction_crowbar(user, W))
-			return TRUE
+		return
 	if(istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
 		if(!G.force_danger())

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -182,7 +182,6 @@
 			return
 
 /obj/machinery/smartfridge/Process()
-	..()
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(src.seconds_electrified > 0)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -98,7 +98,7 @@ Class Procs:
 	var/power_init_complete = FALSE // Helps with bookkeeping when initializing atoms. Don't modify.
 	var/list/component_parts           //List of component instances. Expected type: /obj/item/weapon/stock_parts
 	var/list/uncreated_component_parts = list(/obj/item/weapon/stock_parts/power/apc) //List of component paths which have delayed init. Indeces = number of components.
-	var/list/maximum_component_parts   //null - no max. list(type part = number max).
+	var/list/maximum_component_parts = list(/obj/item/weapon/stock_parts = 8)         //null - no max. list(type part = number max).
 	var/uid
 	var/panel_open = 0
 	var/global/gl_uid = 1

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -239,13 +239,8 @@ Class Procs:
 		else if(prob(H.getBrainLoss()))
 			to_chat(user, "<span class='warning'>You momentarily forget how to use \the [src].</span>")
 			return 1
-
-	for(var/obj/item/weapon/stock_parts/part in component_parts)
-		if(!components_are_accessible(part.type))
-			continue
-		if((. = part.attack_hand(user)))
-			return
-
+	if((. = component_attack_hand(user)))
+		return
 	return ..()
 
 /obj/machinery/proc/RefreshParts()
@@ -287,46 +282,6 @@ Class Procs:
 		if(user.stunned)
 			return 1
 	return 0
-
-/obj/machinery/proc/default_deconstruction_crowbar(var/mob/user, var/obj/item/weapon/crowbar/C)
-	if(!istype(C))
-		return 0
-	if(!panel_open)
-		return 0
-	. = dismantle()
-
-/obj/machinery/proc/default_deconstruction_screwdriver(var/mob/user, var/obj/item/weapon/screwdriver/S)
-	if(!istype(S))
-		return 0
-	playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-	panel_open = !panel_open
-	to_chat(user, "<span class='notice'>You [panel_open ? "open" : "close"] the maintenance hatch of \the [src].</span>")
-	update_icon()
-	return 1
-
-/obj/machinery/proc/default_part_replacement(var/mob/user, var/obj/item/weapon/storage/part_replacer/R)
-	if(!istype(R))
-		return 0
-	if(panel_open)
-		for(var/obj/item/weapon/stock_parts/A in component_parts)
-			if(!A.base_type)
-				continue
-			for(var/obj/item/weapon/stock_parts/B in R.contents)
-				if(istype(B, A.base_type) && B.rating > A.rating)
-					replace_part(user, R, A, B)
-					break
-		for(var/path in uncreated_component_parts)
-			if(ispath(path, /obj/item/weapon/stock_parts))
-				var/obj/item/weapon/stock_parts/A = path
-				var/base_type = initial(A.base_type)
-				if(base_type)
-					for(var/obj/item/weapon/stock_parts/B in R.contents)
-						if(istype(B, base_type) && B.rating > initial(A.rating))
-							replace_part(user, R, A, B)
-							break					
-	else
-		display_parts(user)
-	return 1
 
 /obj/machinery/proc/replace_part(mob/user, var/obj/item/weapon/storage/part_replacer/R, var/obj/item/weapon/stock_parts/old_part, var/obj/item/weapon/stock_parts/new_part)
 	old_part = uninstall_component(old_part)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -98,6 +98,7 @@ Class Procs:
 	var/power_init_complete = FALSE // Helps with bookkeeping when initializing atoms. Don't modify.
 	var/list/component_parts           //List of component instances. Expected type: /obj/item/weapon/stock_parts
 	var/list/uncreated_component_parts = list(/obj/item/weapon/stock_parts/power/apc) //List of component paths which have delayed init. Indeces = number of components.
+	var/list/maximum_component_parts   //null - no max. list(type part = number max).
 	var/uid
 	var/panel_open = 0
 	var/global/gl_uid = 1
@@ -282,14 +283,6 @@ Class Procs:
 		if(user.stunned)
 			return 1
 	return 0
-
-/obj/machinery/proc/replace_part(mob/user, var/obj/item/weapon/storage/part_replacer/R, var/obj/item/weapon/stock_parts/old_part, var/obj/item/weapon/stock_parts/new_part)
-	old_part = uninstall_component(old_part)
-	if(R)
-		R.remove_from_storage(new_part, src)
-		R.handle_item_insertion(old_part, 1)
-	install_component(new_part)
-	to_chat(user, "<span class='notice'>[old_part.name] replaced with [new_part.name].</span>")
 
 /obj/machinery/proc/dismantle()
 	playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)

--- a/code/game/machinery/machinery_components.dm
+++ b/code/game/machinery/machinery_components.dm
@@ -103,6 +103,14 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		GLOB.destroyed_event.unregister(part, src)
 		return part
 
+/obj/machinery/proc/replace_part(mob/user, var/obj/item/weapon/storage/part_replacer/R, var/obj/item/weapon/stock_parts/old_part, var/obj/item/weapon/stock_parts/new_part)
+	old_part = uninstall_component(old_part)
+	if(R)
+		R.remove_from_storage(new_part, src)
+		R.handle_item_insertion(old_part, 1)
+	install_component(new_part)
+	to_chat(user, "<span class='notice'>[old_part.name] replaced with [new_part.name].</span>")
+
 /obj/machinery/proc/component_destroyed(var/obj/item/component)
 	GLOB.destroyed_event.unregister(component, src)
 	LAZYREMOVE(component_parts, component)
@@ -129,6 +137,17 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 // Use to block interactivity if panel is not open, etc.
 /obj/machinery/proc/components_are_accessible(var/path)
 	return panel_open
+
+// Installation
+/obj/machinery/proc/can_add_component(var/obj/item/weapon/stock_parts/component, var/mob/user)
+	if(!components_are_accessible(component.type))
+		to_chat(user, SPAN_WARNING("The insertion point for \the [component] is inaccessible!"))
+		return FALSE
+	for(var/path in maximum_component_parts)
+		if(istype(component, path) && (number_of_components(path) == maximum_component_parts[path]))
+			to_chat(user, SPAN_WARNING("There are too many parts of this type installed in \the [src] already!"))
+			return FALSE
+	return TRUE
 
 // Hook to get updates.
 /obj/machinery/proc/component_stat_change(var/obj/item/weapon/stock_parts/part, old_stat, flag)

--- a/code/game/machinery/machinery_components.dm
+++ b/code/game/machinery/machinery_components.dm
@@ -134,9 +134,22 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 /obj/machinery/proc/component_stat_change(var/obj/item/weapon/stock_parts/part, old_stat, flag)
 
 /obj/machinery/attackby(obj/item/I, mob/user)
+	if(component_attackby(I, user))
+		return TRUE
+	return ..()
+
+/obj/machinery/proc/component_attackby(obj/item/I, mob/user)
 	for(var/obj/item/weapon/stock_parts/part in component_parts)
 		if(!components_are_accessible(part.type))
 			continue
 		if((. = part.attackby(I, user)))
 			return
-	return ..()
+	return construct_state && construct_state.attackby(I, user, src)
+
+/obj/machinery/proc/component_attack_hand(mob/user)
+	for(var/obj/item/weapon/stock_parts/part in component_parts)
+		if(!components_are_accessible(part.type))
+			continue
+		if((. = part.attack_hand(user)))
+			return
+	return construct_state && construct_state.attack_hand(user, src)

--- a/code/game/machinery/machinery_deconstruction.dm
+++ b/code/game/machinery/machinery_deconstruction.dm
@@ -102,10 +102,14 @@
 		to_chat(user, SPAN_NOTICE("You close the maintenance hatch of \the [machine]."))
 		machine.update_icon()
 		return
+
+	// Part modifications. First: part replacer
 	if(istype(I, /obj/item/weapon/storage/part_replacer))
 		var/obj/item/weapon/storage/part_replacer/R = I
 		for(var/obj/item/weapon/stock_parts/A in machine.component_parts)
 			if(!A.base_type)
+				continue
+			if(!(A.part_flags & PART_FLAG_HAND_REMOVE))
 				continue
 			for(var/obj/item/weapon/stock_parts/B in R.contents)
 				if(istype(B, A.base_type) && B.rating > A.rating)
@@ -113,12 +117,44 @@
 					return TRUE
 		for(var/path in machine.uncreated_component_parts)
 			var/obj/item/weapon/stock_parts/A = path
+			if(!(initial(A.part_flags) & PART_FLAG_HAND_REMOVE))
+				continue
 			var/base_type = initial(A.base_type)
 			if(base_type)
 				for(var/obj/item/weapon/stock_parts/B in R.contents)
 					if(istype(B, base_type) && B.rating > initial(A.rating))
 						machine.replace_part(user, R, A, B)
 						return TRUE
+
+	// Second: Part insertion
+	if(istype(I, /obj/item/weapon/stock_parts) && user.canUnEquip(I))
+		if(machine.can_add_component(I, user))
+			user.unEquip(I, machine)
+			machine.install_component(I)
+			user.visible_message(SPAN_NOTICE("\The [user] installs \the [I] in \the [machine]!"), SPAN_NOTICE("You install \the [I] in \the [machine]!"))
+		return TRUE
+
+	// Finally: Part removal with wrench
+	if(isWrench(I))
+		var/list/removable_parts = list()
+		for(var/path in machine.types_of_component(/obj/item/weapon/stock_parts))
+			var/obj/item/weapon/stock_parts/part = path
+			if(!(initial(part.part_flags) & PART_FLAG_HAND_REMOVE))
+				continue
+			if(machine.components_are_accessible(path))
+				removable_parts[initial(part.name)] = path
+		if(length(removable_parts))
+			var/input = input(user, "Which part would you like to uninstall from \the [machine]?", "Part Removal") as null|anything in removable_parts
+			if(!input || QDELETED(machine) || !machine.Adjacent(user) || !isWrench(user.get_active_hand()) || user.incapacitated())
+				return TRUE
+			var/path = removable_parts[input]
+			if(!path || !machine.components_are_accessible(path))
+				return TRUE
+			var/obj/item/weapon/stock_parts/part = machine.uninstall_component(path)
+			if(part)
+				user.put_in_hands(part) // Already dropped at loc, so that's the fallback.
+				user.visible_message(SPAN_NOTICE("\The [user] removes \the [part] from \the [machine]."), SPAN_NOTICE("You remove \the [part] from \the [machine]."))
+			return TRUE
 
 // Not implemented fully as the machine will qdel on transition to this. Path needed for checks.
 /decl/machine_construction/default/deconstructed

--- a/code/game/machinery/machinery_deconstruction.dm
+++ b/code/game/machinery/machinery_deconstruction.dm
@@ -1,0 +1,112 @@
+/obj/machinery
+	var/decl/machine_construction/construct_state
+
+/obj/machinery/Initialize()
+	if(construct_state)
+		construct_state = decls_repository.get_decl(construct_state)
+	. = ..()
+
+// Called on state transition; can intercept, but must call parent.
+/obj/machinery/proc/state_transition(var/decl/machine_construction/new_state)
+	construct_state = new_state
+
+// Return true or a fail message to block transition.
+/obj/machinery/proc/cannot_transition_to(var/state_path)
+
+// There are many machines, so this is designed to catch errors.  This proc must either return TRUE or set the machine's construct_state to a valid one (or null).
+/decl/machine_construction/proc/validate_state(obj/machinery/machine)
+	if(!state_is_valid(machine))
+		machine.construct_state = null
+		return FALSE
+	return TRUE
+
+/decl/machine_construction/proc/state_is_valid(obj/machinery/machine)
+	return TRUE
+
+/decl/machine_construction/proc/try_change_state(obj/machinery/machine, path, user)
+	var/decl/machine_construction/state = decls_repository.get_decl(path)
+	if(state && state.state_is_valid(machine))
+		var/fail = machine.cannot_transition_to(/decl/machine_construction/default/panel_open)
+		if(fail)
+			if(istext(fail))
+				to_chat(user, fail)
+			return FALSE
+		machine.state_transition(state)
+		return TRUE
+	return FALSE
+
+/decl/machine_construction/proc/attack_hand(mob/user, obj/machinery/machine)
+	if(!validate_state(machine))
+		crash_with("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
+		machine.attack_hand(user)
+		return TRUE
+
+/decl/machine_construction/proc/attackby(obj/item/I, mob/user, obj/machinery/machine)
+	if(!validate_state(machine))
+		crash_with("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
+		machine.attackby(I, user)
+		return TRUE
+
+
+// Used to be called default_deconstruction_screwdriver -> default_deconstruction_crowbar and default_part_replacement
+
+/decl/machine_construction/default/panel_closed/state_is_valid(obj/machinery/machine)
+	return !machine.panel_open
+
+/decl/machine_construction/default/panel_closed/validate_state(obj/machinery/machine)
+	. = ..()
+	if(!.)
+		try_change_state(machine, /decl/machine_construction/default/panel_open)
+
+/decl/machine_construction/default/panel_closed/attackby(obj/item/I, mob/user, obj/machinery/machine)
+	if((. = ..()))
+		return
+	if(isScrewdriver(I) && try_change_state(machine, /decl/machine_construction/default/panel_open, user))
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		machine.panel_open = TRUE
+		to_chat(user, SPAN_NOTICE("You open the maintenance hatch of \the [machine]."))
+		machine.update_icon()
+		return TRUE
+	if(istype(I, /obj/item/weapon/storage/part_replacer))
+		machine.display_parts(user)
+		return TRUE
+
+/decl/machine_construction/default/panel_open/state_is_valid(obj/machinery/machine)
+	return machine.panel_open
+
+/decl/machine_construction/default/panel_open/validate_state(obj/machinery/machine)
+	. = ..()
+	if(!.)
+		try_change_state(machine, /decl/machine_construction/default/panel_closed)
+
+/decl/machine_construction/default/panel_open/attackby(obj/item/I, mob/user, obj/machinery/machine)
+	if((. = ..()))
+		return
+	if(isCrowbar(I) && try_change_state(machine, /decl/machine_construction/default/deconstructed, user))
+		return machine.dismantle()
+	if(isScrewdriver(I) && try_change_state(machine, /decl/machine_construction/default/panel_closed, user))
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		machine.panel_open = FALSE
+		to_chat(user, SPAN_NOTICE("You close the maintenance hatch of \the [machine]."))
+		machine.update_icon()
+		return TRUE
+	if(istype(I, /obj/item/weapon/storage/part_replacer))
+		var/obj/item/weapon/storage/part_replacer/R = I
+		for(var/obj/item/weapon/stock_parts/A in machine.component_parts)
+			if(!A.base_type)
+				continue
+			for(var/obj/item/weapon/stock_parts/B in R.contents)
+				if(istype(B, A.base_type) && B.rating > A.rating)
+					machine.replace_part(user, R, A, B)
+					return TRUE
+		for(var/path in machine.uncreated_component_parts)
+			var/obj/item/weapon/stock_parts/A = path
+			var/base_type = initial(A.base_type)
+			if(base_type)
+				for(var/obj/item/weapon/stock_parts/B in R.contents)
+					if(istype(B, base_type) && B.rating > initial(A.rating))
+						machine.replace_part(user, R, A, B)
+						return TRUE
+
+// Not implemented fully as the machine will qdel on transition to this. Path needed for checks.
+/decl/machine_construction/default/deconstructed

--- a/code/game/machinery/machinery_deconstruction.dm
+++ b/code/game/machinery/machinery_deconstruction.dm
@@ -11,7 +11,7 @@
 	construct_state = new_state
 
 // Return true or a fail message to block transition.
-/obj/machinery/proc/cannot_transition_to(var/state_path)
+/obj/machinery/proc/cannot_transition_to(var/state_path, var/mob/user)
 
 // There are many machines, so this is designed to catch errors.  This proc must either return TRUE or set the machine's construct_state to a valid one (or null).
 /decl/machine_construction/proc/validate_state(obj/machinery/machine)
@@ -25,8 +25,8 @@
 
 /decl/machine_construction/proc/try_change_state(obj/machinery/machine, path, user)
 	var/decl/machine_construction/state = decls_repository.get_decl(path)
-	if(state && state.state_is_valid(machine))
-		var/fail = machine.cannot_transition_to(/decl/machine_construction/default/panel_open)
+	if(state)
+		var/fail = machine.cannot_transition_to(path, user)
 		if(fail)
 			if(istext(fail))
 				to_chat(user, fail)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -39,7 +39,6 @@ var/bomb_set
 	return ..()
 
 /obj/machinery/nuclearbomb/Process(var/wait)
-	..()
 	if(timing)
 		timeleft = max(timeleft - (wait / 10), 0)
 		playsound(loc, 'sound/items/timer.ogg', 50)

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -171,7 +171,6 @@
 
 
 /obj/machinery/oxygen_pump/Process()
-	..()
 	if(breather)
 		if(!can_apply_to_target(breather))
 			detach_mask()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -437,9 +437,6 @@ var/list/turret_icons
 	atom_flags |= ATOM_FLAG_CLIMBABLE // they're now climbable
 
 /obj/machinery/porta_turret/Process()
-	..()
-	//the main machinery process
-
 	if(stat & (NOPOWER|BROKEN))
 		//if the turret has no power or is broken, make the turret pop down if it hasn't already
 		popDown()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -11,6 +11,7 @@
 		/obj/item/weapon/stock_parts/power/battery,
 		/obj/item/weapon/stock_parts/power/apc
 	)
+	construct_state = /decl/machine_construction/default/panel_closed
 	var/mob/living/occupant = null
 	var/charging = 0
 	var/last_overlay_state
@@ -104,16 +105,12 @@
 		cell.emp_act(severity)
 	..(severity)
 
-/obj/machinery/recharge_station/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(!occupant)
-		if(default_deconstruction_screwdriver(user, O))
-			return
-		if(default_deconstruction_crowbar(user, O))
-			return
-		if(default_part_replacement(user, O))
-			return
+/obj/machinery/recharge_station/components_are_accessible(path)
+	return !occupant && ..()
 
-	return ..()
+/obj/machinery/recharge_station/cannot_transition_to(state_path)
+	if(occupant)
+		return SPAN_NOTICE("You cannot do this while \the [src] is occupied!.")
 
 /obj/machinery/recharge_station/RefreshParts()
 	..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -115,8 +115,8 @@
 
 /obj/machinery/recharge_station/RefreshParts()
 	..()
-	var/man_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator)
-	var/cap_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor)
+	var/man_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator), 0, 10)
+	var/cap_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 0, 10)
 
 	charging_power = 40000 + 40000 * cap_rating
 	restore_power_active = 10000 + 15000 * cap_rating

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -111,6 +111,7 @@
 /obj/machinery/recharge_station/cannot_transition_to(state_path)
 	if(occupant)
 		return SPAN_NOTICE("You cannot do this while \the [src] is occupied!.")
+	return ..()
 
 /obj/machinery/recharge_station/RefreshParts()
 	..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -29,8 +29,6 @@
 	update_icon()
 
 /obj/machinery/recharge_station/Process()
-	..()
-
 	if(stat & (BROKEN | NOPOWER))
 		return
 

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -8,12 +8,11 @@
 	use_power = POWER_USE_ACTIVE
 	idle_power_usage = 10
 	active_power_usage = 2000
+	construct_state = /decl/machine_construction/default/panel_closed
 
 obj/machinery/seed_extractor/attackby(var/obj/item/O, var/mob/user)
-	if(default_deconstruction_screwdriver(user, O))
-		return TRUE
-	if(default_deconstruction_crowbar(user, O))
-		return TRUE
+	if((. = component_attackby(O, user)))
+		return
 	// Fruits and vegetables.
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown) || istype(O, /obj/item/weapon/grown))
 		if(!user.unEquip(O))

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -156,7 +156,6 @@
 	updateDialog()
 
 /obj/machinery/space_heater/Process()
-	..()
 	if(on)
 		if(powered() || (cell && cell.charge))
 			var/datum/gas_mixture/env = loc.return_air()

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -315,8 +315,6 @@
 	updateUsrDialog()
 
 /obj/machinery/suit_cycler/Process()
-	..()
-
 	if(electrified > 0)
 		electrified--
 

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -100,10 +100,8 @@
 	..()
 
 /obj/machinery/power/supply_beacon/Process()
-	. = ..()
 	if(expended)
-		return
-	. = 0
+		return PROCESS_KILL
 	if(!use_power)
 		return
 	if(draw_power(500) < 500)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -91,11 +91,6 @@
 	var/active = 0
 	var/icontype = "beacon"
 
-/obj/machinery/power/singularity_beacon/Destroy()
-	if(active)
-		STOP_PROCESSING(SSmachines, src)
-	. = ..()
-
 /obj/machinery/power/singularity_beacon/proc/Activate(mob/user = null)
 	if(surplus() < 1500)
 		if(user) to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
@@ -106,7 +101,7 @@
 	icon_state = "[icontype]1"
 	active = 1
 
-	START_PROCESSING(SSmachines, src)
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	if(user)
 		to_chat(user, "<span class='notice'>You activate the beacon.</span>")
 
@@ -162,10 +157,8 @@
 
 //stealth direct power usage
 /obj/machinery/power/singularity_beacon/Process()
-	. = ..()
 	if(!active)
-		return
-	. = 0
+		return PROCESS_KILL
 	if(draw_power(1500) < 1500)
 		Deactivate()
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -122,6 +122,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	machinetype = 6
 	produces_heat = 0
 	circuitboard = /obj/item/weapon/stock_parts/circuitboard/telecomms/allinone
+	maximum_component_parts = list(/obj/item/weapon/stock_parts = 12)
 	var/listening_freqs
 	var/channel_color
 	var/channel_name

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -172,7 +172,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	update_use_power(on)
 
 /obj/machinery/telecomms/Process()
-	..()
 	update_power()
 
 	if(overloaded_for)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -498,7 +498,6 @@
 	SSnano.update_uis(src)
 
 /obj/machinery/vending/Process()
-	..()
 	if(stat & (BROKEN|NOPOWER))
 		return
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -14,6 +14,7 @@
 	density = 1
 	anchored = 1
 	interact_offline = TRUE
+	construct_state = /decl/machine_construction/default/panel_closed
 	var/state = 0
 	var/gibs_ready = 0
 	var/obj/crayon
@@ -200,11 +201,6 @@
 		to_chat(user, SPAN_WARNING("\The [src] is currently running."))
 		return TRUE
 
-	if(default_deconstruction_screwdriver(user, W))
-		update_icon()
-		return TRUE
-	if(default_deconstruction_crowbar(user, W))
-		return TRUE
 	return ..()
 
 /obj/machinery/washing_machine/attack_hand(mob/user)

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -10,6 +10,7 @@
 	idle_power_usage = 200	// Some electronics, passive drain.
 	active_power_usage = 60 KILOWATTS // When charging
 	base_type = /obj/machinery/mech_recharger
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/obj/mecha/charging = null
 	var/base_charge_rate = 60 KILOWATTS
@@ -81,14 +82,6 @@
 // An ugly proc, but apparently mechs don't have maxhealth var of any kind.
 /obj/machinery/mech_recharger/proc/fully_repaired()
 	return charging && (charging.health == initial(charging.health))
-
-/obj/machinery/mech_recharger/attackby(var/obj/item/I, var/mob/user)
-	if(default_deconstruction_screwdriver(user, I))
-		return
-	if(default_deconstruction_crowbar(user, I))
-		return
-	if(default_part_replacement(user, I))
-		return
 
 /obj/machinery/mech_recharger/proc/start_charging(var/obj/mecha/M)
 	if(stat & (NOPOWER | BROKEN))

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -45,7 +45,6 @@
 		change_power_consumption(base_charge_rate, POWER_USE_ACTIVE)
 
 /obj/machinery/mech_recharger/Process()
-	..()
 	if(!charging)
 		update_use_power(POWER_USE_IDLE)
 		return

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -9,6 +9,7 @@
 	active_power_usage = 5000
 	req_access = list(access_robotics)
 	base_type = /obj/machinery/mecha_part_fabricator
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/speed = 1
 	var/mat_efficiency = 1
@@ -132,17 +133,17 @@
 
 	return 1
 
+/obj/machinery/mecha_part_fabricator/components_are_accessible(path)
+	return !busy && ..()
+
+/obj/machinery/mecha_part_fabricator/cannot_transition_to(state_path)
+	if(busy)
+		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
+
 /obj/machinery/mecha_part_fabricator/attackby(var/obj/item/I, var/mob/user)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy. Please wait for completion of previous operation.</span>")
 		return 1
-	if(default_deconstruction_screwdriver(user, I))
-		return
-	if(default_deconstruction_crowbar(user, I))
-		return
-	if(default_part_replacement(user, I))
-		return
-
 	if(!istype(I, /obj/item/stack/material))
 		return ..()
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -32,7 +32,6 @@
 	. = ..()
 
 /obj/machinery/mecha_part_fabricator/Process()
-	..()
 	if(stat)
 		return
 	if(busy)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -139,6 +139,7 @@
 /obj/machinery/mecha_part_fabricator/cannot_transition_to(state_path)
 	if(busy)
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
+	return ..()
 
 /obj/machinery/mecha_part_fabricator/attackby(var/obj/item/I, var/mob/user)
 	if(busy)

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -105,7 +105,6 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 	return node.pipe_color
 
 /obj/machinery/atmospherics/Process()
-	..() // do not return process kill by default
 	last_flow_rate = 0
 	last_power_draw = 0
 

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -26,15 +26,20 @@
 	carbon_efficiency = initial(carbon_efficiency)
 	carbon_efficiency += 0.25 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
 	carbon_efficiency -= 0.25 * number_of_components(/obj/item/weapon/stock_parts/matter_bin)
+	carbon_efficiency = Clamp(carbon_efficiency, initial(carbon_efficiency), 5)
 
-	intake_power_efficiency = initial(carbon_efficiency)
+	intake_power_efficiency = initial(intake_power_efficiency)
 	intake_power_efficiency -= 0.1 * total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator)
-	intake_power_efficiency += 0.25 * number_of_components(/obj/item/weapon/stock_parts/manipulator)
+	intake_power_efficiency += 0.1 * number_of_components(/obj/item/weapon/stock_parts/manipulator)
+	intake_power_efficiency = Clamp(intake_power_efficiency, 0.1, initial(intake_power_efficiency))
 
-	power_rating = initial(carbon_efficiency)
+	power_rating = 1
 	power_rating -= 0.05 * total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser)
 	power_rating += 0.05 * number_of_components(/obj/item/weapon/stock_parts/micro_laser)
+	power_rating = Clamp(power_rating, 0.1, 1)
+	power_rating *= initial(power_rating)
 	..()
+
 /obj/machinery/atmospherics/binary/oxyregenerator/examine(user)
 	..()
 	to_chat(user,"Its outlet port is to the [dir2text(dir)]")

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -9,6 +9,8 @@
 	idle_power_usage = 200		//internal circuitry, friction losses and stuff
 	power_rating = 10000
 	base_type = /obj/machinery/atmospherics/binary/oxyregenerator
+	construct_state = /decl/machine_construction/default/panel_closed
+
 	var/target_pressure = 10*ONE_ATMOSPHERE
 	var/id = null
 	var/power_setting = 1 //power consumption setting, 1 through five
@@ -38,12 +40,8 @@
 	to_chat(user,"Its outlet port is to the [dir2text(dir)]")
 
 /obj/machinery/atmospherics/binary/oxyregenerator/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
+	if(component_attackby(O, user))
+		return TRUE
 	if(isWrench(O))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		anchored = !anchored
@@ -154,7 +152,7 @@
 			phase = "filling"
 
 /obj/machinery/atmospherics/binary/oxyregenerator/on_update_icon()
-	if(!powered())
+	if(stat & NOPOWER)
 		icon_state = "off"
 	else
 		icon_state = "[use_power ? "on" : "off"]"
@@ -163,6 +161,8 @@
 	ui_interact(user)
 
 /obj/machinery/atmospherics/binary/oxyregenerator/attack_hand(mob/user as mob)
+	if(..())
+		return TRUE
 	ui_interact(user)
 
 /obj/machinery/atmospherics/binary/oxyregenerator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
+++ b/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
@@ -273,7 +273,6 @@
 		src.set_dir(turn(src.dir, 90))
 
 /obj/machinery/power/turbinemotor/Process()
-	process_parts()
 	updateConnection()
 	if(!turbine || !anchored || stat & (BROKEN))
 		return

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -69,7 +69,6 @@ Thus, the two variables affect pump operation are set in New():
 	update_underlays()
 
 /obj/machinery/atmospherics/binary/pump/Process()
-	process_parts()
 	last_power_draw = 0
 	last_flow_rate = 0
 

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -64,7 +64,6 @@
 	return
 
 /obj/machinery/atmospherics/omni/Process()
-	process_parts()
 	last_power_draw = 0
 	last_flow_rate = 0
 

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -143,9 +143,9 @@
 //upgrading parts
 /obj/machinery/atmospherics/unary/freezer/RefreshParts()
 	..()
-	var/cap_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor) || 1
-	var/manip_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator) || 1
-	var/bin_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin) || 1
+	var/cap_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 0, 20)
+	var/manip_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator), 1, 10)
+	var/bin_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 10)
 
 	power_rating = initial(power_rating) * cap_rating / 2			//more powerful
 	heatsink_temperature = initial(heatsink_temperature) / ((manip_rating + bin_rating) / 2)	//more efficient

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -11,6 +11,7 @@
 	use_power = POWER_USE_OFF
 	idle_power_usage = 5			// 5 Watts for thermostat related circuitry
 	base_type = /obj/machinery/atmospherics/unary/freezer
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/heatsink_temperature = T20C	// The constant temperature reservoir into which the freezer pumps heat. Probably the hull of the station or something.
 	var/internal_volume = 600		// L
@@ -52,10 +53,12 @@
 		icon_state = "freezer_0"
 	return
 
-/obj/machinery/atmospherics/unary/freezer/attack_ai(mob/user as mob)
+/obj/machinery/atmospherics/unary/freezer/attack_ai(mob/user)
 	ui_interact(user)
 
-/obj/machinery/atmospherics/unary/freezer/attack_hand(mob/user as mob)
+/obj/machinery/atmospherics/unary/freezer/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	ui_interact(user)
 
 /obj/machinery/atmospherics/unary/freezer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
@@ -152,16 +155,6 @@
 /obj/machinery/atmospherics/unary/freezer/proc/set_power_level(var/new_power_setting)
 	power_setting = new_power_setting
 	power_rating = max_power_rating * (power_setting/100)
-
-/obj/machinery/atmospherics/unary/freezer/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-
-	..()
 
 /obj/machinery/atmospherics/unary/freezer/examine(mob/user)
 	. = ..(user)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -11,6 +11,7 @@
 	use_power = POWER_USE_OFF
 	idle_power_usage = 5			//5 Watts for thermostat related circuitry
 	base_type = /obj/machinery/atmospherics/unary/heater
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/max_temperature = T20C + 680
 	var/internal_volume = 600	//L
@@ -74,10 +75,12 @@
 
 	update_icon()
 
-/obj/machinery/atmospherics/unary/heater/attack_ai(mob/user as mob)
+/obj/machinery/atmospherics/unary/heater/attack_ai(mob/user)
 	ui_interact(user)
 
-/obj/machinery/atmospherics/unary/heater/attack_hand(mob/user as mob)
+/obj/machinery/atmospherics/unary/heater/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	ui_interact(user)
 
 /obj/machinery/atmospherics/unary/heater/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
@@ -141,16 +144,6 @@
 /obj/machinery/atmospherics/unary/heater/proc/set_power_level(var/new_power_setting)
 	power_setting = new_power_setting
 	power_rating = max_power_rating * (power_setting/100)
-
-/obj/machinery/atmospherics/unary/heater/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-
-	..()
 
 /obj/machinery/atmospherics/unary/heater/examine(mob/user)
 	. = ..(user)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -133,8 +133,8 @@
 //upgrading parts
 /obj/machinery/atmospherics/unary/heater/RefreshParts()
 	..()
-	var/cap_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor)
-	var/bin_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
+	var/cap_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 1, 20)
+	var/bin_rating = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 10)
 
 	max_power_rating = initial(max_power_rating) * cap_rating / 2
 	max_temperature = max(initial(max_temperature) - T20C, 0) * ((bin_rating * 4 + cap_rating) / 5) + T20C

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -37,7 +37,7 @@
 
 /obj/machinery/atmospherics/pipe/proc/set_leaking(var/new_leaking)
 	if(new_leaking && !leaking)
-		START_PROCESSING(SSmachines, src)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		leaking = TRUE
 		if(parent)
 			parent.leaks |= src
@@ -45,7 +45,7 @@
 				parent.network.leaks |= src
 	else if (!new_leaking && leaking)
 		update_sound(0)
-		STOP_PROCESSING(SSmachines, src)
+		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		leaking = FALSE
 		if(parent)
 			parent.leaks -= src

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -8,7 +8,6 @@
 	anchored = 1
 
 /obj/machinery/artillerycontrol/Process()
-	..()
 	if(src.reload<180)
 		src.reload++
 

--- a/code/modules/bsa/bsa.dm
+++ b/code/modules/bsa/bsa.dm
@@ -35,6 +35,7 @@
 		from the material deconstructor to the particle beam generator.\
 		<br>A sign on it reads: <i>EXPLOSIVE! DO NOT OVERHEAT!</i>"
 	icon_state = "middle"
+	maximum_component_parts = list(/obj/item/weapon/stock_parts = 12)
 
 /obj/machinery/bsa/back
 	name = "bluespace material deconstructor mark VI."

--- a/code/modules/bsa/bsa.dm
+++ b/code/modules/bsa/bsa.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/bsa.dmi'
 	density = TRUE
 	anchored = TRUE
+	construct_state = /decl/machine_construction/default/panel_closed
 
 /obj/machinery/bsa/examine(mob/user)
 	. = ..()
@@ -12,10 +13,6 @@
 		to_chat(user, "The maintenance panel is open.")
 
 /obj/machinery/bsa/attackby(obj/item/I, mob/user)
-	if(default_deconstruction_screwdriver(user, I))
-		return
-	if(default_deconstruction_crowbar(user, I))
-		return
 	if(isWrench(I))
 		if(panel_open)
 			user.visible_message("<span class='notice'>\The [user] rotates \the [src] with \the [I].</span>", "<span class='notice'>You rotate \the [src] with \the [I].</span>")
@@ -24,7 +21,7 @@
 		else
 			to_chat(user,"<span class='notice'>The maintenance panel must be screwed open for this!</span>")
 	else
-		..()
+		return ..()
 
 /obj/machinery/bsa/front
 	name = "bluespace particle beam generator mark VI."

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -85,7 +85,6 @@
 	return 1
 
 /obj/machinery/dnaforensics/Process()
-	..()
 	if(scanning)
 		if(!bloodsamp || bloodsamp.loc != src)
 			bloodsamp = null

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -33,7 +33,6 @@
 	spark_system.attach(src)
 
 /obj/machinery/atm/Process()
-	..()
 	if(stat & NOPOWER)
 		return
 

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -103,11 +103,12 @@
 	return 1
 
 /obj/machinery/food_replicator/RefreshParts()
-	deconstruct_eff = 0.5 * total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser)
-	biomass_max = 100 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
+	deconstruct_eff = 0.5 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser), 0, 10)
+	biomass_max = 100 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 10)
 	biomass_per = max(1, 20 - 5 * total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator))
 
 	biomass = min(biomass,biomass_max)
+	..()
 
 /obj/machinery/food_replicator/proc/queue_dish(var/text)
 	if(!(text in menu))

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -139,7 +139,6 @@
 			if(queued_dishes && queued_dishes.len) //more to come
 				queued_dishes -= queued_dishes[1]
 				start_making = 1
-	..()
 
 /obj/machinery/food_replicator/examine(mob/user)
 	. = ..(user)

--- a/code/modules/food/replicator.dm
+++ b/code/modules/food/replicator.dm
@@ -8,6 +8,8 @@
 	idle_power_usage = 40
 	obj_flags = OBJ_FLAG_ANCHORABLE
 	base_type = /obj/machinery/food_replicator
+	construct_state = /decl/machine_construction/default/panel_closed
+
 	var/biomass = 100
 	var/biomass_max = 100
 	var/biomass_per = 10
@@ -40,16 +42,7 @@
 		if(success)
 			S.finish_bulk_removal()
 			to_chat(user, "You empty \the [O] into \the [src]")
-
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	else if(default_deconstruction_crowbar(user, O))
-		return
-	else if(default_part_replacement(user, O))
-		return
-	else
-		..()
-	return
+	return ..()
 
 /obj/machinery/food_replicator/on_update_icon()
 	if(stat & BROKEN)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -128,6 +128,8 @@
 		return
 
 /obj/machinery/beehive/attack_hand(var/mob/user)
+	if((. = ..()))
+		return
 	if(!closed)
 		if(honeycombs < 100)
 			to_chat(user, "<span class='notice'>There are no filled honeycombs.</span>")
@@ -177,14 +179,17 @@
 /obj/machinery/honey_extractor/components_are_accessible(path)
 	return !processing && ..()
 
+/obj/machinery/honey_extractor/cannot_transition_to(state_path, mob/user)
+	if(processing)
+		return SPAN_NOTICE("You must wait for \the [src] to finish first!")
+	return ..()	
+
 /obj/machinery/honey_extractor/attackby(var/obj/item/I, var/mob/user)
 	if(processing)
 		to_chat(user, "<span class='notice'>\The [src] is currently spinning, wait until it's finished.</span>")
 		return
-	if(default_deconstruction_screwdriver(user, I))
-		return TRUE
-	if(default_deconstruction_crowbar(user, I))
-		return TRUE
+	if((. = component_attackby(I, user)))
+		return
 	if(istype(I, /obj/item/honey_frame))
 		var/obj/item/honey_frame/H = I
 		if(!H.honey)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -146,7 +146,6 @@
 		return
 
 /obj/machinery/beehive/Process()
-	..()
 	if(closed && !smoked && bee_count)
 		pollinate_flowers()
 		update_icon()

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -41,8 +41,6 @@
 	var/disk_needs_genes = 0
 
 /obj/machinery/botany/Process()
-
-	..()
 	if(!active) return
 
 	if(world.time > last_action + action_time)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	volume = 100
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/mechanical = 1         // Set to 0 to stop it from drawing the alert lights.
 	var/base_name = "tray"
@@ -145,6 +146,8 @@
 		harvest()
 
 /obj/machinery/portable_atmospherics/hydroponics/Initialize()
+	if(!mechanical)
+		construct_state = null
 	. = ..()
 	temp_chem_holder = new()
 	temp_chem_holder.create_reagents(10)
@@ -507,13 +510,8 @@
 		if(!dead)
 			health -= O.force
 			check_health()
-
-	if(mechanical)
-		if(default_deconstruction_screwdriver(user, O))
-			return
-		if(default_deconstruction_crowbar(user, O))
-			return
-		return ..()
+	else if(mechanical)
+		return component_attackby(O, user)
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/plant_seed(var/mob/user, var/obj/item/seeds/S)
 

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -153,7 +153,7 @@
 	if(mechanical)
 		connect()
 	update_icon()
-	STOP_PROCESSING(SSmachines, src)
+	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_ALL)
 	START_PROCESSING(SSplants, src)
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -146,6 +146,7 @@
 /obj/machinery/mining/drill/cannot_transition_to(state_path)
 	if(active)
 		return SPAN_NOTICE("You must turn \the [src] off first.")
+	return ..()
 
 /obj/machinery/mining/drill/components_are_accessible(path)
 	return !active && ..()
@@ -265,6 +266,7 @@
 /obj/machinery/mining/brace/cannot_transition_to(state_path)
 	if(connected && connected.active)
 		return SPAN_NOTICE("You can't work with the brace of a running drill!")
+	return ..()
 
 /obj/machinery/mining/brace/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(connected && connected.active)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -5,6 +5,7 @@
 	density = 1
 	plane = ABOVE_HUMAN_PLANE
 	layer = ABOVE_HUMAN_LAYER //So it draws over mobs in the tile north of it.
+	construct_state = /decl/machine_construction/default/panel_closed
 
 /obj/machinery/mining/drill
 	name = "mining drill head"
@@ -38,7 +39,6 @@
 	//Upgrades
 	var/harvest_speed
 	var/capacity
-	var/obj/item/weapon/cell/cell = null
 
 	//Flags
 	var/need_update_field = 0
@@ -143,18 +143,12 @@
 /obj/machinery/mining/drill/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/machinery/mining/drill/attackby(obj/item/O as obj, mob/user as mob)
-	if(!active)
-		if(default_deconstruction_screwdriver(user, O))
-			return TRUE
-		if(default_deconstruction_crowbar(user, O))
-			return TRUE
-		if(default_part_replacement(user, O))
-			return TRUE
-	return ..()
+/obj/machinery/mining/drill/cannot_transition_to(state_path)
+	if(active)
+		return SPAN_NOTICE("You must turn \the [src] off first.")
 
 /obj/machinery/mining/drill/components_are_accessible(path)
-	return panel_open && !active	
+	return !active && ..()
 
 /obj/machinery/mining/drill/attack_hand(mob/user as mob)
 	check_supports()
@@ -268,16 +262,16 @@
 
 	var/obj/machinery/mining/drill/connected
 
+/obj/machinery/mining/brace/cannot_transition_to(state_path)
+	if(connected && connected.active)
+		return SPAN_NOTICE("You can't work with the brace of a running drill!")
+
 /obj/machinery/mining/brace/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(connected && connected.active)
 		to_chat(user, "<span class='notice'>You can't work with the brace of a running drill!</span>")
-		return
-
-	if(default_deconstruction_screwdriver(user, W))
-		return
-	if(default_deconstruction_crowbar(user, W))
-		return
-
+		return TRUE
+	if(component_attackby(W, user))
+		return TRUE
 	if(isWrench(W))
 
 		if(istype(get_turf(src), /turf/space))
@@ -325,7 +319,7 @@
 	connected.check_supports()
 	connected = null
 
-/obj/machinery/mining/brace/default_deconstruction_crowbar(var/mob/user, var/obj/item/weapon/crowbar/C)
+/obj/machinery/mining/brace/dismantle()
 	if(connected)
 		disconnect()
 	..()

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -191,9 +191,9 @@
 
 /obj/machinery/mining/drill/RefreshParts()
 	..()
-	harvest_speed = total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser)
-	capacity = 200 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
-	var/charge_multiplier = total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor) || 1
+	harvest_speed = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser), 0, 10)
+	capacity = 200 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 10)
+	var/charge_multiplier = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 0.1, 10)
 	change_power_consumption(initial(active_power_usage) / charge_multiplier, POWER_USE_ACTIVE)
 
 /obj/machinery/mining/drill/proc/check_supports()

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -45,8 +45,6 @@
 	var/need_player_check = 0
 
 /obj/machinery/mining/drill/Process()
-	..()
-
 	if(need_player_check)
 		return
 

--- a/code/modules/mining/machinery/_mineral.dm
+++ b/code/modules/mining/machinery/_mineral.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	density =  TRUE
 	anchored = TRUE
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/turf/input_turf
 	var/turf/output_turf
@@ -22,15 +23,10 @@
 	find_console()
 	. = ..()
 
-/obj/machinery/mineral/attackby(var/obj/item/O, var/mob/user)
-	if(default_deconstruction_screwdriver(user, O))
-		updateUsrDialog()
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
+/obj/machinery/mineral/state_transition(var/decl/machine_construction/default/new_state)
 	. = ..()
+	if(istype(new_state))
+		updateUsrDialog()
 
 /obj/machinery/mineral/proc/set_input(var/_dir)
 	input_turf = _dir ? get_step(loc, _dir) : null

--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -25,7 +25,6 @@
 	. = ..()
 
 /obj/machinery/mineral/processing_unit/Process()
-	..()
 	//Grab some more ore to process this tick.
 	if(input_turf)
 		for(var/obj/item/I in recursive_content_check(input_turf, sight_check = FALSE, include_mobs = FALSE))

--- a/code/modules/mining/machinery/mineral_stacker.dm
+++ b/code/modules/mining/machinery/mineral_stacker.dm
@@ -8,7 +8,6 @@
 	var/list/stacks = list()
 
 /obj/machinery/mineral/stacking_machine/Process()
-	..()
 	if(input_turf)
 		for(var/obj/item/I in input_turf)
 			if(istype(I, /obj/item/stack/material))

--- a/code/modules/mining/machinery/mineral_unloader.dm
+++ b/code/modules/mining/machinery/mineral_unloader.dm
@@ -5,7 +5,6 @@
 	output_turf = EAST
 
 /obj/machinery/mineral/unloading_machine/Process()
-	..()
 	if(input_turf && output_turf)
 		if(length(output_turf.contents) < 15)
 			var/ore_this_tick = 10

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -38,8 +38,6 @@
 		icon_state = "drone_fab_nopower"
 
 /obj/machinery/drone_fabricator/Process()
-	..()
-
 	if(GAME_STATE < RUNLEVEL_GAME)
 		return
 

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -54,7 +54,6 @@
 		dos_failure = 0
 		update_icon()
 		ntnet_global.add_log("Quantum relay switched from overload recovery mode to normal operation mode.")
-	..()
 
 /obj/machinery/ntnet_relay/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	var/list/data = list()

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -238,7 +238,6 @@
 	queue_icon_update()
 
 /obj/machinery/shipsensors/Process()
-	..()
 	if(use_power) //can't run in non-vacuum
 		if(!in_vacuum())
 			toggle()

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -27,13 +27,14 @@
 	var/ui_tick = 0
 
 /obj/machinery/power/smes/batteryrack/RefreshParts()
-	var/capacitor_efficiency = total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor)
+	var/capacitor_efficiency = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 0, 10)
 	var/maxcells = 3 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
 
 	max_transfer_rate = 10000 * capacitor_efficiency // 30kw - 90kw depending on used capacitors.
 	max_cells = min(PSU_MAXCELLS, maxcells)
 	input_level = max_transfer_rate
 	output_level = max_transfer_rate
+	..()
 
 /obj/machinery/power/smes/batteryrack/Destroy()
 	for(var/obj/item/weapon/cell/C in internal_cells)

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -16,6 +16,7 @@
 	charge = 0
 	should_be_mapped = 1
 	base_type = /obj/machinery/power/smes/batteryrack
+	maximum_component_parts = list(/obj/item/weapon/stock_parts = 12)
 
 	var/max_transfer_rate = 0							// Maximal input/output rate. Determined by used capacitors when building the device.
 	var/mode = PSU_OFFLINE								// Current inputting/outputting mode

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -228,12 +228,8 @@
 	return ..()
 
 /obj/machinery/power/smes/batteryrack/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	if(!..())
-		return 0
-	if(default_deconstruction_crowbar(user, W))
-		return
-	if(default_part_replacement(user, W))
-		return
+	if(..())
+		return TRUE
 	if(istype(W, /obj/item/weapon/cell)) // ID Card, try to insert it.
 		if(insert_cell(W, user))
 			to_chat(user, "You insert \the [W] into \the [src].")

--- a/code/modules/power/debug_items.dm
+++ b/code/modules/power/debug_items.dm
@@ -30,7 +30,6 @@
 	var/power_generation_rate = 1000000
 
 /obj/machinery/power/debug_items/infinite_generator/Process()
-	..()
 	add_avail(power_generation_rate)
 
 /obj/machinery/power/debug_items/infinite_generator/show_info(var/mob/user)
@@ -46,7 +45,6 @@
 	var/last_used = 0
 
 /obj/machinery/power/debug_items/infinite_cable_powersink/Process()
-	..()
 	last_used = draw_power(power_usage_rate)
 
 /obj/machinery/power/debug_items/infinite_cable_powersink/show_info(var/mob/user)

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -30,7 +30,6 @@
 		fusion.set_tag(null, initial_id_tag)
 
 /obj/machinery/power/fusion_core/Process()
-	..()
 	if((stat & BROKEN) || !powernet || !owned_field)
 		Shutdown()
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -30,7 +30,6 @@
 	anchored = 1
 
 /obj/machinery/fusion_fuel_injector/Process()
-	..()
 	if(injecting)
 		if(stat & (BROKEN|NOPOWER))
 			StopInjecting()

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -70,8 +70,6 @@
 		ui.set_auto_update(1)
 
 /obj/machinery/kinetic_harvester/Process()
-	..()
-
 	if(harvest_from && get_dist(src, harvest_from) > 10)
 		harvest_from = null
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -65,7 +65,6 @@
 			overlays += image('icons/obj/power.dmi', "teg-op[lastgenlev]")
 
 /obj/machinery/power/generator/Process()
-	..()
 	if(!circ1 || !circ2 || !anchored || stat & (BROKEN|NOPOWER))
 		stored_energy = 0
 		return

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -149,9 +149,10 @@
 	var/temp_rating = total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser)
 	temp_rating += total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor)
 
-	max_sheets = 50 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin) ** 2
+	max_sheets = 50 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 5) ** 2
 
-	power_gen = round(initial(power_gen) * (max(2, temp_rating) / 2))
+	power_gen = round(initial(power_gen) * Clamp(temp_rating, 0, 20) / 2)
+	..()
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..(user)

--- a/code/modules/power/power_components.dm
+++ b/code/modules/power/power_components.dm
@@ -7,7 +7,6 @@
 	part_flags = PART_FLAG_QDEL // For integrated components, which are built from uncreated_component_parts. Use subtypes with this off for buildable ones.
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "teslalink"
-	can_be_uninstalled = FALSE  // For integrated components, which are built from uncreated_component_parts. Use subtypes with this off for buildable ones.
 	var/priority = 0            // Higher priority is used first
 	var/cached_channel
 

--- a/code/modules/power/power_components.dm
+++ b/code/modules/power/power_components.dm
@@ -7,6 +7,7 @@
 	part_flags = PART_FLAG_QDEL // For integrated components, which are built from uncreated_component_parts. Use subtypes with this off for buildable ones.
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "teslalink"
+	can_be_uninstalled = FALSE  // For integrated components, which are built from uncreated_component_parts. Use subtypes with this off for buildable ones.
 	var/priority = 0            // Higher priority is used first
 	var/cached_channel
 

--- a/code/modules/power/sensors/sensor_monitoring.dm
+++ b/code/modules/power/sensors/sensor_monitoring.dm
@@ -22,7 +22,6 @@
 
 // Checks the sensors for alerts. If change (alerts cleared or detected) occurs, calls for icon update.
 /obj/machinery/computer/power_monitor/Process()
-	..()
 	var/alert = check_warnings()
 	if(alert != alerting)
 		alerting = !alerting

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -30,7 +30,6 @@ var/global/list/rad_collectors = list()
 	. = ..()
 
 /obj/machinery/power/rad_collector/Process()
-	..()
 	if((stat & BROKEN) || melted)
 		return
 	var/turf/T = get_turf(src)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -94,7 +94,6 @@
 	return 1
 
 /obj/machinery/power/emitter/Process()
-	..()
 	if(stat & (BROKEN))
 		return
 	if(src.state != 2 || (!powernet && active_power_usage))

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -61,7 +61,6 @@ field_generator power level display
 	connected_gens = list()
 
 /obj/machinery/field_generator/Process()
-	..()
 	if(Varedit_start == 1)
 		if(active == 0)
 			active = 1

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -10,7 +10,6 @@
 	var/energy = 0
 
 /obj/machinery/the_singularitygen/Process()
-	..()
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)
 		new /obj/singularity/(T, 50)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -145,7 +145,6 @@
 		update_use_power(POWER_USE_IDLE)
 
 /obj/machinery/particle_accelerator/control_box/Process()
-	..()
 	if(src.active)
 		//a part is missing!
 		if( length(connected_parts) < 6 )

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -14,6 +14,7 @@
 	power_channel = LOCAL // Draws power from direct connections to powernets.
 	stat = BROKEN         // Should be removed if the terminals initialize fully.
 	construct_state = /decl/machine_construction/default/panel_closed
+	stat = BROKEN         // Should be removed if the terminals initialize fully.
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 1e6 // actual charge
@@ -233,7 +234,7 @@
 		return TRUE
 
 	if (!panel_open)
-		to_chat(user, "<span class='warning'>You need to open access hatch on [src] first!</span>")
+		to_chat(user, "<span class='warning'>You need to open the access hatch on \the [src] first!</span>")
 		return TRUE
 
 	if(isWelder(W))

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -73,7 +73,6 @@
 	update_icon()
 
 /obj/machinery/power/smes/populate_parts()
-	..()
 	for(var/d in GLOB.cardinal)
 		var/obj/item/weapon/stock_parts/power/terminal/part = install_component(/obj/item/weapon/stock_parts/power/terminal, refresh_parts = FALSE)
 		part.terminal_dir = d
@@ -82,7 +81,7 @@
 			if(term.dir == turn(d, 180) && !term.master)
 				part.set_terminal(src, term)
 				term.connect_to_network()
-		
+	..()
 
 /obj/machinery/power/smes/add_avail(var/amount)
 	if(..(amount))
@@ -230,11 +229,11 @@
 	ui_interact(user)
 
 /obj/machinery/power/smes/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	if (!panel_open)
-		to_chat(user, "<span class='warning'>You need to open access hatch on [src] first!</span>")
+	if(component_attackby(W, user))
 		return TRUE
 
-	if(component_attackby(W, user))
+	if (!panel_open)
+		to_chat(user, "<span class='warning'>You need to open access hatch on [src] first!</span>")
 		return TRUE
 
 	if(isWelder(W))

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -147,7 +147,6 @@
 		set_broken(!num_terminals)
 
 /obj/machinery/power/smes/Process()
-	..()
 	if(stat & BROKEN)	return
 	if(failure_timer)	// Disabled by gridcheck.
 		failure_timer--

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -13,6 +13,7 @@
 	clicksound = "switch"
 	power_channel = LOCAL // Draws power from direct connections to powernets.
 	stat = BROKEN         // Should be removed if the terminals initialize fully.
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 1e6 // actual charge
@@ -223,21 +224,18 @@
 	ui_interact(user)
 
 /obj/machinery/power/smes/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	add_fingerprint(user)
 	ui_interact(user)
 
-
 /obj/machinery/power/smes/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-
-	if(default_deconstruction_screwdriver(user, W))
-		return TRUE
-
 	if (!panel_open)
 		to_chat(user, "<span class='warning'>You need to open access hatch on [src] first!</span>")
 		return TRUE
 
-	if((. = ..()))
-		return
+	if(component_attackby(W, user))
+		return TRUE
 
 	if(isWelder(W))
 		var/obj/item/weapon/weldingtool/WT = W

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -69,7 +69,7 @@
 	should_be_mapped = 1
 	base_type = /obj/machinery/power/smes/buildable
 	uncreated_component_parts = null
-	maximum_component_parts = list(/obj/item/weapon/stock_parts/smes_coil = 6)
+	maximum_component_parts = list(/obj/item/weapon/stock_parts/smes_coil = 6, /obj/item/weapon/stock_parts = 12)
 	interact_offline = TRUE
 
 /obj/machinery/power/smes/buildable/malf_upgrade(var/mob/living/silicon/ai/user)

--- a/code/modules/power/smes_presets.dm
+++ b/code/modules/power/smes_presets.dm
@@ -4,7 +4,6 @@
 	var/_input_on = FALSE
 	var/_output_maxed = FALSE
 	var/_output_on = FALSE
-	cur_coils = 0
 
 /obj/machinery/power/smes/buildable/preset/Initialize()
 	. = ..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -117,7 +117,6 @@ var/list/solars_list = list()
 	//isn't the power recieved from the incoming light proportionnal to cos(p_angle) (Lambert's cosine law) rather than cos(p_angle)^2 ?
 
 /obj/machinery/power/solar/Process()
-	..()
 	if(stat & BROKEN)
 		return
 	if(!GLOB.sun || !control) //if there's no sun or the panel is not linked to a solar control computer, no need to proceed
@@ -433,7 +432,6 @@ var/list/solars_list = list()
 	return
 
 /obj/machinery/power/solar_control/Process()
-	..()
 	lastgen = gen
 	gen = 0
 

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -63,7 +63,6 @@
 #define COMPSTARTERLOAD 2800
 
 /obj/machinery/compressor/Process()
-	..()
 	if(!starter)
 		return
 	overlays.Cut()
@@ -121,7 +120,6 @@
 #define TURBGENG 0.8
 
 /obj/machinery/power/turbine/Process()
-	..()
 	if(!compressor.starter)
 		return
 	overlays.Cut()

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -48,11 +48,12 @@
 	. = ..()
 
 /obj/machinery/reagent_temperature/RefreshParts()
-	heating_power = initial(heating_power) * total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor)
+	heating_power = initial(heating_power) * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 0, 10)
 
 	var/comp = 0.25 KILOWATTS * total_component_rating_of_type(/obj/item/weapon/stock_parts/micro_laser)
 	if(comp)
 		change_power_consumption(max(0.5 KILOWATTS, initial(active_power_usage) - comp), POWER_USE_ACTIVE)
+	..()
 
 /obj/machinery/reagent_temperature/Process()
 	..()

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -14,6 +14,7 @@
 	anchored =   TRUE
 	idle_power_usage = 0
 	active_power_usage = 1.2 KILOWATTS
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/image/glow_icon
 	var/image/beaker_icon
@@ -27,7 +28,6 @@
 	var/last_temperature
 	var/target_temperature
 	var/obj/item/container
-	var/circuit_type = /obj/item/weapon/stock_parts/circuitboard/reagent_heater
 
 /obj/machinery/reagent_temperature/cooler
 	name = "chemical cooler"
@@ -36,7 +36,6 @@
 	heater_mode =      HEATER_MODE_COOL
 	max_temperature =  30 CELSIUS
 	min_temperature = -80 CELSIUS
-	circuit_type =     /obj/item/weapon/stock_parts/circuitboard/reagent_heater/cooler
 
 /obj/machinery/reagent_temperature/Initialize()
 	target_temperature = min_temperature
@@ -64,6 +63,8 @@
 		queue_icon_update()
 
 /obj/machinery/reagent_temperature/attack_hand(var/mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	interact(user)
 
 /obj/machinery/reagent_temperature/attack_ai(var/mob/user)
@@ -84,16 +85,6 @@
 	. = ..()
 
 /obj/machinery/reagent_temperature/attackby(var/obj/item/thing, var/mob/user)
-
-	if(default_deconstruction_screwdriver(user, thing))
-		return
-
-	if(default_deconstruction_crowbar(user, thing))
-		return
-
-	if(default_part_replacement(user, thing))
-		return
-
 	if(isWrench(thing))
 		if(use_power == POWER_USE_ACTIVE)
 			to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
@@ -115,7 +106,6 @@
 					update_icon()
 				return
 		to_chat(user, SPAN_WARNING("\The [src] cannot accept \the [thing]."))
-	..()
 
 /obj/machinery/reagent_temperature/on_update_icon()
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -62,7 +62,6 @@
 	// machine process
 	// move items to the target location
 /obj/machinery/conveyor/Process()
-	..()
 	if(stat & (BROKEN | NOPOWER))
 		return
 	if(!operating)
@@ -183,7 +182,6 @@
 // if the switch changed, update the linked conveyors
 
 /obj/machinery/conveyor_switch/Process()
-	..()
 	if(!operated)
 		return
 	operated = 0

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -90,6 +90,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 /obj/machinery/r_n_d/circuit_imprinter/cannot_transition_to(state_path)
 	if(busy)
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
+	return ..()
 
 /obj/machinery/r_n_d/circuit_imprinter/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -10,6 +10,8 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	icon_state = "circuit_imprinter"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	base_type = /obj/machinery/r_n_d/circuit_imprinter
+	construct_state = /decl/machine_construction/default/panel_closed
+
 	var/list/datum/design/queue = list()
 	var/progress = 0
 
@@ -76,20 +78,25 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	else
 		icon_state = "circuit_imprinter"
 
+/obj/machinery/r_n_d/circuit_imprinter/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state) && linked_console.linked_imprinter)
+		linked_console.linked_imprinter = null
+		linked_console = null
+
+/obj/machinery/r_n_d/circuit_imprinter/components_are_accessible(path)
+	return !busy && ..()
+
+/obj/machinery/r_n_d/circuit_imprinter/cannot_transition_to(state_path)
+	if(busy)
+		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 
 /obj/machinery/r_n_d/circuit_imprinter/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy. Please wait for completion of previous operation.</span>")
 		return 1
-	if(default_deconstruction_screwdriver(user, O))
-		if(linked_console)
-			linked_console.linked_imprinter = null
-			linked_console = null
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
+	if(component_attackby(O, user))
+		return TRUE
 	if(panel_open)
 		to_chat(user, "<span class='notice'>You can't load \the [src] while it's opened.</span>")
 		return 1

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -64,11 +64,12 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		else
 			reagents.maximum_volume = T
 
-	max_material_storage = 75000 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
+	max_material_storage = 75000 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 10)
 
-	T = total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator)
+	T = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator), 0, 3)
 	mat_efficiency = 1 - (T - 1) / 4
 	speed = T
+	..()
 
 /obj/machinery/r_n_d/circuit_imprinter/on_update_icon()
 	if(panel_open)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -45,6 +45,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 	if(loaded_item)
 		return SPAN_NOTICE("There is something already loaded into \the [src]. You must remove it first.")
+	return ..()
 
 /obj/machinery/r_n_d/destructive_analyzer/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -21,7 +21,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/S in src)
 		T += S.rating
-	decon_mod = T * 0.1
+	decon_mod = min(T * 0.1, 3)
+	..()
 
 /obj/machinery/r_n_d/destructive_analyzer/on_update_icon()
 	if(panel_open)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -58,11 +58,12 @@
 		else
 			reagents.maximum_volume = T
 
-	max_material_storage = 75000 * total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin)
+	max_material_storage = 75000 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 10)
 
-	T = total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator)
+	T = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/manipulator), 0, 6)
 	mat_efficiency = 1 - (T - 2) / 8
 	speed = T / 2
+	..()
 
 
 /obj/machinery/r_n_d/protolathe/on_update_icon()

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -85,6 +85,7 @@
 /obj/machinery/r_n_d/protolathe/cannot_transition_to(state_path)
 	if(busy)
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
+	return ..()
 
 /obj/machinery/r_n_d/protolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -7,6 +7,7 @@
 	idle_power_usage = 30
 	active_power_usage = 5000
 	base_type = /obj/machinery/r_n_d/protolathe
+	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/max_material_storage = 250000
 
@@ -72,19 +73,25 @@
 	else
 		icon_state = "protolathe"
 
+/obj/machinery/r_n_d/protolathe/state_transition(var/decl/machine_construction/default/new_state)
+	. = ..()
+	if(istype(new_state) && linked_console)
+		linked_console.linked_lathe = null
+		linked_console = null
+
+/obj/machinery/r_n_d/protolathe/components_are_accessible(path)
+	return !busy && ..()
+
+/obj/machinery/r_n_d/protolathe/cannot_transition_to(state_path)
+	if(busy)
+		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
+
 /obj/machinery/r_n_d/protolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy. Please wait for completion of previous operation.</span>")
 		return 1
-	if(default_deconstruction_screwdriver(user, O))
-		if(linked_console)
-			linked_console.linked_lathe = null
-			linked_console = null
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
+	if(component_attackby(O, user))
+		return TRUE
 	if(O.is_open_container())
 		return 1
 	if(panel_open)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "server"
 	base_type = /obj/machinery/r_n_d/server
+	construct_state = /decl/machine_construction/default/panel_closed
 	var/datum/research/files
 	var/health = 100
 	var/list/id_with_upload = list()	//List of R&D consoles with upload to server access.
@@ -81,14 +82,6 @@
 				removed.add_thermal_energy(heat_produced)
 
 			env.merge(removed)
-
-/obj/machinery/r_n_d/server/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
 
 /obj/machinery/r_n_d/server/centcom
 	name = "Central R&D Database"
@@ -204,7 +197,9 @@
 	if(. == TOPIC_REFRESH)
 		attack_hand(user)
 
-/obj/machinery/computer/rdservercontrol/attack_hand(mob/user as mob)
+/obj/machinery/computer/rdservercontrol/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	if(stat & (BROKEN|NOPOWER))
 		return
 	user.set_machine(src)

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -63,10 +63,13 @@
 
 /obj/item/weapon/stock_parts/proc/start_processing(var/obj/machinery/machine)
 	LAZYDISTINCTADD(machine.processing_parts, src)
+	START_PROCESSING_MACHINE(machine, MACHINERY_PROCESS_COMPONENTS)
 	set_status(machine, PART_STAT_PROCESSING)
 
 /obj/item/weapon/stock_parts/proc/stop_processing(var/obj/machinery/machine)
 	LAZYREMOVE(machine.processing_parts, src)
+	if(!LAZYLEN(machine.processing_parts))
+		STOP_PROCESSING_MACHINE(machine, MACHINERY_PROCESS_COMPONENTS)
 	unset_status(machine, PART_STAT_PROCESSING)
 
 /obj/item/weapon/stock_parts/proc/machine_process(var/obj/machinery/machine)

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -9,6 +9,8 @@
 	anchored = 1
 	density = 0
 	level = 1
+	construct_state = /decl/machine_construction/default/panel_closed
+
 	var/alarm = 0
 	var/enabled = 1
 
@@ -26,14 +28,6 @@
 		for(var/obj/effect/shield/S in shielded_tile)
 			S.diffuse(5)
 
-/obj/machinery/shield_diffuser/attackby(obj/item/O as obj, mob/user as mob)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-
 /obj/machinery/shield_diffuser/on_update_icon()
 	if(alarm)
 		icon_state = "fdiffuser_emergency"
@@ -43,16 +37,18 @@
 	else
 		icon_state = "fdiffuser_on"
 
-/obj/machinery/shield_diffuser/attack_hand()
+/obj/machinery/shield_diffuser/attack_hand(mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	if(alarm)
-		to_chat(usr, "You press an override button on \the [src], re-enabling it.")
+		to_chat(user, "You press an override button on \the [src], re-enabling it.")
 		alarm = 0
 		update_icon()
 		return
 	enabled = !enabled
 	update_use_power(enabled + 1)
 	update_icon()
-	to_chat(usr, "You turn \the [src] [enabled ? "on" : "off"].")
+	to_chat(user, "You turn \the [src] [enabled ? "on" : "off"].")
 
 /obj/machinery/shield_diffuser/proc/meteor_alarm(var/duration)
 	if(!duration)

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -13,7 +13,6 @@
 	var/enabled = 1
 
 /obj/machinery/shield_diffuser/Process()
-	..()
 	if(alarm)
 		alarm--
 		if(!alarm)

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -117,7 +117,6 @@
 
 
 /obj/machinery/power/shield_generator/Process()
-	..()
 	upkeep_power_usage = 0
 	power_usage = 0
 

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -66,6 +66,7 @@
 	mitigation_em = between(0, mitigation_em, mitigation_max)
 	mitigation_physical = between(0, mitigation_physical, mitigation_max)
 	mitigation_heat = between(0, mitigation_heat, mitigation_max)
+	..()
 
 
 // Shuts down the shield, removing all shield segments and unlocking generator settings.

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -172,6 +172,7 @@
 		return SPAN_NOTICE("Turn off \the [src] first!")
 	if(offline_for)
 		return SPAN_NOTICE("Wait until \the [src] cools down from emergency shutdown first!")
+	return ..()
 
 /obj/machinery/power/shield_generator/attackby(obj/item/O as obj, mob/user as mob)
 	if(panel_open && isMultitool(O) || isWirecutter(O))

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -164,28 +164,20 @@
 	else if (field_integrity() > 25)
 		overloaded = 0
 
+/obj/machinery/power/shield_generator/components_are_accessible(path)
+	return !running && ..()
+
+/obj/machinery/power/shield_generator/cannot_transition_to(state_path)
+	if(running)
+		return SPAN_NOTICE("Turn off \the [src] first!")
+	if(offline_for)
+		return SPAN_NOTICE("Wait until \the [src] cools down from emergency shutdown first!")
 
 /obj/machinery/power/shield_generator/attackby(obj/item/O as obj, mob/user as mob)
 	if(panel_open && isMultitool(O) || isWirecutter(O))
 		attack_hand(user)
-		return
-
-	if(default_deconstruction_screwdriver(user, O))
-		return
-
-	// Prevents dismantle-rebuild tactics to reset the emergency shutdown timer.
-	if(running)
-		to_chat(user, "Turn off \the [src] first!")
-		return
-	if(offline_for)
-		to_chat(user, "Wait until \the [src] cools down from emergency shutdown first!")
-		return
-
-	if(default_deconstruction_crowbar(user, O))
-		return
-	if(default_part_replacement(user, O))
-		return
-
+		return TRUE
+	return component_attackby(O, user)
 
 /obj/machinery/power/shield_generator/proc/energy_failure()
 	if(running == SHIELD_DISCHARGING)
@@ -229,6 +221,8 @@
 
 
 /obj/machinery/power/shield_generator/attack_hand(var/mob/user)
+	if(component_attackby(user))
+		return TRUE
 	ui_interact(user)
 	if(panel_open)
 		wires.Interact(user)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -18,7 +18,6 @@
 	health = max_health/2 // Half health, it's not suposed to resist much.
 
 /obj/machinery/shield/malfai/Process()
-	..()
 	health -= 0.5 // Slowly lose integrity over time
 	check_failure()
 

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -302,7 +302,6 @@
 	playsound(loc, 'sound/weapons/smash.ogg', 75, 1)
 
 /obj/machinery/shieldwall/Process()
-	..()
 	if(needs_power)
 		if(isnull(gen_primary)||isnull(gen_secondary))
 			qdel(src)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -309,8 +309,6 @@
 
 
 /obj/machinery/power/supermatter/Process()
-	..()
-
 	var/turf/L = loc
 
 	if(isnull(L))		// We have a null turf...something is wrong, stop processing this entity.

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -24,7 +24,6 @@
 	user.visible_message("[user] adds \a [O] to \the [src]!", "You add \a [O] to \the [src]!")
 
 /obj/machinery/disease2/diseaseanalyser/Process()
-	..()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/virus2/antibodyanalyser.dm
+++ b/code/modules/virus2/antibodyanalyser.dm
@@ -27,7 +27,6 @@
 		return
 
 /obj/machinery/disease2/antibodyanalyser/Process()
-	..()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -78,7 +78,6 @@
 		ui.open()
 
 /obj/machinery/computer/centrifuge/Process()
-	..()
 	if (stat & (NOPOWER|BROKEN)) return
 
 	if (curing)

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -66,8 +66,6 @@
 	return
 
 /obj/machinery/computer/curer/Process()
-	..()
-
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -85,7 +85,6 @@
 		ui.open()
 
 /obj/machinery/computer/diseasesplicer/Process()
-	..()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -105,7 +105,6 @@
 		ui.open()
 
 /obj/machinery/disease2/isolator/Process()
-	..()
 	if (isolating > 0)
 		isolating -= 1
 		if(virus2)

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -54,7 +54,6 @@
 	. = ..()
 
 /obj/machinery/artifact/Process()
-	..()
 	var/turf/L = loc
 	if(!istype(L)) 	// We're inside a container or on null turf, either way stop processing effects
 		return

--- a/code/modules/xenoarcheaology/artifacts/autocloner.dm
+++ b/code/modules/xenoarcheaology/artifacts/autocloner.dm
@@ -40,7 +40,6 @@
 
 //todo: how the hell is the asteroid permanently powered?
 /obj/machinery/auto_cloner/Process()
-	..()
 	if(powered(power_channel))
 		if(!previous_power_state)
 			previous_power_state = 1

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -82,8 +82,7 @@
 		[pick("front","side","top","bottom","rear","inside")].</span>"
 
 /obj/machinery/replicator/Process()
-	..()
-	if(spawning_types.len && powered())
+	if(spawning_types.len && !(stat & NOPOWER))
 		spawn_progress_time += world.time - last_process_time
 		if(spawn_progress_time > max_spawn_time)
 			src.visible_message("<span class='notice'>\icon[src] [src] pings!</span>")

--- a/code/modules/xenoarcheaology/tools/artifact_analyser.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_analyser.dm
@@ -55,7 +55,6 @@
 	onclose(user, "artanalyser")
 
 /obj/machinery/artifact_analyser/Process()
-	..()
 	if(scan_in_progress && world.time > scan_completion_time)
 		scan_in_progress = 0
 		updateDialog()

--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -69,7 +69,6 @@
 	onclose(user, "artharvester")
 
 /obj/machinery/artifact_harvester/Process()
-	..()
 	if(stat & (NOPOWER|BROKEN))
 		return
 

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -162,7 +162,6 @@
 		ui.set_auto_update(1)
 
 /obj/machinery/radiocarbon_spectrometer/Process()
-	..()
 	if(scanning)
 		if(!scanned_item || scanned_item.loc != src)
 			scanned_item = null

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -137,6 +137,7 @@
 		return SPAN_NOTICE("Unlock \the [src] first.")
 	if(suspension_field)
 		return SPAN_NOTICE("Turn \the [src] off first.")
+	return ..()
 
 /obj/machinery/suspension_gen/attackby(obj/item/weapon/W, mob/user)
 	if(component_attackby(W, user))

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -16,7 +16,6 @@
 	src.cell = new /obj/item/weapon/cell/high(src)
 
 /obj/machinery/suspension_gen/Process()
-	..()
 	if(suspension_field)
 		cell.use(power_use * CELLRATE)
 

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -5,6 +5,8 @@
 	icon_state = "suspension2"
 	density = 1
 	req_access = list(access_research)
+	construct_state = /decl/machine_construction/default/panel_closed
+
 	var/obj/item/weapon/cell/cell
 	var/obj/item/weapon/card/id/auth_card
 	var/locked = 1
@@ -114,6 +116,8 @@
 		interact(user)
 
 /obj/machinery/suspension_gen/attack_hand(var/mob/user)
+	if(component_attack_hand(user))
+		return TRUE
 	if(!panel_open)
 		interact(user)
 	else if(cell)
@@ -125,9 +129,18 @@
 		cell = null
 		to_chat(user, "<span class='info'>You remove the power cell</span>")
 
-/obj/machinery/suspension_gen/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(!locked && !suspension_field && default_deconstruction_screwdriver(user, W))
-		return
+/obj/machinery/suspension_gen/components_are_accessible(path)
+	return !locked && !suspension_field && ..()
+
+/obj/machinery/suspension_gen/cannot_transition_to(state_path)
+	if(locked)
+		return SPAN_NOTICE("Unlock \the [src] first.")
+	if(suspension_field)
+		return SPAN_NOTICE("Turn \the [src] off first.")
+
+/obj/machinery/suspension_gen/attackby(obj/item/weapon/W, mob/user)
+	if(component_attackby(W, user))
+		return TRUE
 	else if(isWrench(W))
 		if(!suspension_field)
 			if(anchored)

--- a/code/unit_tests/machine_tests.dm
+++ b/code/unit_tests/machine_tests.dm
@@ -1,0 +1,22 @@
+datum/unit_test/machines_shall_obey_part_maximum
+	name = "MACHINE: All mapped machines shall respect their own maximum component limit."
+
+datum/unit_test/machines_shall_obey_part_maximum/start_test()
+	var/failed = list()
+	var/passed = list()
+	for(var/thing in SSmachines.machinery)
+		var/obj/machinery/machine = thing
+		if(passed[machine.type] || failed[machine.type])
+			continue
+		for(var/path in machine.maximum_component_parts)
+			if(machine.number_of_components(path) > machine.maximum_component_parts[path])
+				failed[machine.type] = TRUE
+				log_bad("[log_info_line(machine)] had too many components of type [path].")
+		if(!failed[machine.type])
+			passed[machine.type] = TRUE
+
+	if(length(failed))
+		fail("One or more machine had too many components.")
+	else
+		pass("All machines respected component limits.")
+	return  1

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -14782,7 +14782,6 @@
 /obj/machinery/power/smes/buildable{
 	capacity = 1e+007;
 	charge = 0;
-	cur_coils = 4;
 	RCon_tag = "Solar - Bridge"
 	},
 /obj/item/device/radio/intercom{


### PR DESCRIPTION
:cl:
tweak: Machine interaction has been reworked further. Be ready for some issues.
tweak: You may now install and remove machine components by hand on (some) machines you can build from circuits. To do this, first open the panel with the screwdriver (you may need to make sure the machine is off or other conditions are met). Then either insert a component by clicking on the machine with it, or use a wrench on the machine to remove the component.
/:cl:


Wasn't pleased with the old one. This lets components and machines process independently, and removes the need for mandatory parent calls.

The reason the components don't just process on SSobjs or something is to maintain strict processing order (and potentially let machines impose further checks on whether components should process, etc, down the road).

Also adds datumized machine construction states, currently only implemented for machines using legacy default circuit-based deconstruction. Other machines may exhibit somewhat inconsistent behavior until the next round of stuff.

The upshot is that you can now install and uninstall components freely in the machines which support that via construction states. Most notable with the SMES, but potentially you can upgrade machines by had, juggle parts around from some machines into others, etc. The new power components aren't removable at the moment, but that will be changed soon.