### PR TITLE
Tweaks blob resistances

### DIFF
--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -186,7 +186,7 @@
 		if(prob(user.skill_fail_chance(SKILL_SCIENCE, 90, SKILL_EXPERT)))
 			to_chat(user, SPAN_WARNING("You fail to collect a sample from \the [src]."))
 			return
-		else	
+		else
 			if(!pruned)
 				to_chat(user, SPAN_NOTICE("You collect a sample from \the [src]."))
 				new product(user.loc)
@@ -213,8 +213,7 @@
 	desc = "A huge glowing nucleus surrounded by thick tendrils."
 	icon_state = "blob_core"
 	maxHealth = 200
-	brute_resist = 1
-	fire_resist = 4
+	fire_resist = 2
 	regen_rate = 2
 	damage_min = 30
 	damage_max = 40
@@ -277,6 +276,7 @@
 	damage_min = 16
 	damage_max = 28
 	attack_freq = 5
+	regen_rate = 4
 	expandType = /obj/effect/blob/ravaging
 	light_color = BLOB_COLOR_SHIELD
 


### PR DESCRIPTION
First pass - Makes fire/laser more effective against cores than brute, slightly reduces shield regeneration rate.

Current blob resist values are what I'd set before Sabira overhauled blob mechanics, and were based on a balance of using torches and lasers against the green bits, and having to get in close for melee against the cores. The new blob overhaul makes going in for melee too dangerous to be feasible.

Current balance requires 20 laser shots to kill an aux core, and 40 laser shots to kill a main core, not counting any additional shots required to account for regen rates while having to recharge and burn time firing on rebuilt shield. In testing, I also found that ravaging masses respawned around shields before you could get more than one shot off on a shield mass.

New changes brings shots to kill down to 5 for auxiliary cores, and 10 for main cores, and slightly reduces shield regen rate. Nothing else is changed.

More changes may come if this turns out to make blobs too easy now.

![unknown 1](https://user-images.githubusercontent.com/11140088/60821313-287d3900-a158-11e9-90f5-b90f01166c8c.png)

:cl:
tweak: Blob resistance values have been tweaked. Cores are now weak to fire and laser, and strong to brute, like green blob.
tweak: Blob shielding mass regeneration rate has been very slightly reduced.
/:cl: