### PR TITLE
'Ejected Datapod' and map load landmark tweaks

### DIFF
--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -1,18 +1,7 @@
-//Load a random map template from the list
+//Load a random map template from the list. Maploader handles it to avoid order of init madness
 /obj/effect/landmark/map_load_mark
 	name = "map loader landmark"
-	delete_me = TRUE
 	var/list/templates	//list of template types to pick from
-
-/obj/effect/landmark/map_load_mark/Initialize()
-	..() 
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/effect/landmark/map_load_mark/LateInitialize()
-	if(LAZYLEN(templates))
-		var/template = pick(templates)
-		var/datum/map_template/M = new template()
-		M.load(get_turf(src), TRUE)
 
 //Throw things in the area around randomly
 /obj/effect/landmark/carnage_mark

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -7,6 +7,7 @@
 	var/list/mappaths = null
 	var/loaded = 0 // Times loaded this round
 	var/list/shuttles_to_initialise = list()
+	var/list/subtemplates_to_spawn = list()
 	var/base_turf_for_zs = null
 	var/accessibility_weight = 0
 	var/template_flags = TEMPLATE_FLAG_ALLOW_DUPLICATES
@@ -56,6 +57,8 @@
 			atmos_machines += A
 		if(istype(A, /obj/machinery))
 			machines += A
+		if(istype(A,/obj/effect/landmark/map_load_mark))
+			subtemplates_to_spawn += A
 
 	SSatoms.InitializeAtoms() // The atoms should have been getting queued there. This flushes the queue.
 
@@ -156,7 +159,12 @@
 	return TRUE
 
 /datum/map_template/proc/after_load(z)
