### PR TITLE
Spacies/Grav-adapted/Unathi oxygen requirement tweaks

### DIFF
--- a/code/modules/organs/internal/species/nabber.dm
+++ b/code/modules/organs/internal/species/nabber.dm
@@ -141,7 +141,6 @@
 	organ_tag = BP_TRACH
 	parent_organ = BP_GROIN
 	active_breathing = 0
-	min_breath_pressure = 30
 	safe_toxins_max = 10
 
 /obj/item/organ/internal/lungs/insectoid/nabber/rupture()

--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -12,9 +12,11 @@
 
 	flash_mod =     0.9
 	oxy_mod =       1.1
+	breath_pressure = 18
 	radiation_mod = 0.5
 	brute_mod =     0.85
 	slowdown =      1
+	strength = STR_HIGH
 
 	descriptors = list(
 		/datum/mob_descriptor/height = -1,
@@ -33,6 +35,7 @@
 	preview_icon= 'icons/mob/human_races/species/human/subspecies/spacer_preview.dmi'
 
 	oxy_mod =   0.8
+	breath_pressure = 14
 	toxins_mod =   0.9
 	flash_mod = 1.2
 	brute_mod = 1.1

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -20,6 +20,7 @@
 	darksight_tint = DARKTINT_MODERATE
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
+	breath_pressure = 20
 	slowdown = 0.5
 	brute_mod = 0.8
 	flash_mod = 1.2


### PR DESCRIPTION
🆑
tweak: Space adapted human oxygen pressure requirement has been lowered to 14 kPa.
tweak: Grav adapted human oxygen pressure requirement has been increased to 18 kPa.
tweak: Grav adapted strength has been increased to high, this means they get reduced slowdown for wearing or carrying heavier gear, eg. dufflebags, voidsuit. Still slower than human in most regards.
tweak: Unathi oxygen pressure requirement has been increased to  20 kPa. They need more oxygen to support their extremely robust metabolism.
/🆑 

I would do more, change blood types and such but If I dive into that code, I wouldn't be out for weeks.
also remove redudant gas oxygen requirement from their lung organs as it's overridden anyways