### PR TITLE
Suggested safety check on player_list.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2,6 +2,7 @@
 	STOP_PROCESSING(SSmobs, src)
 	GLOB.dead_mob_list_ -= src
 	GLOB.living_mob_list_ -= src
+	GLOB.player_list -= src
 	unset_machine()
 	QDEL_NULL(hud_used)
 	if(istype(skillset))


### PR DESCRIPTION
mob/Logout is known to not be called consistently; I'm not sure as to why and whether or not that's our issue. It may instead be necessary to put this in mob/Del, or that neither is sufficient. I'm not sure.

Closes #22315.

This is a runtime that, if it occurs, will be spammed tens of thousands of times. If it's reopened, I'll do a localized fix for the place it's triggered.