### PR TITLE
Fixes constructing multi-tile glass airlocks.

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -56,7 +56,7 @@
 	dir = EAST
 	var/width = 1
 	airlock_type = /obj/machinery/door/airlock/multi_tile
-	glass_type = "/multi_tile/glass"
+	glass_type = /obj/machinery/door/airlock/multi_tile/glass
 
 	New()
 		if(dir in list(EAST, WEST))


### PR DESCRIPTION
🆑 mikomyazaki
bugfix: Can now properly construct multi-tile glass airlocks.
/🆑

Was an issue where multi-tile glass airlocks were being treated as if they were mineral plating airlocks.

Fixes #26223 #24749