### PR TITLE
Adds Vecuronium Bromide, a paralytic drug

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -49,6 +49,7 @@
 #define CE_THIRDEYE      "thirdeye"     // Gives xray vision.
 #define CE_SEDATE        "sedate"       // Applies sedation effects, i.e. paralysis, inability to use items, etc.
 #define CE_ENERGETIC     "energetic"    // Speeds up stamina recovery.
+#define	CE_VOICELOSS     "whispers"     // Lowers the subject's voice to a whisper
 
 //reagent flags
 #define IGNORE_MOB_SIZE 0x1

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -15,6 +15,9 @@
 				emote("custom", AUDIBLE_MESSAGE, "[pick("grunts", "babbles", "gibbers", "jabbers", "burbles")] aimlessly.")
 				return
 
+	if(has_chem_effect(CE_VOICELOSS, 1))
+		whispering = TRUE
+
 	message = sanitize(message)
 	var/obj/item/organ/internal/voicebox/vox = locate() in internal_organs
 	var/snowflake_speak = (speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) || (vox && vox.is_usable() && vox.assists_languages[speaking])

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -455,7 +455,7 @@
 	if(alien == IS_SKRELL)
 		threshold = 1.2
 
-	if(M.chem_doses[type] == metabolism * threshold)
+	if(M.chem_doses[type] >= metabolism * threshold)
 		M.confused += 2
 		M.drowsyness += 2
 	else if(M.chem_doses[type] < 2 * threshold)
@@ -478,6 +478,38 @@
 
 	glass_name = "beer"
 	glass_desc = "A freezing pint of beer"
+
+/datum/reagent/vecuronium_bromide
+	name = "Vecuronium Bromide"
+	description = "A powerful paralytic."
+	taste_description = "metallic"
+	reagent_state = SOLID
+	color = "#ff337d"
+	metabolism = REM * 0.5
+	overdose = REAGENTS_OVERDOSE * 0.5
+	value = 2.6
+
+/datum/reagent/vecuronium_bromide/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+
+	var/threshold = 2
+	if(alien == IS_SKRELL)
+		threshold = 1.2
+
+	if(M.chem_doses[type] >= metabolism * threshold)
+		M.confused = max(M.confused, 2)
+	if(M.chem_doses[type] >= 3 * threshold)
+		M.Weaken(30)
+		M.make_dizzy(3)
+		M.add_chemical_effect(CE_SEDATE, 1)
+		M.add_chemical_effect(CE_VOICELOSS, 1)
+		M.eye_blurry = max(M.eye_blurry, 10)
+		to_chat(M, SPAN_WARNING("Your muscles slacken and cease to obey you."))
+
+	if(M.chem_doses[type] > 1 * threshold)
+		M.adjustToxLoss(removed)
+
 /* Drugs */
 
 /datum/reagent/space_drugs

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -333,6 +333,12 @@
 	required_reagents = list(/datum/reagent/ethanol = 1, /datum/reagent/acid/hydrochloric = 3, /datum/reagent/water = 1)
 	result_amount = 1
 
+/datum/chemical_reaction/vecuronium_bromide
+	name = "Vecuronium Bromide"
+	result = /datum/reagent/vecuronium_bromide
+	required_reagents = list(/datum/reagent/ethanol = 1, /datum/reagent/mercury = 2, /datum/reagent/hydrazine = 2)
+	result_amount = 1
+
 /datum/chemical_reaction/potassium_chloride
 	name = "Potassium Chloride"
 	result = /datum/reagent/toxin/potassium_chloride


### PR DESCRIPTION
🆑 MikoMyazaki
rscadd: Adds Vecuronium Bromide, a paralytic drug.
/🆑

Essentially this acts similarly to sedative drugs, except instead of making the victim's screen go black (sleep) it keeps them aware but unable to speak above a whisper.

Recipe is : 1 Ethanol + 2 Mercury + 2 Hydrazine -> 1 Vecuronium Bromide.

I think this would be useful to have for two cases:
- Interrogation of troublesome prisoners, current sedatives make it difficult to actually talk to them.
- As an antagonist using drugs for my plans, I dislike making a player's screen go black for a few minutes - It's very boring for them. Sometimes I'd like them to be able to watch me doing my antagonistic plots -- Or my ambition involves being able to speak with them for threats, information etc.