### PR TITLE
Runtimes fix and minor gas analyzer poke

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -155,7 +155,7 @@ var/obj/screen/robot_inventory
 
 
 /datum/hud/proc/update_robot_modules_display()
-	if(!isrobot(mymob))
+	if(!isrobot(mymob) || !mymob.client)
 		return
 
 	var/mob/living/silicon/robot/r = mymob

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -105,7 +105,7 @@ obj/item/clothing
 
 // Does this clothing slot count as wizard garb? (Combines a few checks)
 /proc/is_wiz_garb(var/obj/item/clothing/C)
-	return C && C.wizard_garb
+	return istype(C) && C.wizard_garb
 
 /*Checks if the wizard is wearing the proper attire.
 Made a proc so this is not repeated 14 (or more) times.*/

--- a/code/game/objects/items/devices/scanners/gas.dm
+++ b/code/game/objects/items/devices/scanners/gas.dm
@@ -1,6 +1,6 @@
-#define DEFAULT_MODE 1
-#define MV_MODE 2 //moles and volume
-#define GAS_TRAIT_MODE 3 //gas traits and constants
+#define DEFAULT_MODE 0
+#define MV_MODE 1 //moles and volume
+#define GAS_TRAIT_MODE 2 //gas traits and constants
 
 /obj/item/device/scanner/gas
 	name = "gas analyzer"
@@ -60,12 +60,12 @@
 
 			var/perGas_add_string = ""
 			for(var/mix in mixture.gas)
-				var/percentage = round(mixture.gas[mix]/total_moles * 100, mode ? 0.001 : 0.01)
+				var/percentage = round(mixture.gas[mix]/total_moles * 100, 0.01)
 				if(!percentage)
 					continue
 				switch(mode)
 					if(MV_MODE)
-						perGas_add_string = ", Moles: [mixture.gas[mix]]"
+						perGas_add_string = ", Moles: [round(mixture.gas[mix], 0.01)]"
 					if(GAS_TRAIT_MODE)
 						var/list/traits = list()
 						if(gas_data.flags[mix] & XGM_GAS_FUEL)
@@ -80,7 +80,7 @@
 				. += "[gas_data.name[mix]]: [percentage]%[perGas_add_string]"
 			var/totalGas_add_string = ""
 			if(mode == MV_MODE)
-				totalGas_add_string = ", Total moles: [mixture.total_moles], Volume: [mixture.volume]L"
+				totalGas_add_string = ", Total moles: [round(mixture.total_moles, 0.01)], Volume: [mixture.volume]L"
 			. += "Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K[totalGas_add_string]"
 
 			return

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -50,6 +50,8 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 
 	if(href_list["new"])
 		var/datum/paiCandidate/candidate = locate(href_list["candidate"])
+		if(!istype(candidate))
+			return
 		var/option = href_list["option"]
 		var/t = ""
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -135,7 +135,7 @@
 		src.druggy = max(0, src.druggy)
 
 	//update the state of modules and components here
-	if (src.stat != 0)
+	if (src.stat != CONSCIOUS)
 		uneq_all()
 
 	if(silicon_radio)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -34,7 +34,7 @@
 	var/computer_id = null
 	var/last_ckey
 
-	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
+	var/stat = CONSCIOUS //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 
 	var/obj/screen/hands = null
 	var/obj/screen/pullin = null

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -136,7 +136,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 
 /obj/aiming_overlay/proc/aim_at(var/mob/target, var/obj/thing)
 
-	if(!owner)
+	if(!owner || !isliving(target))
 		return
 
 	if(owner.incapacitated())

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -13,10 +13,11 @@
 	delicate = 1
 
 /decl/surgery_step/limb/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!affected)
-		var/list/organ_data = target.species.has_limbs["[target_zone]"]
-		return !isnull(organ_data)
+	if(..())
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(!affected)
+			var/list/organ_data = target.species.has_limbs["[target_zone]"]
+			return !isnull(organ_data)
 
 //////////////////////////////////////////////////////////////////
 //	 limb attachment surgery step
@@ -43,8 +44,7 @@
 		. = TRUE
 
 /decl/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	. = ..()
-	if(.)
+	if(..())
 		var/obj/item/organ/external/E = tool
 		var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
 		. = (P && !P.is_stump() && !(BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E)))
@@ -86,8 +86,9 @@
 	max_duration = 120
 
 /decl/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = target.get_organ(target_zone)
-	return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
+	if(..())
+		var/obj/item/organ/external/E = target.get_organ(target_zone)
+		return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
 
 /decl/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
@@ -124,9 +125,9 @@
 
 /decl/surgery_step/limb/mechanize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	if(target.isSynthetic())
-		return SURGERY_SKILLS_ROBOTIC 
+		return SURGERY_SKILLS_ROBOTIC
 	else
-		return SURGERY_SKILLS_ROBOTIC_ON_MEAT 
+		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 
 /decl/surgery_step/limb/mechanize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	var/shock_level = 0	                 // what shock level will this step put patient on
 	var/delicate = 0                     // if this step NEEDS stable optable or can be done on any valid surface with no penalty
 	var/surgery_candidate_flags = 0      // Various bitflags for requirements of the surgery.
-	var/strict_access_requirement = TRUE // Whether or not this surgery will be fuzzy on size requirements. 
+	var/strict_access_requirement = TRUE // Whether or not this surgery will be fuzzy on size requirements.
 
 //returns how well tool is suited for this step
 /decl/surgery_step/proc/tool_quality(obj/item/tool)
@@ -91,8 +91,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 					open_threshold = SURGERY_RETRACTED
 				else if(surgery_candidate_flags & SURGERY_NEEDS_ENCASEMENT)
 					open_threshold = (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)
-				if(open_threshold                                                      && \
-				 ((strict_access_requirement && affected.how_open() != open_threshold) || \
+				if(open_threshold && ((strict_access_requirement && affected.how_open() != open_threshold) || \
 				 affected.how_open() < open_threshold))
 					return FALSE
 			return affected
@@ -128,7 +127,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	. = tool_quality(tool)
 	if(user == target)
 		. -= 10
-	
+
 	var/skill_reqs = get_skill_reqs(user, target, tool)
 	for(var/skill in skill_reqs)
 		var/penalty = delicate ? 40 : 20
@@ -215,7 +214,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 	// Otherwise we can make a start on surgery!
 	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
-		// Double-check this in case it changed between initial check and now. 
+		// Double-check this in case it changed between initial check and now.
 		if(zone in M.surgeries_in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		else if(S.can_use(user, M, zone, src) && S.is_valid_target(M))

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -92,7 +92,7 @@
 
 /obj/vehicle/bike/load(var/atom/movable/C)
 	var/mob/living/M = C
-	if(!istype(C)) return 0
+	if(!istype(M)) return 0
 	if(M.buckled || M.restrained() || !Adjacent(M) || !M.Adjacent(src))
 		return 0
 	return ..(M)


### PR DESCRIPTION
1. Makes a tradeoff for having the gas analyzer moles modes. Sacrifices the third decimal for pressure % (not much of a sacrifice but still), and also rounds all mole counts to 2 decimals thus having both % and moles to 2 decimals.

2. fixes #14748
fixes #14961
fixes #14962
fixes #16290
fixes #16924
fixes #26955
fixes #26958
fixes #26959
fixes #26961
fixes #26962
fixes #26963
fixes #26965
fixes #26966
fixes #26968
fixes #26970 
fixes #26972 
fixes #26973 
fixes #26978 
fixes #26979 