### PR TITLE
Surveyor drone gets skills

### DIFF
--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -15,6 +15,14 @@
 		/obj/item/stack/flag/green,
 		/obj/item/stack/flag/red
 	)
+	skills = list(
+		SKILL_ELECTRICAL          = SKILL_PROF,
+		SKILL_ATMOS               = SKILL_PROF,
+		SKILL_PILOT               = SKILL_EXPERT,
+		SKILL_BOTANY              = SKILL_PROF,
+		SKILL_EVA                 = SKILL_PROF,
+		SKILL_MECH                = HAS_PERK,
+	)
 
 	equipment = list(
 		/obj/item/weapon/material/hatchet/machete/unbreakable,


### PR DESCRIPTION
:cl:
bugfix: Surveyor drone now has skills.
/:cl:

Got missed when the rest of the robot modules got given skills. Similar skillset to mining module plus botany & atmos.