### PR TITLE
Adds a very, very small chance for offmap roles to be latent psionics, take two.

### DIFF
--- a/maps/torch/torch_submaps.dm
+++ b/maps/torch/torch_submaps.dm
@@ -3,3 +3,6 @@
 	branch = /datum/mil_branch/alien
 	allowed_branches = list(/datum/mil_branch/alien)
 	allowed_ranks = list(/datum/mil_rank/alien)
+
+/datum/job/submap
+	psi_latency_chance = 1

--- a/maps/torch/torch_submaps.dm
+++ b/maps/torch/torch_submaps.dm
@@ -6,3 +6,4 @@
 
 /datum/job/submap
 	psi_latency_chance = 1
+	give_psionic_implant_on_join = FALSE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Now that Sabira's plan fell through. If @MistakeNot4892 has other plans, I can close this.