### PR TITLE
Broad shield rebalance.

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -3,7 +3,8 @@
 #define SHIELD_DAMTYPE_HEAT 3		// Heat damage - Lasers, fire
 
 #define ENERGY_PER_HP (50 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
-#define ENERGY_UPKEEP_PER_TILE 100	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
+#define ENERGY_UPKEEP_PER_TILE (10 KILOWATTS)	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
+#define ENERGY_UPKEEP_IDLE 50                  // Base upkeep when idle; modified by other factors.
 
 // This shield model is slightly inspired by Sins of a Solar Empire series. In short, shields are designed to analyze what hits them, and adapt themselves against that type of damage.
 // This means shields will become increasingly effective against things like emitters - as they will adapt to heat damage, however they will be vulnerable to brute and EM damage.
@@ -53,5 +54,7 @@
 #define SHIELD_OFF 0				// The shield is offline
 #define SHIELD_DISCHARGING 1		// The shield is shutting down and discharging.
 #define SHIELD_RUNNING 2			// The shield is running
+#define SHIELD_IDLE        3        // The shield is being kept at an idle state
+#define SHIELD_SPINNING_UP 4        // Going from idle to running
 
-#define SHIELD_SHUTDOWN_DISPERSION_RATE (500 KILOWATTS)		// The rate at which shield energy disperses when shutdown is initiated.
+#define SHIELD_SHUTDOWN_DISPERSION_RATE (10000 KILOWATTS)		// The rate at which shield energy disperses when shutdown is initiated.

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -19,6 +19,7 @@
 	var/max_energy = 0					// Maximal stored energy. In joules. Depends on the type of used SMES coil when constructing this generator.
 	var/current_energy = 0				// Current stored energy.
 	var/field_radius = 1				// Current field radius.
+	var/target_radius = 1               // Desired field radius.
 	var/running = SHIELD_OFF			// Whether the generator is enabled or not.
 	var/input_cap = 1 MEGAWATTS			// Currently set input limit. Set to 0 to disable limits altogether. The shield will try to input this value per tick at most
 	var/upkeep_power_usage = 0			// Upkeep power usage last tick.
@@ -31,6 +32,12 @@
 	var/mode_changes_locked = 0			// Whether the control wire is cut, locking out changes.
 	var/ai_control_disabled = 0			// Whether the AI control is disabled.
 	var/list/mode_list = null			// A list of shield_mode datums.
+	var/full_shield_strength = 0        // The amount of power shields need to be at full operating strength.
+
+	var/idle_multiplier   = 1           // Trades off cost vs. spin-up time from idle to running
+	var/idle_valid_values = list(1, 2, 5, 10)
+	var/spinup_delay      = 20
+	var/spinup_counter    = 0
 
 /obj/machinery/power/shield_generator/on_update_icon()
 	if(running)
@@ -59,8 +66,10 @@
 
 /obj/machinery/power/shield_generator/RefreshParts()
 	max_energy = 0
+	full_shield_strength = 0
 	for(var/obj/item/weapon/stock_parts/smes_coil/S in component_parts)
-		max_energy += (S.ChargeCapacity / CELLRATE)
+		full_shield_strength += (S.ChargeCapacity / CELLRATE) * 5
+	max_energy = full_shield_strength * 20
 	current_energy = between(0, current_energy, max_energy)
 
 	mitigation_max = MAX_MITIGATION_BASE + MAX_MITIGATION_RESEARCH * total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor)
@@ -125,19 +134,31 @@
 	if(offline_for)
 		offline_for = max(0, offline_for - 1)
 	// We're turned off.
-	if(!running)
+	if(running == SHIELD_OFF)
 		return
+
+	if(target_radius != field_radius && running != SHIELD_RUNNING) // Do not recalculate the field while it's running; that's extremely laggy.
+		field_radius += (target_radius > field_radius) ? 1 : -1
+
 	// We are shutting down, therefore our stored energy disperses faster than usual.
 	else if(running == SHIELD_DISCHARGING)
 		current_energy -= SHIELD_SHUTDOWN_DISPERSION_RATE
+	else if(running == SHIELD_SPINNING_UP)
+		spinup_counter--
+		if(spinup_counter <= 0)
+			running = SHIELD_RUNNING
+			regenerate_field()
 
 	mitigation_em = between(0, mitigation_em - MITIGATION_LOSS_PASSIVE, mitigation_max)
 	mitigation_heat = between(0, mitigation_heat - MITIGATION_LOSS_PASSIVE, mitigation_max)
 	mitigation_physical = between(0, mitigation_physical - MITIGATION_LOSS_PASSIVE, mitigation_max)
 
-	upkeep_power_usage = round((field_segments.len - damaged_segments.len) * ENERGY_UPKEEP_PER_TILE * upkeep_multiplier)
+	if(running == SHIELD_RUNNING)
+		upkeep_power_usage = round((field_segments.len - damaged_segments.len) * ENERGY_UPKEEP_PER_TILE * upkeep_multiplier)
+	else if(running > SHIELD_RUNNING)
+		upkeep_power_usage = round(ENERGY_UPKEEP_IDLE * idle_multiplier * (field_radius * 8) * upkeep_multiplier) // Approximates number of turfs.
 
-	if(powernet && (running == SHIELD_RUNNING) && !input_cut)
+	if(powernet && (running >= SHIELD_RUNNING) && !input_cut)
 		var/energy_buffer = 0
 		energy_buffer = draw_power(min(upkeep_power_usage, input_cap))
 		power_usage += round(energy_buffer)
@@ -148,7 +169,7 @@
 		// Now try to recharge our internal energy.
 		var/energy_to_demand
 		if(input_cap)
-			energy_to_demand = between(0, max_energy - current_energy, input_cap - upkeep_power_usage)
+			energy_to_demand = between(0, max_energy - current_energy, input_cap - energy_buffer)
 		else
 			energy_to_demand = max(0, max_energy - current_energy)
 		energy_buffer = draw_power(energy_to_demand)
@@ -191,6 +212,18 @@
 		for(var/obj/effect/shield/S in field_segments)
 			S.fail(1)
 
+/obj/machinery/power/shield_generator/proc/set_idle(var/new_state)
+	if(new_state)
+		if(running == SHIELD_IDLE)
+			return
+		running = SHIELD_IDLE
+		for(var/obj/effect/shield/S in field_segments)
+			qdel(S)
+	else
+		if(running != SHIELD_IDLE)
+			return
+		running = SHIELD_SPINNING_UP
+		spinup_counter = round(spinup_delay / idle_multiplier)
 
 /obj/machinery/power/shield_generator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
@@ -209,11 +242,14 @@
 	data["total_segments"] = field_segments ? field_segments.len : 0
 	data["functional_segments"] = damaged_segments ? data["total_segments"] - damaged_segments.len : data["total_segments"]
 	data["field_radius"] = field_radius
+	data["target_radius"] = target_radius
 	data["input_cap_kw"] = round(input_cap / 1000)
 	data["upkeep_power_usage"] = round(upkeep_power_usage / 1000, 0.1)
 	data["power_usage"] = round(power_usage / 1000)
 	data["hacked"] = hacked
 	data["offline_for"] = offline_for * 2
+	data["idle_multiplier"] = idle_multiplier
+	data["idle_valid_values"] = idle_valid_values
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -232,18 +268,30 @@
 		return STATUS_UPDATE
 	return ..()
 
-/obj/machinery/power/shield_generator/OnTopic(user, href_list)
+/obj/machinery/power/shield_generator/OnTopic(user, href_list, datum/topic_state/state)
 	if(href_list["begin_shutdown"])
-		if(running != SHIELD_RUNNING)
+		if(running < SHIELD_RUNNING)
 			return
-		running = SHIELD_DISCHARGING
+		var/alert = alert(user, "Are you sure you wish to do this? It will drain the power inside the internal storage rapidly.", "Are you sure?", "Yes", "No")
+		if(!CanInteract(user, state))
+			return
+		if(running < SHIELD_RUNNING)
+			return
+		if(alert == "Yes")
+			set_idle(TRUE) // do this first to clear the field
+			running = SHIELD_DISCHARGING
 		return TOPIC_REFRESH
 
 	if(href_list["start_generator"])
 		if(offline_for)
 			return
-		running = SHIELD_RUNNING
-		regenerate_field()
+		set_idle(TRUE)
+		return TOPIC_REFRESH
+
+	if(href_list["toggle_idle"])
+		if(running < SHIELD_RUNNING)
+			return TOPIC_HANDLED
+		set_idle(text2num(href_list["toggle_idle"]))
 		return TOPIC_REFRESH
 
 	// Instantly drops the shield, but causes a cooldown before it may be started again. Also carries a risk of EMP at high charge.
@@ -273,8 +321,7 @@
 		var/new_range = input(user, "Enter new field range (1-[world.maxx]). Leave blank to cancel.", "Field Radius Control", field_radius) as num
 		if(!new_range)
 			return TOPIC_HANDLED
-		field_radius = between(1, new_range, world.maxx)
-		regenerate_field()
+		target_radius = between(1, new_range, world.maxx)
 		return TOPIC_REFRESH
 
 	if(href_list["set_input_cap"])
@@ -293,10 +340,17 @@
 		toggle_flag(text2num(href_list["toggle_mode"]))
 		return TOPIC_REFRESH
 
+	if(href_list["switch_idle"])
+		if(running == SHIELD_SPINNING_UP)
+			return TOPIC_REFRESH
+		var/new_idle = text2num(href_list["switch_idle"])
+		if(new_idle in idle_valid_values)
+			idle_multiplier = new_idle
+		return TOPIC_REFRESH
 
 /obj/machinery/power/shield_generator/proc/field_integrity()
