### PR TITLE
Rad Collector adjustments

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -21,6 +21,12 @@ var/global/list/rad_collectors = list()
 	var/locked = 0
 	var/drainratio = 1
 
+	var/max_rads = 250 // rad collector will reach max power output at this value, and break at twice this value
+	var/max_power = 5e5
+	var/pulse_coeff = 20
+	var/end_time = 0
+	var/alert_delay = 10 SECONDS
+
 /obj/machinery/power/rad_collector/New()
 	..()
 	rad_collectors += src
@@ -43,18 +49,24 @@ var/global/list/rad_collectors = list()
 	//so that we don't zero out the meter if the SM is processed first.
 	last_power = last_power_new
 	last_power_new = 0
-
+	var/rads = SSradiation.get_rads_at_turf(get_turf(src))
 	if(P && active)
-		var/rads = SSradiation.get_rads_at_turf(get_turf(src))
+		if(rads > max_rads*2)
+			collector_break()
 		if(rads)
-			receive_pulse(rads * 5) //Maths is hard
+			if(rads > max_rads)
+				if(world.time > end_time)
+					end_time = world.time + alert_delay
+					visible_message("\icon[src] \the [src] beeps loudly as the radiation reaches dangerous levels, indicating imminent damage.")
+					playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
+			receive_pulse(12.5*(rads/max_rads)/(0.3+(rads/max_rads)))
 
 	if(P)
 		if(P.air_contents.gas[GAS_PHORON] == 0)
 			investigate_log("<font color='red'>out of fuel</font>.","singulo")
 			eject()
 		else
-			P.air_adjust_gas(GAS_PHORON, -0.001*drainratio)
+			P.air_adjust_gas(GAS_PHORON, -0.01*drainratio*min(rads,max_rads)/max_rads) //fuel cost increases linearly with incoming radiation
 
 /obj/machinery/power/rad_collector/CanUseTopic(mob/user)
 	if(!anchored)
@@ -171,7 +183,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(P && active)
 		var/power_produced = 0
-		power_produced = P.air_contents.gas[GAS_PHORON]*pulse_strength*20
+		power_produced = min(100*P.air_contents.gas[GAS_PHORON]*pulse_strength*pulse_coeff,max_power)
 		add_avail(power_produced)
 		last_power_new = power_produced
 		return


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Radiation collectors are now capped at 500kW output at 250Bq radiation. They are more efficient at lower radiation levels.
tweak: Radiation collectors will have variable fuel usage, capping out at 250Bq radiation. Fuel usage increased significantly (1-10x depending on radiation levels)
tweak: Radiation collectors will now break from high radiation levels (500Bq) as well as temperature, they will display a warning and play a warning sound.
/:cl:

500kW per rad collector seems like a good level to me, maybe even still on the high-side. But making 4-6 of them for 2-3MW boost that will power a shield or the ship seems okay in my opinion. Note: 250Bq is the level of radiation you receive at two tiles distance from the SM at 800 EER, which is an easily sustainable level of engine operation on hydrogen or phoron coolant, with one  emitter. Putting it directly next to the SM using an atmospheric shield to remove the temperature issue is likely to break the rad collector.

Current radiation collectors don't really use any of their fuel, one tank of phoron will last the entire round. Intention is to make this actually matter, although it still doesn't use very much phoron.

Intent is to make people not place rad-collectors directly next to the SM, using an atmospheric containment shield to create a dangerous, but extremely effective, power source. Rad Collectors cannot break due to temperature with this arrangement. Allows for extremely high levels of power generation, see picture below:

![rad_collectors](https://user-images.githubusercontent.com/47489928/62235228-66225a00-b3c4-11e9-9233-8081632bc684.PNG)

This is something that happens and has happened on live in a recent round.

Singularities etc. will still work fine as a power source, I think.