### PR TITLE
Adjust the stacktrace from crash_with()

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1109,8 +1109,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	STOP_PROCESSING(SSmobs, src)
 
 // call to generate a stack trace and print to runtime logs
-/proc/crash_with(msg)
-	CRASH(msg)
+/proc/crash_at(msg, file, line)
+	CRASH("%% [file],[line] %% [msg]")
 
 /proc/pass()
 	return

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -192,3 +192,5 @@
 #define FONT_HUGE(X) "<font size='4'>[X]</font>"
 
 #define FONT_GIANT(X) "<font size='5'>[X]</font>"
+
+#define crash_with(X) crash_at(X, __FILE__, __LINE__)


### PR DESCRIPTION
Minimal impact attempt to have stacktraces generated via crash_with()
 instead use the file name and line of where the proc is called from

Assuming a file `loggin.dm` has the proc `crash_at()` at line 33 and a file `mob.dm` calls `crash_with()` at line 8 it turns the stacktrace
```
[16:05:39] Runtime in logging.dm,33: Oh no, a crash
  proc name: crash with (/proc/crash_with)
  usr: PsiOmegaDelta (/mob) ([0x3000000]) (the turf) (1,1,1) (/turf) (psiomegadelta)
  usr.loc: The turf (/turf) ([0x1000000]) (1,1,1) (/area/test)
  src: null
  call stack:
  crash with("Oh no, a crash")
  TestB("test_arg1", "test_arg2")
  TestA("test_arg1")
  PsiOmegaDelta (/mob): Login()
```
into
```
[16:05:39] Runtime in mob.dm,8: Oh no, a crash
  proc name: crash at (/proc/crash_at)
  usr: PsiOmegaDelta (/mob) ([0x3000000]) (the turf) (1,1,1) (/turf) (psiomegadelta)
  usr.loc: The turf (/turf) ([0x1000000]) (1,1,1) (/area/test)
  src: null
  call stack:
  crash at("Oh no, a crash", "mob.dm", 8)
  TestB("test_arg", "test_arg2")
  TestA("test_arg")
  PsiOmegaDelta (/mob): Login()
```