### PR TITLE
Raises away site budgets and numbers.

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -41,7 +41,7 @@
 	//Flags deciding what features to pick
 	var/ruin_tags_whitelist
 	var/ruin_tags_blacklist
-	var/features_budget = 4
+	var/features_budget = 5
 	var/list/possible_features = list()
 	var/list/spawned_features
 

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -27,7 +27,7 @@
 	//These should probably be moved into the evac controller...
 	shuttle_docked_message = "Attention all hands: Jump preparation complete. The bluespace drive is now spooling up, secure all stations for departure. Time to jump: approximately %ETD%."
 	shuttle_leaving_dock = "Attention all hands: Jump initiated, exiting bluespace in %ETA%."
-	shuttle_called_message = "Attention all hands: Jump sequence initiated. Transit procedures are now in effect. Jump in %ETA%."
+	shuttle_called_message = "Attention all hands: Jump sequence initiated. Scanning of the next destination has begun, transit procedures are now in effect. Jump in %ETA%."
 	shuttle_recall_message = "Attention all hands: Jump sequence aborted, return to normal operating conditions."
 
 	evac_controller_type = /datum/evacuation_controller/starship
@@ -36,5 +36,5 @@
 	use_overmap = 1
 	num_exoplanets = 1
 
-	away_site_budget = 3
+	away_site_budget = 5
 	id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'


### PR DESCRIPTION
🆑
tweak: Raises the exoplanet feature number and away site budget meaning the sector won't be as barren as before.
/🆑

This may need tweaking to a degree and test merge(s) so it doesn't melt the server, so if this gets support, I'll have to ask for that from devs etc. because I can't reliably compare local to live.

The purpose of this PR is to raise the amount of sites that exploration and similar roles can visit in a round, as with the introduction of the Vox, Skrell and Ascent roles the sector can get a bit too cramped (not necessarily always bad as it means they interact with eachother).

Screenshots about the expected spawn rate:
![image](https://user-images.githubusercontent.com/6581435/65140689-6677c280-da0f-11e9-9b04-9a4af24c6d78.png)
![image](https://user-images.githubusercontent.com/6581435/65141696-6e386680-da11-11e9-97e2-325c9dca7b8d.png)
![image](https://user-images.githubusercontent.com/6581435/65143334-fc621c00-da14-11e9-949c-6eef0af9a533.png)
![image](https://user-images.githubusercontent.com/6581435/65145519-0a666b80-da1a-11e9-81e8-ca086cdaf77c.png)
![image](https://user-images.githubusercontent.com/6581435/65147288-16542c80-da1e-11e9-875a-d3c1373a6bc7.png)