### PR TITLE
Fixes #26562 - airlock bolt door buttons

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -157,6 +157,7 @@
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/button/airlock_bolt)
 
 /decl/stock_part_preset/radio/basic_transmitter/button/airlock_bolt
+	frequency = AIRLOCK_FREQ
 	transmit_on_change = list("toggle_bolts" = /decl/public_access/public_variable/button_active)
 
 // Valve control


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Airlock bolt buttons (e.g. SMES room and engine hatch doors) will now work.
/:cl:

Frequency wasn't set right so it was 1301 not 1305.

Fixes #26562 