### PR TITLE
Fixes powersink

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -20,10 +20,43 @@
 	var/power_drained = 0 			// Amount of power drained.
 	var/max_power = 5e9				// Detonation point.
 	var/mode = 0					// 0 = off, 1=clamped (off), 2=operating
-	var/drained_this_tick = 0		// This is unfortunately necessary to ensure we process powersinks BEFORE other machinery such as APCs.
-
 	var/datum/powernet/PN			// Our powernet
+
+	var/const/DISCONNECTED = 0
+	var/const/CLAMPED_OFF = 1
+	var/const/OPERATING = 2
+
 	var/obj/structure/cable/attached		// the attached cable
+
+/obj/item/device/powersink/on_update_icon()
+	icon_state = "powersink[mode == OPERATING]"
+
+/obj/item/device/powersink/proc/set_mode(value)
+	if(value == mode)
+		return
+	switch(value)
+		if(DISCONNECTED)
+			attached = null
+			if(mode == OPERATING)
+				STOP_PROCESSING(SSobj, src)
+			anchored = FALSE
+
+		if(CLAMPED_OFF)
+			if(!attached)
+				return
+			if(mode == OPERATING)
+				STOP_PROCESSING(SSobj, src)
+			anchored = TRUE
+
+		if(OPERATING)
+			if(!attached)
+				return
+			START_PROCESSING(SSobj, src)
+			anchored = TRUE
+
+	mode = value
+	update_icon()
+	set_light(0)
 
 /obj/item/device/powersink/Destroy()
 	if(mode == 2)
@@ -32,90 +65,83 @@
 
 /obj/item/device/powersink/attackby(var/obj/item/I, var/mob/user)
 	if(isScrewdriver(I))
-		if(mode == 0)
+		if(mode == DISCONNECTED)
 			var/turf/T = loc
 			if(isturf(T) && !!T.is_plating())
 				attached = locate() in T
 				if(!attached)
-					to_chat(user, "No exposed cable here to attach to.")
-					return
+					to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
 				else
-					anchored = 1
-					mode = 1
-					src.visible_message("<span class='notice'>[user] attaches [src] to the cable!</span>")
-					return
+					set_mode(CLAMPED_OFF)
+					user.visible_message( \
+						"[user] attaches \the [src] to the cable.", \
+						"<span class='notice'>You attach \the [src] to the cable.</span>",
+						"<span class='italics'>You hear some wires being connected to something.</span>")
 			else
-				to_chat(user, "Device must be placed over an exposed cable to attach to it.")
-				return
+				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
 		else
-			if (mode == 2)
-				STOP_PROCESSING_POWER_OBJECT(src)
-			anchored = 0
-			mode = 0
-			src.visible_message("<span class='notice'>[user] detaches [src] from the cable!</span>")
-			set_light(0)
-			icon_state = "powersink0"
-
-			return
+			set_mode(DISCONNECTED)
+			user.visible_message( \
+				"[user] detaches \the [src] from the cable.", \
+				"<span class='notice'>You detach \the [src] from the cable.</span>",
+				"<span class='italics'>You hear some wires being disconnected from something.</span>")
 	else
-		..()
+		return ..()
 
 /obj/item/device/powersink/attack_ai()
 	return
 
 /obj/item/device/powersink/attack_hand(var/mob/user)
+	. = ..()
+	if(.)
+		return
 	switch(mode)
-		if(0)
+		if(DISCONNECTED)
 			..()
-		if(1)
-			src.visible_message("<span class='notice'>[user] activates [src]!</span>")
-			mode = 2
-			icon_state = "powersink1"
-			START_PROCESSING_POWER_OBJECT(src)
-		if(2)  //This switch option wasn't originally included. It exists now. --NeoFite
-			src.visible_message("<span class='notice'>[user] deactivates [src]!</span>")
-			mode = 1
-			set_light(0)
-			icon_state = "powersink0"
-			STOP_PROCESSING_POWER_OBJECT(src)
 
-/obj/item/device/powersink/pwr_drain()
-	if(!attached)
-		return 0
-	if(drained_this_tick)
-		return 1
-	drained_this_tick = 1
-	var/drained = 0
-	if(!PN)
-		return 1
-	set_light(0.5, 0.1, 12)
-	PN.trigger_warning()
-	// found a powernet, so drain up to max power from it
-	drained = PN.draw_power(drain_rate)
-	// if tried to drain more than available on powernet
-	// now look for APCs and drain their cells
-	if(drained < drain_rate)
-		for(var/obj/machinery/power/terminal/T in PN.nodes)
-			// Enough power drained this tick, no need to torture more APCs
-			if(drained >= drain_rate)
-				break
-			var/obj/machinery/power/apc/A = T.master_machine()
-			if(istype(A))
-				drained += A.drain_power(amount = drain_rate)
-	power_drained += drained
-	return 1
+		if(CLAMPED_OFF)
+			user.visible_message( \
+				"[user] activates \the [src]!", \
+				"<span class='notice'>You activate \the [src].</span>",
+				"<span class='italics'>You hear a click.</span>")
+			message_admins("Power sink activated by [key_name_admin(user)] at (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+			log_game("Power sink activated by [key_name(user)] at [get_area_name(src)]")
+			set_mode(OPERATING)
 
+		if(OPERATING)
+			user.visible_message( \
+				"[user] deactivates \the [src]!", \
+				"<span class='notice'>You deactivate \the [src].</span>",
+				"<span class='italics'>You hear a click.</span>")
+			set_mode(CLAMPED_OFF)
 
 /obj/item/device/powersink/Process()
-	drained_this_tick = 0
-	power_drained -= min(dissipation_rate, power_drained)
+	if(!attached)
+		set_mode(DISCONNECTED)
+		return
+
+	var/datum/powernet/PN = attached.powernet
+	var/drained = 0
+	if(PN)
+		set_light(0.5, 0.1, 12)
+		PN.trigger_warning()
+		// found a powernet, so drain up to max power from it
+		drained = PN.draw_power(drain_rate)
+		// if tried to drain more than available on powernet
+		// now look for APCs and drain their cells
+		if(drained < drain_rate)
+			for(var/obj/machinery/power/terminal/T in PN.nodes)
+				// Enough power drained this tick, no need to torture more APCs
+				if(drained >= drain_rate)
+					break
+				var/obj/machinery/power/apc/A = T.master_machine()
+				if(istype(A))
+					drained += A.drain_power(amount = drain_rate)
+		power_drained += drained
+
 	if(power_drained > max_power * 0.95)
 		playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
 	if(power_drained >= max_power)
+		STOP_PROCESSING(SSobj, src)
 		explosion(src.loc, 3,6,9,12)
 		qdel(src)
-		return
-	if(attached && attached.powernet)
-		PN = attached.powernet
-	else
-		PN = null

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -38,20 +38,20 @@
 		if(DISCONNECTED)
 			attached = null
 			if(mode == OPERATING)
-				STOP_PROCESSING(SSobj, src)
+				STOP_PROCESSING_POWER_OBJECT(src)
 			anchored = FALSE
 
 		if(CLAMPED_OFF)
 			if(!attached)
 				return
 			if(mode == OPERATING)
-				STOP_PROCESSING(SSobj, src)
+				STOP_PROCESSING_POWER_OBJECT(src)
 			anchored = TRUE
 
 		if(OPERATING)
 			if(!attached)
 				return
-			START_PROCESSING(SSobj, src)
+			START_PROCESSING_POWER_OBJECT(src)
 			anchored = TRUE
 
 	mode = value
@@ -115,7 +115,7 @@
 				"<span class='italics'>You hear a click.</span>")
 			set_mode(CLAMPED_OFF)
 
-/obj/item/device/powersink/Process()
+/obj/item/device/powersink/pwr_drain()
 	if(!attached)
 		set_mode(DISCONNECTED)
 		return
@@ -142,6 +142,6 @@
 	if(power_drained > max_power * 0.95)
 		playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
 	if(power_drained >= max_power)
-		STOP_PROCESSING(SSobj, src)
+		STOP_PROCESSING_POWER_OBJECT(src)
 		explosion(src.loc, 3,6,9,12)
 		qdel(src)


### PR DESCRIPTION
Awful way to fix it, but magically work. Fixes #21810
Now powersink use Process() call to drain power. The issue is been what previously powersinks don't call needed function to actually drain power. I though what previously way to make powersink work using PROCESSING_POWER_OBJECT is too expensive for one only powersink. Really, why only powersinks?