### PR TITLE
Adds preference for playing the custom vote sound

### DIFF
--- a/code/datums/vote/vote.dm
+++ b/code/datums/vote/vote.dm
@@ -53,8 +53,11 @@
 	var/text = get_start_text()
 
 	log_vote(text)
+	for(var/mob/M in GLOB.player_list)
+		if(M.get_preference_value(/datum/client_preference/custom_vote_sound) == GLOB.PREF_YES)
+			sound_to(M, sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = GLOB.vote_sound_channel))
 	to_world("<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[SSvote];vote_panel=1'>here</a> to place your votes.\nYou have [config.vote_period/10] seconds to vote.</font>")
-	to_world(sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = GLOB.vote_sound_channel))
+
 
 /datum/vote/proc/get_start_text()
 	return "[capitalize(name)] vote started by [initiator]."

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -219,6 +219,10 @@ var/list/_client_preferences_by_type
 	key = "EXAMINE_MESSAGES"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/custom_vote_sound
+	description = "Play vote sound"
+	key = "CUSTOM_VOTE_SOUND"
+
 /********************
 * General Staff Preferences *
 ********************/


### PR DESCRIPTION
:cl: mikomyazaki
rscadd: Adds a preference for playing the custom vote WONKWONKWONK sound.
/:cl:

People like to spam votes that have no purpose, e.g. Is X a potato, 'yes', 'yes' - Which I don't like distracting me from stuff in the round.

This adds a preference to disable the very loud and annoying sound effect.