### PR TITLE
Memory Caps on Forensics

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -9,6 +9,10 @@
  * Misc
  */
 
+// Truncates a list "L" to "max" size by deleting the oldest (from index 1) entries.
+// Will not affect lists that are under the max size.
+#define truncate_oldest(L, max) (L.len + 1 > max ? L.Cut(1, 1 + (L.len - max)) : null)
+
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "," )
 	switch(input.len)


### PR DESCRIPTION
Nerfing forensics to hold a maximum of 64 prints, dna, residues, or traces (per each) for their respective atoms.

    This should not affect gameplay terribly but *does* provide a strong ceiling to the amount of memory that can be consumed by forensics instead of the previously unlimited amount.

This shouldn't require a changelog.
