### PR TITLE
Fixes D1 and D3 nacelles

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1293,6 +1293,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"cS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/ignition{
+	id_tag = "engines_starboard";
+	pixel_x = -24;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3starboard)
 "cT" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -1314,6 +1329,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"cV" = (
+/obj/machinery/sparker{
+	id_tag = "engines_starboard";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 4;
+	internal_pressure_bound = 35000;
+	internal_pressure_bound_default = 35000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/reinforced/airless,
+/area/thruster/d3starboard)
 "cW" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1609,9 +1637,58 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hydroponics/storage)
+"dB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4;
+	icon_state = "intact";
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/reinforced/oxygen,
+/area/thruster/d3starboard)
+"dC" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	color = "";
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	frequency = 1441;
+	icon_state = "map_vent_in";
+	id_tag = "d3so2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/oxygen,
+/area/thruster/d3starboard)
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
+"dE" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 2;
+	regulate_mode = 1;
+	target_pressure = 35000;
+	use_power = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/button/blast_door{
+	id_tag = "cChamber3sV";
+	name = "combustion chamber vent control";
+	pixel_x = -24;
+	pixel_y = 0;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3starboard)
 "dF" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -1673,6 +1750,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
+"dK" = (
+/obj/machinery/button/blast_door{
+	id_tag = "d3portnacelle";
+	name = "combustion chamber blast door control";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3port)
 "dL" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -2039,10 +2131,44 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/crew_quarters/galley)
+"ez" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 1;
+	regulate_mode = 1;
+	target_pressure = 35000;
+	use_power = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/button/blast_door{
+	id_tag = "cChamber3pV";
+	name = "combustion chamber vent control";
+	pixel_x = -24;
+	pixel_y = 0;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3port)
 "eA" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/monotile,
 /area/vacant/brig)
+"eB" = (
+/obj/machinery/sparker{
+	id_tag = "engines_port";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 4;
+	internal_pressure_bound = 35000;
+	internal_pressure_bound_default = 35000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/reinforced/airless,
+/area/thruster/d3port)
 "eC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2058,6 +2184,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hydroponics)
+"eD" = (
+/obj/machinery/button/ignition{
+	id_tag = "engines_port";
+	pixel_x = -24;
+	step_x = 31
+	},
+/turf/simulated/wall/ocp_wall,
+/area/thruster/d3port)
+"eE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4;
+	icon_state = "intact";
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/reinforced/oxygen,
+/area/thruster/d3port)
 "eF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2084,6 +2227,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/mess)
+"eH" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	color = "";
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	frequency = 1441;
+	icon_state = "map_vent_in";
+	id_tag = "d3po2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/oxygen,
+/area/thruster/d3port)
 "eI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/substation/thirddeck)
@@ -2401,6 +2563,31 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/tcommsat/chamber)
+"fl" = (
+/obj/machinery/button/blast_door{
+	id_tag = "d3starboardnacelle";
+	name = "combustion chamber blast door control";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 2
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3starboard)
+"fm" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced/airless,
+/area/thruster/d3starboard)
 "fn" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Hard Storage"
@@ -2408,6 +2595,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/engineering/engine_eva)
+"fo" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 2002;
+	id_tag = "vox_ship_in";
+	injecting = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/airless,
+/area/thruster/d3port)
 "fp" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -2508,6 +2704,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
+"fz" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced/airless,
+/area/thruster/d3port)
 "fA" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -6308,14 +6515,6 @@
 "nD" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/mess)
-"nE" = (
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	id_tag = "fuelmode"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/oxygen,
-/area/thruster/d3port)
 "nG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -9832,24 +10031,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/office)
-"vj" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	frequency = 1441;
-	icon_state = "map_vent_in";
-	id_tag = "d3po2_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/turf/simulated/floor/reinforced/oxygen,
-/area/thruster/d3port)
 "vk" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -13272,14 +13453,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled,
 /area/vacant/cabin)
-"DX" = (
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	id_tag = "fuelmode"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/oxygen,
-/area/thruster/d3starboard)
 "DZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16133,19 +16306,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"KO" = (
-/obj/machinery/button/blast_door{
-	id_tag = "d3starboardnacelle";
-	name = "combustion chamber blast door controll";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3starboard)
 "KP" = (
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d3starboard)
@@ -16180,18 +16340,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3starboard)
-"KU" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/airless,
 /area/thruster/d3starboard)
 "KV" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
@@ -16234,17 +16382,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3port)
-"Ld" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/airless,
 /area/thruster/d3port)
 "Le" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
@@ -16321,21 +16458,6 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3port)
-"Lo" = (
-/obj/machinery/button/blast_door{
-	id_tag = "d3portnacelle";
-	name = "combustion chamber blast door controll";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3port)
 "Lp" = (
@@ -16506,24 +16628,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
-"LH" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	frequency = 1441;
-	icon_state = "map_vent_in";
-	id_tag = "d3so2_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/turf/simulated/floor/reinforced/oxygen,
-/area/thruster/d3starboard)
 "LI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16559,19 +16663,6 @@
 /obj/effect/shuttle_landmark/skipjack/deck3,
 /turf/space,
 /area/space)
-"LO" = (
-/obj/machinery/sparker{
-	id_tag = "engines";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	dir = 4;
-	internal_pressure_bound = 35000;
-	internal_pressure_bound_default = 35000
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
-/area/thruster/d3port)
 "LQ" = (
 /obj/structure/table/standard,
 /obj/item/weapon/pen,
@@ -16929,19 +17020,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_eva)
-"MW" = (
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 1;
-	regulate_mode = 1;
-	target_pressure = 35000;
-	use_power = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3port)
 "MY" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -17460,15 +17538,6 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/chapel/office)
-"OH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3starboard)
 "OI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19168,13 +19237,6 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d3starboard)
-"Uf" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	injecting = 1;
-	use_power = 1
-	},
-/turf/simulated/floor/airless,
-/area/thruster/d3port)
 "Ug" = (
 /obj/machinery/smartfridge/drinks{
 	icon_state = "fridge_dark";
@@ -19447,19 +19509,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
-"UR" = (
-/obj/machinery/sparker{
-	id_tag = "engines";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	dir = 4;
-	internal_pressure_bound = 35000;
-	internal_pressure_bound_default = 35000
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
-/area/thruster/d3starboard)
 "UU" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -20892,19 +20941,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"YT" = (
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 2;
-	regulate_mode = 1;
-	target_pressure = 35000;
-	use_power = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3starboard)
 "YU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -49224,7 +49260,7 @@ Xe
 KJ
 KL
 td
-KU
+fm
 KP
 bd
 aa
@@ -49256,7 +49292,7 @@ aa
 rD
 aU
 La
-Ld
+fz
 Qi
 Ll
 Ls
@@ -49420,14 +49456,14 @@ aa
 aa
 aa
 bd
-DX
+dB
 WF
 KF
 KK
 KM
 te
 KV
-UR
+cV
 KP
 bd
 aa
@@ -49457,14 +49493,14 @@ aa
 aa
 pI
 La
-LO
+eB
 Le
 Ri
 Lm
 Lt
 Lu
 Ws
-nE
+eE
 pI
 aa
 aa
@@ -49622,7 +49658,7 @@ aa
 aa
 aa
 bd
-LH
+dC
 WF
 Jm
 Aj
@@ -49666,7 +49702,7 @@ Ln
 Kq
 Bb
 Ws
-vj
+eH
 pI
 aa
 aa
@@ -49828,7 +49864,7 @@ SJ
 WF
 Jh
 zf
-KO
+fl
 KP
 KP
 KP
@@ -49862,9 +49898,9 @@ aa
 pI
 La
 La
+eD
 La
-La
-Lo
+dK
 Jj
 Jk
 Ws
@@ -50032,8 +50068,8 @@ KG
 Al
 Jo
 KT
-OH
-YT
+cS
+dE
 Ye
 RI
 Mt
@@ -50060,10 +50096,10 @@ aa
 aa
 aa
 aa
-Uf
+fo
 Or
 Rv
-MW
+ez
 Mg
 Lc
 Lp

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1334,9 +1334,59 @@
 "act" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod12/station)
+"acu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4;
+	icon_state = "intact";
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/reinforced/oxygen,
+/area/thruster/d1starboard)
+"acv" = (
+/obj/machinery/button/blast_door{
+	id_tag = "d1starboardnacelle";
+	name = "combustion chamber blast door control";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 2
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d1starboard)
 "acw" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod13/station)
+"acx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/ignition{
+	id_tag = "engines_starboard";
+	pixel_x = -24;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d1starboard)
+"acy" = (
+/obj/machinery/sparker{
+	id_tag = "engines_starboard";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 4;
+	internal_pressure_bound = 35000;
+	internal_pressure_bound_default = 35000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/reinforced,
+/area/thruster/d1starboard)
 "acz" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod14/station)
@@ -1345,6 +1395,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
+"acB" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 2;
+	regulate_mode = 1;
+	target_pressure = 35000;
+	use_power = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/button/blast_door{
+	id_tag = "cChamber1sV";
+	name = "combustion chamber vent";
+	pixel_x = -24;
+	pixel_y = 0;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d1starboard)
 "acC" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1353,6 +1424,46 @@
 "acD" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/centralstarboard)
