### PR TITLE
Makes drowsyness slow you down regardless of move intent

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -186,7 +186,7 @@
 		var/turf/T = loc
 		. += T.movement_delay
 
-	if ((drowsyness > 0) && !MOVING_DELIBERATELY(src))
+	if (drowsyness > 0)
 		. += 6
 	if(lying) //Crawling, it's slower
 		. += (8 + ((weakened * 3) + (confused * 2)))


### PR DESCRIPTION
Currently, if you're drowsy, creep intent has a delay of 6, walk intent has a delay of 4 and run intent has a delay of 8. 

This change properly makes all movement intents slower when you're drowsy, you can still run and expend stamina for not much gain if it's that important to you. (creep = 12, walk = 10, run = 8)