### PR TITLE
Buffed EVA Supply

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -6080,6 +6080,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ai_monitored/storage/eva)
 "mb" = (
@@ -6102,6 +6105,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
+/obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled/dark/monotile,


### PR DESCRIPTION
🆑 
tweak: Due to the space related mortality rate of our recent expedition, the EXO has increased funding to restock EVA equipment. There are now 5 jetpacks and 3 cooling units in EVA on deck 3.
/🆑 