### PR TITLE
Away site RnD servers will no longer be visible to the Torch.

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -204,9 +204,10 @@
 	switch(screen)
 		if(0) //Main Menu
 			dat += "Connected Servers:<BR><BR>"
-
+			var/turf/T = get_turf(src)
 			for(var/obj/machinery/r_n_d/server/S in SSmachines.machinery)
-				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
+				var/turf/ST = get_turf(S)
+				if((istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin) || (ST && !AreConnectedZLevels(ST.z, T.z)))
 					continue
 				dat += "[S.name] || "
 				dat += "<A href='?src=\ref[src];access=[S.server_id]'> Access Rights</A> | "

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
@@ -23,7 +23,10 @@
 /turf/simulated/floor/reinforced,
 /area/map_template/datacapsule)
 "h" = (
-/obj/machinery/r_n_d/server/core,
+/obj/machinery/r_n_d/server/core{
+	id_with_upload_string = "";
+	id_with_download_string = ""
+	},
 /turf/simulated/floor/reinforced,
 /area/map_template/datacapsule)
 "i" = (


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: RnD server control consoles will only connect to things on connected Z-levels. So the Torch won't pick up away-site RnD servers only the RnD server control console.
/:cl:

Also tweaked one of the away site RnD servers vars because it shouldn't be set to connect to the Torch's RnD stuff.