### PR TITLE
Fixes 26200 - Duplicate scanning message

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -28,10 +28,8 @@
 
 	var/mob/living/carbon/human/scan_subject = null
 	if (istype(target, /mob/living/carbon/human))
-		user.visible_message("<span class='notice'>\The [user] runs \the [scanner] over \the [target].</span>")
 		scan_subject = target
 	else if (istype(target, /obj/structure/closet/body_bag))
-		user.visible_message("<span class='notice'>\The [user] runs \the [scanner] over \the [target].</span>")
 		var/obj/structure/closet/body_bag/B = target
 		if(!B.opened)
 			var/list/scan_content = list()


### PR DESCRIPTION
The scanning message is also posted by /obj/item/device/scanner/afterattack , which I feel is more general than having it in /proc/medical_scan_action

So I've taken it out of /proc/medical_scan_action, and it only displays once now as it should.