### PR TITLE
Readds line I removed yesterday in skybox

### DIFF
--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -21,6 +21,7 @@
 		if(rebuild)
 			skybox.overlays.Cut()
 			skybox.overlays += SSskybox.get_skybox(T.z)
+			screen |= skybox
 		skybox.screen_loc = "CENTER:[-224 - T.x],CENTER:[-224 - T.y]"
 
 /mob/Login()


### PR DESCRIPTION
It wasn't old code I forgot to remove, it was actually needed for ghosting/etc cause in that case skybox is removed from screen, but not nulled so update_skybox didn't reapply it. Now always readding to screen on rebuild.
