### PR TITLE
Fixes Adjacent reciprocity.

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -36,7 +36,7 @@
 
 	if(T0.x == x || T0.y == y)
 		// Check for border blockages
-		return T0.ClickCross(get_dir(T0,src), border_only = 1) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target)
+		return T0.ClickCross(get_dir(T0,src), border_only = 1, target_atom = neighbor) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target)
 
 	// Not orthagonal
 	var/in_dir = get_dir(neighbor,src) // eg. northwest (1+8)
@@ -44,7 +44,7 @@
 	var/d2 = in_dir - d1			// eg north		(1+8) - 8 = 1
 
 	for(var/d in list(d1,d2))
-		if(!T0.ClickCross(d, border_only = 1))
+		if(!T0.ClickCross(d, border_only = 1, target_atom = neighbor))
 			continue // could not leave T0 in that direction
 
 		var/turf/T1 = get_step(T0,d)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -156,7 +156,7 @@
 		shatter()
 		return
 
-/obj/machinery/door/window/interface_interact(mob/user)
+/obj/machinery/door/window/physical_attack_hand(mob/user)
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.species.can_shred(H))
@@ -164,7 +164,6 @@
 			visible_message("<span class='danger'>[user] smashes against the [src.name].</span>", 1)
 			take_damage(25)
 			return TRUE
-	return src.attackby(user, user)
 
 /obj/machinery/door/window/emag_act(var/remaining_charges, var/mob/user)
 	if (density && operable())


### PR DESCRIPTION
Fixes #26193

This should also fix other issues with CanUseTopic for atoms with `ATOM_FLAG_CHECKS_BORDER`. Basically, 
`X.Adjacent(Y)` would make sure to bypass `X` blocking itself (by virtue of being dense), but made no similar exclusion for `Y`. This makes `X.Adjacent(Y)` and `Y.Adjacent(X)` behave the same.