### PR TITLE
Fix Newscasters Eating Photos

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 43 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 479 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 477 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 23 "text2path uses" 'text2path'
 exactly 1 "update_icon() override" '/update_icon\((.*)\)'  -P


### PR DESCRIPTION
:cl: WezYo
tweak: Attaching a photo to a newscaster story will no longer remove it from your hand
/:cl:

Order of operations error. We were dropping the photo from our hand and then trying to get the photo in our hand and attach it to the newscaster story. This was causing a ton of issues having to do with the photo_data not being null but the photo_data.photo being null

Fixes #25024
Fixes #22232
Closes #26426 <- A non issue but just for the sake of closing the ticket
Fixes #22575
Closes #22233 <- A non issue but just for the sake of closing the ticket
Fixes #21353

Redid the UI just a little bit to show the photo when you're submitting the story
![news](https://user-images.githubusercontent.com/44451125/61922612-16a8dd80-af2f-11e9-91c1-baba1e979c0e.png)
