### PR TITLE
More FBP species mods fixes

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -81,7 +81,7 @@
 				continue
 			if(ishuman(O))
 				var/mob/living/carbon/human/H = O
-				flash_time = round(H.species.flash_mod * flash_time)
+				flash_time = round(H.getFlashMod() * flash_time)
 				if(flash_time <= 0)
 					return
 				var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[H.species.vision_organ]

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -74,7 +74,7 @@
 			if(safety < FLASH_PROTECTION_MODERATE)
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
-					flash_strength = round(H.species.flash_mod * flash_strength)
+					flash_strength = round(H.getFlashMod() * flash_strength)
 				if(flash_strength > 0)
 					M.flash_eyes(FLASH_PROTECTION_MODERATE - safety)
 					M.Stun(flash_strength / 2)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -557,6 +557,9 @@
 			I.additional_flash_effects(intensity)
 	return ..()
 
+/mob/living/carbon/human/proc/getFlashMod()
+	return (BP_IS_ROBOTIC(internal_organs_by_name[BP_EYES]) ? 1 : species.flash_mod)
+
 //Used by various things that knock people out by applying blunt trauma to the head.
 //Checks that the species has a "head" (brain containing organ) and that hit_zone refers to it.
 /mob/living/carbon/human/proc/headcheck(var/target_zone, var/brain_tag = BP_BRAIN)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -558,7 +558,25 @@
 	return ..()
 
 /mob/living/carbon/human/proc/getFlashMod()
-	return (BP_IS_ROBOTIC(internal_organs_by_name[BP_EYES]) ? 1 : species.flash_mod)
+	if(species.vision_organ)
+		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		if(!istype(I))
+			return I.flash_mod
+	return species.flash_mod
+
+/mob/living/carbon/human/proc/getDarkvisionRange()
+	if(species.vision_organ)
+		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		if(!istype(I))
+			return I.darksight_range
+	return species.darksight_range
+
+/mob/living/carbon/human/proc/getDarkvisionTint()
+	if(species.vision_organ)
+		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		if(!istype(I))
+			return I.darksight_tint
+	return species.darksight_tint
 
 //Used by various things that knock people out by applying blunt trauma to the head.
 //Checks that the species has a "head" (brain containing organ) and that hit_zone refers to it.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,7 +4,7 @@
 /mob/living/carbon/human/movement_delay()
 	var/tally = ..()
 
-	if(species.slowdown)
+	if(species.slowdown && !isSynthetic())
 		tally += species.slowdown
 
 	tally += species.handle_movement_delay_special(src)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -15,6 +15,9 @@
 	var/apply_eye_colour = TRUE
 	var/tmp/last_cached_eye_colour
 	var/tmp/last_eye_cache_key
+	var/flash_mod
+	var/darksight_range
+	var/darksight_tint
 
 /obj/item/organ/internal/eyes/proc/get_eye_cache_key()
 	last_cached_eye_colour = rgb(eye_colour[1],eye_colour[2], eye_colour[3])
@@ -93,6 +96,12 @@
 	if(is_broken())
 		owner.eye_blind = 20
 
+/obj/item/organ/internal/eyes/New()
+	..()
+	flash_mod = species.flash_mod
+	darksight_range = species.darksight_range
+	darksight_tint = species.darksight_range
+
 /obj/item/organ/internal/eyes/proc/get_total_protection(var/flash_protection = FLASH_PROTECTION_NONE)
 	return (flash_protection + innate_flash_protection)
 
@@ -114,6 +123,9 @@
 	dead_icon = "camera_broken"
 	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 	update_colour()
+	flash_mod = 1
+	darksight_range = 2
+	darksight_tint = DARKTINT_NONE
 
 /obj/item/organ/internal/eyes/get_mechanical_assisted_descriptor()
 	return "retinal overlayed [name]"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -513,13 +513,13 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	var/list/vision = H.get_accumulated_vision_handlers()
 	H.update_sight()
 	H.set_sight(H.sight|get_vision_flags(H)|H.equipment_vision_flags|vision[1])
-	H.change_light_colour(darksight_tint)
+	H.change_light_colour(H.getDarkvisionTint())
 
 	if(H.stat == DEAD)
 		return 1
 
 	if(!H.druggy)
-		H.set_see_in_dark((H.sight == (SEE_TURFS|SEE_MOBS|SEE_OBJS)) ? 8 : min(darksight_range + H.equipment_darkness_modifier, 8))
+		H.set_see_in_dark((H.sight == (SEE_TURFS|SEE_MOBS|SEE_OBJS)) ? 8 : min(H.getDarkvisionRange() + H.equipment_darkness_modifier, 8))
 		if(H.equipment_see_invis)
 			H.set_see_invisible(max(min(H.see_invisible, H.equipment_see_invis), vision[2]))
 


### PR DESCRIPTION
:cl: mikomyazaki
tweak: FBPs don't get affected by their species slowdown stat, positive or negative.
tweak: Robotic eyes ignore your species flash modifier.
tweak: Robotic eyes don't get species darkvision bonuses (e.g. from Space-Adapted Humans)
/:cl:

Since we just merged a human subspecies that can get bonus speed and flash_mod... same reasoning as #26108 that removed FBPs getting species brute/burn mods.