### PR TITLE
Antag's Languages Sorting

### DIFF
--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -1,8 +1,12 @@
 /datum/language/antag
+	name = "antag"
+	desc = "You shouldn't have this."
 	hidden_from_codex = TRUE
 	flags = RESTRICTED
 
 /datum/language/antag/hiveminded
+	name = "hivemind"
+	desc = "You shouldn't have this."
 	flags = RESTRICTED | HIVEMIND
 
 

--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -1,21 +1,28 @@
-/datum/language/ling
+/datum/language/antag
+	hidden_from_codex = TRUE
+	flags = RESTRICTED
+
+/datum/language/antag/hiveminded
+	flags = RESTRICTED | HIVEMIND
+
+
+
+/datum/language/antag/hiveminded/ling
 	name = LANGUAGE_CHANGELING_GLOBAL
 	desc = "Although they are normally wary and suspicious of each other, changelings can commune over a distance."
 	speech_verb = "says"
 	colour = "changeling"
 	key = "g"
-	flags = RESTRICTED | HIVEMIND
 	shorthand = "N/A"
-	hidden_from_codex = TRUE
 
-/datum/language/ling/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
+/datum/language/antag/hiveminded/ling/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 
 	if(speaker.mind && speaker.mind.changeling)
 		..(speaker,message,speaker.mind.changeling.changelingID)
 	else
 		..(speaker,message)
 
-/datum/language/corticalborer
+/datum/language/antag/hiveminded/corticalborer
 	name = LANGUAGE_BORER_GLOBAL
 	desc = "Cortical borers possess a strange link between their tiny minds."
 	speech_verb = "sings"
@@ -23,11 +30,9 @@
 	exclaim_verb = "sings"
 	colour = "alien"
 	key = "z"
-	flags = RESTRICTED | HIVEMIND
 	shorthand = "N/A"
-	hidden_from_codex = TRUE
 
-/datum/language/corticalborer/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
+/datum/language/antag/hiveminded/corticalborer/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 
 	var/mob/living/simple_animal/borer/B
 
@@ -46,6 +51,58 @@
 		speaker_mask = B.truename
 	..(speaker,message,speaker_mask)
 
+/datum/language/antag/cultcommon
+	name = LANGUAGE_CULT
+	desc = "The chants of the occult, the incomprehensible."
+	speech_verb = "intones"
+	ask_verb = "intones"
+	exclaim_verb = "chants"
+	colour = "cult"
+	key = "f"
+	space_chance = 100
+	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
+		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \
+		"mah'weyh", "pleggh", "at", "e'ntrath", "tok-lyr", "rqa'nap", "g'lt-ulotf", "ta'gh", "fara'qha", "fel", "d'amar det", \
+		"yu'gular", "faras", "desdae", "havas", "mithum", "javara", "umathar", "uf'kal", "thenar", "rash'tla", \
+		"sektath", "mal'zua", "zasan", "therium", "viortia", "kla'atu", "barada", "nikt'o", "fwe'sh", "mah", "erl", "nyag", "r'ya", \
+		"gal'h'rfikk", "harfrandid", "mud'gib", "fuu", "ma'jin", "dedo", "ol'btoh", "n'ath", "reth", "sh'yro", "eth", \
+		"d'rekkathnor", "khari'd", "gual'te", "nikka", "nikt'o", "barada", "kla'atu", "barhah", "hra" ,"zar'garis")
+	machine_understands = 0
+	shorthand = "CT"
+
+/datum/language/antag/hiveminded/cult
+	name = LANGUAGE_CULT_GLOBAL
+	desc = "The initiated can share their thoughts by means defying all reason."
+	speech_verb = "intones"
+	ask_verb = "intones"
+	exclaim_verb = "chants"
+	colour = "cult"
+	key = "y"
+	shorthand = "N/A"
+
+/datum/language/antag/alium
+	name = LANGUAGE_ALIUM
+	colour = "cult"
+	speech_verb = "hisses"
+	key = "c"
+	syllables = list("qy","bok","mok","yok","dy","gly","ryl","byl","dok","forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor","niii",
+	"d'rekkathnor", "khari'd", "gual'te", "ki","ki","ki","ki","ya","ta","wej","nym","assah","qwssa","nieasl","qyno","shaffar",
+	"eg","bog","voijs","nekks","bollos","qoulsan","borrksakja","neemen","aka","nikka","qyegno","shafra","beolas","Byno")
+	machine_understands = 0
+	shorthand = "AL"
+
+/datum/language/antag/alium/New()
+	speech_verb = pick("hisses","growls","whistles","blubbers","chirps","skreeches","rumbles","clicks")
+	..()
+
+/datum/language/antag/alium/get_random_name()
+	var/new_name = ""
+	var/length = rand(1,3)
+	for(var/i=0 to length)
+		new_name += pick(syllables)
+	return capitalize(new_name)
+
+// semi antagonists
 /datum/language/vox
 	name = LANGUAGE_VOX
 	desc = "The common tongue of the various Vox ships making up the Shoal. It sounds like chaotic shrieking to everyone else."
