### PR TITLE
Macroizes escape pods

### DIFF
--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -3,179 +3,52 @@
 	category = /datum/shuttle/autodock/ferry/escape_pod/torchpod
 	sound_takeoff = 'sound/effects/rocket.ogg'
 	sound_landing = 'sound/effects/rocket_backwards.ogg'
-	var/number
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/New()
-	name = "Escape Pod [number]"
-	dock_target = "escape_pod_[number]"
-	arming_controller = "escape_pod_[number]_berth"
-	waypoint_station = "escape_pod_[number]_start"
-	landmark_transition = "escape_pod_[number]_internim"
-	waypoint_offsite = "escape_pod_[number]_out"
-	..()
-
-/obj/effect/shuttle_landmark/escape_pod/
-	var/number
+	warmup_time = 10
 
 /obj/effect/shuttle_landmark/escape_pod/start
 	name = "Docked"
-
-/obj/effect/shuttle_landmark/escape_pod/start/New()
-	landmark_tag = "escape_pod_[number]_start"
-	docking_controller = "escape_pod_[number]_berth"
-	..()
+	base_turf = /turf/simulated/floor/reinforced/airless
 
 /obj/effect/shuttle_landmark/escape_pod/transit
 	name = "In transit"
 
-/obj/effect/shuttle_landmark/escape_pod/transit/New()
-	landmark_tag = "escape_pod_[number]_internim"
-	..()
-
 /obj/effect/shuttle_landmark/escape_pod/out
 	name = "Escaped"
 
-/obj/effect/shuttle_landmark/escape_pod/out/New()
-	landmark_tag = "escape_pod_[number]_out"
-	..()
-
 //Pods
