### PR TITLE
Adjust unit testing

### DIFF
--- a/code/unit_tests/_template.dm
+++ b/code/unit_tests/_template.dm
@@ -6,9 +6,9 @@
  */
 
 /datum/unit_test/template
-	name = "Test Template - Change My name"		// If it's a template leave the word "template" in it's name so it's not ran.
-
-	async = 1 // Set if we should continue testing elsewhere and come back and check on the results.
+	name = "Test Template - Change My name"
+	template = /datum/unit_test/template    // Set this var equal to the test path to treat it as a template, i.e. it should not be run
+	async = 1                               // Set if we should continue testing elsewhere and come back and check on the results.
 
 
 /datum/unit_test/template/start_test()

--- a/code/unit_tests/atmospherics_tests.dm
+++ b/code/unit_tests/atmospherics_tests.dm
@@ -4,6 +4,7 @@
 #define ALL_GASIDS gas_data.gases
 
 /datum/unit_test/atmos_machinery
+	template = /datum/unit_test/atmos_machinery
 	var/list/test_cases = list()
 
 /datum/unit_test/atmos_machinery/proc/create_gas_mixes(gas_mix_data)
@@ -61,6 +62,7 @@
 		pass("[case_name]: conserved moles of each gas ID.")
 
 /datum/unit_test/atmos_machinery/conserve_moles
