### PR TITLE
Added autolathe queueing.

### DIFF
--- a/code/modules/fabrication/designs/_design.dm
+++ b/code/modules/fabrication/designs/_design.dm
@@ -3,9 +3,9 @@
 	var/path
 	var/hidden
 	var/category = "General"
-	var/is_stack
 	var/list/resources
 	var/list/fabricator_types = list(FABRICATOR_CLASS_GENERAL)
+	var/build_time = 5 SECONDS
 
 /datum/fabricator_recipe/New()
 	..()

--- a/code/modules/fabrication/designs/general/designs_devices_components.dm
+++ b/code/modules/fabrication/designs/general/designs_devices_components.dm
@@ -44,7 +44,6 @@
 
 /datum/fabricator_recipe/device_component/cable_coil
 	path = /obj/item/stack/cable_coil/single
-	is_stack = TRUE
 
 /datum/fabricator_recipe/device_component/electropack
 	path = /obj/item/device/radio/electropack

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -52,30 +52,6 @@
 /datum/fabricator_recipe/weldermask
 	path = /obj/item/clothing/head/welding
 
-/datum/fabricator_recipe/metal
-	path = /obj/item/stack/material/steel
-	is_stack = TRUE
-
-/datum/fabricator_recipe/glass
-	path = /obj/item/stack/material/glass
-	is_stack = TRUE
-
-/datum/fabricator_recipe/aluminium
-	path = /obj/item/stack/material/aluminium
-	is_stack = TRUE
-
-/datum/fabricator_recipe/rglass
-	path = /obj/item/stack/material/glass/reinforced
-	is_stack = TRUE
-
-/datum/fabricator_recipe/plastic
-	path = /obj/item/stack/material/plastic
-	is_stack = TRUE
-
-/datum/fabricator_recipe/rods
-	path = /obj/item/stack/material/rods
-	is_stack = TRUE
-
 /datum/fabricator_recipe/knife
 	path = /obj/item/weapon/material/knife/kitchen
 


### PR DESCRIPTION
My plan to kill the protolathe and circuit printer continues apace.

- Allowed recipes to be queued on the autolathe and descendants.
- Updated UI to show current build and build queue, and to allow queued builds to be cancelled (at a slight resource loss).
- Removed sheet recipes - there is now an Eject button to remove materials.
- Converted autolathe to use a process counter instead of a callback for build times.
- Moved build times onto the recipes instead of the lathe.

![image](https://user-images.githubusercontent.com/2468979/63224477-42567500-c208-11e9-86cb-86fec4db3163.png)
