### PR TITLE
 Fixes being able to drag people onto optables while buckled

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -141,7 +141,7 @@
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/M = user
-	if(user.stat || user.restrained() || !check_table(user) || !iscarbon(target))
+	if(user.stat || user.restrained() || !check_table(target) || !iscarbon(target))
 		return
 	if(istype(M))
 		take_victim(target,user)


### PR DESCRIPTION
🆑 MikoMyazaki
bugfix: Can no longer drag people off of something they are buckled into (e.g. roller bed) onto an op table without unbuckling.
/🆑

Fixes #26009