### PR TITLE
Exploration dept goals fixes and additions

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -243,6 +243,11 @@
 #define EMAIL_SYSADMIN  "admin@internal-services.net"
 #define EMAIL_BROADCAST "broadcast@internal-services.net"
 
+//Stats for department goals etc
+#define STAT_XENOPLANTS_SCANNED  "xenoplants_scanned"
+#define STAT_XENOFAUNA_SCANNED  "xenofauna_scanned"
+#define STAT_FLAGS_PLANTED  "planet_flags"
+
 //Number of slots a modular computer has which can be tweaked via gear tweaks.
 #define TWEAKABLE_COMPUTER_PART_SLOTS 7
 

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -48,6 +48,7 @@
 #define SS_INIT_MISC_CODEX      -3
 #define SS_INIT_ALARM           -4
 #define SS_INIT_SHUTTLE         -5
+#define SS_INIT_GOALS           -5
 #define SS_INIT_LIGHTING        -6
 #define SS_INIT_XENOARCH        -10
 #define SS_INIT_BAY_LEGACY      -12

--- a/code/controllers/subsystems/goals.dm
+++ b/code/controllers/subsystems/goals.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(goals)
 	name = "Goals"
-	init_order = SS_INIT_MISC_LATE
+	init_order = SS_INIT_GOALS
 	flags = SS_NO_FIRE
 	var/list/global_personal_goals = list(
 		/datum/goal/achievement/specific_object/food,

--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -53,7 +53,7 @@
 		var/area/map = locate(/area/overmap)
 		for(var/obj/effect/overmap/sector/exoplanet/P in map)
 			if(grown_seed in P.seeds)
-				SSstatistics.add_field("xenoplants_scanned", 1)
+				SSstatistics.add_field(STAT_XENOPLANTS_SCANNED, 1)
 				break
 
 	var/list/dat = list()

--- a/code/game/objects/items/devices/scanners/xenobio.dm
+++ b/code/game/objects/items/devices/scanners/xenobio.dm
@@ -52,6 +52,16 @@
 		. += "Breathes:\t[list_gases(A.min_gas)]"
 		. += "Known toxins:\t[list_gases(A.max_gas)]"
 		. += "Temperature comfort zone:\t[A.minbodytemp] K to [A.maxbodytemp] K"
+		var/area/map = locate(/area/overmap)
+		for(var/obj/effect/overmap/sector/exoplanet/P in map)
+			if((A in P.animals) || is_type_in_list(A, P.repopulate_types))
+				var/list/discovered = SSstatistics.get_field(STAT_XENOFAUNA_SCANNED)
+				if(!discovered)
+					discovered = list()
+				discovered |= "[P.name]-[A.type]"
+				SSstatistics.set_field(STAT_XENOFAUNA_SCANNED, discovered)
+				. += "New xenofauna species discovered!"
+				break
 	else if(istype(target, /mob/living/carbon/slime/))
 		var/mob/living/carbon/slime/T = target
 		. += "Slime scan result for \the [T]:"

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -254,7 +254,7 @@
 			var/gasnum = min(rand(1,3), goodgases.len)
 			for(var/i = 1 to gasnum)
 				var/gas = pick(goodgases)
-				breathgas[gas] = round(0.4*goodgases[gas])
+				breathgas[gas] = round(0.4*goodgases[gas], 0.1)
 				goodgases -= gas
 		if(!badgas)
 			var/list/badgases = gas_data.gases.Copy()

--- a/maps/torch/datums/department_exploration.dm
+++ b/maps/torch/datums/department_exploration.dm
@@ -3,14 +3,16 @@
 	flag = EXP
 	goals = list(
 		/datum/goal/department/planet_claim,
-		/datum/goal/department/plant_samples
+		/datum/goal/department/plant_samples,
+		/datum/goal/department/fauna_samples
 	)
+	max_goals = 3
 
 /datum/goal/department/planet_claim
 	description = "Plant the SCG banner on the surface of an exoplanet."
 
 /datum/goal/department/planet_claim/check_success()
-	return (SSstatistics.get_field("planet_flags") > 0)
+	return (SSstatistics.get_field(STAT_FLAGS_PLANTED) > 0)
 
 /datum/goal/department/plant_samples
 	var/seeds
@@ -20,15 +22,38 @@
 	var/area/map = locate(/area/overmap)
 	for(var/obj/effect/overmap/sector/exoplanet/P in map)
 		total_seeds += P.seeds.len
-	seeds = rand(total_seeds)
+	if(total_seeds)
+		seeds = max(1, round(0.5 * total_seeds))
 	..()
 
 /datum/goal/department/plant_samples/update_strings()
 	description = "Scan at least [seeds] different plant\s native to exoplanets."
 	
 /datum/goal/department/plant_samples/get_summary_value()
-	var/scanned = SSstatistics.get_field("xenoplants_scanned")
+	var/scanned = SSstatistics.get_field(STAT_XENOPLANTS_SCANNED)
 	return " ([scanned ? scanned : 0 ] plant specie\s so far)"
 
 /datum/goal/department/plant_samples/check_success()
-	return (SSstatistics.get_field("xenoplants_scanned") >= seeds)
+	return (SSstatistics.get_field(STAT_XENOPLANTS_SCANNED) >= seeds)
+
+/datum/goal/department/fauna_samples
+	var/species
+
+/datum/goal/department/fauna_samples/New()
+	var/list/total_species = list()
+	var/area/map = locate(/area/overmap)
+	for(var/obj/effect/overmap/sector/exoplanet/P in map)
+		for(var/mob/living/simple_animal/A in P.animals)
+			total_species |= A.type
+	species = rand(length(total_species))
+	..()
+
+/datum/goal/department/fauna_samples/update_strings()
+	description = "Scan at least [species] different creature\s native to exoplanets."
+	
+/datum/goal/department/fauna_samples/get_summary_value()
+	var/scanned = length(SSstatistics.get_field(STAT_XENOFAUNA_SCANNED))
+	return " ([scanned ? scanned : 0 ] xenofauna specie\s so far)"
+
+/datum/goal/department/fauna_samples/check_success()
+	return (length(SSstatistics.get_field(STAT_XENOFAUNA_SCANNED)) >= species)

--- a/maps/torch/items/solbanner.dm
+++ b/maps/torch/items/solbanner.dm
@@ -44,6 +44,10 @@
 		return
 	if(user.unEquip(src))
 		forceMove(T)
+		if(GLOB.using_map.use_overmap)
+			var/obj/effect/overmap/sector/exoplanet/P = map_sectors["[z]"]
+			if(istype(P))
+				SSstatistics.add_field(STAT_FLAGS_PLANTED, 1)
 		qdel(src)
 		var/obj/structure/solbanner/exo/E = new(T)
 		var/obj/item/weapon/card/id/ID = user.GetIdCard()
@@ -53,7 +57,3 @@
 		E.plantedby = "Planted on [stationdate2text()] by [dudename], [user.get_assignment()] of [GLOB.using_map.full_name]."
 		T.visible_message("<span class='notice'>[user] successfully claims this world with \the [E]!</span>")
 		
-		if(GLOB.using_map.use_overmap)
-			var/obj/effect/overmap/sector/exoplanet/P = map_sectors["[z]"]
-			if(istype(P))
-				SSstatistics.add_field("planet_flags", 1)


### PR DESCRIPTION
Fixed seeds objective always having 0 seeds.
What was happening goals were created before the planets. Moved goals SS priority to later.

Fixed banner objective not registering. It was looking for the planet AFTER qdel, so in nullspace.

Added objective to scan xeno animals on the planets, similar to plant one.

Changed rounding on animals breathgas in planet gen, thye kept ending up with 'requiring' 0 moles of their gas.
