### PR TITLE
Adds some naive spam prevention to instant verbs.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1232,6 +1232,7 @@
 #include "code\modules\admin\persistence.dm"
 #include "code\modules\admin\player_notes.dm"
 #include "code\modules\admin\player_panel.dm"
+#include "code\modules\admin\spam_prevention.dm"
 #include "code\modules\admin\ticket.dm"
 #include "code\modules\admin\topic.dm"
 #include "code\modules\admin\buildmode\advance.dm"

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -203,6 +203,8 @@
 		holder.callproc.do_args()
 
 /client/Click(atom/A)
+	if(!user_acted(src))
+		return
 	if(holder && holder.callproc && holder.callproc.waiting_for_click)
 		if(alert("Do you want to select \the [A] as the [holder.callproc.arguments.len+1]\th argument?",, "Yes", "No") == "Yes")
 			holder.callproc.arguments += A

--- a/code/modules/admin/spam_prevention.dm
+++ b/code/modules/admin/spam_prevention.dm
@@ -1,0 +1,49 @@
+#define MAX_ACTS_PER_INTERVAL 15
+#define ACT_INTERVAL_TIME 1
+
+GLOBAL_LIST_EMPTY(ckey_to_actions)
+GLOBAL_LIST_EMPTY(ckey_to_act_time)
+GLOBAL_LIST_EMPTY(ckey_punished_for_spam) // this round; to avoid redundant record-keeping.
+
+// Should be checked on all instant client verbs.
+/proc/user_acted(client/C)
+	var/ckey = C && C.ckey
+	if(!ckey)
+		return FALSE
+	var/time = world.time
+	if(GLOB.ckey_to_act_time[ckey] + ACT_INTERVAL_TIME < time)
+		GLOB.ckey_to_act_time[ckey] = time
+		GLOB.ckey_to_actions[ckey] = 1
+		return TRUE
+	if(GLOB.ckey_to_actions[ckey] <= MAX_ACTS_PER_INTERVAL)
+		GLOB.ckey_to_actions[ckey]++
+		return TRUE
+
+	// Punitive action
+	. = FALSE
+	log_and_message_admins("Kicking due to possible spam abuse", C)
+	to_chat(C, SPAN_DANGER("Possible spam abuse detected; you are being kicked from the server."))
+	if(GLOB.ckey_punished_for_spam[ckey])
+		qdel(C)
+		return
+	GLOB.ckey_punished_for_spam[ckey] = TRUE
+	notes_add(ckey, "\[AUTO\] Kicked for possible spam abuse.")
+	qdel(C)
+
+/client/Center()
+	if(!user_acted(src))
+		return
+	return ..()
+
+/client/DblClick()
+	if(!user_acted(src))
+		return
+	return ..()
+
+/client/MouseDrop()
+	if(!user_acted(src))
+		return
+	return ..()
+
+#undef MAX_ACTS_PER_INTERVAL
+#undef ACT_INTERVAL_TIME

--- a/code/modules/admin/verbs/SDQL.dm
+++ b/code/modules/admin/verbs/SDQL.dm
@@ -322,14 +322,6 @@
 				//text += "[t]<br>"
 			usr << browse(text, "window=sdql_result")
 
-
-/client/Topic(href,href_list[],hsrc)
-	if(href_list["SDQL_select"])
-		debug_variables(locate(href_list["SDQL_select"]))
-
-	..()
-
-
 /proc/SDQL_evaluate(datum/object, list/equation)
 	if(equation.len == 0)
 		return null

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -23,6 +23,8 @@
 /client/Topic(href, href_list, hsrc)
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
+	if(!user_acted(src))
+		return
 
 	#if defined(TOPIC_DEBUGGING)
 	log_debug("[src]'s Topic: [href] destined for [hsrc].")
@@ -76,8 +78,6 @@
 
 		ticket.close(client_repository.get_lite_client(usr.client))
 
-
-
 	//Logs all hrefs
 	if(config && config.log_hrefs && href_logfile)
 		to_chat(href_logfile, "<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>")
@@ -88,10 +88,19 @@
 		if("prefs")		return prefs.process_link(usr,href_list)
 		if("vars")		return view_var_Topic(href,href_list,hsrc)
 
+	if(codex_topic(href, href_list))
+		return
+
+	if(href_list["SDQL_select"])
+		debug_variables(locate(href_list["SDQL_select"]))
+		return
+
 	..()	//redirect to hsrc.Topic()
 
 //This stops files larger than UPLOAD_LIMIT being sent from client to server via input(), client.Import() etc.
 /client/AllowUpload(filename, filelength)
+	if(!user_acted(src))
+		return 0
 	if(filelength > UPLOAD_LIMIT)
 		to_chat(src, "<font color='red'>Error: AllowUpload(): File Upload too large. Upload Limit: [UPLOAD_LIMIT/1024]KiB.</font>")
 		return 0

--- a/code/modules/codex/entries/codex.dm
+++ b/code/modules/codex/entries/codex.dm
@@ -38,16 +38,11 @@
 	dat += jointext(categories, " ")
 	return "<font color = '[CODEX_COLOR_MECHANICS]'>[jointext(dat, null)]</font>"
 
-/client/Topic(href, href_list, hsrc)
-	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
-		return
-
+/client/proc/codex_topic(href, href_list)
 	if(href_list["codex_search"]) //nano throwing errors
 		search_codex()
-		return
+		return TRUE
 
 	if(href_list["codex_index"]) //nano throwing errors
 		list_codex_entries()
-		return
-	
-	..()
+		return TRUE

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -159,6 +159,8 @@
 			src.last_move = get_dir(A, src.loc)
 
 /client/Move(n, direction)
+	if(!user_acted(src))
+		return
 	if(!mob)
 		return // Moved here to avoid nullrefs below
 	return mob.SelfMove(direction)


### PR DESCRIPTION
:cl:
admin: Some rudimentary spam prevention has been added. Offending users will be kicked and noted, and you will receive notice of this. If you see patterns of abuse, further admin action may be warranted. False positives due to overly aggressive client macros may be possible.
/:cl:

Not sure if worth it on the click actions. Not sure if the thresholds need to be lower. Can obviously be gated in config, but this is essentially the free time I had today. If others have better implementations, go for it.