### PR TITLE
capsaicin uses the wrong proc

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -496,7 +496,7 @@
 	else
 		M.apply_effect(6, PAIN, 0)
 		if(prob(5))
-			M.visible_message("<span class='danger'>You feel like your insides are burning!</span>")
+			to_chat(M, "<span class='danger'>You feel like your insides are burning!</span>")
 			M.custom_emote(2, "[pick("coughs.","gags.","retches.")]")
 			M.Stun(2)
 	if(istype(M, /mob/living/carbon/slime))


### PR DESCRIPTION
Let's not have people completely unaffected by the reagent get told they need to RP pain.

Capsaicin used the wrong proc to display its pain message to the person being hit by it, causing it to display to everyone within visible range of the mob whether they were actually hit by the Capsaicin or not.