### PR TITLE
Table update!

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -75,7 +75,7 @@
 			playsound(loc, material.tableslam_noise, 50, 1)
 		else
 			playsound(loc, 'sound/weapons/tablehit1.ogg', 50, 1)
-		var/list/L = take_damage(rand(1,5))
+		var/list/L = take_damage(rand(1,10))
 		for(var/obj/item/weapon/material/shard/S in L)
 			if(S.sharp && prob(50))
 				G.affecting.visible_message("<span class='danger'>\The [S] slices into [G.affecting]'s face!</span>", "<span class='danger'>\The [S] slices into your face!</span>")

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -153,11 +153,13 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/table_frame
 	title = "table frame"
 	result_type = /obj/structure/table
+	difficulty = 1
 	time = 10
 
 /datum/stack_recipe/furniture/rack
 	title = "rack"
 	result_type = /obj/structure/table/rack
+	req_amount = 2
 
 /datum/stack_recipe/furniture/closet
 	title = "closet"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -146,6 +146,8 @@ default behaviour is:
 					for(var/obj/structure/window/win in get_step(AM,t))
 						now_pushing = 0
 						return
+				if(!t && AM.atom_flags & ATOM_FLAG_CHECKS_BORDER)//allows you to bump into border stuff
+					t = AM.dir
 				step(AM, t)
 				if (istype(AM, /mob/living))
 					var/mob/living/tmob = AM

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -230,7 +230,7 @@
 	return ..()
 
 /obj/item/weapon/gun/energy/plasmacutter/proc/slice(var/mob/M = null)
-	if(power_supply.checked_use(charge_cost/2)) //consumes half a shot per use
+	if(!safety() && power_supply.checked_use(charge_cost/2)) //consumes half a shot per use
 		if(M)//makes spark and eyecheck for deconstructing things
 			M.welding_eyecheck()
 		spark_system.start()

--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -1,14 +1,36 @@
+//handles flips & unanchoring tables
+/obj/structure/table/CtrlClick()
+	if(Adjacent(usr))
+		if(anchored)
+			unlock()
+		else
+			.=..()
+		return TRUE	
+	return FALSE
+
+/obj/structure/table/ShiftClick()
+	if(Adjacent(usr))
+		if(!flipped)
+			do_flip()
+		else
+			do_put()
+	else
+		.=..()
+
+/obj/structure/table/Move()
+	var/old_dir = dir
+	. = ..()
+	set_dir(old_dir)
+	playsound(src, pick(move_sounds), 75, 1)
 
 /obj/structure/table/proc/straight_table_check(var/direction)
-	if(health > 100)
-		return 0
 	var/obj/structure/table/T
 	for(var/angle in list(-90,90))
 		T = locate() in get_step(src.loc,turn(direction,angle))
-		if(T && T.flipped == 0 && T.material && material && T.material.name == material.name)
+		if(can_connect(T))
 			return 0
 	T = locate() in get_step(src.loc,direction)
-	if (!T || T.flipped == 1 || T.material != material)
+	if(!can_connect(T))
 		return 1
 	return T.straight_table_check(direction)
 
@@ -18,7 +40,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if (!can_touch(usr) || ismouse(usr))
+	if (!can_touch(usr) || ismouse(usr) || manipulating)
 		return
 
 	if(reinforced || flipped < 0 || !flip(get_cardinal_dir(usr,src)))
@@ -31,6 +53,53 @@
 		object_shaken()
 
 	return
+
+/obj/structure/table/proc/flip(var/direction)
+	if(anchored && ( !straight_table_check(turn(direction,90)) || !straight_table_check(turn(direction,-90)) ) )
+		return FALSE
+
+	manipulating = 1
+	if(!do_after(usr, 1 SECOND, src))
+		manipulating = 0
+		return FALSE
+	manipulating = 0
+
+	verbs -=/obj/structure/table/verb/do_flip
+	verbs +=/obj/structure/table/proc/do_put
+
+	var/list/targets = list(get_step(src,dir),get_step(src,turn(dir, 45)),get_step(src,turn(dir, -45)))
+	for (var/atom/movable/A in get_turf(src))
+		if (!A.anchored && A != src)//don't throw the table itself
+			spawn(0)
+				A.throw_at(pick(targets),1,1)
+
+	set_dir(direction)
+	flipped = 1
+	atom_flags |= ATOM_FLAG_CHECKS_BORDER
+	obj_flags |= OBJ_FLAG_ROTATABLE
+	for(var/D in list(turn(direction, 90), turn(direction, -90)))
+		var/obj/structure/table/T = locate() in get_step(src,D)
+		if(can_connect(T, FALSE) && !T.flipped)
+			T.flip(direction)
+	take_damage(rand(1, 8))
+	update_connections(1)
+	update_icon()
+
+	return TRUE
+
+/obj/structure/table/proc/do_put()
+	set name = "Put table back"
+	set desc = "Puts flipped table back"
+	set category = "Object"
+	set src in oview(1)
+
+	if (!can_touch(usr) || ismouse(usr) || manipulating)
+		return
+
+	if (!unflipping_check())
+		to_chat(usr, "<span class='notice'>It won't budge.</span>")
+		return
+	unflip()
 
 /obj/structure/table/proc/unflipping_check(var/direction)
 
