### PR TITLE
Shrouded planets actually weaken lights

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -6,6 +6,7 @@
 	rock_colors = list(COLOR_INDIGO, COLOR_DARK_BLUE_GRAY, COLOR_NAVY_BLUE)
 	map_generators = list(/datum/random_map/noise/exoplanet/shrouded, /datum/random_map/noise/ore/poor)
 	ruin_tags_blacklist = RUIN_HABITAT
+	lightlevel = -0.15
 
 /obj/effect/overmap/sector/exoplanet/shrouded/generate_atmosphere()
 	..()


### PR DESCRIPTION

![](https://i.imgur.com/Xqghf3z.png)
As their description says, they have NEGATIVE LIGHT now so all lights are weaker on the surface
