### PR TITLE
Updated example config with RESOURCE_URLS config option and documentation.

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -43,4 +43,10 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
-	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
+	/*
+	As of byond 512, due to how broken preloading is, preload_rsc MUST be set to 1 at compile time if resource URLs are *not* in use,
+	BUT you still want resource preloading enabled (from the server itself). If using resource URLs, it should be set to 0 and
+	changed to a URL at runtime (see client_procs.dm for procs that do this automatically). More information about how goofy this broken setting works at
+	http://www.byond.com/forum/post/1906517?page=2#comment23727144
+	*/
+	preload_rsc = 0

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -423,3 +423,10 @@ RADIATION_LOWER_LIMIT 0.15
 
 ## Clients will be unable to connect unless their build is equal to or higher than this (a number, e.g. 1000)
 #MINIMUM_BYOND_BUILD
+
+## Direct clients to preload the server resource file from a URL pointing to a .rsc file. NOTE: At this time (byond 512),
+## the client/resource_rsc var does not function as one would expect. See client_defines.dm, the "preload_rsc" var's
+## comments on how to use it properly. If you use a resource URL, you must set preload_rsc to 0 at compile time or
+## clients will still download from the server *too*. This will randomly select one URL if more than one is provided.
+## Spaces are prohibited in each URL by spec, you must use encoded spaces.
+#RESOURCE_URLS URL URL2 URL3


### PR DESCRIPTION
From: http://www.byond.com/forum/post/1906517?page=2#comment23727144 

> If you set preload_rsc to a url at compile time, the client will download both from the url, and the server, and block the connection until both complete

> If you set preload_rsc to 0 at compile time, and a url at runtime in client/New(), the client will passively load the url while joined into the game, and only download resources from the server as needed to display an icon or a sound until the url compleates.

~~Since baystation is not using URLs, this setting is being changed to 1 in accordance with information provided in that post, as well as according to Lohikar.~~

There are some weird oddities in the engine. If you are defining a resource URL, you follow MSO's advice and set it to 0 at compile, and to a URL at runtime... but if you're not using a resource URL, this needs to be set to 1 at *compile time* or it won't work at all. This is because resource URLs and the preload_rsc setting is not functioning as expected, and it has not for many years.

~~Clients will now download the resource file upon login. Resource files contain the server assets. This may eliminate a lot of client momentary hangs, such as near jukeboxes, but things like admin midis aren't "preloaded" (not possible unless it's baked in), and this setting will have no effect on those.~~

Credit to @Lohikar and @MrStonedOne for their experiences with this setting.

EDIT: See https://github.com/Baystation12/Baystation12/pull/27045#issuecomment-532080605 . This PR's purpose has changed.