### PR TITLE
Kills unapologetic meme names

### DIFF
--- a/config/names/last.txt
+++ b/config/names/last.txt
@@ -502,7 +502,6 @@ Stamos
 Sagan
 Hawking
 Dawkins
-Goebbles
 McShain
 McDonohugh
 Power

--- a/config/names/last.txt
+++ b/config/names/last.txt
@@ -491,13 +491,6 @@ Blyant
 Rhinehart
 Prescott
 Kirkson
-Picard
-Riker
-Spock
-Skywalker
-Vader
-Muggins
-Buttersworth
 Stamos
 Sagan
 Hawking


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

Goebbles -- presumably a misspelled "Goebbels" -- is the sort of name that might get people in trouble. And by might be, I mean... I may have done exactly this.

It's also placed at the end of the meme names ("Skywalker," "Riker," "Picard," etc) which implies it's meant to be a reference to something.

I think it's not a great thing, tbh!