### PR TITLE
Adds green glow to rad hotspots on garbage planets

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/garbage.dm
+++ b/code/modules/overmap/exoplanets/planet_types/garbage.dm
@@ -63,6 +63,7 @@
 			var/datum/radiation_source/S = new(T, 2*fallout, FALSE)
 			S.range = 4
 			SSradiation.add_source(S)
+			T.set_light(0.4, 1, 2, l_color = PIPE_COLOR_GREEN)
 		if(prob(0.02))
 			var/datum/artifact_find/A = new()
 			new A.artifact_find_type(T)


### PR DESCRIPTION
As we all know, rads glow green.
Barely, but visible on lit planets, very visible on dark ones.
