### PR TITLE
Adds gas products to chemical explosions

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -263,6 +263,10 @@
 	if(volume <= 50)
 		return
 	var/turf/T = get_turf(holder)
+	var/datum/gas_mixture/products = new(_temperature = 5 * PHORON_FLASHPOINT)
+	var/gas_moles = 3 * volume
+	products.adjust_multi(GAS_NO, 0.1 * gas_moles, GAS_NO2, 0.1 * gas_moles, GAS_NITROGEN, 0.6 * gas_moles, GAS_HYDROGEN, 0.02 * gas_moles)
+	T.assume_air(products)
 	if(volume > 500)
 		explosion(T,1,2,4)
 	else if(volume > 100)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -497,6 +497,10 @@
 	var/turf/T = get_turf(holder)
 	if(T)
 		var/adj_power = round(boompower * activated_volume/60)
+		var/datum/gas_mixture/products = new(_temperature = 5 * PHORON_FLASHPOINT)
+		var/gas_moles = 3 * volume
+		products.adjust_multi(GAS_CO2, 0.5 * gas_moles, GAS_NITROGEN, 0.3 * gas_moles, GAS_STEAM, 0.2 * gas_moles)
+		T.assume_air(products)
 		explosion(T, adj_power, adj_power + 1, adj_power*2 + 2)
 		remove_self(activated_volume)
 


### PR DESCRIPTION
Most noticeable with fueltank booms.
They now will increase temperature and pressure in the room where hey went off, and full fuel tank will also release bit of hydrogen for 3-10 seconds long weak fire.
Also lets forensics tell apart what went off - TTVs leave their contents, fueltanks and ANFO leave different gases too.

:cl: Chinsky
rscadd: Chemical explosions (welderfuel and ANFO) now produce a bunch of heated gas during explosion.
rscadd: Welderfuel produces N, NO, NO2 and a pinch of Hydrogen for flavor
rscadd: ANFO produces CO2, nitrogen and water
/:cl: