### PR TITLE
Lets you smash inflatables with non-sharp items

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -86,7 +86,7 @@
 /obj/structure/inflatable/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(!istype(W) || istype(W, /obj/item/weapon/inflatable_dispenser)) return
 
-	if((W.damtype == BRUTE || W.damtype == BURN) && W.can_puncture())
+	if((W.damtype == BRUTE || W.damtype == BURN) && (W.can_puncture() || W.force > 10))
 		..()
 		if(hit(W.force))
 			visible_message("<span class='danger'>[user] pierces [src] with [W]!</span>")


### PR DESCRIPTION
:cl:
tweak: Blunt yet sufficiently strong weapons can now pop inflatables
/:cl:

Weapons with force over 10 will now damage it too (kill in one hit most likely)

Heard complaints of them being used as an instant barrier, this should let you break through them fairly easy with stuff you were planning on hit whoever you're chasing with.