### PR TITLE
Removed the psi implant from the Counselor.

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -222,7 +222,7 @@
 		/datum/computer_file/program/suit_sensors,
 		/datum/computer_file/program/camera_monitor
 	)
-	//give_psionic_implant_on_join = FALSE
+	give_psionic_implant_on_join = FALSE
 
 /datum/job/psychiatrist/New()
 	psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -16981,6 +16981,7 @@
 	},
 /obj/item/weapon/storage/medical_lolli_jar,
 /obj/structure/table/standard,
+/obj/item/weapon/book/manual/psionics,
 /turf/simulated/floor/tiled/white,
 /area/medical/counselor)
 "dTb" = (
@@ -19249,7 +19250,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue,
-/obj/machinery/psi_monitor,
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary/annex)
 "gvb" = (


### PR DESCRIPTION
- Counselor no longer spawns with psi implant.
- Psi-implant control computer removed from Counselor office.
- Psionics manual spawns in Counselor office.