### PR TITLE
Fixes #26212 ironing operation order.

### DIFF
--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -82,12 +82,6 @@
 	else if(istype(I,/obj/item/weapon/ironingiron))
 		var/obj/item/weapon/ironingiron/R = I
 
-		if(!holding && !R.enabled && user.unEquip(I, src))
-			holding = R
-			GLOB.destroyed_event.register(I, src, /obj/structure/bed/roller/ironingboard/proc/remove_item)
-			update_icon()
-			return
-
 		// anti-wrinkle "massage"
 		if(buckled_mob && ishuman(buckled_mob))
 			var/mob/living/carbon/human/H = buckled_mob
@@ -105,6 +99,11 @@
 			return
 
 		if(!cloth)
+			if(!holding && !R.enabled && user.unEquip(I, src))
+				holding = R
+				GLOB.destroyed_event.register(I, src, /obj/structure/bed/roller/ironingboard/proc/remove_item)
+				update_icon()
+				return	
 			to_chat(user, "<span class='notice'>There isn't anything on the ironing board.</span>")
 			return
 
@@ -114,7 +113,6 @@
 
 		visible_message("[user] finishes ironing [cloth].")
 		cloth.ironed_state = WRINKLES_NONE
-
 		return
 
 	..()


### PR DESCRIPTION
You can now only replace the iron on an ironing board if there are no clothes on it, else you will iron the clothes.