### PR TITLE
HoS is now unable to be a traitor

### DIFF
--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -15,7 +15,7 @@
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/submap)
 
 /datum/antagonist/traitor
-	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap)
+	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos)
 
 /datum/antagonist/ert
 	var/sic //Second-In-Command


### PR DESCRIPTION
🆑 Piccione
tweak: Heads of Security are now are better screened to ensure loyalty to the SCG
/🆑
Sec Traitors start priviledged compared to other Traitors and are incredibly hard to deal with, as Crew often leaves hunting Antags to Sec due to the rules, so they're pretty much free to do whatever they want.
(Edit:Following a Compromise after much, much community discussion, now only HoS can't be traitor)