### PR TITLE
APC construction Quick fix

### DIFF
--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -21,7 +21,7 @@
 
 /datum/wires/apc/CanUse(var/mob/living/L)
 	var/obj/machinery/power/apc/A = holder
-	if(A.wiresexposed)
+	if(A.wiresexposed && !(A.stat & BROKEN))
 		return 1
 	return 0
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -671,6 +671,9 @@
 					to_chat(user, "<span class='warning'>You fail to [ locked ? "unlock" : "lock"] the APC interface.</span>")
 				return 1
 
+/obj/machinery/power/apc/CanUseTopicPhysical(var/mob/user)
+	return GLOB.physical_state.can_use_topic(nano_host(), user)
+
 /obj/machinery/power/apc/physical_attack_hand(mob/user)
 	//Human mob special interaction goes here.
 	if(istype(user,/mob/living/carbon/human))


### PR DESCRIPTION
:cl:
bugfix: APC construction has been fixed, they will now be deconstructable even when broken.
/:cl: 

APC construction is now 10% less janky
Quick wires oversight fixed, you can't touch the wires if the APC is broken
Fixes #26066
Fixes #26532