### PR TITLE
Random closets can no longer be prisoner attire closets.

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -447,8 +447,7 @@ obj/random/closet/spawn_choices()
 				/obj/structure/largecrate,
 				/obj/structure/closet/wardrobe/xenos,
 				/obj/structure/closet/wardrobe/mixed,
-				/obj/structure/closet/wardrobe/suit,
-				/obj/structure/closet/wardrobe/orange)
+				/obj/structure/closet/wardrobe/suit)
 
 /obj/random/coin
 	name = "random coin"


### PR DESCRIPTION
🆑 MikoMyazaki
tweak: Random closets can no longer be prisoner clothing closets.
/🆑

#25734 missed these. Prisoner clothes will only exist on the maps that specifically have them mapped in after this. (So not the Torch)