### PR TITLE
Fixes #26990, minor bump to medical voidsuit bomb resistance.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -168,6 +168,7 @@
 		piece.permeability_coefficient = permeability_coefficient
 		piece.unacidable = unacidable
 		if(islist(armor))
+			piece.armor = armor.Copy() // codex reads the armor list, not extensions. this list does not have any effect on in game mechanics
 			remove_extension(piece, /datum/extension/armor)
 			set_extension(piece, /datum/extension/armor, /datum/extension/armor/rig, armor)
 

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -197,15 +197,15 @@
 	desc = "A trendy, lightly radiation-shielded voidsuit helmet trimmed in a fetching blue."
 	icon_state = "rig0-medicalalt"
 	item_state = "medicalalt_helm"
-	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 5, bio = 100, rad = 30)
+	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 25, bio = 100, rad = 30)
 	light_overlay = "helmet_light_dual_green"
 
 /obj/item/clothing/suit/space/void/medical/alt
 	icon_state = "rig-medicalalt"
 	name = "streamlined medical voidsuit"
-	desc = "A more recent model of Vey-Med voidsuit, featuring the latest in radiation shielding technology, without sacrificing comfort or style."
+	desc = "A more recent and stylish model of Vey-Med voidsuit, with a minor upgrade to radiation shielding."
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/firstaid,/obj/item/device/scanner/health,/obj/item/stack/medical)
-	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 5, bio = 100, rad = 30)
+	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 25, bio = 100, rad = 30)
 
 /obj/item/clothing/suit/space/void/medical/alt/New()
 	..()


### PR DESCRIPTION
Now once again copies the armor list to each piece. Only serves to fix the codex; this has no bearing whatsoever on damage calculations in the game, those were *not* broken.

The parent type of medical voidsuits had a bomb resistance value of 25, while the medical/alt types have 5. Changed /medical/alt values to match parent. It's still not a good bomb suit, one of the weakest.

Tweaked the description on /medical/alt too. See changelog.

Fixes #26990

:cl:
bugfix: Rigsuit codex entries now read the correct armor values for each piece. Has no effect on damage calculations, that has always worked correctly.
tweak: Medical voidsuit descriptions no longer imply that they have some incredible radiation resistance, but it's still relatively good to most things in the game.
tweak: Medical voidsuit bomb resistance values increased slightly. It's still not a bomb suit!
/:cl: