### PR TITLE
Fixes #26673 - Airlock access buttons needing power

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -240,6 +240,7 @@
 	var/datum/radio_frequency/radio_connection
 
 	var/on = 1
+	interact_offline = TRUE
 
 
 /obj/machinery/access_button/on_update_icon()


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Airlock access buttons will now work even if the area they are in has no power.
/:cl:

They have an idle and active power use of 0, so this has no effect on the power consumed. They'll just work even if their area is unpowered (e.g. they're in space where they usually are)

Fixes #26673 