### PR TITLE
Made nabbers immune to methyl bromide.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -882,10 +882,10 @@
 	heating_point = null
 
 /datum/reagent/toxin/methyl_bromide/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
-	. = (alien != IS_MANTID && ..())
+	. = (alien != IS_MANTID && alien != IS_NABBER && ..())
 
 /datum/reagent/toxin/methyl_bromide/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	. = (alien != IS_MANTID && ..())
+	. = (alien != IS_MANTID && alien != IS_NABBER && ..())
 
 /datum/reagent/toxin/methyl_bromide/touch_turf(var/turf/simulated/T)
 	if(istype(T))
@@ -893,7 +893,7 @@
 		remove_self(volume)
 
 /datum/reagent/toxin/methyl_bromide/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	. = (alien != IS_MANTID && ..())
+	. = (alien != IS_MANTID && alien != IS_NABBER && ..())
 	if(istype(M))
 		for(var/obj/item/organ/external/E in M.organs)
 			if(LAZYLEN(E.implants))


### PR DESCRIPTION
Paging @PurpleMartinJCK.

The alternative to this is giving nabbers both a mask slot and a gasmask subtype to filter it out when they're in Ascent environments.