-	return
+	for(var/obj/effect/landmark/map_load_mark/mark in subtemplates_to_spawn)
+		if(LAZYLEN(mark.templates))
+			var/template = pick(mark.templates)
+			var/datum/map_template/M = new template()
+			M.load(get_turf(mark), TRUE)
+			qdel(mark)
 
 /datum/map_template/proc/extend_bounds_if_needed(var/list/existing_bounds, var/list/new_bounds)
 	var/list/bounds_to_combine = existing_bounds.Copy()

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/contents_1.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/contents_1.dmm
@@ -1,0 +1,54 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/table/steel,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/random_podchem,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/random_podchem,
+/obj/structure/window/basic/full,
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/turf/template_noop,
+/area/template_noop)
+"c" = (
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+"d" = (
+/obj/machinery/constructable_frame/machine_frame,
+/turf/template_noop,
+/area/template_noop)
+"e" = (
+/obj/item/modular_computer/console/preset/library{
+	icon_state = "console";
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"f" = (
+/obj/structure/table,
+/turf/template_noop,
+/area/template_noop)
+"g" = (
+/obj/item/stack/material/steel,
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+c
+d
+f
+a
+"}
+(2,1,1) = {"
+c
+b
+b
+c
+"}
+(3,1,1) = {"
+c
+e
+c
+g
+"}

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/contents_2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/contents_2.dmm
@@ -1,0 +1,62 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/telecomms/server,
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/mob/living/simple_animal/hostile/viscerator,
+/turf/template_noop,
+/area/template_noop)
+"c" = (
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+"d" = (
+/obj/machinery/r_n_d/server/core{
+	id_with_upload_string = "";
+	id_with_download_string = ""
+	},
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+"e" = (
+/obj/item/modular_computer/console/preset/library{
+	icon_state = "console";
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"f" = (
+/obj/structure/backup_server,
+/turf/template_noop,
+/area/template_noop)
+"g" = (
+/obj/machinery/constructable_frame/machine_frame,
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+"h" = (
+/obj/structure/backup_server,
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+a
+g
+f
+h
+"}
+(2,1,1) = {"
+c
+c
+c
+b
+"}
+(3,1,1) = {"
+d
+e
+f
+h
+"}

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/contents_3.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/contents_3.dmm
@@ -1,0 +1,59 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/spider/stickyweb,
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+"c" = (
+/obj/effect/spider/eggcluster,
+/turf/template_noop,
+/area/template_noop)
+"d" = (
+/obj/effect/spider/eggcluster,
+/obj/item/weapon/material/shard,
+/turf/template_noop,
+/area/template_noop)
+"e" = (
+/mob/living/simple_animal/hostile/giant_spider/guard,
+/turf/template_noop,
+/area/template_noop)
+"f" = (
+/mob/living/simple_animal/hostile/giant_spider/nurse,
+/turf/template_noop,
+/area/template_noop)
+"g" = (
+/obj/item/weapon/material/shard,
+/turf/template_noop,
+/area/template_noop)
+"h" = (
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/material/shard,
+/turf/template_noop,
+/area/template_noop)
+"i" = (
+/obj/effect/landmark/corpse/zombiescience,
+/obj/structure/foamedmetal,
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+b
+d
+g
+c
+"}
+(2,1,1) = {"
+i
+a
+e
+f
+"}
+(3,1,1) = {"
+b
+g
+c
+h
+"}

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -36,16 +36,44 @@
 	color = "#800000"
 	amount_to_zombify = 3
 
+/obj/item/weapon/reagent_containers/glass/beaker/vial/random_podchem
+	name = "unmarked vial"
 
-/obj/item/weapon/reagent_containers/glass/bottle/zombiescience
-	name = "unknown bottle"
-	desc = "A small bottle of some dark, oily liquid."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle-3"
-
-
-/obj/item/weapon/reagent_containers/glass/bottle/zombiescience/Initialize()
+/obj/item/weapon/reagent_containers/glass/beaker/vial/random_podchem/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/toxin/zombie/science, 5) //Should pretty much be death if they decide to chug it, unless explorers happen to follow chemical procedure for once - Pandolphina
-	update_icon()
+	desc += "Label is smudged, and there's crusted blood fingerprints on it."
+	var/reagent_type = pick(/datum/reagent/random, /datum/reagent/toxin/zombie/science, /datum/reagent/rezadone, /datum/reagent/three_eye)
+	reagents.add_reagent(pick(reagent_type), 5)
 
+/obj/structure/backup_server
+	name = "backup server"
+	icon = 'icons/obj/machines/research.dmi'
+	icon_state = "server"
+	desc = "Impact resistant server rack. You might be able to pry a disk out."
+	var/disk_looted
+
+/obj/structure/backup_server/attackby(obj/item/W, mob/user, var/click_params)
+	if(isCrowbar(W))
+		to_chat(user, SPAN_NOTICE("You pry out the data drive from \the [src]."))
+		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+		var/obj/item/weapon/stock_parts/computer/hard_drive/cluster/drive = new(get_turf(src))
+		drive.origin_tech = list(TECH_DATA = rand(4,5), TECH_ENGINEERING = rand(4,5), TECH_PHORON = rand(4,5), TECH_COMBAT = rand(2,5), TECH_ESOTERIC = rand(0,6))
+		
+/obj/effect/landmark/map_load_mark/ejected_datapod
+	name = "random datapod contents"
+	templates = list(/datum/map_template/ejected_datapod_contents, /datum/map_template/ejected_datapod_contents/type2, /datum/map_template/ejected_datapod_contents/type3)
+
+/datum/map_template/ejected_datapod_contents
+	name = "random datapod contents #1 (chem vials)"
+	id = "datapod_1"
+	mappaths = list("maps/random_ruins/exoplanet_ruins/datacapsule/contents_1.dmm")
+
+/datum/map_template/ejected_datapod_contents/type2
+	name = "random datapod contents #2 (servers)"
+	id = "datapod_2"
+	mappaths = list("maps/random_ruins/exoplanet_ruins/datacapsule/contents_2.dmm")
+
+/datum/map_template/ejected_datapod_contents/type3
+	name = "random datapod contents #2 (spiders)"
+	id = "datapod_3"
+	mappaths = list("maps/random_ruins/exoplanet_ruins/datacapsule/contents_3.dmm")

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
@@ -7,313 +7,105 @@
 /turf/simulated/wall/ocp_wall,
 /area/map_template/datacapsule)
 "c" = (
-/obj/effect/paint/black,
-/obj/structure/sign/warning/server_room,
-/turf/simulated/wall/ocp_wall,
-/area/map_template/datacapsule)
+/obj/effect/scorcher,
+/turf/template_noop,
+/area/template_noop)
 "d" = (
 /obj/machinery/door/blast/shutters,
 /turf/simulated/floor/reinforced,
 /area/map_template/datacapsule)
+"e" = (
+/turf/simulated/wall/ocp_wall,
+/area/map_template/datacapsule)
 "f" = (
-/obj/machinery/telecomms/server,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/map_template/datacapsule)
 "g" = (
-/turf/simulated/floor/reinforced,
-/area/map_template/datacapsule)
-"h" = (
-/obj/machinery/r_n_d/server/core{
-	id_with_upload_string = "";
-	id_with_download_string = ""
-	},
-/turf/simulated/floor/reinforced,
-/area/map_template/datacapsule)
-"i" = (
-/obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor/plating,
-/area/map_template/datacapsule)
-"j" = (
-/obj/item/modular_computer/console/preset/library{
-	icon_state = "console";
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/map_template/datacapsule)
-"k" = (
-/obj/structure/table,
-/turf/simulated/floor/reinforced,
-/area/map_template/datacapsule)
-"l" = (
-/obj/structure/table/steel,
-/obj/item/weapon/reagent_containers/glass/bottle/zombiescience,
-/turf/simulated/floor/reinforced,
-/area/map_template/datacapsule)
-"m" = (
-/obj/effect/landmark/corpse/zombiescience,
-/turf/simulated/floor/reinforced,
-/area/map_template/datacapsule)
-"n" = (
-/obj/item/stack/material/steel,
-/turf/simulated/floor/plating,
-/area/map_template/datacapsule)
-"p" = (
-/obj/structure/sign/warning/server_room,
-/turf/simulated/wall/ocp_wall,
+/obj/effect/landmark/map_load_mark/ejected_datapod,
+/turf/simulated/floor/reinforced/airless,
 /area/map_template/datacapsule)
 
 (1,1,1) = {"
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+c
+c
+b
+b
+b
+b
+b
+b
 a
 "}
 (2,1,1) = {"
 a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+c
+b
+b
+b
+b
+b
+b
+b
+b
 "}
 (3,1,1) = {"
-a
-a
-b
-b
-b
-b
-b
-b
-b
-b
-a
-a
-a
-a
-a
-"}
-(4,1,1) = {"
-a
-a
-b
-b
-b
-b
-b
-b
-b
-b
-a
-a
-a
-a
-a
-"}
-(5,1,1) = {"
-a
-a
-p
+c
+c
+e
 b
 f
-i
-k
-l
+f
+f
+f
 b
 b
-a
-a
-a
-a
-a
+"}
+(4,1,1) = {"
+c
+c
+c
+d
+f
+g
+f
+f
+b
+b
+"}
+(5,1,1) = {"
+c
+c
+b
+b
+f
+f
+f
+f
+b
+b
 "}
 (6,1,1) = {"
-a
-a
-a
-d
-g
-g
-g
-m
+c
+c
 b
 b
-a
-a
-a
-a
-a
+b
+b
+b
+b
+b
+b
 "}
 (7,1,1) = {"
 a
-a
+c
 c
 b
-h
-j
-g
-n
-b
-b
-a
-a
-a
-a
-a
-"}
-(8,1,1) = {"
-a
-a
 b
 b
 b
 b
 b
-b
-b
-b
-a
-a
-a
-a
-a
-"}
-(9,1,1) = {"
-a
-a
-b
-b
-b
-b
-b
-b
-b
-b
-a
-a
-a
-a
-a
-"}
-(10,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-"}
-(11,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-"}
-(12,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-"}
-(13,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-"}
-(14,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-"}
-(15,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
 a
 "}


### PR DESCRIPTION
Spiced up 'Ejected Datapod' ruin slightly - now has 3 random variants for insides:
1.Kinda like current with random OP chem vials (zombie/rezadone/randomchem/threeeye)
2.Bunch of server structures that can be crowbared for techlevel-carrying disks
3.SPIDERS! Everyone love those.

Also during actual use of mapload landmark discovered it causes some init fuckery since it KEEPS GETTING PUT INTO INIT QUEUE OVER AND OVER.
Now maploader itself handles subtemplates, in after_load proc
