### PR TITLE
Reagent Sublimators (including the sauna heater) can now be emagged

### DIFF
--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -166,7 +166,14 @@
 			to_chat(user, "\The [src] has \a [container] loaded. It is empty.")
 	if(holding)
 		to_chat(user, "\The [src] has \a [holding] connected.")
+	if(reagent_whitelist)
+		to_chat(user, "\The [src]'s safety light is on.")
 
+/obj/machinery/portable_atmospherics/reagent_sublimator/emag_act(var/remaining_charges, var/mob/user)
+	if(!emagged && reagent_whitelist)
+		emagged = !emagged
+		reagent_whitelist.Cut()
+		to_chat(user, "\The [src]'s safety light turns off.")
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/sauna
 	name = "sauna heater"

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -174,6 +174,8 @@
 		emagged = !emagged
 		reagent_whitelist.Cut()
 		to_chat(user, "\The [src]'s safety light turns off.")
+		return 1
+	return
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/sauna
 	name = "sauna heater"

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -170,12 +170,11 @@
 		to_chat(user, "\The [src]'s safety light is on.")
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/emag_act(var/remaining_charges, var/mob/user)
-	if(!emagged && reagent_whitelist)
-		emagged = !emagged
+	if(!emagged && length(reagent_whitelist))
+		emagged = TRUE
 		reagent_whitelist.Cut()
 		to_chat(user, "\The [src]'s safety light turns off.")
 		return 1
-	return
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/sauna
 	name = "sauna heater"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Doing so removes their reagent whitelist, if applicable. 
:cl:
rscadd: Sauna heaters and reagent sublimators can now be emagged to make them accept any reagent.
/:cl:
I can't squash this, as I'm on holiday.