### PR TITLE
Fixes invisible vines

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -80,6 +80,9 @@
 	if(!isnull(lbound))  nval = max(nval,lbound)
 	traits["[trait]"] =  nval
 
+	if(trait == TRAIT_PLANT_ICON)
+		update_growth_stages()
+
 /datum/seed/proc/create_spores(var/turf/T)
 	if(!T)
 		return


### PR DESCRIPTION
It happens when something changes plant icon without calling this proc to udpate growth stages.
I can just plug couple places that I found to do that, but I think this is way more robust solutino not relying on people knowing they need to do additional call for THIS trait.
