### PR TITLE
Fixes #26508 - sanitizing underwear on species change runtime

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -376,7 +376,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 			sanitize_organs()
 
-			if(!has_flag(pref.species, HAS_UNDERWEAR))
+			if(!has_flag(all_species[pref.species], HAS_UNDERWEAR))
 				pref.all_underwear.Cut()
 
 			return TOPIC_REFRESH_UPDATE_PREVIEW


### PR DESCRIPTION
Fixes #26508 runtime that occurred when sanitizing underwear after a species change.