### PR TITLE
Vendor construction

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -692,6 +692,7 @@
 #include "code\game\machinery\teleporter.dm"
 #include "code\game\machinery\turret_control.dm"
 #include "code\game\machinery\vending.dm"
+#include "code\game\machinery\vending_deconstruction.dm"
 #include "code\game\machinery\wall_frames.dm"
 #include "code\game\machinery\washing_machine.dm"
 #include "code\game\machinery\wishgranter.dm"

--- a/code/datums/vending/stored_item.dm
+++ b/code/datums/vending/stored_item.dm
@@ -21,35 +21,37 @@
 
 /datum/stored_items/Destroy()
 	storing_object = null
-	if(instances)
-		for(var/instance in instances)
-			qdel(instance)
-		instances = null
+	QDEL_NULL_LIST(instances)
 	. = ..()
 
 /datum/stored_items/dd_SortValue()
 	return item_name
 
 /datum/stored_items/proc/get_amount()
-	return instances ? instances.len : amount
+	return amount
 
 /datum/stored_items/proc/add_product(var/atom/movable/product)
 	if(product.type != item_path)
 		return 0
-	init_products()
 	if(product in instances)
 		return 0
 	product.forceMove(storing_object)
-	instances += product
+	LAZYADD(instances, product)
+	amount++
 	return 1
 
 /datum/stored_items/proc/get_product(var/product_location)
 	if(!get_amount() || !product_location)
 		return
-	init_products()
 
-	var/atom/movable/product = instances[instances.len]	// Remove the last added product
-	instances -= product
+	var/atom/movable/product
+	if(LAZYLEN(instances))
+		product = instances[instances.len]	// Remove the last added product
+		LAZYREMOVE(instances, product)
+	else
+		product = new item_path(storing_object)
+
+	amount--
 	product.forceMove(product_location)
 	return product
 
@@ -61,10 +63,21 @@
 	if(.)
 		product.forceMove(product_location)
 
-/datum/stored_items/proc/init_products()
-	if(instances)
-		return
-	instances = list()
-	for(var/i = 1 to amount)
-		var/new_product = new item_path(storing_object)
-		instances += new_product
+/datum/stored_items/proc/merge(datum/stored_items/other)
+	if(other.item_path != item_path)
+		return FALSE
+	for(var/atom/movable/thing in other.instances)
+		other.instances -= thing
+		if(thing in instances)
+			amount-- // Don't double-count
+		else
+			thing.forceMove(storing_object)
+			LAZYADD(instances, thing)
+	amount += other.amount
+	qdel(other)
+	return TRUE
+
+/datum/stored_items/proc/migrate(atom/new_storing_obj)
+	storing_object = new_storing_obj
+	for(var/atom/movable/thing in instances)
+		thing.forceMove(new_storing_obj)

--- a/code/game/machinery/vending_deconstruction.dm
+++ b/code/game/machinery/vending_deconstruction.dm
@@ -1,0 +1,52 @@
+// Dumping the stock of a vending machine causes lots of items and client lag, so use this thing instead.
+
+/obj/structure/vending_refill
+	name = "vendor restock"
+	desc = "A large sealed container containing items sold from a vending machine."
+	icon = 'icons/obj/closets/bases/large_crate.dmi'
+	icon_state = "base"
+	color = COLOR_BEASTY_BROWN
+	w_class = ITEM_SIZE_HUGE
+	var/expected_type
+	var/list/product_records
+
+/obj/structure/vending_refill/Destroy()
+	QDEL_NULL_LIST(product_records)
+	. = ..()
+
+/obj/structure/vending_refill/get_lore_info()
+	return "Vendor restock containers are notoriously difficult to open, representing the pinnacle of humanity's antitheft technologies."
+
+/obj/structure/vending_refill/get_mechanics_info()
+	return "Drag to a vendor to restock. Generally can not be opened."
+
+/obj/structure/vending_refill/MouseDrop(obj/machinery/vending/over)
+	if(!CanMouseDrop(over, usr))
+		return
+	if(!istype(over))
+		return ..()
+	var/target_type = over.base_type || over.type
+	if(!ispath(expected_type, target_type))
+		return ..()
+
+	for(var/datum/stored_items/R in product_records)
+		for(var/datum/stored_items/record in over.product_records)
+			if(record.merge(R))
+				break
+		if(!QDELETED(R))
+			R.migrate(over)
+			over.product_records += R
+
+	product_records = null
+	SSnano.update_uis(over)
+	qdel(src)
+
+/obj/machinery/vending/dismantle()
+	var/obj/structure/vending_refill/dump = new(loc)
+	dump.SetName("[dump.name] ([name])")
+	dump.expected_type = base_type || type
+	for(var/datum/stored_items/vending_products/R in product_records)
+		R.migrate(dump)
+	dump.product_records = product_records
+	product_records = null
+	. = ..()

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -52,4 +52,5 @@
 	. = ..()
 	if(buildtype_select && machine)
 		build_path = machine.base_type || machine.type
-		SetName(T_BOARD(machine.name))
+		var/obj/machinery/thing = build_path
+		SetName(T_BOARD(initial(thing.name)))

--- a/code/game/objects/items/weapons/circuitboards/machinery/household.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/household.dm
@@ -70,3 +70,26 @@
 		/obj/item/weapon/stock_parts/micro_laser = 1,
 		/obj/item/weapon/stock_parts/matter_bin = 1,
 		/obj/item/pipe = 1)
+
+/obj/item/weapon/stock_parts/circuitboard/vending
+	name = T_BOARD("vending machine")
+	build_path = /obj/machinery/vending/assist
+	board_type = "machine"
+	origin_tech = list(TECH_ENGINEERING = 2)
+	req_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 1,
+		/obj/item/weapon/stock_parts/manipulator = 1
+	)
+	additional_spawn_components = list(
+		/obj/item/weapon/stock_parts/console_screen = 1,
+		/obj/item/weapon/stock_parts/keyboard = 1,
+		/obj/item/weapon/stock_parts/power/apc/buildable = 1
+	)
+	buildtype_select = TRUE
+
+/obj/item/weapon/stock_parts/circuitboard/vending/get_buildable_types()
+	. = list()
+	for(var/path in typesof(/obj/machinery/vending))
+		var/obj/machinery/vending/vendor = path
+		var/base_type = initial(vendor.base_type) || path
+		. |= base_type

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -6,6 +6,7 @@
 	icon_state = "portgen0"
 	density = 1
 	anchored = 0
+	interact_offline = TRUE
 
 	var/active = 0
 	var/power_gen = 5000

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -810,6 +810,13 @@
 	build_path = /obj/item/weapon/stock_parts/circuitboard/honey/seed
 	sort_string = "WAAAX"
 
+/datum/design/circuit/vending
+	name = "vending machine"
+	id = "vending"
+	req_tech = list(TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/stock_parts/circuitboard/vending
+	sort_string = "WAABA"
+
 /datum/design/circuit/aicore
 	name = "AI core"
 	id = "aicore"


### PR DESCRIPTION
:cl:
rscadd: Vending machines are now constructable using circuits, and also can be deconstructed. Drag the container they drop to another vendor of the same type to restock it.
tweak: To add things back to vending machines, you now must be on help intent (useful for tool machines).
/:cl:

Also fixes pacmen, and makes vendors lazy-init their contents more aggressively.