### PR TITLE
Removes some cameras

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -1226,7 +1226,6 @@
 	},
 /obj/structure/handrai,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/exploration_shuttle,
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1331;
 	master_tag = "calypso_shuttle";
@@ -2128,10 +2127,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -2183,10 +2178,6 @@
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
-	},
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -2302,10 +2293,6 @@
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
 "eX" = (
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 4
-	},
 /obj/structure/handrai{
 	icon_state = "handrail";
 	dir = 4
@@ -2990,18 +2977,6 @@
 "gO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/shuttlefuel)
-"gP" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/floodlight,
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Warehouse Aft";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "gT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/floodlight,
@@ -3460,10 +3435,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"ir" = (
-/obj/machinery/camera/network/hangar,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
 "iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3569,6 +3540,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
 "iE" = (
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Fifth Deck Hallway - Stairwell";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
 "iF" = (
@@ -3679,11 +3654,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/network/exploration{
-	c_tag = "Exploration Equipment";
-	dir = 8;
-	icon_state = "camera"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "iP" = (
@@ -3779,10 +3749,6 @@
 "ja" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Warehouse Fore";
-	dir = 2
 	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
@@ -4071,11 +4037,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/network/exploration{
-	c_tag = "Exploration EVA";
-	dir = 4;
-	icon_state = "camera"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "jF" = (
@@ -4099,11 +4060,6 @@
 "jG" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/machinery/camera/network/exploration{
-	c_tag = "Pilot's Lounge";
-	dir = 4;
-	icon_state = "camera"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/pilot)
 "jH" = (
@@ -4330,7 +4286,6 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/obj/machinery/camera/network/hangar,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "kb" = (
@@ -4967,11 +4922,6 @@
 	},
 /obj/structure/ladder/up,
 /obj/machinery/light/small,
-/obj/machinery/camera/network/hangar{
-	c_tag = "Expedition Storage";
-	dir = 1;
-	icon_state = "camera"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/expedition/storage)
 "lz" = (
@@ -5923,10 +5873,6 @@
 "nA" = (
 /obj/machinery/suit_storage_unit/science,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/expedition{
-	c_tag = "Expedition - EVA Prep";
-	dir = 2
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
 "nB" = (
@@ -6560,21 +6506,12 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
-"oI" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "oJ" = (
 /obj/turbolift_map_holder/torch,
 /turf/unsimulated/mask,
 /area/hallway/primary/fifthdeck/fore)
 "oL" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	icon_state = "camera";
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6584,30 +6521,6 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 21
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"oM" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	icon_state = "camera";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"oN" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	icon_state = "camera";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"oO" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	icon_state = "camera";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -6677,10 +6590,6 @@
 /obj/effect/floor_decal/corner/mauve/half,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/obj/machinery/camera/network/fifth_deck{
-	c_tag = "Fifth Deck Hallway - Lift";
-	dir = 1
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -8169,10 +8078,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/fifth_deck{
-	c_tag = "Fifth Deck Hallway - Stairwell";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rN" = (
@@ -8476,10 +8381,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
 "sp" = (
-/obj/machinery/camera/network/expedition{
-	c_tag = "Expedition - Prep";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
@@ -10656,10 +10557,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
 "yM" = (
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/tank{
 	icon_state = "air_map";
 	dir = 8
@@ -11539,10 +11436,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -11909,10 +11802,6 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow,
-/obj/machinery/camera/network/exploration_shuttle{
-	icon_state = "camera";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "Ds" = (
@@ -11993,10 +11882,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
 "DE" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - EVA";
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = 12
@@ -12050,10 +11935,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Anomaly Aft";
-	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -12265,10 +12146,6 @@
 	pixel_x = -24;
 	pixel_y = 12
 	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Toxins";
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -12332,10 +12209,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "EJ" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Desublimation";
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -12506,10 +12379,6 @@
 /turf/space,
 /area/space)
 "FU" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Hallway Aft";
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	layer = 2.4;
@@ -13250,10 +13119,6 @@
 /area/shuttle/petrov/equipment)
 "IB" = (
 /obj/machinery/disposal,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Fabrication";
-	dir = 2
-	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
 	pixel_y = 24
@@ -14422,10 +14287,6 @@
 "Mz" = (
 /obj/structure/stasis_cage,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Equipment";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/equipment)
 "MB" = (
@@ -15165,10 +15026,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Anomaly Fore";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
 "Pt" = (
@@ -15378,10 +15235,6 @@
 	name = "Biohazard Shutter Control";
 	pixel_x = -5;
 	pixel_y = -3
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Security";
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -15805,10 +15658,6 @@
 /obj/item/weapon/anobattery{
 	pixel_x = 6;
 	pixel_y = 6
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Analysis";
-	dir = 4
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -16807,10 +16656,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Chief Science Officer";
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -33405,7 +33250,7 @@ kU
 aX
 Jn
 aX
-oM
+aX
 zf
 aX
 aX
@@ -33416,7 +33261,7 @@ ev
 aX
 aX
 aX
-oM
+aX
 kU
 aX
 aX
@@ -34835,7 +34680,7 @@ Kz
 gx
 gy
 fS
-oO
+aX
 gO
 gO
 gO
@@ -36224,7 +36069,7 @@ jb
 jb
 sh
 aJ
-ir
+UH
 nN
 ee
 bo
@@ -37058,7 +36903,7 @@ Ho
 Ho
 Ho
 hT
-oO
+aX
 aJ
 mU
 sk
@@ -38446,7 +38291,7 @@ sv
 sw
 sy
 ag
-oI
+aX
 eH
 eT
 eT
@@ -38670,7 +38515,7 @@ aX
 aX
 aX
 kT
-oN
+aX
 iU
 iV
 iV
@@ -40090,7 +39935,7 @@ hR
 iG
 mD
 jl
-gP
+jl
 Em
 uh
 pt

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1378,10 +1378,6 @@
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Mess Hall - Officer's Mess";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/command/captainmess)
 "eB" = (
@@ -1479,10 +1475,6 @@
 /area/maintenance/fourthdeck/starboard)
 "eX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Starboard Escape Pods";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/half{
@@ -2975,10 +2967,6 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Pathfinder's Office";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/command/pathfinder)
 "ki" = (
@@ -3192,6 +3180,10 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Ladders";
+	dir = 2
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
@@ -4033,10 +4025,6 @@
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Fore Starboard";
-	dir = 1
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
@@ -5390,10 +5378,6 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Primary Docking Port";
-	dir = 8
-	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
@@ -6156,10 +6140,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Tool Storage";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "tZ" = (
@@ -6452,10 +6432,6 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/green,
-/obj/machinery/camera/network/supply{
-	c_tag = "Flight Control Tower";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/flightcontrol)
 "uH" = (
@@ -7173,9 +7149,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Fourth Deck - Security Checkpoint"
-	},
 /obj/effect/floor_decal/corner/red/half{
 	icon_state = "bordercolorhalf";
 	dir = 1
@@ -7484,10 +7457,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Fore Port";
-	dir = 2
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -8085,10 +8054,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Port";
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
@@ -8262,10 +8227,6 @@
 /obj/random_multi/single_item/boombox,
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Deck Four";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/hangcheck)
 "AO" = (
@@ -9128,16 +9089,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
-"EW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Lounge Aft";
-	name = "security camera"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
 "EY" = (
 /obj/item/weapon/paper_bin,
 /obj/structure/table/woodentable,
@@ -9810,10 +9761,6 @@
 "Hn" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Ladders";
-	dir = 2
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -12405,10 +12352,6 @@
 /obj/item/weapon/storage/box/detergent{
 	pixel_x = -3
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Laundry Room";
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22;
@@ -13536,10 +13479,6 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "Quartermaster's Office"
 	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Deck Officer";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/deckchief)
 "Si" = (
@@ -13960,12 +13899,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
-"SY" = (
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Adherent Maintenance"
-	},
-/turf/simulated/floor/crystal,
-/area/crew_quarters/adherent)
 "Ta" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14569,10 +14502,6 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Desk";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "UJ" = (
@@ -15546,16 +15475,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
-"Xt" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Lounge Fore";
-	name = "security camera"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
 "Xv" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -16043,10 +15962,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/light,
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Ladders";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "YC" = (
@@ -33582,7 +33497,7 @@ Tp
 mB
 WI
 Sd
-Xt
+ET
 PK
 Zq
 Mu
@@ -35198,7 +35113,7 @@ aY
 Wf
 WI
 Sd
-EW
+ET
 PK
 Pe
 Qt
@@ -39424,7 +39339,7 @@ XT
 XT
 kz
 kz
-SY
+lz
 mP
 nZ
 lz

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -484,9 +484,6 @@
 "bx" = (
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/corner/green/mono,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Hydro Storage"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics/storage)
 "by" = (
@@ -1592,10 +1589,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Hydroponics - Fore";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics)
@@ -1646,10 +1639,6 @@
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
 	dir = 1
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - EVA";
-	dir = 8
 	},
 /obj/machinery/light/small{
 	icon_state = "bulb1";
@@ -2090,9 +2079,6 @@
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/camera/network/third_deck{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "eM" = (
@@ -5918,10 +5904,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Storage";
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
@@ -6272,10 +6254,6 @@
 /area/ai_monitored/storage/eva)
 "nK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Suit Cyclers";
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
@@ -7606,10 +7584,6 @@
 /obj/item/stack/material/glass{
 	amount = 50
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA- Center";
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24;
@@ -7633,10 +7607,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - EVA";
-	dir = 8
-	},
 /obj/effect/catwalk_plated,
 /obj/machinery/alarm{
 	dir = 8;
@@ -7920,9 +7890,6 @@
 /area/hallway/primary/thirddeck/aft)
 "rv" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Holodeck - Center"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 4;
@@ -10144,10 +10111,6 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Firing Range";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/range)
 "wf" = (
@@ -10361,10 +10324,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Miscellaneous Suit Storage";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "wH" = (
@@ -10476,9 +10435,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Teleporter"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -11360,11 +11316,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Diplomatic Quarter";
-	dir = 4;
-	name = "Diplomatic Quarters"
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/diplomat)
 "yz" = (
@@ -11716,10 +11667,6 @@
 /turf/simulated/floor/tiled,
 /area/security/range)
 "zn" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Vacant Offices";
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -12034,10 +11981,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Offices";
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12082,10 +12025,6 @@
 "An" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Suit Storage";
-	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -12313,9 +12252,6 @@
 "AM" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck - Auxillary Storage"
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -13455,14 +13391,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/thirddeck/port)
-"DU" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bluespace Artillery - Storage";
-	dir = 4;
-	network = list("Command")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/bsa)
 "DV" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
@@ -20508,10 +20436,6 @@
 /obj/item/weapon/grenade/chem_grenade/metalfoam,
 /obj/item/weapon/grenade/chem_grenade/metalfoam,
 /obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Hard Storage";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/yellow/half{
 	icon_state = "bordercolorhalf";
 	dir = 8
@@ -20556,10 +20480,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
 "XJ" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Deck Three";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
@@ -43053,7 +42973,7 @@ aa
 Qq
 HX
 DM
-DU
+Pp
 IK
 rG
 Pp

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -653,9 +653,6 @@
 	icon_state = "warning";
 	dir = 4
 	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Prototype SMES"
-	},
 /obj/machinery/light_switch{
 	pixel_x = 6;
 	pixel_y = 24
@@ -4182,9 +4179,6 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Custodial Closet"
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
@@ -4671,9 +4665,6 @@
 	name = "north bump";
 	pixel_x = 0;
 	pixel_y = 24
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Waste Tank"
 	},
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor,
@@ -5495,10 +5486,6 @@
 /area/engineering/engine_room)
 "lQ" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Access";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -6555,9 +6542,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 5
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Central West"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck)
@@ -10209,9 +10193,6 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Robotics - Lower"
-	},
 /obj/machinery/cell_charger,
 /obj/item/organ/internal/posibrain,
 /obj/item/organ/internal/posibrain,
@@ -11577,9 +11558,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
-	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Tech Storage - Main - Center"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
@@ -13505,10 +13483,6 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Fuel Bay";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
 "Fs" = (
@@ -14041,9 +14015,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Monitoring Room"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24;
@@ -14530,15 +14501,14 @@
 /obj/machinery/porta_turret{
 	dir = 8
 	},
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Synthetic Station";
-	dir = 8
-	},
 /obj/machinery/computer/cryopod/robot{
 	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "AI Core - Synthetic Station"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/turret_protected/ai_cyborg_station)
@@ -14736,10 +14706,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
 "Js" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - Entry";
-	dir = 4
-	},
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
 	dir = 8
@@ -15229,16 +15195,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/forestarboard)
-"LD" = (
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Central East"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
 "LF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	icon_state = "intact";
@@ -37453,7 +37409,7 @@ xF
 MH
 KY
 gg
-LD
+oq
 Wi
 Ms
 VE


### PR DESCRIPTION
The following areas do get cameras:
Public spaces.
**Critical** infrastructure control areas.
Reasonable expectation of emergency habitation
Locations (not objects) that have a higher-than-normal expectation of security.

The following areas do not:
Anywhere with a reasonable expectation of privacy. (These areas cannot be viewed into either)
Of note, additionally.
The places that fit the criteria for getting cameras, will only get cameras viewing the critical aspects or areas of high likelihood of habitation.
Camera coverage is not, by design, 100%.

This removes the ability for the AI to control non-critical infrastructure without the use of remote computers.
This is intentional. The AI doesn't need to be a door/shutter/window tint opener.