### PR TITLE
Removes Stowaway.

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -14,7 +14,7 @@ var/list/dreams = list(
 	"an unathi","the ai core","a beaker of strange liquid","the supermatter", "a creature built completely of stolen flesh",
 	"a GAS", "a IPC", "a Dionaea", "a being made of light", "the commanding officer", "the executive officer", "the chief of security", "the corporate liason",
 	"the representative", "the senior advisor", "the bridge officer", "the senior engineer", "the physician", "the corpsman", "the counselor",
-	"the medical contractor", "the security contractor", "the stowaway", "an old friend", "the prospector", "the pilot", "the passenger", "the chief of security",
+	"the medical contractor", "the security contractor", "a stowaway", "an old friend", "the prospector", "the pilot", "the passenger", "the chief of security",
 	"the master at arms", "the forensic technician", "the brig chief", "the tower", "the man with no face", "a field of flowers", "an old home", "the merc",
 	"a surgery table", "a needle", "a blade", "an ocean", "right behind you", "standing above you", "someone near by", "a place forgotten", "the exodus",
 	)

--- a/html/changelogs/mistakenot-noaway.yml
+++ b/html/changelogs/mistakenot-noaway.yml
@@ -1,0 +1,4 @@
+author: MistakeNot4892
+delete-after: True
+changes: 
+  - rscdel: "Removed stowaway."

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -216,24 +216,3 @@
 	job_access_type = /datum/job/merchant
 	color = COLOR_OFF_WHITE
 	detail_color = COLOR_BEIGE
-
-//Stowaway
-/obj/item/weapon/card/id/torch/stowaway
-	desc = "An identification card issued to personnel aboard the SEV Torch. Looks like the photo fell off this one."
-	job_access_type = /datum/job/crew
-	color = "#b4cbd7"
-
-/obj/item/weapon/card/id/torch/stowaway/New()
-	..()
-	var/species = SPECIES_HUMAN
-	if(prob(10))
-		species = pick(SPECIES_SKRELL,SPECIES_IPC)
-	var/datum/species/S = all_species[species]
-	var/decl/cultural_info/culture/C = SSculture.get_culture(S.default_cultural_info[TAG_CULTURE])
-	var/gender = pick(MALE,FEMALE)
-	registered_name = C.get_random_name(gender)
-	sex = capitalize(gender)
-	age = rand(19,25)
-	fingerprint_hash = md5(registered_name)
-	dna_hash = md5(fingerprint_hash)
-	blood_type = RANDOM_BLOOD_TYPE

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -76,36 +76,3 @@ Civilian
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 	skill_points = 24
 	required_language = null
-
-/datum/job/stowaway
-	title = "Stowaway"
-	department = "Civilian"
-	department_flag = CIV
-	total_positions = 1
-	spawn_positions = 1
-	availablity_chance = 20
-	supervisors = "yourself"
-	ideal_character_age = 30
-	minimal_player_age = 0
-	create_record = 0
-	account_allowed = 0
-	outfit_type = /decl/hierarchy/outfit/job/torch/stowaway
-	allowed_branches = list(
-		/datum/mil_branch/civilian,
-		/datum/mil_branch/alien
-	)
-	allowed_ranks = list(
-		/datum/mil_rank/civ/civ,
-		/datum/mil_rank/alien
-	)
-	latejoin_at_spawnpoints = 1
-	announced = FALSE
-	required_language = null
-	is_semi_antagonist = TRUE
-	var/list/soft_antag_species = list(SPECIES_VOX, SPECIES_VOX_ARMALIS)
-
-/datum/job/stowaway/post_equip_rank(mob/person, alt_title)
-	var/mob/living/carbon/human/H = person
-	is_semi_antagonist = (istype(H) && (H.species.name in soft_antag_species))
-	..()
-	is_semi_antagonist = initial(is_semi_antagonist)

--- a/maps/torch/job/outfits/misc_outfits.dm
+++ b/maps/torch/job/outfits/misc_outfits.dm
@@ -32,19 +32,6 @@
 	pda_type = /obj/item/modular_computer/pda
 	id_type = /obj/item/weapon/card/id/torch/merchant
 
-/decl/hierarchy/outfit/job/torch/stowaway
-	name = OUTFIT_JOB_NAME("Stowaway - Torch")
-	id_type = null
-	pda_type = null
-	l_ear = null
-	l_pocket = /obj/item/weapon/wrench
-	r_pocket = /obj/item/weapon/crowbar
-
-/decl/hierarchy/outfit/job/torch/stowaway/post_equip(var/mob/living/carbon/human/H)
-	..()
-	var/obj/item/weapon/card/id/torch/stowaway/ID = new(H.loc)
-	H.put_in_hands(ID)
-
 /decl/hierarchy/outfit/job/torch/ert
 	name = OUTFIT_JOB_NAME("ERT - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -5,7 +5,7 @@
 										/datum/job/mining),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant, /datum/job/chemist,
 									 /datum/job/roboticist, /datum/job/biomech, /datum/job/cargo_tech, /datum/job/chef, /datum/job/engineer, /datum/job/doctor, /datum/job/bartender),
-		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/stowaway)
+		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder
@@ -29,7 +29,7 @@
 						/datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant,
 						/datum/job/ai, /datum/job/cyborg,
 						/datum/job/crew, /datum/job/assistant,
-						/datum/job/merchant, /datum/job/stowaway
+						/datum/job/merchant
 						)
 
 	access_modify_region = list(

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -1,16 +1,16 @@
 //The following is a list of defs to be used for the Torch loadout.
 
 //For jobs that allow for decorative or ceremonial clothing
-#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/bodyguard, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway, /datum/job/detective, /datum/job/chaplain)
+#define FORMAL_ROLES list(/datum/job/liaison, /datum/job/bodyguard, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/representative, /datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/detective, /datum/job/chaplain)
 
 //For civilian jobs that may have a uniform, but not a strict one
-#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/stowaway, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/detective, /datum/job/chaplain)
+#define SEMIFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/scientist, /datum/job/senior_scientist, /datum/job/detective, /datum/job/chaplain)
 
 //For civilian jobs that may have a strict uniform.
-#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/bodyguard, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative,/datum/job/stowaway, /datum/job/detective, /datum/job/chaplain)
+#define SEMIANDFORMAL_ROLES list(/datum/job/assistant,/datum/job/mining, /datum/job/scientist_assistant, /datum/job/psychiatrist, /datum/job/bartender, /datum/job/merchant, /datum/job/nt_pilot, /datum/job/liaison, /datum/job/bodyguard, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/representative, /datum/job/detective, /datum/job/chaplain)
 
 //For roles with no uniform or formal clothing requirements
-#define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant, /datum/job/stowaway)
+#define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant)
 
 //For members of the medical department
 #define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/medical_trainee, /datum/job/biomech)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -7174,9 +7174,6 @@
 "pN" = (
 /obj/structure/closet/crate/plastic,
 /obj/item/bodybag,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /turf/simulated/floor/tiled/white,
 /area/vacant/infirmary)
 "pO" = (
@@ -7235,9 +7232,6 @@
 /obj/random/torchcloset,
 /obj/random/maintenance,
 /obj/random/maintenance,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
 "pR" = (
@@ -10018,9 +10012,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "vK" = (
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "vL" = (

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -8718,9 +8718,6 @@
 	dir = 5
 	},
 /obj/random/torchcloset,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -19397,9 +19397,6 @@
 /area/maintenance/thirddeck/foreport)
 "UJ" = (
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/forestarboard)
 "UK" = (
@@ -20582,9 +20579,6 @@
 /area/crew_quarters/cryolocker)
 "XS" = (
 /obj/random/torchcloset,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
@@ -20646,9 +20640,6 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/mime,
 /obj/random/junk,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /turf/simulated/floor/carpet,
 /area/vacant/cabin)
 "Yb" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -14648,9 +14648,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -16465,9 +16462,6 @@
 /area/engineering/atmos)
 "Po" = (
 /obj/structure/closet/coffin,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /turf/simulated/floor/wood/walnut,
 /area/vacant/chapel)
 "Pq" = (
@@ -18196,9 +18190,6 @@
 /area/maintenance/seconddeck/central)
 "Wa" = (
 /obj/structure/closet/crate/freezer/rations,
-/obj/effect/landmark/start{
-	name = "Stowaway"
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/central)


### PR DESCRIPTION
- It is a role that exists to spark Security action, but isn't an antagonist. 
- It baits people into either being disruptive, or being peaceful and becoming a glorified passenger. 
- It was one of the only methods available to play Vox, but they now have an alternate method to be played.