### PR TITLE
Improves maint_all_access handling.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -16,8 +16,6 @@
 	var/obj/item/weapon/card/id/id = GetIdCard()
 	if(id)
 		. += id.GetAccess()
-	if(maint_all_access)
-		. |= access_maint_tunnels
 
 /atom/movable/proc/GetIdCard()
 	return null
@@ -32,6 +30,11 @@
 		R = list()
 	if(!istype(L, /list))
 		return FALSE
+
+	if(maint_all_access)
+		L = L.Copy()
+		L |= access_maint_tunnels
+
 	return has_access(R, L)
 
 /proc/has_access(list/req_access, list/accesses)

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -7,13 +7,13 @@
 	color = COLOR_PALE_GREEN_GRAY
 	detail_color = COLOR_GREEN
 
-	var/temp_access = list() //to prevent agent cards stealing access as permanent
+	var/list/temp_access = list() //to prevent agent cards stealing access as permanent
 	var/expiration_time = 0
 	var/reason = "NOT SPECIFIED"
 
 /obj/item/weapon/card/id/guest/GetAccess()
 	if (world.time > expiration_time)
-		return access
+		return ..()
 	else
 		return temp_access
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -163,7 +163,7 @@ var/const/NO_EMAG_ACT = -50
 	item_state = "card-id"
 	slot_flags = SLOT_ID
 
-	var/access = list()
+	var/list/access = list()
 	var/registered_name = "Unknown" // The name registered_name on the card
 	var/associated_account_number = 0
 	var/list/associated_email_login = list("login" = "", "password" = "")


### PR DESCRIPTION
Things weren't calling parent, so not getting that maint access during rad storms. Moving this to a proc which nothing overrides and generally everything calls.

Closes #25894 
Closes #25239

These issues are confusing as they complain about specific jobs, while what matters are specific item loadouts.