### PR TITLE
Lets overmap shuttles catch other overmap shuttles.

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -62,10 +62,11 @@
 
 /datum/shuttle/autodock/overmap/proc/get_possible_destinations()
 	var/list/res = list()
-	for (var/obj/effect/overmap/S in range(waypoint_sector(current_location), range))
-		for(var/obj/effect/shuttle_landmark/LZ in S.get_waypoints(src.name))
+	for (var/obj/effect/overmap/S in range(get_turf(waypoint_sector(current_location)), range))
+		var/list/waypoints = S.get_waypoints(name)
+		for(var/obj/effect/shuttle_landmark/LZ in waypoints)
 			if(LZ.is_valid(src))
-				res["[S.name] - [LZ.name]"] = LZ
+				res["[waypoints[LZ]] - [LZ.name]"] = LZ
 	return res
 
 /datum/shuttle/autodock/overmap/get_location_name()

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -89,11 +89,14 @@
 		generic_waypoints -= landmark
 
 /obj/effect/overmap/proc/get_waypoints(var/shuttle_name)
-	. = generic_waypoints.Copy()
-	if(shuttle_name in restricted_waypoints)
-		. += restricted_waypoints[shuttle_name]
+	. = list()
 	for(var/obj/effect/overmap/contained in src)
 		. += contained.get_waypoints(shuttle_name)
+	for(var/thing in generic_waypoints)
+		.[thing] = name
+	if(shuttle_name in restricted_waypoints)
+		for(var/thing in restricted_waypoints[shuttle_name])
+			.[thing] = name
 
 /obj/effect/overmap/sector
 	name = "generic sector"

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -43,13 +43,20 @@
 				if(x == round(world.maxx/2) && y == round(world.maxy/2))//Skips the center spawn
 					continue
 				new /obj/effect/landmark/carpspawn(locate(x + rand(-2, 2), y + rand(-4, 4), world.maxz))//not too far, not too close
-		// Not really the center, but rather where the shuttle landmark should be
-		if(i == multiz)
-			var/turf/center_loc = locate(round(world.maxx/2), round(world.maxy/2), world.maxz)
-			landmark = new (center_loc, shuttle)
-			add_landmark(landmark, shuttle)
-			if(multiz)
-				new /obj/effect/landmark/map_data(center_loc, (multiz + 1))
+
+	var/turf/center_loc = locate(round(world.maxx/2), round(world.maxy/2), world.maxz)
+	landmark = new (center_loc, shuttle)
+	add_landmark(landmark, shuttle)
+
+	var/visitor_dir = fore_dir
+	for(var/landmark_name in list("FORE", "PORT", "AFT", "STARBOARD"))
+		var/turf/visitor_turf = get_ranged_target_turf(center_loc, visitor_dir, round(min(world.maxx/4, world.maxy/4)))
+		var/obj/effect/shuttle_landmark/visiting_shuttle/visitor_landmark = new (visitor_turf, landmark, landmark_name)
+		add_landmark(visitor_landmark)
+		visitor_dir = turn(visitor_dir, 90)
+
+	if(multiz)
+		new /obj/effect/landmark/map_data(center_loc, (multiz + 1))
 
 /obj/effect/landmark/carpspawn
 	name ="carpspawn"
@@ -71,9 +78,12 @@
 	name = "Open Space"
 	landmark_tag = "ship"
 	flags = SLANDMARK_FLAG_AUTOSET | SLANDMARK_FLAG_ZERO_G
+	var/shuttle_name
+	var/list/visitors // landmark -> visiting shuttle stationed there
 
 /obj/effect/shuttle_landmark/ship/Initialize(mapload, shuttle_name)
 	landmark_tag += "_[shuttle_name]"
+	src.shuttle_name = shuttle_name
 	. = ..()
 
 /obj/effect/shuttle_landmark/ship/Destroy()
@@ -81,6 +91,46 @@
 	if(istype(ship) && ship.landmark == src)
 		ship.landmark = null
 	. = ..()
+
+/obj/effect/shuttle_landmark/ship/cannot_depart(datum/shuttle/shuttle)
+	if(LAZYLEN(visitors))
+		return "Grappled by other shuttle; cannot manouver."
+
+/obj/effect/shuttle_landmark/visiting_shuttle
+	flags = SLANDMARK_FLAG_AUTOSET | SLANDMARK_FLAG_ZERO_G
+	var/obj/effect/shuttle_landmark/ship/core_landmark
+
+/obj/effect/shuttle_landmark/visiting_shuttle/Initialize(mapload, obj/effect/shuttle_landmark/ship/master, _name)
+	core_landmark = master
+	SetName(_name)
+	landmark_tag = master.shuttle_name + _name
+	GLOB.destroyed_event.register(master, src, /datum/proc/qdel_self)
+	. = ..()
+
+/obj/effect/shuttle_landmark/visiting_shuttle/Destroy()
+	GLOB.destroyed_event.unregister(core_landmark, src)
+	LAZYREMOVE(core_landmark.visitors, src)
+	core_landmark = null
+	. = ..()
+
+/obj/effect/shuttle_landmark/visiting_shuttle/is_valid(datum/shuttle/shuttle)
+	. = ..()
+	if(!.)
+		return
+	var/datum/shuttle/boss_shuttle = SSshuttle.shuttles[core_landmark.shuttle_name]
+	if(boss_shuttle.current_location != core_landmark)
+		return FALSE // Only available when our governing shuttle is in space.
+	if(shuttle == boss_shuttle) // Boss shuttle only lands on main landmark
+		return FALSE
+
+/obj/effect/shuttle_landmark/visiting_shuttle/shuttle_arrived(datum/shuttle/shuttle)
+	LAZYSET(core_landmark.visitors, src, shuttle)
+	GLOB.shuttle_moved_event.register(shuttle, src, .proc/shuttle_left)
+
+/obj/effect/shuttle_landmark/visiting_shuttle/proc/shuttle_left(datum/shuttle/shuttle, obj/effect/shuttle_landmark/old_landmark, obj/effect/shuttle_landmark/new_landmark)
+	if(old_landmark == src)
+		GLOB.shuttle_moved_event.unregister(shuttle, src)
+		LAZYREMOVE(core_landmark.visitors, src)
 
 /obj/effect/overmap/ship/landable/proc/on_shuttle_jump(datum/shuttle/given_shuttle, obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
 	if(given_shuttle != SSshuttle.shuttles[shuttle])

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -58,11 +58,16 @@
 
 //Projected acceleration based on information from engines
 /obj/effect/overmap/ship/proc/get_acceleration()
-	return round(get_total_thrust()/vessel_mass, SHIP_MOVE_RESOLUTION)
+	return round(get_total_thrust()/get_vessel_mass(), SHIP_MOVE_RESOLUTION)
 
 //Does actual burn and returns the resulting acceleration
 /obj/effect/overmap/ship/proc/get_burn_acceleration()
-	return round(burn() / vessel_mass, SHIP_MOVE_RESOLUTION)
+	return round(burn() / get_vessel_mass(), SHIP_MOVE_RESOLUTION)
+
+/obj/effect/overmap/ship/proc/get_vessel_mass()
+	. = vessel_mass
+	for(var/obj/effect/overmap/ship/ship in src)
+		. += ship.get_vessel_mass()
 
 /obj/effect/overmap/ship/proc/get_speed()
 	return round(sqrt(speed[1] ** 2 + speed[2] ** 2), SHIP_MOVE_RESOLUTION)

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -78,6 +78,11 @@
 			return FALSE
 	return TRUE
 
+/obj/effect/shuttle_landmark/proc/cannot_depart(datum/shuttle/shuttle)
+	return FALSE
+
+/obj/effect/shuttle_landmark/proc/shuttle_arrived(datum/shuttle/shuttle)
+
 /proc/check_collision(area/target_area, list/target_turfs)
 	for(var/target_turf in target_turfs)
 		var/turf/target = target_turf

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -140,6 +140,8 @@
 
 	if(!destination.is_valid(src))
 		return FALSE
+	if(current_location.cannot_depart(src))
+		return FALSE
 	testing("[src] moving to [destination]. Areas are [english_list(shuttle_area)]")
 	var/list/translation = list()
 	for(var/area/A in shuttle_area)
@@ -149,6 +151,7 @@
 	GLOB.shuttle_pre_move_event.raise_event(src, old_location, destination)
 	shuttle_moved(destination, translation)
 	GLOB.shuttle_moved_event.raise_event(src, old_location, destination)
+	destination.shuttle_arrived(src)
 	return TRUE
 
 //just moves the shuttle from A to B, if it can be moved

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -123,7 +123,7 @@
 	return move_time
 
 /datum/shuttle/autodock/proc/process_launch()
-	if(!next_location.is_valid(src))
+	if(!next_location.is_valid(src) || current_location.cannot_depart(src))
 		process_state = IDLE_STATE
 		in_use = null
 		return
@@ -137,10 +137,10 @@
 	Guards
 */
 /datum/shuttle/autodock/proc/can_launch()
-	return (next_location && moving_status == SHUTTLE_IDLE && !in_use)
+	return (next_location && next_location.is_valid(src) && !current_location.cannot_depart(src) && moving_status == SHUTTLE_IDLE && !in_use)
 
 /datum/shuttle/autodock/proc/can_force()
-	return (next_location && moving_status == SHUTTLE_IDLE && process_state == WAIT_LAUNCH)
+	return (next_location && next_location.is_valid(src) && !current_location.cannot_depart(src) && moving_status == SHUTTLE_IDLE && process_state == WAIT_LAUNCH)
 
 /datum/shuttle/autodock/proc/can_cancel()
 	return (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH || process_state == FORCE_LAUNCH)


### PR DESCRIPTION
:cl:
rscadd: An overmap-capable shuttle can now catch/grapple another overmap-capable shuttle currently moving on the overmap. You do this by moving to an appropriate landmark on the shuttle console.
rscadd: If a shuttle is grappling another shuttle, it cannot move on the overmap; it will be moved by the other shuttle.
rscadd: If a shuttle is being grappled by another shuttle, it cannot make shuttle jumps until the grappler has left.
tweak: Ships within ships count towards vessel mass now, meaning you'll accelerate slower with them landed/attached.
/:cl:

In principle only the grappled shuttle needs to be a shuttle-ship; the grappler can be an arbitrary overmap shuttle. Four shuttles can grapple one at a time, and you can select the dir you do it from. You cannot grapple a grappling shuttle. You'll need to go EVA to get to the shuttle you're grappling, and it's not super close; bring a jetpack.

I believe that you can initiate the jump whenever the target is in your range, and then it will basically succeed, but I'm not entirely sure of all the possible scenarios concerning range/overmap movement. It should be identical to shuttles jumping onto a moving Torch currently.