### PR TITLE
Minor map cleanup

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -38,6 +38,7 @@
 	name = "randomly spawned object"
 	desc = "This item type is used to randomly spawn a given object at round-start."
 	icon_state = "x3"
+	spawn_nothing_percentage = 50
 	var/spawn_object = null
 
 /obj/random/single/spawn_choices()
@@ -46,7 +47,7 @@
 /obj/random/tool
 	name = "random tool"
 	desc = "This is a random tool."
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/tools.dmi'
 	icon_state = "welder"
 
 /obj/random/tool/spawn_choices()
@@ -296,7 +297,7 @@
 	name = "Random Handgun"
 	desc = "This is a random sidearm."
 	icon = 'icons/obj/guns/pistol.dmi'
-	icon_state = "secgundark"
+	icon_state = "secguncomp"
 
 /obj/random/handgun/spawn_choices()
 	return list(/obj/item/weapon/gun/projectile/pistol/sec = 3,
@@ -310,7 +311,7 @@
 	name = "Random Ammunition"
 	desc = "This is random ammunition."
 	icon = 'icons/obj/ammo.dmi'
-	icon_state = "45-10"
+	icon_state = "magnum"
 
 /obj/random/ammo/spawn_choices()
 	return list(/obj/item/weapon/storage/box/ammo/beanbags = 6,
@@ -467,8 +468,8 @@ obj/random/closet //A couple of random closets to spice up maint
 /obj/random/coin
 	name = "random coin"
 	desc = "This is a random coin."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "coin"
+	icon = 'icons/obj/coin.dmi'
+	icon_state = "coin1"
 
 /obj/random/coin/spawn_choices()
 	return list(/obj/item/weapon/material/coin/gold = 3,
@@ -842,7 +843,7 @@ obj/random/obstruction/spawn_choices()
 	name = "random clothes"
 	desc = "This is a random piece of clothing."
 	icon = 'icons/obj/clothing/obj_under.dmi'
-	icon_state = "grey"
+	icon_state = "jumpsuit"
 
 /obj/random/clothing/spawn_choices()
 	return list(/obj/item/clothing/under/syndicate/tacticool = 2,
@@ -1222,7 +1223,7 @@ var/list/random_useful_
 /obj/random/mre/main
 	name = "random MRE main course"
 	desc = "This is a random main course for MREs."
-	icon_state = "pouch"
+	icon_state = "pouch_medium"
 
 /obj/random/mre/main/spawn_choices()
 	return list(/obj/item/weapon/storage/mrebag,
@@ -1237,7 +1238,7 @@ var/list/random_useful_
 /obj/random/mre/dessert
 	name = "random MRE dessert"
 	desc = "This is a random dessert for MREs."
-	icon_state = "pouch"
+	icon_state = "pouch_medium"
 
 /obj/random/mre/dessert/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/snacks/candy,
@@ -1262,7 +1263,7 @@ var/list/random_useful_
 /obj/random/mre/drink
 	name = "random MRE drink"
 	desc = "This is a random drink for MREs."
-	icon_state = "packet"
+	icon_state = "packet_small"
 
 /obj/random/mre/drink/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee,
@@ -1276,7 +1277,7 @@ var/list/random_useful_
 /obj/random/mre/spread
 	name = "random MRE spread"
 	desc = "This is a random spread packet for MREs."
-	icon_state = "packet"
+	icon_state = "packet_small"
 
 /obj/random/mre/spread/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/jelly,
@@ -1292,7 +1293,7 @@ var/list/random_useful_
 /obj/random/mre/sauce
 	name = "random MRE sauce"
 	desc = "This is a random sauce packet for MREs."
-	icon_state = "packet"
+	icon_state = "packet_small"
 
 /obj/random/mre/sauce/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/salt,
@@ -1339,3 +1340,21 @@ var/list/random_useful_
 				/obj/machinery/vending/sol,
 				/obj/machinery/vending/snix
 				)
+
+/obj/random/single/playing_cards
+	name = "randomly spawned deck of cards"
+	icon = 'icons/obj/playing_cards.dmi'
+	icon_state = "deck"
+	spawn_object = /obj/item/weapon/deck
+
+/obj/random/single/lighter
+	name = "randomly spawned lighter"
+	icon = 'icons/obj/lighters.dmi'
+	icon_state = "lighter"
+	spawn_object = /obj/item/weapon/flame/lighter
+
+/obj/random/single/cola
+	name = "randomly spawned cola"
+	icon = 'icons/obj/drinks.dmi'
+	icon_state = "cola"
+	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola

--- a/code/unit_tests/icon_tests.dm
+++ b/code/unit_tests/icon_tests.dm
@@ -141,3 +141,28 @@
 	else
 		pass("All item modifiers have valid icon states.")
 	return 1
+
+/datum/unit_test/icon_test/random_spawners_shall_have_icon_states
+	name = "ICON STATE - Random Spawners Shall Have Icon States"
+
+/datum/unit_test/icon_test/random_spawners_shall_have_icon_states/start_test()
+	var/states_per_icon = list()
+	var/list/invalid_spawners = list()
+	for(var/random_type in typesof(/obj/random))
+		var/obj/random/R = random_type
+		var/icon = initial(R.icon)
+		var/icon_state = initial(R.icon_state) || ""
+
+		var/icon_states = states_per_icon[icon]
+		if(!icon_states)
+			icon_states = icon_states(icon)
+			states_per_icon[icon] = icon_states
+
+		if(!(icon_state in icon_states))
+			invalid_spawners += random_type
+
+	if(invalid_spawners.len)
+		fail("[invalid_spawners.len] /obj/random type\s with missing icon states: [json_encode(invalid_spawners)]")
+	else
+		pass("All /obj/random types have valid icon states.")
+	return 1

--- a/maps/away/blueriver/blueriver-1.dmm
+++ b/maps/away/blueriver/blueriver-1.dmm
@@ -10,11 +10,6 @@
 "c" = (
 /turf/unsimulated/wall/away/blueriver/livingwall,
 /area/bluespaceriver/underground)
-"d" = (
-/turf/unsimulated/wall/supermatter/no_spread{
-	plane = -19
-	},
-/area/bluespaceriver/underground)
 "e" = (
 /obj/machinery/crystal_static{
 	alpha = 120;
@@ -4365,7 +4360,7 @@ a
 a
 b
 b
-d
+b
 e
 f
 f

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -96,7 +96,7 @@
 	name = "Random Ammo Magazine"
 	desc = "This is smuggler's random ammo magazine."
 	icon = 'icons/obj/ammo.dmi'
-	icon_state = "45-10"
+	icon_state = "magnum"
 
 /obj/random/ammo_magazine_smug/spawn_choices()
 	return list(

--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -5,8 +5,8 @@ Random item spawning
 /obj/random/solgov
 	name = "random solgov equipment"
 	desc = "This is a random piece of solgov equipment or clothing."
-	icon = 'icons/obj/clothing/obj_head.dmi'
-	icon_state = "helmet_sol"
+	icon = 'maps/torch/icons/obj/obj_head_solgov.dmi'
+	icon_state = "solsoft"
 
 /obj/random/solgov/spawn_choices()
 	return list(/obj/item/clothing/head/solgov/utility/fleet = 4,

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1659,13 +1659,7 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov/clean,
-/obj/random/single{
-	icon = 'icons/obj/playing_cards.dmi';
-	icon_state = "deck";
-	name = "randomly spawned deck of cards";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/deck
-	},
+/obj/random/single/playing_cards,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3981,13 +3975,7 @@
 	dir = 1;
 	target_pressure = 200
 	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /obj/structure/table/gamblingtable,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -8203,13 +8191,7 @@
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
-/obj/random/single{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "lighter-g";
-	name = "randomly spawned lighter";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/flame/lighter
-	},
+/obj/random/single/lighter,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)
 "At" = (
@@ -8244,27 +8226,9 @@
 /area/maintenance/fourthdeck/port)
 "AD" = (
 /obj/structure/closet/crate/freezer,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
+/obj/random/single/cola,
+/obj/random/single/cola,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
@@ -11303,13 +11267,7 @@
 /area/maintenance/fourthdeck/forestarboard)
 "LZ" = (
 /obj/structure/table/rack,
-/obj/random/single{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "lighter-g";
-	name = "randomly spawned lighter";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/flame/lighter
-	},
+/obj/random/single/lighter,
 /obj/machinery/newscaster{
 	pixel_x = 0;
 	pixel_y = 32
@@ -12432,13 +12390,7 @@
 "Pi" = (
 /obj/structure/closet/crate/plastic,
 /obj/random/maintenance/solgov,
-/obj/random/single{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "lighter-g";
-	name = "randomly spawned lighter";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/flame/lighter
-	},
+/obj/random/single/lighter,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "Pj" = (
@@ -12788,13 +12740,7 @@
 /area/quartermaster/office)
 "PY" = (
 /obj/structure/table/rack,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -14148,13 +14094,7 @@
 "Tt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/single{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "lighter-g";
-	name = "randomly spawned lighter";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/flame/lighter
-	},
+/obj/random/single/lighter,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)
 "Tu" = (
@@ -16098,13 +16038,7 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/random/single{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "lighter-g";
-	name = "randomly spawned lighter";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/flame/lighter
-	},
+/obj/random/single/lighter,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3363,41 +3363,11 @@
 /area/vacant/mess)
 "gJ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
+/obj/random/single/cola,
+/obj/random/single/cola,
+/obj/random/single/cola,
+/obj/random/single/cola,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
@@ -6412,13 +6382,7 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "mq" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1255,13 +1255,7 @@
 /area/storage/medical)
 "ct" = (
 /obj/structure/table/standard,
-/obj/random/single{
-	icon = 'icons/obj/playing_cards.dmi';
-	icon_state = "deck";
-	name = "randomly spawned deck of cards";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/deck
-	},
+/obj/random/single/playing_cards,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -2956,6 +2950,7 @@
 "gh" = (
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/stack/material/glass{
@@ -10859,13 +10854,7 @@
 /area/engineering/atmos)
 "zA" = (
 /obj/structure/closet,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "zB" = (
@@ -12336,13 +12325,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
@@ -14953,13 +14936,7 @@
 /area/engineering/bluespace)
 "KT" = (
 /obj/structure/closet/crate,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /obj/random/tech_supply,
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
@@ -16049,6 +16026,7 @@
 "OQ" = (
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -11129,9 +11129,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "aOK" = (
-/obj/machinery/status_display{
-	density = 0;
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/wing)
 "aOL" = (
@@ -16950,6 +16948,7 @@
 "ehb" = (
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/clothing/head/welding{
@@ -22462,13 +22461,7 @@
 /area/medical/infirmary)
 "kld" = (
 /obj/structure/closet/crate/freezer/rations,
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -24514,6 +24507,7 @@
 /obj/item/weapon/storage/box/masks,
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -4554,13 +4554,7 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/random/single{
-	icon = 'icons/obj/drinks.dmi';
-	icon_state = "cola";
-	name = "randomly spawned cola";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/reagent_containers/food/drinks/cans/cola
-	},
+/obj/random/single/cola,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
@@ -7664,9 +7658,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "pG" = (
-/obj/machinery/status_display{
-	density = 0;
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/security/bridgecheck)
 "pI" = (
@@ -8633,9 +8625,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/co)
 "rQ" = (
-/obj/machinery/status_display{
-	density = 0;
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/bridge)
 "rR" = (
@@ -11279,9 +11269,7 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "yg" = (
-/obj/machinery/status_display{
-	density = 0;
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "yh" = (
@@ -13417,9 +13405,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HE" = (
-/obj/machinery/status_display{
-	density = 0;
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall/r_wall/hull,
 /area/bridge)
 "HF" = (

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -16396,13 +16396,7 @@
 /area/merchant_station)
 "aMZ" = (
 /obj/structure/table/woodentable,
-/obj/random/single{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "lighter-g";
-	name = "randomly spawned lighter";
-	spawn_nothing_percentage = 50;
-	spawn_object = /obj/item/weapon/flame/lighter
-	},
+/obj/random/single/lighter,
 /obj/random/toy,
 /turf/simulated/floor/carpet/blue,
 /area/merchant_station)

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -203,6 +203,7 @@ function run_code_tests {
     run_test "check travis contains all maps" "scripts/validateTravisContainsAllMaps.sh"
     run_test_fail "maps contain no step_[xy]" "grep 'step_[xy]' maps/**/*.dmm"
     run_test_fail "maps contain no layer adjustments" "grep 'layer = ' maps/**/*.dmm"
+    run_test_fail "maps contain no plane adjustments" "grep 'plane = ' maps/**/*.dmm"
     run_test_fail "ensure nanoui templates unique" "find nano/templates/ -type f -exec md5sum {} + | sort | uniq -D -w 32 | grep nano"
     run_test_fail "no invalid spans" "grep -En \"<\s*span\s+class\s*=\s*('[^'>]+|[^'>]+')\s*>\" **/*.dm"
     run_test "code quality checks" "test/check-paths.sh"


### PR DESCRIPTION
Adds appropriate item spawner subtypes
Ensures that item spawners have valid icons
Removes plane edits and ensures there will be no further ones

Also cleaned up entries of `/obj/machinery/status_display` that overrode the default density value with the same value
The map cleaner insisted of adding random newlines, and it displeased me.