### PR TITLE
Resolves issues with pipe deconstruction.

### DIFF
--- a/code/__defines/atmospherics.dm
+++ b/code/__defines/atmospherics.dm
@@ -1,75 +1,7 @@
-//Simple pipes. Values: 100-199
-#define PIPE_SIMPLE_STRAIGHT        100
-#define PIPE_SIMPLE_BENT            101
-#define PIPE_MANIFOLD               102
-#define PIPE_MANIFOLD4W             103
-#define PIPE_UP                     104
-#define PIPE_DOWN                   105
-#define PIPE_CAP                    106
-
-//Supply Pipes. Values: 200-299
-#define PIPE_SUPPLY_STRAIGHT        200
-#define PIPE_SUPPLY_BENT            201
-#define PIPE_SUPPLY_MANIFOLD        202
-#define PIPE_SUPPLY_MANIFOLD4W      203
-#define PIPE_SUPPLY_UP              204
-#define PIPE_SUPPLY_DOWN            205
-#define PIPE_SUPPLY_CAP             206
-
-//Scrubber Pipes. Values: 300-399
-#define PIPE_SCRUBBERS_STRAIGHT     300
-#define PIPE_SCRUBBERS_BENT         301
-#define PIPE_SCRUBBERS_MANIFOLD     302
-#define PIPE_SCRUBBERS_MANIFOLD4W   303
-#define PIPE_SCRUBBERS_UP           304
-#define PIPE_SCRUBBERS_DOWN         305
-#define PIPE_SCRUBBERS_CAP          306
-
-//Fuel Pipes. Values: 400-499
-#define PIPE_FUEL_STRAIGHT          400
-#define PIPE_FUEL_BENT              401
-#define PIPE_FUEL_MANIFOLD          402
-#define PIPE_FUEL_MANIFOLD4W        403
-#define PIPE_FUEL_UP                404
-#define PIPE_FUEL_DOWN              405
-#define PIPE_FUEL_CAP               406
-
-//Heat Exchange Pipes. Values: 500-599
-#define PIPE_HE_STRAIGHT            500
-#define PIPE_HE_BENT                501
-//Reserved for Manifold             502
-//Reserved for Manifold4W           503
-//Reserved for Up                   504
-//Reserved for Down                 505
-//Reserved for Cap                  506
-#define PIPE_JUNCTION               507
-#define PIPE_HEAT_EXCHANGE          508
-
-//Any new pipe types should be defined in range 600-900
-
-//This should always be set to the start of the "equipment" range
-//If the equipment range gets changed, this value needs to be changed.
-#define PIPE_UTILITY_START          1000
-
-//Utility/Equipment Pipes. Values: 1000-1099
-#define PIPE_CONNECTOR              1000
-#define PIPE_UVENT                  1001
-#define PIPE_MVALVE                 1002
-#define PIPE_DVALVE                 1003
-#define PIPE_PUMP                   1004
-#define PIPE_SCRUBBER               1005
-#define PIPE_PASSIVE_GATE           1006
-#define PIPE_VOLUME_PUMP            1007
-#define PIPE_MTVALVE                1008
-#define PIPE_OMNI_MIXER             1009
-#define PIPE_OMNI_FILTER            1010
-#define PIPE_UNIVERSAL              1011
-#define PIPE_MTVALVEM               1012
-#define PIPE_SVALVE                 1013
-#define PIPE_INJECTOR               1014
-#define PIPE_DTVALVE                1015
-#define PIPE_DTVALVEM               1016
-#define PIPE_TANK                   1017
+// For use with pipe rotate verb
+#define PIPE_ROTATE_STANDARD 0 // usual rotate
+#define PIPE_ROTATE_TWODIR   1 // Sanitizes cardinal directions to just two, leaves corner directions alone
+#define PIPE_ROTATE_ONEDIR   2 // Only has one dir, south
 
 //Connection Type Definitions
 #define CONNECT_TYPE_REGULAR        1

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(atoms)
 	init_order = SS_INIT_ATOMS
 	flags = SS_NO_FIRE
 
-	var/init_state
+	var/init_state = INITIALIZATION_INSSATOMS
 	var/old_init_state
 
 	var/list/late_loaders

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -27,7 +27,6 @@
 	. = ..()
 	icon = 'icons/obj/cryogenics_split.dmi'
 	update_icon()
-	initialize_directions = dir
 	atmos_init()
 
 /obj/machinery/atmospherics/unary/cryo_cell/Destroy()

--- a/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
@@ -8,17 +8,16 @@
 	name = "universal pipe adapter"
 	desc = "an adapter designed to fit any type of pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_UNIVERSAL
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_FUEL|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_HE
 	build_icon_state = "universal"
 	constructed_path = /obj/machinery/atmospherics/pipe/simple/hidden/universal
 	pipe_class = PIPE_CLASS_BINARY
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/device/connector
 	name = "connector"
 	desc = "a connector for canisters."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_CONNECTOR
 	connect_types = CONNECT_TYPE_REGULAR
 	build_icon_state = "connector"
 	constructed_path = /obj/machinery/atmospherics/portables_connector
@@ -28,7 +27,6 @@
 	name = "unary vent"
 	desc = "a unary vent"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_UVENT
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_FUEL
 	build_icon_state = "uvent"
 	constructed_path = /obj/machinery/atmospherics/unary/vent_pump
@@ -43,7 +41,6 @@
 	name = "gas pump"
 	desc = "a pump. For gasses."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_PUMP
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	build_icon_state = "pump"
 	constructed_path = /obj/machinery/atmospherics/binary/pump
@@ -53,7 +50,6 @@
 	name = "pressure regulator"
 	desc = "a device that regulates pressure."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_PASSIVE_GATE
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	build_icon_state = "passivegate"
 	constructed_path = /obj/machinery/atmospherics/binary/passive_gate
@@ -63,7 +59,6 @@
 	name = "high powered gas pump"
 	desc = "a high powered pump. For gasses."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_VOLUME_PUMP
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	build_icon_state = "volumepump"
 	constructed_path = /obj/machinery/atmospherics/binary/pump/high_power
@@ -73,7 +68,6 @@
 	name = "scrubber"
 	desc = "scrubs out undesirable gasses"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBER
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER
 	build_icon_state = "scrubber"
 	constructed_path = /obj/machinery/atmospherics/unary/vent_scrubber
@@ -83,7 +77,6 @@
 	name = "meter"
 	desc = "a meter that monitors pressure and temperature on the attached pipe."
 	build_path = /obj/item/pipe_meter
-	pipe_type = null
 	pipe_color = null
 	connect_types = null
 	colorable = FALSE
@@ -95,7 +88,6 @@
 	name = "omni gas mixer"
 	desc = "a device that takes in two or three gasses and mixes them into a precise output."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_OMNI_MIXER
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "omni_mixer"
 	constructed_path = /obj/machinery/atmospherics/omni/mixer
@@ -105,7 +97,6 @@
 	name = "omni gas filter"
 	desc = "a device that filters out undesireable elements"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_OMNI_FILTER
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "omni_filter"
 	constructed_path = /obj/machinery/atmospherics/omni/filter
@@ -115,34 +106,33 @@
 	name = "manual valve"
 	desc = "a valve that has to be manipulated by hand"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_MVALVE
 	build_icon_state = "mvalve"
 	constructed_path = /obj/machinery/atmospherics/valve
 	pipe_class = PIPE_CLASS_BINARY
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/device/digitalvalve
 	name = "digital valve"
 	desc = "a valve controlled electronically"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_DVALVE
 	build_icon_state = "dvalve"
 	constructed_path = /obj/machinery/atmospherics/valve/digital
 	pipe_class = PIPE_CLASS_BINARY
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/device/autoshutoff
 	name = "automatic shutoff valve"
 	desc = "a valve that can automatically shut itself off"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SVALVE
 	build_icon_state = "svalve"
 	constructed_path = /obj/machinery/atmospherics/valve/shutoff
 	pipe_class = PIPE_CLASS_BINARY
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/device/mtvalve
 	name = "manual t-valve"
 	desc = "a three-way valve. T-shaped."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_MTVALVE
 	build_icon_state = "mtvalve"
 	constructed_path = /obj/machinery/atmospherics/tvalve
 	pipe_class = PIPE_CLASS_TRINARY
@@ -151,7 +141,6 @@
 	name = "manual t-valve (mirrored)"
 	desc = "a three-way valve. T-shaped."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_MTVALVEM
 	build_icon_state = "mtvalvem"
 	constructed_path = /obj/machinery/atmospherics/tvalve/mirrored
 	pipe_class = PIPE_CLASS_TRINARY
@@ -160,7 +149,6 @@
 	name = "digital t-valve"
 	desc = "a three-way valve. T-shaped. This one can be controlled electronically."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_DTVALVE
 	build_icon = 'icons/atmos/digital_tvalve.dmi'
 	build_icon_state = "map_tvalve0"
 	constructed_path = /obj/machinery/atmospherics/tvalve/digital
@@ -170,7 +158,6 @@
 	name = "digital t-valve (mirrored)"
 	desc = "a three-way valve. T-shaped. This one can be controlled electronically."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_DTVALVEM
 	build_icon = 'icons/atmos/digital_tvalve.dmi'
 	build_icon_state = "map_tvalvem0"
 	constructed_path = /obj/machinery/atmospherics/tvalve/mirrored/digital
@@ -180,7 +167,6 @@
 	name = "gas sensor"
 	desc = "a sensor. It detects gasses."
 	build_path = /obj/item/air_sensor
-	pipe_type = null
 	build_icon_state = "gsensor1"
 	build_icon = 'icons/obj/stationobjs.dmi'
 	pipe_color = null
@@ -197,7 +183,6 @@
 	build_path = /obj/item/pipe
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	colorable = FALSE
-	pipe_type = PIPE_INJECTOR
 	pipe_color = null
 	constructed_path = /obj/machinery/atmospherics/unary/outlet_injector
 	pipe_class = PIPE_CLASS_UNARY
@@ -210,7 +195,6 @@
 	build_path = /obj/item/drain
 	connect_types = null
 	colorable = FALSE
-	pipe_type = null
 	pipe_color = null
 	constructed_path = /obj/structure/drain
 	pipe_class = PIPE_CLASS_OTHER
@@ -222,6 +206,5 @@
 	build_icon_state = "air"
 	build_path = /obj/item/pipe/tank
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
-	pipe_type = PIPE_TANK
 	constructed_path = /obj/machinery/atmospherics/unary/tank
 	pipe_class = PIPE_CLASS_UNARY

--- a/code/game/machinery/pipe/pipe_datums/pipe_datum_base.dm
+++ b/code/game/machinery/pipe/pipe_datums/pipe_datum_base.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 	var/desc = "a pipe"														//item description
 	var/build_path = /obj/item/pipe											//path of the object that's being created
 	var/category = "general"												//Allows for easy sorting in the menu.
-	var/pipe_type = PIPE_SIMPLE_STRAIGHT									//What sort of pipe this is
+	var/pipe_type                       									//What sort of pipe this is. Used by disposals currently.
 	var/connect_types = CONNECT_TYPE_REGULAR								//what sort of connection this has
 	var/pipe_color = PIPE_COLOR_WHITE										//what color the pipe should be by default
 	var/build_icon_state = "simple"											//Which icon state to use when creating a new pipe item.
@@ -37,6 +37,7 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 	var/colorable = TRUE													//Can this pipe be colored?
 	var/constructed_path = /obj/machinery/atmospherics/pipe/simple/hidden	//What's the final form of this item?
 	var/pipe_class = PIPE_CLASS_BINARY										//The node classification for this item.
+	var/rotate_class = PIPE_ROTATE_STANDARD                                 //How it behaves when rotated
 
 //==========
 //Procedures
@@ -63,14 +64,13 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 /datum/pipe/proc/Build(var/datum/pipe/D, var/loc, var/pipe_color = PIPE_COLOR_GREY)
 	if(D.build_path)
 		var/obj/item/pipe/new_item = new build_path(loc)
-		if(D.pipe_type != null)
-			new_item.pipe_type = D.pipe_type
 		if(D.connect_types != null)
 			new_item.connect_types = D.connect_types
 		if(D.colorable)
 			new_item.color = pipe_color
 		else if (D.pipe_color != null)
 			new_item.color = D.pipe_color
+		new_item.rotate_class = D.rotate_class
 		new_item.SetName(D.name)
 		new_item.desc = D.desc
 		new_item.set_dir(D.dir)

--- a/code/game/machinery/pipe/pipe_datums/pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/pipe_datums.dm
@@ -13,20 +13,19 @@
 	name = "a pipe fitting"
 	desc = "a straight pipe segment."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SIMPLE_STRAIGHT
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/simple/bent
 	name = "bent pipe fitting"
 	desc = "a bent pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SIMPLE_BENT
 	dir = PIPE_BENT
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/simple/manifold
 	name = "pipe manifold fitting"
 	desc = "a pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_MANIFOLD
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden
 	pipe_class = PIPE_CLASS_TRINARY
@@ -35,16 +34,15 @@
 	name = "four-way pipe manifold fitting"
 	desc = "a four-way pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_MANIFOLD4W
 	build_icon_state = "manifold4w"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold4w/hidden
 	pipe_class = PIPE_CLASS_QUATERNARY
+	rotate_class = PIPE_ROTATE_ONEDIR
 
 /datum/pipe/pipe_dispenser/simple/cap
 	name = "pipe cap fitting"
 	desc = "a pipe cap for a regular pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden
 	pipe_class = PIPE_CLASS_UNARY
@@ -53,7 +51,6 @@
 	name = "downward pipe fitting"
 	desc = "a downward pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_DOWN
 	build_icon = 'icons/obj/structures.dmi'
 	build_icon_state = "down"
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down
@@ -62,7 +59,6 @@
 	name = "upward pipe fitting"
 	desc = "an upward pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_UP
 	build_icon = 'icons/obj/structures.dmi'
 	build_icon_state = "up"
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up
@@ -79,20 +75,19 @@
 	name = "supply pipe fitting"
 	desc = "a straight supply pipe segment."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_STRAIGHT
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/supply/bent
 	name = "bent supply pipe fitting"
 	desc = "a bent supply pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_BENT
 	dir = PIPE_BENT
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/supply/manifold
 	name = "supply pipe manifold fitting"
 	desc = "a supply pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_MANIFOLD
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/supply
 	pipe_class = PIPE_CLASS_TRINARY
