### PR TITLE
The Supermatter can now pull anchored items again.

### DIFF
--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -46,8 +46,6 @@
 
 /obj/item/singularity_pull(S, current_size)
 	set waitfor = 0
-	if(anchored)
-		return
 	sleep(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
 	if(current_size >= STAGE_FOUR)
 		//throw_at(S, 14, 3)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: The supermatter can now once-again pull in anchored items while delaminating.
/:cl:
This reverts #12409