### PR TITLE
Removes the holdout pistol from the liaison kit.

### DIFF
--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -104,7 +104,6 @@ Unique items
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = 4
 	startswith = list(
-			/obj/item/weapon/gun/projectile/pistol/holdout/liaison,
 			/obj/item/weapon/reagent_containers/pill/tox,
 			/obj/item/weapon/paper/liason_note
 	)

--- a/maps/torch/items/manuals.dm
+++ b/maps/torch/items/manuals.dm
@@ -97,7 +97,7 @@
 /obj/item/weapon/paper/liason_note
 	name = "note"
 	info = {"
-	<i>Pick your way out.<br>
+	<i>Here's your back-out plan.<br>
 	H.B.</i>
 	"}
 


### PR DESCRIPTION
Joke works fine with just the pill, and this stops people printing ammo for the stupid thing and using it as a free pistol.