### PR TITLE
Cryo drugs can no longer fix necrotic organs

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -242,7 +242,8 @@ var/list/organ_cache = list()
 	CRASH("Not Implemented")
 
 /obj/item/organ/proc/heal_damage(amount)
-	damage = between(0, damage - round(amount, 0.1), max_damage)
+	if (can_recover())
+		damage = between(0, damage - round(amount, 0.1), max_damage)
 
 
 /obj/item/organ/proc/robotize() //Being used to make robutt hearts, etc


### PR DESCRIPTION
🆑 mikomyazaki
bugfix: Clonexadone and Cryoxadone no longer reduce damage on necrotic organs.
/🆑

Necrotic organs are dead, and should be transplanted. This seems to be a case of a missing check. 

Fixes #26190 