### PR TITLE
Makes Sleepy Pen use Vecuronium Bromide rather than Chloral Hydrate

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -28,8 +28,8 @@
 	path = /obj/item/weapon/storage/box/syndie_kit/toxin
 
 /datum/uplink_item/item/stealthy_weapons/sleepy
-	name = "Sleepy Pen"
-	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be out like a light."
+	name = "Paralytic Pen"
+	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be on the ground mumbling."
 	item_cost = 20
 	path = /obj/item/weapon/pen/reagent/sleepy
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -122,7 +122,7 @@
 
 /obj/item/weapon/pen/reagent/sleepy/New()
 	..()
-	reagents.add_reagent(/datum/reagent/chloralhydrate, 15)	//Used to be 100 sleep toxin//30 Chloral seems to be fatal, reducing it to 22, reducing it further to 15 because fuck you OD code./N
+	reagents.add_reagent(/datum/reagent/vecuronium_bromide, 15)
 
 
 /*


### PR DESCRIPTION
:cl: Rain7x
tweak: The sleepy pen now contains Vecuronium Bromide instead of Chloral Hydrate.
/:cl:

Vecuronium Bromide seems to be superior in almost every way to Chloral, as it has essentially the same effect as chloral in that in incapacitates the target, but the target can do something other than stare at a black screen.