### PR TITLE
Adds recovery handling for runtimes I can't resolve.

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -19,8 +19,7 @@
 
 /proc/living_observers_present(var/list/zlevels)
 	if(LAZYLEN(zlevels))
-		for(var/A in GLOB.player_list) //if a tree ticks on the empty zlevel does it really tick
-			var/mob/M = A
+		for(var/mob/M in GLOB.player_list) //if a tree ticks on the empty zlevel does it really tick
 			if(M.stat != DEAD) //(no it doesn't)
 				var/turf/T = get_turf(M)
 				if(T && (T.z in zlevels))

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -158,6 +158,22 @@ datum/controller/subsystem/machines/proc/setup_atmos_machinery(list/machines)
 	while(current_run.len)
 		var/obj/machinery/M = current_run[current_run.len]
 		current_run.len--
+
+		if(!istype(M)) // Below is a debugging and recovery effort. This should never happen, but has been observed recently.
+			if(M in processing)
+				processing.Remove(M)
+				M.is_processing = null
+				crash_with("[log_info_line(M)] was found illegally queued on SSmachines.")
+				continue
+			else if(resumed)
+				current_run.Cut() // Abandon current run; assuming that we were improperly resumed with the wrong process queue.
+				crash_with("[log_info_line(M)] was in the wrong subqueue on SSmachines on a resumed fire.")
+				process_machinery(0)
+				return
+			else // ??? possibly dequeued by another machine or something ???
+				crash_with("[log_info_line(M)] was in the wrong subqueue on SSmachines on an unresumed fire.")
+				continue
+
 		if(!QDELETED(M) && (M.ProcessAll(wait) == PROCESS_KILL))
 			processing.Remove(M)
 			M.is_processing = null


### PR DESCRIPTION
There are two runtimes I've looked at that I consider important but don't know how to resolve.

Closes #25969, which suggests some logic error inside SSmachines/fire. I can't find it, so this should generate slightly more useful debugging information and bypass the issue somewhat cleanly. If what I said on the issue is accurate, further action will be required.

Closes #22315. This is an issue seemingly involving Logout and client deletion, and I don't know how to address it other than just assume the list in question is unsafe. Again, this proc is called hundreds of thousands of times.

Would alternatively appreciate any advice.