@@ -48,84 +117,119 @@
 	else
 		L.Add(turn(src.dir,-90))
 		L.Add(turn(src.dir,90))
-	for(var/new_dir in L)
+	for(var/new_dir in L)//checking side group?
 		var/obj/structure/table/T = locate() in get_step(src.loc,new_dir)
-		if(T && T.material && material && T.material.name == material.name)
+		if(can_connect(T, FALSE))
 			if(T.flipped == 1 && T.dir == src.dir && !T.unflipping_check(new_dir))
 				return 0
 	return 1
 
-/obj/structure/table/proc/do_put()
-	set name = "Put table back"
-	set desc = "Puts flipped table back"
-	set category = "Object"
-	set src in oview(1)
-
-	if (!can_touch(usr))
-		return
-
-	if (!unflipping_check())
-		to_chat(usr, "<span class='notice'>It won't budge.</span>")
-		return
-	unflip()
-
-/obj/structure/table/proc/flip(var/direction)
-	if( !straight_table_check(turn(direction,90)) || !straight_table_check(turn(direction,-90)) )
-		return FALSE
-
-	if(!do_after(usr, 1 SECOND, src))
-		return FALSE
-	verbs -=/obj/structure/table/verb/do_flip
-	verbs +=/obj/structure/table/proc/do_put
-
-	var/list/targets = list(get_step(src,dir),get_step(src,turn(dir, 45)),get_step(src,turn(dir, -45)))
-	for (var/atom/movable/A in get_turf(src))
-		if (!A.anchored)
-			spawn(0)
-				A.throw_at(pick(targets),1,1)
-
-	set_dir(direction)
-	if(dir != NORTH)
-		plane = ABOVE_HUMAN_PLANE
-		layer = ABOVE_HUMAN_LAYER
-	atom_flags &= ~ATOM_FLAG_CLIMBABLE //flipping tables allows them to be used as makeshift barriers
-	flipped = 1
-	atom_flags |= ATOM_FLAG_CHECKS_BORDER
-	for(var/D in list(turn(direction, 90), turn(direction, -90)))
-		var/obj/structure/table/T = locate() in get_step(src,D)
-		if(T && T.can_connect() && T.flipped == 0 && material && T.material && T.material.name == material.name)
-			T.flip(direction)
-	take_damage(rand(5, 10))
-	update_connections(1)
-	update_icon()
-
-	return TRUE
-
 /obj/structure/table/proc/unflip()
-	if(!do_after(usr, 1 SECOND, src))
+	manipulating = 1
+	if(!do_after(usr, 2 SECOND, src))
+		manipulating = 0
 		return FALSE
+	manipulating = 0
+
 	verbs -=/obj/structure/table/proc/do_put
 	verbs +=/obj/structure/table/verb/do_flip
 
-	reset_plane_and_layer()
-	atom_flags |= ATOM_FLAG_CLIMBABLE
 	flipped = 0
 	atom_flags &= ~ATOM_FLAG_CHECKS_BORDER
+	obj_flags &= ~OBJ_FLAG_ROTATABLE
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		var/obj/structure/table/T = locate() in get_step(src.loc,D)
-		if(T && T.flipped == 1 && T.dir == src.dir && material && T.material&& T.material.name == material.name)
+		if(can_connect(T, FALSE) && T.flipped && T.dir == dir)
 			T.unflip()
 
 	update_connections(1)
 	update_icon()
+	playsound(src, pick(move_sounds), 75, 1)
 
 	return TRUE
 
