### PR TITLE
Stopped catwalks from randomizing their neighboring floors.

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -110,6 +110,11 @@
 /obj/structure/proc/can_visually_connect_to(var/obj/structure/S)
 	return istype(S, src)
 
+/obj/structure/proc/refresh_neighbors()
+	for(var/thing in RANGE_TURFS(src, 1))
+		var/turf/T = thing
+		T.update_icon()
+
 /obj/structure/proc/update_connections(propagate = 0)
 	var/list/dirs = list()
 	var/list/other_dirs = list()
@@ -125,7 +130,7 @@
 	if(!can_visually_connect())
 		connections = list("0", "0", "0", "0")
 		other_connections = list("0", "0", "0", "0")
-		return
+		return FALSE
 
 	for(var/direction in GLOB.cardinal)
 		var/turf/T = get_step(src, direction)
@@ -162,9 +167,8 @@
 			dirs += get_dir(src, T)
 			other_dirs += get_dir(src, T)
 
-	for(var/thing in RANGE_TURFS(src, 1))
-		var/turf/T = thing
-		T.update_icon()
+	refresh_neighbors()
 
 	connections = dirs_to_corner_states(dirs)
 	other_connections = dirs_to_corner_states(other_dirs)
+	return TRUE

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -121,6 +121,9 @@
 						break
 				update_icon()
 
+/obj/structure/catwalk/refresh_neighbors()
+	return
+
 /obj/effect/catwalk_plated
 	name = "plated catwalk spawner"
 	icon = 'icons/obj/catwalks.dmi'

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -60,6 +60,7 @@ var/list/flooring_cache = list()
 					if(!flooring.symmetric_test_link(src, get_step(src, direction)))
 						overlays |= get_flooring_overlay("[flooring.icon]_[flooring.icon_base]-edge-[direction]", "[flooring.icon_base]_edges", direction,(flooring.flags & TURF_HAS_EDGES))
 
+		/*
 		//Now lets handle those fancy floors which have many centre icons
 		if(flooring.has_base_range)
 			if (!has_border || (flooring.flags & TURF_HAS_RANDOM_BORDER))
@@ -68,6 +69,7 @@ var/list/flooring_cache = list()
 				flooring_override = icon_state
 			else
 				icon_state = flooring.icon_base+"0"
+		*/
 
 	if(decals && decals.len)
 		for(var/image/I in decals)


### PR DESCRIPTION
This behavior results from [this commit](https://github.com/Baystation12/Baystation12/commit/fe960417590b6a33b279464551b153b062a9d900#diff-ac67a04d0e99b8458714248c84118bedR165) and appears to randomize the state of turfs with a `base_range` on their flooring decl, as well as regenerating AO (making it flicker). This is a shitty solution to it but I'm not really willing to delve into the icon update logic to work out what actually needs to update every neighboring turf, or why `flooring_override` isn't being set/respected by some turfs.

Second commit comments out the block that was causing the random icon_states in the first place. It bypasses the check done on `flooring_override` earlier and doesn't appear to have any real impact on the border icons other than possibly making carpets slightly uglier.