### PR TITLE
New pencode tags, more gas analyzer info, refactoring and bug fixes

### DIFF
--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -1,4 +1,4 @@
-/obj/proc/analyze_gases(var/obj/A, var/mob/user, advanced)
+/obj/proc/analyze_gases(var/obj/A, var/mob/user, mode)
 	user.visible_message("<span class='notice'>\The [user] has used \an [src] on \the [A].</span>")
 	A.add_fingerprint(user)
 
@@ -7,45 +7,10 @@
 		to_chat(user, "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>")
 		return 0
 
-	var/list/result = atmosanalyzer_scan(A, air_contents, advanced)
+	var/list/result = atmosanalyzer_scan(A, air_contents, mode)
 	print_atmos_analysis(user, result)
 	return 1
 
 /proc/print_atmos_analysis(user, var/list/result)
 	for(var/line in result)
 		to_chat(user, "<span class='notice'>[line]</span>")
-
-/proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture, advanced)
-	. = list()
-	. += "Results of the analysis of \the [target]:"
-	if(!mixture)
-		mixture = target.return_air()
-
-	if(mixture)
-		var/pressure = mixture.return_pressure()
-		var/total_moles = mixture.total_moles
-
-		if (total_moles>0)
-			if(abs(pressure - ONE_ATMOSPHERE) < 10)
-				. += "<span class='notice'>Pressure: [round(pressure,0.01)] kPa</span>"
-			else
-				. += "<span class='warning'>Pressure: [round(pressure,0.01)] kPa</span>"
-			for(var/mix in mixture.gas)
-				var/percentage = round(mixture.gas[mix]/total_moles * 100, advanced ? 0.001 : 0.01)
-				if(!percentage)
-					continue
-				. += "[gas_data.name[mix]]: [percentage]%"
-				if(advanced)
-					var/list/traits = list()
-					if(gas_data.flags[mix] & XGM_GAS_FUEL)
-						traits += "can be used as combustion fuel"
-					if(gas_data.flags[mix] & XGM_GAS_OXIDIZER)
-						traits += "can be used as oxidizer"
-					if(gas_data.flags[mix] & XGM_GAS_CONTAMINANT)
-						traits += "contaminates clothing with toxic residue"
-					if(gas_data.flags[mix] & XGM_GAS_FUSION_FUEL)
-						traits += "can be used to fuel fusion reaction" 
-					. += "\tSpecific heat: [gas_data.specific_heat[mix]] J/(mol*K), Molar mass: [gas_data.molar_mass[mix]] kg/mol.[traits.len ? "\n\tThis gas [english_list(traits)]" : ""]"
-			. += "Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K"
-			return
-	. += "<span class='warning'>\The [target] has no gases!</span>"

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -424,8 +424,25 @@ proc/TextPreview(var/string,var/len=40)
 	t = replacetext(t, "\[editorbr\]", "")
 	return t
 
+//pencode translation to html for tags exclusive to digital files (currently email, nanoword, report editor fields,
+//modular scanner data and txt file printing) and prints from them
+/proc/digitalPencode2html(var/text)
+	text = replacetext(text, "\[pre\]", "<pre>")
+	text = replacetext(text, "\[/pre\]", "</pre>")
+	text = replacetext(text, "\[fontred\]", "<font color=\"red\">")
+	text = replacetext(text, "\[fontblue\]", "<font color=\"blue\">")
+	text = replacetext(text, "\[fontgreen\]", "<font color=\"green\">")
+	text = replacetext(text, "\[/font\]", "</font>")
+	return pencode2html(text)
+
 //Will kill most formatting; not recommended.
 /proc/html2pencode(t)
+	t = replacetext(t, "<pre>", "\[pre\]")
+	t = replacetext(t, "</pre>", "\[/pre\]")
+	t = replacetext(t, "<font color=\"red\">", "\[fontred\]")
+	t = replacetext(t, "<font color=\"blue\">", "\[fontblue\]")
+	t = replacetext(t, "<font color=\"green\">", "\[fontgreen\]")
+	t = replacetext(t, "</font>", "\[/font\]")
 	t = replacetext(t, "<BR>", "\[br\]")
 	t = replacetext(t, "<br>", "\[br\]")
 	t = replacetext(t, "<B>", "\[b\]")

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -429,8 +429,8 @@ proc/TextPreview(var/string,var/len=40)
 /proc/digitalPencode2html(var/text)
 	text = replacetext(text, "\[pre\]", "<pre>")
 	text = replacetext(text, "\[/pre\]", "</pre>")
-	text = replacetext(text, "\[fontred\]", "<font color=\"red\">")
-	text = replacetext(text, "\[fontblue\]", "<font color=\"blue\">")
+	text = replacetext(text, "\[fontred\]", "<font color=\"red\">") //</font> to pass travis html tag integrity check
+	text = replacetext(text, "\[fontblue\]", "<font color=\"blue\">")//</font> to pass travis html tag integrity check
 	text = replacetext(text, "\[fontgreen\]", "<font color=\"green\">")
 	text = replacetext(text, "\[/font\]", "</font>")
 	return pencode2html(text)
@@ -439,8 +439,8 @@ proc/TextPreview(var/string,var/len=40)
 /proc/html2pencode(t)
 	t = replacetext(t, "<pre>", "\[pre\]")
 	t = replacetext(t, "</pre>", "\[/pre\]")
-	t = replacetext(t, "<font color=\"red\">", "\[fontred\]")
-	t = replacetext(t, "<font color=\"blue\">", "\[fontblue\]")
+	t = replacetext(t, "<font color=\"red\">", "\[fontred\]")//</font> to pass travis html tag integrity check
+	t = replacetext(t, "<font color=\"blue\">", "\[fontblue\]")//</font> to pass travis html tag integrity check
 	t = replacetext(t, "<font color=\"green\">", "\[fontgreen\]")
 	t = replacetext(t, "</font>", "\[/font\]")
 	t = replacetext(t, "<BR>", "\[br\]")

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -10,7 +10,7 @@ var/obj/screen/robot_inventory
 
 	var/obj/screen/using
 
-//Radio
+	//Radio
 	using = new /obj/screen()
 	using.SetName("radio")
 	using.set_dir(SOUTHWEST)
@@ -19,7 +19,7 @@ var/obj/screen/robot_inventory
 	using.screen_loc = ui_movi
 	src.adding += using
 
-//Module select
+	//Module select
 
 	using = new /obj/screen()
 	using.SetName("module1")
@@ -48,9 +48,9 @@ var/obj/screen/robot_inventory
 	src.adding += using
 	mymob:inv3 = using
 
-//End of module select
+	//End of module select
 
-//Intent
+	//Intent
 	using = new /obj/screen()
 	using.SetName("act_intent")
 	using.set_dir(SOUTHWEST)
@@ -60,28 +60,28 @@ var/obj/screen/robot_inventory
 	src.adding += using
 	action_intent = using
 
-//Cell
+	//Cell
 	mymob:cells = new /obj/screen()
 	mymob:cells.icon = 'icons/mob/screen1_robot.dmi'
 	mymob:cells.icon_state = "charge-empty"
 	mymob:cells.SetName("cell")
 	mymob:cells.screen_loc = ui_toxin
 
-//Health
+	//Health
 	mymob.healths = new /obj/screen()
 	mymob.healths.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.healths.icon_state = "health0"
 	mymob.healths.SetName("health")
 	mymob.healths.screen_loc = ui_borg_health
 
-//Installed Module
+	//Installed Module
 	mymob.hands = new /obj/screen()
 	mymob.hands.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.hands.icon_state = "nomod"
 	mymob.hands.SetName("module")
 	mymob.hands.screen_loc = ui_borg_module
 
-//Module Panel
+	//Module Panel
 	using = new /obj/screen()
 	using.SetName("panel")
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -89,21 +89,21 @@ var/obj/screen/robot_inventory
 	using.screen_loc = ui_borg_panel
 	src.adding += using
 
-//Store
+	//Store
 	mymob.throw_icon = new /obj/screen()
 	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.throw_icon.icon_state = "store"
 	mymob.throw_icon.SetName("store")
 	mymob.throw_icon.screen_loc = ui_borg_store
 
-//Inventory
+	//Inventory
 	robot_inventory = new /obj/screen()
 	robot_inventory.SetName("inventory")
 	robot_inventory.icon = 'icons/mob/screen1_robot.dmi'
 	robot_inventory.icon_state = "inventory"
 	robot_inventory.screen_loc = ui_borg_inventory
 
-//Temp
+	//Temp
 	mymob.bodytemp = new /obj/screen()
 	mymob.bodytemp.icon = 'icons/mob/status_indicators.dmi'
 	mymob.bodytemp.icon_state = "temp0"
@@ -122,7 +122,7 @@ var/obj/screen/robot_inventory
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.SetName("pull")
 	mymob.pullin.screen_loc = ui_borg_pull
-	
+
 	mymob.fire = new /obj/screen()
 	mymob.fire.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.fire.icon_state = "fire0"

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -18,7 +18,6 @@
 	var/temperature_resistance = 1000 + T0C
 	volume = 1000
 	interact_offline = 1 // Allows this to be used when not in powered area.
-	var/release_log = ""
 	var/update_flag = 0
 
 /obj/machinery/portable_atmospherics/canister/drain_power()
@@ -305,16 +304,8 @@ update_flag
 
 /obj/machinery/portable_atmospherics/canister/OnTopic(var/mob/user, href_list, state)
 	if(href_list["toggle"])
-		if (valve_open)
-			if (holding)
-				release_log += "Valve was <b>closed</b> by [user] ([user.ckey]), stopping the transfer into the [holding]<br>"
-			else
-				release_log += "Valve was <b>closed</b> by [user] ([user.ckey]), stopping the transfer into the <font color='red'><b>air</b></font><br>"
-		else
-			if (holding)
-				release_log += "Valve was <b>opened</b> by [user] ([user.ckey]), starting the transfer into the [holding]<br>"
-			else
-				release_log += "Valve was <b>opened</b> by [user] ([user.ckey]), starting the transfer into the <font color='red'><b>air</b></font><br>"
+		if (!valve_open)
+			if(!holding)
 				log_open()
 		valve_open = !valve_open
 		. = TOPIC_REFRESH
@@ -324,7 +315,6 @@ update_flag
 			return TOPIC_HANDLED
 		if (valve_open)
 			valve_open = 0
-			release_log += "Valve was <b>closed</b> by [user] ([user.ckey]), stopping the transfer into the [holding]<br>"
 		if(istype(holding, /obj/item/weapon/tank))
 			holding.manipulated_by = user.real_name
 		holding.dropInto(loc)

--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -13,14 +13,14 @@
 	//For displaying scans
 	var/window_width = 450
 	var/window_height = 600
-	
+
 	var/use_delay
 	var/scan_sound
-	
-/obj/item/device/scanner/attack_self(mob/user)
-	show_results(user)
 
-/obj/item/device/scanner/proc/show_results(mob/user)
+/obj/item/device/scanner/attack_self(mob/user)
+	show_menu(user)
+
+/obj/item/device/scanner/proc/show_menu(mob/user)
 	var/datum/browser/popup = new(user, "scanner", scan_title, window_width, window_height)
 	popup.set_content("[get_header()]<hr>[scan_data]")
 	popup.open()

--- a/code/game/objects/items/devices/scanners/gas.dm
+++ b/code/game/objects/items/devices/scanners/gas.dm
@@ -1,22 +1,34 @@
+#define DEFAULT_MODE 1
+#define MV_MODE 2 //moles and volume
+#define GAS_TRAIT_MODE 3 //gas traits and constants
+
 /obj/item/device/scanner/gas
 	name = "gas analyzer"
-	desc = "A hand-held environmental scanner which reports current gas levels."
+	desc = "A hand-held environmental scanner which reports current gas levels. Has a button to cycle modes."
 	icon_state = "atmos"
 	item_state = "analyzer"
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 	window_width = 350
 	window_height = 400
-	var/advanced_mode = 0
+	var/mode = DEFAULT_MODE
 
-/obj/item/device/scanner/gas/verb/verbosity(mob/user)
-	set name = "Toggle Advanced Gas Analysis"
-	set category = "Object"
-	set src in usr
+/obj/item/device/scanner/gas/get_header()
+	return "[..()]<a href='?src=\ref[src];switchmode=1'>Switch Mode</a>"
 
-	if (!user.incapacitated())
-		advanced_mode = !advanced_mode
-		to_chat(user, "You toggle advanced gas analysis [advanced_mode ? "on" : "off"].")
+/obj/item/device/scanner/gas/OnTopic(var/user, var/list/href_list)
+	..()
+	if(href_list["switchmode"])
+		++mode
+		switch(mode)
+			if(MV_MODE)
+				to_chat(user, "You set the gas analyzer to Moles and volume.")
+			if(GAS_TRAIT_MODE)
+				to_chat(user, "You set the gas analyzer to Gas traits and data.")
+			else
+				to_chat(user, "You set the gas analyzer to Default.")
+				mode = DEFAULT_MODE
+		playsound(src.loc, 'sound/machines/button4.ogg', 30, 0)
 
 /obj/item/device/scanner/gas/is_valid_scan_target(atom/O)
 	return istype(O)
@@ -26,6 +38,54 @@
 	if(!air_contents)
 		to_chat(user, "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>")
 		return
-	scan_data = atmosanalyzer_scan(A, air_contents, advanced_mode)
+	scan_data = atmosanalyzer_scan(A, air_contents, mode)
 	scan_data = jointext(scan_data, "<br>")
 	user.show_message(SPAN_NOTICE(scan_data))
+
+/proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture, mode)
+	. = list()
+	. += "Results of the analysis of \the [target]:"
+	if(!mixture)
+		mixture = target.return_air()
+
+	if(mixture)
+		var/pressure = mixture.return_pressure()
+		var/total_moles = mixture.total_moles
+
+		if (total_moles>0)
+			if(abs(pressure - ONE_ATMOSPHERE) < 10)
+				. += "<span class='notice'>Pressure: [round(pressure,0.01)] kPa</span>"
+			else
+				. += "<span class='warning'>Pressure: [round(pressure,0.01)] kPa</span>"
+
+			var/perGas_add_string = ""
+			for(var/mix in mixture.gas)
+				var/percentage = round(mixture.gas[mix]/total_moles * 100, mode ? 0.001 : 0.01)
+				if(!percentage)
+					continue
+				switch(mode)
+					if(MV_MODE)
+						perGas_add_string = ", Moles: [mixture.gas[mix]]"
+					if(GAS_TRAIT_MODE)
+						var/list/traits = list()
+						if(gas_data.flags[mix] & XGM_GAS_FUEL)
+							traits += "can be used as combustion fuel"
+						if(gas_data.flags[mix] & XGM_GAS_OXIDIZER)
+							traits += "can be used as oxidizer"
+						if(gas_data.flags[mix] & XGM_GAS_CONTAMINANT)
+							traits += "contaminates clothing with toxic residue"
+						if(gas_data.flags[mix] & XGM_GAS_FUSION_FUEL)
+							traits += "can be used to fuel fusion reaction"
+						perGas_add_string = "\n\tSpecific heat: [gas_data.specific_heat[mix]] J/(mol*K), Molar mass: [gas_data.molar_mass[mix]] kg/mol.[traits.len ? "\n\tThis gas [english_list(traits)]" : ""]"
+				. += "[gas_data.name[mix]]: [percentage]%[perGas_add_string]"
+			var/totalGas_add_string = ""
+			if(mode == MV_MODE)
+				totalGas_add_string = ", Total moles: [mixture.total_moles], Volume: [mixture.volume]L"
+			. += "Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K[totalGas_add_string]"
+
+			return
+	. += "<span class='warning'>\The [target] has no gases!</span>"
+
+#undef DEFAULT_MODE
+#undef MV_MODE
+#undef GAS_TRAIT_MODE

--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -21,7 +21,7 @@
 /obj/item/device/scanner/plant/scan(atom/A, mob/user)
 	scan_title = "[A] at [get_area(A)]"
 	scan_data = plant_scan_results(A)
-	show_results(user)
+	show_menu(user)
 
 /proc/plant_scan_results(obj/target)
 	var/datum/seed/grown_seed
@@ -50,7 +50,7 @@
 
 	if(grown_seed.mysterious && !grown_seed.scanned && !(get_z(src) in GLOB.using_map.station_levels))
 		grown_seed.scanned = TRUE
-		SSstatistics.add_field("xenoplants_scanned", 1) 
+		SSstatistics.add_field("xenoplants_scanned", 1)
 
 	var/list/dat = list()
 
@@ -179,5 +179,5 @@
 
 	if(grown_seed.get_trait(TRAIT_CONSUME_GASSES))
 		dat += "<br>It will remove gas from the environment."
-	
+
 	return JOINTEXT(dat)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -21,16 +21,6 @@ FLOOR SAFES
 	var/space = 0		//the combined w_class of everything in the safe
 	var/maxspace = 24	//the maximum combined w_class of stuff in the safe
 
-
-/obj/structure/safe/Initialize()
-	. = ..()
-	tumbler_1_pos = rand(0, 72)
-	tumbler_1_open = rand(0, 72)
-
-	tumbler_2_pos = rand(0, 72)
-	tumbler_2_open = rand(0, 72)
-
-
 /obj/structure/safe/Initialize()
 	for(var/obj/item/I in loc)
 		if(space >= maxspace)
@@ -39,6 +29,11 @@ FLOOR SAFES
 			space += I.w_class
 			I.forceMove(src)
 	. = ..()
+	tumbler_1_pos = rand(0, 72)
+	tumbler_1_open = rand(0, 72)
+
+	tumbler_2_pos = rand(0, 72)
+	tumbler_2_open = rand(0, 72)
 
 /obj/structure/safe/proc/check_unlocked(mob/user as mob, canhear)
 	if(user && canhear)

--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -208,3 +208,9 @@
 	antag_text = "Each tank may be incited to burn by attaching wires and an igniter assembly, though the igniter can only be used once and the mixture only burn if the igniter pushes a flammable gas mixture above the minimum burn temperature (126?C). \
 	Wired and assembled tanks may be disarmed with a set of wirecutters. Any exploding or rupturing tank will generate shrapnel, assuming their relief valves have been welded beforehand. Even if not, they can be incited to expel hot gas on ignition if pushed above 173?C. \
 	Relatively easy to make, the single tank bomb requries no tank transfer valve, and is still a fairly formidable weapon that can be manufactured from any tank."
+
+/datum/codex_entry/gas_analyzer
+	associated_paths = list(/obj/item/device/scanner/gas)
+	mechanics_text = "A device that analyzes the gas contents of a tile or atmospherics devices. Has 3 modes: Default operates without \
+	additional output data; Moles and volume shows the moles per gas in the mixture and the total moles and volume; Gas \
+	traits and data describes the traits per gas, how it interacts with the world, and some of its property constants."

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -49,6 +49,7 @@
 		module_state_3 = null
 		inv3.icon_state = "inv3"
 	update_icon()
+	hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/uneq_all()
 	module_active = null
@@ -78,6 +79,7 @@
 		module_state_3 = null
 		inv3.icon_state = "inv3"
 	update_icon()
+	hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/activated(obj/item/O)
 	if(module_state_1 == O)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -253,6 +253,8 @@
 /mob/living/silicon/robot/proc/reset_module(var/suppress_alert = null)
 	// Clear hands and module icon.
 	uneq_all()
+	if(shown_robot_modules)
+		hud_used.toggle_show_robot_modules()
 	modtype = initial(modtype)
 	if(hands)
 		hands.icon_state = initial(hands.icon_state)

--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -17,7 +17,7 @@
 	size = max(1, round(length(stored_data) / block_size))
 
 /datum/computer_file/data/proc/generate_file_data(var/mob/user)
-	return pencode2html(stored_data)
+	return digitalPencode2html(stored_data)
 
 /datum/computer_file/data/logfile
 	filetype = "LOG"
@@ -26,7 +26,7 @@
 	filetype = "TXT"
 
 /datum/computer_file/data/bodyscan
-	filetype = "BSC"	
+	filetype = "BSC"
 	read_only = 1
 	papertype = /obj/item/weapon/paper/bodyscan
 

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -88,7 +88,7 @@
 		var/list/msg = list()
 		msg += "*--*\n"
 		msg += "<span class='notice'>New mail received from [received_message.source]:</span>\n"
-		msg += "<b>Subject:</b> [received_message.title]\n<b>Message:</b>\n[pencode2html(received_message.stored_data)]\n"
+		msg += "<b>Subject:</b> [received_message.title]\n<b>Message:</b>\n[digitalPencode2html(received_message.stored_data)]\n"
 		if(received_message.attachment)
 			msg += "<b>Attachment:</b> [received_message.attachment.filename].[received_message.attachment.filetype] ([received_message.attachment.size]GQ)\n"
 		msg += "<a href='?src=\ref[src];open;reply=[received_message.uid]'>Reply</a>\n"
@@ -213,7 +213,7 @@
 		else if(new_message)
 			data["new_message"] = 1
 			data["msg_title"] = msg_title
-			data["msg_body"] = pencode2html(msg_body)
+			data["msg_body"] = digitalPencode2html(msg_body)
 			data["msg_recipient"] = msg_recipient
 			if(msg_attachment)
 				data["msg_hasattachment"] = 1
@@ -221,7 +221,7 @@
 				data["msg_attachment_size"] = msg_attachment.size
 		else if (current_message)
 			data["cur_title"] = current_message.title
-			data["cur_body"] = pencode2html(current_message.stored_data)
+			data["cur_body"] = digitalPencode2html(current_message.stored_data)
 			data["cur_timestamp"] = current_message.timestamp
 			data["cur_source"] = current_message.source
 			data["cur_uid"] = current_message.uid
