### PR TITLE
Fix rd labcoat loadout

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -96,13 +96,6 @@
 	icon_open = "labcoat_tox_open"
 	icon_closed = "labcoat_tox"
 
-/obj/item/clothing/suit/storage/toggle/labcoat/science/cso
-	name = "chief science officer's labcoat"
-	desc = "A coat that protects against minor chemical spills. It has purple stripes on the shoulders denoting it as an Expeditionary Corps labcoat, and purple trim to indicate a Chief Science Officer."
-	icon_state = "labcoat_cso_open"
-	icon_open = "labcoat_cso_open"
-	icon_closed = "labcoat_cso"
-
 /obj/item/clothing/suit/storage/toggle/labcoat/science/nanotrasen
 	name = "\improper NanoTrasen labcoat"
 	desc = "A suit that protects against minor chemical spills. it has a red stripe on the shoulder and red trim on the sleeves, denoting it as a NanoTrasen labcoat."
@@ -163,9 +156,17 @@
 	icon_open = "labcoat_rd_heph_open"
 	icon_closed = "labcoat_rd_heph"
 
-/obj/item/clothing/suit/storage/toggle/labcoat/rd/heph
+/obj/item/clothing/suit/storage/toggle/labcoat/rd/zeng
 	name = "\improper Z-H research director's labcoat"
 	desc = "A full-body labcoat covered in cyan and black designs, denoting it as a Zeng-Hu Pharmaceuticals management coat. Judging by the amount of designs on it, it is only to be worn by the most enthusiastic of employees."
 	icon_state = "labcoat_rd_zeng_open"
 	icon_open = "labcoat_rd_zeng_open"
 	icon_closed = "labcoat_rd_zeng"
+
+/obj/item/clothing/suit/storage/toggle/labcoat/rd/ec
+	name = "chief science officer's labcoat"
+	desc = "A coat that protects against minor chemical spills. It has purple stripes on the shoulders denoting it as an Expeditionary Corps labcoat, and purple trim to indicate a Chief Science Officer."
+	icon_state = "labcoat_cso_open"
+	icon_open = "labcoat_cso_open"
+	icon_closed = "labcoat_cso"
+	body_parts_covered = UPPER_TORSO|ARMS

--- a/maps/torch/datums/uniforms_expedition.dm
+++ b/maps/torch/datums/uniforms_expedition.dm
@@ -461,4 +461,4 @@
 						 /obj/item/clothing/head/ushanka/solgov,
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov,
 						 /obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
-						 /obj/item/clothing/suit/storage/toggle/labcoat/science/cso)
+						 /obj/item/clothing/suit/storage/toggle/labcoat/rd/ec)

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -66,7 +66,7 @@
 
 /datum/gear/suit/labcoat_ec_cso
 	display_name = "labcoat, chief science officer, Expeditionary Corps"
-	path = /obj/item/clothing/suit/storage/toggle/labcoat/science/cso
+	path = /obj/item/clothing/suit/storage/toggle/labcoat/rd/ec
 	allowed_roles = list(/datum/job/rd)
 
 /datum/gear/suit/wintercoat_dais

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -25,7 +25,7 @@
 	return list(
 		/obj/item/clothing/suit/storage/toggle/labcoat,
 		/obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
-		/obj/item/clothing/suit/storage/toggle/labcoat/science/cso,
+		/obj/item/clothing/suit/storage/toggle/labcoat/rd/ec,
 		/obj/item/clothing/gloves/latex,
 		/obj/item/clothing/glasses/science,
 		/obj/item/device/radio/headset/heads/torchntdirector,


### PR DESCRIPTION
All subtypes of `science/` are available in the loadout menu, exclusive items can't be in that type