### PR TITLE
Major firefighting buffs

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -441,12 +441,12 @@
 	to_chat(usr, "<span class='notice'>You start washing \the [I].</span>")
 
 	busy = 1
-	sleep(40)
+	if(!do_after(user, 40, src))
+		busy = 0
+		return TRUE
 	busy = 0
 
-	if(user.loc != location) return				//User has moved
-	if(!I) return 								//Item's been destroyed while washing
-	if(user.get_active_hand() != I) return		//Person has switched hands or the item in their hands
+	if(istype(O, /obj/item/weapon/extinguisher/)) return TRUE // We're washing, not filling.
 
 	O.clean_blood()
 	user.visible_message( \

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -88,7 +88,7 @@
 	possible_transfer_amounts = "10;25;50;100"
 	initial_capacity = 50000
 	initial_reagent_types = list(/datum/reagent/water = 1)
-	atom_flags = ATOM_FLAG_CLIMBABLE
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
 
 /obj/structure/reagent_dispensers/watertank/proc/drain_water()
 	if(reagents.total_volume <= 0)


### PR DESCRIPTION
Credit to afterthought and PsiOmegaDelta for the bits and pieces of help.

:cl:
rscadd: Water tanks are now immune to atmospheric temperatures
rscadd: Fire extinguishers can be filled from sinks! When full, they are instead washed.
rscadd: Fancy progress bar when washing in a sink!
bugfix: Slightly refactored sink washing code. if a user interrupts the process, it will not continue processing the item or most item effects.
/:cl: