### PR TITLE
Fix Secbot spawn runtime

### DIFF
--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -39,11 +39,11 @@
 	desc = "It's Officer Beep O'sky! Powered by a potato and a shot of whiskey."
 	will_patrol = 1
 
-/mob/living/bot/secbot/New()
-	..()
+/mob/living/bot/secbot/Initialize()
 	stun_baton = new(src)
 	stun_baton.bcell = new /obj/item/weapon/cell/infinite(stun_baton)
 	stun_baton.set_status(1, null)
+	. = ..()
 
 	handcuffs = new(src)
 


### PR DESCRIPTION
..() calls /mob/libin/bot/Initialize() which calls `turn_on()`, and secbot overrides turn_on to set the status of the stun baton which hasn't been created yet. Gotta move the parent call after we initialize the stun baton on secbots.

Fixes #27042
Fixes #20854
Fixes #26915
Fixes #26942
