### PR TITLE
critical and noncritical fixes for deck 3 sauna-lavatory space

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -325,3 +325,9 @@
 		to_chat(user, "You are too far away to read the gauge.")
 	if(welded)
 		to_chat(user, "It seems welded shut.")
+
+
+
+/obj/machinery/atmospherics/unary/vent_scrubber/on/sauna/Initialize()
+	. = ..()
+	scrubbing_gas -= GAS_STEAM

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -4406,10 +4406,21 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_eva)
 "iF" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
+/obj/item/weapon/reagent_containers/food/drinks/cans/ale,
+/obj/item/weapon/reagent_containers/food/drinks/cans/ale,
+/obj/item/weapon/reagent_containers/food/drinks/cans/ale,
+/obj/item/weapon/reagent_containers/food/drinks/cans/artbru,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 /obj/machinery/firealarm{
 	pixel_y = 21
 	},
-/obj/item/weapon/stool/wood,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)
 "iG" = (
@@ -4755,7 +4766,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/item/weapon/stool/wood,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)
 "jm" = (
@@ -5273,9 +5283,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/holocontrol)
 "ke" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1;
-	frequency = 1438
+/obj/machinery/atmospherics/unary/vent_scrubber/on/sauna{
+	icon_state = "map_scrubber_on";
+	dir = 1
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)
@@ -5390,21 +5400,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/thirddeck)
 "kt" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
-/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
-/obj/item/weapon/reagent_containers/food/drinks/cans/speer,
-/obj/item/weapon/reagent_containers/food/drinks/cans/ale,
-/obj/item/weapon/reagent_containers/food/drinks/cans/ale,
-/obj/item/weapon/reagent_containers/food/drinks/cans/ale,
-/obj/item/weapon/reagent_containers/food/drinks/cans/artbru,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 4;
+	external_pressure_bound = 202;
+	external_pressure_bound_default = 202
 	},
+/obj/machinery/space_heater,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)
 "ku" = (
@@ -5566,10 +5567,13 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	in_use = 0
 	},
 /obj/item/weapon/reagent_containers/glass/bucket/wood,
-/obj/item/weapon/stool/wood,
+/obj/structure/hygiene/sink{
+	pixel_z = -14
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)
 "kN" = (
@@ -7226,10 +7230,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ai_monitored/storage/eva)
-"oK" = (
-/obj/structure/sign/poster,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/head)
 "oL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19109,6 +19109,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/office)
+"TZ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/flashlight/lamp/lava/red{
+	pixel_z = 14
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/head)
 "Ub" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40323,7 +40332,7 @@ vY
 eE
 YK
 gK
-LL
+TZ
 hL
 iF
 jO
@@ -40523,7 +40532,7 @@ dB
 uU
 uU
 fz
-oK
+YK
 gK
 LL
 hP


### PR DESCRIPTION
removes superflous poster from the floor - I feel one poster on the wall just gives the place that little carefree'ness of a public bathroom space.

replaces the scrubber in sauna chamber with one that ignores gas_steam, meaning it can be filled with steam as intended. (In conjunction with discovering the input vent refused to input into the chamber see below)

additionally it also adjusts the output vent of the subliminator hookup to allow it to output steam at a slightly higher than normal room pressure, meaning steam goes into the sauna.

no idea how to make the atmos alarm stop shrieking about all this DEADLY STEAM in the room, but that's for a later PR I suppose.

finally: rearranges some furniture and adds a lava lamp and a space heater to the sauna chamber, because the lizerbs are gonna drag one in there anyway. May as well pre-empt them.
Also added a water sink in there for the sublimator because doors.