### PR TITLE
Diona Nascent Gestalt katamari

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_attacks.dm
@@ -3,7 +3,7 @@
 		return
 
 	if(istype(user, /mob/living/carbon/alien/diona) && user.a_intent != I_HURT)
-		take_nymph(user)
+		can_roll_up_atom(user)
 		return
 
 	visible_message("<span class='danger'>\The [user] has [attack_message] \the [src]!</span>")

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_movement.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_movement.dm
@@ -55,4 +55,6 @@
 		return ITEM_SIZE_HUGE
 	if(nymphs.len > 4)
 		return ITEM_SIZE_LARGE
-	return ITEM_SIZE_NORMAL
+	if(nymphs.len > 2)
+		return ITEM_SIZE_NORMAL
+	return ITEM_SIZE_SMALL

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_movement.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_movement.dm
@@ -4,12 +4,11 @@
 // Naaaa na na na na naa naa https://www.youtube.com/watch?v=iMH49ieL4es
 /obj/structure/diona_gestalt/Bump(var/atom/movable/AM, var/yes) // what a useful argname, thanks oldcoders
 	. = ..()
-	if(AM && AM.Adjacent(src))
-		if(AM && can_roll_up_atom(AM) && AM.Adjacent(src))
-			var/turf/stepping = AM.loc
-			roll_up_atom(AM)
-			if(stepping)
-				step_towards(src, stepping)
+	if(AM && can_roll_up_atom(AM) && AM.Adjacent(src))
+		var/turf/stepping = AM.loc
+		roll_up_atom(AM)
+		if(stepping)
+			step_towards(src, stepping)
 
 		
 	else if(istype(AM, /obj/structure/diona_gestalt) && AM != src) // Combine!?

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_movement.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_movement.dm
@@ -4,16 +4,19 @@
 // Naaaa na na na na naa naa https://www.youtube.com/watch?v=iMH49ieL4es
 /obj/structure/diona_gestalt/Bump(var/atom/movable/AM, var/yes) // what a useful argname, thanks oldcoders
 	. = ..()
-	if(AM && valid_things_to_roll_up[AM.type] && AM.Adjacent(src))
-		var/turf/stepping = AM.loc
-		take_nymph(AM)
-		if(stepping)
-			step_towards(src, stepping)
+	if(AM && AM.Adjacent(src))
+		if(AM && can_roll_up_atom(AM) && AM.Adjacent(src))
+			var/turf/stepping = AM.loc
+			roll_up_atom(AM)
+			if(stepping)
+				step_towards(src, stepping)
+
+		
 	else if(istype(AM, /obj/structure/diona_gestalt) && AM != src) // Combine!?
 		var/obj/structure/diona_gestalt/gestalt = AM
 		if(LAZYLEN(gestalt.nymphs))
 			for(var/nimp in gestalt.nymphs)
-				take_nymph(nimp, silent = TRUE)
+				roll_up_atom(nimp, silent = TRUE)
 			gestalt.nymphs.Cut()
 		var/gestalt_loc = gestalt.loc
 		qdel(gestalt)
@@ -23,4 +26,33 @@
 /obj/structure/diona_gestalt/Bumped(var/atom/A)
 	. = ..()
 	if(istype(A, /mob/living/carbon/alien/diona) && A.Adjacent(src)) // Combine...
-		take_nymph(A)
+		roll_up_atom(A)
+
+/obj/structure/diona_gestalt/Move() 
+	. = ..()
+	if(.)
+		for(var/atom/movable/AM in loc)
+			if(can_roll_up_atom(AM))
+				AM.forceMove(src)
+
+/obj/structure/diona_gestalt/proc/can_roll_up_atom(var/atom/movable/thing)
+	if(!istype(thing) || thing.anchored || !thing.simulated)
+		return FALSE
+	if(valid_things_to_roll_up[thing.type])
+		return TRUE
+	if(istype(thing, /obj))
+		var/obj/rolling_up = thing
+		return rolling_up.w_class <= get_max_item_rollup_size()
+	if(istype(thing, /mob))
+		var/mob/rolling_up = thing
+		return rolling_up.mob_size <= MOB_SMALL
+	return FALSE
+
+/obj/structure/diona_gestalt/proc/get_max_item_rollup_size()
+	if(nymphs.len > 9)
+		return ITEM_SIZE_GARGANTUAN
+	if(nymphs.len > 6)
+		return ITEM_SIZE_HUGE
+	if(nymphs.len > 4)
+		return ITEM_SIZE_LARGE
+	return ITEM_SIZE_NORMAL

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_nymph.dm
@@ -5,16 +5,19 @@
 		return FALSE
 	visible_message("<span class='notice'>\The [chirp] and \the [src] twine together in gestalt!</span>")
 	var/obj/structure/diona_gestalt/blob = new(get_turf(src))
-	blob.take_nymph(chirp, silent = TRUE)
-	blob.take_nymph(src, silent = TRUE)
+	blob.roll_up_atom(chirp, silent = TRUE)
+	blob.roll_up_atom(src, silent = TRUE)
 	return TRUE
 
-/obj/structure/diona_gestalt/proc/take_nymph(var/mob/living/carbon/alien/diona/chirp, var/silent)
+/obj/structure/diona_gestalt/proc/roll_up_atom(var/mob/living/carbon/alien/diona/chirp, var/silent)
+	if(!istype(chirp))
+		return
 	if(!silent)
 		visible_message("<span class='notice'>\The [chirp] is engulfed by \the [src].</span>")
-	nymphs[chirp] = TRUE
+	if(istype(chirp, /mob/living/carbon/alien/diona))
+		nymphs[chirp] = TRUE
+		queue_icon_update()
 	chirp.forceMove(src)
-	update_icon()
 
 /obj/structure/diona_gestalt/proc/shed_nymph(var/mob/living/carbon/alien/diona/nymph, var/silent, var/forcefully)
 	if(!nymph && LAZYLEN(nymphs))


### PR DESCRIPTION
:cl: NobleCaos
Tweak: Diona Nascent Gestalts can now katamari up items as well as nymphs based on the amount of nymphs in the gestalt
/:cl:
forceMove s items in to the nascent gestalt upon moving to the same loc.
Item size is based on amount of nymphs in gestalt.
Part of a greater Diona rework, but this was the simplest starting point.

Thanks to @MistakeNot4892 and @afterthought2 for code help and... copy pasting.