### PR TITLE
Gas thruster machinining

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -19,6 +19,9 @@
 	start_processing(machine)
 
 /obj/item/weapon/stock_parts/power/battery/on_uninstall(var/obj/machinery/machine)
+	if(status & PART_STAT_ACTIVE)
+		machine.update_power_channel(cached_channel)
+		unset_status(machine, PART_STAT_ACTIVE)
 	if(cell && (part_flags & PART_FLAG_QDEL))
 		cell.dropInto(loc)
 		remove_cell()
@@ -97,7 +100,6 @@
 
 /obj/item/weapon/stock_parts/power/battery/can_provide_power(var/obj/machinery/machine)
 	if(cell && cell.check_charge(CELLRATE * machine.get_power_usage()))
-		cached_channel = machine.power_channel
 		machine.update_power_channel(LOCAL)
 		set_status(machine, PART_STAT_ACTIVE)
 		return TRUE

--- a/code/game/machinery/_machines_base/stock_parts/power/power.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/power.dm
@@ -14,6 +14,7 @@
 	..()
 	ADD_SORTED(machine.power_components, src, /proc/cmp_power_component_priority)
 	machine.power_change() // Makes the machine recompute its power status.
+	cached_channel = initial(machine.power_channel)
 
 /obj/item/weapon/stock_parts/power/on_uninstall(var/obj/machinery/machine)
 	machine.power_components -= src

--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -9,6 +9,9 @@
 	var/terminal_dir = 0
 
 /obj/item/weapon/stock_parts/power/terminal/on_uninstall(var/obj/machinery/machine)
+	if(status & PART_STAT_ACTIVE)
+		machine.update_power_channel(cached_channel)
+		unset_status(machine, PART_STAT_ACTIVE)
 	unset_terminal(loc, terminal)
 	..()
 
@@ -38,7 +41,6 @@
 /obj/item/weapon/stock_parts/power/terminal/can_provide_power(var/obj/machinery/machine)
 	if(terminal && terminal.surplus() && machine.can_use_power_oneoff(machine.get_power_usage(), LOCAL) <= 0)
 		set_status(machine, PART_STAT_ACTIVE)
-		cached_channel = machine.power_channel
 		machine.update_power_channel(LOCAL)
 		start_processing(machine)
 		return TRUE

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -13,19 +13,17 @@
 	power_channel = LIGHT
 	use_power = POWER_USE_OFF
 
-	var/on = 0
-
 	//better laser, increased brightness & power consumption
 	var/l_max_bright = 0.8 //brightness of light when on, can be negative
 	var/l_inner_range = 0 //inner range of light when on, can be negative
 	var/l_outer_range = 4.5 //outer range of light when on, can be negative
 
 /obj/machinery/floodlight/on_update_icon()
-	icon_state = "flood[panel_open ? "o" : ""][panel_open && get_cell() ? "b" : ""]0[on]"
+	icon_state = "flood[panel_open ? "o" : ""][panel_open && get_cell() ? "b" : ""]0[use_power]"
 
 /obj/machinery/floodlight/power_change()
 	. = ..()
-	if(!. || !on) return
+	if(!. || !use_power) return
 
 	if(stat & NOPOWER)
 		turn_off(1)
@@ -35,7 +33,7 @@
 	if(prob(30))
 		set_light(l_max_bright / 2, l_inner_range, l_outer_range)
 		spawn(20)
-			if(on)
+			if(use_power)
 				set_light(l_max_bright, l_inner_range, l_outer_range)
 
 // Returns 0 on failure and 1 on success
@@ -43,7 +41,6 @@
 	if(stat & NOPOWER)
 		return 0
 
-	on = 1
 	set_light(l_max_bright, l_inner_range, l_outer_range)
 	update_use_power(POWER_USE_ACTIVE)
 	use_power_oneoff(active_power_usage)//so we drain cell if they keep trying to use it
@@ -54,7 +51,6 @@
 	return 1
 
 /obj/machinery/floodlight/proc/turn_off(var/loud = 0)
-	on = 0
 	set_light(0, 0)
 	update_use_power(POWER_USE_OFF)
 	update_icon()
@@ -65,7 +61,7 @@
 /obj/machinery/floodlight/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
-	if(on)
+	if(use_power)
 		turn_off(1)
 	else
 		if(!turn_on(1))
@@ -82,5 +78,5 @@
 	l_inner_range = light_mod     + initial(l_inner_range)
 	l_outer_range = light_mod*1.5 + initial(l_outer_range)
 	change_power_consumption(initial(active_power_usage) * light_mod , POWER_USE_ACTIVE)
-	if(on)
+	if(use_power)
 		set_light(l_max_bright, l_inner_range, l_outer_range)

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -50,8 +50,8 @@
 	if(href_list["global_toggle"])
 		linked.engines_state = !linked.engines_state
 		for(var/datum/ship_engine/E in linked.engines)
-			if(linked.engines_state != E.is_on())
-				E.toggle()				
+			if(linked.engines_state == !E.is_on())
+				E.toggle()
 		return TOPIC_REFRESH
 
 	if(href_list["set_global_limit"])

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -27,10 +27,25 @@
 	return nozzle.thrust_limit
 
 /datum/ship_engine/gas_thruster/is_on()
-	return nozzle.is_on()
+	if(nozzle.use_power && nozzle.operable())
+		if(nozzle.next_on > world.time)
+			return -1
+		else
+			return 1
+	return 0
 
 /datum/ship_engine/gas_thruster/toggle()
-	nozzle.on = !nozzle.on
+	if(nozzle.use_power)
+		nozzle.update_use_power(POWER_USE_OFF)
+	else
+		if(nozzle.blockage)
+			if(nozzle.check_blockage())
+				return
+		nozzle.update_use_power(POWER_USE_IDLE)
+		if(nozzle.stat & NOPOWER)//try again
+			nozzle.power_change()
+		if(nozzle.is_on())//if everything is in working order, start booting!
+			nozzle.next_on = world.time + nozzle.boot_time
 
 /datum/ship_engine/gas_thruster/can_burn()
 	return nozzle.is_on() && nozzle.check_fuel()
@@ -42,18 +57,26 @@
 	desc = "Simple rocket nozzle, expelling gas at hypersonic velocities to propell the ship."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle"
-	use_power = POWER_USE_OFF
-	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
 	opacity = 1
 	density = 1
 	atmos_canpass = CANPASS_NEVER
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
+
 	construct_state = /decl/machine_construction/default/panel_closed
-	var/on = 1
+	maximum_component_parts = list(/obj/item/weapon/stock_parts = 6)//don't want too many, let upgraded component shine
+	uncreated_component_parts = null
+
+	use_power = POWER_USE_OFF
+	power_channel = EQUIP
+	idle_power_usage = 21600 //6 Wh per tick for default 2 capacitor. Gives them a reason to turn it off, really to nerf backup battery
+
 	var/datum/ship_engine/gas_thruster/controller
 	var/thrust_limit = 1	//Value between 1 and 0 to limit the resulting thrust
-	var/volume_per_burn = 20 //litres
+	var/volume_per_burn = 15 //20 litres(with bin)
+	var/charge_per_burn = 36000 //10Wh for default 2 capacitor, chews through that battery power! Makes a trade off of fuel efficient vs energy efficient
+	var/boot_time = 35
+	var/next_on
+	var/blockage
 
 /obj/machinery/atmospherics/unary/engine/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 0
@@ -63,6 +86,14 @@
 	controller = new(src)
 	update_nearby_tiles(need_rebuild=1)
 
+	for(var/ship in SSshuttle.ships)
+		var/obj/effect/overmap/ship/S = ship
+		if(S.check_ownership(src))
+			S.engines |= controller
+			if(dir != S.fore_dir)
+				set_broken(TRUE)
+			break
+
 /obj/machinery/atmospherics/unary/engine/Destroy()
 	QDEL_NULL(controller)
 	update_nearby_tiles()
@@ -71,18 +102,27 @@
 /obj/machinery/atmospherics/unary/engine/proc/get_status()
 	. = list()
 	.+= "Location: [get_area(src)]."
-	if(!powered())
-		.+= "Insufficient power to operate."
+	if(stat & NOPOWER)
+		.+= "<span class='average'>Insufficient power to operate.</span>"
 	if(!check_fuel())
-		.+= "Insufficient fuel for a burn."
+		.+= "<span class='average'>Insufficient fuel for a burn.</span>"
+	if(stat & BROKEN)
+		.+= "<span class='average'>Inoperable engine configuration.</span>"
+	if(blockage)
+		.+= "<span class='average'>Obstruction of airflow detected.</span>"
 
 	.+= "Propellant total mass: [round(air_contents.get_mass(),0.01)] kg."
 	.+= "Propellant used per burn: [round(air_contents.get_mass() * volume_per_burn * thrust_limit / air_contents.volume,0.01)] kg."
 	.+= "Propellant pressure: [round(air_contents.return_pressure()/1000,0.1)] MPa."
 	. = jointext(.,"<br>")
 
+/obj/machinery/atmospherics/unary/engine/power_change()
+	. = ..()
+	if(stat & NOPOWER)
+		update_use_power(POWER_USE_OFF)
+
 /obj/machinery/atmospherics/unary/engine/proc/is_on()
-	return on && powered()
+	return use_power && operable() && (next_on < world.time)
 
 /obj/machinery/atmospherics/unary/engine/proc/check_fuel()
 	return air_contents.total_moles > 5 // minimum fuel usage is five moles, for EXTREMELY hot mix or super low pressure
@@ -94,14 +134,27 @@
 	. = calculate_thrust(air_contents, used_part)
 	return
 
-/obj/machinery/atmospherics/unary/engine/proc/burn()
-	if (!is_on())
-		return 0
-	if(!check_fuel())
-		audible_message(src,"<span class='warning'>[src] coughs once and goes silent!</span>")
-		on = !on
-		return 0
+/obj/machinery/atmospherics/unary/engine/proc/check_blockage()
+	blockage = FALSE
 	var/exhaust_dir = reverse_direction(dir)
+	var/turf/A = get_step(src, exhaust_dir)
+	var/turf/B = A
+	while(isturf(A) && !(isspace(A) || isopenspace(A)))
+		if((B.c_airblock(A)) & AIR_BLOCKED)
+			blockage = TRUE
+			break
+		B = A
+		A = get_step(A, exhaust_dir)
+	return blockage
+
+/obj/machinery/atmospherics/unary/engine/proc/burn()
+	if(!is_on())
+		return 0
+	if(!check_fuel() || (0 < use_power_oneoff(charge_per_burn)) || check_blockage())
+		audible_message(src,"<span class='warning'>[src] coughs once and goes silent!</span>")
+		update_use_power(POWER_USE_OFF)
+		return 0
+
 	var/datum/gas_mixture/removed = air_contents.remove_ratio(volume_per_burn * thrust_limit / air_contents.volume)
 	if(!removed)
 		return 0
@@ -109,6 +162,8 @@
 	playsound(loc, 'sound/machines/thruster.ogg', 100 * thrust_limit, 0, world.view * 4, 0.1)
 	if(network)
 		network.update = 1
+
+	var/exhaust_dir = reverse_direction(dir)
 	var/turf/T = get_step(src,exhaust_dir)
 	if(T)
 		T.assume_air(removed)
@@ -116,6 +171,17 @@
 
 /obj/machinery/atmospherics/unary/engine/proc/calculate_thrust(datum/gas_mixture/propellant, used_part = 1)
 	return round(sqrt(propellant.get_mass() * used_part * sqrt(air_contents.return_pressure()/200)),0.1)
+
+/obj/machinery/atmospherics/unary/engine/RefreshParts()
+	..()
+	//allows them to upgrade the max limit of fuel intake (which only gives diminishing returns) for increase in max thrust but massive reduction in fuel economy
+	var/bin_upgrade = 5 * Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/matter_bin), 0, 6)//5 litre per rank
+	volume_per_burn = bin_upgrade ? initial(volume_per_burn) + bin_upgrade : 2 //Penalty missing part: 10% fuel use, no thrust
+	boot_time = bin_upgrade ? initial(boot_time) - bin_upgrade : initial(boot_time) * 2
+	//energy cost - thb all of this is to limit the use of back up batteries
+	var/energy_upgrade = Clamp(total_component_rating_of_type(/obj/item/weapon/stock_parts/capacitor), 0.1, 6)
+	charge_per_burn = initial(charge_per_burn) / energy_upgrade
+	change_power_consumption(initial(idle_power_usage) / energy_upgrade, POWER_USE_IDLE)
 
 //Exhaust effect
 /obj/effect/engine_exhaust
@@ -135,13 +201,15 @@
 	spawn(20)
 		qdel(src)
 
-/obj/item/weapon/stock_parts/circuitboard/unary_atmos/engine
+/obj/item/weapon/stock_parts/circuitboard/unary_atmos/engine//why don't we move this elsewhere?
 	name = T_BOARD("gas thruster")
 	icon_state = "mcontroller"
 	build_path = /obj/machinery/atmospherics/unary/engine
 	origin_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 2)
 	req_components = list(
-							/obj/item/stack/cable_coil = 2,
-							/obj/item/weapon/stock_parts/matter_bin = 1,
-							/obj/item/weapon/stock_parts/capacitor = 1,
-							/obj/item/pipe = 2)
+		/obj/item/stack/cable_coil = 30,
+		/obj/item/pipe = 2)
+	additional_spawn_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 1,
+		/obj/item/weapon/stock_parts/capacitor = 2,
+		/obj/item/weapon/stock_parts/power/apc/buildable = 1)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -28,7 +28,7 @@
 
 	var/obj/machinery/computer/ship/helm/nav_control
 	var/list/engines = list()
-	var/engines_state = 1 //global on/off toggle for all engines
+	var/engines_state = 0 //global on/off toggle for all engines
 	var/thrust_limit = 1  //global thrust limit for all engines, 0..1
 	var/halted = 0        //admin halt or other stop.
 	var/skill_needed = SKILL_ADEPT  //piloting skill needed to steer it without going in random dir

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1016,7 +1016,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/floor/plating,
 /area/thruster/d3starboard)
 "cv" = (
 /obj/structure/lattice,
@@ -15912,7 +15912,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/floor/plating,
 /area/thruster/d3port)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1131,7 +1131,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/floor/plating,
 /area/thruster/d1starboard)
 "acb" = (
 /obj/structure/sign/warning/airlock,
@@ -11636,7 +11636,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/floor/plating,
 /area/thruster/d1port)
 "aQp" = (
 /obj/structure/table/rack,

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -89,9 +89,9 @@
 /obj/effect/overmap/ship/landable/guppy
 	name = "Guppy"
 	shuttle = "Guppy"
-	max_speed = 1/(5 SECONDS)
+	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
-	vessel_mass = 2500 //very inefficient pod
+	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_TINY

--- a/nano/templates/engines_control.tmpl
+++ b/nano/templates/engines_control.tmpl
@@ -38,9 +38,8 @@
 					<span class='white'>Engine #{{:(index + 1)}}:</span>
 				</div>
 				<div class="itemContent">
-						{{:helper.link(value.eng_on ? 'Shutdown' : 'Power up', 'power', { 'toggle' : 1, 'engine' : value.eng_reference }, null, value.eng_on ? 'selected' : null)}}
+						{{:helper.link(value.eng_on ? 'Shutdown' : 'Power up', 'power', { 'toggle' : 1, 'engine' : value.eng_reference }, null, value.eng_on ? value.eng_on == 1 ? 'linkOn' : 'yellowButton' : null)}}
 				</div>
-			</div>
 			<div class='statusDisplay'>
 			  <div class='item'>
 				<div class="itemLabel">
@@ -55,7 +54,7 @@
 					<span class='average'>Status:</span>
 				</div>
 				<div class="itemContent">
-					<span class='{{:value.eng_on ? 'good' : 'bad'}}'>{{:value.eng_on ? 'Online' : 'Offline'}}</span><br>
+					<span class='{{:value.eng_on ? value.eng_on == 1 ? 'good' : 'average' : 'bad'}}'>{{:value.eng_on ?  value.eng_on == 1 ? 'Online' : 'Booting' : 'Offline'}}</span><br>
 					<span class='white'>{{:value.eng_status}}</span>
 				</div>
 			  </div>
@@ -90,7 +89,7 @@
 						<span class='white'>Engine #{{:(index + 1)}}:</span>
 					</div>
 					<div class="itemContent">
-						{{:helper.link(value.eng_on ? 'Shutdown' : 'Power up', 'power', { 'toggle' : 1, 'engine' : value.eng_reference }, null, value.eng_on ? 'selected' : null)}}
+						{{:helper.link(value.eng_on ? 'Shutdown' : 'Power up', 'power', { 'toggle' : 1, 'engine' : value.eng_reference }, null, value.eng_on ? value.eng_on == 1 ? 'linkOn' : 'yellowButton' : null)}}
 					</div>
 				</div>
 				<div class='item'>


### PR DESCRIPTION
Updates Gas thruster to the machine update level!
🆑 
rscadd: Gas thruster is now modifiable machine.
bugfix: Gas thruster now hooks up to their ship when built.
rscadd: Gas thrusters now has a boot up time.
rscadd: Gas thruster can be upgraded with matter bin for extra fuel intake volume and less boot up time or capacitor for energy efficiency.
rscadd: Gas thrusters has an increased energy usage on idle (6 Wh per tick so every 2 second) and 10 Wh per burn. So please keep them off unless you need them, for that same reason all thrusts starts offline.
tweak: Guppy's mass and max speed has both been increased.
/🆑 

https://i.imgur.com/JJdzPuN.gif

Also cleaned up some floodlight code
Why did I increase the guppy's mass and max speed? Because there's no point of adding more thrusters to these ships unless you can go fast!