### PR TITLE
Makes access_network more available

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -91,7 +91,8 @@ obj/item/weapon/stock_parts/circuitboard/rdserver
 	additional_spawn_components = list(
 		/obj/item/weapon/stock_parts/console_screen = 1,
 		/obj/item/weapon/stock_parts/keyboard = 1,
-		/obj/item/weapon/stock_parts/power/apc/buildable = 1
+		/obj/item/weapon/stock_parts/power/apc/buildable = 1,
+		/obj/item/weapon/stock_parts/computer/hard_drive/portable = 1
 	)
 
 /obj/item/weapon/stock_parts/circuitboard/suspension_gen

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -64,6 +64,16 @@ var/global/datum/ntnet/ntnet_global = new()
 			else
 				break
 
+	for(var/obj/machinery/ntnet_relay/R in ntnet_global.relays)
+		var/obj/item/weapon/stock_parts/computer/hard_drive/portable/P = R.get_component_of_type(/obj/item/weapon/stock_parts/computer/hard_drive/portable)
+		if(P)
+			var/datum/computer_file/data/logfile/file = P.find_file_by_name("ntnet_log")
+			if(!istype(file))
+				file = new()
+				file.filename = "ntnet_log"
+				P.store_file(file)
+			file.stored_data += log_text + "\[br\]"
+
 /datum/ntnet/proc/get_computer_by_nid(var/NID)
 	for(var/obj/item/modular_computer/comp in SSobj.processing)
 		if(comp && comp.network_card && comp.network_card.identification_id == NID)

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -64,6 +64,7 @@
 	data["dos_capacity"] = dos_capacity
 	data["dos_overload"] = dos_overload
 	data["dos_crashed"] = dos_failure
+	data["portable_drive"] = !!get_component_of_type(/obj/item/weapon/stock_parts/computer/hard_drive/portable)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -94,6 +95,8 @@
 		ntnet_global.banned_nids.Cut()
 		ntnet_global.add_log("Manual override: Network blacklist cleared.")
 		return 1
+	else if(href_list["eject_drive"] && uninstall_component(/obj/item/weapon/stock_parts/computer/hard_drive/portable))
+		visible_message("\icon[src] [src] beeps and ejects its portable disk.")
 
 /obj/machinery/ntnet_relay/New()
 	uid = gl_uid
@@ -113,3 +116,12 @@
 		D.target = null
 		D.error = "Connection to quantum relay severed"
 	..()
+
+/obj/machinery/ntnet_relay/attackby(obj/item/P, mob/user)
+	if (!istype(P,/obj/item/weapon/stock_parts/computer/hard_drive/portable))
+		return
+	else if (get_component_of_type(/obj/item/weapon/stock_parts/computer/hard_drive/portable))
+		to_chat(user, "This relay's portable drive slot is already occupied.")
+	else if(user.unEquip(P,src))
+		install_component(P)
+		to_chat(user, "You install \the [P] into \the [src]")

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -35,7 +35,7 @@
 
 	access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-			            access_tcomsat, access_solgov_crew, access_seneng, access_hangar)
+			            access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
 							 /datum/computer_file/program/supermatter_monitor,

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -795,6 +795,8 @@
 /obj/item/weapon/stock_parts/subspace/transmitter,
 /obj/item/weapon/stock_parts/subspace/transmitter,
 /obj/structure/table/rack,
+/obj/item/weapon/stock_parts/computer/hard_drive/portable,
+/obj/item/weapon/stock_parts/computer/hard_drive/portable,
 /turf/simulated/floor/tiled/monotile,
 /area/tcommsat/storage)
 "bY" = (

--- a/nano/templates/ntnet_relay.tmpl
+++ b/nano/templates/ntnet_relay.tmpl
@@ -29,4 +29,11 @@
 <div class="itemContent">
 	{{:helper.link('Purge network blacklist', null, { 'purge' : 1 })}}
 </div>
+{{if data.portable_drive}}
+	<div class = "item">
+		{{:helper.link('Eject Drive', 'circle-arrow-e', {'eject_drive' : 1}, null)}}
+	</div>
+{{else}}
+	<div class="notice">Drive slot empty.</div>
+{{/if}}
 {{/if}}


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Senior Engineer now gets access_network, allowing them to use the NTNet Diagnostics and Monitoring program and various command line tools.
tweak: Access hacking antag program can now hack access_network, if the antag has master level IT skill.
tweak: The NTNet Quantum Relay in telecomms will now keep physical logs of network activity, wiping the NTNet Diagnostics Program logs will not affect these, and they cannot be accessed remotely. The portable drive can be removed via a UI eject button and the data imported from it into a modular computer.
maptweak: Telecomms storage room now has a couple of spare portable hard disks.
/:cl:

access_network is currently only available to the CO, XO, CE and AI/borgs, despite having many uses that are solely for antagonists (proxies etc.)

This change makes it so that antagonists with high IT skill and an emag can access the hacking minigame, which can lead to interesting times for Forensics + Engineering trying to chase them down.

I've also given access_network to the Senior Engineer to increase the chances there is someone able to oppose an antagonist who uses the hacking features. The Senior Engineer already has access to telecomms.

Physical logs will require the antagonist to do more to cover their tracks, and they'll probably leave some fingerprints and fibers around unless they're very careful.

(I recently wrote a wiki guide on how to use the network hacking tools and defend against them, so while this is a kind of rarely used feature, I hope people will be able to work it out easily as it becomes a more commonly used tool by antagonists.)