### PR TITLE
Gives service module some tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -56,7 +56,9 @@
 		SKILL_BUREAUCRACY         = SKILL_PROF,
 		SKILL_COMPUTER            = SKILL_EXPERT,
 		SKILL_COOKING             = SKILL_PROF,
-		SKILL_BOTANY              = SKILL_PROF
+		SKILL_BOTANY              = SKILL_PROF,
+		SKILL_MEDICAL             = SKILL_BASIC,
+		SKILL_CHEMISTRY           = SKILL_ADEPT
 	)
 
 /obj/item/weapon/robot_module/clerical/butler/finalize_equipment()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -120,11 +120,42 @@
 	desc = "A portable drink dispencer."
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "shaker"
-	charge_cost = 20
+	charge_cost = 5
 	recharge_time = 3
 	volume = 60
 	possible_transfer_amounts = "5;10;20;30"
-	reagent_ids = list(/datum/reagent/ethanol/beer, /datum/reagent/ethanol/coffee/kahlua, /datum/reagent/ethanol/whiskey, /datum/reagent/ethanol/wine, /datum/reagent/ethanol/vodka, /datum/reagent/ethanol/gin, /datum/reagent/ethanol/rum, /datum/reagent/ethanol/tequilla, /datum/reagent/ethanol/vermouth, /datum/reagent/ethanol/cognac, /datum/reagent/ethanol/ale, /datum/reagent/ethanol/mead, /datum/reagent/water, /datum/reagent/sugar, /datum/reagent/drink/ice, /datum/reagent/drink/tea, /datum/reagent/drink/tea/icetea, /datum/reagent/drink/space_cola, /datum/reagent/drink/spacemountainwind, /datum/reagent/drink/dr_gibb, /datum/reagent/drink/space_up, /datum/reagent/drink/tonic, /datum/reagent/drink/sodawater, /datum/reagent/drink/lemon_lime, /datum/reagent/drink/juice/orange, /datum/reagent/drink/juice/lime, /datum/reagent/drink/juice/watermelon)
+	reagent_ids = list(
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/green_tea,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/cola,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/smw,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/dr_gibb,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/spaceup,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/tonic,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/sodawater,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon_lime,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/beer,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/kahlua,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/whiskey,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/wine,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/vodka,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/gin,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/rum,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/tequila,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/vermouth,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/cognac,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,
+		/obj/item/weapon/reagent_containers/chem_disp_cartridge/mead
+		)
 
 /obj/item/weapon/reagent_containers/borghypo/service/attack(var/mob/M, var/mob/user)
 	return


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Adds basic medical and trained chemistry skills to the Service Module. Gives the Service Module the full selection of booze and soft drink dispenser drinks. Significantly reduces power requirement of the drink dispenser tool.
/:cl:

- Adds all drinks from the booze and soft drinks dispensers to their portable version. They were missing a few.
- Reduces power usage of their dispenser, so you don't burn 20-30% of the default battery making a single drink, which can happen if you use the 5u dispenser mode.
- Adds basic medical and trained chemistry skills, so the Service 'bot knows what they're serving is/isn't poison, and lets them use chem dispensers fully.