### PR TITLE
Fixes ineligible jobs being made antag while in a transformed state.

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -6,8 +6,7 @@
 		if(player.current.faction != MOB_FACTION_NEUTRAL)
 			return 0
 
-	var/datum/job/J = SSjobs.get_by_title(player.assigned_role)
-	if(is_type_in_list(J,blacklisted_jobs))
+	if(is_type_in_list(player.assigned_job, blacklisted_jobs))
 		return 0
 
 	if(!ignore_role)
@@ -16,7 +15,7 @@
 			// Limits antag status to clients above player age, if the age system is being used.
 			if(C && config.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(min_player_age) && (C.player_age < min_player_age))
 				return 0
-		if(is_type_in_list(J,restricted_jobs))
+		if(is_type_in_list(player.assigned_job, restricted_jobs))
 			return 0
 		if(player.current && (player.current.status_flags & NO_ANTAG))
 			return 0


### PR DESCRIPTION
Fixes #24076. 

The two vars are handled differently: rank is (apparently) reflective of the mob's current state, while job is tracking the mind's actual job assignment.