### PR TITLE
Turf Click Interception

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -289,6 +289,7 @@
 #include "code\datums\extensions\multitool\items\stock_parts_radio.dm"
 #include "code\datums\extensions\on_click\on_alt_click.dm"
 #include "code\datums\extensions\on_click\on_click.dm"
+#include "code\datums\extensions\on_click\turf_hand.dm"
 #include "code\datums\graph\graph.dm"
 #include "code\datums\graph\node.dm"
 #include "code\datums\helper_datums\construction_datum.dm"

--- a/code/datums/extensions/on_click/turf_hand.dm
+++ b/code/datums/extensions/on_click/turf_hand.dm
@@ -1,0 +1,19 @@
+/*
+	This extension is used on airlocks and cult runes.
+	When a mob [attack_hand]s a turf, it will look for objects in itself containing this component.
+	If such is found, it will call attack_hand on that atom
+
+	When multiple of these components are in the tile, the one with the highest priority wins it.
+*/
+/datum/extension/turf_hand
+	var/priority = 1
+	expected_type = /atom
+
+/datum/extension/turf_hand/New(var/holder, var/priority = 1)
+	..()
+	src.priority = priority
+
+
+/datum/extension/turf_hand/proc/OnHandInterception(var/mob/user)
+	var/atom/A = holder
+	return A.attack_hand(user)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -17,6 +17,7 @@
 	bcolor = blcolor
 	blood = nblood
 	update_icon()
+	set_extension(src, /datum/extension/turf_hand, /datum/extension/turf_hand, 10)
 
 /obj/effect/rune/on_update_icon()
 	overlays.Cut()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -41,6 +41,9 @@
 	dir = SOUTH
 	var/width = 1
 
+	//Used for intercepting clicks on our turf. Set 0 to disable click interception
+	var/turf_hand_priority = 3
+
 	// turf animation
 	var/atom/movable/overlay/c_animation = null
 
@@ -73,6 +76,9 @@
 		else
 			bound_width = world.icon_size
 			bound_height = width * world.icon_size
+
+	if (turf_hand_priority)
+		set_extension(src, /datum/extension/turf_hand, /datum/extension/turf_hand, turf_hand_priority)
 
 	health = maxhealth
 	update_connections(1)
@@ -515,7 +521,7 @@
 				W.update_connections(1)
 				W.update_icon()
 
-		else if( istype(T, /turf/simulated/shuttle/wall) ||  istype(T, /turf/unsimulated/wall))
+		else if( istype(T, /turf/simulated/shuttle/wall) ||	istype(T, /turf/unsimulated/wall))
 			success = 1
 		else
 			for(var/obj/O in T)
@@ -554,7 +560,7 @@
 	var/area/aft = access_area_by_dir(GLOB.reverse_dir[dir])
 	fore = fore || aft
 	aft = aft || fore
-	
+
 	if (!fore && !aft)
 		req_access = list()
 	else if (fore.secure || aft.secure)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -47,6 +47,8 @@
 	var/list/tile_info[4]
 	var/list/dir_alerts[4] // 4 dirs, bitflags
 
+	turf_hand_priority = 2 //Lower priority than normal doors to prevent interference
+
 	// MUST be in same order as FIREDOOR_ALERT_*
 	var/list/ALERT_STATES=list(
 		"hot",

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -6,6 +6,10 @@
 	opacity = 1
 	density = 0
 
+/obj/structure/curtain/Initialize()
+	.=..()
+	set_extension(src, /datum/extension/turf_hand, /datum/extension/turf_hand)
+
 /obj/structure/curtain/open
 	icon_state = "open"
 	layer = ABOVE_HUMAN_LAYER

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -69,13 +69,26 @@
 
 	if(user.restrained())
 		return 0
-	if(isnull(user.pulling) || user.pulling.anchored || !isturf(user.pulling.loc))
-		return 0
-	if(user.pulling.loc != user.loc && get_dist(user, user.pulling) > 1)
-		return 0
-	if(user.pulling)
+	if (user.pulling)
+		if(user.pulling.anchored || !isturf(user.pulling.loc))
+			return 0
+		if(user.pulling.loc != user.loc && get_dist(user, user.pulling) > 1)
+			return 0
 		do_pull_click(user, src)
-	return 1
+
+	.=handle_hand_interception(user)
+	if (!.)
+		return 1
+
+/turf/proc/handle_hand_interception(var/mob/user)
+	var/datum/extension/turf_hand/THE
+	for (var/A in src)
+		var/datum/extension/turf_hand/TH = get_extension(A, /datum/extension/turf_hand)
+		if (istype(TH) && TH.priority > THE?.priority) //Only overwrite if the new one is higher. For matching values, its first come first served
+			THE = TH
+
+	if (THE)
+		return THE.OnHandInterception(user)
 
 /turf/attack_robot(var/mob/user)
 	if(Adjacent(user))
@@ -87,7 +100,6 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(S.use_to_pickup && S.collection_mode)
 			S.gather_all(src, user)
 	return ..()
-
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -32,6 +32,10 @@
 				return
 	update_icon()
 
+
+	set_extension(src, /datum/extension/turf_hand, /datum/extension/turf_hand)
+
+
 /obj/structure/ladder/Destroy()
 	if(target_down)
 		target_down.target_up = null
@@ -264,10 +268,10 @@
 /obj/structure/stairs/west
 	dir = WEST
 	bound_width = 64
-	
+
 /obj/structure/stairs/short
 	bound_height = 32
 	bound_width = 32
-	
+
 /obj/structure/stairs/short/west
 	dir = WEST

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -55,6 +55,7 @@
 	icon_state = "button"
 	var/light_up = FALSE
 	var/datum/turbolift_floor/floor
+	mouse_opacity = 2 //No more eyestrain aiming at tiny pixels
 
 /obj/structure/lift/button/Destroy()
 	if(floor && floor.ext_panel == src)
@@ -94,6 +95,7 @@
 /obj/structure/lift/panel
 	name = "elevator control panel"
 	icon_state = "panel"
+	mouse_opacity = 2 //No more eyestrain aiming at tiny pixels
 
 
 /obj/structure/lift/panel/attack_ghost(var/mob/user)


### PR DESCRIPTION
A short 30 minute project I made to reduce some of the frustration of certain objects:

This PR adds support for an extension which intercepts attack_hand calls on a turf, passing them on to objects in that turf which have the extension. This allows interacting with those objects by just clicking the floor they're on.

This extension is currently applied to:
Airlocks (makes closing them far less of a pain)
Cult runes
Ladders
Shower curtains

It includes a priority var, only a single object - the one with the highest priority - will intercept a click. Cult runes get the highest, normal airlocks are prioritised above  firelocks

Lastly, a minor change Chinsky gave me the idea for. Sets Mouse Opacity to 2 for elevator panels and call buttons. This makes these far less of a pain to click on

:cl: Nanako
rscadd: Airlocks, curtains, ladders and cult runes can now be interacted with by clicking the floor in their tile.
tweak: Lift call buttons and panels are now easier to click
/:cl: