### PR TITLE
Emagged/Traitor Surveyor Module Borgs get an energy machete

### DIFF
--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -34,6 +34,8 @@
 		/obj/item/bioreactor
 	)
 
+	emag = /obj/item/weapon/melee/energy/machete
+
 /obj/item/weapon/robot_module/flying/surveyor/finalize_synths()
 	. = ..()
 	for(var/flag_type in flag_types)


### PR DESCRIPTION
:cl: mikomyazaki
rscadd: Surveyor Flying Robots now have an emag item, an energy machete.
/:cl:

They seem to be the only module that doesn't get an emag item. So, let's give them an energy machete.