### PR TITLE
Removed stunbatons from default borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_standard.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_standard.dm
@@ -8,7 +8,6 @@
 	)
 	equipment = list(
 		/obj/item/device/flash,
-		/obj/item/weapon/melee/baton/loaded,
 		/obj/item/weapon/extinguisher,
 		/obj/item/weapon/wrench,
 		/obj/item/weapon/crowbar,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
So they can't be discount secborgs.
:cl:
tweak: Default Cyborgs no longer have stunbatons
/:cl: