### PR TITLE
Fixes missing descriptions on examine

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -161,7 +161,7 @@
 	..()
 	
 /obj/examine(mob/user)
-	. = ..(user)
+	. = ..()
 	if(. && (obj_flags & OBJ_FLAG_ROTATABLE))
 		to_chat(user, "<span class='subtle'>Can be rotated with alt-click.</span>")
 


### PR DESCRIPTION
Should fix science googles not being able to see item sizes and matter contents.