### PR TITLE
moves spam prevention values to configuration

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -229,6 +229,10 @@ var/list/gamemode_cache = list()
 
 	var/allow_unsafe_narrates = FALSE //Whether admins can use unsanitized narration; when true, allows HTML etc.
 
+	var/do_not_prevent_spam = FALSE //If this is true, skips spam prevention for user actions; inputs, verbs, macros, etc.
+	var/max_acts_per_interval = 140 //Number of actions per interval permitted for spam protection.
+	var/act_interval = 0.1 SECONDS //Interval for spam prevention.
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -747,6 +751,13 @@ var/list/gamemode_cache = list()
 
 				if ("allow_unsafe_narrates")
 					config.allow_unsafe_narrates = TRUE
+
+				if ("do_not_prevent_spam")
+					config.do_not_prevent_spam = TRUE
+				if ("max_acts_per_interval")
+					config.max_acts_per_interval = text2num(value)
+				if ("act_interval")
+					config.act_interval = text2num(value) SECONDS
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/admin/spam_prevention.dm
+++ b/code/modules/admin/spam_prevention.dm
@@ -1,6 +1,3 @@
-#define MAX_ACTS_PER_INTERVAL 140
-#define ACT_INTERVAL_TIME 1
-
 GLOBAL_LIST_EMPTY(ckey_to_actions)
 GLOBAL_LIST_EMPTY(ckey_to_act_time)
 GLOBAL_LIST_EMPTY(ckey_punished_for_spam) // this round; to avoid redundant record-keeping.
@@ -10,12 +7,14 @@ GLOBAL_LIST_EMPTY(ckey_punished_for_spam) // this round; to avoid redundant reco
 	var/ckey = C && C.ckey
 	if(!ckey)
 		return FALSE
+	if (config.do_not_prevent_spam)
+		return TRUE
 	var/time = world.time
-	if(GLOB.ckey_to_act_time[ckey] + ACT_INTERVAL_TIME < time)
+	if(GLOB.ckey_to_act_time[ckey] + config.act_interval < time)
 		GLOB.ckey_to_act_time[ckey] = time
 		GLOB.ckey_to_actions[ckey] = 1
 		return TRUE
-	if(GLOB.ckey_to_actions[ckey] <= MAX_ACTS_PER_INTERVAL)
+	if(GLOB.ckey_to_actions[ckey] <= config.max_acts_per_interval)
 		GLOB.ckey_to_actions[ckey]++
 		return TRUE
 
@@ -44,6 +43,3 @@ GLOBAL_LIST_EMPTY(ckey_punished_for_spam) // this round; to avoid redundant reco
 	if(!user_acted(src))
 		return
 	return ..()
-
-#undef MAX_ACTS_PER_INTERVAL
-#undef ACT_INTERVAL_TIME

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -409,6 +409,15 @@ RADIATION_LOWER_LIMIT 0.15
 ## Uncomment this to allow admins to narrate using HTML tags
 #ALLOW_UNSAFE_NARRATES
 
+## Uncomment this to DISABLE action spam kicking. Not recommended; this helps protect from spam attacks.
+#DO_NOT_PREVENT_SPAM
+
+## Uncomment this to modify the length of the spam kicking interval in seconds.
+#ACT_INTERVAL 0.1
+
+## Uncomment this to modify the number of actions permitted per interval before being kicked for spam.
+#MAX_ACTS_PER_INTERVAL 140
+
 ##Clients will be unable to connect unless their version is equal to or higher than this (a number, e.g. 511)
 #MINIMUM_BYOND_VERSION
 


### PR DESCRIPTION
Allows for config & live tweaking of window and threshold, and disabling if someone wants that for testing purposes.