### PR TITLE
Fixes #18850 - Glasses that apply a vision overlay will no longer work with overmap sensors

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -51,14 +51,15 @@
 	equipment_darkness_modifier = 0
 	equipment_overlays.Cut()
 
-	if(istype(src.head, /obj/item/clothing/head))
-		add_clothing_protection(head)
-	if(istype(src.glasses, /obj/item/clothing/glasses))
-		process_glasses(glasses)
-	if(istype(src.wear_mask, /obj/item/clothing/mask))
-		add_clothing_protection(wear_mask)
-	if(istype(back,/obj/item/weapon/rig))
-		process_rig(back)
+	if (!client || client.eye == src) // !client is so the unit tests function
+		if(istype(src.head, /obj/item/clothing/head))
+			add_clothing_protection(head)
+		if(istype(src.glasses, /obj/item/clothing/glasses))
+			process_glasses(glasses)
+		if(istype(src.wear_mask, /obj/item/clothing/mask))
+			add_clothing_protection(wear_mask)
+		if(istype(back,/obj/item/weapon/rig))
+			process_rig(back)
 
 /mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
 	if(G)


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Glasses that apply a vision overlay (mesons, tactical goggles, etc.) will no longer function when you are using a sensor console to view the overmap.
/:cl:

Fixes #18850