### PR TITLE
Fixes #26431 - Makes IV and Plastic Bag show up as different on construction menu.

### DIFF
--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -171,7 +171,7 @@
 	on_floor = 1
 
 /datum/stack_recipe/ivbag
-	title = "bag"
+	title = "IV bag"
 	result_type = /obj/item/weapon/reagent_containers/ivbag
 	req_amount = 4
 	difficulty = 2


### PR DESCRIPTION
:cl:
bugfix: IV Bag construction option name changed from 'plastic bag' to 'plastic IV bag' so it is different from the other 'plastic bag'.
/:cl:

Fixes #26431 