### PR TITLE
Adds a webhook for Travis failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,8 @@ addons:
 
 script:
   - test/run-test.sh
+
+after_failure:
+  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh failure $WEBHOOK_URL


### PR DESCRIPTION
Based on https://github.com/DiscordHooks/travis-ci-discord-webhook.

Testing suggests it likely works with failures of dev builds. It cannot be used for PR builds.