### PR TITLE
Double sets of windoors on desks now have only the interior windoor

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -84,6 +84,20 @@
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/galley)
+"au" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	name = "Deck Chief"
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "do_office";
+	name = "DO Office Shutters"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/deckchief)
 "av" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -91,6 +105,59 @@
 "aw" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod7/station)
+"ax" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	name = "Supply Desk"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id_tag = "sup_office";
+	name = "Supply Desk Shutters"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/office)
+"ay" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 4;
+	name = "Security Checkpoint"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id_tag = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/hangcheck)
 "az" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/fourthdeck)
@@ -4471,25 +4538,6 @@
 	},
 /turf/simulated/open,
 /area/quartermaster/hangar/top)
-"oZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 8;
-	name = "Supply Desk"
-	},
-/obj/machinery/door/window/southleft{
-	autoset_access = 0;
-	dir = 4;
-	name = "Supply Desk"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id_tag = "sup_office";
-	name = "Supply Desk Shutters"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/office)
 "pc" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
@@ -13143,49 +13191,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"Rl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 4;
-	name = "Security Checkpoint"
-	},
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Security Checkpoint"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id_tag = "hangar_checkpoint_shutters";
-	name = "Hangar Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hangcheck)
 "Rm" = (
 /obj/structure/sign/warning/high_voltage{
 	icon_state = "shock";
@@ -16386,24 +16391,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
-"Zn" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	name = "Deck Chief"
-	},
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Deck Officer"
-	},
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id_tag = "do_office";
-	name = "DO Office Shutters"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/deckchief)
 "Zo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30776,7 +30763,7 @@ sB
 rj
 vC
 Nm
-Rl
+ay
 XQ
 OX
 OX
@@ -37649,7 +37636,7 @@ wa
 wa
 oP
 PX
-oZ
+ax
 vQ
 YS
 ZN
@@ -39662,7 +39649,7 @@ qy
 So
 SO
 WS
-Zn
+au
 xn
 zM
 Ad

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1668,6 +1668,26 @@
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
+"dE" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "hab_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Checkpoint Desk"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/habcheck)
 "dF" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -10111,29 +10131,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
-"vL" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "hab_checkpoint_shutters";
-	name = "Hangar Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Checkpoint Desk"
-	},
-/obj/machinery/door/window/westright{
-	name = "Checkpoint Desk"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/habcheck)
 "vM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35328,7 +35325,7 @@ sh
 tt
 uK
 xU
-vL
+dE
 up
 Vx
 LB

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1554,6 +1554,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/expedition)
+"cZ" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "engineering front desk"
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "engineeringdeskshutters";
+	name = "Engineering Desk Shutters";
+	opacity = 0
+	},
+/obj/item/weapon/material/bell,
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/engineering_monitoring)
 "da" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight,
@@ -14679,27 +14696,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
-"Jk" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/northright{
-	dir = 2;
-	name = "engineering front desk"
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "engineering front desk"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "engineeringdeskshutters";
-	name = "Engineering Desk Shutters";
-	opacity = 0
-	},
-/obj/item/weapon/material/bell,
-/turf/simulated/floor/tiled/monotile,
-/area/engineering/engineering_monitoring)
 "Jl" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 5;
@@ -39885,7 +39881,7 @@ hT
 kJ
 mR
 mu
-Jk
+cZ
 IK
 qC
 tA

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1390,9 +1390,22 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
 "acB" = (
-/obj/effect/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/assembly/robotics)
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Emergency Armory Desk"
+	},
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "acC" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1417,6 +1430,24 @@
 /obj/item/clothing/under/rank/roboticist/skirt,
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics)
+"acG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/material/bell,
+/obj/machinery/door/window/southright{
+	dir = 2;
+	name = "Fabricator Lab Desk"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/monotile,
+/area/rnd/development)
 "acH" = (
 /obj/structure/bed/chair/wheelchair,
 /obj/effect/decal/cleanable/cobweb,
@@ -14341,26 +14372,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
-"bsb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel_reinforced,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/window/brigdoor/westright{
-	name = "Emergency Armory Desk"
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Emergency Armory Desk"
-	},
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "bta" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 2;
@@ -20037,28 +20048,6 @@
 	pixel_z = 0
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/rnd/development)
-"hxb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/material/bell,
-/obj/machinery/door/window/northleft{
-	dir = 1;
-	name = "Fabricator Lab Desk"
-	},
-/obj/machinery/door/window/southright{
-	dir = 2;
-	name = "Fabricator Lab Desk"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/monotile,
 /area/rnd/development)
 "hyb" = (
 /obj/structure/disposalpipe/segment,
@@ -49582,7 +49571,7 @@ kvb
 ohy
 kNb
 kVb
-acB
+acE
 qGx
 ayg
 fnu
@@ -49986,7 +49975,7 @@ amA
 wtS
 kPb
 kXb
-acB
+acE
 axh
 ayi
 ghI
@@ -54636,7 +54625,7 @@ gXb
 axz
 ayy
 iXb
-hxb
+acG
 hKb
 ibb
 isb
@@ -59077,7 +59066,7 @@ atp
 aum
 aGN
 aGN
-bsb
+acB
 ayK
 jrH
 aAX


### PR DESCRIPTION
:cl: mikomyazaki
maptweak: Double sets of windoors now have only the interior windoor at department reception desks.
/:cl:

Was quite inconsistent, with half of them (XOs office, various sec checkpoints) only having one, but others having two. Made it difficult with access - You couldn't open the department windoor to get to the bell to ring for attention, since the outer windoors kept the department access.

They're kind of hard to get through. Having two isn't significantly more secure than having one, since they need an emag to get through. 

Also it was very annoying having to open both windoors and for someone else to place an item for you before the closing time delay elapsed.