### PR TITLE
Remove access requirement on old brig wall shield generators.

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -71,8 +71,7 @@
 /area/vacant/brig)
 "am" = (
 /obj/machinery/shieldwallgen{
-	anchored = 1;
-	req_access = list("ACCESS_RESEARCH")
+	anchored = 1
 	},
 /turf/simulated/floor/plating,
 /area/vacant/brig)


### PR DESCRIPTION
Defaults to ACCESS_ENGINE_EQUIP and ACCESS_RESEARCH as opposed to just ACCESS_RESEARCH.