### PR TITLE
Allows some interactions by pilot if exosuit cockpit is open

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -49,11 +49,6 @@
 
 	next_click = world.time + 1
 
-	// I hate to do this but intercepting it here is much nicer than a dozen overrides.
-	if(istype(loc, /mob/living/exosuit) && !(A in src.contents))
-		var/mob/living/exosuit/M = loc
-		return M.ClickOn(A, params, src)
-
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -11,10 +11,6 @@
 		return
 	next_click = world.time + 1
 
-	if(istype(loc, /mob/living/exosuit) && !(A in src.contents))
-		var/mob/living/exosuit/M = loc
-		return M.ClickOn(A, params, src)
-
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)

--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -1,7 +1,7 @@
 /mob/living/exosuit/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)
 	if(!effect || (blocked >= 100))
 		return 0
-	if(LAZYLEN(pilots) && !prob(body.pilot_coverage))
+	if(LAZYLEN(pilots) && (!hatch_closed || !prob(body.pilot_coverage)))
 		if(effect > 0 && effecttype == IRRADIATE)
 			effect = max((1-(get_armors_by_zone(null, IRRADIATE)/100))*effect/(blocked+1),0)
 		var/mob/living/pilot = pick(pilots)
@@ -14,11 +14,18 @@
 		user.visible_message(SPAN_NOTICE("\The [user] bonks \the [src] harmlessly with \the [I]."))
 		return
 
-	if(LAZYLEN(pilots) && !prob(body.pilot_coverage))
+	if(LAZYLEN(pilots) && (!hatch_closed || !prob(body.pilot_coverage)))
 		var/mob/living/pilot = pick(pilots)
 		return pilot.resolve_item_attack(I, user, def_zone)
 
 	return def_zone //Careful with effects, mechs shouldn't be stunned
+
+/mob/living/exosuit/hitby(atom/movable/AM, speed)
+	if(LAZYLEN(pilots) && (!hatch_closed || !prob(body.pilot_coverage)))
+		var/mob/living/pilot = pick(pilots)
+		return pilot.hitby(AM, speed)
+	. = ..()
+	
 
 /mob/living/exosuit/get_armors_by_zone(def_zone, damage_type, damage_flags)
 	. = ..()

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -33,6 +33,30 @@
 	if(selected_system)
 		return selected_system.MouseDragInteraction(src_object, over_object, src_location, over_location, src_control, over_control, params, user)
 
+/datum/click_handler/default/mech/OnClick(var/atom/A, var/params)
+	var/mob/living/exosuit/E = user.loc
+	if(!istype(E))
+		//If this happens something broke tbh
+		user.RemoveClickHandler(src)
+		return
+	if(E.hatch_closed)
+		return E.ClickOn(A, params, user)
+	else return ..()
+
+/datum/click_handler/default/mech/OnDblClick(var/atom/A, var/params)
+	OnClick(A, params)
+
+//We will allow interaction if cockpit is open
+/mob/living/exosuit/contents_nano_distance(var/src_object, var/mob/living/user)
+	if(!hatch_closed)
+		return shared_living_nano_distance(src_object)
+	return ..()
+
+/mob/living/exosuit/contents_nano_distance(var/src_object, var/mob/living/user)
+	if(!hatch_closed)
+		return shared_living_nano_distance(src_object)
+	return ..()
+
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)
 
 	if(!user || incapacitated() || user.incapacitated())
@@ -211,6 +235,7 @@
 	if(user.client) user.client.screen |= hud_elements
 	LAZYDISTINCTADD(user.additional_vision_handlers, src)
 	update_pilots()
+	user.PushClickHandler(/datum/click_handler/default/mech)
 	return 1
 
 /mob/living/exosuit/proc/sync_access()
@@ -235,6 +260,8 @@
 		if(!silent)
 			to_chat(user, SPAN_NOTICE("You climb out of \the [src]."))
 
+	for(var/datum/click_handler/default/mech/H in user.click_handlers)
+		user.RemoveClickHandler(H)
 	user.forceMove(get_turf(src))
 	LAZYREMOVE(user.additional_vision_handlers, src)
 	if(user.client)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -46,17 +46,6 @@
 /datum/click_handler/default/mech/OnDblClick(var/atom/A, var/params)
 	OnClick(A, params)
 
-//We will allow interaction if cockpit is open
-/mob/living/exosuit/contents_nano_distance(var/src_object, var/mob/living/user)
-	if(!hatch_closed)
-		return shared_living_nano_distance(src_object)
-	return ..()
-
-/mob/living/exosuit/contents_nano_distance(var/src_object, var/mob/living/user)
-	if(!hatch_closed)
-		return shared_living_nano_distance(src_object)
-	return ..()
-
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)
 
 	if(!user || incapacitated() || user.incapacitated())


### PR DESCRIPTION
🆑CrimsonShrike
rscadd: Exosuit pilots can now manage their inventory, throw items and some other minor actions so long the cockpit is open. This prevents usage of exosuit modules.
/🆑