### PR TITLE
Fix runtime on juicer skillcheck

### DIFF
--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -296,4 +296,4 @@
 		return
 	visible_message(SPAN_NOTICE("\The [src] whirrs violently and spills its contents all over \the [user]!"))
 	if(beaker && beaker.reagents)
-		beaker.reagents.splash(user, reagents.total_volume)
+		beaker.reagents.splash(user, beaker.reagents.total_volume)


### PR DESCRIPTION
Fixes #26351 

Let me know if the Changelog is incorrect, its been a while.

:cl:
bugfix: Bad Chefs no longer make runtimes with the juicer.
/:cl: