### PR TITLE
Make draining a proc of hygiene, retypes drains

### DIFF
--- a/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
@@ -212,7 +212,7 @@
 	colorable = FALSE
 	pipe_type = null
 	pipe_color = null
-	constructed_path = /obj/structure/drain
+	constructed_path = /obj/structure/hygiene/drain
 	pipe_class = PIPE_CLASS_OTHER
 
 /datum/pipe/pipe_dispenser/device/tank

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -1,6 +1,6 @@
 // Cheap, shitty, hacky means of draining water without a proper pipe system.
 // TODO: water pipes.
-/obj/structure/drain
+/obj/structure/hygiene/drain
 	name = "gutter"
 	desc = "You probably can't get sucked down the plughole."
 	icon = 'icons/obj/drain.dmi'
@@ -8,19 +8,11 @@
 	anchored = 1
 	density = 0
 	layer = TURF_LAYER+0.1
-	var/drainage = 0.5
-	var/last_gurgle = 0
+	can_drain = 1
 	var/welded
 
-/obj/structure/drain/New()
+/obj/structure/hygiene/drain/attackby(var/obj/item/thing, var/mob/user)
 	..()
-	START_PROCESSING(SSobj, src)
-
-/obj/structure/drain/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	. = ..()
-
-/obj/structure/drain/attackby(var/obj/item/thing, var/mob/user)
 	if(isWelder(thing))
 		var/obj/item/weapon/weldingtool/WT = thing
 		if(WT.isOn())
@@ -38,23 +30,13 @@
 		return
 	return ..()
 
-/obj/structure/drain/on_update_icon()
+/obj/structure/hygiene/drain/on_update_icon()
 	icon_state = "[initial(icon_state)][welded ? "-welded" : ""]"
 
-/obj/structure/drain/Process()
+/obj/structure/hygiene/drain/Process()
 	if(welded)
 		return
-	var/turf/T = get_turf(src)
-	if(!istype(T)) return
-	var/fluid_here = T.get_fluid_depth()
-	if(fluid_here <= 0)
-		return
-
-	T.remove_fluid(ceil(fluid_here*drainage))
-	T.show_bubbles()
-	if(world.time > last_gurgle + 80)
-		last_gurgle = world.time
-		playsound(T, pick(SSfluids.gurgles), 50, 1)
+	..()
 
 //for construction.
 /obj/item/drain
@@ -65,7 +47,7 @@
 
 /obj/item/drain/attackby(var/obj/item/thing, var/mob/user)
 	if(isWrench(thing))
-		new /obj/structure/drain(src.loc)
+		new /obj/structure/hygiene/drain(src.loc)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		to_chat(user, "<span class='warning'>[user] wrenches the [src] down.</span>")
 		qdel(src)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -3677,7 +3677,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "gE" = (
@@ -4436,7 +4436,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "hX" = (
@@ -5108,7 +5108,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/jail)
 "iY" = (
@@ -6524,7 +6524,7 @@
 /turf/simulated/floor/grass,
 /area/map_template/colony/hydroponics)
 "lp" = (
-/obj/structure/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "lq" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3486,7 +3486,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "jc" = (
-/obj/structure/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "je" = (


### PR DESCRIPTION
Any /obj/structure/hygiene can now drain water if its `can drain` is set to 1.

@MistakeNot4892 