### PR TITLE
Turns movable flags into actual flags

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -21,8 +21,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 
 #define MOVABLE_FLAG_PROXMOVE            0x0001 // Does this object require proximity checking in Enter()?
 #define MOVABLE_FLAG_Z_INTERACT          0x0002 // Should attackby and attack_hand be relayed through ladders and open spaces?
-#define MOVABLE_FLAG_EFFECTMOVE          0x0003 // Is this an effect that should move?
-#define MOVABLE_FLAG_DEL_SHUTTLE         0x0004 // Shuttle transistion will delete this.
+#define MOVABLE_FLAG_EFFECTMOVE          0x0004 // Is this an effect that should move?
+#define MOVABLE_FLAG_DEL_SHUTTLE         0x0008 // Shuttle transistion will delete this.
 
 #define OBJ_FLAG_ANCHORABLE              0x0001 // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE             0x0002 // Conducts electricity. (metal etc.)


### PR DESCRIPTION
No player facing changes.

Movable flag was counting upwards as if it was an enum. This corrects that.