### PR TITLE
Fixes #26015 - Telecomms equipment now doesn't break when moving z-levels

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -161,6 +161,16 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	else
 		icon_state = "[initial(icon_state)]_off"
 
+/obj/machinery/telecomms/Move()
+	. = ..()
+	listening_levels = GetConnectedZlevels(z)
+	update_power()
+
+/obj/machinery/telecomms/forceMove(var/newloc)
+	. = ..(newloc)
+	listening_levels = GetConnectedZlevels(z)
+	update_power()
+
 /obj/machinery/telecomms/proc/update_power()
 	if(toggled)
 		if(stat & (BROKEN|NOPOWER|EMPED) || integrity <= 0) // if powered, on. if not powered, off. if too damaged, off
@@ -353,11 +363,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	long_range_link = 1
 	var/broadcasting = 1
 	var/receiving = 1
-
-/obj/machinery/telecomms/relay/forceMove(var/newloc)
-	. = ..(newloc)
-	listening_levels = GetConnectedZlevels(z)
-	update_power()
 
 // Relays on ship's Z levels use less power as they don't have to transmit over such large distances.
 /obj/machinery/telecomms/relay/update_power()


### PR DESCRIPTION
Fixes #26015 

Makes all telecomms equipment update 'listening_levels' when they are forceMove'd.

This doesn't /technically/ change any gameplay possibilities, but it does make it /much easier/ to achieve long-distance communication across any distance. (This was already possible if you dismantled and rebuilt all the telecomms equipment every time you changed z-level). If this is not desirable, then I can code in some sort of range check for the telecomms relays.

I think this is a useful bugfix if anyone ever wants to make an overmap capable ship with radio channels.