@@ -250,7 +250,7 @@
 				for(var/datum/computer_file/data/email_message/message in message_source)
 					all_messages.Add(list(list(
 						"title" = message.title,
-						"body" = pencode2html(message.stored_data),
+						"body" = digitalPencode2html(message.stored_data),
 						"source" = message.source,
 						"timestamp" = message.timestamp,
 						"uid" = message.uid
@@ -444,7 +444,7 @@
 		msg_recipient = M.source
 		msg_title = "Re: [M.title]"
 		var/atom/movable/AM = host
-		if(istype(AM))		
+		if(istype(AM))
 			if(ismob(AM.loc))
 				ui_interact(AM.loc)
 		return 1

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -124,7 +124,7 @@
 		if(!computer.nano_printer)
 			error = "Missing Hardware: Your computer does not have required hardware to complete this operation."
 			return 1
-		if(!computer.nano_printer.print_text(pencode2html(F.stored_data),F.filename,F.papertype, F.metadata))
+		if(!computer.nano_printer.print_text(digitalPencode2html(F.stored_data),F.filename,F.papertype, F.metadata))
 			error = "Hardware error: Printer was unable to print the file. It may be out of paper."
 			return 1
 	if(href_list["PRG_copytousb"])

--- a/code/modules/modular_computers/file_system/programs/generic/scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/scanner.dm
@@ -98,7 +98,7 @@
 	if(prog.metadata_buffer.len > 0 && prog.paper_type == /obj/item/weapon/paper/bodyscan)
 		data["data_buffer"] = display_medical_data(prog.metadata_buffer.Copy(), user.get_skill_value(SKILL_MEDICAL, TRUE))
 	else
-		data["data_buffer"] = pencode2html(prog.data_buffer)
+		data["data_buffer"] = digitalPencode2html(prog.data_buffer)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -46,7 +46,7 @@
 		return 1
 
 	if(href_list["PRG_txtrpeview"])
-		show_browser(usr,"<HTML><HEAD><TITLE>[open_file]</TITLE></HEAD>[pencode2html(loaded_data)]</BODY></HTML>", "window=[open_file]")
+		show_browser(usr,"<HTML><HEAD><TITLE>[open_file]</TITLE></HEAD>[digitalPencode2html(loaded_data)]</BODY></HTML>", "window=[open_file]")
 		return 1
 
 	if(href_list["PRG_taghelp"])
@@ -162,7 +162,7 @@
 		if(!computer.nano_printer)
 			error = "Missing Hardware: Your computer does not have the required hardware to complete this operation."
 			return 1
-		if(!computer.nano_printer.print_text(pencode2html(loaded_data)))
+		if(!computer.nano_printer.print_text(digitalPencode2html(loaded_data)))
 			error = "Hardware error: Printer was unable to print the file. It may be out of paper."
 			return 1
 
@@ -205,10 +205,10 @@
 						)))
 				data["usbfiles"] = usbfiles
 	else if(PRG.open_file)
-		data["filedata"] = pencode2html(PRG.loaded_data)
+		data["filedata"] = digitalPencode2html(PRG.loaded_data)
 		data["filename"] = PRG.is_edited ? "[PRG.open_file]*" : PRG.open_file
 	else
-		data["filedata"] = pencode2html(PRG.loaded_data)
+		data["filedata"] = digitalPencode2html(PRG.loaded_data)
 		data["filename"] = "UNNAMED"
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/code/modules/modular_computers/file_system/programs/research/email_administration.dm
+++ b/code/modules/modular_computers/file_system/programs/research/email_administration.dm
@@ -32,7 +32,7 @@
 		data["error"] = error
 	else if(istype(current_message))
 		data["msg_title"] = current_message.title
-		data["msg_body"] = pencode2html(current_message.stored_data)
+		data["msg_body"] = digitalPencode2html(current_message.stored_data)
 		data["msg_timestamp"] = current_message.timestamp
 		data["msg_source"] = current_message.source
 	else if(istype(current_account))

--- a/code/modules/modular_computers/file_system/reports/report_field.dm
+++ b/code/modules/modular_computers/file_system/reports/report_field.dm
@@ -50,7 +50,7 @@
 /datum/report_field/proc/set_value(given_value)
 	value = given_value
 
-//Exports the contents of the field into html for viewing. 
+//Exports the contents of the field into html for viewing.
 /datum/report_field/proc/get_value()
 	return value
 
@@ -128,7 +128,7 @@ Basic field subtypes.
 	needs_big_box = 1
 
 /datum/report_field/pencode_text/get_value()
-	return pencode2html(value)
+	return digitalPencode2html(value)
 
 /datum/report_field/pencode_text/set_value(given_value)
 	if(istext(given_value))

--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -5,23 +5,23 @@
 		<p>Downloading attachment...</p>
 		<div class="item">
 		<div class="itemLabel">
-			File name: 
+			File name:
 		</div>
 		<div class="itemContent">
 			{{:data.down_filename}}&nbsp
 		</div>
 		<div class="itemLabel">
-			Progress: 
+			Progress:
 		</div>
 		<div class="itemContent">
 			{{:helper.displayBar(data.down_progress, 0, data.down_size)}} {{:data.down_progress}} / {{:data.down_size}} GQ
 		</div>
 		<div class="itemLabel">
-			Download rate: 
+			Download rate:
 		</div>
 		<div class="itemContent">
 			{{:data.down_speed}} GQ/s&nbsp
-		</div>		
+		</div>
 	</div>
 	{{:helper.link('Cancel Download', null, {'canceldownload' : 1})}}
 {{else data.current_account}}
@@ -42,7 +42,7 @@
 	{{else data.new_message}}
 		<div class="item">
 			<div class="itemLabel">
-				{{:helper.link('', 'pencil', {'edit_title' : 1})}} Title: 
+				{{:helper.link('', 'pencil', {'edit_title' : 1})}} Title:
 			</div>
 			<div class="itemContent">
 				<div class="statusDisplayComm" style="width:100%;min-height:1.7em;padding-bottom: 0;">
@@ -92,7 +92,7 @@
 	{{else data.cur_title}}
 		<div class="item">
 			<div class="itemLabel">
-				Title: 
+				Title:
 			</div>
 			<div class="itemContent">
 				{{:data.cur_title}}&nbsp
@@ -130,12 +130,12 @@
 				{{:helper.link('Reply', null, {'reply' : data.cur_uid})}}
 				{{:helper.link('Delete', null, {'delete' : data.cur_uid})}}
 				{{:helper.link('Close', null, {'cancel' : data.cur_uid})}}
-				{{:helper.link('Save to Disk', null, {'cancel' : data.cur_uid})}}
+				{{:helper.link('Save to Disk', null, {'save' : data.cur_uid})}}
 				{{if data.cur_hasattachment}}
 					{{:helper.link('Save Attachment', null, {'downloadattachment' : 1})}}
 				{{/if}}
 			</div>
-		</div>		
+		</div>
 	{{else}}
 		{{:helper.link('Inbox', 'mail-closed', {'set_folder' : 'Inbox'}, data.folder == 'Inbox' ? 'selected' : null)}}
 		{{:helper.link('Sent', 'arrowreturnthick-1-w', {'set_folder' : 'Sent'}, data.folder == 'Sent' ? 'selected' : null)}}


### PR DESCRIPTION
- Refactored some comments and a ..() and removed an unused log string for admins, fixed robot inventory bug. Removed some trailing whitespace automatically.

- Gas analyzers now have a switchable operation mode in the UI menu called switch modes with a new mode that shows total mole count and moles per gas in the mixture as well as volume of the mixture. Also added a codex entry to explain how all 3 modes work.

- New pencode tags [pre] [fontblue] [fontred] [fontgreen] for digital use only (nanoword, emails, reports, software txt files, etc.) which cannot be used when writing with a pen on paper. [Pre] has a closing tag and all three fonts are universally closed with [/font]. Fonts just change the font color same as a multicolor pen does, and [pre] is the html `<pre>` tag that conserves whitespace spaces but apparently not tabs. Printing papers conserve them and can be scanned back into a device with a scanner module giving back the correct pencodes.

:cl: Nirnael
rscadd: Adds pencode tags [pre] [fontblue] [fontred] [fontgreen], with closing [/pre] and [/font] universal for the three fonts. They only work digitally with nanoword, emails, report editors and direct txt files. Font color gives color, [pre] gives monospace font and preserves whitespace spaces only and not tabs, e.g. for ascii art.
rscadd: Gas analyzers now show total moles, total volume and moles per gas, check codex for more info.
bugfix: Fixed robot inventory not updating automatically when dropping items which are stored back into it.
bugfix: Saving emails to a txt file on disk now works correctly and can be printed with the new tags.
/:cl: