### PR TITLE
Lowered Shield power usage

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -3,7 +3,7 @@
 #define SHIELD_DAMTYPE_HEAT 3		// Heat damage - Lasers, fire
 
 #define ENERGY_PER_HP (50 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
-#define ENERGY_UPKEEP_PER_TILE (10 KILOWATTS)	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
+#define ENERGY_UPKEEP_PER_TILE (6 KILOWATTS)	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
 #define ENERGY_UPKEEP_IDLE 50                  // Base upkeep when idle; modified by other factors.
 
 // This shield model is slightly inspired by Sins of a Solar Empire series. In short, shields are designed to analyze what hits them, and adapt themselves against that type of damage.


### PR DESCRIPTION
Decreased Shield Power usage.
Previously it seemed to me that the shields aren't used at all anymore since even after an hour of charging it doesn't hold much longer than a Minute. 
With this value running the shields will still drain them rather fast but not too fast. 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: reduced shield power usage
/:cl:
