### PR TITLE
Cardemon expansion pack

### DIFF
--- a/code/datums/supplypacks/nonessent.dm
+++ b/code/datums/supplypacks/nonessent.dm
@@ -33,6 +33,7 @@
 /decl/hierarchy/supply_pack/nonessent/card_packs
 	num_contained = 5
 	contains = list(/obj/item/weapon/pack/cardemon,
+					/obj/item/weapon/pack/cardemoncircus,
 					/obj/item/weapon/pack/spaceball,
 					/obj/item/weapon/deck/holder)
 	name = "Rec - Trading Cards"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -35,6 +35,10 @@
 /datum/gear/cardemon_pack
 	display_name = "Cardemon booster pack"
 	path = /obj/item/weapon/pack/cardemon
+	
+/datum/gear/cardemon_pack_circus
+	display_name = "Cardemon Circus Expansion booster pack"
+	path = /obj/item/weapon/pack/cardemoncircus
 
 /datum/gear/spaceball_pack
 	display_name = "Spaceball booster pack"

--- a/code/modules/games/carddemoncircus
+++ b/code/modules/games/carddemoncircus
@@ -22,7 +22,7 @@
 				rarity = "Silver"
 
 		var/nam = pick("Funny","Short","Smelly","Ugly","Two-headed","Fat","Fire-tossing ","Water-slipping","Killer","Holy", "Comedic", "Ordinary","Demon","Unfunny", "Stupid", "Mad", "Insane", "Annoying", "Loud", "Unbearable")
-		var/nam2 = pick("Lion", "Clown", "Mime", "Jester", "Juggler", "Bear", "Monkey", "Joker", "Comedian", "Magician", "Freak", "Dancer", "Tightrope Walker", "Rock")
+		var/nam2 = pick("Lion", "Clown", "Mime", "Jester", "Juggler", "Bear", "Monkey", "Joker", "Comedian", "Magician", "Freak", "Dancer", "Tightrope Walker", "Flea")
 
 		P = new()
 		P.name = "[nam] [nam2] [stats["HP"]]/[stats["DP"]]/[stats["SP"]]"

--- a/code/modules/games/carddemoncircus
+++ b/code/modules/games/carddemoncircus
@@ -16,8 +16,8 @@
 					rarity = "Plasteel"
 				else
 					rarity = "Platinum"
-        else if(prob(25))
-          rarity = "Bananium"
+        		else if(prob(25))
+          			rarity = "Bananium"
 			else
 				rarity = "Silver"
 

--- a/code/modules/games/carddemoncircus
+++ b/code/modules/games/carddemoncircus
@@ -1,0 +1,41 @@
+/obj/item/weapon/pack/cardemoncircus
+	name = "\improper Cardemon Circus Expansion booster pack"
+	desc = "Finally! A children's card game in space! With clowns!"
+	icon_state = "card_pack_cardemon"
+
+/obj/item/weapon/pack/cardemoncircus/New()
+	var/datum/playingcard/P
+	var/i
+	for(i=0; i<6; i++)
+		var/element = pick("ire","spaghetti","meat","metal","money","brain")
+		var/stats = list("HP"=rand(1,13),"DP"=rand(2,13),"SP"=rand(2,17))
+		var/rarity
+		if(prob(10))
+			if(prob(5))
+				if(prob(5))
+					rarity = "Plasteel"
+				else
+					rarity = "Platinum"
+        else if(prob(25))
+          rarity = "Bananium"
+			else
+				rarity = "Silver"
+
+		var/nam = pick("Funny","Short","Smelly","Ugly","Two-headed","Fat","Fire-tossing ","Water-slipping","Killer","Holy", "Comedic", "Ordinary","Demon","Unfunny", "Stupid", "Mad", "Insane", "Annoying", "Loud", "Unbearable")
+		var/nam2 = pick("Lion", "Clown", "Mime", "Jester", "Juggler", "Bear", "Monkey", "Joker", "Comedian", "Magician", "Freak", "Dancer", "Tightrope Walker", "Rock")
+
+		P = new()
+		P.name = "[nam] [nam2] [stats["HP"]]/[stats["DP"]]/[stats["SP"]]"
+		P.card_icon = "card_cardemon"
+		if(rarity)
+			P.name = "[rarity] [P.name]"
+			P.card_icon += "_[rarity]"
+		P.back_icon = "card_back_cardemon"
+		P.desc = "Wow! A Cardemon card. Its element is: [element]. Its stats are: [stats["HP"]] HP, [stats["DP"]] DP, [stats["SP"]] SP"
+		cards += P
+	P = new()
+	P.name = "Cardemon Instructions"
+	P.card_icon = "card_cardemon_instructional"
+	P.back_icon = "card_back_cardemon"
+	P.desc = "How To Play Cardemon: every card has 3 stats and an Element. The first stat is Health, second is Damage, third is Speed. Each player plays two cards, and they attack in order of card speed on whichever target the owner selects. Discard cards with no health left over. Once every card has moved or died, a round has finished; you can replace fallen cards with new ones from your hand between rounds. Finally, elements: they do half damage to the one before it, and do double damage to the one after it: ire > spaghetti > metal > money > meat > brain > ire."
+cards += P


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: chesse20
rscadd: adds a booster pack for carddemon with circus themed monsters, faster on average but less physically dangerous on average
\ :cl: