### PR TITLE
Fixes Mend Psychic Power

### DIFF
--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -63,7 +63,7 @@
 		user.visible_message(SPAN_NOTICE("<i>\The [user] rests a hand on \the [target]'s [E.name]...</i>"))
 		to_chat(target, SPAN_NOTICE("A healing warmth suffuses you."))
 
-		var/redaction_rank = user.psi.get_rank(PSI_PSYCHOKINESIS)
+		var/redaction_rank = user.psi.get_rank(PSI_REDACTION)
 		var/pk_rank = user.psi.get_rank(PSI_PSYCHOKINESIS)
 		if(pk_rank >= PSI_RANK_LATENT && redaction_rank >= PSI_RANK_MASTER)
 			var/removal_size = Clamp(5-pk_rank, 0, 5)
@@ -94,12 +94,14 @@
 				return TRUE
 
 		for(var/datum/wound/W in E.wounds)
-			if(W.bleeding() && W.wound_damage() <= W.bleed_threshold)
+			if (W.bleeding() && (W.current_stage > 1 || redaction_rank >= PSI_RANK_MASTER)) 
 				to_chat(user, SPAN_NOTICE("You knit together severed veins and broken flesh, stemming the bleeding."))
 				W.bleed_timer = 0
 				W.clamped = TRUE
 				E.status &= ~ORGAN_BLEEDING
 				return TRUE
+			else if (W.current_stage == 1)
+				to_chat(user, SPAN_NOTICE("This [W.desc] is beyond your power to heal."))
 
 		if(redaction_rank >= PSI_RANK_GRANDMASTER)
 			for(var/obj/item/organ/internal/I in E.internal_organs)


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Mend psychic power now works properly on operant level to fix bleeding.
/:cl:

Now correctly stops bleeding, requiring a PSI_RANK_MASTER Redaction if the wound is at its most severe stage.
Also corrects an incorrect check for Psychokinesis rank rather than Redaction.

Fixes https://github.com/Baystation12/Baystation12/issues/26245