### PR TITLE
Codex additions

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -76,17 +76,8 @@ SUBSYSTEM_DEF(codex)
 
 /datum/controller/subsystem/codex/proc/present_codex_entry(var/mob/presenting_to, var/datum/codex_entry/entry)
 	if(entry && istype(presenting_to) && presenting_to.client)
-		var/list/dat = list()
-		if(entry.lore_text)
-			dat += "<font color = '[CODEX_COLOR_LORE]'>[parse_links(entry.lore_text, presenting_to)]</font>"
-		if(entry.mechanics_text)
-			dat += "<h3>OOC Information</h3>"
-			dat += "<font color = '[CODEX_COLOR_MECHANICS]'>[parse_links(entry.mechanics_text, presenting_to)]</font>"
-		if(entry.antag_text && presenting_to.mind && player_is_antag(presenting_to.mind))
-			dat += "<h3>Antagonist Information</h3>"
-			dat += "<font color='[CODEX_COLOR_ANTAG]'>[parse_links(entry.antag_text, presenting_to)]</font>"
 		var/datum/browser/popup = new(presenting_to, "codex", "Codex - [entry.display_name]")
-		popup.set_content(jointext(dat, null))
+		popup.set_content(parse_links(entry.get_text(presenting_to), presenting_to))
 		popup.open()
 
 /datum/controller/subsystem/codex/proc/retrieve_entries_for_string(var/searching)

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -1,2 +1,16 @@
+/datum/codex_category
+	var/name = "Generic Category"
+	var/desc = "Some description for category's codex entry"
+	var/list/items = list()
+
+//Children should call ..() at the end after filling the items list
 /datum/codex_category/proc/Initialize()
-	return
+	if(items.len)
+		var/datum/codex_entry/entry = new(_display_name = "[name] (category)")
+		entry.lore_text = desc + "<hr>"
+		var/list/links = list()
+		for(var/item in items)
+			links+= "<l>[item]</l>"
+		entry.lore_text += jointext(links, "<br>")
+		SScodex.add_entry_by_string(lowertext(entry.display_name), entry)
+

--- a/code/modules/codex/categories/category_cultures.dm
+++ b/code/modules/codex/categories/category_cultures.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/cultures/
+	name = "Factions and Culture"
+	desc = "Prominent planets, cultures, factions and religions of known space."
+
 /datum/codex_category/cultures/Initialize()
 
 	for(var/thing in SSculture.cultural_info_by_name)
@@ -7,3 +11,5 @@
 			entry.lore_text = culture.description
 			entry.update_links()
 			SScodex.add_entry_by_string(culture.name, entry)
+			items += culture.name
+	..()

--- a/code/modules/codex/categories/category_gases.dm
+++ b/code/modules/codex/categories/category_gases.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/gases/
+	name = "Gases"
+	desc = "Notable gases."
+
 /datum/codex_category/gases/Initialize()
 	for(var/gas in gas_data.gases)
 		if(gas_data.hidden_from_codex[gas])
@@ -20,3 +24,5 @@
 			gas_info+= "At [gas_data.condensation_points[gas]] K it condenses into [initial(product.name)]."
 		var/datum/codex_entry/entry = new(_display_name = lowertext(trim("[gas_data.name[gas]] (gas)")), _mechanics_text = jointext(gas_info, "<br>"))
 		SScodex.add_entry_by_string(entry.display_name, entry)
+		items += entry.display_name
+	..()

--- a/code/modules/codex/categories/category_languages.dm
+++ b/code/modules/codex/categories/category_languages.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/languages/
+	name = "Languages"
+	desc = "Languages spoken in known space."
+
 /datum/codex_category/languages/Initialize()
 	var/example_line = "This is just some random words. What did you expect here? Hah hah!"
 	for(var/langname in all_languages)
@@ -30,3 +34,5 @@
 		entry.associated_strings += L.name
 		entry.associated_strings += L.shorthand
 		SScodex.add_entry_by_string(entry.display_name, entry)
