### PR TITLE
Post-merge Ascent ship tweaks.

### DIFF
--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -28,7 +28,7 @@
 /area/ship/ascent/fore_starboard_prow)
 "ai" = (
 /obj/machinery/recharge_station/ascent,
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/drone,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/drone,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/wing_starboard)
 "aj" = (
@@ -182,7 +182,7 @@
 "aG" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_internal"
+	id_tag = "ascent_seedship_fore_internal"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_hallway)
@@ -388,11 +388,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/effect/overmap/ship/ascent_cutter,
+/obj/effect/overmap/ship/ascent_seedship,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
 "bl" = (
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/alate,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/alate,
 /obj/structure/ascent_spawn,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
@@ -510,9 +510,9 @@
 /area/ship/ascent/wing_starboard)
 "by" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	airflow_dest = "ascent_cutter_fore_external";
+	airflow_dest = "ascent_seedship_fore_external";
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_external"
+	id_tag = "ascent_seedship_fore_external"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_hallway)
@@ -520,7 +520,7 @@
 /turf/simulated/wall/ascent,
 /area/ship/ascent/habitation)
 "bA" = (
-/obj/effect/submap_landmark/joinable_submap/ascent_cutter,
+/obj/effect/submap_landmark/joinable_submap/ascent_seedship,
 /turf/simulated/wall/ascent,
 /area/ship/ascent/habitation)
 "bB" = (
@@ -857,7 +857,7 @@
 /area/ship/ascent/bridge)
 "ch" = (
 /obj/structure/ascent_spawn,
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
 "ci" = (
@@ -902,14 +902,14 @@
 /area/ship/ascent/wing_port)
 "cm" = (
 /obj/structure/ascent_spawn,
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/adjunct,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/adjunct,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
 "cn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on/ascent,
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1331;
-	master_tag = "ascent_cutter_fore_dock_controller";
+	master_tag = "ascent_seedship_fore_dock_controller";
 	pixel_x = -4;
 	pixel_y = 24
 	},
@@ -1454,7 +1454,7 @@
 /area/ship/ascent/wing_port)
 "dB" = (
 /obj/structure/ascent_spawn,
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/queen,
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/queen,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
 "dC" = (
@@ -1475,7 +1475,7 @@
 "dD" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_external"
+	id_tag = "ascent_seedship_fore_external"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_hallway)
@@ -1830,16 +1830,16 @@
 "em" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_pumps"
+	id_tag = "ascent_seedship_fore_pumps"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	airflow_dest = "ascent_cutter_fore_dock_controller";
+	airflow_dest = "ascent_seedship_fore_dock_controller";
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_dock_controller";
+	id_tag = "ascent_seedship_fore_dock_controller";
 	pixel_y = 24;
-	tag_airpump = "ascent_cutter_fore_pumps";
-	tag_exterior_door = "ascent_cutter_fore_external";
-	tag_interior_door = "ascent_cutter_fore_internal"
+	tag_airpump = "ascent_seedship_fore_pumps";
+	tag_exterior_door = "ascent_seedship_fore_external";
+	tag_interior_door = "ascent_seedship_fore_internal"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_hallway)
@@ -1889,7 +1889,7 @@
 "er" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_internal"
+	id_tag = "ascent_seedship_fore_internal"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1960,11 +1960,11 @@
 "ew" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_pumps"
+	id_tag = "ascent_seedship_fore_pumps"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_dock_sensor";
+	id_tag = "ascent_seedship_fore_dock_sensor";
 	pixel_y = 24
 	},
 /turf/simulated/floor/ascent,
@@ -1990,7 +1990,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/shuttle_landmark/ascent_cutter/start,
+/obj/effect/shuttle_landmark/ascent_seedship/start,
 /obj/machinery/access_button/airlock_interior{
 	command = "cycle_exterior";
 	master_tag = "ascent_port_dock";
@@ -2929,7 +2929,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "ascent_cutter_fore_pumps"
+	id_tag = "ascent_seedship_fore_pumps"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_hallway)
@@ -3949,7 +3949,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/shuttle_landmark/ascent_cutter/start/two,
+/obj/effect/shuttle_landmark/ascent_seedship/start/two,
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_starboard)
@@ -4529,7 +4529,7 @@
 /obj/machinery/access_button/airlock_interior{
 	command = "cycle_exterior";
 	frequency = 1331;
-	master_tag = "ascent_cutter_fore_dock_controller";
+	master_tag = "ascent_seedship_fore_dock_controller";
 	pixel_x = -8;
 	pixel_y = -4
 	},

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -1,20 +1,22 @@
+#define ASCENT_COLONY_SHIP_NAME "\improper Ascent seedship"
+
 #include "ascent_areas.dm"
 #include "ascent_shuttles.dm"
 #include "ascent_jobs.dm"
 #include "ascent_atoms.dm"
 
 // Map template data.
-/datum/map_template/ruin/away_site/ascent_cutter
-	name = "Ascent Cutter"
-	id = "awaysite_ascent_cutter"
-	description = "A small Ascent warship."
+/datum/map_template/ruin/away_site/ascent_seedship
+	name = ASCENT_COLONY_SHIP_NAME
+	id = "awaysite_ascent_seedship"
+	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm")
 	cost = INFINITY
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/ascent, /datum/shuttle/autodock/overmap/ascent/two)
 
 // Overmap objects.
-/obj/effect/overmap/ship/ascent_cutter
-	name = "Unknown Vessel"
+/obj/effect/overmap/ship/ascent_seedship
+	name = ASCENT_COLONY_SHIP_NAME
 	desc = "Wake signature indicates a small to medium sized vessel of unknown design."
 	vessel_mass = 6500
 	max_speed = 1/(1 SECOND)
@@ -23,9 +25,7 @@
 		"Lepidoptera" = list("nav_hangar_ascent_two")
 	)
 
-/obj/effect/submap_landmark/joinable_submap/ascent_cutter
-	name = "Ascent Cutter"
-	archetype = /decl/submap_archetype/ascent_cutter
+/obj/effect/submap_landmark/joinable_submap/ascent_seedship
+	name = ASCENT_COLONY_SHIP_NAME
+	archetype = /decl/submap_archetype/ascent_seedship
 	submap_datum_type = /datum/submap/ascent
-
-#undef WEBHOOK_SUBMAP_LOADED_ASCENT

--- a/maps/away/ascent/ascent_atoms.dm
+++ b/maps/away/ascent/ascent_atoms.dm
@@ -66,7 +66,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	color = COLOR_PURPLE
 	closed_system = TRUE
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 // No maintenance needed.
 /obj/machinery/portable_atmospherics/hydroponics/ascent/Process()
@@ -101,7 +101,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 /obj/machinery/recharge_station/ascent
 	construct_state = null
 	base_type = /obj/machinery/recharge_station/ascent
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/body_scanconsole/ascent
 	name = "mantid scanner console"
@@ -109,14 +109,14 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	req_access = list(access_ascent)
 	icon = 'icons/obj/ascent_sleepers.dmi'
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/bodyscanner/ascent
 	name = "mantid body scanner"
 	desc = "Some kind of strange alien body scanning technology."
 	icon = 'icons/obj/ascent_sleepers.dmi'
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/sleeper/ascent
 	name = "mantid sleeper"
@@ -124,7 +124,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	icon = 'icons/obj/ascent_sleepers.dmi'
 	construct_state = null
 	base_type = /obj/machinery/sleeper/ascent
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/structure/bed/chair/padded/purple/ascent
 	icon_state = "nest_chair"
@@ -143,7 +143,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	req_access = list(access_ascent)
 	construct_state = null
 	base_type = /obj/machinery/autolathe/ascent
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/power/apc/hyper/ascent
 	req_access = list(access_ascent)
@@ -244,7 +244,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	icon_screen = "ascent_screen"
 	req_access = list(access_ascent)
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/computer/ship/engines/ascent
 	icon_state = "ascent"
@@ -252,7 +252,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	icon_screen = "ascent_screen"
 	req_access = list(access_ascent)
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/computer/ship/navigation/ascent
 	icon_state = "ascent"
@@ -260,7 +260,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	icon_screen = "ascent_screen"
 	req_access = list(access_ascent)
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 /obj/machinery/computer/ship/sensors/ascent
 	icon_state = "ascent"
@@ -268,7 +268,7 @@ MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place"
 	icon_screen = "ascent_screen"
 	req_access = list(access_ascent)
 	construct_state = null
-	stat_immune = EMPED | NOSCREEN | NOINPUT
+	stat_immune = EMPED | NOSCREEN | NOINPUT | NOPOWER
 
 // This is an absolutely stupid machine. Basically the same as the debug one with some alterations.
 // It is a placeholder for a proper reactor setup (probably a RUST descendant)

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -18,9 +18,9 @@
 /decl/webhook/submap_loaded/ascent
 	id = WEBHOOK_SUBMAP_LOADED_ASCENT
 
-/decl/submap_archetype/ascent_cutter
-	descriptor = "Ascent Cutter"
-	map = "Ascent Cutter"
+/decl/submap_archetype/ascent_seedship
+	descriptor = ASCENT_COLONY_SHIP_NAME
+	map = ASCENT_COLONY_SHIP_NAME
 	crew_jobs = list(
 		/datum/job/submap/ascent,
 		/datum/job/submap/ascent/alate,
@@ -165,20 +165,20 @@
 */
 
 // Spawn points.
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship
 	name = "Ascent Gyne"
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/alate
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/alate
 	name = "Ascent Alate"
 
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/drone
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/drone
 	name = "Ascent Drone"
 
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/adjunct
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/adjunct
 	name = "Serpentid Adjunct"
 
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/queen
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/queen
 	name = "Serpentid Queen"
 
 /*
@@ -189,7 +189,7 @@
 	info = "You are a Machine Intelligence of an independent Ascent vessel. The Gyne you assist, and her children, have wandered into this sector full of primitive bioforms. Try to keep them alive, and assist where you can."
 	set_species_on_join = /mob/living/silicon/ai/ascent
 
-/obj/effect/submap_landmark/spawnpoint/ascent_cutter/control
+/obj/effect/submap_landmark/spawnpoint/ascent_seedship/control
 	name = "Ascent Control Mind"
 
 /mob/living/silicon/ai/ascent

--- a/maps/away/ascent/ascent_shuttles.dm
+++ b/maps/away/ascent/ascent_shuttles.dm
@@ -29,14 +29,14 @@
 	name = "shuttle control console"
 	shuttle_tag = "Lepidoptera"
 
-/obj/effect/shuttle_landmark/ascent_cutter/start
+/obj/effect/shuttle_landmark/ascent_seedship/start
 	name = "Trichoptera Docked"
 	landmark_tag = "nav_hangar_ascent_one"
 	docking_controller = "ascent_port_dock"
 	base_area = /area/ship/ascent/wing_port
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
-/obj/effect/shuttle_landmark/ascent_cutter/start/two
+/obj/effect/shuttle_landmark/ascent_seedship/start/two
 	name = "Lepidoptera Docked"
 	landmark_tag = "nav_hangar_ascent_two"
 	docking_controller = "ascent_starboard_dock"


### PR DESCRIPTION
- Added power stat immunity for machines, as component checks are hardcoded and Ascent machinery is not currently constructable.
- Renamed/repathed cutter to seedship to make their goal more clear/less antagonistic.