### PR TITLE
Fixes fuel mode control and ignition buttons for nacelle combustion

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1295,6 +1295,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
+"cS" = (
+/obj/machinery/button/blast_door{
+	id_tag = "d3starboardnacelle";
+	name = "combustion chamber blast door control";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 2
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3starboard)
 "cT" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -1316,6 +1329,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"cV" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced/airless,
+/area/thruster/d3starboard)
 "cW" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1611,6 +1636,32 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hydroponics/storage)
+"dB" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced/airless,
+/area/thruster/d3port)
+"dC" = (
+/obj/machinery/button/blast_door{
+	id_tag = "d3portnacelle";
+	name = "combustion chamber blast door control";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d3port)
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
@@ -16135,19 +16186,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"KO" = (
-/obj/machinery/button/blast_door{
-	id_tag = "d3starboardnacelle";
-	name = "combustion chamber blast door controll";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3starboard)
 "KP" = (
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d3starboard)
@@ -16182,18 +16220,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3starboard)
-"KU" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/airless,
 /area/thruster/d3starboard)
 "KV" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
@@ -16236,17 +16262,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3port)
-"Ld" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/airless,
 /area/thruster/d3port)
 "Le" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
@@ -16323,21 +16338,6 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d3port)
-"Lo" = (
-/obj/machinery/button/blast_door{
-	id_tag = "d3portnacelle";
-	name = "combustion chamber blast door controll";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3port)
 "Lp" = (
@@ -49226,7 +49226,7 @@ Xe
 KJ
 KL
 td
-KU
+cV
 KP
 bd
 aa
@@ -49258,7 +49258,7 @@ aa
 rD
 aU
 La
-Ld
+dB
 Qi
 Ll
 Ls
@@ -49830,7 +49830,7 @@ SJ
 WF
 Jh
 zf
-KO
+cS
 KP
 KP
 KP
@@ -49866,7 +49866,7 @@ La
 La
 La
 La
-Lo
+dC
 Jj
 Jk
 Ws

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1457,6 +1457,27 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/seconddeck/central)
+"cS" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/button/toggle/valve{
+	id_tag = "fuelmode";
+	name = "fuel mode control";
+	operating = 0;
+	pixel_x = 24;
+	pixel_y = 4
+	},
+/obj/machinery/button/ignition{
+	id_tag = "engines";
+	operating = 0;
+	pixel_x = 24;
+	pixel_y = -4
+	},
+/obj/machinery/computer/ship/engines{
+	icon_state = "computer";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/engineering_monitoring)
 "cU" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarstarboard)
@@ -14456,27 +14477,6 @@
 "Ir" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/auxsolarport)
-"It" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/button/toggle/valve{
-	id_tag = "fuelmode";
-	name = "fuel mode control";
-	operating = 0;
-	pixel_x = 24;
-	pixel_y = 4
-	},
-/obj/machinery/button/ignition{
-	id_tag = "engines";
-	operating = 1;
-	pixel_x = 24;
-	pixel_y = -4
-	},
-/obj/machinery/computer/ship/engines{
-	icon_state = "computer";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/engineering/engineering_monitoring)
 "Iv" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -40289,7 +40289,7 @@ Iv
 jw
 jw
 ib
-It
+cS
 Ii
 nA
 jw

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1334,9 +1334,45 @@
 "act" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod12/station)
+"acu" = (
+/obj/machinery/button/blast_door{
+	id_tag = "d1starboardnacelle";
+	name = "combustion chamber blast door control";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 2
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/thruster/d1starboard)
+"acv" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced,
+/area/thruster/d1starboard)
 "acw" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod13/station)
+"acx" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1447;
+	id = "fuelmode";
+	injecting = 1;
+	use_power = 1;
+	volume_rate = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced,
+/area/thruster/d1port)
 "acz" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod14/station)
@@ -1810,19 +1846,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/meter,
-/turf/simulated/floor/tiled/techfloor,
-/area/thruster/d1starboard)
-"adH" = (
-/obj/machinery/button/blast_door{
-	id_tag = "d1starboardnacelle";
-	name = "combustion chamber blast door controll";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "adI" = (
@@ -2538,18 +2561,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"afv" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1starboard)
 "afw" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -12308,17 +12319,6 @@
 	},
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
-"aSg" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1447;
-	id = "fuelmode";
-	injecting = 1;
-	use_power = 0;
-	volume_rate = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced,
-/area/thruster/d1port)
 "aSh" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -59449,7 +59449,7 @@ nys
 ada
 adE
 bbb
-afv
+acv
 aet
 abN
 abM
@@ -59485,7 +59485,7 @@ acd
 aLj
 xPU
 aPq
-aSg
+acx
 byb
 aTk
 aTU
@@ -60053,7 +60053,7 @@ hml
 vci
 bqv
 kfG
-adH
+acu
 aet
 aet
 aet


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Nacelle control switches in the engineering monitoring room will now work.
/:cl:

Fixes some button names.
Makes ignition switch work (var operating = 1 caused it to never trigger)

Fixes #26483 