### PR TITLE
Makes antagonist implants hidden from bodyscanners

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -13,6 +13,7 @@
 	var/implant_color = "b"
 	var/malfunction = 0
 	var/known //if advanced scanners would name these in results
+	var/hidden //if scanners will locate this implant at all
 
 /obj/item/weapon/implant/proc/trigger(emote, source)
 	return

--- a/code/game/objects/items/weapons/implants/implants/adrenaline.dm
+++ b/code/game/objects/items/weapons/implants/implants/adrenaline.dm
@@ -1,7 +1,8 @@
 /obj/item/weapon/implant/adrenalin
-	name = "adrenalin"
+	name = "adrenalin implant"
 	desc = "Removes all stuns and knockdowns."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 2)
+	hidden = 1
 	var/uses
 
 /obj/item/weapon/implant/adrenalin/get_data()

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -3,8 +3,10 @@
 	desc = "Based on compressed matter technology, can store a single item."
 	icon_state = "implant_evil"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_BIO = 2, TECH_ILLEGAL = 2)
+	hidden = 1
 	var/activation_emote
 	var/obj/item/scanned
+
 
 /obj/item/weapon/implant/compressed/get_data()
 	var/dat = {"

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -4,6 +4,7 @@
 	desc = "A military grade micro bio-explosive. Highly dangerous."
 	icon_state = "implant_evil"
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
+	hidden = 1
 	var/elevel
 	var/phrase
 	var/code = 13

--- a/code/game/objects/items/weapons/implants/implants/freedom.dm
+++ b/code/game/objects/items/weapons/implants/implants/freedom.dm
@@ -5,6 +5,7 @@
 	desc = "Use this to escape from those evil Red Shirts."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 2)
 	implant_color = "r"
+	hidden = 1
 	var/activation_emote
 	var/uses
 

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -2,7 +2,8 @@
 	name = "imprinting implant"
 	desc = "Latest word in training your peons."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_DATA = 3)
-	var/list/instructions = list("Do your job.", "Respect your superiours.", "Wash you hands after using the toilet.")
+	hidden = 1
+	var/list/instructions = list("Do your job.", "Respect your superiors.", "Wash you hands after using the toilet.")
 	var/brainwashing = 0
 	var/last_reminder
 

--- a/code/game/objects/items/weapons/implants/implants/translator.dm
+++ b/code/game/objects/items/weapons/implants/implants/translator.dm
@@ -4,6 +4,7 @@
 	desc = "A small implant with a microphone on it."
 	icon_state = "implant_evil"
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
+	hidden = 1
 	var/list/languages = list()
 	var/learning_threshold = 20 //need to hear language spoken this many times to learn it
 	var/max_languages = 5

--- a/code/game/objects/items/weapons/implants/implants/uplink.dm
+++ b/code/game/objects/items/weapons/implants/implants/uplink.dm
@@ -1,7 +1,8 @@
 /obj/item/weapon/implant/uplink
-	name = "uplink"
+	name = "uplink implant"
 	desc = "Summon things."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
+	hidden = 1
 	var/activation_emote
 
 /obj/item/weapon/implant/uplink/New(var/loc, var/amount)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1387,6 +1387,8 @@ obj/item/organ/external/proc/remove_clamps()
 			var/list/bits = list()
 			for(var/obj/item/organ/internal/organ in internal_organs)
 				bits += organ.get_visible_state()
+			for(var/obj/item/weapon/implant in implants)
+				bits += implant.name
 			if(bits.len)
 				wound_descriptors["[english_list(bits)] visible in the wounds"] = 1
 
@@ -1421,10 +1423,11 @@ obj/item/organ/external/proc/remove_clamps()
 		var/unknown_body = 0
 		for(var/I in implants)
 			var/obj/item/weapon/implant/imp = I
-			if(istype(imp) && imp.known)
-				. += "[capitalize(imp.name)] implanted"
-			else
-				unknown_body++
+			if (!imp.hidden)
+				if(istype(imp) && imp.known)
+					. += "[capitalize(imp.name)] implanted"
+				else
+					unknown_body++
 		if(unknown_body)
 			. += "Unknown body present"
 	for(var/obj/item/organ/internal/augment/aug in internal_organs)


### PR DESCRIPTION
🆑 MikoMyazaki
tweak: Antagonist implants are now not visible to the bodyscanner, you can find them by opening the implanted bodypart and examining.
/🆑

These implants should not be as trivial for medical to find and remove as they currently are, given the cost and effort required for an antagonist to implant them. If someone's implant is to be removed, they should have a RP-reason to have medical look for and remove them - Not just 'there's an unknown thing on the scanner'. Or they can be accidentally found during normal surgery.