### PR TITLE
Fixes bug where you could deconstruct an empty stack of material

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -457,7 +457,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			qdel(M)
 		if(istype(I,/obj/item/stack/material))//Only deconsturcts one sheet at a time instead of the entire stack
 			var/obj/item/stack/material/S = I
-			if(S.use(1))
+			if(S.use(1) && S.amount)
 				linked_destroy.loaded_item = S
 			else
 				qdel(S)


### PR DESCRIPTION
:cl: mikomyazaki
bugfix: Stacks of one sheet will now not be deconstructable twice in the deconstructive analyzer.
/:cl:

Fixes #26731 