### PR TITLE
Petrov Fabrication Lab console will start with upload/download rights

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -273,6 +273,6 @@
 
 /obj/machinery/r_n_d/server/core
 	name = "Core R&D Server"
-	id_with_upload_string = "1"
-	id_with_download_string = "1"
+	id_with_upload_string = "1;3"
+	id_with_download_string = "1;3"
 	server_id = 1


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Petrov RnD console will start the round able to access the Core RnD server data and sync with the rest of the Torch.
/:cl:

I think this was a mapping oversight. There's no reason to require scientists to poke the AI/engineering to be allowed to access their RnD designs on the Petrov if they want to.