-	if(max_energy)
-		return (current_energy / max_energy) * 100
+	if(full_shield_strength)
+		return round(CLAMP01(current_energy / full_shield_strength) * 100)
 	return 0
 
 
@@ -350,7 +404,7 @@
 	for(var/obj/effect/shield/S in field_segments)
 		S.flags_updated()
 
-	if((flag & (MODEFLAG_HULL|MODEFLAG_MULTIZ)) && running)
+	if((flag & (MODEFLAG_HULL|MODEFLAG_MULTIZ)) && (running == SHIELD_RUNNING))
 		regenerate_field()
 
 	if(flag & MODEFLAG_MODULATE)

--- a/nano/templates/shieldgen.tmpl
+++ b/nano/templates/shieldgen.tmpl
@@ -13,10 +13,14 @@
 				{{if data.overloaded}}
 					Recovering
 				{{else}}
-					Online
+					Active
 				{{/if}}
 			{{else data.running == 1}}
 				Shutting Down
+			{{else data.running == 3}}
+				Inactive
+			{{else data.running == 4}}
+				Spinning Up
 			{{else}}
 				Offline
 			{{/if}}
@@ -24,10 +28,18 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Shield Capacity:
+			Energy Storage:
 		</div>
 		<div class="itemContent">
 			{{:data.current_energy}}/{{:data.max_energy}} MJ ({{:data.percentage_energy}}%)
+		</div>
+	</div>
+	<div class="item">
+		<div class="itemLabel">
+			Shield Integrity:
+		</div>
+		<div class="itemContent">
+			{{:data.field_integrity}}%
 		</div>
 	</div>
 	<div class="item">
@@ -63,14 +75,19 @@
 			Field Size:
 		</div>
 		<div class="itemContent">
-			{{:data.functional_segments}} / {{:data.total_segments}} m2 (Radius {{:data.field_radius}})
+			{{:data.functional_segments}} / {{:data.total_segments}} m2 (radius {{:data.field_radius}}, target {{:data.target_radius}})
 		</div>
 	</div>
 	<h2>CONTROLS</h2>
 		<table>
 			<tr>
-			{{if (data.running == 2)}}
+			{{if (data.running >= 2)}}
 				<td>{{:helper.link('Turn off', null, {'begin_shutdown' : '1'})}}
+				{{if (data.running == 3)}}
+					<td>{{:helper.link('Activate', null, {'toggle_idle' : '0'})}} </td>
+				{{else}}
+					<td>{{:helper.link('Deactivate', null, {'toggle_idle' : '1'})}} </td>
+				{{/if}}
 			{{else}}
 				<td>{{:helper.link('Turn on', null, {'start_generator' : '1'})}}
 			{{/if}}
@@ -83,6 +100,13 @@
 			<tr>
 			<td>{{:helper.link('Set Field Range', null, {'set_range' : '1'})}}
 			<td>{{:helper.link('Set Input Cap', null, {'set_input_cap' : '1'})}}
+			<tr>
+			<td>Set inactive power use intensity:</td>
+			<td>
+			{{for data.idle_valid_values}}
+				{{:helper.link(value, null, {'switch_idle' : value}, (value == data.idle_multiplier) ? 'selected' : (data.running == 4 ? 'disabled' : null))}}
+			{{/for}}
+			</td>
 		</table>
 	<h2>FIELD CALIBRATION</h2>
 	<hr>


### PR DESCRIPTION
:cl:
tweak: The shield generator has been reworked. It is now much more expensive to keep the shields on continuously, and for large shields it's likely not viable.
rscadd: The shield generator now has an idle and active state (as well as the off state). In the idle state, it consumes limited power and does not generate a shield. In the active state, it consumes a lot of power and produces a shield.
rscadd: If an idle generator is toggled on, it takes a short amount of time to spin up to active state. If an active generator is toggled to idle, it will switch to that state instantly.
rscadd: There are several levels of idle power usage that can be selected. Higher power usage decreases the spin-up time proportionately.
rscadd: The shield generator takes time to adjust the radius of the shield. The radius will not be adjusted while the shield is active.
tweak: The shield generator's power storage has been vastly expanded.
tweak: The shield generator's field integrity is now tracked separately from the power storage (it's determined by the amount of power stored, up to a threshold).
/:cl:

General idea: this encourages active usage, and also gives a power sink for engineering shenanigans. With overmap shuttles relatively developed, the requirement for the Torch to be overmap-mobile early in the round is greatly diminished; at the same time, with reasonable active usage, it's likely still possible to turn the shield on while passing impassible obstacles at around the same time it's usually turned on now.

On the other hand, using shields to bypass random events and such by keeping them always on is extremely difficult now.

There are many numbers here which may need tweaking.