### PR TITLE
Revert "Disable end user macros"

### DIFF
--- a/code/client_macros.dm
+++ b/code/client_macros.dm
@@ -1,5 +1,5 @@
 /client
-	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_SKIN
+	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_MACROS | CONTROL_FREAK_SKIN
 
 var/list/registered_macros_by_ckey_
 


### PR DESCRIPTION
Reverts Baystation12/Baystation12#27001

The server killing exploit appears to be separate from macros, or at least separate from this solution.