### PR TITLE
Fire shutters fixes

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -189,18 +189,25 @@
 	if(isWelder(C) && !repairing)
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0, user))
-			blocked = !blocked
-			user.visible_message("<span class='danger'>\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [W].</span>",\
-			"You [blocked ? "weld" : "unweld"] \the [src] with \the [W].",\
-			"You hear something being welded.")
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			update_icon()
-			return
+			if(do_after(user, 2 SECONDS, src))
+				if(!W.isOn()) return
+				blocked = !blocked
+				user.visible_message("<span class='danger'>\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [W].</span>",\
+				"You [blocked ? "weld" : "unweld"] \the [src] with \the [W].",\
+				"You hear something being welded.")
+				playsound(src, 'sound/items/Welder.ogg', 100, 1)
+				update_icon()
+				return
+			else
+				to_chat(user, SPAN_WARNING("You must remain still to complete this task."))
+				return
 
 	if(density && isScrewdriver(C))
 		hatch_open = !hatch_open
 		user.visible_message("<span class='danger'>[user] has [hatch_open ? "opened" : "closed"] \the [src] maintenance hatch.</span>",
 									"You have [hatch_open ? "opened" : "closed"] the [src] maintenance hatch.")
+		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		update_icon()
 		return
 

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -8,11 +8,8 @@ obj/structure/firedoor_assembly
 	density = 1
 	var/wired = 0
 
-obj/structure/firedoor_assembly/on_update_icon()
-	if(anchored)
-		icon_state = "door_anchored"
-	else
-		icon_state = "construction"
+//construction: wrenched > cables > electronics > screwdriver & open
+//deconstruction: closed & welded > screwdriver > crowbar > wire cutters > wrench > welder
 
 obj/structure/firedoor_assembly/attackby(var/obj/item/C, var/mob/user)
 	if(isCoil(C) && !wired && anchored)
@@ -41,12 +38,14 @@ obj/structure/firedoor_assembly/attackby(var/obj/item/C, var/mob/user)
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			user.visible_message("<span class='warning'>[user] has inserted a circuit into \the [src]!</span>",
 								  "You have inserted the circuit into \the [src]!")
-			new /obj/machinery/door/firedoor(src.loc)
+			var/obj/machinery/door/firedoor/D = new(src.loc)
+			D.hatch_open = 1
+			D.close()
 			qdel(C)
 			qdel(src)
 		else
 			to_chat(user, "<span class='warning'>You must secure \the [src] first!</span>")
-	else if(isWrench(C))
+	else if(isWrench(C) && !wired)
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		user.visible_message("<span class='warning'>[user] has [anchored ? "" : "un" ]secured \the [src]!</span>",
@@ -61,7 +60,7 @@ obj/structure/firedoor_assembly/attackby(var/obj/item/C, var/mob/user)
 				if(!src || !WT.isOn()) return
 				user.visible_message("<span class='warning'>[user] has dissassembled \the [src].</span>",
 									"You have dissassembled \the [src].")
-				new /obj/item/stack/material/steel(src.loc, 2)
+				new /obj/item/stack/material/steel(src.loc, 4)
 				qdel(src)
 		else
 			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")


### PR DESCRIPTION
🆑
bugfix: Fixes various bugs for emergency fire shutters construction/deconstruction, such as going invisible, returning incorrect amount of metal and skipping steps.
tweak: Emergency fire shutters will now have a delay for welding them.
/🆑

might need a wiki update on this one:
Construction: build > wrench > cables > electronics > open
Deconstruction: closed & welded > screwdriver > crowbar > wire cutters > wrench > welder