### PR TITLE
Sets default value for autoset access in airlock boards to on

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -16,7 +16,7 @@
 	var/last_configurator = null
 	var/locked = 1
 	var/lockable = 1
-	var/autoset = FALSE // Whether the door should inherit access from surrounding areas
+	var/autoset = TRUE // Whether the door should inherit access from surrounding areas
 
 /obj/item/weapon/airlock_electronics/attack_self(mob/user)
 	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))


### PR DESCRIPTION
A small QOL change for engineers - 99% of the time, you're installing an airlock board into a door that should be autoset anyway, and most people don't bother to actually set this flag or manually set access when installing a board.

:cl:
tweak: Airlock control boards now have 'Autoset Access' enabled by default.
/:cl: