### PR TITLE
Misc. Ascent fixes.

### DIFF
--- a/code/modules/ascent/ascent_id.dm
+++ b/code/modules/ascent/ascent_id.dm
@@ -19,6 +19,12 @@
 /obj/item/weapon/card/id/ascent/prevent_tracking()
 	return TRUE
 
+/obj/item/weapon/card/id/ascent/attack_self(mob/user)
+	return
+
+/obj/item/weapon/card/id/ascent/show()
+	return
+
 // ID implant/organ/interface device.
 /obj/item/organ/internal/controller
 	name = "system controller"

--- a/code/modules/ascent/ascent_outfit.dm
+++ b/code/modules/ascent/ascent_outfit.dm
@@ -7,7 +7,7 @@
 	pda_type = null
 	pda_slot = 0
 	flags =    0
-	
+
 /decl/hierarchy/outfit/job/ascent/tech
 	name = "Ascent - Technician"
 	suit = /obj/item/clothing/suit/storage/ascent

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_ascent.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_ascent.dm
@@ -16,9 +16,11 @@
 		/obj/item/clustertool, 
 		/obj/item/clustertool,
 		/obj/item/weapon/weldingtool/electric/mantid,
+		/obj/item/stack/cable_coil/fabricator,
 		/obj/item/weapon/extinguisher,
 		/obj/item/device/t_scanner,
 		/obj/item/device/scanner/gas,
+		/obj/item/device/scanner/health,
 		/obj/item/device/geiger,
 		/obj/item/weapon/gripper,
 		/obj/item/weapon/gripper/no_use/loader,
@@ -27,8 +29,23 @@
 		/obj/item/weapon/surgicaldrill,
 		/obj/item/weapon/hemostat,
 		/obj/item/weapon/bonesetter,
-		/obj/item/weapon/circular_saw
+		/obj/item/weapon/circular_saw,
+		/obj/item/stack/material/cyborg/steel,
+		/obj/item/stack/material/cyborg/aluminium,
+		/obj/item/stack/material/rods/cyborg,
+		/obj/item/stack/tile/floor/cyborg,
+		/obj/item/stack/material/cyborg/glass,
+		/obj/item/stack/material/cyborg/glass/reinforced,
+		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/stack/material/cyborg/plasteel,
+		/obj/item/device/plunger/robot
 	)
+	synths = list(
+		/datum/matter_synth/metal = 	30000,
+		/datum/matter_synth/glass = 	20000,
+		/datum/matter_synth/plasteel = 	10000
+	)
+
 	languages = list(
 		LANGUAGE_MANTID_VOCAL     = TRUE,
 		LANGUAGE_MANTID_NONVOCAL  = TRUE,

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -55,8 +55,9 @@
 		return
 
 	log_debug("Player: [joining] is now offsite rank: [job.title] ([name]), JCP:[job.current_positions], JPL:[job.total_positions]")
-	joining.mind.assigned_job = job
-	joining.mind.assigned_role = job.title
+	if(joining.mind)
+		joining.mind.assigned_job = job
+		joining.mind.assigned_role = job.title
 	joining.faction = name
 	job.current_positions++
 

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -7,6 +7,8 @@
 /decl/submap_archetype/ascent_seedship
 	descriptor = "Ascent colony ship"
 	map = ASCENT_COLONY_SHIP_NAME
+	blacklisted_species = null
+	whitelisted_species = null
 	crew_jobs = list(
 		/datum/job/submap/ascent,
 		/datum/job/submap/ascent/alate,
@@ -83,6 +85,9 @@
 	supervisors = "nobody but yourself"
 	info = "You are the Gyne of an independent Ascent vessel. Your hunting has brought you to this remote sector full of crawling primitives. Impose your will, found a new nest, and bring prosperity to your lineage."
 	outfit_type = /decl/hierarchy/outfit/job/ascent
+	blacklisted_species = null
+	whitelisted_species = null
+	loadout_allowed = FALSE
 	var/set_species_on_join = SPECIES_MANTID_GYNE
 
 /datum/job/submap/ascent/is_available(client/caller)


### PR DESCRIPTION
- Stops the Ascent ID chip from being displayed like an ID card.
- Adds a health analyzer, a cable fabricator and some matter synthesisers to the Ascent drone module.
- Cleared the blacklist and whitelist for the Ascent map and jobs.
- Disabled loadouts on Ascent jobs.