### PR TITLE
Fixes masks not being able to hide ears or eyes

### DIFF
--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -3,7 +3,7 @@
 	desc = "Designed to both hide identities and keep your face comfy and warm."
 	icon_state = "balaclava"
 	item_state = "balaclava"
-	flags_inv = HIDEFACE|BLOCKHAIR
+	flags_inv = HIDEFACE|BLOCKHAIR|HIDEEARS
 	body_parts_covered = FACE|HEAD
 	down_body_parts_covered = HEAD
 	down_flags_inv = BLOCKHEADHAIR
@@ -24,7 +24,7 @@
 	desc = "Worn by robust fighters, flying high to defeat their foes!"
 	icon_state = "luchag"
 	item_state = "luchag"
-	flags_inv = HIDEFACE|BLOCKHAIR
+	flags_inv = HIDEFACE|BLOCKHAIR|HIDEEARS
 	body_parts_covered = HEAD|FACE
 	w_class = ITEM_SIZE_SMALL
 	siemens_coefficient = 3.0

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -22,6 +22,8 @@
 		skipface = head.flags_inv & HIDEFACE
 
 	if(wear_mask)
+		skipeyes |= wear_mask.flags_inv & HIDEEYES
+		skipears |= wear_mask.flags_inv & HIDEEARS
 		skipface |= wear_mask.flags_inv & HIDEFACE
 
 	//no accuately spotting headsets from across the room.


### PR DESCRIPTION
Adds appropriate hidears flags to certain masks

Fixes #26337

:cl:
bugfix: Masks can now properly hide ear and eye slot items if configured to do so.
/:cl: