### PR TITLE
gravity event area safety

### DIFF
--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -18,7 +18,7 @@
 		gravity_is_on = 1
 
 		for(var/area/A in world)
-			if((A.z in GLOB.using_map.station_levels) && initial(A.has_gravity))
+			if(A && (A.z in GLOB.using_map.station_levels) && initial(A.has_gravity))
 				A.gravitychange(gravity_is_on)
 
 		command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "Gravity Restored", zlevels = affecting_z)


### PR DESCRIPTION
Apparently `for (areas in world)` can have nulls, so it's possible for this event to just never end due to resulting runtimes.