### PR TITLE
Robots can open the door menu again

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -801,6 +801,9 @@ About the new airlock wires panel:
 			update_icon()
 	return
 
+/obj/machinery/door/airlock/attack_robot(mob/user)
+	ui_interact(user)
+
 /obj/machinery/door/airlock/attack_ai(mob/user)
 	ui_interact(user)
 


### PR DESCRIPTION
:cl: mikomyazaki
tweak: Robots can open the door control menu again, like AI.
/:cl:

I don't think it makes sense for them to not have the door menu, but still be able to interface with doors remotely via the hotkeys. They should have either both or none (and I think they should have both).

This menu here:
![door_controls](https://user-images.githubusercontent.com/47489928/63055576-1e302680-bede-11e9-8ea2-368bfe4ff19d.PNG)
