### PR TITLE
Extra Detective Slot

### DIFF
--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -38,8 +38,8 @@
 
 /datum/job/detective
 	title = "Forensic Technician"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Chief of Security"
 	economic_power = 5
 	minimal_player_age = 7

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -44,7 +44,6 @@
 	economic_power = 5
 	minimal_player_age = 7
 	ideal_character_age = 35
-	skill_points = 14
 	alt_titles = list(
 		"Criminal Investigator"
 	)


### PR DESCRIPTION
Detective has always been a two part job. 
One person roams the mean streets in a fedora and trenchcoat,infiltrating plots and questioning people
While the other wears a labcoat and latex gloves, carefully collecting and analying samples to bring the truth to light using their fancy science.

We even have the alt titles fot both of these.
There can be a lot of overlap in their duties, and i don't think they should be forced to be seperate roles. But when both are present, they can divide the work and function as an efficient team. Which brings me to the problem here. 
There was only one slot for this job

I've changed it, now there's two.
I feel like a hard limit of 2 is a bit restrictive, but this is at least hopefully uncontroversial

Additionally, the number of skillpoints for the job had a duplicate definition. one at 14 and one at 20.  Since this is an intellectual sort of job, i figured the larger value is probably the correct one, and deleted the 14 which was already being overridden anyway

:cl: Nanako
tweak: Added an extra detective slot
/:cl: