### PR TITLE
[Option 2] Space is cold again

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -5,7 +5,7 @@
 	name = "\proper space"
 	icon_state = "default"
 	dynamic_lighting = 0
-	temperature = T20C
+	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	var/static/list/dust_cache
 	permit_ao = FALSE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This is to dissuade people from going out and sitting in space with internals and no voidsuit.
I know space isn't *actually* cold, but it works from a balance perspective.

This is the more lethal of the two options.
:cl:
tweak: Space is cold again.
/:cl: