### PR TITLE
Tweaks to chopping vines

### DIFF
--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -201,7 +201,7 @@
 /obj/effect/vine/attackby(var/obj/item/weapon/W, var/mob/user)
 	START_PROCESSING(SSvines, src)
 
-	if(W.edge)
+	if(W.edge && W.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
 		if(!is_mature())
 			to_chat(user, "<span class='warning'>\The [src] is not mature enough to yield a sample yet.</span>")
 			return
@@ -217,6 +217,21 @@
 			damage *= 2
 		adjust_health(-damage)
 		playsound(get_turf(src), W.hitsound, 100, 1)
+		
+/obj/effect/vine/AltClick(var/mob/user)
+	if(!CanPhysicallyInteract(user) || user.incapacitated())
+		return ..()
+	var/obj/item/W = user.get_active_hand()
+	if(istype(W) && W.edge && W.w_class >= ITEM_SIZE_NORMAL)
+		visible_message(SPAN_NOTICE("[user] starts chopping down \the [src]."))
+		playsound(, W.hitsound, 100, 1)
+		var/chop_time = (health/W.force) * 0.5 SECONDS
+		if(user.skill_check(SKILL_BOTANY, SKILL_ADEPT))
+			chop_time *= 0.5
+		if(do_after(user, chop_time, src, TRUE))
+			visible_message(SPAN_NOTICE("[user] chops down \the [src]."))
+			playsound(get_turf(src), W.hitsound, 100, 1)
+			die_off()
 
 //handles being overrun by vines - note that attacker_parent may be null in some cases
 /obj/effect/vine/proc/vine_overrun(datum/seed/attacker_seed, obj/effect/plant/attacker_parent)


### PR DESCRIPTION
Can no longer sample with normal-sized blades or bigger. It was getting in the way of chopping vines.
Added ability to 'continously' chop a vine, alt click on it to do so. Hopefully would help with BOLD RED SPAM.

:cl: Chinsky
tweak: Can no longer sample plants with machet. Need an edged weapon of size 'small' or 'tiny'. Normal size and above will chop as usual now. Harm intent also forces chopping instead of sampling.
tweak: Can alt-click vines when holding normal-sized blade (machet) in hand to chop them down. It'll take a short time, faster if you have Trained botany skill. Basically less chat-spamming alternative to just bashing them down.
/:cl: