### PR TITLE
Reduce memory/note logging

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -160,12 +160,7 @@
 
 	if(href_list["remove_memory"])
 		var/memory = locate(href_list["remove_memory"]) in memories
-		if(!memory)
-			return TRUE
-
-		LAZYREMOVE(memories, memory)
-		ShowMemory(usr)
-		to_chat(usr, SPAN_NOTICE("You have removed a memory."))
+		RemoveMemory(memory, usr)
 		return TRUE
 
 	if(href_list["abandon_goal"])

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 43 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 480 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 479 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 23 "text2path uses" 'text2path'
 exactly 1 "update_icon() override" '/update_icon\((.*)\)'  -P


### PR DESCRIPTION
By administration request
Also adds proper tagging by storing and utilizing the creation source

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->