+		items += entry.display_name
+	..()

--- a/code/modules/codex/categories/category_materials.dm
+++ b/code/modules/codex/categories/category_materials.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/materials/
+	name = "Materials"
+	desc = "Various natural and artificial materials."
+
 /datum/codex_category/materials/Initialize()
 	for(var/thing in SSmaterials.materials)
 		var/material/mat = thing
@@ -89,3 +93,5 @@
 			entry.mechanics_text = jointext(material_info,"<br>")
 			entry.update_links()
 			SScodex.add_entry_by_string(entry.display_name, entry)
+			items += entry.display_name
+	..()

--- a/code/modules/codex/categories/category_reagents.dm
+++ b/code/modules/codex/categories/category_reagents.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/reagents/
+	name = "Reagents"
+	desc = "Chemicals and reagents, both natural and artificial."
+
 /datum/codex_category/reagents/Initialize()
 
 	for(var/thing in subtypesof(/datum/reagent))
@@ -46,3 +50,5 @@
 
 		entry.update_links()
 		SScodex.add_entry_by_string(entry.display_name, entry)
+		items += entry.display_name
+	..()

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/recipes/
+	name = "Recipies"
+	desc = "Recipies for a variety of reagents."
+
 /datum/codex_category/recipes/Initialize()
 	for(var/datum/recipe/recipe in SScuisine.microwave_recipes)
 		if(recipe.hidden_from_codex || !recipe.result)
@@ -34,3 +38,5 @@
 		)
 		entry.update_links()
 		SScodex.add_entry_by_string(entry.display_name, entry)
+		items += entry.display_name
+	..()

--- a/code/modules/codex/categories/category_species.dm
+++ b/code/modules/codex/categories/category_species.dm
@@ -1,3 +1,7 @@
+/datum/codex_category/species/
+	name = "Species"
+	desc = "Sapient species encountered in known space."
+
 /datum/codex_category/species/Initialize()
 	for(var/thing in all_species)
 		var/datum/species/species = all_species[thing]
@@ -8,3 +12,5 @@
 			entry.update_links()
 			SScodex.add_entry_by_string(entry.display_name, entry)
 			SScodex.add_entry_by_string(species.name, entry)
+			items += entry.display_name
+	..()

--- a/code/modules/codex/codex_client.dm
+++ b/code/modules/codex/codex_client.dm
@@ -12,7 +12,7 @@
 		return
 
 	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, "<span class='warning'>You cannot perform codex actions currently.</span>")
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
 		return
 
 	if(!searching)
@@ -21,7 +21,7 @@
 			return
 
 	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, "<span class='warning'>You cannot perform codex actions currently.</span>")
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
 		return
 
 	codex_on_cooldown = TRUE
@@ -56,7 +56,7 @@
 			popup.set_content(jointext(codex_data, null))
 			popup.open()
 		else
-			to_chat(src, "<span class='notice'>The codex reports <b>no matches</b> for '[searching]'.</span>")
+			to_chat(src, SPAN_NOTICE("The codex reports <b>no matches</b> for '[searching]'."))
 
 /client/verb/list_codex_entries()
 
@@ -68,12 +68,12 @@
 		return
 
 	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, "<span class='warning'>You cannot perform codex actions currently.</span>")
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
 		return
 	codex_on_cooldown = TRUE
 	addtimer(CALLBACK(src, .proc/reset_codex_cooldown), 10 SECONDS)
 
-	to_chat(mob, "<span class='notice'>The codex forwards you an index file.</span>")
+	to_chat(mob, SPAN_NOTICE("The codex forwards you an index file."))
 
 	var/datum/browser/popup = new(mob, "codex-index", "Codex Index")
 	var/list/codex_data = list("<h2>Codex Entries</h2>")
@@ -100,3 +100,21 @@
 
 /client/proc/reset_codex_cooldown()
 	codex_on_cooldown = FALSE
