### PR TITLE
Adds a warning if you break a RIG while hacking it

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -45,6 +45,8 @@
 			rig.ai_override_enabled = !rig.ai_override_enabled
 			rig.visible_message("A small red light on [rig] [rig.ai_override_enabled?"goes dead":"flickers on"].")
 		if(RIG_SYSTEM_CONTROL)
+			if (rig.offline)
+				rig.visible_message("\The [rig] sparks, damaging its delicate control systems.")
 			rig.malfunctioning += 10
 			if(rig.malfunction_delay <= 0)
 				rig.malfunction_delay = 20


### PR DESCRIPTION
🆑 MikoMyazaki
tweak: RIGs will now warn you if you make them malfunction while offline, requiring nanopaste to repair.
/🆑

