### PR TITLE
Dynamic Drone Fabrication

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -137,3 +137,23 @@
 			drone.status_flags |= NO_ANTAG
 		return 1
 	return
+
+//UNIFY start
+/obj/machinery/drone_fabricator/unify	//Non-Specific dronetype
+	drone_type = null //var filled by drone choice.
+	fabricator_tag = "Unified Drone Fabricator"
+	
+	var/list/possible_drones = list("Construction Module" = /mob/living/silicon/robot/drone/construction,
+									"Maintenance Module" = /mob/living/silicon/robot/drone,
+									) //List of drone types to choose from.//Changeable in mapping.
+	
+	create_drone(var/client/player)
+		choose_dronetype(possible_drones) //Call Drone choice before executing create_drone
+		..()
+	
+/obj/machinery/drone_fabricator/proc/choose_dronetype(possible_drones)
+	var/choice
+	choice = input(usr,"What module would you like to use?") as null|anything in possible_drones
+	if(!choice) return
+	drone_type = possible_drones[choice]
+//UNIFY end


### PR DESCRIPTION
Reduces possible waste of both space and power, on maps that use more than 1 dronetype by simply combinig all drone fabricators into one.

By default asks players for all dronetypes which exist on bay currently, but can be mapped to only have one type ore more.

Not much of a benefit to torch as it only has 1 Dronetype but simply adding/removing a line of code rather than adding in an entirely new object for each drone type possibly created in the future seems a lot more sane either way.

This fab can still be modified in mapping to only use a specific given dronetype and so could even be a full replacement for the old drone fabs.