### PR TITLE
Makes Boot Selection civilian only

### DIFF
--- a/maps/torch/loadout/loadout_shoes.dm
+++ b/maps/torch/loadout/loadout_shoes.dm
@@ -29,3 +29,6 @@
 
 /datum/gear/shoes/heels
 	allowed_roles = SEMIANDFORMAL_ROLES
+
+/datum/gear/shoes/boots
+	allowed_branches = CIVILIAN_BRANCHES


### PR DESCRIPTION
:cl: Rain7x
tweak: Makes the "boot selection" in loadout available to civilians only.
/:cl:

Continuation of #25653

They aren't part of the standard uniform for uniformed people. Civilians can still select them.