### PR TITLE
Revert "Makes Sleepy Pen use Vecuronium Bromide rather than Chloral Hydrate"

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -28,8 +28,8 @@
 	path = /obj/item/weapon/storage/box/syndie_kit/toxin
 
 /datum/uplink_item/item/stealthy_weapons/sleepy
-	name = "Paralytic Pen"
-	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be on the ground mumbling."
+	name = "Sleepy Pen"
+	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be out like a light."
 	item_cost = 20
 	path = /obj/item/weapon/pen/reagent/sleepy
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -122,7 +122,7 @@
 
 /obj/item/weapon/pen/reagent/sleepy/New()
 	..()
-	reagents.add_reagent(/datum/reagent/vecuronium_bromide, 15)
+	reagents.add_reagent(/datum/reagent/chloralhydrate, 15)	//Used to be 100 sleep toxin//30 Chloral seems to be fatal, reducing it to 22, reducing it further to 15 because fuck you OD code./N
 
 
 /*


### PR DESCRIPTION
Reverts Baystation12/Baystation12#26798
This change hinders any traitors who want to kidnap someone without them knowing where they are taken or implant them etc. making it unnecessarily more complicated to do so without having/getting chem access, duct tape or more tools in general.