### PR TITLE
Minor Deity Mode Bugfixes (Robes and Punishment Menu)

### DIFF
--- a/code/modules/mob/living/deity/phenomena/communication.dm
+++ b/code/modules/mob/living/deity/phenomena/communication.dm
@@ -55,7 +55,7 @@
 	var/static/list/punishment_list = list("Pain (0)" = 0, "Light Wound (5)" = 5, "Brain Damage (10)" = 10, "Heavy Wounds (20)" = 20)
 
 /datum/phenomena/punish/activate(var/mob/living/L)
-	var/pain = input(linked, "Choose their punishment.", "Punishment") as anything in punishment_list
+	var/pain = input(linked, "Choose their punishment.", "Punishment") as null|anything in punishment_list
 	if(!pain)
 		return
 	if(punishment_list[pain] && linked.power < punishment_list[pain])

--- a/code/modules/spells/aoe_turf/conjure/faithful_hound.dm
+++ b/code/modules/spells/aoe_turf/conjure/faithful_hound.dm
@@ -20,3 +20,4 @@
 
 /spell/aoe_turf/conjure/faithful_hound/tower
 	charge_max = 1
+	spell_flags = 0

--- a/code/modules/spells/aoe_turf/conjure/force_portal.dm
+++ b/code/modules/spells/aoe_turf/conjure/force_portal.dm
@@ -13,3 +13,4 @@
 
 /spell/aoe_turf/conjure/force_portal/tower
 	charge_max = 2
+	spell_flags = 0

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -83,6 +83,7 @@
 
 /spell/targeted/heal_target/major/tower
 	charge_max = 1
+	spell_flags = INCLUDEUSER | SELECTABLE
 
 /spell/targeted/heal_target/area
 	name = "Cure Area"

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -119,3 +119,4 @@
 
 /spell/targeted/ethereal_jaunt/tower
 	charge_max = 2
+	spell_flags = Z2NOCAST | INCLUDEUSER


### PR DESCRIPTION
🆑 MikoMyazaki
bugfix: Spells granted by The Tower deity no longer require robes to cast.
tweak: Adds an exit button to the Deity punishment menu incase you open it accidentally.
/🆑

Fixes #24703 
