### PR TITLE
Caps medtechs at Trained Anatomy

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -75,7 +75,6 @@
 	                    SKILL_ANATOMY = SKILL_BASIC)
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
-	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX,
 	                    SKILL_VIROLOGY    = SKILL_MAX)
 


### PR DESCRIPTION
Playing whackamole with cost adjustments gets tiring.
There's no legit uses corpsmen need more than Trained anatomy for (or even Basic tbh).
Only place it's used in is CPR, for speed of it, and for effectiveness highest of Anatomy and Medicine is used, so they can just take high Medicine skill if they want to be turbopumpers.
Heck even Expert level of Anatomy desc says 'you're a surgeon etc'

:cl: Chinsky
tweak: Medical Technicians can no longer have Anatomy skill at Experienced or higher.
/:cl: