### PR TITLE
Fixes power channel swapping.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -76,6 +76,7 @@
 	anchored = 1
 	use_power = POWER_USE_IDLE // Has custom handling here.
 	power_channel = LOCAL      // Do not manipulate this; you don't want to power the APC off itself.
+	interact_offline = TRUE    // Can use UI even if unpowered
 	uncreated_component_parts = list(
 		/obj/item/weapon/stock_parts/power/terminal,
 		/obj/item/weapon/stock_parts/power/apc,

--- a/code/modules/power/power_usage.dm
+++ b/code/modules/power/power_usage.dm
@@ -117,11 +117,10 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power)
 
 /obj/machinery/proc/update_power_channel(new_channel)
+	if(power_channel == new_channel)
+		return
 	if(!power_init_complete)
 		power_channel = new_channel
-		return
-	var/old_channel = power_channel
-	if(old_channel == old_channel)
 		return
 	var/power = get_power_usage()
 	REPORT_POWER_CONSUMPTION_CHANGE(power, 0)


### PR DESCRIPTION
Fixes #25862. Power channel swapping was almost never used before recently, so this slipped past.

Partly fixes the issues with apc interaction and no power, but a full fix requires the attack_hand changes in #25818 and maybe even more on top of that.