### PR TITLE
Picks out deconstruct cleanup; minor code improvements.

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -129,7 +129,13 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 
 #define MESSAGE_RESEND_TIME 5	//how long (in seconds) do we wait before resending a message
 
+// obj/item/weapon/stock_parts status flags
 #define PART_STAT_INSTALLED  1
 #define PART_STAT_PROCESSING 2
 #define PART_STAT_ACTIVE     4
 #define PART_STAT_CONNECTED  8
+
+// part_flags
+#define PART_FLAG_LAZY_INIT   1 // Will defer init on stock parts until machine is destroyed or parts are otherwise queried.
+#define PART_FLAG_QDEL        2 // Will delete on uninstall
+#define PART_FLAG_HAND_REMOVE 4 // Can be removed by hand

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -342,10 +342,10 @@ Class Procs:
 	M.state = 2
 	M.icon_state = "box_1"
 	for(var/I in component_parts)
-		uninstall_component(I)
+		uninstall_component(I, refresh_parts = FALSE)
 	while(LAZYLEN(uncreated_component_parts))
 		var/path = uncreated_component_parts[1]
-		uninstall_component(path)
+		uninstall_component(path, refresh_parts = FALSE)
 
 	qdel(src)
 	return 1

--- a/code/game/machinery/machinery_components.dm
+++ b/code/game/machinery/machinery_components.dm
@@ -36,13 +36,6 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		if(ispath(path, part_type))
 			.[path] += uncreated_component_parts[path]
 
-/obj/machinery/proc/component_is_installed(var/obj/item/part)
-	. = FALSE
-	if(part in component_parts)
-		return TRUE
-	if(LAZYACCESS(uncreated_component_parts, part.type) && (part in src))
-		return TRUE
-
 // Returns a component instance of the given type, or null if no such type is present.
 /obj/machinery/proc/get_component_of_type(var/part_type)
 	. = locate(part_type) in component_parts
@@ -59,8 +52,13 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 // If an instance is given or created, it is returned, otherwise null is returned.
 /obj/machinery/proc/install_component(var/obj/item/weapon/stock_parts/part, force = FALSE, refresh_parts = TRUE)
 	if(ispath(part))
-		if(force || !(ispath(part, /obj/item/weapon/stock_parts) && initial(part.lazy_initialize)))
+		if(force || !(ispath(part, /obj/item/weapon/stock_parts) && initial(part.part_flags) & PART_FLAG_LAZY_INIT))
 			part = new part(src) // Forced to make, or we don't lazy-init, so create.
+
+			if(istype(part, /obj/item/stack)) // Compatibility with legacy construction code
+				var/obj/item/stack/stack = part
+				stack.amount = 1
+
 			. = part
 	else
 		part.forceMove(src) // Were given an instance to begin with.
@@ -83,22 +81,22 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		RefreshParts()
 
 // This will force-init components.
-/obj/machinery/proc/uninstall_component(var/obj/item/weapon/stock_parts/part)
+/obj/machinery/proc/uninstall_component(var/obj/item/weapon/stock_parts/part, refresh_parts = TRUE)
 	if(ispath(part))
 		part = get_component_of_type(part)
-	else if(!component_is_installed(part))
+	else if(!(part in component_parts))
 		return
 
 	if(istype(part))
 		part.on_uninstall(src)
 		LAZYREMOVE(component_parts, part)
+		if(refresh_parts)
+			RefreshParts()
 		if(QDELETED(part)) // unremovable stuff
 			return
-
-	part.dropInto(loc)
-	GLOB.destroyed_event.unregister(part, src)
-	RefreshParts()
-	return part
+		part.dropInto(loc)
+		GLOB.destroyed_event.unregister(part, src)
+		return part
 
 /obj/machinery/proc/component_destroyed(var/obj/item/component)
 	GLOB.destroyed_event.unregister(component, src)
@@ -125,7 +123,7 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 
 // Use to block interactivity if panel is not open, etc.
 /obj/machinery/proc/components_are_accessible(var/path)
-	return TRUE
+	return panel_open
 
 // Hook to get updates.
 /obj/machinery/proc/component_stat_change(var/obj/item/weapon/stock_parts/part, old_stat, flag)

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -18,7 +18,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 15
-	lazy_initialize = FALSE
+	part_flags = 0
 	var/build_path = null
 	var/board_type = "computer"
 	var/list/req_components = null

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -621,11 +621,11 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 /obj/item/stack/cable_coil/transfer_to(obj/item/stack/cable_coil/S)
 	if(!istype(S))
-		return
+		return 0
 	if(!(can_merge(S) || S.can_merge(src)))
-		return
+		return 0
 
-	..()
+	return ..()
 
 ///////////////////////////////////////////////
 // Cable laying procedures

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -12,6 +12,7 @@
 	anchored = 1
 	clicksound = "switch"
 	power_channel = LOCAL // Draws power from direct connections to powernets.
+	stat = BROKEN         // Should be removed if the terminals initialize fully.
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 1e6 // actual charge
@@ -80,6 +81,7 @@
 			if(term.dir == turn(d, 180) && !term.master)
 				part.set_terminal(src, term)
 				term.connect_to_network()
+		
 
 /obj/machinery/power/smes/add_avail(var/amount)
 	if(..(amount))

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -14,7 +14,7 @@
 	w_class = ITEM_SIZE_LARGE							// It's LARGE (backpack size)
 	origin_tech = list(TECH_MATERIAL = 7, TECH_POWER = 7, TECH_ENGINEERING = 5)
 	base_type = /obj/item/weapon/stock_parts/smes_coil
-	lazy_initialize = FALSE
+	part_flags = PART_FLAG_HAND_REMOVE
 	var/ChargeCapacity = 50 KILOWATTS
 	var/IOCapacity = 250 KILOWATTS
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -22,11 +22,10 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	randpixel = 5
 	w_class = ITEM_SIZE_SMALL
+	var/part_flags = PART_FLAG_LAZY_INIT | PART_FLAG_HAND_REMOVE
 	var/rating = 1
-	var/lazy_initialize = TRUE // Will defer init on stock parts until machine is destroyed or parts are otherwise queried.
 	var/status = 0             // Flags using PART_STAT defines.
 	var/base_type              // Type representing parent of category for replacer usage.
-	var/can_be_uninstalled = TRUE // If false, will qdel on uninstall and should not be exposed to the user for uninstallation.
 
 /obj/item/weapon/stock_parts/attack_hand(mob/user)
 	if(istype(loc, /obj/machinery))
@@ -57,7 +56,7 @@
 /obj/item/weapon/stock_parts/proc/on_uninstall(var/obj/machinery/machine)
 	unset_status(machine, PART_STAT_INSTALLED)
 	stop_processing(machine)
-	if(!can_be_uninstalled)
+	if(part_flags & PART_FLAG_QDEL)
 		qdel(src)
 
 // Use to process on the machine it's installed on.
@@ -285,7 +284,7 @@
 	desc = "Various standard wires, pipes, and other materials."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"
-	lazy_initialize = FALSE
+	part_flags = PART_FLAG_QDEL
 	var/list/materials
 
 /obj/item/weapon/stock_parts/building_material/Destroy()
@@ -296,10 +295,8 @@
 	if(istype(new_material, /obj/item/stack))
 		var/obj/item/stack/stack = new_material
 		for(var/obj/item/stack/old_stack in materials)
-			if(old_stack.stacktype == stack.stacktype)
-				stack.transfer_to(old_stack, stack.amount)
-				if(QDELETED(stack))
-					return
+			if(stack.transfer_to(old_stack) && QDELETED(stack))
+				return
 	LAZYADD(materials, new_material)
 	new_material.forceMove(null)
 
@@ -324,8 +321,7 @@
 			return item
 
 /obj/item/weapon/stock_parts/building_material/on_uninstall(var/obj/machinery/machine)
-	..()
 	for(var/obj/item/I in materials)
 		I.dropInto(loc)
 	materials = null
-	qdel(src)
+	..()


### PR DESCRIPTION
This contains some parts of #25818 which fix deconstruct/construct code a bit and add part flags, in case that takes a while to review. Currently machines return wildly unreasonable quantities of cable coils if deconstructed.

Fixes #25858.