### PR TITLE
Gives vatgrown appendixes again

### DIFF
--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -63,6 +63,7 @@
 		BP_LUNGS =    /obj/item/organ/internal/lungs,
 		BP_LIVER =    /obj/item/organ/internal/liver,
 		BP_KIDNEYS =  /obj/item/organ/internal/kidneys,
+		BP_APPENDIX = /obj/item/organ/internal/appendix,
 		BP_BRAIN =    /obj/item/organ/internal/brain,
 		BP_EYES =     /obj/item/organ/internal/eyes
 		)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Now that we've (IRL) determined that the appendix does have a positive function (As an important part of the immune system), it doesn't make sense for them not to have it anymore.

[link](https://en.wikipedia.org/wiki/Appendix_(anatomy)#Immune_and_lymphatic_system)
[link 2](https://en.wikipedia.org/wiki/Appendix_(anatomy)#History)

:cl:
tweak: Vat-growns have appendixes now.
/:cl: