### PR TITLE
Makes mapped apcs and alarms on away sites not require req_access.

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -163,6 +163,9 @@
 		elect_master()
 	update_icon()
 
+	if(!locked)
+		req_access.Cut()
+
 /obj/machinery/alarm/Process()
 	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)
 		return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -187,6 +187,9 @@
 		src.update()
 	power_change()
 
+	if(!locked)
+		req_access.Cut()
+
 /obj/machinery/power/apc/Destroy()
 	src.update()
 	area.apc = null


### PR DESCRIPTION
So this fix is pretty crap. Apparently mappers were not actually (un)setting req_access on alarms and apcs which are off-ship, instead just leaving them unlocked, but with Torch-esque access. The proper fix would repath all apcs and air alarms either (on the Torch) or (off the Torch); given the huge map diff of that, I'm not willing to do that right now.