@@ -101,16 +96,15 @@
 	name = "four-way supply pipe manifold fitting"
 	desc = "a four-way supply pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_MANIFOLD4W
 	build_icon_state = "manifold4w"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply
 	pipe_class = PIPE_CLASS_QUATERNARY
+	rotate_class = PIPE_ROTATE_ONEDIR
 
 /datum/pipe/pipe_dispenser/supply/cap
 	name = "supply pipe cap fitting"
 	desc = "a pipe cap for a regular pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden/supply
 	pipe_class = PIPE_CLASS_UNARY
@@ -119,7 +113,6 @@
 	name = "upward supply pipe fitting"
 	desc = "an upward supply pipe segment."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_UP
 	build_icon = 'icons/obj/structures.dmi'
 	build_icon_state = "up"
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up/supply
@@ -128,7 +121,6 @@
 	name = "downward supply pipe fitting"
 	desc = "a downward supply pipe segment."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SUPPLY_DOWN
 	build_icon = 'icons/obj/structures.dmi'
 	build_icon_state = "down"
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down/supply
@@ -145,20 +137,19 @@
 	name = "scrubber pipe fitting"
 	desc = "a straight scrubber pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_STRAIGHT
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/scrubber/bent
 	name = "bent scrubber pipe fitting"
 	desc = "a bent scrubber pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_BENT
+	rotate_class = PIPE_ROTATE_TWODIR
 	dir = PIPE_BENT
 
 /datum/pipe/pipe_dispenser/scrubber/manifold
 	name = "scrubber pipe manifold fitting"
 	desc = "a scrubber pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_MANIFOLD
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers
 	pipe_class = PIPE_CLASS_TRINARY
@@ -167,16 +158,15 @@
 	name = "four-way scrubber pipe manifold fitting"
 	desc = "a four-way scrubber pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_MANIFOLD4W
 	build_icon_state = "manifold4w"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers
 	pipe_class = PIPE_CLASS_QUATERNARY
+	rotate_class = PIPE_ROTATE_ONEDIR
 
 /datum/pipe/pipe_dispenser/scrubber/up
 	name = "upward scrubber pipe fitting"
 	desc = "an upward scrubber pipe segment."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_UP
 	build_icon = 'icons/obj/structures.dmi'
 	build_icon_state = "up"
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up/supply
@@ -185,7 +175,6 @@
 	name = "downward scrubber pipe fitting"
 	desc = "a downward scrubber pipe segment."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_DOWN
 	build_icon = 'icons/obj/structures.dmi'
 	build_icon_state = "down"
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down/supply
@@ -194,7 +183,6 @@
 	name = "scrubber pipe cap fitting"
 	desc = "a pipe cap for a scrubber pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_SCRUBBERS_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden/scrubbers
 	pipe_class = PIPE_CLASS_UNARY
@@ -211,20 +199,19 @@
 	name = "fuel pipe fitting"
 	desc = "a striaght fuel pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_FUEL_STRAIGHT
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/fuel/bent
 	name = "bent fuel pipe fitting"
 	desc = "a bent fuel pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_FUEL_BENT
+	rotate_class = PIPE_ROTATE_TWODIR
 	dir = PIPE_BENT
 
 /datum/pipe/pipe_dispenser/fuel/manifold
 	name = "fuel pipe manifold fitting"
 	desc = "a fuel pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_FUEL_MANIFOLD
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/fuel
 	pipe_class = PIPE_CLASS_TRINARY
@@ -233,16 +220,15 @@
 	name = "four-way supply pipe manifold fitting"
 	desc = "a four-way fuel pipe manifold segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_FUEL_MANIFOLD4W
 	build_icon_state = "manifold4w"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel
 	pipe_class = PIPE_CLASS_QUATERNARY
+	rotate_class = PIPE_ROTATE_ONEDIR
 
 /datum/pipe/pipe_dispenser/fuel/cap
 	name = "fuel pipe cap fitting"
 	desc = "a pipe cap for a fuel pipe."
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_FUEL_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden/fuel
 	pipe_class = PIPE_CLASS_UNARY
@@ -258,15 +244,15 @@
 	name = "heat exchanger pipe fitting"
 	desc = "a heat exchanger pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_HE_STRAIGHT
 	build_icon_state = "he"
+	rotate_class = PIPE_ROTATE_TWODIR
 
 /datum/pipe/pipe_dispenser/he/bent
 	name = "bent heat exchanger pipe fitting"
 	desc = "a bent heat exchanger pipe segment"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_HE_BENT
 	connect_types = CONNECT_TYPE_HE
+	rotate_class = PIPE_ROTATE_TWODIR
 	build_icon_state = "he"
 	dir = PIPE_BENT
 
@@ -274,7 +260,6 @@
 	name = "heat exchanger junction"
 	desc = "a heat exchanger junction"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_JUNCTION
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_HE
 	build_icon_state = "junction"
 	constructed_path = /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
@@ -283,7 +268,6 @@
 	name = "heat exchanger"
 	desc = "a heat exchanger"
 	build_path = /obj/item/pipe
-	pipe_type = PIPE_HEAT_EXCHANGE
 	connect_types = CONNECT_TYPE_REGULAR
 	build_icon_state = "heunary"
 	constructed_path = /obj/machinery/atmospherics/unary/heat_exchanger

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -119,17 +119,14 @@
 	if(!use_metal(0.25))
 		return reset()
 	var/fdirn = turn(M_Dir,180)
-	var/p_type
 	var/p_dir
 
 	if (fdirn!=old_dir)
-		p_type=1+P_type
 		p_dir=old_dir+M_Dir
 	else
-		p_type=0+P_type
 		p_dir=M_Dir
 
-	var/obj/item/pipe/P = new (w_turf, pipe_type=p_type, dir=p_dir)
+	var/obj/item/pipe/P = new (w_turf, dir=p_dir)
 	P.attackby(W , src)
 
 	return 1

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -22,6 +22,7 @@ Pipelines + Other Objects -> Pipe network
 	layer = EXPOSED_PIPE_LAYER
 
 	var/connect_types = CONNECT_TYPE_REGULAR
+	var/connect_dir_type = SOUTH // Assume your dir is SOUTH. What dirs should you connect to?
 	var/icon_connect_type = "" //"-supply" or "-scrubbers"
 
 	var/initialize_directions = 0
@@ -32,11 +33,11 @@ Pipelines + Other Objects -> Pipe network
 	var/obj/machinery/atmospherics/node2
 
 	var/atmos_initalized = FALSE
-	var/pipe_type = PIPE_SIMPLE_STRAIGHT
 	var/build_icon = 'icons/obj/pipe-item.dmi'
 	var/build_icon_state = "buildpipe"
 
 	var/pipe_class = PIPE_CLASS_OTHER //If somehow something isn't set properly, handle it as something with zero connections. This will prevent runtimes.
+	var/rotate_class = PIPE_ROTATE_STANDARD
 
 /obj/machinery/atmospherics/New()
 	if(!icon_manager)
@@ -48,6 +49,8 @@ Pipelines + Other Objects -> Pipe network
 
 	if(!pipe_color_check(pipe_color))
 		pipe_color = null
+
+	set_dir(dir) // Does full dir init.
 	..()
 
 /obj/machinery/atmospherics/proc/atmos_init()
@@ -141,3 +144,33 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 
 /obj/machinery/atmospherics/on_update_icon()
 	return null
+
+// returns all pipe's endpoints. You can override, but you may then need to use a custom /item/pipe constructor.
+/obj/machinery/atmospherics/proc/get_initialze_directions()
+	return base_pipe_initialize_directions(dir, connect_dir_type)
+
+/proc/base_pipe_initialize_directions(dir, connect_dir_type)
+	if(!dir)
+		return 0
+	if(!(dir in GLOB.cardinal))
+		return dir // You're on your own. Used for bent pipes.
+	. = 0
+
+	if(connect_dir_type & SOUTH)
+		. |= dir
+	if(connect_dir_type & NORTH)
+		. |= turn(dir, 180)
+	if(connect_dir_type & WEST)
+		. |= turn(dir, -90)
+	if(connect_dir_type & EAST)
+		. |= turn(dir, 90)
+
+/obj/machinery/atmospherics/set_dir(new_dir)
+	. = ..()
+	initialize_directions = get_initialze_directions()
+
+// Used by constructors. Shouldn't generally be called from elsewhere.
+/obj/machinery/proc/set_initial_level()
+	var/turf/T = get_turf(src)
+	if(T)
+		level = (!T.is_plating() ? 2 : 1)

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -39,7 +39,7 @@ Pipelines + Other Objects -> Pipe network
 	var/pipe_class = PIPE_CLASS_OTHER //If somehow something isn't set properly, handle it as something with zero connections. This will prevent runtimes.
 	var/rotate_class = PIPE_ROTATE_STANDARD
 
-/obj/machinery/atmospherics/New()
+/obj/machinery/atmospherics/Initialize()
 	if(!icon_manager)
 		icon_manager = new()
 
@@ -51,7 +51,7 @@ Pipelines + Other Objects -> Pipe network
 		pipe_color = null
 
 	set_dir(dir) // Does full dir init.
-	..()
+	. = ..()
 
 /obj/machinery/atmospherics/proc/atmos_init()
 	atmos_initalized = TRUE

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -9,18 +9,10 @@
 	var/datum/pipe_network/network2
 
 	pipe_class = PIPE_CLASS_BINARY
+	connect_dir_type = SOUTH | NORTH
 
 /obj/machinery/atmospherics/binary/New()
 	..()
-	switch(dir)
-		if(NORTH)
-			initialize_directions = NORTH|SOUTH
-		if(SOUTH)
-			initialize_directions = NORTH|SOUTH
-		if(EAST)
-			initialize_directions = EAST|WEST
-		if(WEST)
-			initialize_directions = EAST|WEST
 	air1 = new
 	air2 = new
 

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -11,13 +11,13 @@
 	pipe_class = PIPE_CLASS_BINARY
 	connect_dir_type = SOUTH | NORTH
 
-/obj/machinery/atmospherics/binary/New()
-	..()
+/obj/machinery/atmospherics/binary/Initialize()
 	air1 = new
 	air2 = new
 
 	air1.volume = 200
 	air2.volume = 200
+	. = ..()
 
 // Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/binary/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -22,8 +22,8 @@
 
 	density = 1
 
-/obj/machinery/atmospherics/binary/circulator/New()
-	..()
+/obj/machinery/atmospherics/binary/circulator/Initialize()
+	. = ..()
 	desc = initial(desc) + " Its outlet port is to the [dir2text(dir)]."
 	air1.volume = 400
 

--- a/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
@@ -41,8 +41,8 @@
 	//2: Do not pass input_pressure_min
 	//4: Do not pass output_pressure_max
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/New()
-	..()
+/obj/machinery/atmospherics/binary/dp_vent_pump/Initialize()
+	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP
 	icon = null
@@ -50,8 +50,8 @@
 /obj/machinery/atmospherics/binary/dp_vent_pump/high_volume
 	name = "Large Dual Port Air Vent"
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume/New()
-	..()
+/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume/Initialize()
+	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -32,8 +32,8 @@
 	unlocked = 1
 	icon_state = "map_on"
 
-/obj/machinery/atmospherics/binary/passive_gate/New()
-	..()
+/obj/machinery/atmospherics/binary/passive_gate/Initialize()
+	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -26,7 +26,6 @@
 	var/datum/radio_frequency/radio_connection
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
-	pipe_type = PIPE_PASSIVE_GATE
 	build_icon_state = "passivegate"
 
 /obj/machinery/atmospherics/binary/passive_gate/on

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -36,8 +36,8 @@ Thus, the two variables affect pump operation are set in New():
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	build_icon_state = "pump"
 
-/obj/machinery/atmospherics/binary/pump/New()
-	..()
+/obj/machinery/atmospherics/binary/pump/Initialize()
+	. = ..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP
 	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -34,7 +34,6 @@ Thus, the two variables affect pump operation are set in New():
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
-	pipe_type = PIPE_PUMP
 	build_icon_state = "pump"
 
 /obj/machinery/atmospherics/binary/pump/New()

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -24,6 +24,6 @@
 	target_pressure = MAX_PUMP_PRESSURE
 
 // A possible variant for Atmospherics distribution feed.
-/obj/machinery/atmospherics/binary/pump/high_power/on/distribution/New()
-	..()
+/obj/machinery/atmospherics/binary/pump/high_power/on/distribution/Initialize()
+	. = ..()
 	target_pressure = round(3 * ONE_ATMOSPHERE)

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -17,7 +17,6 @@
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER
 
 	var/list/filtering_outputs = list()	//maps gasids to gas_mixtures
-	pipe_type = PIPE_OMNI_FILTER
 	build_icon_state = "omni_filter"
 /obj/machinery/atmospherics/omni/filter/New()
 	..()

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -18,8 +18,8 @@
 
 	var/list/filtering_outputs = list()	//maps gasids to gas_mixtures
 	build_icon_state = "omni_filter"
-/obj/machinery/atmospherics/omni/filter/New()
-	..()
+/obj/machinery/atmospherics/omni/filter/Initialize()
+	. = ..()
 	rebuild_filtering_list()
 	for(var/datum/omni_port/P in ports)
 		P.air.volume = ATMOS_DEFAULT_VOLUME_FILTER

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -22,7 +22,6 @@
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_MIXER
 
 	var/list/mixing_inputs = list()
-	pipe_type = PIPE_OMNI_MIXER
 	build_icon_state = "omni_mixer"
 
 /obj/machinery/atmospherics/omni/mixer/New()

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -24,8 +24,8 @@
 	var/list/mixing_inputs = list()
 	build_icon_state = "omni_mixer"
 
-/obj/machinery/atmospherics/omni/mixer/New()
-	..()
+/obj/machinery/atmospherics/omni/mixer/Initialize()
+	. = ..()
 	if(mapper_set())
 		var/con = 0
 		for(var/datum/omni_port/P in ports)

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -25,6 +25,7 @@
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 
 	pipe_class = PIPE_CLASS_OMNI
+	connect_dir_type = SOUTH | NORTH | EAST | WEST
 
 /obj/machinery/atmospherics/omni/New()
 	..()

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -27,8 +27,8 @@
 	pipe_class = PIPE_CLASS_OMNI
 	connect_dir_type = SOUTH | NORTH | EAST | WEST
 
-/obj/machinery/atmospherics/omni/New()
-	..()
+/obj/machinery/atmospherics/omni/Initialize()
+	. = ..()
 	icon_state = "base"
 
 	ports = new()

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -20,7 +20,6 @@
 	level = 1
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
-	pipe_type = PIPE_CONNECTOR
 	build_icon_state = "connector"
 
 	pipe_class = PIPE_CLASS_UNARY

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -24,10 +24,6 @@
 
 	pipe_class = PIPE_CLASS_UNARY
 
-/obj/machinery/atmospherics/portables_connector/Initialize()
-	initialize_directions = dir
-	. = ..()
-
 /obj/machinery/atmospherics/portables_connector/on_update_icon()
 	icon_state = "connector"
 

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -16,10 +16,10 @@
 	..()
 	to_chat(user, "The automatic shutoff circuit is [close_on_leaks ? "enabled" : "disabled"].")
 
-/obj/machinery/atmospherics/valve/shutoff/New()
+/obj/machinery/atmospherics/valve/shutoff/Initialize()
+	. = ..()
 	open()
 	hide(1)
-	..()
 
 /obj/machinery/atmospherics/valve/shutoff/attack_hand(var/mob/user as mob)
 	close_on_leaks = !close_on_leaks

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -7,7 +7,6 @@
 	var/close_on_leaks = TRUE	// If false it will be always open
 	level = 1
 	connect_types = CONNECT_TYPE_SCRUBBER | CONNECT_TYPE_SUPPLY | CONNECT_TYPE_REGULAR | CONNECT_TYPE_FUEL
-	pipe_type = PIPE_SVALVE
 	build_icon_state = "svalve"
 
 /obj/machinery/atmospherics/valve/shutoff/on_update_icon()

--- a/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
@@ -14,18 +14,10 @@
 	var/datum/pipe_network/network3
 
 	pipe_class = PIPE_CLASS_TRINARY
+	connect_dir_type = SOUTH | NORTH | WEST
 
 /obj/machinery/atmospherics/trinary/New()
 	..()
-	switch(dir)
-		if(NORTH)
-			initialize_directions = EAST|NORTH|SOUTH
-		if(SOUTH)
-			initialize_directions = SOUTH|WEST|NORTH
-		if(EAST)
-			initialize_directions = EAST|WEST|SOUTH
-		if(WEST)
-			initialize_directions = WEST|NORTH|EAST
 	air1 = new
 	air2 = new
 	air3 = new

--- a/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
@@ -16,8 +16,7 @@
 	pipe_class = PIPE_CLASS_TRINARY
 	connect_dir_type = SOUTH | NORTH | WEST
 
-/obj/machinery/atmospherics/trinary/New()
-	..()
+/obj/machinery/atmospherics/trinary/Initialize()
 	air1 = new
 	air2 = new
 	air3 = new
@@ -25,6 +24,7 @@
 	air1.volume = 200
 	air2.volume = 200
 	air3.volume = 200
+	. = ..()
 
 // Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/trinary/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -26,10 +26,6 @@
 	build_icon = 'icons/atmos/tvalve.dmi'
 	build_icon_state = "map_tvalve0"
 
-/obj/machinery/atmospherics/tvalve/New()
-	initialize_directions()
-	..()
-
 /obj/machinery/atmospherics/tvalve/on_update_icon(animation)
 	if(animation)
 		flick("tvalve[src.state][!src.state]",src)
@@ -53,17 +49,6 @@
 
 /obj/machinery/atmospherics/tvalve/hide(var/i)
 	update_underlays()
-
-/obj/machinery/atmospherics/tvalve/proc/initialize_directions()
-	switch(dir)
-		if(NORTH)
-			initialize_directions = SOUTH|NORTH|EAST
-		if(SOUTH)
-			initialize_directions = NORTH|SOUTH|WEST
-		if(EAST)
-			initialize_directions = WEST|EAST|SOUTH
-		if(WEST)
-			initialize_directions = EAST|WEST|NORTH	
 
 /obj/machinery/atmospherics/tvalve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(reference == node1)
@@ -338,10 +323,6 @@
 	build_icon = 'icons/atmos/digital_tvalve.dmi'
 	build_icon_state = "map_tvalve0"
 
-/obj/machinery/atmospherics/tvalve/digital/New()
-	..()
-	initialize_directions()
-
 /obj/machinery/atmospherics/tvalve/digital/Initialize()
 	. = ..()
 	if(frequency)
@@ -401,10 +382,6 @@
 
 	build_icon = 'icons/atmos/digital_tvalve.dmi'
 	build_icon_state = "map_tvalvem0"
-
-/obj/machinery/atmospherics/tvalve/mirrored/digital/New()
-	..()
-	initialize_directions()
 
 /obj/machinery/atmospherics/tvalve/mirrored/digital/Initialize()
 	. = ..()

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -20,8 +20,7 @@
 	var/datum/pipe_network/network_node3
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
-	
-	pipe_type = PIPE_MTVALVE
+	connect_dir_type = SOUTH | WEST | NORTH
 	pipe_class = PIPE_CLASS_TRINARY
 
 	build_icon = 'icons/atmos/tvalve.dmi'
@@ -303,12 +302,11 @@
 /obj/machinery/atmospherics/tvalve/mirrored
 	icon_state = "map_tvalvem0"
 	
-	pipe_type =  PIPE_MTVALVEM
+	connect_dir_type = SOUTH | EAST | NORTH
 	build_icon_state = "map_tvalvem0"
 
 /obj/machinery/atmospherics/tvalve/mirrored/atmos_init()
 	..()
-	initialize_directions()
 
 	var/node1_dir
 	var/node2_dir
@@ -320,16 +318,6 @@
 
 	init_nodes(node1_dir, node2_dir, node3_dir)
 
-/obj/machinery/atmospherics/tvalve/mirrored/initialize_directions()
-	switch(dir)
-		if(NORTH)
-			initialize_directions = SOUTH|NORTH|WEST
-		if(SOUTH)
-			initialize_directions = NORTH|SOUTH|EAST
-		if(EAST)
-			initialize_directions = WEST|EAST|NORTH
-		if(WEST)
-			initialize_directions = EAST|WEST|SOUTH
 
 /obj/machinery/atmospherics/tvalve/mirrored/on_update_icon(animation)
 	if(animation)
@@ -347,7 +335,6 @@
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 	
-	pipe_type =  PIPE_DTVALVE
 	build_icon = 'icons/atmos/digital_tvalve.dmi'
 	build_icon_state = "map_tvalve0"
 
@@ -411,7 +398,6 @@
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
-	pipe_type =  PIPE_DTVALVEM
 
 	build_icon = 'icons/atmos/digital_tvalve.dmi'
 	build_icon_state = "map_tvalvem0"

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -11,7 +11,6 @@
 	var/update_cycle
 
 	connect_types = CONNECT_TYPE_REGULAR
-	pipe_type = PIPE_HEAT_EXCHANGE
 	build_icon_state = "heunary"
 
 	update_icon()

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -21,7 +21,6 @@
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
-	pipe_type = PIPE_INJECTOR
 
 	level = 1
 

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -29,8 +29,8 @@
 	build_icon = 'icons/atmos/injector.dmi'
 	build_icon_state = "map_injector"
 
-/obj/machinery/atmospherics/unary/outlet_injector/New()
-	..()
+/obj/machinery/atmospherics/unary/outlet_injector/Initialize()
+	. = ..()
 	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500	
 

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -18,7 +18,6 @@
 	density = 1
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	pipe_class = PIPE_CLASS_UNARY
-	pipe_type = PIPE_TANK
 
 	build_icon = 'icons/atmos/tank.dmi'
 	build_icon_state = "air"
@@ -35,11 +34,11 @@
 			gases += start_pressure * filling[gas] * (air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature)
 		air_temporary.adjust_multi(arglist(gases))
 		update_icon()
-
-	initialize_directions = dir
-	set_dir(dir)
 	..()
-	
+
+/obj/machinery/atmospherics/unary/tank/set_initial_level()
+	level = 1 // Always on top, apparently.
+
 /obj/machinery/atmospherics/unary/tank/Initialize()
 	atmos_init()
 	build_network()
@@ -156,7 +155,6 @@
 	name =  "Pressure Tank"
 	desc = "A large vessel containing pressurized gas."
 	color =  PIPE_COLOR_WHITE
-	pipe_type = PIPE_TANK
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL	
 	w_class = ITEM_SIZE_HUGE
 	level = 1

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -22,7 +22,8 @@
 	build_icon = 'icons/atmos/tank.dmi'
 	build_icon_state = "air"
 
-/obj/machinery/atmospherics/unary/tank/New()
+/obj/machinery/atmospherics/unary/tank/Initialize()
+	. = ..()
 	if(filling)
 		air_temporary = new
 		air_temporary.volume = volume
@@ -34,19 +35,17 @@
 			gases += start_pressure * filling[gas] * (air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature)
 		air_temporary.adjust_multi(arglist(gases))
 		update_icon()
-	..()
 
 /obj/machinery/atmospherics/unary/tank/set_initial_level()
 	level = 1 // Always on top, apparently.
 
 /obj/machinery/atmospherics/unary/tank/Initialize()
+	. = ..()
 	atmos_init()
 	build_network()
 	if(node)
 		node.atmos_init()
 		node.build_network()
-
-	. = ..()
 
 /obj/machinery/atmospherics/unary/tank/Process()
 	if(!parent)

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -12,11 +12,10 @@
 
 	pipe_class = PIPE_CLASS_UNARY
 
-/obj/machinery/atmospherics/unary/New()
+/obj/machinery/atmospherics/unary/Initialize()
 	air_contents = new
-	..()
-	initialize_directions = dir
 	air_contents.volume = 200
+	. = ..()
 
 // Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/unary/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -72,8 +72,8 @@
 	pressure_checks = 2
 	pressure_checks_default = 2
 
-/obj/machinery/atmospherics/unary/vent_pump/New()
-	..()
+/obj/machinery/atmospherics/unary/vent_pump/Initialize()
+	. = ..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP
 	icon = null
 
@@ -89,8 +89,8 @@
 	power_channel = EQUIP
 	power_rating = 45000
 
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/New()
-	..()
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/Initialize()
+	. = ..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 
 /obj/machinery/atmospherics/unary/vent_pump/engine
@@ -98,8 +98,8 @@
 	power_channel = ENVIRON
 	power_rating = 30000
 
-/obj/machinery/atmospherics/unary/vent_pump/engine/New()
-	..()
+/obj/machinery/atmospherics/unary/vent_pump/engine/Initialize()
+	. = ..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500 //meant to match air injector
 
 /obj/machinery/atmospherics/unary/vent_pump/on_update_icon(var/safety = 0)

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -49,7 +49,6 @@
 	var/radio_filter_in
 
 	var/controlled = TRUE  //if we should register with an air alarm on spawn
-	pipe_type = PIPE_UVENT
 	build_icon_state = "uvent"
 
 /obj/machinery/atmospherics/unary/vent_pump/on

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -35,8 +35,8 @@
 	use_power = POWER_USE_IDLE
 	icon_state = "map_scrubber_on"
 
-/obj/machinery/atmospherics/unary/vent_scrubber/New()
-	..()
+/obj/machinery/atmospherics/unary/vent_scrubber/Initialize()
+	. = ..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
 	icon = null
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -29,7 +29,6 @@
 
 	var/welded = 0
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER
-	pipe_type = PIPE_SCRUBBER
 	build_icon_state = "scrubber"
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -17,7 +17,8 @@
 	var/datum/pipe_network/network_node2
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
-	pipe_type = PIPE_MVALVE
+	connect_dir_type = SOUTH | NORTH
+	rotate_class = PIPE_ROTATE_TWODIR
 	build_icon_state = "mvalve"
 
 /obj/machinery/atmospherics/valve/open
@@ -41,14 +42,6 @@
 
 /obj/machinery/atmospherics/valve/hide(var/i)
 	update_underlays()
-
-/obj/machinery/atmospherics/valve/Initialize()
-	switch(dir)
-		if(NORTH, SOUTH)
-			initialize_directions = NORTH|SOUTH
-		if(EAST, WEST)
-			initialize_directions = EAST|WEST
-	. = ..()
 
 /obj/machinery/atmospherics/valve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(reference == node1)
@@ -121,12 +114,6 @@
 
 	return 1
 
-/obj/machinery/atmospherics/valve/proc/normalize_dir()
-	if(dir==3)
-		set_dir(1)
-	else if(dir==12)
-		set_dir(4)
-
 /obj/machinery/atmospherics/valve/attack_ai(mob/user as mob)
 	return
 
@@ -145,8 +132,6 @@
 
 /obj/machinery/atmospherics/valve/atmos_init()
 	..()
-	normalize_dir()
-
 	var/node1_dir
 	var/node2_dir
 
@@ -230,7 +215,6 @@
 	var/frequency = 0
 	var/id = null
 	var/datum/radio_frequency/radio_connection
-	pipe_type = PIPE_DVALVE
 	build_icon_state = "dvalve"
 
 /obj/machinery/atmospherics/valve/digital/Destroy()

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -21,8 +21,8 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging
 	can_buckle = 1
 	buckle_lying = 1
 
-obj/machinery/atmospherics/pipe/simple/heat_exchanging/New()
-	..()
+obj/machinery/atmospherics/pipe/simple/heat_exchanging/Initialize()
+	. = ..()
 	color = "#404040" //we don't make use of the fancy overlay system for colours, use this to set the default.
 
 obj/machinery/atmospherics/pipe/simple/heat_exchanging/set_dir(new_dir)

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -23,12 +23,14 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging
 
 obj/machinery/atmospherics/pipe/simple/heat_exchanging/New()
 	..()
-	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 	color = "#404040" //we don't make use of the fancy overlay system for colours, use this to set the default.
+
+obj/machinery/atmospherics/pipe/simple/heat_exchanging/set_dir(new_dir)
+	..()
+	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 
 obj/machinery/atmospherics/pipe/simple/heat_exchanging/atmos_init()
 	..()
-	normalize_dir()
 	var/node1_dir
 	var/node2_dir
 
