### PR TITLE
Gives a robot its default language when it gets reset

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -176,6 +176,7 @@
 	for(var/original_language in original_languages)
 		R.add_language(original_language, original_languages[original_language])
 	original_languages.Cut()
+	R.add_language(R.default_language)
 
 /obj/item/weapon/robot_module/proc/add_camera_networks(var/mob/living/silicon/robot/R)
 	if(R.camera && (NETWORK_ROBOTS in R.camera.network))


### PR DESCRIPTION
🆑 MikoMyazaki
bugfix: Module-less robots will now always have their default language.
/🆑

Currently, a robot that gets a reset card will not get its default language (Zurich Accord Common) while it has no module chosen. It does have this language when it first spawns in this state.

This makes it hard to say things like, "What module should I take?" to people.

This PR makes it so they get their default language when they get fed a reset card.