### PR TITLE
Forensics bot can hold photos and paper, adds note about how they can print them

### DIFF
--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -38,7 +38,10 @@
 	can_hold = list(
 		/obj/item/weapon/sample,
 		/obj/item/weapon/evidencebag,
-		/obj/item/weapon/forensics
+		/obj/item/weapon/forensics,
+		/obj/item/weapon/photo,
+		/obj/item/weapon/paper,
+		/obj/item/weapon/paper_bundle
 	)
 	allow_quick_gather = 1
 	allow_quick_empty = 1

--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -26,9 +26,9 @@
 	if(C.connected_ai)
 		C.connected_ai.silicon_camera.injectaialbum(p.copy(1), " (synced from [C.name])")
 		to_chat(C.connected_ai, "<span class='unconscious'>Image uploaded by [C.name]</span>")
-		to_chat(usr, "<span class='unconscious'>Image synced to remote database</span>")//feedback to the Cyborg player that the picture was taken
+		to_chat(usr, "<span class='unconscious'>Image synced to remote database, and can be printed from any photocopier.</span>")//feedback to the Cyborg player that the picture was taken
 	else
-		to_chat(usr, "<span class='unconscious'>Image recorded</span>")
+		to_chat(usr, "<span class='unconscious'>Image recorded, and can be printed from any photocopier.</span>")
 	// Always save locally
 	injectaialbum(p)
 


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Forensics 'bots can now hold photos, paper and paper stacks in their evidence bag module.
tweak: Adds a note about how robots can print the photos they take with the 'take photo' verb, to make this clearer to players.
/;cl:

Can't reopen my other PR, so... a shiny new PR. 
Goal is to make it easier for Forensics 'bots to handle photographs.