### PR TITLE
Field Generator safe at 3 tiles rather than 201.

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -52,7 +52,7 @@
 		user.electrocute_act(shock_damage, src)
 
 		var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
-		user.throw_at(target, 200, 4)
+		user.throw_at(target, 2, 4)
 
 		sleep(20)
 


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Field generators activating their containment field now push you back with a range of 2 rather than 200, which was impossible to survive.
/:cl:

Fixes #26614 