### PR TITLE
Resisting will cancel resting

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -622,6 +622,8 @@ default behaviour is:
 	if(!incapacitated(INCAPACITATION_KNOCKOUT) && last_resist + 2 SECONDS <= world.time)
 		last_resist = world.time
 		resist_grab()
+		if(resting)
+			lay_down()
 		if(!weakened)
 			process_resist()
 


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Resisting will auto-cancel resting.
/:cl:

This lead to some situations, e.g. being cuffed on a medical bed, where you couldn't resist out of the cuffs and it didn't say why - Due to being in a resting state that you did not toggle on yourself. Leading to confusion and ahelps about why I couldn't resist.

So this just makes it so that resist calls lay_down() if you're resting already.