### PR TITLE
Forensics bot can hold photos and paper, adds note about how they can print them

### DIFF
--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -38,7 +38,10 @@
 	can_hold = list(
 		/obj/item/weapon/sample,
 		/obj/item/weapon/evidencebag,
-		/obj/item/weapon/forensics
+		/obj/item/weapon/forensics,
+		/obj/item/weapon/photo,
+		/obj/item/weapon/paper,
+		/obj/item/weapon/paper_bundle
 	)
 	allow_quick_gather = 1
 	allow_quick_empty = 1

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -23,7 +23,8 @@
 		/obj/item/weapon/autopsy_scanner,
 		/obj/item/weapon/reagent_containers/spray/luminol,
 		/obj/item/device/uv_light,
-		/obj/item/weapon/crowbar
+		/obj/item/weapon/crowbar,
+		/obj/item/device/camera/mounted
 	)
 	emag = /obj/item/weapon/gun/energy/laser/mounted
 	skills = list(

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -151,6 +151,7 @@ var/global/photo_count = 0
 	var/icon_on = "camera"
 	var/icon_off = "camera_off"
 	var/size = 3
+	var/uses_film = TRUE
 /obj/item/device/camera/on_update_icon()
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
 	if(on)
@@ -216,8 +217,9 @@ var/global/photo_count = 0
 
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)
 
-	pictures_left--
-	to_chat(user, "<span class='notice'>[pictures_left] photos left.</span>")
+	if(uses_film)
+		pictures_left--
+		to_chat(user, "<span class='notice'>[pictures_left] photos left.</span>")
 
 	on = 0
 	update_icon()
@@ -225,8 +227,13 @@ var/global/photo_count = 0
 /obj/item/device/camera/examine(mob/user)
 	if(!..(user))
 		return
+	if (uses_film)
+		to_chat(user, "It has [pictures_left] photo\s left.")
 
-	to_chat(user, "It has [pictures_left] photo\s left.")
+/obj/item/device/camera/mounted
+	uses_film = FALSE
+
+
 
 //Proc for capturing check
 /mob/living/proc/can_capture_turf(turf/T)


### PR DESCRIPTION
:cl: 
tweak: Cyborgs now have a note that they can print the photos they take from a photocopier, since this was not obvious to players.
tweak: Forensics Module's evidence storage can now hold photos, paper and paper bundles.
/:cl:

I've changed this PR to just give forensics bots photo + paper storage abilities, and gives them a note to say how they can print their verb-sourced photos.