### PR TITLE
Suspended processes now do not fire.

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -397,6 +397,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			continue
 		if (SS.next_fire > world.time)
 			continue
+		if(SS.suspended)
+			continue
 		SS_flags = SS.flags
 		if (SS_flags & SS_NO_FIRE)
 			subsystemstocheck -= SS


### PR DESCRIPTION
Probably extremely wrong about this, but during testing of some flooding optimizations, suspending various subsystems did exactly nothing. Commenting out `var/suspended` only indicated that it was set, never actually used beyond a cosmetic stat line.

This at least prevents fluids from spreading if the controller is suspended. Someone more knowledgable than me about the subsystems should review.