### PR TITLE
Anchors the ion engines.

### DIFF
--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -41,6 +41,7 @@
 	icon_state = "nozzle"
 	power_channel = ENVIRON
 	idle_power_usage = 100
+	anchored = TRUE
 	var/datum/ship_engine/ion/controller
 	var/thrust_limit = 1
 	var/on = 1


### PR DESCRIPTION
Why is `/obj/machinery/engine` a thing? Nothing is implemented on it.