### PR TITLE
Adds limits to inflatables

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -3,6 +3,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	icon = 'icons/obj/inflatable.dmi'
 	var/deploy_path = null
+	var/inflatable_health
 
 	atmos_canpass = CANPASS_DENSITY
 
@@ -17,6 +18,8 @@
 	var/obj/structure/inflatable/R = new deploy_path(user.loc)
 	transfer_fingerprints_to(R)
 	R.add_fingerprint(user)
+	if(inflatable_health)
+		R.health = inflatable_health
 	qdel(src)
 
 
@@ -43,6 +46,10 @@
 
 	var/undeploy_path = null
 	var/health = 10
+	var/taped
+
+	var/max_pressure_diff = RIG_MAX_PRESSURE
+	var/max_temp = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/structure/inflatable/wall
 	name = "inflatable wall"
@@ -52,21 +59,55 @@
 	..()
 	update_nearby_tiles(need_rebuild=1)
 
+/obj/structure/inflatable/Initialize()
+	. = ..()
+	START_PROCESSING(SSobj,src)
+
 /obj/structure/inflatable/Destroy()
 	update_nearby_tiles()
+	STOP_PROCESSING(SSobj,src)
 	return ..()
+
+/obj/structure/inflatable/Process()
+	check_environment()
+
+/obj/structure/inflatable/proc/check_environment()
+	var/min_pressure = INFINITY
+	var/max_pressure = 0
+	var/max_local_temp = 0
+
+	for(var/check_dir in GLOB.cardinal)
+		var/turf/T = get_step(get_turf(src), check_dir)
+		var/datum/gas_mixture/env = T.return_air()
+		var/pressure = env.return_pressure()
+		min_pressure = min(min_pressure, pressure)
+		max_pressure = max(max_pressure, pressure)
+		max_local_temp = max(max_local_temp, env.temperature)
+
+	if(prob(50) && (max_pressure - min_pressure > max_pressure_diff || max_local_temp > max_temp))
+		take_damage(1)
+		if(health == round(0.7*initial(health)))
+			visible_message(SPAN_WARNING("\The [src] is taking damage!"))
+		if(health == round(0.3*initial(health)))
+			visible_message(SPAN_WARNING("\The [src] is barely holding up!"))
+
+/obj/structure/inflatable/examine(mob/user)
+	. = ..()
+	if(.)
+		if(health >= initial(health))
+			to_chat(user, SPAN_NOTICE("It's undamaged."))
+		else if(health >= 0.5 * initial(health))
+			to_chat(user, SPAN_WARNING("It's showing signs of damage."))
+		else if(health >= 0)
+			to_chat(user, SPAN_DANGER("It's heavily damaged!"))
+		to_chat(user, SPAN_NOTICE("It's been duct taped in few places."))
 
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 0
 
 /obj/structure/inflatable/bullet_act(var/obj/item/projectile/Proj)
-	var/proj_damage = Proj.get_structure_damage()
-	if(!proj_damage) return
-
-	health -= proj_damage
-	..()
+	take_damage(Proj.get_structure_damage())
 	if(health <= 0)
-		deflate(1)
 		return PROJECTILE_CONTINUE
 
 /obj/structure/inflatable/ex_act(severity)
@@ -86,23 +127,34 @@
 	add_fingerprint(user)
 	return
 
-/obj/structure/inflatable/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/inflatable/attackby(obj/item/weapon/W, mob/user)
 	if(!istype(W) || istype(W, /obj/item/weapon/inflatable_dispenser)) return
 
-	if((W.damtype == BRUTE || W.damtype == BURN) && (W.can_puncture() || W.force > 10))
+	if(istype(W, /obj/item/weapon/tape_roll) && health < initial(health) - 3)
+		if(taped)
+			to_chat(user, SPAN_NOTICE("\The [src] can't be patched any more with \the [W]!"))
+			return TRUE
+		else
+			taped = TRUE
+			to_chat(user, SPAN_NOTICE("You patch some damage in \the [src] with \the [W]!"))
+			take_damage(-3)
+			return TRUE
+	else if((W.damtype == BRUTE || W.damtype == BURN) && (W.can_puncture() || W.force > 10))
 		..()
 		if(hit(W.force))
 			visible_message("<span class='danger'>[user] pierces [src] with [W]!</span>")
 	return
 
 /obj/structure/inflatable/proc/hit(var/damage, var/sound_effect = 1)
-	health = max(0, health - damage)
+	take_damage(damage)
 	if(sound_effect)
 		playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
+	return health <= 0
+
+/obj/structure/inflatable/take_damage(damage)
+	health = max(0, health - damage)
 	if(health <= 0)
 		deflate(1)
-		return 1
-	return 0
 
 /obj/structure/inflatable/CtrlClick()
 	return hand_deflate()
@@ -121,6 +173,7 @@
 		spawn(50)
 			var/obj/item/inflatable/R = new undeploy_path(src.loc)
 			src.transfer_fingerprints_to(R)
+			R.inflatable_health = health
 			qdel(src)
 
 /obj/structure/inflatable/verb/hand_deflate()


### PR DESCRIPTION
They now have maximum pressure diff and maximum temperature.
Values are 50 atm pressure difference and 5000 K max temp.
Every tick inflatable is exposed to things worse than that it'll take 1 damage (out of 10 health). They can be patched once with duct tape to fix 3 damage but that's it.

:cl: Chinsky
tweak: Inflatables now have maximum pressure difference and maximum temperature they can endure. Currently it's 5000 kPa pressure difference and 5000 K temperature. Every second or so when they're in worse condition than that it'll take damage. You can patch them once with duct tape but otherwise just consider more permanent solutions.
/:cl: