### PR TITLE
Planet grass will now always assume same color

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -19,7 +19,10 @@
 	var/maxx
 	var/maxy
 	var/landmark_type = /obj/effect/shuttle_landmark/automatic
+
 	var/list/rock_colors = list(COLOR_ASTEROID_ROCK)
+	var/list/plant_colors = list("RANDOM")
+	var/grass_color
 
 	var/list/actors = list() //things that appear in engravings on xenoarch finds.
 	var/list/species = list() //list of names to use for simple animals
@@ -157,6 +160,11 @@
 	repopulate_types |= M.type
 
 /obj/effect/overmap/sector/exoplanet/proc/generate_map()
+	var/list/grasscolors = plant_colors.Copy()
+	grasscolors -= "RANDOM"
+	if(length(grasscolors))
+		grass_color = pick(grasscolors)
+
 	for(var/datum/exoplanet_theme/T in themes)
 		T.before_map_generation(src)
 	for(var/zlevel in map_z)
@@ -170,7 +178,7 @@
 		var/padding = TRANSITIONEDGE
 		for(var/map_type in map_generators)
 			if(ispath(map_type, /datum/random_map/noise/exoplanet))
-				var/datum/random_map/noise/exoplanet/RM = new map_type(null,padding,padding,zlevel,maxx-padding,maxy-padding,0,1,1,planetary_area)
+				var/datum/random_map/noise/exoplanet/RM = new map_type(null,padding,padding,zlevel,maxx-padding,maxy-padding,0,1,1,planetary_area, plant_colors)
 				get_biostuff(RM)
 			else
 				new map_type(null,1,1,zlevel,maxx,maxy,0,1,1)

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -4,6 +4,7 @@
 	color = "#efff7c"
 	planetary_area = /area/exoplanet/chlorine
 	rock_colors = list(COLOR_GRAY80, COLOR_PALE_GREEN_GRAY, COLOR_PALE_BTL_GREEN)
+	plant_colors = list("#eba487", "#ceeb87", "#eb879c", "#ebd687", "#f6d6c9", "#f2b3e0")
 	map_generators = list(/datum/random_map/noise/exoplanet/chlorine, /datum/random_map/noise/ore/poor)
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 
@@ -31,7 +32,6 @@
 	water_type = /turf/simulated/floor/exoplanet/water/shallow/chlorine_liquid
 	water_level_min = 2
 	water_level_max = 3
-	plantcolors = list("#eba487", "#ceeb87", "#eb879c", "#ebd687", "#f6d6c9", "#f2b3e0")
 	fauna_prob = 2
 	flora_prob = 30
 	large_flora_prob = 0

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -4,6 +4,7 @@
 	color = "#d6cca4"
 	planetary_area = /area/exoplanet/desert
 	rock_colors = list(COLOR_BEIGE, COLOR_PALE_YELLOW, COLOR_GRAY80, COLOR_BROWN)
+	plant_colors = list("#efdd6f","#7b4a12","#e49135","#ba6222","#5c755e","#420d22")
 	map_generators = list(/datum/random_map/noise/exoplanet/desert, /datum/random_map/noise/ore/rich)
 
 /obj/effect/overmap/sector/exoplanet/desert/generate_map()
@@ -38,7 +39,6 @@
 	descriptor = "desert exoplanet"
 	smoothing_iterations = 4
 	land_type = /turf/simulated/floor/exoplanet/desert
-	plantcolors = list("#efdd6f","#7b4a12","#e49135","#ba6222","#5c755e","#420d22")
 
 	flora_prob = 10
 	large_flora_prob = 0

--- a/code/modules/overmap/exoplanets/planet_types/garbage.dm
+++ b/code/modules/overmap/exoplanets/planet_types/garbage.dm
@@ -5,6 +5,7 @@
 	planetary_area = /area/exoplanet/garbage
 	map_generators = list(/datum/random_map/noise/exoplanet/garbage, /datum/random_map/noise/ore/poor)
 	ruin_tags_whitelist = RUIN_ALIEN|RUIN_NATURAL|RUIN_WRECK
+	plant_colors = list("#efdd6f","#7b4a12","#e49135","#ba6222","#5c755e","#120309")
 
 /obj/effect/overmap/sector/exoplanet/garbage/generate_map()
 	if(prob(50))
@@ -36,7 +37,6 @@
 	descriptor = "garbage exoplanet"
 	smoothing_iterations = 4
 	land_type = /turf/simulated/floor/exoplanet/desert
-	plantcolors = list("#efdd6f","#7b4a12","#e49135","#ba6222","#5c755e","#120309")
 	flora_prob = 1
 	large_flora_prob = 0
 	flora_diversity = 2

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -4,6 +4,7 @@
 	color = "#538224"
 	planetary_area = /area/exoplanet/grass
 	rock_colors = list(COLOR_ASTEROID_ROCK, COLOR_GRAY80, COLOR_BROWN)
+	plant_colors = list("#0e1e14","#1a3e38","#5a7467","#9eab88","#6e7248", "RANDOM")
 	map_generators = list(/datum/random_map/noise/exoplanet/grass)
 
 /obj/effect/overmap/sector/exoplanet/grass/generate_map()
@@ -56,26 +57,12 @@
 	smoothing_iterations = 2
 	land_type = /turf/simulated/floor/exoplanet/grass
 	water_type = /turf/simulated/floor/exoplanet/water/shallow
-	plantcolors = list("#0e1e14","#1a3e38","#5a7467","#9eab88","#6e7248", "RANDOM")
 
 	flora_prob = 30
 	large_flora_prob = 50
 	flora_diversity = 6
 	fauna_types = list(/mob/living/simple_animal/yithian, /mob/living/simple_animal/tindalos, /mob/living/simple_animal/hostile/retaliate/jelly)
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/parrot/space/megafauna)
-
-	var/grass_color
-
-/datum/random_map/noise/exoplanet/grass/New()
-	var/list/colors = plantcolors.Copy()
-	colors -= "RANDOM"
-	grass_color = pick(colors)
-	..()
-
-/datum/random_map/noise/exoplanet/grass/get_additional_spawns(var/value, var/turf/T)
-	..()
-	if(istype(T,/turf/simulated/floor/exoplanet/grass))
-		T.color = grass_color
 
 /turf/simulated/floor/exoplanet/grass
 	name = "grass"
@@ -87,6 +74,10 @@
 
 /turf/simulated/floor/exoplanet/grass/Initialize()
 	. = ..()
+	if(GLOB.using_map.use_overmap)
+		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		if(istype(E) && E.grass_color)
+			color = E.grass_color
 	if(!resources)
 		resources = list()
 	if(prob(70))
@@ -100,4 +91,5 @@
 	if((temperature > T0C + 200 && prob(5)) || temperature > T0C + 1000)
 		SetName("scorched ground")
 		icon_state = "scorched"
+		footstep_type = FOOTSTEP_ASTEROID
 		color = null

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -4,6 +4,7 @@
 	color = "#3e3960"
 	planetary_area = /area/exoplanet/shrouded
 	rock_colors = list(COLOR_INDIGO, COLOR_DARK_BLUE_GRAY, COLOR_NAVY_BLUE)
+	plant_colors = list("#3c5434", "#2f6655", "#0e703f", "#495139", "#394c66", "#1a3b77", "#3e3166", "#52457c", "#402d56", "#580d6d")
 	map_generators = list(/datum/random_map/noise/exoplanet/shrouded, /datum/random_map/noise/ore/poor)
 	ruin_tags_blacklist = RUIN_HABITAT
 	lightlevel = -0.15
@@ -30,7 +31,6 @@
 					   /mob/living/simple_animal/hostile/retaliate/beast/shantak/alt,
 					   /mob/living/simple_animal/hostile/leech)
 	megafauna_types = list(/obj/structure/leech_spawner)
-	plantcolors = list("#3c5434", "#2f6655", "#0e703f", "#495139", "#394c66", "#1a3b77", "#3e3166", "#52457c", "#402d56", "#580d6d")
 
 /area/exoplanet/shrouded
 	forced_ambience = list("sound/ambience/spookyspace1.ogg", "sound/ambience/spookyspace2.ogg")

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -4,6 +4,7 @@
 	color = "#e8faff"
 	planetary_area = /area/exoplanet/snow
 	rock_colors = list(COLOR_DARK_BLUE_GRAY, COLOR_GUNMETAL, COLOR_GRAY80, COLOR_DARK_GRAY)
+	plant_colors = list("#d0fef5","#93e1d8","#93e1d8", "#b2abbf", "#3590f3", "#4b4e6d")
 	map_generators = list(/datum/random_map/noise/exoplanet/snow, /datum/random_map/noise/ore/poor)
 
 /obj/effect/overmap/sector/exoplanet/snow/generate_atmosphere()
@@ -26,7 +27,6 @@
 	water_type = /turf/simulated/floor/exoplanet/ice
 	fauna_types = list(/mob/living/simple_animal/hostile/retaliate/beast/samak, /mob/living/simple_animal/hostile/retaliate/beast/diyaab, /mob/living/simple_animal/hostile/retaliate/beast/shantak)
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/giant_crab)
-	plantcolors = list("#d0fef5","#93e1d8","#93e1d8", "#b2abbf", "#3590f3", "#4b4e6d")
 
 /area/exoplanet/snow
 	ambience = list('sound/effects/wind/tundra0.ogg','sound/effects/wind/tundra1.ogg','sound/effects/wind/tundra2.ogg','sound/effects/wind/spooky0.ogg','sound/effects/wind/spooky1.ogg')

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -4,13 +4,14 @@
 	color = "#8e3900"
 	planetary_area = /area/exoplanet/volcanic
 	rock_colors = list(COLOR_DARK_GRAY)
+	plant_colors = list("#a23c05","#3f1f0d","#662929","#ba6222","#5c755e","#120309")
 	possible_themes = list()
 	map_generators = list(/datum/random_map/automata/cave_system/mountains/volcanic, /datum/random_map/noise/exoplanet/volcanic, /datum/random_map/noise/ore/filthy_rich)
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 
 /obj/effect/overmap/sector/exoplanet/volcanic/generate_habitability()
 	return HABITABILITY_BAD
-	
+
 /obj/effect/overmap/sector/exoplanet/volcanic/generate_atmosphere()
 	..()
 	if(atmosphere)
@@ -33,7 +34,6 @@
 	water_type = /turf/simulated/floor/exoplanet/lava
 	water_level_min = 5
 	water_level_max = 6
-	plantcolors = list("#a23c05","#3f1f0d","#662929","#ba6222","#5c755e","#120309")
 
 	fauna_prob = 1
 	flora_prob = 7
@@ -77,7 +77,7 @@
 
 /datum/random_map/automata/cave_system/mountains/volcanic/get_additional_spawns(value, var/turf/simulated/mineral/T)
 	..()
-	if(planetary_area)	
+	if(planetary_area)
 		T.mined_turf = prob(90) ? planetary_area.base_turf : /turf/simulated/floor/exoplanet/lava
 
 /turf/simulated/floor/exoplanet/lava

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -24,7 +24,7 @@
 	var/list/big_flora_types = list()
 	var/list/plantcolors = list("RANDOM")
 
-/datum/random_map/noise/exoplanet/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0, var/_planetary_area)
+/datum/random_map/noise/exoplanet/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0, var/_planetary_area, var/list/_plant_colors)
 	target_turf_type = world.turf
 	water_level = rand(water_level_min,water_level_max)
 	generate_flora()
@@ -34,14 +34,15 @@
 	flora_prob *= size_mod
 	large_flora_prob *= size_mod
 	fauna_prob *= size_mod
-
+	if(_plant_colors)
+		plantcolors = _plant_colors
 	..()
 
 	GLOB.using_map.base_turf_by_z[num2text(tz)] = land_type
 
 /datum/random_map/noise/exoplanet/proc/noise2value(var/value)
 	return min(9,max(0,round((value/cell_range)*10)))
-	
+
 /datum/random_map/noise/exoplanet/proc/is_edge_turf(turf/T)
 	return T.x <= TRANSITIONEDGE || T.x >= (limit_x - TRANSITIONEDGE + 1) || T.y <= TRANSITIONEDGE || T.y >= (limit_y - TRANSITIONEDGE + 1)
 


### PR DESCRIPTION
Moved plant colors out of randomgen map into planet datum, it now also handles grass color.
Grass now checks if it's on a planet and if so assumes right color.
