### PR TITLE
Fixes to disposals stuff.

### DIFF
--- a/code/__defines/atmospherics.dm
+++ b/code/__defines/atmospherics.dm
@@ -78,29 +78,6 @@
 #define CONNECT_TYPE_HE				8
 #define CONNECT_TYPE_FUEL           16
 
-//Disposal Pipe Definitions
-#define DISPOSAL_STRAIGHT           0
-#define DISPOSAL_BENT               1
-#define DISPOSAL_JUNCTION1          2
-#define DISPOSAL_JUNCTION2          3
-#define DISPOSAL_JUNCTION_Y         4
-#define DISPOSAL_TRUNK              5
-#define DISPOSAL_BIN                6
-#define DISPOSAL_OUTLET             7
-#define DISPOSAL_INLET              8
-#define DISPOSAL_JUNCTION_SORT1     9
-#define DISPOSAL_JUNCTION_SORT2     10
-#define DISPOSAL_UP                 11
-#define DISPOSAL_DOWN               12
-#define DISPOSAL_TAGGER             13
-#define DISPOSAL_TAGGER_PARTIAL     14
-#define DISPOSAL_DIVERSION          15
-
-//Disposal Sorting Subtype Definitions
-#define DISPOSAL_SUB_SORT_NORMAL    0
-#define DISPOSAL_SUB_SORT_WILD      1
-#define DISPOSAL_SUB_SORT_UNTAGGED  2
-
 #define DISPOSAL_FLIP_NONE          0
 #define DISPOSAL_FLIP_FLIP          1
 #define DISPOSAL_FLIP_LEFT          2

--- a/code/game/machinery/pipe/pipe_datums/disposal_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/disposal_pipe_datums.dm
@@ -1,6 +1,5 @@
 /datum/pipe/disposal_dispenser
 	name = "Disposal pipe. You should never see this."
-	var/subtype = DISPOSAL_SUB_SORT_NORMAL
 	pipe_type = null
 	pipe_color = null
 	connect_types = null
@@ -12,9 +11,8 @@
 	name = "disposal pipe segment"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-s"
+	build_icon_state = "pipe-s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_STRAIGHT
 	turn = DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/segment
 
@@ -22,19 +20,17 @@
 	name = "bent disposal pipe segment"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-c"
+	build_icon_state = "pipe-c"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_BENT
-	turn = DISPOSAL_FLIP_FLIP|DISPOSAL_FLIP_RIGHT
-	constructed_path = /obj/structure/disposalpipe/segment
+	turn = DISPOSAL_FLIP_RIGHT
+	constructed_path = /obj/structure/disposalpipe/segment/bent
 
 /datum/pipe/disposal_dispenser/simple/junction
 	name = "disposal pipe junction"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j1"
+	build_icon_state = "pipe-j1"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION1
 	turn = DISPOSAL_FLIP_RIGHT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/junction
 
@@ -42,19 +38,17 @@
 	name = "disposal pipe junction (mirrored)"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j2"
+	build_icon_state = "pipe-j2"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION2
 	turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_FLIP
-	constructed_path = /obj/structure/disposalpipe/junction
+	constructed_path = /obj/structure/disposalpipe/junction/mirrored
 
 /datum/pipe/disposal_dispenser/simple/yjunction
 	name = "disposal pipe y-junction"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-y"
+	build_icon_state = "pipe-y"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_Y
 	turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_RIGHT
 	constructed_path = /obj/structure/disposalpipe/junction
 
@@ -62,9 +56,8 @@
 	name = "disposal pipe trunk"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-t"
+	build_icon_state = "pipe-t"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_TRUNK
 	constructed_path = /obj/structure/disposalpipe/trunk
 
 /datum/pipe/disposal_dispenser/simple/up
@@ -73,7 +66,6 @@
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "pipe-u"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_UP
 	constructed_path = /obj/structure/disposalpipe/up
 
 /datum/pipe/disposal_dispenser/simple/down
@@ -82,16 +74,14 @@
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "pipe-d"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_DOWN
 	constructed_path = /obj/structure/disposalpipe/down
 
 /datum/pipe/disposal_dispenser/device/bin
 	name = "disposal bin"
 	desc = "A bin used to dispose of trash."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "condisposal"
-	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_BIN
+	build_icon_state = "disposal"
+	build_path = /obj/structure/disposalconstruct/machine
 	constructed_path = /obj/machinery/disposal
 
 /datum/pipe/disposal_dispenser/device/outlet
@@ -99,8 +89,7 @@
 	desc = "an outlet that ejects things from a disposal network."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "outlet"
-	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_OUTLET
+	build_path = /obj/structure/disposalconstruct/machine/outlet
 	constructed_path = /obj/structure/disposaloutlet
 
 /datum/pipe/disposal_dispenser/device/chute
@@ -109,17 +98,14 @@
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "intake"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_INLET
 	constructed_path = /obj/machinery/disposal/deliveryChute
 
 /datum/pipe/disposal_dispenser/device/sorting
 	name = "disposal sorter"
 	desc = "Sorts things in a disposal system"
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j1s"
+	build_icon_state = "pipe-j1s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_SORT1
-	subtype = DISPOSAL_SUB_SORT_NORMAL
 	turn = DISPOSAL_FLIP_RIGHT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/sortjunction
 
@@ -127,10 +113,8 @@
 	name = "wildcard disposal sorter"
 	desc = "Sorts things in a disposal system"
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j1s"
+	build_icon_state = "pipe-j1s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_SORT1
-	subtype = DISPOSAL_SUB_SORT_WILD
 	turn = DISPOSAL_FLIP_RIGHT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/sortjunction/wildcard
 
@@ -138,10 +122,8 @@
 	name = "untagged disposal sorter"
 	desc = "Sorts things in a disposal system"
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j1s"
+	build_icon_state = "pipe-j1s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_SORT1
-	subtype = DISPOSAL_SUB_SORT_UNTAGGED
 	turn = DISPOSAL_FLIP_RIGHT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/sortjunction/untagged
 
@@ -149,10 +131,8 @@
 	name = "disposal sorter (mirrored)"
 	desc = "Sorts things in a disposal system"
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j2s"
+	build_icon_state = "pipe-j2s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_SORT2
-	subtype = DISPOSAL_SUB_SORT_NORMAL
 	turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/sortjunction/flipped
 
@@ -160,10 +140,8 @@
 	name = "wildcard disposal sorter (mirrored)"
 	desc = "Sorts things in a disposal system"
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j2s"
+	build_icon_state = "pipe-j2s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_SORT2
-	subtype = DISPOSAL_SUB_SORT_WILD
 	turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/sortjunction/wildcard/flipped
 
@@ -171,10 +149,8 @@
 	name = "untagged disposal sorter (mirrored)"
 	desc = "Sorts things in a disposal system"
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j2s"
+	build_icon_state = "pipe-j2s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_JUNCTION_SORT2
-	subtype = DISPOSAL_SUB_SORT_UNTAGGED
 	turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/sortjunction/untagged/flipped
 
@@ -184,7 +160,6 @@
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "pipe-tagger"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_TAGGER
 	turn = DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/tagger
 
@@ -194,7 +169,6 @@
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "pipe-tagger-partial"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_TAGGER_PARTIAL
 	turn = DISPOSAL_FLIP_FLIP
 	constructed_path = /obj/structure/disposalpipe/tagger/partial
 
@@ -202,18 +176,7 @@
 	name = "disposal diverter"
 	desc = "A huge pipe segment used for constructing disposal systems."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j1s"
+	build_icon_state = "pipe-j1s"
 	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_DIVERSION
-	turn = DISPOSAL_FLIP_FLIP
-	constructed_path = /obj/structure/disposalpipe/diversion_junction
-
-/datum/pipe/disposal_dispenser/device/diversion/switch
-	name = "disposal diverter switch"
-	desc = "A huge pipe segment used for constructing disposal systems."
-	build_icon = 'icons/obj/pipes/disposal.dmi'
-	build_icon_state = "conpipe-j1s"
-	build_path = /obj/structure/disposalconstruct
-	pipe_type = DISPOSAL_DIVERSION
-	turn = DISPOSAL_FLIP_FLIP
+	turn = DISPOSAL_FLIP_FLIP | DISPOSAL_FLIP_RIGHT
 	constructed_path = /obj/structure/disposalpipe/diversion_junction

--- a/code/game/machinery/pipe/pipe_datums/pipe_datum_base.dm
+++ b/code/game/machinery/pipe/pipe_datums/pipe_datum_base.dm
@@ -81,13 +81,12 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 /datum/pipe/disposal_dispenser/Build(var/datum/pipe/disposal_dispenser/D, var/loc, var/pipe_color = PIPE_COLOR_GREY)
 	if(D.build_path)
 		var/obj/structure/disposalconstruct/new_item = new build_path(loc)
