### PR TITLE
Added cooldown to the electron reservoir

### DIFF
--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -6,6 +6,7 @@
 	anchored = TRUE
 	density = TRUE
 	opacity = FALSE
+	var/next_use
 
 /obj/structure/adherent_pylon/attack_ai(var/mob/living/user)
 	if(Adjacent(user))
@@ -15,6 +16,8 @@
 	charge_user(user)
 
 /obj/structure/adherent_pylon/proc/charge_user(var/mob/living/user)
+	if(next_use > world.time) return
+	next_use = world.time + 10
 	var/mob/living/carbon/human/H = user
 	var/obj/item/weapon/cell/power_cell
 	if(ishuman(user))


### PR DESCRIPTION
Does what it says on the tin
Why? to prevent adherent from ramming into the plyon 20 times a second and making a bunch of noise and text