### PR TITLE
Fixed misused sqllogging. Closes #26427

### DIFF
--- a/code/_global_vars/sensitive.dm
+++ b/code/_global_vars/sensitive.dm
@@ -1,4 +1,6 @@
 // MySQL configuration
+GLOBAL_REAL_VAR(sqlenabled)   = FALSE
+
 GLOBAL_REAL_VAR(sqladdress)   = "localhost"
 GLOBAL_REAL_VAR(sqlport)      = "3306"
 GLOBAL_REAL_VAR(sqldb)        = "tgstation"
@@ -9,4 +11,3 @@ GLOBAL_REAL_VAR(sqlpass)      = ""
 GLOBAL_REAL_VAR(sqlfdbkdb)    = "test"
 GLOBAL_REAL_VAR(sqlfdbklogin) = "root"
 GLOBAL_REAL_VAR(sqlfdbkpass)  = ""
-GLOBAL_REAL_VAR(sqllogging)   = 0 // Should we log deaths, population stats, etc.?

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -785,14 +785,14 @@
 			return global.sqladdress;
 		if("sqldb")
 			return global.sqldb;
+		if("sqlenabled")
+			return global.sqlenabled;
 		if("sqlfdbkdb")
 			return global.sqlfdbkdb;
 		if("sqlfdbklogin")
 			return global.sqlfdbklogin;
 		if("sqlfdbkpass")
 			return global.sqlfdbkpass;
-		if("sqllogging")
-			return global.sqllogging;
 		if("sqllogin")
 			return global.sqllogin;
 		if("sqlpass")
@@ -1704,14 +1704,14 @@
 			global.sqladdress=newval;
 		if("sqldb")
 			global.sqldb=newval;
+		if("sqlenabled")
+			global.sqlenabled=newval;
 		if("sqlfdbkdb")
 			global.sqlfdbkdb=newval;
 		if("sqlfdbklogin")
 			global.sqlfdbklogin=newval;
 		if("sqlfdbkpass")
 			global.sqlfdbkpass=newval;
-		if("sqllogging")
-			global.sqllogging=newval;
 		if("sqllogin")
 			global.sqllogin=newval;
 		if("sqlpass")
@@ -2230,10 +2230,10 @@
 	"splatter_cache",
 	"sqladdress",
 	"sqldb",
+	"sqlenabled",
 	"sqlfdbkdb",
 	"sqlfdbklogin",
 	"sqlfdbkpass",
-	"sqllogging",
 	"sqllogin",
 	"sqlpass",
 	"sqlport",

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -20,7 +20,6 @@ var/list/gamemode_cache = list()
 	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
 	var/log_runtime = 0					// logs world.log to a file
 	var/log_world_output = 0			// log world.log << messages
-	var/sql_enabled = 1					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/ert_admin_call_only = 0
@@ -301,9 +300,6 @@ var/list/gamemode_cache = list()
 				if ("log_access")
 					config.log_access = 1
 
-				if ("sql_enabled")
-					config.sql_enabled = text2num(value)
-
 				if ("log_say")
 					config.log_say = 1
 
@@ -345,7 +341,7 @@ var/list/gamemode_cache = list()
 
 				if ("log_hrefs")
 					config.log_hrefs = 1
-				
+
 				if ("log_runtime")
 					config.log_runtime = 1
 
@@ -610,7 +606,7 @@ var/list/gamemode_cache = list()
 
 				if("forbidden_versions")
 					config.forbidden_versions = splittext(value, ";")
-				
+
 				if("minimum_byond_version")
 					config.minimum_byond_version = text2num(value)
 
@@ -848,6 +844,8 @@ var/list/gamemode_cache = list()
 			continue
 
 		switch (name)
+			if ("enabled")
+				sqlenabled = TRUE
 			if ("address")
 				sqladdress = value
 			if ("port")
@@ -864,8 +862,6 @@ var/list/gamemode_cache = list()
 				sqlfdbklogin = value
 			if ("feedback_password")
 				sqlfdbkpass = value
-			if ("enable_stat_tracking")
-				sqllogging = 1
 			else
 				log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/procs/dbcore.dm
+++ b/code/procs/dbcore.dm
@@ -56,9 +56,10 @@ DBConnection/New(dbi_handler,username,password_handler,cursor_handler)
 	_db_con = _dm_db_new_con()
 
 DBConnection/proc/Connect(dbi_handler=src.dbi,user_handler=src.user,password_handler=src.password,cursor_handler)
-	if(!sqllogging)
-		return 0
-	if(!src) return 0
+	if(!sqlenabled)
+		return FALSE
+	if(!src)
+		return FALSE
 	cursor_handler = src.default_cursor
 	if(!cursor_handler) cursor_handler = Default_Cursor
 	return _dm_db_connect(_db_con,dbi_handler,user_handler,password_handler,cursor_handler,null)
@@ -66,7 +67,8 @@ DBConnection/proc/Connect(dbi_handler=src.dbi,user_handler=src.user,password_han
 DBConnection/proc/Disconnect() return _dm_db_close(_db_con)
 
 DBConnection/proc/IsConnected()
-	if(!sqllogging) return 0
+	if(!sqlenabled)
+		return FALSE
 	var/success = _dm_db_is_connected(_db_con)
 	return success
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -72,9 +72,6 @@ LOG_PDA
 ## log admin warning messages
 ##LOG_ADMINWARN  ## Also duplicates a bunch of other messages.
 
-## sql switching
-# SQL_ENABLED
-
 ## disconnect players who did nothing during the set amount of minutes
 # KICK_INACTIVE 10
 
@@ -165,7 +162,6 @@ ANTAG_HUD_RESTRICTED
 
 ## allow AI job
 ALLOW_AI
-
 
 ## disable abandon mob
 # NORESPAWN

--- a/config/example/dbconfig.txt
+++ b/config/example/dbconfig.txt
@@ -1,5 +1,8 @@
 # MySQL Connection Configuration
 
+# First of all, should SQL be used at all. Unhash next line, if yes
+# ENABLED
+
 # Server the MySQL database can be found at
 # Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.
 ADDRESS localhost
@@ -20,7 +23,3 @@ PASSWORD mypassword
 FEEDBACK_DATABASE test
 FEEDBACK_LOGIN mylogin
 FEEDBACK_PASSWORD mypassword
-
-# Track population and death statistics
-# Comment this out to disable
-#ENABLE_STAT_TRACKING

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -228,7 +228,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< 'd2c5f1941c7c73c401882701228b3bbf *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '63275db99f28e357b00a779560736699 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Hey, guys!

You have `sqllogging`, which usage was misplaced. This PR fixes that, and it turns out, that `sqllogging` is actually never used at all.

IDK, how do I properly generate global vars file, or fix MD5 in run_test.sh, but I did 
```
python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm
```
and then just copied MD5 to run_test.sh

Closes #26427