### PR TITLE
Fixes #26432 - Duplicate vending machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -953,8 +953,15 @@
 	vend_delay = 14
 	base_type = /obj/machinery/vending/security
 	req_access = list(access_security)
-	products = list(/obj/item/weapon/handcuffs = 14,/obj/item/weapon/grenade/flashbang = 4,/obj/item/weapon/grenade/chem_grenade/teargas = 4,/obj/item/device/flash = 7,
-					/obj/item/weapon/reagent_containers/spray/pepper = 4, /obj/item/device/holowarrant = 4, /obj/item/weapon/reagent_containers/food/snacks/donut/normal = 12,/obj/item/weapon/storage/box/evidence = 8)
+	products = list(
+	/obj/item/weapon/handcuffs = 14,
+	/obj/item/weapon/grenade/flashbang = 4,
+	/obj/item/weapon/grenade/chem_grenade/teargas = 4,
+	/obj/item/device/flash = 7,
+	/obj/item/weapon/reagent_containers/spray/pepper = 4,
+	/obj/item/device/holowarrant = 4,
+	/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 12,
+	/obj/item/weapon/storage/box/evidence = 8)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/weapon/storage/box/donut = 2)
 
 /obj/machinery/vending/hydronutrients

--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -79,16 +79,3 @@
 	mask = /obj/item/clothing/mask/breath
 	req_access = list(access_bridge, access_keycard_auth)
 	islocked = 1
-
-/obj/machinery/vending/security
-	name = "SecTech"
-	desc = "A security equipment vendor."
-	product_ads = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't tase me bro!;Tase them, bro.;Why not have a donut?"
-	icon_state = "sec"
-	icon_deny = "sec-deny"
-	icon_vend = "sec-vend"
-	vend_delay = 14
-	req_access = list(access_security)
-	products = list(/obj/item/weapon/handcuffs = 8,/obj/item/weapon/grenade/flashbang = 4,/obj/item/weapon/grenade/chem_grenade/teargas = 4,/obj/item/device/flash = 5,
-					/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 12,/obj/item/weapon/storage/box/evidence = 6,/obj/item/clothing/accessory/badge/solgov/security = 6)
-	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/weapon/storage/box/donut = 2)


### PR DESCRIPTION
Fixes #26432 

Issue was that there was both a general and a Torch-specific sectech vending machine, and #25153 adjusted only the general one, therefore the Torch one did not show the updated contents as desired.

Since the vending machines are otherwise the same, I have just removed the Torch specific vending machine.