### PR TITLE
Tweaked water to line up with the sublimator and function as steam.

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -318,7 +318,7 @@
 			newgases -= "phoron"
 		if(prob(50)) //alium gas should be slightly less common than mundane shit
 			newgases -= "aliether"
-		newgases -= "watervapor"
+		newgases -= "water"
 
 		var/total_moles = MOLES_CELLSTANDARD * rand(80,120)/100
 		var/badflag = 0

--- a/code/modules/xgm/gases.dm
+++ b/code/modules/xgm/gases.dm
@@ -106,7 +106,7 @@
 	specific_heat = 100	// J/(mol*K)
 	molar_mass = 0.002	// kg/mol
 	flags = XGM_GAS_FUEL|XGM_GAS_FUSION_FUEL
-	burn_product = "watervapor"
+	burn_product = "water"
 	symbol_html = "H<sub>2</sub>"
 	symbol = "H2"
 
@@ -199,9 +199,10 @@
 	symbol = "Cl"
 
 /decl/xgm_gas/vapor
-	id = "watervapor"
-	name = "Water Vapor"
-
+	id = "water"
+	name = "Steam"
+	tile_overlay = "generic"
+	overlay_limit = 0.5
 	specific_heat = 30	// J/(mol*K)
 	molar_mass = 0.020	// kg/mol
 	breathed_product =     /datum/reagent/water


### PR DESCRIPTION
- Changing the name means that water reagent will map to water gas properly rather than becoming water-but-a-gas.
- Overlay makes for steamy clouds in areas with vapor.
![image](https://user-images.githubusercontent.com/2468979/60750743-8727a300-9ff0-11e9-91ea-7ac92a4e0007.png)
