### PR TITLE
Removes the adminspawn breacher from the raider list.

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1054,8 +1054,7 @@ something, make sure it's not in one of the other lists.*/
 				/obj/item/weapon/rig/light/hacker,
 				/obj/item/weapon/rig/light/stealth,
 				/obj/item/weapon/rig/light,
-				/obj/item/weapon/rig/unathi,
-				/obj/item/weapon/rig/unathi/fancy)
+				/obj/item/weapon/rig/unathi)
 
 /obj/random/hostile
 	name = "Random Hostile Mob"


### PR DESCRIPTION
Blame and history are not being clear, but whoever added these to general rotation either didn't understand what they were, or was sneaking in a large buff. The genuine breacher suit was added as adminspawn and even with the nerfs done to it, it's still batshit insane as a piece of gear given to space pirates.