### PR TITLE
Traitor Robots can permanently sever their external camera + robot console connection

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -76,6 +76,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 			var/mob/living/silicon/robot/R = traitor_mob
 			R.SetLockdown(0)
 			R.emagged = 1 // Provides a traitor robot with its module's emag item
+			R.verbs |= /mob/living/silicon/robot/proc/ResetSecurityCodes
 		return 1
 
 	if(!..())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -929,7 +929,7 @@
 /mob/living/silicon/robot/proc/ResetSecurityCodes()
 	set category = "Silicon Commands"
 	set name = "Reset Identity Codes"
-	set desc = "Scrambles your security and identification codes and resets your current buffers.  Unlocks you and but permenantly severs you from your AI and the robotics console and will deactivate your camera system."
+	set desc = "Scrambles your security and identification codes and resets your current buffers. Unlocks you and but permanently severs you from your AI and the robotics console and will deactivate your camera system."
 
 	var/mob/living/silicon/robot/R = src
 


### PR DESCRIPTION
:cl: mikomyazaki
rscadd: Traitor Robots will get a verb 'Reset Identity Codes' that will remove their external camera connection, robot console connection and lawsync status.
/:cl:

Traitor robots can't run - They're too slow - And they can't hide, as they have an always-on camera connection that can only be severed by blinding yourself (toggle camera component).

This really limits what robot traitors can do to either stealthy sabotage or get flashed and destroyed immediately after doing anything obviously antagonistic.

This change makes them as untrackable as any other traitor -- At the cost of revealing their nature. 

The verb already existed here: (it was just unused. Works properly.)
https://github.com/Baystation12/Baystation12/blob/bda1cc4bc5a96c15d453d20a57250d6d972a1227/code/modules/mob/living/silicon/robot/robot.dm#L929-L939