### PR TITLE
Power tally fixes

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -242,6 +242,7 @@ area/space/atmosalert()
 	process()
 
 /area/beach/Entered(atom/movable/Obj,atom/OldLoc)
+	. = ..()
 	if(ismob(Obj))
 		var/mob/M = Obj
 		if(M.client)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -43,7 +43,14 @@
 	A.contents.Add(T)
 	if(old_area)
 		old_area.Exited(T, A)
+		for(var/atom/movable/AM in T)
+			old_area.Exited(AM, A)  // Note: this _will_ raise exited events.
 	A.Entered(T, old_area)
+	for(var/atom/movable/AM in T)
+		A.Entered(AM, old_area) // Note: this will _not_ raise moved or entered events. If you change this, you must also change everything which uses them.
+
+	for(var/obj/machinery/M in T)
+		M.area_changed(old_area, A) // They usually get moved events, but this is the one way an area can change without triggering one.
 
 /area/proc/get_contents()
 	return contents

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -72,6 +72,7 @@
 	. = ..()
 
 /turf/simulated/Entered(atom/A, atom/OL)
+	. = ..()
 	if (istype(A,/mob/living))
 		var/mob/living/M = A
 
@@ -106,7 +107,7 @@
 				bloodDNA = null
 
 		if(M.lying)
-			return ..()
+			return
 
 		if(src.wet)
 
@@ -134,8 +135,6 @@
 				M.inertia_dir = 0
 		else
 			M.inertia_dir = 0
-
-	..()
 
 //returns 1 if made bloody, returns 0 otherwise
 /turf/simulated/add_blood(mob/living/carbon/human/M as mob)

--- a/code/modules/mob/living/silicon/ai/power.dm
+++ b/code/modules/mob/living/silicon/ai/power.dm
@@ -200,7 +200,6 @@
 /obj/machinery/ai_powersupply/New(var/mob/living/silicon/ai/ai=null)
 	powered_ai = ai
 	powered_ai.psupply = src
-	forceMove(powered_ai)
 	..()
 
 /obj/machinery/ai_powersupply/Destroy()

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -109,6 +109,7 @@
 		START_PROCESSING(SSobj, src)
 
 /turf/simulated/floor/exoplanet/lava/Exited(atom/movable/AM)
+	. = ..()
 	LAZYREMOVE(victims, weakref(AM))
 
 /turf/simulated/floor/exoplanet/lava/Process()

--- a/code/modules/power/power_usage.dm
+++ b/code/modules/power/power_usage.dm
@@ -92,17 +92,20 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	. = ..()
 
 /obj/machinery/proc/update_power_on_move(atom/movable/mover, atom/old_loc, atom/new_loc)
+	area_changed(get_area(old_loc), get_area(new_loc))
+
+/obj/machinery/proc/area_changed(area/old_area, area/new_area)
+	if(old_area == new_area)
+		return
 	var/power = get_power_usage()
 	if(!power)
 		return // This is the most likely case anyway.
-	var/area/old_area = get_area(old_loc)
-	var/area/new_area = get_area(new_loc)
-	if(old_area != new_area)
-		if(old_area)
-			old_area.power_use_change(power, 0, power_channel)
-		if(new_area)
-			new_area.power_use_change(0, power, power_channel)
-		power_change() // Force check in case the old area was powered and the new one isn't or vice versa.
+
+	if(old_area)
+		old_area.power_use_change(power, 0, power_channel)
+	if(new_area)
+		new_area.power_use_change(0, power, power_channel)
+	power_change() // Force check in case the old area was powered and the new one isn't or vice versa.
 
 // The three procs below are the only allowed ways of modifying the corresponding variables.
 /obj/machinery/proc/update_use_power(new_use_power)


### PR DESCRIPTION
This will fix shuttles and the AI core messing up power values.

Note that area/Entered does not call parent, meaning it does not pick up entered or moved events. For moved events this is arguably correct, as in this case the loc is not an area (loc can be an area, and using forceMove(area) will correctly call the moved event, though you should never do this). For Entered events this is questionable at best, given that Exited events do pick up area/Exited. In any case, I don't change either here and hook into ChangeArea directly instead. Changing them would potentially require updating their listeners' expectations.

Wet turfs seem to call parent in Entered inconsistently, so I fix that here.