+	template = /datum/unit_test/atmos_machinery/conserve_moles
 	test_cases = list(
 		uphill = list(
 			source = list(

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -2,14 +2,15 @@
 #define FAILURE 0
 
 
-datum/unit_test/vision_glasses/
+/datum/unit_test/vision_glasses
 	name = "EQUIPMENT: Vision Template"
+	template = /datum/unit_test/vision_glasses
 	var/mob/living/carbon/human/H = null
 	var/expectation = SEE_INVISIBLE_NOLIGHTING
 	var/glasses_type = null
 	async = 1
 
-datum/unit_test/vision_glasses/start_test()
+/datum/unit_test/vision_glasses/start_test()
 	spawn(0)
 		var/list/test = create_test_mob_with_mind(null, /mob/living/carbon/human)
 		if(isnull(test))
@@ -29,10 +30,10 @@ datum/unit_test/vision_glasses/start_test()
 	return 1
 
 
-datum/unit_test/vision_glasses/check_result()
+/datum/unit_test/vision_glasses/check_result()
 
 	if(isnull(H) || H.life_tick < 2)
-		return 0       
+		return 0
 
 	if(isnull(H.glasses))
 		fail("Mob doesn't have glasses on")
@@ -46,25 +47,25 @@ datum/unit_test/vision_glasses/check_result()
 
 	return 1
 
-datum/unit_test/vision_glasses/NVG
+/datum/unit_test/vision_glasses/NVG
 	name = "EQUIPMENT: NVG see_invis"
 	glasses_type = /obj/item/clothing/glasses/night
 
-datum/unit_test/vision_glasses/mesons
+/datum/unit_test/vision_glasses/mesons
 	name = "EQUIPMENT: Mesons see_invis"
 	glasses_type = /obj/item/clothing/glasses/meson
 
-datum/unit_test/vision_glasses/plain
+/datum/unit_test/vision_glasses/plain
 	name = "EQUIPMENT: Plain glasses. see_invis"
 	glasses_type = /obj/item/clothing/glasses/regular
 	expectation = SEE_INVISIBLE_LIVING
 
 // ============================================================================
 
-datum/unit_test/storage_capacity_test
+/datum/unit_test/storage_capacity_test
 	name = "EQUIPMENT: Storage items should be able to actually hold their initial contents"
 
-datum/unit_test/storage_capacity_test/start_test()
+/datum/unit_test/storage_capacity_test/start_test()
 	var/bad_tests = 0
 
 	// obj/item/weapon/storage/internal cannot be tested sadly, as they expect their host object to create them

--- a/code/unit_tests/extension_tests.dm
+++ b/code/unit_tests/extension_tests.dm
@@ -1,5 +1,6 @@
 /datum/unit_test/extensions
 	name = "EXTENSIONS template"
+	template = /datum/unit_test/extensions
 	async = 0
 
 /datum/unit_test/extensions/shall_initalize_as_expected

--- a/code/unit_tests/foundation_tests.dm
+++ b/code/unit_tests/foundation_tests.dm
@@ -1,14 +1,15 @@
 /*
 * Unit tests for built-in BYOND procs, to ensure overrides have not affected functionality.
 */
-datum/unit_test/foundation
+/datum/unit_test/foundation
 	name = "FOUNDATION template"
+	template = /datum/unit_test/foundation
 	async = 0
 
-datum/unit_test/foundation/step_shall_return_true_on_success
+/datum/unit_test/foundation/step_shall_return_true_on_success
 	name = "FOUNDATION: step() shall return true on success"
 
-datum/unit_test/foundation/step_shall_return_true_on_success/start_test()
+/datum/unit_test/foundation/step_shall_return_true_on_success/start_test()
 	var/mob_step_result = TestStep(/mob)
 	var/obj_step_result = TestStep(/obj)
 
@@ -19,7 +20,7 @@ datum/unit_test/foundation/step_shall_return_true_on_success/start_test()
 
 	return 1
 
-datum/unit_test/foundation/proc/TestStep(type_to_test)
+/datum/unit_test/foundation/proc/TestStep(type_to_test)
 	var/turf/start = get_safe_turf()
 	var/atom/movable/T = new type_to_test(start)
 

--- a/code/unit_tests/icon_tests.dm
+++ b/code/unit_tests/icon_tests.dm
@@ -1,5 +1,6 @@
 /datum/unit_test/icon_test
 	name = "ICON STATE template"
+	template = /datum/unit_test/icon_test
 
 /datum/unit_test/icon_test/robots_shall_have_eyes_for_each_state
 	name = "ICON STATE - Robot shall have eyes for each icon state"

--- a/code/unit_tests/integrated_circuits.dm
+++ b/code/unit_tests/integrated_circuits.dm
@@ -1,3 +1,6 @@
+/datum/unit_test/integrated_circuits
+	template = /datum/unit_test/integrated_circuits
+
 /datum/unit_test/integrated_circuits/unique_names
 	name = "INTEGRATED CIRCUITS - Circuits must have unique names"
 
@@ -61,6 +64,7 @@
 
 /datum/unit_test/integrated_circuits/input_output
 	name = "INTEGRATED CIRCUITS - INPUT/OUTPUT - TEMPLATE"
+	template = /datum/unit_test/integrated_circuits/input_output
 	var/list/all_inputs = list()
 	var/list/all_expected_outputs = list()
 	var/activation_pin = 1

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -16,12 +16,12 @@
 // Tests Life() and mob breathing in space.
 //
 
-datum/unit_test/human_breath
+/datum/unit_test/human_breath
 	name = "MOB: Breathing Species Suffocate in Space"
 	var/list/test_subjects = list()
 	async = 1
 
-datum/unit_test/human_breath/start_test()
+/datum/unit_test/human_breath/start_test()
 	var/turf/T = get_space_turf()
 
 	if(!istype(T, /turf/space))	//If the above isn't a space turf then we force it to find one will most likely pick 1,1,1
@@ -38,7 +38,7 @@ datum/unit_test/human_breath/start_test()
 			test_subjects[S.name] = list(H, damage_check(H, OXY))
 	return 1
 
-datum/unit_test/human_breath/check_result()
+/datum/unit_test/human_breath/check_result()
 	for(var/i in test_subjects)
 		var/mob/living/carbon/human/H = test_subjects[i][1]
 		if(H.life_tick < 10) 	// Finish Condition
@@ -134,8 +134,9 @@ proc/damage_check(var/mob/living/M, var/damage_type)
 //==============================================================================================================
 
 
-datum/unit_test/mob_damage
+/datum/unit_test/mob_damage
 	name = "MOB: Template for mob damage"
+	template = /datum/unit_test/mob_damage
 	var/mob/living/carbon/human/testmob = null
 	var/damagetype = BRUTE
 	var/mob_type = /mob/living/carbon/human
@@ -143,7 +144,7 @@ datum/unit_test/mob_damage
 	var/check_health = 0
 	var/damage_location = BP_CHEST
 
-datum/unit_test/mob_damage/start_test()
+/datum/unit_test/mob_damage/start_test()
 	var/list/test = create_test_mob_with_mind(null, mob_type)
 	var/damage_amount = 4	// Do not raise, if damage >= 5 there is a % chance to reduce damage by half in /obj/item/organ/external/take_damage()
 							// Which makes checks impossible.
@@ -262,32 +263,33 @@ datum/unit_test/mob_damage/halloss
 // Unathi
 // =================================================================
 
-datum/unit_test/mob_damage/unathi
+/datum/unit_test/mob_damage/unathi
 	name = "MOB: Unathi damage check template"
+	template = /datum/unit_test/mob_damage/unathi
 	mob_type = /mob/living/carbon/human/unathi
 
-datum/unit_test/mob_damage/unathi/brute
+/datum/unit_test/mob_damage/unathi/brute
 	name = "MOB: Unathi Brute Damage Check"
 	damagetype = BRUTE
 	expected_vulnerability = ARMORED
 
-datum/unit_test/mob_damage/unathi/fire
+/datum/unit_test/mob_damage/unathi/fire
 	name = "MOB: Unathi Fire Damage Check"
 	damagetype = BURN
 
-datum/unit_test/mob_damage/unathi/tox
+/datum/unit_test/mob_damage/unathi/tox
 	name = "MOB: Unathi Toxins Damage Check"
 	damagetype = TOX
 
-datum/unit_test/mob_damage/unathi/oxy
+/datum/unit_test/mob_damage/unathi/oxy
 	name = "MOB: Unathi Oxygen Damage Check"
 	damagetype = OXY
 
-datum/unit_test/mob_damage/unathi/clone
+/datum/unit_test/mob_damage/unathi/clone
 	name = "MOB: Unathi Clone Damage Check"
 	damagetype = CLONE
 
-datum/unit_test/mob_damage/unathi/halloss
+/datum/unit_test/mob_damage/unathi/halloss
 	name = "MOB: Unathi Halloss Damage Check"
 	damagetype = PAIN
 
@@ -295,34 +297,35 @@ datum/unit_test/mob_damage/unathi/halloss
 // Skrell
 // =================================================================
 
-datum/unit_test/mob_damage/skrell
+/datum/unit_test/mob_damage/skrell
 	name = "MOB: Skrell damage check template"
+	template = /datum/unit_test/mob_damage/skrell
 	mob_type = /mob/living/carbon/human/skrell
 
-datum/unit_test/mob_damage/skrell/brute
+/datum/unit_test/mob_damage/skrell/brute
 	name = "MOB: Skrell Brute Damage Check"
 	damagetype = BRUTE
 
-datum/unit_test/mob_damage/skrell/fire
+/datum/unit_test/mob_damage/skrell/fire
 	name = "MOB: Skrell Fire Damage Check"
 	damagetype = BURN
 	expected_vulnerability = ARMORED
 
-datum/unit_test/mob_damage/skrell/tox
+/datum/unit_test/mob_damage/skrell/tox
 	name = "MOB: Skrell Toxins Damage Check"
 	damagetype = TOX
 	expected_vulnerability = ARMORED
 
-datum/unit_test/mob_damage/skrell/oxy
+/datum/unit_test/mob_damage/skrell/oxy
 	name = "MOB: Skrell Oxygen Damage Check"
 	damagetype = OXY
 	expected_vulnerability = EXTRA_VULNERABLE
 
-datum/unit_test/mob_damage/skrell/clone
+/datum/unit_test/mob_damage/skrell/clone
 	name = "MOB: Skrell Clone Damage Check"
 	damagetype = CLONE
 
-datum/unit_test/mob_damage/skrell/halloss
+/datum/unit_test/mob_damage/skrell/halloss
 	name = "MOB: Skrell Halloss Damage Check"
 	damagetype = PAIN
 
@@ -330,33 +333,34 @@ datum/unit_test/mob_damage/skrell/halloss
 // Vox
 // =================================================================
 
-datum/unit_test/mob_damage/vox
+/datum/unit_test/mob_damage/vox
 	name = "MOB: Vox damage check template"
+	template = /datum/unit_test/mob_damage/vox
 	mob_type = /mob/living/carbon/human/vox
 
-datum/unit_test/mob_damage/vox/brute
+/datum/unit_test/mob_damage/vox/brute
 	name = "MOB: Vox Brute Damage Check"
 	damagetype = BRUTE
 
-datum/unit_test/mob_damage/vox/fire
+/datum/unit_test/mob_damage/vox/fire
 	name = "MOB: Vox Fire Damage Check"
 	damagetype = BURN
 
-datum/unit_test/mob_damage/vox/tox
+/datum/unit_test/mob_damage/vox/tox
 	name = "MOB: Vox Toxins Damage Check"
 	damagetype = TOX
 
-datum/unit_test/mob_damage/vox/oxy
+/datum/unit_test/mob_damage/vox/oxy
 	name = "MOB: Vox Oxygen Damage Check"
 	damagetype = OXY
 
-datum/unit_test/mob_damage/vox/clone
+/datum/unit_test/mob_damage/vox/clone
 	name = "MOB: Vox Clone Damage Check"
 	damagetype = CLONE
 	expected_vulnerability = IMMUNE
 
 
-datum/unit_test/mob_damage/vox/halloss
+/datum/unit_test/mob_damage/vox/halloss
 	name = "MOB: Vox Halloss Damage Check"
 	damagetype = PAIN
 
@@ -364,33 +368,34 @@ datum/unit_test/mob_damage/vox/halloss
 // Diona
 // =================================================================
 
-datum/unit_test/mob_damage/diona
+/datum/unit_test/mob_damage/diona
 	name = "MOB: Diona damage check template"
+	template = /datum/unit_test/mob_damage/diona
 	mob_type = /mob/living/carbon/human/diona
 
-datum/unit_test/mob_damage/diona/brute
+/datum/unit_test/mob_damage/diona/brute
 	name = "MOB: Diona Brute Damage Check"
 	damagetype = BRUTE
 
-datum/unit_test/mob_damage/diona/fire
+/datum/unit_test/mob_damage/diona/fire
 	name = "MOB: Diona Fire Damage Check"
 	damagetype = BURN
 
-datum/unit_test/mob_damage/diona/tox
+/datum/unit_test/mob_damage/diona/tox
 	name = "MOB: Diona Toxins Damage Check"
 	damagetype = TOX
 
-datum/unit_test/mob_damage/diona/oxy
+/datum/unit_test/mob_damage/diona/oxy
 	name = "MOB: Diona Oxygen Damage Check"
 	damagetype = OXY
 	expected_vulnerability = IMMUNE
 
-datum/unit_test/mob_damage/diona/clone
+/datum/unit_test/mob_damage/diona/clone
 	name = "MOB: Diona Clone Damage Check"
 	damagetype = CLONE
 	expected_vulnerability = IMMUNE
 
-datum/unit_test/mob_damage/diona/halloss
+/datum/unit_test/mob_damage/diona/halloss
 	name = "MOB: Diona Halloss Damage Check"
 	damagetype = PAIN
 	expected_vulnerability = IMMUNE
@@ -399,34 +404,35 @@ datum/unit_test/mob_damage/diona/halloss
 // Nabbers
 // =================================================================
 
-datum/unit_test/mob_damage/nabber
+/datum/unit_test/mob_damage/nabber
 	name = "MOB: GAS damage check template"
+	template = /datum/unit_test/mob_damage/nabber
 	mob_type = /mob/living/carbon/human/nabber
 
-datum/unit_test/mob_damage/nabber/brute
+/datum/unit_test/mob_damage/nabber/brute
 	name = "MOB: GAS Brute Damage Check"
 	damagetype = BRUTE
 	expected_vulnerability = ARMORED
 
-datum/unit_test/mob_damage/nabber/fire
+/datum/unit_test/mob_damage/nabber/fire
 	name = "MOB: GAS Fire Damage Check"
 	damagetype = BURN
 	expected_vulnerability = EXTRA_VULNERABLE
 
-datum/unit_test/mob_damage/nabber/tox
+/datum/unit_test/mob_damage/nabber/tox
 	name = "MOB: GAS Toxins Damage Check"
 	damagetype = TOX
 
-datum/unit_test/mob_damage/nabber/oxy
+/datum/unit_test/mob_damage/nabber/oxy
 	name = "MOB: GAS Oxygen Damage Check"
 	damagetype = OXY
 	expected_vulnerability = ARMORED
 
-datum/unit_test/mob_damage/nabber/clone
+/datum/unit_test/mob_damage/nabber/clone
 	name = "MOB: GAS Clone Damage Check"
 	damagetype = CLONE
 
-datum/unit_test/mob_damage/nabber/halloss
+/datum/unit_test/mob_damage/nabber/halloss
 	name = "MOB: GAS Halloss Damage Check"
 	damagetype = PAIN
 
@@ -434,34 +440,35 @@ datum/unit_test/mob_damage/nabber/halloss
 // SPECIAL WHITTLE SNOWFLAKES aka IPC
 // =================================================================
 
-datum/unit_test/mob_damage/machine
+/datum/unit_test/mob_damage/machine
 	name = "MOB: IPC damage check template"
+	template = /datum/unit_test/mob_damage/machine
 	mob_type = /mob/living/carbon/human/machine
 
-datum/unit_test/mob_damage/machine/brute
+/datum/unit_test/mob_damage/machine/brute
 	name = "MOB: IPC Brute Damage Check"
 	damagetype = BRUTE
 
-datum/unit_test/mob_damage/machine/fire
+/datum/unit_test/mob_damage/machine/fire
 	name = "MOB: IPC Fire Damage Check"
 	damagetype = BURN
 
-datum/unit_test/mob_damage/machine/tox
+/datum/unit_test/mob_damage/machine/tox
 	name = "MOB: IPC Toxins Damage Check"
 	damagetype = TOX
 	expected_vulnerability = IMMUNE
 
-datum/unit_test/mob_damage/machine/oxy
+/datum/unit_test/mob_damage/machine/oxy
 	name = "MOB: IPC Oxygen Damage Check"
 	damagetype = OXY
 	expected_vulnerability = IMMUNE
 
-datum/unit_test/mob_damage/machine/clone
+/datum/unit_test/mob_damage/machine/clone
 	name = "MOB: IPC Clone Damage Check"
 	damagetype = CLONE
 	expected_vulnerability = IMMUNE
 
-datum/unit_test/mob_damage/machine/halloss
+/datum/unit_test/mob_damage/machine/halloss
 	name = "MOB: IPC Halloss Damage Check"
 	damagetype = PAIN
 	expected_vulnerability = IMMUNE
@@ -470,11 +477,11 @@ datum/unit_test/mob_damage/machine/halloss
 // ==============================================================================
 
 
-datum/unit_test/robot_module_icons
+/datum/unit_test/robot_module_icons
 	name = "MOB: Robot module icon check"
 	var/icon_file = 'icons/mob/screen1_robot.dmi'
 
-datum/unit_test/robot_module_icons/start_test()
+/datum/unit_test/robot_module_icons/start_test()
 	var/failed = 0
 	if(!isicon(icon_file))
 		fail("[icon_file] is not a valid icon file.")
@@ -503,12 +510,12 @@ datum/unit_test/robot_module_icons/start_test()
 #undef SUCCESS
 #undef FAILURE
 
-datum/unit_test/species_base_skin
+/datum/unit_test/species_base_skin
 	name = "MOB: Species base skin presence"
 //	async = 1
 	var/failcount = 0
 
-datum/unit_test/species_base_skin/start_test()
+/datum/unit_test/species_base_skin/start_test()
 	for(var/species_name in all_species)
 		var/datum/species/S = all_species[species_name]
 		if(S.base_skin_colours)

--- a/code/unit_tests/movement_tests.dm
+++ b/code/unit_tests/movement_tests.dm
@@ -1,5 +1,6 @@
 /datum/unit_test/movement
 	name = "MOVEMENT template"
+	template = /datum/unit_test/movement
 	async = 0
 
 /datum/unit_test/movement/force_move_shall_trigger_crossed_when_entering_turf

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -3,6 +3,7 @@
 
 /datum/unit_test/observation
 	name = "OBSERVATION template"
+	template = /datum/unit_test/observation
 	async = 0
 	var/list/received_moves
 

--- a/code/unit_tests/override_tests.dm
+++ b/code/unit_tests/override_tests.dm
@@ -2,6 +2,7 @@
 
 /datum/unit_test/override
 	name = "OVERRIDE template"
+	template = /datum/unit_test/override
 
 /datum/unit_test/override/obj_random_shall_spawn_heaviest_item
 	name = "OVERRIDE - obj/random shall spawn heaviest item"

--- a/code/unit_tests/virtual_mob_tests.dm
+++ b/code/unit_tests/virtual_mob_tests.dm
@@ -1,10 +1,12 @@
 #ifdef UNIT_TEST
 
-datum/unit_test/virtual
+/datum/unit_test/virtual
 	name = "VIRTUAL - Template"
+	template = /datum/unit_test/virtual
 
-datum/unit_test/virtual/helper
+/datum/unit_test/virtual/helper
 	name = "VIRTUAL - Template Helper"
+	template = /datum/unit_test/virtual/helper
 
 	var/helper_proc
 	var/list/expected_mobs
@@ -13,7 +15,7 @@ datum/unit_test/virtual/helper
 	var/mob/mob_two
 	var/mob/mob_three
 
-datum/unit_test/virtual/helper/start_test()
+/datum/unit_test/virtual/helper/start_test()
 	standard_setup()
 
 	var/list/actual_mobs = call(helper_proc)(mob_one)
@@ -32,73 +34,73 @@ datum/unit_test/virtual/helper/start_test()
 	standard_cleanup()
 	return TRUE
 
-datum/unit_test/virtual/helper/check_hearers_in_range
+/datum/unit_test/virtual/helper/check_hearers_in_range
 	name = "VIRTUAL - Helper Test - Check Hearers In Range"
 	helper_proc = /proc/hearers_in_range
-datum/unit_test/virtual/helper/check_hearers_in_range/standard_setup()
+/datum/unit_test/virtual/helper/check_hearers_in_range/standard_setup()
 	..()
 	expected_mobs = list(mob_one, mob_two, mob_three)
 
-datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage
+/datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage
 	name = "VIRTUAL - Helper Test - Check Hearers In Range - With Mob Inside Storage"
 	helper_proc = /proc/hearers_in_range
 	var/obj/storage
-datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage/standard_setup()
+/datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage/standard_setup()
 	..()
 	storage = new(mob_one.loc)
 	mob_one.forceMove(storage)
 	expected_mobs = list(mob_one, mob_two, mob_three)
-datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage/Destroy()
+/datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage/Destroy()
 	QDEL_NULL(storage)
 	. = ..()
 
-datum/unit_test/virtual/helper/check_viewers_in_range
+/datum/unit_test/virtual/helper/check_viewers_in_range
 	name = "VIRTUAL - Helper Test - Check Viewers In Range"
 	helper_proc = /proc/viewers_in_range
-datum/unit_test/virtual/helper/check_viewers_in_range/standard_setup()
+/datum/unit_test/virtual/helper/check_viewers_in_range/standard_setup()
 	..()
 	expected_mobs = list(mob_one, mob_two, mob_three)
 
-datum/unit_test/virtual/helper/check_all_hearers
+/datum/unit_test/virtual/helper/check_all_hearers
 	name = "VIRTUAL - Helper Test - Check All Hearers"
 	helper_proc = /proc/all_hearers
-datum/unit_test/virtual/helper/check_all_hearers/standard_setup()
+/datum/unit_test/virtual/helper/check_all_hearers/standard_setup()
 	..()
 	expected_mobs = list(mob_one, mob_two)
 
-datum/unit_test/virtual/helper/check_all_viewers
+/datum/unit_test/virtual/helper/check_all_viewers
 	name = "VIRTUAL - Helper Test - Check All Viewers"
 	helper_proc = /proc/all_viewers
-datum/unit_test/virtual/helper/check_all_viewers/standard_setup()
+/datum/unit_test/virtual/helper/check_all_viewers/standard_setup()
 	..()
 	expected_mobs = list(mob_one, mob_two)
 
-datum/unit_test/virtual/helper/check_mobs_in_viewing_range
+/datum/unit_test/virtual/helper/check_mobs_in_viewing_range
 	name = "VIRTUAL - Helper Test - Check Mobs In Viewing Range"
 	helper_proc = /proc/hosts_in_view_range
-datum/unit_test/virtual/helper/check_mobs_in_viewing_range/standard_setup()
+/datum/unit_test/virtual/helper/check_mobs_in_viewing_range/standard_setup()
 	..()
 	expected_mobs = list(mob_one, mob_two)
 
-datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object
+/datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object
 	name = "VIRTUAL - Helper Test - Check Hosts in View Range - With Mob Inside Object"
 	helper_proc = /proc/hosts_in_view_range
 	var/obj/storage
-datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object/standard_setup()
+/datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object/standard_setup()
 	..()
 	storage = new(mob_one.loc)
 	mob_one.forceMove(storage)
 	expected_mobs = list(mob_one, mob_two)
-datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object/Destroy()
+/datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object/Destroy()
 	QDEL_NULL(storage)
 	. = ..()
 
-datum/unit_test/virtual/helper/proc/standard_setup()
+/datum/unit_test/virtual/helper/proc/standard_setup()
 	mob_one   = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/effect/landmark/virtual_spawn/one)),   "Test Mob 1")
 	mob_two   = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/effect/landmark/virtual_spawn/two)),   "Test Mob 2")
 	mob_three = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/effect/landmark/virtual_spawn/three)), "Test Mob 3")
 
