### PR TITLE
Corrects logic behind hidden implants

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1423,11 +1423,11 @@ obj/item/organ/external/proc/remove_clamps()
 		var/unknown_body = 0
 		for(var/I in implants)
 			var/obj/item/weapon/implant/imp = I
-			if(istype(I,/obj/item/weapon/implant) && imp.known)
-				if (!imp.hidden)
+			if(istype(I,/obj/item/weapon/implant) && !imp.hidden)
+				if (imp.known)
 					. += "[capitalize(imp.name)] implanted"
-			else
-				unknown_body++
+				else
+					unknown_body++
 		if(unknown_body)
 			. += "Unknown body present"
 	for(var/obj/item/organ/internal/augment/aug in internal_organs)


### PR DESCRIPTION
Fixes #26340 

In my testing I think I accidentally made an error due to the skill requirements to find implants. This corrects the logic.

If hidden implant -> nothing
If not hidden implant -> unknown body
If not hidden and known implant -> implant name