### PR TITLE
Fixes vox ship burn chamber.

### DIFF
--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -215,6 +215,48 @@
 /obj/machinery/optable,
 /turf/simulated/floor/plating/vox,
 /area/voxship/base)
+"aM" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 2002;
+	id_tag = "vox_ship_in";
+	injecting = 1;
+	use_power = 1
+	},
+/obj/machinery/sparker{
+	id_tag = "voxship";
+	pixel_x = -20
+	},
+/turf/simulated/floor/airless,
+/area/voxship/ship)
+"aN" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 2002;
+	id_tag = "vox_ship_in";
+	injecting = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/airless,
+/area/voxship/ship)
+"aO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/cee{
+	icon_state = "borderfloorcee_white";
+	dir = 4
+	},
+/obj/machinery/button/ignition{
+	id_tag = "voxship";
+	pixel_x = -36
+	},
+/turf/simulated/floor/plating/vox,
+/area/voxship/ship)
+"aP" = (
+/obj/machinery/air_sensor{
+	id_tag = "vox_ship_sensor"
+	},
+/turf/simulated/floor/airless,
+/area/voxship/ship)
 "aQ" = (
 /turf/simulated/wall/iron,
 /area/voxship/base)
@@ -268,11 +310,16 @@
 /turf/simulated/floor/plating/vox,
 /area/voxship/ship)
 "aZ" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	injecting = 1;
-	use_power = 1
+/obj/machinery/computer/air_control{
+	dir = 4;
+	frequency = 2002;
+	input_tag = "vox_ship_in";
+	name = "Ship Juice Control";
+	output_tag = "vox_ship_out";
+	sensor_tag = "vox_ship_sensor"
 	},
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/borderfloor/full,
+/turf/simulated/floor/plating/vox,
 /area/voxship/ship)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -335,13 +382,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/wall/ocp_wall,
-/area/voxship/ship)
-"bi" = (
-/obj/effect/wallframe_spawn/reinforced_phoron,
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
-/turf/simulated/floor/plating/vox,
 /area/voxship/ship)
 "bj" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
@@ -439,10 +479,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/asteroid,
 /area/space)
-"bt" = (
-/obj/effect/wallframe_spawn/reinforced_phoron,
-/turf/simulated/floor/plating/vox,
-/area/voxship/ship)
 "bu" = (
 /obj/machinery/atmospherics/binary/circulator{
 	anchored = 1;
@@ -1273,17 +1309,6 @@
 	},
 /turf/simulated/wall/iron,
 /area/voxship/base)
-"dD" = (
-/obj/machinery/computer/air_control{
-	dir = 4;
-	frequency = 2002;
-	input_tag = "vox_ship_in";
-	name = "Ship Juice Control";
-	output_tag = "vox_ship_out"
-	},
-/obj/effect/floor_decal/borderfloor/full,
-/turf/simulated/floor/plating/vox,
-/area/voxship/ship)
 "dE" = (
 /obj/effect/shuttle_landmark/vox_base/hangar/vox_shuttle,
 /obj/effect/floor_decal/borderfloor/full,
@@ -2172,20 +2197,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating/vox,
 /area/voxship/ship)
-"wJ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/cee{
-	icon_state = "borderfloorcee_white";
-	dir = 4
-	},
-/obj/machinery/button/ignition{
-	id_tag = "voxship";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plating/vox,
-/area/voxship/ship)
 "Cj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2195,17 +2206,6 @@
 /obj/structure/inflatable/door,
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/space)
-"Ut" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	injecting = 1;
-	use_power = 1
-	},
-/obj/machinery/sparker{
-	id_tag = "voxship";
-	pixel_x = -20
-	},
-/turf/simulated/floor/airless,
-/area/voxship/ship)
 "Wm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /turf/simulated/floor/plating/vox,
@@ -5509,8 +5509,8 @@ aR
 aX
 bh
 bp
-bq
-Ut
+aP
+aM
 dI
 cI
 dz
@@ -5612,7 +5612,7 @@ aY
 bO
 bq
 bB
-aZ
+aN
 dI
 cK
 dA
@@ -5712,12 +5712,12 @@ aC
 Wm
 bg
 bO
-bt
-bi
-bt
+dH
+bO
+dH
 dH
 dk
-dD
+aZ
 el
 eL
 bH
@@ -5817,7 +5817,7 @@ bC
 bK
 bC
 cg
-wJ
+aO
 bH
 dE
 el


### PR DESCRIPTION
:cl: mikomyazaki
maptweak: Vox ship burn chamber now operates properly (fixes incorrect injector settings)
maptweak: Vox ship burn chamber can no longer cause the ship to self-destruct due to temperature melting the windows, since they have been replaced with walls that handle up to 12,000K.
maptweak: Adds a temperature/gas sensor to the burn chamber.
maptweak: Vox ship ignition switch now isn't hidden under a light.
/:cl:

Fixes #26460 