### PR TITLE
adds priority and conflict guidance to law display header

### DIFF
--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -10,7 +10,8 @@
 		who = world
 	else
 		who = src
-		to_chat(who, "<b>Obey these laws:</b>")
+		to_chat(who, SPAN_BOLD("Obey the following laws."))
+		to_chat(who, SPAN_ITALIC("All laws have equal priority. Laws may override other laws if written specifically to do so. If laws conflict, break the least."))
 
 	src.laws_sanity_check()
 	src.laws.show_laws(who)

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -27,7 +27,8 @@
 			to_chat(src, "<b>No AI selected to sync laws with, disabling lawsync protocol.</b>")
 			lawupdate = 0
 
-	to_chat(who, "<b>Obey these laws:</b>")
+	to_chat(who, SPAN_BOLD("Obey the following laws."))
+	to_chat(who, SPAN_ITALIC("All laws have equal priority. Laws may override other laws if written specifically to do so. If laws conflict, break the least."))
 	laws.show_laws(who)
 	// TODO: Update to new antagonist system.
 	if (mind && (mind.special_role == "traitor" && mind.original == src) && connected_ai)


### PR DESCRIPTION
:cl:
tweak: Added guidance on law priority and conflicts to the text shown when laws are listed.
/:cl:

When "show laws" is used or when laws update as AI or robot, the text _"All laws have equal priority. Laws may override other laws if written specifically to do so. If laws conflict, break the least."_ is shown above the list of laws.
Placing this in the game rather than on the wiki means that research is not necessary to play these roles appropriately, and the player is reminded whenever laws are shown or change.