-/obj/structure/table/CtrlClick()
-	if(usr && usr.Adjacent(src))
-		if(!flipped)
-			do_flip()
-		else
-			do_put()
-		return TRUE
-	return FALSE
+/obj/structure/table/verb/unlock()
+	set name = "Unlock table"
+	set desc = "Unlock a non-reinforced table from the ground"
+	set category = "Object"
+	set src in oview(1)
+
+	if (!can_touch(usr) || ismouse(usr) || manipulating)
+		return
+
+	if(reinforced)
+		to_chat(usr, "<span class='notice'>It won't budge.</span>")
+		return
+
+	playsound(src, pick(move_sounds), 75, 1)
+	usr.visible_message("<span class='notice'>\The [usr] starts to pull \the [src] from its anchoring locks.</span>",
+		                            "<span class='notice'>You start to pull \the [src] from its anchoring locks.</span>")
+
+	manipulating = 1
+	if(!do_after(usr, 1.5 SECOND, src)) 
+		manipulating = 0
+		return
+	manipulating = 0
+	usr.visible_message("<span class='notice'>\The [usr] pulls \the [src] free from its anchoring locks.</span>",
+		                            "<span class='notice'>You pulls \the [src] free from its anchoring locks.</span>")
+	anchored = 0
+	update_connections(1)
+	update_icon()
+	verbs +=/obj/structure/table/proc/lock
+	verbs -=/obj/structure/table/verb/unlock
+
+	if(atom_flags & ATOM_FLAG_CLIMBABLE)
+		object_shaken()
+
+/obj/structure/table/proc/lock()
+	set name = "lock table"
+	set desc = "lock a table to the ground"
+	set category = "Object"
+	set src in oview(1)
+
+	if (!can_touch(usr) || ismouse(usr) || manipulating)
+		return
+
+	if(reinforced)
+		to_chat(usr, "<span class='notice'>It won't budge.</span>")
+		return
+
+	usr.visible_message("<span class='notice'>\The [usr] starts locking \the [src] to the ground.</span>",
+		                            "<span class='notice'>You start locking \the [src] to the ground.</span>")
+
+	manipulating = 1
+	if(!do_after(usr, 3 SECOND, src))
+		manipulating = 0
+		return
+	manipulating = 0
+	
+	usr.visible_message("<span class='notice'>\The [usr] locks \the [src] to the ground.</span>",
+		                            "<span class='notice'>You lock \the [src] to the ground.</span>")
+	
+	anchored = 1
+	update_connections(1)
+	update_icon()
+	verbs +=/obj/structure/table/verb/unlock
+	verbs -=/obj/structure/table/proc/lock
+
+/obj/structure/table/rotate(mob/user)
+	if(!CanPhysicallyInteract(user))
+		to_chat(user, SPAN_NOTICE("You can't interact with \the [src] right now!"))
+		return
+
+	if(anchored || !flipped)
+		to_chat(user, "<span class='notice'>It won't budge.</span>")
+		return
+
+	if(manipulating)
+		return
+
+	manipulating = 1
+	
+	if(!do_after(usr, 1 SECOND, src)) 
+		manipulating = 0
+		return
+	set_dir(turn(dir, 90))
+	update_icon()
+	playsound(src, pick(move_sounds), 75, 1)
+	manipulating = 0

--- a/code/modules/tables/rack.dm
+++ b/code/modules/tables/rack.dm
@@ -7,7 +7,7 @@
 	can_reinforce = 0
 	flipped = -1
 
-	material = DEFAULT_FURNITURE_MATERIAL
+	material = MATERIAL_STEEL
 
 /obj/structure/table/rack/New()
 	..()
@@ -29,6 +29,18 @@
 
 /obj/structure/table/rack/can_connect()
 	return FALSE
+
+/obj/structure/table/rack/CtrlClick()
+	return
+
+/obj/structure/table/rack/ShiftClick()
+	examine(usr)
+
+/obj/structure/table/rack/attack_hand(mob/user as mob)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	if(user.a_intent && user.a_intent == I_HURT)
+		user.visible_message(SPAN_DANGER("\The [user] kicks \The [src]!"))
+		playsound(src, 'sound/effects/grillehit.ogg', 100, 1)
 
 /obj/structure/table/rack/holorack/dismantle(obj/item/weapon/wrench/W, mob/user)
 	to_chat(user, "<span class='warning'>You cannot dismantle \the [src].</span>")


### PR DESCRIPTION
Tables can now be unlocked from the ground and moved around!
https://i.imgur.com/m4xPZih.gif
🆑
rscadd: Tables can now be unlocked/locked from the ground, to be move around.
rscadd: Tables can now be rotated when unlocked and flipped
rscadd: Tables can now be attacked when on harm intent
tweak: Table will now only need basic construction to build
rscadd: Ctrl clicking tables will now unlock them if they're secured
rscadd: Shift clicking tables when adjacent to them will now flip/unflip them.
rscadd: Alt clicking tables will rotate them
rscadd: Plasma-cutter can now deconstruct table and racks 
bugfix: Fixed rack deconstruction giving more material than needed
/🆑

Damnit I need to make border obj movement work better now
And also need to rebase it

And also the following features:
- hotkeys
- Being able to hit tables with harm intent
- Reduces table recipe difficulty to basic

- Allows Plasma cutter can deconstruct tables
- Adds a little safety feature to plasmacutter preventing it from cutting if the safety is on.

- Allows tables to be unlocked/lock from the ground

- Allows unlocked and flipped tables to be rotated

- Adds annoying metal scrapping sound for tables

- Adjusts table health and damage taken

- Allow tables to attacked by weapons by harm intent

- Adds unarmed flavor interactions

- Adds hitby effects for when things are thrown into tables

- Fixes minor rack bugs allowing them to be flipped

- Fixes rack recipe giving away materials

- Fixes some movement oversight that prevents pushing border objects