### PR TITLE
Elevator will no longer get stuck

### DIFF
--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -45,6 +45,7 @@
 	switch(busy_state)
 		if(LIFT_MOVING)
 			if(!do_move())
+				queued_floors.Cut()
 				return PROCESS_KILL
 			else if(!next_process)
 				next_process = world.time + move_delay
@@ -54,8 +55,11 @@
 			next_process = world.time + floor_wait_delay
 			busy_state = LIFT_WAITING_B
 		if(LIFT_WAITING_B)
-			busy_state = null
-			return PROCESS_KILL
+			if(queued_floors.len)
+				busy_state = LIFT_MOVING
+			else
+				busy_state = null
+				return PROCESS_KILL
 
 /datum/turbolift/proc/do_move()
 	next_process = null


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Elevator will no longer get stuck when you give it multiple move orders via the elevator panel or the buttons on each floor. It will wait for nine seconds on each floor and then move to the next one in the list.
/:cl:

Was missing some logic for its third state, where it should decide if it should stop process OR move to the next floor on its list...instead it just stopped.

Fixes #24825