### PR TITLE
Reduces point cost of Ascent and vox ships

### DIFF
--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -10,7 +10,7 @@
 	id = "awaysite_ascent_seedship"
 	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 1
+	cost = 0.5
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent, 
 		/datum/shuttle/autodock/overmap/ascent/two

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -10,9 +10,9 @@
 	id = "awaysite_ascent_seedship"
 	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 0.5
+	cost = 1
 	shuttles_to_initialise = list(
-		/datum/shuttle/autodock/overmap/ascent,
+		/datum/shuttle/autodock/overmap/ascent, 
 		/datum/shuttle/autodock/overmap/ascent/two
 	)
 

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -10,9 +10,9 @@
 	id = "awaysite_ascent_seedship"
 	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 1
+	cost = 0.5
 	shuttles_to_initialise = list(
-		/datum/shuttle/autodock/overmap/ascent, 
+		/datum/shuttle/autodock/overmap/ascent,
 		/datum/shuttle/autodock/overmap/ascent/two
 	)
 

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -8,7 +8,7 @@
 	id = "awaysite_voxship"
 	description = "Vox ship and base."
 	suffixes = list("voxship/voxship-1.dmm")
-	cost = 1
+	cost = 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -8,7 +8,7 @@
 	id = "awaysite_voxship"
 	description = "Vox ship and base."
 	suffixes = list("voxship/voxship-1.dmm")
-	cost = 0.5
+	cost = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 


### PR DESCRIPTION
Brought the point cost of the Ascent and vox ships in line with the skrell ship's. Should make them more likely to spawn, in addition to allowing for more away sites in total when these ships are around.

Currently, the vox and Ascent ships only tend to spawn once or twice a day, which is pretty inconvenient when they show up at 3 AM for most of the player base.