+"acE" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced,
+/area/thruster/d1starboard)
+"acF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/ignition{
+	id_tag = "engines_port";
+	pixel_x = -24;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d1port)
+"acG" = (
+/obj/machinery/sparker{
+	id_tag = "engines_port";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 4;
+	internal_pressure_bound = 35000;
+	internal_pressure_bound_default = 35000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/reinforced,
+/area/thruster/d1port)
 "acH" = (
 /obj/structure/bed/chair/wheelchair,
 /obj/effect/decal/cleanable/cobweb,
@@ -1397,6 +1508,27 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"acO" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 1;
+	regulate_mode = 1;
+	target_pressure = 35000;
+	use_power = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/button/blast_door{
+	id_tag = "cChamber1pV";
+	name = "combustion chamber vent";
+	pixel_x = -24;
+	pixel_y = 0;
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d1port)
 "acP" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1424,6 +1556,17 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"acU" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced,
+/area/thruster/d1port)
 "acV" = (
 /obj/structure/table/rack,
 /obj/random/toolbox,
@@ -1565,6 +1708,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/forestarboard)
+"adh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4;
+	icon_state = "intact";
+	step_x = 0;
+	step_y = 0
+	},
+/turf/simulated/floor/reinforced/oxygen,
+/area/thruster/d1port)
 "adi" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Shower"
@@ -1810,19 +1962,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/meter,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d1starboard)
-"adH" = (
-/obj/machinery/button/blast_door{
-	id_tag = "d1starboardnacelle";
-	name = "combustion chamber blast door controll";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "adI" = (
@@ -2538,18 +2677,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"afv" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
 "afw" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -2558,15 +2685,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
-"afz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "afA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -2885,32 +3003,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"agw" = (
-/obj/machinery/sparker{
-	id_tag = "engines";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	dir = 4;
-	internal_pressure_bound = 35000;
-	internal_pressure_bound_default = 35000
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
-"agy" = (
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 2;
-	regulate_mode = 1;
-	target_pressure = 35000;
-	use_power = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d1starboard)
 "agz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9;
@@ -11845,37 +11937,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
-"aRg" = (
-/obj/machinery/sparker{
-	id_tag = "engines";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	dir = 4;
-	internal_pressure_bound = 35000;
-	internal_pressure_bound_default = 35000
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1port)
 "aRh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
-/area/thruster/d1port)
-"aRj" = (
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 1;
-	regulate_mode = 1;
-	target_pressure = 35000;
-	use_power = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
 "aRk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -12308,17 +12374,6 @@
 	},
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
-"aSg" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1port)
 "aSh" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -12327,15 +12382,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
-/area/thruster/d1port)
-"aSk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
 "aSl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -19789,14 +19835,6 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
-"hmQ" = (
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	id_tag = "fuelmode"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/oxygen,
-/area/thruster/d1port)
 "hnL" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -29660,14 +29698,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"sCx" = (
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	id_tag = "fuelmode"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/oxygen,
-/area/thruster/d1starboard)
 "sCM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -59449,7 +59479,7 @@ nys
 ada
 adE
 bbb
-afv
+acE
 aet
 abN
 abM
@@ -59485,7 +59515,7 @@ acd
 aLj
 xPU
 aPq
-aSg
+acU
 byb
 aTk
 aTU
@@ -59645,14 +59675,14 @@ aaa
 aaa
 aaa
 abN
-sCx
+acu
 vci
 acn
 adb
 adF
 aet
 afw
-agw
+acy
 aet
 abN
 aaa
@@ -59686,14 +59716,14 @@ acd
 aaa
 xPU
 aPq
-aRg
+acG
 aSh
 bzb
 aTl
 aTV
 aUk
 iej
-hmQ
+adh
 xPU
 aaa
 aaa
@@ -60053,7 +60083,7 @@ hml
 vci
 bqv
 kfG
-adH
+acv
 aet
 aet
 aet
@@ -60257,8 +60287,8 @@ acp
 add
 adI
 aey
-afz
-agy
+acx
+acB
 ahA
 aiI
 ajJ
@@ -60292,8 +60322,8 @@ aaa
 aOD
 aPs
 aQm
-aRj
-aSk
+acO
+acF
 aSS
 aTo
 aTX


### PR DESCRIPTION
:cl: mikomyazaki
maptweak: Torch D1 and D3 nacelles can now be used properly as an alternate gas heating method for the thrusters. Switch the digital valves and hit the ignition switch to operate.
maptweak: Torch D1 and D3 nacelles now have ignition switches and vent switches.
/:cl:

Issues solved - No ignition switch, no vent switches, injector had the wrong settings so could never be turned on.

Fixes #26483 

This doesn't significantly speed up the Torch, although I don't think that would be a problem even if it did - Given the speed of the recently added awayships. Provides an alternative to the SM Engine heating if that is desirable for whatever reason.

This will allow significantly faster thruster startup at the beginning of a round, since it is much, much faster than SM Engine Setup + Heating time.

New mapping (same changes for each Nacelle)
![nacelle](https://user-images.githubusercontent.com/47489928/61996060-9e9dfd00-b07f-11e9-8203-55547e02358e.PNG)
