### PR TITLE
Fixes #25503

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -75,10 +75,9 @@ var/list/gear_datums = list()
 
 /datum/category_item/player_setup_item/loadout/proc/skill_check(var/list/jobs, var/list/skills_required)
 	for(var/datum/job/J in jobs)
-		var/list/skills = pref.skills_allocated[J]
 		. = TRUE
 		for(var/R in skills_required)
-			if(skills[R] + pref.get_min_skill(J, R) < skills_required[R])
+			if(pref.get_total_skill_value(J, R) < skills_required[R])
 				. = FALSE
 				break
 		if(.)

--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -13,6 +13,14 @@
 		. = SKILL_MAX
 	. = max(min, .)
 
+/datum/preferences/proc/get_total_skill_value(datum/job/job, skill_type)
+	if(!(job in skills_allocated))
+		return 0
+	var/allocated = skills_allocated[job]
+	for(var/decl/hierarchy/skill/S in allocated)
+		if(S.type == skill_type)
+			return allocated[S] + get_min_skill(job, S)
+
 /datum/preferences/proc/get_min_skill(datum/job/job, decl/hierarchy/skill/S)
 	if(job && job.min_skill)
 		. = job.min_skill[S.type]


### PR DESCRIPTION
Pref skill list uses INSTANCES as keys, not types (unlike every other skill list ree)
As a side effect skill-locked loadout items now will properly report if they can't be taken in char setup.
