### PR TITLE
Moved foundation agent ID spawn onto the antag datum from the outfit.

### DIFF
--- a/code/datums/outfits/spec_op.dm
+++ b/code/datums/outfits/spec_op.dm
@@ -92,5 +92,4 @@
 	l_hand =   /obj/item/weapon/storage/briefcase/foundation
 	l_ear =    /obj/item/device/radio/headset/foundation
 	holster =  /obj/item/clothing/accessory/storage/holster/armpit
-	id_type =  /obj/item/weapon/card/id/foundation
 	id_slot =  slot_wear_id

--- a/code/game/antagonist/outsider/foundation.dm
+++ b/code/game/antagonist/outsider/foundation.dm
@@ -25,6 +25,7 @@ GLOBAL_DATUM_INIT(foundation_agents, /datum/antagonist/foundation, new)
 	initial_spawn_target = 2
 	min_player_age = 14
 	faction = "foundation"
+	id_type = /obj/item/weapon/card/id/foundation
 
 /datum/antagonist/foundation/equip(var/mob/living/carbon/human/player)
 
@@ -39,3 +40,5 @@ GLOBAL_DATUM_INIT(foundation_agents, /datum/antagonist/foundation, new)
 
 	var/decl/hierarchy/outfit/foundation = outfit_by_type(/decl/hierarchy/outfit/foundation)
 	foundation.equip(player)
+
+	create_id("Foundation Agent", player)


### PR DESCRIPTION
Should prevent the ID not updating when the antag appearance editor is used on spawn.