### PR TITLE
Fixes Vat-Grown Naming

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -156,4 +156,5 @@
 	. = 1 // Never executed, works around http://www.byond.com/forum/?post=2072419
 	#undef LTR
 	#undef NUM
+	#undef FIRST
 	#undef NAME

--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -146,11 +146,12 @@
 	// #defines so it's easier to read what's actually being generated
 	#define LTR ascii2text(rand(65,90)) // A-Z
 	#define NUM ascii2text(rand(48,57)) // 0-9
-	#define NAME capitalize(pick(gender == FEMALE ? GLOB.first_names_female : GLOB.first_names_male))
+	#define FIRST capitalize(pick(gender == FEMALE ? GLOB.first_names_female : GLOB.first_names_male))
+	#define NAME capitalize(pick(gender == FEMALE ? GLOB.first_names_female : GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
 	switch(rand(1,4))
 		if(1) return NAME
-		if(2) return "[LTR][LTR]-[NAME]"
-		if(3) return "[NAME]-[NUM][NUM][NUM]"
+		if(2) return "[LTR][LTR]-[FIRST]"
+		if(3) return "[FIRST]-[NUM][NUM][NUM]"
 		if(4) return "[LTR][LTR]-[NUM][NUM][NUM]"
 	. = 1 // Never executed, works around http://www.byond.com/forum/?post=2072419
 	#undef LTR


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
I fixed this thing. Vat-Growns will no longer spawn with just a first name. Existing naming schemes work as before.

Fixes #24938