@@ -72,60 +129,3 @@
 
 /datum/language/vox/get_random_name()
 	return ..(FEMALE,1,6)
-
-/datum/language/cultcommon
-	name = LANGUAGE_CULT
-	desc = "The chants of the occult, the incomprehensible."
-	speech_verb = "intones"
-	ask_verb = "intones"
-	exclaim_verb = "chants"
-	colour = "cult"
-	key = "f"
-	flags = RESTRICTED
-	space_chance = 100
-	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
-		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \
-		"mah'weyh", "pleggh", "at", "e'ntrath", "tok-lyr", "rqa'nap", "g'lt-ulotf", "ta'gh", "fara'qha", "fel", "d'amar det", \
-		"yu'gular", "faras", "desdae", "havas", "mithum", "javara", "umathar", "uf'kal", "thenar", "rash'tla", \
-		"sektath", "mal'zua", "zasan", "therium", "viortia", "kla'atu", "barada", "nikt'o", "fwe'sh", "mah", "erl", "nyag", "r'ya", \
-		"gal'h'rfikk", "harfrandid", "mud'gib", "fuu", "ma'jin", "dedo", "ol'btoh", "n'ath", "reth", "sh'yro", "eth", \
-		"d'rekkathnor", "khari'd", "gual'te", "nikka", "nikt'o", "barada", "kla'atu", "barhah", "hra" ,"zar'garis")
-	machine_understands = 0
-	shorthand = "CT"
-	hidden_from_codex = TRUE
-
-/datum/language/cult
-	name = LANGUAGE_CULT_GLOBAL
-	desc = "The initiated can share their thoughts by means defying all reason."
-	speech_verb = "intones"
-	ask_verb = "intones"
-	exclaim_verb = "chants"
-	colour = "cult"
-	key = "y"
-	flags = RESTRICTED | HIVEMIND
-	shorthand = "N/A"
-	hidden_from_codex = TRUE
-
-/datum/language/alium
-	name = LANGUAGE_ALIUM
-	colour = "cult"
-	speech_verb = "hisses"
-	key = "c"
-	flags = RESTRICTED
-	syllables = list("qy","bok","mok","yok","dy","gly","ryl","byl","dok","forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor","niii",
-	"d'rekkathnor", "khari'd", "gual'te", "ki","ki","ki","ki","ya","ta","wej","nym","assah","qwssa","nieasl","qyno","shaffar",
-	"eg","bog","voijs","nekks","bollos","qoulsan","borrksakja","neemen","aka","nikka","qyegno","shafra","beolas","Byno")
-	machine_understands = 0
-	shorthand = "AL"
-	hidden_from_codex = TRUE
-
-/datum/language/alium/New()
-	speech_verb = pick("hisses","growls","whistles","blubbers","chirps","skreeches","rumbles","clicks")
-	..()
-
-/datum/language/alium/get_random_name()
-	var/new_name = ""
-	var/length = rand(1,3)
-	for(var/i=0 to length)
-		new_name += pick(syllables)
-	return capitalize(new_name)

--- a/html/changelogs/AlexMorgan-pr-lang-sort.yml
+++ b/html/changelogs/AlexMorgan-pr-lang-sort.yml
@@ -1,0 +1,4 @@
+author: AlexMorgan3817/_Elar_
+delete-after: True
+changes: 
+  - tweak: "Antag's languages was sorted."


### PR DESCRIPTION
## Now `/datum/language` have subtype `antag` and `antag/hivemind`, they allow not to write flags `RESTRICTED` & `HIVEMIND`, and allow not to write `hiden_from_codex = 1`.
## This reduced the number of used lines.