-datum/unit_test/virtual/helper/proc/standard_cleanup()
+/datum/unit_test/virtual/helper/proc/standard_cleanup()
 	QDEL_NULL(mob_one)
 	QDEL_NULL(mob_two)
 	QDEL_NULL(mob_three)

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -18,12 +18,13 @@
 // Generic check for an area.
 //
 
-datum/unit_test/zas_area_test
+/datum/unit_test/zas_area_test
 	name = "ZAS: Area Test Template"
+	template = /datum/unit_test/zas_area_test
 	var/area_path = null                    // Put the area you are testing here.
 	var/expectation = UT_NORMAL             // See defines above.
 
-datum/unit_test/zas_area_test/start_test()
+/datum/unit_test/zas_area_test/start_test()
 	var/list/test = test_air_in_area(area_path, expectation)
 
 	if(isnull(test))
@@ -40,7 +41,7 @@ datum/unit_test/zas_area_test/start_test()
 //
 //	The primary helper proc.
 //
-proc/test_air_in_area(var/test_area, var/expectation = UT_NORMAL)
+/proc/test_air_in_area(var/test_area, var/expectation = UT_NORMAL)
 	var/test_result = list("result" = FAILURE, "msg"    = "")
 
 	var/area/A = locate(test_area)
@@ -107,7 +108,7 @@ proc/test_air_in_area(var/test_area, var/expectation = UT_NORMAL)
 
 // Here we move a shuttle then test it's area once the shuttle has arrived.
 
-datum/unit_test/zas_supply_shuttle_moved
+/datum/unit_test/zas_supply_shuttle_moved
 	name = "ZAS: Supply Shuttle (When Moved)"
 	async=1				// We're moving the shuttle using built in procs.
 
@@ -115,7 +116,7 @@ datum/unit_test/zas_supply_shuttle_moved
 
 	var/testtime = 0	//Used as a timer.
 
-datum/unit_test/zas_supply_shuttle_moved/start_test()
+/datum/unit_test/zas_supply_shuttle_moved/start_test()
 
 	if(!SSshuttle)
 		fail("Shuttle Controller not setup at time of test.")
@@ -134,7 +135,7 @@ datum/unit_test/zas_supply_shuttle_moved/start_test()
 
 	return 1
 
-datum/unit_test/zas_supply_shuttle_moved/check_result()
+/datum/unit_test/zas_supply_shuttle_moved/check_result()
 	if(!shuttle)
 		skip("This map has no supply shuttle.")
 		return 1


### PR DESCRIPTION
The unit test SS now actually waits for round start

Unit tests are marked as templates using path-checking instead of name
Allows tests named, for example, "Shall be able to load map templates"

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->