### PR TITLE
Can no longer put polytool tools in pockets, behind your ear, etc.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -34,6 +34,9 @@
 
 		return 0
 
+	if(!canUnEquip(W))
+		return 0
+
 	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
 	return 1
 


### PR DESCRIPTION
🆑 MikoMyazaki
bugfix: Prevents putting polytool augment tools in your pocket, behind your ear, etc.
/🆑

Fixes #24517

Prevents you moving polytool tools into pockets, ear, whatever other slots they could go into. (Which also prevented you putting the tool back in your hand / back into the augment)