### PR TITLE
Fixes #24871 - Paramount Forcesword can now hit robots

### DIFF
--- a/code/modules/psionics/equipment/psipower_blade.dm
+++ b/code/modules/psionics/equipment/psipower_blade.dm
@@ -9,9 +9,6 @@
 /obj/item/psychic_power/psiblade/master
 	force = 20
 	maintain_cost = 2
-
-/obj/item/psychic_power/psiblade/master/iswirecutter()
-	return TRUE
 	
 /obj/item/psychic_power/psiblade/master/grand
 	force = 30


### PR DESCRIPTION
:cl: mikomyazaki
tweak: The psiblade can now hit robots instead of trying to cut their wires like a wirecutter. 
/:cl:

The Psychokinesis psychic faculty has another power that allows them to summon wirecutters whenever they want. I don't think they need their sword to cut wires as well, and this is probably the simplest way of fixing their inability to hit robots.

@MistakeNot4892 might have something to say about this though.

Fixes #24871