### PR TITLE
Give CSO maint access

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -125,7 +125,7 @@
 		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_rd,
 		access_petrov_security, access_petrov_maint, access_pathfinder, access_explorer, access_eva, access_solgov_crew,
-		access_expedition_shuttle, access_expedition_shuttle_helm
+		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels
 	)
 	minimal_access = list()
 


### PR DESCRIPTION
:cl: WezYo
rscadd: CSO now has maint access
/:cl:

Fixes #26580

CSO has never had maint access but I'm not sure why - all of the other Chief Officers do (CMO/CE/CoS...) so feels like a long time coming? 
I didn't end up giving it Aquila access like the ticket requests because only the CO/XO/BO have access to that and I don't see a reason why CSO should get it.