### PR TITLE
Makes mining console all access again.

### DIFF
--- a/code/modules/mining/machinery/mineral_console.dm
+++ b/code/modules/mining/machinery/mineral_console.dm
@@ -2,7 +2,6 @@
 	name = "ore processing console"
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "console"
-	req_access = list(access_cargo)
 	var/obj/machinery/mineral/connected
 
 /obj/machinery/computer/mining/interface_interact(var/mob/user)


### PR DESCRIPTION
Despite how it looks, this returns it to how it used to work, as actually enforcing req_access for UIs consistently for non-silicon mobs is a new thing.