### PR TITLE
Mapping fixes + Piping fixes + thruster fixes

### DIFF
--- a/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
@@ -41,7 +41,7 @@
 	name = "gas pump"
 	desc = "a pump. For gasses."
 	build_path = /obj/item/pipe
-	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "pump"
 	constructed_path = /obj/machinery/atmospherics/binary/pump
 	pipe_class = PIPE_CLASS_BINARY
@@ -50,7 +50,7 @@
 	name = "pressure regulator"
 	desc = "a device that regulates pressure."
 	build_path = /obj/item/pipe
-	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "passivegate"
 	constructed_path = /obj/machinery/atmospherics/binary/passive_gate
 	pipe_class = PIPE_CLASS_BINARY
@@ -59,7 +59,7 @@
 	name = "high powered gas pump"
 	desc = "a high powered pump. For gasses."
 	build_path = /obj/item/pipe
-	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "volumepump"
 	constructed_path = /obj/machinery/atmospherics/binary/pump/high_power
 	pipe_class = PIPE_CLASS_BINARY

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -25,7 +25,7 @@
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
-	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "passivegate"
 
 /obj/machinery/atmospherics/binary/passive_gate/on

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -33,7 +33,7 @@ Thus, the two variables affect pump operation are set in New():
 	var/frequency = 0
 	var/id = null
 	var/datum/radio_frequency/radio_connection
-	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "pump"
 
 /obj/machinery/atmospherics/binary/pump/Initialize()

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -8,6 +8,7 @@
 
 	idle_power_usage = 450	// oversized pumps means oversized idle use
 	power_rating = 45000	// 45000 W ~ 60 HP
+	build_icon_state = "volumepump"
 
 /obj/machinery/atmospherics/binary/pump/high_power/on
 	use_power = POWER_USE_IDLE

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -47,19 +47,24 @@
 	power_rating = 7500			//7500 W ~ 10 HP
 	opacity = 1
 	density = 1
-	atmos_canpass = CANPASS_DENSITY
+	atmos_canpass = CANPASS_NEVER
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	var/on = 1
 	var/datum/ship_engine/gas_thruster/controller
 	var/thrust_limit = 1	//Value between 1 and 0 to limit the resulting thrust
 	var/volume_per_burn = 20 //litres
 
+/obj/machinery/atmospherics/unary/engine/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	return 0
+
 /obj/machinery/atmospherics/unary/engine/Initialize()
 	. = ..()
 	controller = new(src)
+	update_nearby_tiles(need_rebuild=1)
 
 /obj/machinery/atmospherics/unary/engine/Destroy()
 	QDEL_NULL(controller)
+	update_nearby_tiles()
 	. = ..()
 
 /obj/machinery/atmospherics/unary/engine/proc/get_status()

--- a/code/modules/shuttles/shuttle_engines.dm
+++ b/code/modules/shuttles/shuttle_engines.dm
@@ -22,6 +22,7 @@
 /obj/structure/shuttle/engine/heater
 	name = "heater"
 	icon_state = "heater"
+	atom_flags = ATOM_FLAG_CLIMBABLE
 
 /obj/structure/shuttle/engine/platform
 	name = "platform"

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -81,6 +81,13 @@
 "an" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/fore)
+"ao" = (
+/obj/effect/paint/red,
+/obj/structure/sign/warning/hot_exhaust{
+	dir = 1
+	},
+/turf/simulated/wall/titanium,
+/area/guppy_hangar/start)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -596,13 +603,6 @@
 	dir = 4;
 	id = "guppy_hatch";
 	name = "Rear Hatch"
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "guppy_hatch";
-	name = "Rear Hatch Control";
-	pixel_x = 0;
-	pixel_y = -32;
-	req_access = list("ACCESS_TORCH_GUP")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -1820,9 +1820,9 @@
 /area/hallway/primary/fifthdeck/aft)
 "dT" = (
 /obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/machinery/atmospherics/unary/tank/carbon_dioxide{
+	dir = 4;
+	start_pressure = 1013.25
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
@@ -1837,9 +1837,10 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/binary/pump{
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "dV" = (
@@ -1907,11 +1908,12 @@
 	icon_state = "intact";
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -1963,13 +1965,13 @@
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "eg" = (
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/atmospherics/unary/tank/carbon_dioxide{
-	dir = 4;
-	start_pressure = 1013.25
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
@@ -1979,10 +1981,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1993,9 +1992,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -2099,9 +2100,6 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "eq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -4230,7 +4228,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass/mining{
 	id_tag = null;
-	name = "Shuttle Fuel Bay Interior"
+	name = "Shuttle Fuel Bay Interior";
+	normalspeed = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4251,7 +4250,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass/mining{
 	id_tag = null;
-	name = "Shuttle Fuel Bay Interior"
+	name = "Shuttle Fuel Bay Interior";
+	normalspeed = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11080,7 +11080,8 @@
 /area/shuttle/petrov/equipment)
 "Ar" = (
 /obj/machinery/atmospherics/unary/tank/air{
-	dir = 4
+	dir = 4;
+	start_pressure = 4559.63
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
@@ -11805,6 +11806,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
+"Dc" = (
+/obj/effect/paint/hull,
+/obj/machinery/button/remote/blast_door{
+	id = "guppy_hatch";
+	name = "Rear Hatch Control";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_access = list("ACCESS_TORCH_GUP")
+	},
+/turf/simulated/wall/titanium,
+/area/guppy_hangar/start)
 "Dd" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
@@ -12603,7 +12615,7 @@
 	icon_state = "nosmoking";
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/binary/pump{
+/obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1;
 	name = "CO2 to Hangar"
 	},
@@ -15212,6 +15224,9 @@
 /obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
@@ -37438,7 +37453,7 @@ Ea
 aJ
 aX
 ee
-aY
+ao
 aY
 bH
 cf
@@ -38249,7 +38264,7 @@ ee
 ba
 aY
 bL
-cj
+Dc
 cj
 cj
 cj

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1462,7 +1462,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
 "do" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
@@ -7463,6 +7463,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/crew_quarters/mess)
 "pZ" = (
@@ -9723,6 +9724,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/cryo)
 "uS" = (
@@ -11507,13 +11509,10 @@
 /obj/machinery/door/airlock/civilian{
 	name = "Head"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/cryo)
 "zc" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -12053,10 +12052,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
@@ -16251,6 +16246,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 21
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "Lg" = (
@@ -17077,6 +17075,11 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3port)
+"Nw" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/crew_quarters/mess)
 "Nx" = (
 /obj/machinery/light{
 	dir = 1
@@ -19352,7 +19355,7 @@
 /turf/simulated/floor/plating,
 /area/vacant/brig)
 "UE" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small{
 	dir = 1
@@ -20836,6 +20839,11 @@
 "YN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -21;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "YP" = (
@@ -38909,7 +38917,7 @@ XO
 jn
 RN
 jj
-qb
+Nw
 qQ
 sk
 tI
@@ -39111,7 +39119,7 @@ jd
 nj
 Lx
 fu
-qb
+Nw
 Xn
 sj
 tJ

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -31122,6 +31122,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/item/weapon/storage/mirror{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/washroom)
 "vhs" = (


### PR DESCRIPTION
🆑
bugfix: Shuttle thruster now block air and fire; shuttles are more fireproof and less gas contamination should occur.
tweak: Shuttle engine heater, are now climbable.
maptweak: Medical bathroom now has a mirror, for all your post radiation treatment needs.
maptweak: Charon atmospheric compartment has been returned to its previous state.
maptweak: Hanger fuel bay now has a high power pump, to reduce prep time.
/🆑
Fixed high power pump icon being buggy

Made thrusters block air and fire. Shuttles are now a tiny bit more fire proof.
Make heater climbable for more shenanigans

Deck 1
Added a mirror to medbay toilet, (medbay's private wig collection for radiation victim)
![dreammaker_JYH5MlIwqT](https://user-images.githubusercontent.com/43085828/59923561-12445d00-9477-11e9-8d65-e9bcebcfb749.png)

Deck 5
Fixed charon scrubber
Increase charon air supply (less dying from a vented cargobay)
(subjectively) Better than #25901 😁 
![dreammaker_kJQeB4fj2S](https://user-images.githubusercontent.com/43085828/59923557-0eb0d600-9477-11e9-8b7d-78edc7d50a44.png)

Made fuel bay pump a high powered pump (quality of life)
Made fuel bay close instantly to prevent leaks
![dreammaker_u0u9DAbkFq](https://user-images.githubusercontent.com/43085828/59923581-1a9c9800-9477-11e9-9015-2dfc010e1f30.png)

Deck 3
Fixed weird fire alarm in deck 3 toilets
Shuffled scrubber and locker in maint
Added extra fire alarm doors to mess and bathroom
![dreammaker_RCqlWiH3fZ](https://user-images.githubusercontent.com/43085828/59923599-25efc380-9477-11e9-9682-0f406a2d5ebd.png)