### PR TITLE
Changes RUST manual to use the wiki guide.

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -119,6 +119,7 @@
 		new /obj/item/weapon/book/manual/atmospipes(src)
 		new /obj/item/weapon/book/manual/engineering_singularity_safety(src)
 		new /obj/item/weapon/book/manual/evaguide(src)
+		new /obj/item/weapon/book/manual/rust_engine(src)
 		update_icon()
 
 /obj/structure/bookcase/manuals/research_and_development

--- a/code/modules/library/manuals/engineering.dm
+++ b/code/modules/library/manuals/engineering.dm
@@ -439,54 +439,7 @@
 	icon_state = "bookMagazine"
 	author = "Cindy Crawfish"
 	title = "R-UST Operating Manual"
-
-/obj/item/weapon/book/manual/rust_engine/New()
-	..()
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				body {font-size: 13px; font-family: Verdana;}
-				</style>
-				</head>
-				<body>
-				So you're the poor fucker who has to try and set this piece of shit up this shift. Congratulations! Here's what you need to know: this is a tokamak fusion reactor that uses a high energy plasma stream in a magnetic field enclosure to achieve fusion. It gets extremely hot extremely quickly, and the field is tempramental. The main principle of operation: maximize plasma temperature while minimizing field instability.
-				<br><br>
-				Deuterium and tritium are generally the most available fuel for the beast. If you're cautious, deut-deut reactions are capable of producing power without being unstable. Deut-trit is the bread and butter of the R-UST. You can keep field instability down by using the gyrotron near the core and not sticking your dick into the fusion torus.
-				<br><br>
-				Here's the idiot's guide to setting up a functional fusion cycle:
-				<ol>
-				<li>Put fuel (uranium, tritium) in the portable generator near the gyrotron and turn it to full. This is to provide initial power to the core. If the gen is fucked, hook it into the main grid.</li>
-				<li>Enable and max output on the SMES in the engine room. This is to power the gyrotron.</li>
-				<li>Go into the control room, interact with the fusion core control console. Turn the field on and raise size to 200. Any bigger and it will start EMP the machinery. Any smaller and the fuel pellets might miss.</li>
-				<li>Interact with the gyrotron control computer, set power as high as the SMES can support, usually around 3-5, and turn it on. This will start increasing the plasma temperature to the point where reactions can occur.</li>
-				<li>Go into the engine room and insert a deuterium fuel assembly and a tritium fuel assembly into two of the fuel injectors. You can make deuterium rods in the fuel compressor if you want to play it safe.</li>
-				<li>Go back to the control room and turn the fuel injectors on. This will start firing pellets into the field.</li>
-				<li>Wait for reactions to start (plasma temperature will spike and fuel amounts will drop, forming helium if you're using deut-trit). Adjust the gyrotron power and delay around until it's keeping up with field instability. This will prevent cumulative instability from the deuterium-tritium reaction fucking up the field. If you're using straight deuterium and NOTHING ELSE, instability isn't a problem and you can turn the gyrotron off.</li>
-				<li>Configure the SMES, turn the PACMAN off before it explodes.</li>
-				</ol>
-				<br>
-				<b>NOTES FOR NEWBIES</b>
-				<br>
-				Anything touching the field will mess with its stability and eventually cause it to rupture. Rupturing is bad. Use the gyrotron to keep instability down if you're running the engine on unstable fuel.
-				<br><br>
-				The more fuel in the field, the more fuel will react. Obvious, right? Don't load the field up with the ingredients for an unstable reaction (tritium and deuterium) before it has reached the point of fusion, or you will be trying to deal with a massive instability burst all at once.
-				<br><br>
-				Likewise, no matter how sad the core seems, don't fucking hug it, you'll blow the field out and set the engine room on fire.
-				<br><br>
-				IN CASE OF EMERGENCY:
-				<ol>
-				<li>Turn off the fuel injectors.</li>
-				<li>Maximize the gyrotron fire rate and shot power.</li>
-				<li>Open the main core chamber to vaccuum if you can.</li>
-				<li>Prep for irradiated crewmembers, a large EMP, and broken glass.</li>
-				<ol>
-				</body>
-			</html>"}
+	url = "R-UST"
 
 /obj/item/weapon/book/manual/engineering_hacking
 	name = "Hacking"


### PR DESCRIPTION
🆑
tweak: RUST manual now links to the wiki guide (and doesn't teach you to blow up the RUST)
/🆑