### PR TITLE
Ghost image and deletion tweaks.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -180,6 +180,7 @@
 #include "code\controllers\subsystems\event.dm"
 #include "code\controllers\subsystems\fluids.dm"
 #include "code\controllers\subsystems\garbage.dm"
+#include "code\controllers\subsystems\ghost_images.dm"
 #include "code\controllers\subsystems\goals.dm"
 #include "code\controllers\subsystems\inactivity.dm"
 #include "code\controllers\subsystems\jobs.dm"

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -26,6 +26,7 @@
 #define SS_PRIORITY_INACTIVITY     10	// Idle kicking.
 #define SS_PRIORITY_SUPPLY         10   // Supply point accumulation.
 #define SS_PRIORITY_TRADE          10   // Adds/removes traders.
+#define SS_PRIORITY_GHOST_IMAGES   10   // Updates ghost client images.
 
 // SS_BACKGROUND
 #define SS_PRIORITY_OBJECTS       100	// processing_objects processing.

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -73,6 +73,8 @@
 			return global.SSfluids;
 		if("SSgarbage")
 			return global.SSgarbage;
+		if("SSghost_images")
+			return global.SSghost_images;
 		if("SSgoals")
 			return global.SSgoals;
 		if("SSicon_update")
@@ -990,6 +992,8 @@
 			global.SSfluids=newval;
 		if("SSgarbage")
 			global.SSgarbage=newval;
+		if("SSghost_images")
+			global.SSghost_images=newval;
 		if("SSgoals")
 			global.SSgoals=newval;
 		if("SSicon_update")
@@ -1870,6 +1874,7 @@
 	"SSfastprocess",
 	"SSfluids",
 	"SSgarbage",
+	"SSghost_images",
 	"SSgoals",
 	"SSicon_update",
 	"SSinactivity",

--- a/code/controllers/subsystems/ghost_images.dm
+++ b/code/controllers/subsystems/ghost_images.dm
@@ -1,0 +1,34 @@
+SUBSYSTEM_DEF(ghost_images)
+	name = "Ghost Images"
+	flags = SS_NO_INIT
+	priority = SS_PRIORITY_GHOST_IMAGES
+	wait = 1
+	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	var/list/queue = list()
+	var/queue_all = FALSE
+
+/datum/controller/subsystem/ghost_images/stat_entry()
+	..("P:[queue.len]")
+
+/datum/controller/subsystem/ghost_images/fire(resumed = 0)
+	if(!resumed && queue_all)
+		queue = GLOB.ghost_mob_list.Copy()
+		queue_all = FALSE
+
+	var/list/curr = queue
+	while (curr.len)
+		var/mob/observer/ghost/target = curr[curr.len]
+		curr.len--
+
+		if(!QDELETED(target))
+			target.updateghostimages()
+
+		if(MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/ghost_images/proc/queue_image_update(mob/observer/ghost/ghost)
+	if(!queue_all)
+		queue |= ghost
+
+/datum/controller/subsystem/ghost_images/proc/queue_global_image_update()
+	queue_all = TRUE

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -150,6 +150,8 @@ Works together with spawning an observer, noted above.
 			ghost.verbs -= /mob/observer/ghost/verb/toggle_antagHUD	// Poor guys, don't know what they are missing!
 		return ghost
 
+/mob/observer/ghostize() // Do not create ghosts of ghosts.
+
 /*
 This is the proc mobs get to turn into a ghost. Forked from ghostize due to compatibility issues.
 */
@@ -493,7 +495,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		set_see_invisible(SEE_INVISIBLE_NOLIGHTING)
 	else
 		set_see_invisible(ghostvision ? SEE_INVISIBLE_OBSERVER : SEE_INVISIBLE_LIVING)
-	updateghostimages()
+	SSghost_images.queue_image_update(src)
 
 /mob/observer/ghost/proc/updateghostimages()
 	if (!client)

--- a/code/modules/mob/observer/ghost/login.dm
+++ b/code/modules/mob/observer/ghost/login.dm
@@ -4,5 +4,5 @@
 	if (ghost_image)
 		ghost_image.appearance = src
 		ghost_image.appearance_flags = RESET_ALPHA
-	updateghostimages()
+	SSghost_images.queue_image_update(src)
 	change_light_colour(DARKTINT_GOOD)

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -27,7 +27,7 @@ var/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 		ghost_darkness_images |= ghost_image //so ghosts can see the eye when they disable darkness
 	if(ghost_image_flag & GHOST_IMAGE_SIGHTLESS)
 		ghost_sightless_images |= ghost_image //so ghosts can see the eye when they disable ghost sight
-	updateallghostimages()
+	SSghost_images.queue_global_image_update()
 
 /mob/observer/Destroy()
 	if (ghost_image)
@@ -35,7 +35,7 @@ var/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 		ghost_sightless_images -= ghost_image
 		qdel(ghost_image)
 		ghost_image = null
-		updateallghostimages()
+		SSghost_images.queue_global_image_update()
 	. = ..()
 
 mob/observer/check_airflow_movable()
@@ -58,10 +58,6 @@ mob/observer/check_airflow_movable()
 
 /mob/observer/set_stat()
 	stat = DEAD // They are also always dead
-
-/proc/updateallghostimages()
-	for (var/mob/observer/ghost/O in GLOB.player_list)
-		O.updateghostimages()
 
 /mob/observer/touch_map_edge()
 	if(z in GLOB.using_map.sealed_levels)

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -228,7 +228,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '21e5c211195f8b113088cfd822887e21 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< 'd2c5f1941c7c73c401882701228b3bbf *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
- Offloads ghost image updates to a SS to make sure they run in linear time and check tick.
- Prevents deleting ghost mobs from ghosting the ghost. Ghostception is confusing for admins dealing with grief and for everyone fixing bugs.

The server has some failure state where the ghost image update proc in question is run repeatedly and occupies the entirety of its processing power. I'm not sure how this happens (or whether it's an exploit; the relevant verb can be triggered by various client actions), so this is a kind of brute force solution. It will mean some minor latency to image updates on pref toggle or ghost join, which is likely insignificant.