### PR TITLE
Fix some light fixture runtimes

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -276,6 +276,9 @@
 		update_icon(0)
 
 /obj/machinery/light/proc/set_emergency_lighting(var/enable)
+	if(!lightbulb)
+		return
+
 	if(enable)
 		if(LIGHTMODE_EMERGENCY in lightbulb.lighting_modes)
 			set_mode(LIGHTMODE_EMERGENCY)
@@ -465,7 +468,7 @@
 	update_icon()
 
 /obj/machinery/light/proc/fix()
-	if(get_status() == LIGHT_OK)
+	if(get_status() == LIGHT_OK || !lightbulb)
 		return
 	lightbulb.status = LIGHT_OK
 	on = 1


### PR DESCRIPTION
If you remove a lightbulb, that sets it to null. APC/Admins do a thing to lightbulb, object ref exception.

Fixes #26917 <- APC issue
Fixes #26888 <- APC issue
Fixes #26878 <- APC issue
Fixes #23979 <- APC issue
Fixes #21920 <- APC issue
Fixes #21564 <- APC issue
Fixes #21674 <- Admin Fix All Lights verb
Fixes #24393 <- Admin Fix All Lights verb