+
+/client/verb/codex()
+	set name = "Codex"
+	set category = "IC"
+	set src = usr
+
+	if(!mob || !SScodex)
+		return
+
+	if(codex_on_cooldown || !mob.can_use_codex())
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
+		return
+
+	codex_on_cooldown = TRUE
+	addtimer(CALLBACK(src, .proc/reset_codex_cooldown), 3 SECONDS)
+
+	var/datum/codex_entry/entry = SScodex.get_codex_entry("nexus")
+	SScodex.present_codex_entry(mob, entry)

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -30,3 +30,15 @@
 	else if(associated_strings && associated_strings.len)
 		display_name = associated_strings[1]
 	..()
+
+/datum/codex_entry/proc/get_text(var/mob/presenting_to)
+	var/list/dat = list()
+	if(lore_text)
+		dat += "<font color = '[CODEX_COLOR_LORE]'>[lore_text]</font>"
+	if(mechanics_text)
+		dat += "<h3>OOC Information</h3>"
+		dat += "<font color = '[CODEX_COLOR_MECHANICS]'>[mechanics_text]</font>"
+	if(antag_text && presenting_to.mind && player_is_antag(presenting_to.mind))
+		dat += "<h3>Antagonist Information</h3>"
+		dat += "<font color='[CODEX_COLOR_ANTAG]'>[antag_text]</font>"
+	return jointext(dat, null)

--- a/code/modules/codex/entries/codex.dm
+++ b/code/modules/codex/entries/codex.dm
@@ -16,3 +16,38 @@
 	<br><br> \
 	Information for antagonists will not be shown unless you are an antagonist, and is marked by <b><font color = '[CODEX_COLOR_ANTAG]'>red</font></b> text."
 	..()
+
+/datum/codex_entry/nexus
+	display_name = "Nexus"
+	associated_strings = list("nexus")
+	mechanics_text = "The place to start with <span codexlink='codex'>The Codex</span><br>" 
+
+/datum/codex_entry/nexus/get_text(var/mob/presenting_to)
+	var/list/dat = list("<h3>CODEX NEXUS</h3>")
+	dat += "[mechanics_text]"
+	dat += "You can use <a href='?src=\ref[presenting_to.client];codex_search=1'><b>Search-Codex <i>topic</i></b></a> to look something up, or you can click the links provided when examining some objects.<br>"
+	dat += "You can also use <a href='?src=\ref[presenting_to.client];codex_index=1'><b>List-Codex-Entries</b></a> to get a comprehensive index of all entries.<br><br>"
+	dat += "<h3>Categories</h3>"
+	var/list/categories = list()
+	for(var/type in subtypesof(/datum/codex_category))
+		var/datum/codex_category/C = type
+		var/key = "[initial(C.name)] (category)"
+		var/datum/codex_entry/entry = SScodex.get_codex_entry(key)
+		if(entry)
+			categories += "<span codexlink='[key]'>[initial(C.name)]</span>"
+	dat += jointext(categories, " ")
+	return "<font color = '[CODEX_COLOR_MECHANICS]'>[jointext(dat, null)]</font>"
+
+/client/Topic(href, href_list, hsrc)
+	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
+		return
+
+	if(href_list["codex_search"]) //nano throwing errors
+		search_codex()
+		return
+
+	if(href_list["codex_index"]) //nano throwing errors
+		list_codex_entries()
+		return
+	
+	..()


### PR DESCRIPTION
Adds 'Codex' verb that shows user the 'frontpage' of codex, with links to search / index / categories.
Adds autogenerated entries for categories, listing all their items.
Backend wise moved text generation to the entry datum so I can make snowflake entries (like the nexus front page thing)

![](https://i.imgur.com/WVKCBn0.png)

![](https://i.imgur.com/gK6u55Y.png)

:cl: Chinsky
rscadd: Adds 'Codex' verb that shows user the 'frontpage' of codex, with links to search / index / categories.
/:cl: