### PR TITLE
Crisis locks the security cyborg module

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -36,6 +36,7 @@
 /obj/item/weapon/robot_module/security/general
 	name = "security robot module"
 	display_name = "Security"
+	crisis_locked = TRUE
 	sprites = list(
 		"Basic" = "secborg",
 		"Red Knight" = "Security",


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Upon admin request.
You can still get it if an admin enables your crisis_override var.

:cl:
rscdel: The Security cyborg module has been disabled.
/:cl: