### PR TITLE
Plant sampling skill reqs and plant scan objective fix

### DIFF
--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -48,9 +48,13 @@
 	if(!grown_seed)
 		return
 
-	if(grown_seed.mysterious && !grown_seed.scanned && !(get_z(src) in GLOB.using_map.station_levels))
+	if(grown_seed.mysterious && !grown_seed.scanned)
 		grown_seed.scanned = TRUE
-		SSstatistics.add_field("xenoplants_scanned", 1)
+		var/area/map = locate(/area/overmap)
+		for(var/obj/effect/overmap/sector/exoplanet/P in map)
+			if(grown_seed in P.seeds)
+				SSstatistics.add_field("xenoplants_scanned", 1)
+				break
 
 	var/list/dat = list()
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -203,12 +203,16 @@
 
 	if(W.edge && W.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
 		if(!is_mature())
-			to_chat(user, "<span class='warning'>\The [src] is not mature enough to yield a sample yet.</span>")
+			to_chat(user, SPAN_WARNING("\The [src] is not mature enough to yield a sample yet."))
 			return
 		if(!seed)
-			to_chat(user, "<span class='warning'>There is nothing to take a sample from.</span>")
+			to_chat(user, SPAN_WARNING("There is nothing to take a sample from."))
 			return
-		seed.harvest(user,0,1)
+		var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
+		if(prob(user.skill_fail_chance(SKILL_BOTANY, 90, needed_skill)))
+			to_chat(user, SPAN_WARNING("You failed to get a usable sample."))
+		else
+			seed.harvest(user,0,1)
 		health -= (rand(3,5)*5)
 	else
 		..()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -409,27 +409,31 @@
 
 	return
 
-/obj/machinery/portable_atmospherics/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
+/obj/machinery/portable_atmospherics/hydroponics/attackby(var/obj/item/O, var/mob/user)
 
 	if (O.is_open_container())
 		return 0
 
-	if(isWirecutter(O) || istype(O, /obj/item/weapon/scalpel))
+	if(O.edge && O.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
 
 		if(!seed)
-			to_chat(user, "There is nothing to take a sample from in \the [src].")
+			to_chat(user, SPAN_WARNING("There is nothing to take a sample from in \the [src]."))
 			return
 
 		if(sampled)
-			to_chat(user, "You have already sampled from this plant.")
+			to_chat(user, SPAN_WARNING("There's no bits that can be used for a sampling left."))
 			return
 
 		if(dead)
-			to_chat(user, "The plant is dead.")
+			to_chat(user, SPAN_WARNING("The plant is dead."))
 			return
 
-		// Create a sample.
-		seed.harvest(user,yield_mod,1)
+		var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
+		if(prob(user.skill_fail_chance(SKILL_BOTANY, 90, needed_skill)))
+			to_chat(user, SPAN_WARNING("You failed to get a usable sample."))
+		else
+			// Create a sample.
+			seed.harvest(user,yield_mod,1)
 		health -= (rand(3,5)*10)
 
 		if(prob(30))

--- a/maps/torch/datums/department_exploration.dm
+++ b/maps/torch/datums/department_exploration.dm
@@ -16,12 +16,16 @@
 	var/seeds
 
 /datum/goal/department/plant_samples/New()
-	seeds = rand(3,5)
+	var/total_seeds = 0
+	var/area/map = locate(/area/overmap)
+	for(var/obj/effect/overmap/sector/exoplanet/P in map)
+		total_seeds += P.seeds.len
+	seeds = rand(total_seeds)
 	..()
 
 /datum/goal/department/plant_samples/update_strings()
-	description = "Scan at least [seeds] different plant\s while on the expeditions."
-
+	description = "Scan at least [seeds] different plant\s native to exoplanets."
+	
 /datum/goal/department/plant_samples/get_summary_value()
 	var/scanned = SSstatistics.get_field("xenoplants_scanned")
 	return " ([scanned ? scanned : 0 ] plant specie\s so far)"


### PR DESCRIPTION
Sampling plants now takes skill …
Basic for usual ones, trained for xeno/mutants. Whooping 90% chance to fail if you lack it.
The intent is to provide a sense of pride and accomplishment to nerds who picked botany skill instead of CQC.

:cl: Chinsky
tweak : Sampling plants now requires Botany skill, or there'll be a steep chance to fail. Need Basic skill for mundane plants, Trained for xeno/mutant ones.
/:cl:

Fixes #26010

Now only plants that originated from the planet count. Adjusted objective accordingly.
Objective now checks for spawned planets and randomizes amount of required plants based on total number of seeds on them, to avoid impossible objectives like 5 plant species on a barren planet.