### PR TITLE
Fixes #25613 - Printing txt/log from file manager

### DIFF
--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -9,7 +9,7 @@ var/global/file_uid = 0
 	var/undeletable = 0										// Whether the file may be deleted. Setting to 1 prevents deletion/renaming/etc.
 	var/uid													// UID of this file
 	var/list/metadata											// Any metadata the file uses.
-	var/papertype = /obj/item/paper
+	var/papertype = /obj/item/weapon/paper
 
 /datum/computer_file/New(var/list/md = null)
 	..()


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Printing from the file manager program now prints visible paper.
/:cl:

It was set to /obj/item/paper rather than /obj/item/weapon/paper by default.

Fixes #25613