### PR TITLE
Can't reset techs you didn't have to gain them + Removes TECH_ARCANE

### DIFF
--- a/code/__defines/research.dm
+++ b/code/__defines/research.dm
@@ -10,7 +10,6 @@
 #define TECH_MAGNET "magnets"
 #define TECH_DATA "programming"
 #define TECH_ILLEGAL "syndicate"
-#define TECH_ARCANE "arcane"
 
 #define IMPRINTER	0x1	//For circuits. Uses glass/chemicals.
 #define PROTOLATHE	0x2	//New stuff. Uses glass/metal/chemicals

--- a/code/game/objects/items/weapons/implants/implants/translator.dm
+++ b/code/game/objects/items/weapons/implants/implants/translator.dm
@@ -44,6 +44,6 @@
 	name = "lingophagic node"
 	desc = "A chunk of what could be discolored crystalized brain matter. It seems to pulse occasionally."
 	icon_state = "implant_melted"
-	origin_tech = list(TECH_BIO = 5, TECH_ARCANE = 2)
+	origin_tech = list(TECH_BIO = 5)
 	learning_threshold = 10
 	max_languages = 3

--- a/code/modules/research/part_replacer.dm
+++ b/code/modules/research/part_replacer.dm
@@ -18,4 +18,4 @@
 	desc = "Instant research tool. For testing purposes only."
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "smes_coil"
-	origin_tech = list(TECH_MATERIAL = 19, TECH_ENGINEERING = 19, TECH_PHORON = 19, TECH_POWER = 19, TECH_BLUESPACE = 19, TECH_BIO = 19, TECH_COMBAT = 19, TECH_MAGNET = 19, TECH_DATA = 19, TECH_ILLEGAL = 19, TECH_ARCANE = 19)
+	origin_tech = list(TECH_MATERIAL = 19, TECH_ENGINEERING = 19, TECH_PHORON = 19, TECH_POWER = 19, TECH_BLUESPACE = 19, TECH_BIO = 19, TECH_COMBAT = 19, TECH_MAGNET = 19, TECH_DATA = 19, TECH_ILLEGAL = 19)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -197,12 +197,6 @@ research holder datum.
 	id = TECH_ILLEGAL
 	level = 0
 
-/datum/tech/arcane
-	name = "Arcane"
-	desc = "Techniques not explained by the mainstream science, commonly regarded as 'occult'."
-	id = TECH_ARCANE
-	level = 0
-
 /obj/item/weapon/disk/tech_disk
 	name = "fabricator data disk"
 	desc = "A disk for storing fabricator learning data for backup."

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -174,10 +174,10 @@
 		. = TOPIC_REFRESH
 
 	else if(href_list["reset_tech"])
-		var/choice = alert(user, "Technology Data Rest", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
+		var/choice = alert(user, "Technology Data Reset", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue" && CanUseTopic(user, state))
 			for(var/datum/tech/T in temp_server.files.known_tech)
-				if(T.id == href_list["reset_tech"])
+				if(T.level > 0 && T.id == href_list["reset_tech"])
 					T.level = 1
 					break
 		temp_server.files.RefreshResearch()


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Resetting a tech you have no levels in at the RnD Server will no longer give you 1 in that tech.
rscdel: Removes Arcane Tech, as it did nothing.
/:cl:

Tidies up RnD code by removing Arcane Tech, which had no purpose and doesn't fit the setting.

Also fixes #26668 (resetting TECH_ILLEGAL gave you 1 in tech illegal even if you had 0 before)