### PR TITLE
Fixes #26028

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -141,7 +141,7 @@
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/M = user
-	if(user.stat || user.restrained() || !check_table(target) || !iscarbon(target))
+	if(user.stat || user.restrained() || !iscarbon(target) || !check_table(target))
 		return
 	if(istype(M))
 		take_victim(target,user)


### PR DESCRIPTION
Fixes issue with putting non-/mob/living/carbon stuff on an surgery table. One of the short-circuited checks in the wrong order.

This bug was revealed by #26011 