### PR TITLE
Fix so that Adherents get their speed boost again

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,8 +4,9 @@
 /mob/living/carbon/human/movement_delay()
 	var/tally = ..()
 
-	if(species.slowdown && !isSynthetic())
-		tally += species.slowdown
+	var/obj/item/organ/external/H = get_organ(BP_GROIN) // gets species slowdown, which can be reset by robotize()
+	if(istype(H))
+		tally += H.slowdown
 
 	tally += species.handle_movement_delay_special(src)
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -26,6 +26,10 @@
 		update_emotes()
 	return full_prosthetic
 
+/mob/living/carbon/human/proc/isFBP()
+	return istype(internal_organs_by_name[BP_BRAIN], /obj/item/organ/internal/mmi_holder)
+
+
 /mob/living/silicon/isSynthetic()
 	return 1
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -9,6 +9,8 @@
 	organ_tag = "limb"
 	appearance_flags = PIXEL_SCALE
 
+	var/slowdown = 0
+
 	// Strings
 	var/broken_description             // fracture string if any.
 	var/damage_state = "00"            // Modifier used for generating the on-mob damage overlay for this limb.
@@ -98,6 +100,8 @@
 		replaced(owner)
 		sync_colour_to_human(owner)
 	get_icon()
+
+	slowdown = species.slowdown
 
 /obj/item/organ/external/Destroy()
 
@@ -1096,6 +1100,8 @@ obj/item/organ/external/proc/remove_clamps()
 	remove_splint()
 	update_icon(1)
 	unmutate()
+
+	slowdown = 0
 
 	for(var/obj/item/organ/external/T in children)
 		T.robotize(company, 1)


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Adherents now properly get their speed bonus again.
/:cl:

#26683 accidentally stopped Adherents getting their species bonus to speed, since they're also synthetic.