### PR TITLE
Makes docking init not use tag/locate.

### DIFF
--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -13,6 +13,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/last_landmark_registration_time
 	var/list/shuttle_logs = list()               //Keeps records of shuttle movement, format is list(datum/shuttle = datum/shuttle_log)
 	var/list/shuttle_areas = list()              //All the areas of all shuttles.
+	var/list/docking_registry = list()           //Docking controller tag -> docking controller program, mostly for init purposes.
 
 	var/list/landmarks_awaiting_sector = list()  //Stores automatic landmarks that are waiting for a sector to finish loading.
 	var/list/landmarks_still_needed = list()     //Stores landmark_tags that need to be assigned to the sector (landmark_tag = sector) when registered.

--- a/code/game/machinery/embedded_controller/docking_program.dm
+++ b/code/game/machinery/embedded_controller/docking_program.dm
@@ -66,7 +66,7 @@
 	..()
 	if(id_tag)
 		if(SSshuttle.docking_registry[id_tag])
-			crash_with("Docking controller tag [id_tag] had multiple assotiated programs.")
+			crash_with("Docking controller tag [id_tag] had multiple associated programs.")
 		SSshuttle.docking_registry[id_tag] = src
 
 /datum/computer/file/embedded_program/docking/Destroy()

--- a/code/game/machinery/embedded_controller/docking_program.dm
+++ b/code/game/machinery/embedded_controller/docking_program.dm
@@ -65,7 +65,13 @@
 /datum/computer/file/embedded_program/docking/New(var/obj/machinery/embedded_controller/M)
 	..()
 	if(id_tag)
-		tag = id_tag //set tags for initialization
+		if(SSshuttle.docking_registry[id_tag])
+			crash_with("Docking controller tag [id_tag] had multiple assotiated programs.")
+		SSshuttle.docking_registry[id_tag] = src
+
+/datum/computer/file/embedded_program/docking/Destroy()
+	SSshuttle.docking_registry -= id_tag
+	return ..()
 
 /datum/computer/file/embedded_program/docking/receive_user_command(command)
 	if(command == "dock" || command == "undock")

--- a/code/game/machinery/machinery_components.dm
+++ b/code/game/machinery/machinery_components.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 				if(number == 0)
 					break
 
-// Returns a list of subtypes of the given component type, with assotiated value = number of that component.
+// Returns a list of subtypes of the given component type, with associated value = number of that component.
 /obj/machinery/proc/types_of_component(var/part_type)
 	. = list()
 	for(var/obj/component in component_parts)

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -3,7 +3,7 @@
 // Multiz shuttles currently not supported. Non-autodock shuttles currently not supported.
 
 /obj/effect/overmap/ship/landable
-	var/shuttle                                         // Name of assotiated shuttle. Must be autodock.
+	var/shuttle                                         // Name of associated shuttle. Must be autodock.
 	var/obj/effect/shuttle_landmark/ship/landmark       // Record our open space landmark for easy reference.
 	var/multiz = 0										// Index of multi-z levels, starts at 0
 	var/status = SHIP_STATUS_LANDED

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -18,12 +18,12 @@ var/list/escape_pods_by_name = list()
 
 	//find the arming controller (berth)
 	var/arming_controller_tag = arming_controller
-	arming_controller = locate(arming_controller_tag)
+	arming_controller = SSshuttle.docking_registry[arming_controller_tag]
 	if(!istype(arming_controller))
 		CRASH("Could not find arming controller for escape pod \"[name]\", tag was '[arming_controller_tag]'.")
 
 	//find the pod's own controller
-	var/datum/computer/file/embedded_program/docking/simple/prog = locate(dock_target)
+	var/datum/computer/file/embedded_program/docking/simple/prog = SSshuttle.docking_registry[dock_target]
 	var/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/controller_master = prog.master
 	if(!istype(controller_master))
 		CRASH("Escape pod \"[name]\" could not find it's controller master!")

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -43,7 +43,7 @@
 	if(!docking_controller)
 		return
 	var/docking_tag = docking_controller
-	docking_controller = locate(docking_tag)
+	docking_controller = SSshuttle.docking_registry[docking_tag]
 	if(!istype(docking_controller))
 		log_error("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 	if(GLOB.using_map.use_overmap)

--- a/code/unit_tests/machine_tests.dm
+++ b/code/unit_tests/machine_tests.dm
@@ -35,7 +35,7 @@
 		var/circuit_type = GLOB.machine_path_to_circuit_type[path]
 		if(circuit_type && !machine.construct_state)
 			failed[machine.type] = TRUE
-			log_bad("[log_info_line(machine)] had an assotiated circuit of type [circuit_type] but no construction state.")
+			log_bad("[log_info_line(machine)] had an associated circuit of type [circuit_type] but no construction state.")
 		else
 			passed[machine.type] = TRUE
 


### PR DESCRIPTION
Closes #23793 

Not sure what causes that (unless it's byond-level stuff with tag/locate, which the Travis errors sort of suggest), but this should be faster, cleaner, and simpler to debug.