### PR TITLE
Flooding tweaks.

### DIFF
--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -25,7 +25,7 @@
 /obj/effect/fluid/Initialize()
 	. = ..()
 	start_loc = get_turf(src)
-	if(!istype(start_loc))
+	if(!istype(start_loc) || start_loc.flooded)
 		qdel(src)
 		return
 	var/turf/simulated/T = start_loc

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -1,5 +1,5 @@
 /turf/CanFluidPass(var/coming_from)
-	if(density)
+	if(flooded || density)
 		return FALSE
 	if(isnull(fluid_can_pass))
 		fluid_can_pass = TRUE
@@ -10,9 +10,10 @@
 	return fluid_can_pass
 
 /turf/proc/add_fluid(var/amount, var/fluid)
-	var/obj/effect/fluid/F = locate() in src
-	if(!F) F = new(src)
-	SET_FLUID_DEPTH(F, F.fluid_amount + amount)
+	if(!flooded)
+		var/obj/effect/fluid/F = locate() in src
+		if(!F) F = new(src)
+		SET_FLUID_DEPTH(F, F.fluid_amount + amount)
 
 /turf/proc/remove_fluid(var/amount = 0)
 	var/obj/effect/fluid/F = locate() in src
@@ -23,10 +24,11 @@
 
 /turf/proc/make_flooded()
 	if(!flooded)
-		flooded = 1
+		flooded = TRUE
 		for(var/obj/effect/fluid/F in src)
 			qdel(F)
 		update_icon()
+		fluid_update()
 
 /turf/is_flooded(var/lying_mob, var/absolute)
 	return (flooded || (!absolute && check_fluid_depth(lying_mob ? FLUID_OVER_MOB_HEAD : FLUID_DEEP)))


### PR DESCRIPTION
Tweaks to prevent water from backfilling into already absolute-flooded turfs (largely during map generation).