@@ -112,24 +114,11 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
 	level = 2
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_HE|CONNECT_TYPE_FUEL
 	build_icon_state = "junction"
-	pipe_type = PIPE_JUNCTION
 
 // Doubling up on initialize_directions is necessary to allow HE pipes to connect
-obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/New()
-	.. ()
-	switch (dir)
-		if (SOUTH)
-			initialize_directions_he = SOUTH
-			initialize_directions = NORTH|SOUTH
-		if (NORTH)
-			initialize_directions_he = NORTH
-			initialize_directions = NORTH|SOUTH
-		if (EAST)
-			initialize_directions_he = EAST
-			initialize_directions = EAST|WEST
-		if (WEST)
-			initialize_directions_he = WEST
-			initialize_directions = EAST|WEST
+obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/set_dir(new_dir)
+	..()
+	initialize_directions_he = dir
 
 obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/atmos_init()
 	..()

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -26,10 +26,10 @@
 /obj/machinery/atmospherics/pipe/drain_power()
 	return -1
 
-/obj/machinery/atmospherics/pipe/New()
+/obj/machinery/atmospherics/pipe/Initialize()
+	. = ..()
 	if(istype(get_turf(src), /turf/simulated/wall) || istype(get_turf(src), /turf/simulated/shuttle/wall) || istype(get_turf(src), /turf/unsimulated/wall))
 		level = 1
-	..()
 
 /obj/machinery/atmospherics/pipe/hides_under_flooring()
 	return level != 2
@@ -181,9 +181,8 @@
 	rotate_class = PIPE_ROTATE_TWODIR
 	connect_dir_type = SOUTH | NORTH // Overridden if dir is not a cardinal for bent pipes. For straight pipes this is correct.
 
-/obj/machinery/atmospherics/pipe/simple/New()
-	..()
-
+/obj/machinery/atmospherics/pipe/simple/Initialize()
+	. = ..()
 	// Pipe colors and icon states are handled by an image cache - so color and icon should
 	//  be null. For mapping purposes color is defined in the object definitions.
 	icon = null
@@ -439,20 +438,10 @@
 	pipe_class = PIPE_CLASS_TRINARY
 	connect_dir_type = NORTH | EAST | WEST
 
-/obj/machinery/atmospherics/pipe/manifold/New()
-	..()
+/obj/machinery/atmospherics/pipe/manifold/Initialize()
+	. = ..()
 	alpha = 255
 	icon = null
-
-	switch(dir)
-		if(NORTH)
-			initialize_directions = EAST|SOUTH|WEST
-		if(SOUTH)
-			initialize_directions = WEST|NORTH|EAST
-		if(EAST)
-			initialize_directions = SOUTH|WEST|NORTH
-		if(WEST)
-			initialize_directions = NORTH|EAST|SOUTH
 
 /obj/machinery/atmospherics/pipe/manifold/hide(var/i)
 	if(istype(loc, /turf/simulated))
@@ -707,8 +696,8 @@
 	rotate_class = PIPE_ROTATE_ONEDIR
 	connect_dir_type = NORTH | SOUTH | EAST | WEST
 
-/obj/machinery/atmospherics/pipe/manifold4w/New()
-	..()
+/obj/machinery/atmospherics/pipe/manifold4w/Initialize()
+	. = ..()
 	alpha = 255
 	icon = null
 
@@ -972,10 +961,6 @@
 
 	var/obj/machinery/atmospherics/node
 
-/obj/machinery/atmospherics/pipe/cap/New()
-	..()
-	initialize_directions = dir
-
 /obj/machinery/atmospherics/pipe/cap/hide(var/i)
 	if(istype(loc, /turf/simulated))
 		set_invisibility(i ? 101 : 0)
@@ -1101,11 +1086,6 @@
 
 	var/build_killswitch = 1
 	build_icon_state = "uvent"
-
-
-/obj/machinery/atmospherics/pipe/vent/New()
-	initialize_directions = dir
-	..()
 
 /obj/machinery/atmospherics/pipe/vent/high_volume
 	name = "Larger vent"

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -21,7 +21,6 @@
 	var/datum/sound_token/sound_token
 	build_icon_state = "simple"
 	build_icon = 'icons/obj/pipe-item.dmi'
-	pipe_type = PIPE_SIMPLE_STRAIGHT
 	pipe_class = PIPE_CLASS_BINARY
 
 /obj/machinery/atmospherics/pipe/drain_power()
@@ -132,15 +131,12 @@
 		if (do_after(user, 40, src))
 			user.visible_message("<span class='notice'>\The [user] unfastens \the [src].</span>", "<span class='notice'>You have unfastened \the [src].</span>", "You hear a ratchet.")
 		
-			var/obj/item/pipe/P = new /obj/item/pipe(loc, src)
+			new /obj/item/pipe(loc, src)
 
 			for (var/obj/machinery/meter/meter in T)
 				if (meter.target == src)
 					new /obj/item/pipe_meter(T)
 					qdel(meter)
-
-			P.dir = dir
-
 			qdel(src)
 
 /obj/machinery/atmospherics/proc/change_color(var/new_color)
@@ -182,7 +178,8 @@
 
 	level = 1
 
-	pipe_type = PIPE_SIMPLE_STRAIGHT
+	rotate_class = PIPE_ROTATE_TWODIR
+	connect_dir_type = SOUTH | NORTH // Overridden if dir is not a cardinal for bent pipes. For straight pipes this is correct.
 
 /obj/machinery/atmospherics/pipe/simple/New()
 	..()
@@ -191,20 +188,6 @@
 	//  be null. For mapping purposes color is defined in the object definitions.
 	icon = null
 	alpha = 255
-
-	switch(dir)
-		if(SOUTH || NORTH)
-			initialize_directions = SOUTH|NORTH
-		if(EAST || WEST)
-			initialize_directions = EAST|WEST
-		if(NORTHEAST)
-			initialize_directions = NORTH|EAST
-		if(NORTHWEST)
-			initialize_directions = NORTH|WEST
-		if(SOUTHEAST)
-			initialize_directions = SOUTH|EAST
-		if(SOUTHWEST)
-			initialize_directions = SOUTH|WEST
 
 /obj/machinery/atmospherics/pipe/simple/hide(var/i)
 	if(istype(loc, /turf/simulated))
@@ -251,12 +234,6 @@
 	smoke.set_up(1,0, src.loc, 0)
 	smoke.start()
 	qdel(src)
-
-/obj/machinery/atmospherics/pipe/simple/proc/normalize_dir()
-	if(dir==3)
-		set_dir(1)
-	else if(dir==12)
-		set_dir(4)
 
 /obj/machinery/atmospherics/pipe/simple/Destroy()
 	if(node1)
@@ -308,7 +285,6 @@
 
 /obj/machinery/atmospherics/pipe/simple/atmos_init()
 	..()
-	normalize_dir()
 	var/node1_dir
 	var/node2_dir
 
@@ -364,7 +340,6 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
-	pipe_type = PIPE_SCRUBBERS_STRAIGHT
 
 /obj/machinery/atmospherics/pipe/simple/visible/supply
 	name = "Air supply pipe"
@@ -373,7 +348,6 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
-	pipe_type = PIPE_SUPPLY_STRAIGHT
 
 /obj/machinery/atmospherics/pipe/simple/visible/yellow
 	color = PIPE_COLOR_YELLOW
@@ -400,7 +374,6 @@
 	fatigue_pressure = 350*ONE_ATMOSPHERE
 	alert_pressure = 350*ONE_ATMOSPHERE
 	connect_types = CONNECT_TYPE_FUEL
-	pipe_type = PIPE_FUEL_STRAIGHT
 
 /obj/machinery/atmospherics/pipe/simple/hidden
 	icon_state = "intact"
@@ -414,7 +387,6 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
-	pipe_type = PIPE_SCRUBBERS_STRAIGHT
 
 /obj/machinery/atmospherics/pipe/simple/hidden/supply
 	name = "Air supply pipe"
@@ -423,7 +395,6 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
-	pipe_type = PIPE_SUPPLY_STRAIGHT
 
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow
 	color = PIPE_COLOR_YELLOW
@@ -450,14 +421,12 @@
 	fatigue_pressure = 350*ONE_ATMOSPHERE
 	alert_pressure = 350*ONE_ATMOSPHERE
 	connect_types = CONNECT_TYPE_FUEL
-	pipe_type = PIPE_FUEL_STRAIGHT
 
 /obj/machinery/atmospherics/pipe/manifold
 	icon = 'icons/atmos/manifold.dmi'
 	icon_state = ""
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes."
-	pipe_type = PIPE_MANIFOLD
 	volume = ATMOS_DEFAULT_VOLUME_PIPE * 1.5
 
 	dir = SOUTH
@@ -468,6 +437,7 @@
 	level = 1
 
 	pipe_class = PIPE_CLASS_TRINARY
+	connect_dir_type = NORTH | EAST | WEST
 
 /obj/machinery/atmospherics/pipe/manifold/New()
 	..()
@@ -723,7 +693,6 @@
 	icon_state = ""
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of regular pipes."
-	pipe_type = PIPE_MANIFOLD4W
 	volume = ATMOS_DEFAULT_VOLUME_PIPE * 2
 
 	dir = SOUTH
@@ -735,6 +704,8 @@
 	level = 1
 
 	pipe_class = PIPE_CLASS_QUATERNARY
+	rotate_class = PIPE_ROTATE_ONEDIR
+	connect_dir_type = NORTH | SOUTH | EAST | WEST
 
 /obj/machinery/atmospherics/pipe/manifold4w/New()
 	..()
@@ -993,7 +964,6 @@
 	icon = 'icons/atmos/pipes.dmi'
 	icon_state = ""
 	level = 2
-	pipe_type = PIPE_CAP
 	volume = 35
 
 	dir = SOUTH
@@ -1073,7 +1043,6 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
-	pipe_type = PIPE_SCRUBBERS_CAP
 
 /obj/machinery/atmospherics/pipe/cap/visible/supply
 	name = "supply pipe endcap"
@@ -1082,14 +1051,12 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
-	pipe_type = PIPE_SUPPLY_CAP
 
 /obj/machinery/atmospherics/pipe/cap/visible/fuel
 	name = "fuel pipe endcap"
 	desc = "An endcap for fuel pipes."
 	color = PIPE_COLOR_ORANGE
 	connect_types = CONNECT_TYPE_FUEL
-	pipe_type = PIPE_FUEL_CAP
 
 /obj/machinery/atmospherics/pipe/cap/hidden
 	level = 1
@@ -1103,7 +1070,6 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
-	pipe_type = PIPE_SCRUBBERS_CAP
 
 /obj/machinery/atmospherics/pipe/cap/hidden/supply
 	name = "supply pipe endcap"
@@ -1112,14 +1078,12 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
-	pipe_type = PIPE_SUPPLY_CAP
 
 /obj/machinery/atmospherics/pipe/cap/hidden/fuel
 	name = "fuel pipe endcap"
 	desc = "An endcap for fuel pipes."
 	color = PIPE_COLOR_ORANGE
 	connect_types = CONNECT_TYPE_FUEL
-	pipe_type = PIPE_FUEL_CAP
 
 /obj/machinery/atmospherics/pipe/vent
 	icon = 'icons/obj/atmospherics/pipe_vent.dmi'
@@ -1136,7 +1100,6 @@
 	initialize_directions = SOUTH
 
 	var/build_killswitch = 1
-	pipe_type = PIPE_UVENT
 	build_icon_state = "uvent"
 
 
@@ -1212,7 +1175,6 @@
 	desc = "An adapter for regular, supply, scrubbers, and fuel pipes."
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	icon_state = "map_universal"
-	pipe_type = PIPE_UNIVERSAL
 	build_icon_state = "universal"
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/on_update_icon(var/safety = 0)

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -18,26 +18,6 @@ obj/machinery/atmospherics/pipe/zpipe
 
 	level = 1
 
-obj/machinery/atmospherics/pipe/zpipe/New()
-	..()
-	switch(dir)
-		if(SOUTH)
-			initialize_directions = SOUTH
-		if(NORTH)
-			initialize_directions = NORTH
-		if(WEST)
-			initialize_directions = WEST
-		if(EAST)
-			initialize_directions = EAST
-		if(NORTHEAST)
-			initialize_directions = NORTH
-		if(NORTHWEST)
-			initialize_directions = WEST
-		if(SOUTHEAST)
-			initialize_directions = EAST
-		if(SOUTHWEST)
-			initialize_directions = SOUTH
-
 /obj/machinery/atmospherics/pipe/zpipe/hide(var/i)
 	if(istype(loc, /turf/simulated))
 		set_invisibility(i ? 101 : 0)
@@ -71,12 +51,6 @@ obj/machinery/atmospherics/pipe/zpipe/proc/burst()
 	smoke.set_up(1,0, src.loc, 0)
 	smoke.start()
 	qdel(src) // NOT qdel.
-
-obj/machinery/atmospherics/pipe/zpipe/proc/normalize_dir()
-	if(dir == (NORTH|SOUTH))
-		set_dir(NORTH)
-	else if(dir == (EAST|WEST))
-		set_dir(EAST)
 
 obj/machinery/atmospherics/pipe/zpipe/Destroy()
 	if(node1)
@@ -115,7 +89,6 @@ obj/machinery/atmospherics/pipe/zpipe/up
 
 obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 	..()
-	normalize_dir()
 	var/node1_dir
 
 	for(var/direction in GLOB.cardinal)
@@ -154,7 +127,6 @@ obj/machinery/atmospherics/pipe/zpipe/down
 
 obj/machinery/atmospherics/pipe/zpipe/down/atmos_init()
 	..()
-	normalize_dir()
 	var/node1_dir
 
 	for(var/direction in GLOB.cardinal)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -8195,7 +8195,7 @@
 	dir = 10
 	},
 /obj/structure/sign/warning/nosmoking_burned{
-	dir = 3;
+	dir = 1;
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,


### PR DESCRIPTION
Does a bunch of cleanup. The basic issue was that the pipe_type var I remove from everything wasn't being updated by machinery, as it's not uniquely determined by the machine's type. This instead resolved the issue by axing the var and taking the only stuff relevant from it (dir configuration) from machine state directly.

Now also kills use of `New`. Note that vars set on the map are not available (in their final form) in New if the map is loaded via maploader.