### PR TITLE
Fixes limb surgery not working

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -12,12 +12,13 @@
 	shock_level = 40
 	delicate = 1
 
-/decl/surgery_step/limb/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(..())
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		if(!affected)
-			var/list/organ_data = target.species.has_limbs["[target_zone]"]
-			return !isnull(organ_data)
+/decl/surgery_step/limb/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(affected)
+		return affected
+	else
+		var/list/organ_data = target.species.has_limbs["[target_zone]"]
+		return !isnull(organ_data)
 
 //////////////////////////////////////////////////////////////////
 //	 limb attachment surgery step


### PR DESCRIPTION
It was failing in some parent checks cause well, limb is fucking missing.
Gave it a special assess_bodypart that does understand that limb might be missing.
Fixes #27034