### PR TITLE
Adds a hint if you are missing a tesla link in a machine.

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -414,6 +414,8 @@ Class Procs:
 			to_chat(user, "It is missing a screen, making it hard to interact with.")
 		else if(stat & NOINPUT)
 			to_chat(user, "It is missing any input device.")
+		else if((stat & NOPOWER) && !interact_offline)
+			to_chat(user, "It is not receiving power.")
 		if(construct_state && construct_state.mechanics_info())
 			to_chat(user, "It can be <a href='?src=\ref[src];mechanics_text=1'>manipulated</a> using tools.")
 		var/list/missing = missing_parts()


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Machines will now have a hint if you have forgotten to install a tesla link.
/:cl:

Machines have a hint if you are missing a screen or keyboard, I think they should have one for missing power (either the room is unpowered, or you are missing a tesla link in the machine). This is especially useful due to confusion due to machines being unpowered despite sitting on top of a power cable node.