### PR TITLE
Fix Id spawn location when AI ejects it from a computer

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -1,3 +1,4 @@
+    
 /obj/item/modular_computer/proc/update_verbs()
 	verbs.Cut()
 	if(ai_slot)
@@ -128,8 +129,11 @@
 
 	for(var/datum/computer_file/program/P in idle_threads)
 		P.event_idremoved(1)
-
-	user.put_in_hands(card_slot.stored_card)
+	
+	if(isAI(user))
+		card_slot.stored_card.dropInto(src.loc)
+	else
+		user.put_in_hands(card_slot.stored_card)
 	to_chat(user, "You remove [card_slot.stored_card] from [src].")
 	card_slot.stored_card = null
 	update_uis()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl:
bugfix: AI ejecting an Id card will no longer spawn the Id at its core
/:cl: