### PR TITLE
Some NTOS fixes

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/computer/modular.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/modular.dm
@@ -5,7 +5,7 @@
 		/obj/item/weapon/stock_parts/computer/processor_unit = 1
 	)
 	additional_spawn_components = list(
-		/obj/item/weapon/stock_parts/computer/network_card = 1,
+		/obj/item/weapon/stock_parts/computer/network_card/wired = 1,
 		/obj/item/weapon/stock_parts/computer/hard_drive = 1,
 		/obj/item/weapon/stock_parts/console_screen = 1,
 		/obj/item/weapon/stock_parts/keyboard = 1,

--- a/code/modules/events/computer_update.dm
+++ b/code/modules/events/computer_update.dm
@@ -11,8 +11,8 @@
 		if(EVENT_LEVEL_MAJOR)
 			updates_to_install = rand(500000, 1000000)
 
-	for(var/obj/item/modular_computer/C in SSobj.processing)
+	for(var/obj/C in (SSobj.processing + SSmachines.machinery))
 		if((C.z in GLOB.using_map.station_levels))
-			var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+			var/datum/extension/interactive/ntos/os = get_extension(C, /datum/extension/interactive/ntos)
 			if(os && os.get_ntnet_status() && os.receives_updates)
 				os.updates = updates_to_install

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -75,11 +75,6 @@ var/global/datum/ntnet/ntnet_global = new()
 				P.store_file(file)
 			file.stored_data += log_text + "\[br\]"
 
-/datum/ntnet/proc/get_computer_by_nid(var/NID)
-	for(var/obj/item/modular_computer/comp in SSobj.processing)
-		if(comp && comp.network_card && comp.network_card.identification_id == NID)
-			return comp
-
 /datum/ntnet/proc/get_os_by_nid(var/NID)
 	return registered_nids["[NID]"]
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -35,4 +35,4 @@
 		program.computer.show_error(user, "ID not found")
 
 	prog.authenticated = 0
-	program.computer.kill_program()
+	program.computer.kill_program(program)

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -143,10 +143,7 @@
 				var/input = input(usr, "Please write a message to announce to the [station_name()].", "Priority Announcement") as null|message
 				if(!input || !can_still_topic())
 					return 1
-				var/affected_zlevels = GLOB.using_map.contact_levels
-				var/atom/A = host
-				if(istype(A))
-					affected_zlevels = GetConnectedZlevels(A.z)
+				var/affected_zlevels = GetConnectedZlevels(get_host_z())
 				crew_announcement.Announce(input, zlevels = affected_zlevels)
 				announcment_cooldown = 1
 				spawn(600)//One minute cooldown

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -86,10 +86,7 @@
 // Refreshes list of active sensors kept on this computer.
 /datum/nano_module/power_monitor/proc/refresh_sensors()
 	grid_sensors = list()
-	var/turf/T = get_turf(nano_host())
-	if(!T) // Safety check
-		return
-	var/connected_z_levels = GetConnectedZlevels(T.z)
+	var/connected_z_levels = GetConnectedZlevels(get_host_z())
 	for(var/obj/machinery/power/sensor/S in SSmachines.machinery)
 		if((S.long_range) || (S.loc.z in connected_z_levels)) // Consoles have range on their Z-Level. Sensors with long_range var will work between Z levels.
 			if(S.name_tag == "#UNKN#") // Default name. Shouldn't happen!

--- a/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
@@ -21,12 +21,8 @@
 	deselect_shield()
 
 /datum/nano_module/shields_monitor/proc/get_shields()
-	var/turf/T = get_turf(nano_host())
-	if(!T)
-		return list()
-
 	var/list/shields = list()
-	var/connected_z_levels = GetConnectedZlevels(T.z)
+	var/connected_z_levels = GetConnectedZlevels(get_host_z())
 	for(var/obj/machinery/power/shield_generator/S in SSmachines.machinery)
 		if(!(S.z in connected_z_levels))
 			continue

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -42,10 +42,7 @@
 // Refreshes list of active supermatter crystals
 /datum/nano_module/supermatter_monitor/proc/refresh()
 	supermatters = list()
-	var/turf/T = get_turf(nano_host())
-	if(!T)
-		return
-	var/valid_z_levels = GetConnectedZlevels(T.z)
+	var/valid_z_levels = GetConnectedZlevels(get_host_z())
 	for(var/obj/machinery/power/supermatter/S in SSmachines.machinery)
 		// Delaminating, not within coverage, not on a tile.
 		if(S.grav_pulling || S.exploded || !(S.z in valid_z_levels) || !istype(S.loc, /turf/))

--- a/code/modules/modular_computers/file_system/programs/generic/docks.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/docks.dm
@@ -24,11 +24,8 @@
 		NMD.refresh_docks()
 
 /datum/nano_module/docking/proc/refresh_docks()
-	var/atom/movable/AM = nano_host()
-	if(!istype(AM))
-		return
 	docking_controllers.Cut()
-	var/list/zlevels = GetConnectedZlevels(AM.z)
+	var/list/zlevels = GetConnectedZlevels(get_host_z())
 	for(var/obj/machinery/embedded_controller/radio/airlock/docking_port/D in SSmachines.machinery)
 		if(D.z in zlevels)
 			var/shuttleside = 0

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -100,16 +100,13 @@
 
 /datum/nano_module/email_client/proc/log_in()
 	var/list/id_login
-
-	if(istype(host, /datum/extension/interactive/ntos/))
-		var/datum/extension/interactive/ntos/computer = host
-		var/obj/item/weapon/card/id/id = computer.get_inserted_id()
-		var/atom/A = computer.get_physical_host()
-		if(!id && A && ismob(A.loc))
-			var/mob/M = A.loc
-			id = M.GetIdCard()
-		if(id)
-			id_login = id.associated_email_login.Copy()
+	var/atom/movable/A = nano_host()
+	var/obj/item/weapon/card/id/id = A.GetIdCard()
+	if(!id && ismob(A.loc))
+		var/mob/M = A.loc
+		id = M.GetIdCard()
+	if(id)
+		id_login = id.associated_email_login.Copy()
 
 	var/datum/computer_file/data/email_account/target
 	for(var/datum/computer_file/data/email_account/account in ntnet_global.email_accounts)

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -56,7 +56,7 @@ var/global/ntnet_card_uid = 1
 // Returns a string identifier of this network card
 /obj/item/weapon/stock_parts/computer/network_card/proc/get_network_tag(list/routed_through) // Argument is a safety parameter for internal calls. Don't use manually.
 	if(proxy_id && !(src in routed_through))
-		var/datum/extension/interactive/ntos/comp = ntnet_global.get_computer_by_nid(proxy_id)
+		var/datum/extension/interactive/ntos/comp = ntnet_global.get_os_by_nid(proxy_id)
 		if(comp) // If not we default to exposing ourselves, but it means there was likely a logic error elsewhere.
 			LAZYADD(routed_through, src)
 			var/obj/item/weapon/stock_parts/computer/network_card/network_card = comp.get_component(PART_NETWORK)
@@ -96,7 +96,7 @@ var/global/ntnet_card_uid = 1
 		. = strength - 1
 
 	if(proxy_id)
-		var/datum/extension/interactive/ntos/comp = ntnet_global.get_computer_by_nid(proxy_id)
+		var/datum/extension/interactive/ntos/comp = ntnet_global.get_os_by_nid(proxy_id)
 		if(!comp || !comp.on)
 			return 0
 		if(src in routed_through) // circular proxy chain

--- a/code/modules/modular_computers/ntos/ntos.dm
+++ b/code/modules/modular_computers/ntos/ntos.dm
@@ -79,6 +79,8 @@
 	update_host_icon()
 
 /datum/extension/interactive/ntos/proc/kill_program(var/datum/computer_file/program/P, var/forced = 0)
+	if(!P)
+		return
 	P.on_shutdown(forced)
 	running_programs -= P
 	if(active_program == P)

--- a/code/modules/modular_computers/ntos/subtypes/console.dm
+++ b/code/modules/modular_computers/ntos/subtypes/console.dm
@@ -35,3 +35,15 @@
 	..()
 	var/obj/machinery/M = holder
 	M.update_use_power(POWER_USE_IDLE)
+
+/datum/extension/interactive/ntos/console/host_status()
+	var/obj/machinery/M = holder
+	return !(M.stat & NOPOWER)
+
+// Hack to make status bar work
+
+/obj/machinery/initial_data()
+	. = ..()
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os)
+		. += os.get_header_data()

--- a/code/modules/modular_computers/ntos/subtypes/device.dm
+++ b/code/modules/modular_computers/ntos/subtypes/device.dm
@@ -20,3 +20,11 @@
 /datum/extension/interactive/ntos/device/emagged()
 	var/obj/item/modular_computer/C = holder
 	return C.computer_emagged
+
+// Hack to make status bar work
+
+/obj/item/modular_computer/initial_data()
+	. = ..()
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os)
+		. += os.get_header_data()

--- a/code/modules/modular_computers/ntos/ui.dm
+++ b/code/modules/modular_computers/ntos/ui.dm
@@ -30,7 +30,7 @@
 		program["desc"] = P.filedesc
 		program["icon"] = P.program_menu_icon
 		program["autorun"] = (istype(autorun) && (autorun.stored_data == P.filename)) ? 1 : 0
-		if(P == active_program)
+		if(P in running_programs)
 			program["running"] = 1
 		programs.Add(list(program))
 
@@ -220,3 +220,6 @@
 
 /datum/extension/interactive/ntos/update_layout()
 	return TRUE
+
+/datum/extension/interactive/ntos/nano_host()
+	return holder.nano_host()

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -156,8 +156,8 @@ Subtypes
 	if(!origin || !origin.get_ntnet_status())
 		return
 	var/nid = text2num(copytext(text, 8))
-	var/datum/extension/interactive/ntos/comp = ntnet_global.get_computer_by_nid(nid)
-	if(!comp || !comp.on || !comp.get_ntnet_status())
+	var/datum/extension/interactive/ntos/comp = ntnet_global.get_os_by_nid(nid)
+	if(!comp || !comp.host_status() || !comp.get_ntnet_status())
 		return
 	return "... Estimating location: [get_area(comp)]"
 
@@ -177,8 +177,8 @@ Subtypes
 		. += "failed. Check network status."
 		return
 	var/nid = text2num(copytext(text, 6))
-	var/datum/extension/interactive/ntos/comp = ntnet_global.get_computer_by_nid(nid)
-	if(!comp || !comp.on || !comp.get_ntnet_status())
+	var/datum/extension/interactive/ntos/comp = ntnet_global.get_os_by_nid(nid)
+	if(!comp || !comp.host_status() || !comp.get_ntnet_status())
 		. += "failed. Target device not responding."
 		return
 	. += "ping successful."
@@ -198,10 +198,10 @@ Subtypes
 	if(!origin || !origin.get_ntnet_status())
 		return "ssh: Check network connectivity."
 	var/nid = text2num(copytext(text, 5))
-	var/datum/extension/interactive/ntos/comp = ntnet_global.get_computer_by_nid(nid)
+	var/datum/extension/interactive/ntos/comp = ntnet_global.get_os_by_nid(nid)
 	if(comp == origin)
 		return "ssh: Error; can not open remote terminal to self."
-	if(!comp || !comp.on || !comp.get_ntnet_status())
+	if(!comp || !comp.host_status() || !comp.get_ntnet_status())
 		return "ssh: No active device with this nid found."
 	if(comp.has_terminal(user))
 		return "ssh: A remote terminal to this device is already active."
@@ -247,9 +247,9 @@ Subtypes
 	var/id = text2num(copytext(text, 10))
 	if(!id)
 		return syntax_error
-	var/datum/extension/interactive/ntos/target = ntnet_global.get_computer_by_nid(id)
+	var/datum/extension/interactive/ntos/target = ntnet_global.get_os_by_nid(id)
 	if(target == comp) return "proxy: Cannot setup a device to be its own proxy"
-	if(!target || !target.on || !target.get_ntnet_status())
+	if(!target || !target.host_status() || !target.get_ntnet_status())
 		return "proxy: Error; cannot locate target device."
 	var/datum/computer_file/data/logfile/file = target.get_file("proxy")
 	if(!istype(file))

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -47,8 +47,7 @@
 	. = ..()
 
 /datum/nano_module/proc/get_host_z()
-	var/atom/host = nano_host()
-	return istype(host) ? get_z(host) : 0
+	return get_z(nano_host())
 
 /datum/nano_module/proc/print_text(var/text, var/mob/user)
 	var/datum/extension/interactive/ntos/os = get_extension(nano_host(), /datum/extension/interactive/ntos)


### PR DESCRIPTION
Fixed various monitoring programs. OS will now return physical machine as nano host. Added some ugly hacks to make sure title bar is still working.

Fixed terminal commands getting a modular comp device instead of OS, removed that proc in general since it's unused.

Gave consoles wired network card for peak internet speeds.

Fixes computer update event looking for OS in itself instead of computer.

Fixes tax program bricking devices.

Fixes #27137
Fixes #27138
Fixes #27139
Fixes #27141

Fixes parts of #27140, still need to fix CMO not getting their download programs.