### PR TITLE
Makes can_fall() args defined consistently, avoids a runtime.

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -47,7 +47,7 @@
 /mob/living/silicon/robot/flying/Allow_Spacemove()
 	return (pass_flags & PASS_FLAG_TABLE) || ..()
 
-/mob/living/silicon/robot/flying/can_fall()
+/mob/living/silicon/robot/flying/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	return !Allow_Spacemove()
 
 /mob/living/silicon/robot/flying/can_overcome_gravity()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -195,7 +195,7 @@
 	if(is_client_moving) M.moving = 0
 
 //For children to override
-/atom/movable/proc/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = src.loc)
+/atom/movable/proc/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	if(!simulated)
 		return FALSE
 
@@ -215,16 +215,16 @@
 
 	return TRUE
 
-/obj/can_fall()
+/obj/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	return ..(anchor_fall)
 
-/obj/effect/can_fall()
+/obj/effect/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	return FALSE
 
-/obj/effect/decal/cleanable/can_fall()
+/obj/effect/decal/cleanable/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	return TRUE
 
-/obj/item/pipe/can_fall()
+/obj/item/pipe/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	var/turf/simulated/open/below = loc
 	below = below.below
 
@@ -236,7 +236,7 @@
 	if((locate(/obj/structure/disposalpipe/up) in below) || locate(/obj/machinery/atmospherics/pipe/zpipe/up) in below)
 		return FALSE
 
-/mob/living/carbon/human/can_fall()
+/mob/living/carbon/human/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	if(..())
 		return species.can_fall(src)
 

--- a/code/modules/multiz/zshadow.dm
+++ b/code/modules/multiz/zshadow.dm
@@ -13,7 +13,7 @@
 	//auto_init = FALSE 			// We do not need to be initialize()d
 	var/mob/owner = null		// What we are a shadow of.
 
-/mob/zshadow/can_fall()
+/mob/zshadow/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
 	return FALSE
 
 /mob/zshadow/New(var/mob/L)


### PR DESCRIPTION
Prevents a runtime when mobs are checked for falling.