### PR TITLE
Adds "Resident" and removes "Trauma Surgeon" alt title from physician

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -11,7 +11,7 @@
 	economic_power = 8
 	alt_titles = list(
 		"Surgeon",
-		"Trauma Surgeon")
+		"Resident")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/senior
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,


### PR DESCRIPTION
:cl: Rain7x
rscadd: Added "Resident" Physician Alt Title
rscdel: Removed "Trauma Surgeon" Alt Title
/:cl:

I was originally going to add a completely new job, but in the interest of not overcrowding med-bay, I added this alt title instead. A resident is a post M.D. doctor-in-training. I added this to give an option for people who want to signify OOCly that they are new to the job, so people don't assume they have complete medical knowledge.

Trauma Surgeon isn't really a needed alt title, since 98% of surgery on the Torch is trauma surgery. Also title bloat.