### PR TITLE
Fixes issue where autopilot would try to accelerate by null units

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -55,11 +55,10 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 				linked.decelerate()
 			// Heading does not match direction
 			else if (heading & ~direction)
-				linked.accelerate(turn(heading & ~direction, 180))
+				linked.accelerate(turn(heading & ~direction, 180), accellimit)
 			// All other cases, move toward direction
 			else if (speed + acceleration <= speedlimit)
-				linked.accelerate(direction)
-
+				linked.accelerate(direction, accellimit)
 		return
 
 /obj/machinery/computer/ship/helm/relaymove(var/mob/user, direction)


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Autopilot will now accelerate correctly.
/:cl:

Autopilot was missing the second argument in the accelerate functions, so it was trying to accelerate by null units I think due to a min(num,null).

Fixes #25540