### PR TITLE
SMES slight tweak

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -351,7 +351,10 @@
 		qdel(src) // Either way we want to ensure the SMES is deleted.
 
 /obj/machinery/power/smes/emp_act(severity)
-	if(prob(50))
+	if(!num_terminals)
+		inputting(0)
+		outputting(0)
+	else if(prob(50))
 		inputting(rand(0,1))
 		outputting(rand(0,1))
 	if(prob(50))

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -253,7 +253,7 @@
 					// Not sure if this is necessary, but just in case the SMES *somehow* survived..
 					qdel(src)
 
-/obj/machinery/power/smes/buildable/proc/check_total_system_failure(user)
+/obj/machinery/power/smes/buildable/proc/check_total_system_failure(var/mob/user)
 	// Probability of failure if safety circuit is disabled (in %)
 	var/failure_probability = capacity ? round((charge / capacity) * 100) : 0
 
@@ -261,7 +261,7 @@
 	if (failure_probability < 5)
 		failure_probability = 0
 
-	if (failure_probability && prob(failure_probability))
+	if (failure_probability && prob(failure_probability * (1.5 - (user.get_skill_value(SKILL_ELECTRICAL) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN))))// 0.5 - 1.5, step of 0.25
 		total_system_failure(failure_probability, user)
 		return TRUE
 


### PR DESCRIPTION
🆑 
rscadd: SMES chance to discharge is now skill based, with 50% increase at unskilled and 50% decrease at master.
/🆑 
if there's no terminal, EMP will turn all the input off. Allowing for easier deconstruction

Why?
This is due to SMES emping themself, which might turn on their inputs/outputs, which you can't do anything since you can't add component like a terminal or input controller to turn them off since the input is ON. AGGHH it's a saddening cycle of despair which forces people to hack the SMES.