+#define TORCH_ESCAPE_POD(NUMBER) \
+/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod##NUMBER { \
+	shuttle_area = /area/shuttle/escape_pod##NUMBER/station; \
+	name = "Escape Pod " + #NUMBER; \
+	dock_target = "escape_pod_" + #NUMBER; \
+	arming_controller = "escape_pod_"+ #NUMBER +"_berth"; \
+	waypoint_station = "escape_pod_"+ #NUMBER +"_start"; \
+	landmark_transition = "escape_pod_"+ #NUMBER +"_internim"; \
+	waypoint_offsite = "escape_pod_"+ #NUMBER +"_out"; \
+} \
+/obj/effect/shuttle_landmark/escape_pod/start/pod##NUMBER { \
+	landmark_tag = "escape_pod_"+ #NUMBER +"_start"; \
+	docking_controller = "escape_pod_"+ #NUMBER +"_berth"; \
+} \
+/obj/effect/shuttle_landmark/escape_pod/out/pod##NUMBER { \
+	landmark_tag = "escape_pod_"+ #NUMBER +"_internim"; \
+} \
+/obj/effect/shuttle_landmark/escape_pod/transit/pod##NUMBER { \
+	landmark_tag = "escape_pod_"+ #NUMBER +"_out"; \
+}
 
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod6
-	warmup_time = 10
-	shuttle_area = /area/shuttle/escape_pod6/station
-	number = 6
-/obj/effect/shuttle_landmark/escape_pod/start/pod6
-	number = 6
-/obj/effect/shuttle_landmark/escape_pod/out/pod6
-	number = 6
-/obj/effect/shuttle_landmark/escape_pod/transit/pod6
-	number = 6
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod7
-	warmup_time = 10
-	shuttle_area = /area/shuttle/escape_pod7/station
-	number = 7
-/obj/effect/shuttle_landmark/escape_pod/start/pod7
-	number = 7
-/obj/effect/shuttle_landmark/escape_pod/out/pod7
-	number = 7
-/obj/effect/shuttle_landmark/escape_pod/transit/pod7
-	number = 7
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod8
-	warmup_time = 10
-	shuttle_area = /area/shuttle/escape_pod8/station
-	number = 8
-/obj/effect/shuttle_landmark/escape_pod/start/pod8
-	number = 8
-/obj/effect/shuttle_landmark/escape_pod/out/pod8
-	number = 8
-/obj/effect/shuttle_landmark/escape_pod/transit/pod8
-	number = 8
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod9
-	warmup_time = 10
-	shuttle_area = /area/shuttle/escape_pod9/station
-	number = 9
-/obj/effect/shuttle_landmark/escape_pod/start/pod9
-	number = 9
-/obj/effect/shuttle_landmark/escape_pod/out/pod9
-	number = 9
-/obj/effect/shuttle_landmark/escape_pod/transit/pod9
-	number = 9
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod10
-	warmup_time = 10
-	shuttle_area = /area/shuttle/escape_pod10/station
-	number = 10
-/obj/effect/shuttle_landmark/escape_pod/start/pod10
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 10
-/obj/effect/shuttle_landmark/escape_pod/out/pod10
-	number = 10
-/obj/effect/shuttle_landmark/escape_pod/transit/pod10
-	number = 10
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod11
-	warmup_time = 10
-	shuttle_area = /area/shuttle/escape_pod11/station
-	number = 11
-/obj/effect/shuttle_landmark/escape_pod/start/pod11
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 11
-/obj/effect/shuttle_landmark/escape_pod/out/pod11
-	number = 11
-/obj/effect/shuttle_landmark/escape_pod/transit/pod11
-	number = 11
-
-//Smoll pods
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod12
-	shuttle_area = /area/shuttle/escape_pod12/station
-	number = 12
-/obj/effect/shuttle_landmark/escape_pod/start/pod12
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 12
-/obj/effect/shuttle_landmark/escape_pod/out/pod12
-	number = 12
-/obj/effect/shuttle_landmark/escape_pod/transit/pod12
-	number = 12
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod13
-	shuttle_area = /area/shuttle/escape_pod13/station
-	number = 13
-/obj/effect/shuttle_landmark/escape_pod/start/pod13
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 13
-/obj/effect/shuttle_landmark/escape_pod/out/pod13
-	number = 13
-/obj/effect/shuttle_landmark/escape_pod/transit/pod13
-	number = 13
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod14
-	shuttle_area = /area/shuttle/escape_pod14/station
-	number = 14
-/obj/effect/shuttle_landmark/escape_pod/start/pod14
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 14
-/obj/effect/shuttle_landmark/escape_pod/out/pod14
-	number = 14
-/obj/effect/shuttle_landmark/escape_pod/transit/pod14
-	number = 14
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod15
-	shuttle_area = /area/shuttle/escape_pod15/station
-	number = 15
-/obj/effect/shuttle_landmark/escape_pod/start/pod15
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 15
-/obj/effect/shuttle_landmark/escape_pod/out/pod15
-	number = 15
-/obj/effect/shuttle_landmark/escape_pod/transit/pod15
-	number = 15
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod116
-	shuttle_area = /area/shuttle/escape_pod16/station
-	number = 16
-/obj/effect/shuttle_landmark/escape_pod/start/pod16
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 16
-/obj/effect/shuttle_landmark/escape_pod/out/pod16
-	number = 16
-/obj/effect/shuttle_landmark/escape_pod/transit/pod16
-	number = 16
-
-/datum/shuttle/autodock/ferry/escape_pod/torchpod/escape_pod17
-	shuttle_area = /area/shuttle/escape_pod17/station
-	number = 17
-/obj/effect/shuttle_landmark/escape_pod/start/pod17
-	base_turf = /turf/simulated/floor/reinforced/airless
-	number = 17
-/obj/effect/shuttle_landmark/escape_pod/out/pod17
-	number = 17
-/obj/effect/shuttle_landmark/escape_pod/transit/pod17
-	number = 17
+TORCH_ESCAPE_POD(6)
+TORCH_ESCAPE_POD(7)
+TORCH_ESCAPE_POD(8)
+TORCH_ESCAPE_POD(9)
+TORCH_ESCAPE_POD(10)
+TORCH_ESCAPE_POD(11)
+TORCH_ESCAPE_POD(12)
+TORCH_ESCAPE_POD(13)
+TORCH_ESCAPE_POD(14)
+TORCH_ESCAPE_POD(15)
+TORCH_ESCAPE_POD(16)
+TORCH_ESCAPE_POD(17)
 
 //Petrov
 


### PR DESCRIPTION
Hides some copypaste under macro. Mostly opening to see if it passes unit tests.
Would be even better if it's possible to put macro args inside strings in definitions.