### PR TITLE
Low wall frames deconstruct into 3 steel sheets

### DIFF
--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -164,7 +164,7 @@
 		dismantle()
 
 /obj/structure/wall_frame/proc/dismantle()
-	new /obj/item/stack/material/steel(get_turf(src))
+	new /obj/item/stack/material/steel(get_turf(src), 3)
 	qdel(src)
 
 //Subtypes


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Low wall frames deconstruct into 3 steel sheets, which is the amount required to build them.
/:cl:

Fixes #26565 