### PR TITLE
fixes overlay on lavatory vending machine

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1266,10 +1266,6 @@
 				  /obj/item/weapon/towel/random = 50
 					)
 
-/obj/machinery/vending/lavatory/on_update_icon()
-	..()
-	if(!(stat & NOPOWER))
-		overlays += image(icon, "[initial(icon_state)]-overlay")
 
 //a food variant of the boda machine, only has one item currently.
 /obj/machinery/vending/snix


### PR DESCRIPTION
:cl: Cajoes

rsctweak: fixed broken overlay issue on lavatory essentials vendor, holodisplay should no longer defer to factory defaults.

/:cl: