### PR TITLE
Removes outdated and empty skin category

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -853,20 +853,6 @@ menu "menu"
 		category = "&File"
 		saved-params = "is-checked"
 	elem 
-		name = "&Icons"
-		command = ""
-		saved-params = "is-checked"
-	elem 
-		name = "&Size"
-		command = ""
-		category = "&Icons"
-		saved-params = "is-checked"
-	elem 
-		name = "&Scaling"
-		command = ""
-		category = "&Icons"
-		saved-params = "is-checked"
-	elem 
 		name = "&Size"
 		command = ""
 		saved-params = "is-checked"


### PR DESCRIPTION
Hello. This change removes empty category on window panel:
![image](https://user-images.githubusercontent.com/44920739/60367953-4af4b100-99f8-11e9-88bd-64caba42c5d0.png)
It doesn't affect on the Size and Scaling fictions, because they have they own categories. Previously both functions was been in Icons category, but now it empty, and can be safely deleted.
