### PR TITLE
Makes traitor robots always get their emag items, gives cultivator an emag item

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -80,6 +80,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 		if(istype(traitor_mob, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = traitor_mob
 			R.SetLockdown(0)
+			R.emagged = 1 // Provides a traitor robot with its module's emag item
 		return 1
 
 	if(!..())

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
@@ -20,3 +20,4 @@
 		/obj/item/device/scanner/plant,
 		/obj/item/weapon/robot_harvester
 	)
+	emag = /obj/item/weapon/melee/energy/machete


### PR DESCRIPTION
🆑 MikoMyazaki
rscadd: Traitor robots always get their emag items.
rscadd: Cultivator drone now has an emag item, an energy machete.
/🆑

Traitors get all sorts of neat toys, unless they are a robot.
This change makes it so that robots get access to their emag item when they are made a traitor - So they get something to antagonise with.

Gives the Cultivator Drone an energy machete as an emag item, as it is the only module without an emag item.

(A side effect of this change is that it won't be possible to emag a traitor borg and change their laws to syndicate laws. However this does not change anything in practice, as a traitor borg can always ignore their lawset in favour of their zeroth law.)