### PR TITLE
Drill head requires trained construction to create

### DIFF
--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -269,4 +269,4 @@
 	result_type = /obj/item/weapon/material/drill_head
 	req_amount = 3
 	send_material_data = 1
-	difficulty = 0
+	difficulty = 3


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Drill Heads now require trained construction rather than no construction to create.
/:cl:

Fixes #26681 