-		if(D.pipe_type != null)
-			new_item.ptype = D.pipe_type
 		new_item.SetName(D.name)
 		new_item.desc = D.desc
 		new_item.set_dir(D.dir)
 		new_item.icon = D.build_icon
-		new_item.icon_state = D.build_icon_state
+		new_item.built_icon_state = D.build_icon_state
 		new_item.set_density(1)
 		new_item.turn = D.turn
 		new_item.constructed_path = D.constructed_path
+		new_item.update_icon()

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -10,12 +10,12 @@
 	density = 0
 	matter = list(MATERIAL_STEEL = 1850)
 	level = 2
+	obj_flags = OBJ_FLAG_ROTATABLE
 	var/sort_type = ""
-	var/ptype = DISPOSAL_STRAIGHT
-	var/subtype = 0
 	var/dpdir = 0	// directions as disposalpipe
 	var/turn = DISPOSAL_FLIP_FLIP
 	var/constructed_path = /obj/structure/disposalpipe
+	var/built_icon_state
 
 /obj/structure/disposalconstruct/New(loc, var/P = null)
 	. = ..()
@@ -25,28 +25,26 @@
 			SetName(D.name)
 			desc = D.desc
 			icon = D.icon
-			icon_state = D.icon_state
+			built_icon_state = D.icon_state
 			anchored = D.anchored
 			set_density(D.density)
-			set_dir(D.dir)
-			sort_type = D.sort_type
-			ptype = D.ptype
-			subtype = D.subtype
-			dpdir = D.dpdir
 			turn = D.turn
+			sort_type = D.sort_type
+			dpdir = D.dpdir
 			constructed_path = D.type
+			set_dir(D.dir) // Needs to be set after turn and possibly other state.
 		if(istype(P, /obj/machinery/disposal))
 			var/obj/machinery/disposal/D = P
 			SetName(D.name)
 			desc = D.desc
 			icon = D.icon
-			icon_state = D.icon_state
+			built_icon_state = D.icon_state
 			anchored = D.anchored
 			set_density(D.density)
-			set_dir(D.dir)
-			ptype = D.ptype			
 			turn = D.turn
 			constructed_path = D.type
+			set_dir(D.dir)
+	update_icon()
 
 /obj/structure/disposalconstruct/Initialize()
 	update_verbs()
@@ -58,28 +56,8 @@
 	else
 		verbs += /obj/structure/disposalconstruct/proc/flip
 
-/obj/structure/disposalconstruct/proc/flip_dirs(var/flipvalue)
-	var/finaldir = dir	
-	if(flipvalue&DISPOSAL_FLIP_FLIP)
-		finaldir = finaldir|turn(dir,180)
-	if(flipvalue&DISPOSAL_FLIP_LEFT)
-		finaldir = finaldir|turn(dir,90)
-	if(flipvalue&DISPOSAL_FLIP_RIGHT)
-		finaldir = finaldir|turn(dir,-90)
-	return finaldir
-
-/obj/structure/disposalconstruct/on_update_icon()
-	. = ..()
-	if(ptype == DISPOSAL_BIN)//only the bin has multiple icon states.
-		if(anchored)
-			icon_state = "disposal"
-		else
-			icon_state = "condisposal"
-
 // update iconstate and dpdir due to dir and type
 /obj/structure/disposalconstruct/proc/update()
-	if(!DISPOSAL_BIN)//The bin doesn't flip around.
-		dir = flip_dirs(turn) //does the flipping stuff
 	if(invisibility)      // if invisible, fade icon
 		alpha = 128
 	else
@@ -103,59 +81,52 @@
 		to_chat(usr, "You must unfasten the pipe before flipping it.")
 		return
 
+	if(ispath(constructed_path, /obj/structure/disposalpipe))
+		var/obj/structure/disposalpipe/fake_pipe = constructed_path
+		if(initial(fake_pipe.flipped_state))
+			constructed_path = initial(fake_pipe.flipped_state)
+			fake_pipe = constructed_path
+			turn = initial(fake_pipe.turn)
+			built_icon_state = initial(fake_pipe.icon_state)
+			set_dir(dir) // run the update, as our dpdir is probably wrong after this
+			update_icon()
+			return
 	set_dir(turn(dir, 180))
-	switch(ptype)
-		if(DISPOSAL_JUNCTION1)
-			ptype = DISPOSAL_JUNCTION2
-			turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_FLIP
-		if(DISPOSAL_JUNCTION2)
-			ptype = DISPOSAL_JUNCTION1
-			turn = DISPOSAL_FLIP_RIGHT|DISPOSAL_FLIP_FLIP
-		if(DISPOSAL_JUNCTION_SORT1)
-			ptype = DISPOSAL_JUNCTION_SORT2
-			turn = DISPOSAL_FLIP_LEFT|DISPOSAL_FLIP_FLIP
-		if(DISPOSAL_JUNCTION_SORT2)
-			ptype = DISPOSAL_JUNCTION_SORT1
-			turn = DISPOSAL_FLIP_RIGHT|DISPOSAL_FLIP_FLIP
 
+/obj/structure/disposalconstruct/on_update_icon()
+	if("con[built_icon_state]" in icon_states(icon))
+		icon_state = "con[built_icon_state]"
+	else
+		icon_state = built_icon_state
+
+/obj/structure/disposalconstruct/proc/flip_dirs(var/flipvalue)
+	. = dir
+	if(flipvalue & DISPOSAL_FLIP_FLIP)
+		. |= turn(dir,180)
+	if(flipvalue & DISPOSAL_FLIP_LEFT)
+		. |= turn(dir,90)
+	if(flipvalue & DISPOSAL_FLIP_RIGHT)
+		. |= turn(dir,-90)
+
+/obj/structure/disposalconstruct/set_dir(new_dir)
+	. = ..()
+	dpdir = flip_dirs(turn) //does the flipping stuff
 	update()
+
+/obj/structure/disposalconstruct/Move()
+	var/old_dir = dir
+	. = ..()
+	set_dir(old_dir)
 
 // attackby item
 // wrench: (un)anchor
 // weldingtool: convert to real pipe
 /obj/structure/disposalconstruct/attackby(var/obj/item/I, var/mob/user)
-	var/nicetype = "pipe"
-	var/ispipe = 0 // Indicates if we should change the level of this pipe
-	add_fingerprint(user, 0, I)
-	switch(ptype)
-		if(DISPOSAL_BIN)
-			nicetype = "disposal bin"
-		if(DISPOSAL_OUTLET)
-			nicetype = "disposal outlet"
-		if(DISPOSAL_INLET)
-			nicetype = "delivery chute"
-		if(DISPOSAL_JUNCTION_SORT1, DISPOSAL_JUNCTION_SORT2)
-			switch(subtype)
-				if(DISPOSAL_SUB_SORT_NORMAL)
-					nicetype = "sorting pipe"
-				if(DISPOSAL_SUB_SORT_WILD)
-					nicetype = "wildcard sorting pipe"
-				if(DISPOSAL_SUB_SORT_UNTAGGED)
-					nicetype = "untagged sorting pipe"
-			ispipe = 1
-		if(DISPOSAL_TAGGER)
-			nicetype = "tagging pipe"
-			ispipe = 1
-		if(DISPOSAL_TAGGER_PARTIAL)
-			nicetype = "partial tagging pipe"
-			ispipe = 1
-		else
-			nicetype = "pipe"
-			ispipe = 1
-
-	var/turf/T = src.loc
+	var/turf/T = loc
+	if(!istype(T))
+		return
 	if(!T.is_plating())
-		to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
+		to_chat(user, "You can only manipulate \the [src] if the floor plating is removed.")
 		return
 
 	var/obj/structure/disposalpipe/CP = locate() in T
@@ -163,39 +134,14 @@
 	if(isWrench(I))
 		if(anchored)
 			anchored = 0
-			if(ispipe)
-				level = 2
-				set_density(0)
-			else
-				set_density(1)
-			to_chat(user, "You detach the [nicetype] from the underfloor.")
+			wrench_down(FALSE)
+			to_chat(user, "You detach \the [src] from the underfloor.")
 		else
-			if(ptype>=DISPOSAL_BIN && ptype <= DISPOSAL_INLET) // Disposal or outlet
-				if(CP) // There's something there
-					if(!istype(CP,/obj/structure/disposalpipe/trunk))
-						to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
-						return
-				else // Nothing under, fuck.
-					to_chat(user, "The [nicetype] requires a trunk underneath it in order to work.")
-					return
-			else
-				if(CP)
-					update()
-					var/pdir = CP.dpdir
-					if(istype(CP, /obj/structure/disposalpipe/broken))
-						pdir = CP.dir
-					if(pdir & dpdir)
-						to_chat(user, "There is already a [nicetype] at that location.")
-						return
-
-			anchored = 1
-			if(ispipe)
-				level = 1 // We don't want disposal bins to disappear under the floors
-				set_density(0)
-			else
-				set_density(1) // We don't want disposal bins or outlets to go density 0
-			to_chat(user, "You attach the [nicetype] to the underfloor.")
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+			if(!check_buildability(CP, user))
+				return
+			wrench_down(TRUE)
+			to_chat(user, "You attach \the [src] to the underfloor.")
+		playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
 		update()
 		update_verbs()
 
@@ -204,47 +150,11 @@
 			var/obj/item/weapon/weldingtool/W = I
 			if(W.remove_fuel(0,user))
 				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-				to_chat(user, "Welding the [nicetype] in place.")
+				to_chat(user, "Welding \the [src] in place.")
 				if(do_after(user, 20, src))
 					if(!src || !W.isOn()) return
-					to_chat(user, "The [nicetype] has been welded in place!")
-					update() // TODO: Make this neat
-					if(ispipe) // Pipe
-						
-						var/obj/structure/disposalpipe/P = new src.constructed_path(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.base_icon_state = icon_state
-						P.set_dir(dir)
-						P.dpdir = dpdir
-						P.update_icon()
-
-						//Needs some special treatment ;)
-						if(ptype==DISPOSAL_JUNCTION_SORT1 || ptype==DISPOSAL_JUNCTION_SORT2)
-							var/obj/structure/disposalpipe/sortjunction/SortP = P
-							SortP.sort_type = sort_type
-							SortP.updatedir()
-							SortP.updatedesc()
-							SortP.updatename()
-
-					else if(ptype==DISPOSAL_BIN) // Disposal bin
-						var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.mode = 0 // start with pump off
-
-					else if(ptype==DISPOSAL_OUTLET) // Disposal outlet
-
-						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.set_dir(dir)
-						var/obj/structure/disposalpipe/trunk/Trunk = CP
-						Trunk.linked = P
-
-					else if(ptype==DISPOSAL_INLET) // Disposal outlet
-
-						var/obj/machinery/disposal/deliveryChute/P = new /obj/machinery/disposal/deliveryChute(src.loc)
-						src.transfer_fingerprints_to(P)
-						P.set_dir(dir)
-
+					to_chat(user, "\The [src] has been welded in place!")
+					build(CP)
 					qdel(src)
 					return
 			else
@@ -255,7 +165,77 @@
 			return
 
 /obj/structure/disposalconstruct/hides_under_flooring()
-	if(anchored)
-		return 1
+	return anchored
+
+/obj/structure/disposalconstruct/proc/check_buildability(obj/structure/disposalpipe/CP, mob/user)
+	if(!CP)
+		return TRUE
+	var/pdir = CP.dpdir
+	if(istype(CP, /obj/structure/disposalpipe/broken))
+		pdir = CP.dir
+	if(pdir & dpdir)
+		to_chat(user, "There is already a disposals pipe at that location.")
+		return FALSE
+	return TRUE
+
+/obj/structure/disposalconstruct/proc/wrench_down(anchor)
+	if(anchor)
+		anchored = TRUE
+		level = 1 // We don't want disposal bins to disappear under the floors
+		set_density(0)
 	else
-		return 0
+		anchored = FALSE
+		level = 2
+		set_density(1)
+
+/obj/structure/disposalconstruct/machine/check_buildability(obj/structure/disposalpipe/CP, mob/user)
+	if(CP) // There's something there
+		if(!istype(CP,/obj/structure/disposalpipe/trunk))
+			to_chat(user, "\The [src] requires a trunk underneath it in order to work.")
+			return FALSE
+		return TRUE
+	// Nothing under, fuck.
+	to_chat(user, "\The [src] requires a trunk underneath it in order to work.")
+	return FALSE
+
+/obj/structure/disposalconstruct/proc/build()
+	var/obj/structure/disposalpipe/P = new constructed_path(loc)
+	transfer_fingerprints_to(P)
+	P.base_icon_state = built_icon_state
+	P.icon_state = built_icon_state
+	P.dpdir = dpdir
+	P.sort_type = sort_type
+	P.set_dir(dir)
+	P.on_build()
+
+// Subtypes
+
+/obj/structure/disposalconstruct/machine
+	obj_flags = 0 // No rotating
+
+/obj/structure/disposalconstruct/machine/update_verbs()
+	return // No flipping
+
+/obj/structure/disposalconstruct/machine/wrench_down(anchor)
+	anchored = anchor
+	set_density(1) // We don't want disposal bins or outlets to go density 0
+	update_icon()
+
+/obj/structure/disposalconstruct/machine/build(obj/structure/disposalpipe/CP)
+	var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
+	transfer_fingerprints_to(P)
+	P.set_dir(dir)
+	P.mode = 0 // start with pump off
+
+/obj/structure/disposalconstruct/machine/on_update_icon()
+	if(anchored)
+		icon_state = built_icon_state
+	else
+		..()
+
+/obj/structure/disposalconstruct/machine/outlet/build(obj/structure/disposalpipe/CP)
+	var/obj/structure/disposaloutlet/P = new constructed_path(loc)
+	transfer_fingerprints_to(P)
+	P.set_dir(dir)
+	var/obj/structure/disposalpipe/trunk/Trunk = CP
+	Trunk.linked = P

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -30,7 +30,6 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	active_power_usage = 2200	//the pneumatic pump power. 3 HP ~ 2200W
 	idle_power_usage = 100
 	atom_flags = ATOM_FLAG_CLIMBABLE
-	var/ptype = DISPOSAL_BIN
 	var/turn = DISPOSAL_FLIP_NONE
 
 // create a new disposal
@@ -62,7 +61,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	add_fingerprint(user, 0, I)
 	if(mode<=0) // It's off
 		if(isScrewdriver(I))
-			if(contents.len > 0)
+			if(contents.len > LAZYLEN(component_parts))
 				to_chat(user, "Eject the items first!")
 				return
 			if(mode==0) // It's off but still not unscrewed
@@ -76,7 +75,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 				to_chat(user, "You attach the screws around the power connection.")
 				return
 		else if(isWelder(I) && mode==-1)
-			if(contents.len > 0)
+			if(contents.len > LAZYLEN(component_parts))
 				to_chat(user, "Eject the items first!")
 				return
 			var/obj/item/weapon/weldingtool/W = I
@@ -87,11 +86,8 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 				if(do_after(user,20,src))
 					if(!src || !W.isOn()) return
 					to_chat(user, "You sliced the floorweld off the disposal unit.")
-					var/obj/structure/disposalconstruct/C = new (src.loc)
+					var/obj/structure/disposalconstruct/machine/C = new (loc, src)
 					src.transfer_fingerprints_to(C)
-					C.ptype = DISPOSAL_BIN
-					C.anchored = 1
-					C.set_density(1)
 					C.update()
 					qdel(src)
 				return
@@ -327,7 +323,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 
 // eject the contents of the disposal unit
 /obj/machinery/disposal/proc/eject()
-	for(var/atom/movable/AM in src)
+	for(var/atom/movable/AM in (contents - component_parts))
 		AM.forceMove(src.loc)
 		AM.pipe_eject(0)
 	update_icon()
@@ -570,7 +566,6 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	var/turf/target	// this will be where the output objects are 'thrown' to.
 	var/mode = 0
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
-	var/ptype = DISPOSAL_OUTLET
 
 /obj/structure/disposaloutlet/Initialize()
 	. = ..()
@@ -623,7 +618,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 			if(do_after(user,20, src))
 				if(!src || !W.isOn()) return
 				to_chat(user, "You sliced the floorweld off the disposal outlet.")
-				var/obj/structure/disposalconstruct/C = new (src.loc, src)
+				var/obj/structure/disposalconstruct/machine/outlet/C = new (loc, src)
 				src.transfer_fingerprints_to(C)								
 				C.anchored = 1
 				C.set_density(1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -393,7 +393,6 @@
 	icon_state = "intake"
 
 	var/c_mode = 0
-	ptype = DISPOSAL_INLET
 
 /obj/machinery/disposal/deliveryChute/New()
 	..()
@@ -488,11 +487,8 @@
 				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
 				if(!src || !W.isOn()) return
 				to_chat(user, "You sliced the floorweld off the delivery chute.")
-				var/obj/structure/disposalconstruct/C = new (src.loc)
-				C.ptype = 8 // 8 =  Delivery chute
+				var/obj/structure/disposalconstruct/C = new (loc, src)
 				C.update()
-				C.anchored = 1
-				C.set_density(1)
 				qdel(src)
 			return
 		else


### PR DESCRIPTION
:cl:
tweak: You can rotate disposals pipes now.
tweak: Flipping disposals pipes moves them to the mirrored state (unlike rotating twice).
tweak: Dragging disposals pipes no longer rotates them.
bugfix: various issues with disposals construction have been addressed.
/:cl:

Fixes #25917 
Fixes #25915
