### PR TITLE
Fixes #26180

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1423,11 +1423,11 @@ obj/item/organ/external/proc/remove_clamps()
 		var/unknown_body = 0
 		for(var/I in implants)
 			var/obj/item/weapon/implant/imp = I
-			if (!imp.hidden)
-				if(istype(imp) && imp.known)
+			if(istype(I,/obj/item/weapon/implant) && imp.known)
+				if (!imp.hidden)
 					. += "[capitalize(imp.name)] implanted"
-				else
-					unknown_body++
+			else
+				unknown_body++
 		if(unknown_body)
 			. += "Unknown body present"
 	for(var/obj/item/organ/internal/augment/aug in internal_organs)


### PR DESCRIPTION
Fixes runtime where shrapnel (implantables that aren't item/weapon/implant) wasn't checked for in the unknown body checks, where there was a check for implant vars that shrapnel doesn't have.

Fixes #26180

Was caused by #26158 