### PR TITLE
Air Alarm tweaks for Skrellship

### DIFF
--- a/maps/away/skrellscoutship/skrellscoutship-2.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-2.dmm
@@ -1096,6 +1096,12 @@
 	d2 = 4
 	},
 /obj/machinery/telecomms/allinone/skrellscoutship,
+/obj/machinery/alarm/server{
+	dir = 4;
+	pixel_x = -22;
+	pixel_y = 0;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
 /turf/simulated/floor/plating,
 /area/ship/skrellscoutship/maintenance/power)
 "cA" = (

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -26,11 +26,11 @@
 /obj/effect/submap_landmark/joinable_submap/skrellscoutship
 	name = "Xilvuxix"
 	archetype = /decl/submap_archetype/skrellscoutship
-	
+
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship
 	name = "Qrri-Zuumqix"
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
-	
+
 /obj/effect/submap_landmark/spawnpoint/skrellscoutship/leader
 	name = "Qrri-Vuxix"
 
@@ -46,7 +46,7 @@
 	)
 	call_webhook = WEBHOOK_SUBMAP_LOADED_SKRELL
 
-//Access + Loadout	
+//Access + Loadout
 
 /var/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
 
@@ -59,7 +59,7 @@
 	color = COLOR_GRAY40
 	detail_color = "#7331c4"
 	access = list(access_skrellscoutship)
-	
+
 /datum/job/submap/skrellscoutship_crew
 	title = "Qrri-Zuumqix"
 	supervisors = "your Qrri-Vuxix"
@@ -81,38 +81,38 @@
 	outfit_type = /decl/hierarchy/outfit/job/skrellscoutship
 	info = "Your vessel is scouting through unknown space, working to map out any potential dangers, as well as potential allies."
 	is_semi_antagonist = TRUE
-	
+
 /datum/job/submap/skrellscoutship_crew/equip(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	. = ..(H, alt_title, branch, grade)	//passing through arguments
 	//Limited to subcastes that make sense on the vessel. No need for ground-forces or R&D on such a ship.
 	var/skrellscoutcastes = list(
 		"Malish-Katish" = list(
-			"Mero'ta-Ketish", 
+			"Mero'ta-Ketish",
 			"Toglo'i-Ketish"
 		),
 		"Kanin-Katish" = list(
-			"Xiqarr-Ketish", 
+			"Xiqarr-Ketish",
 			"Mero'tol-Ketish",
 			"Goxo'i-Ketish"
 		),
 		"Raskinta-Katish" = list(
-			"Me'kerr-Ketish", 
+			"Me'kerr-Ketish",
 			"Qi'kerr-Ketish",
 			"Me'xoal-Ketish"
 		)
 	)
-		
+
 	var/skrellcaste = input(H, "What is your Skrell's Caste?", "SDTF Rank") as null|anything in skrellscoutcastes
 	if(skrellcaste)
 		var/skrellsubcaste = input(H, "What is your Skrell's Subcaste?", "SDTF Rank") as null|anything in skrellscoutcastes[skrellcaste]
 		var/obj/item/weapon/card/id/C = H.wear_id
 		if(istype(C))
 			C.assignment = skrellsubcaste
-	
+
 /obj/item/clothing/gloves/thick/swat/skrell
 	name = "black gloves"
 	desc = "A pair of black, reinforced gloves. The tag on the inner stitching appears to be written in some form of Skrellian."
-	
+
 /obj/item/clothing/under/skrelljumpsuit
 	name = "black bodysuit"
 	desc = "A sleek, skin-tight bodysuit designed to not wick moisture away from the body. The inner stitching appears to contain something written in Skrellian."
@@ -139,16 +139,16 @@
 	channel_color = COMMS_COLOR_SKRELL
 	channel_name = "Recon"
 	circuitboard = /obj/item/weapon/stock_parts/circuitboard/telecomms/allinone/skrellscoutship
-	
+
 /obj/item/device/radio/headset/skrellian
 	name = "recon headset"
 	icon_state = "srv_headset"
 	ks1type = /obj/item/device/encryptionkey/skrellian
-	
+
 /obj/item/device/radio/headset/skrellian/Initialize()
 	. = ..()
 	set_frequency(SKRELL_FREQ)	//Not going to be random or just set to the common frequency, but can be set later.
-	
+
 /obj/item/device/encryptionkey/skrellian
 	name = "recon radio encryption key"
 	icon_state = "medsci_cypherkey"
@@ -167,25 +167,25 @@
 /obj/item/weapon/reagent_containers/food/condiment/space_drugs
 	label_text = "Ambrosia"
 	starting_reagents = list(/datum/reagent/space_drugs = 50)
-	
-	
+
+
 /datum/mil_branch/skrell_fleet
 	name = "Skrellian Defense Task Force"
 	name_short = "SDTF"
 	email_domain = "sdtf.qb"
-	
+
 	rank_types = list(/datum/mil_rank/skrell_fleet)
 	spawn_rank_types = list(/datum/mil_rank/skrell_fleet)
-		
+
 /datum/mil_rank/skrell_fleet
 	name = "NULL"
-	
+
 /obj/machinery/power/apc/skrell
 	req_access = list(access_skrellscoutship)
 
 /obj/machinery/alarm/skrell
 	req_access = list(access_skrellscoutship)
-	target_temperature = T0C+65
+	target_temperature = T0C+40
 
 /obj/machinery/alarm/skrell/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl: Boznar
maptweak: Skrell Air alarms are now set to 40 degrees instead of 65 degrees. Server air alarm added to Skrellship engineering bay at 20 degrees.
/:cl:

This should stop the Skrell telecomms from overheating and breaking.

Temp change thrown on at request from @EcklesFire 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->