### PR TITLE
Changes EC scarves to be for all uniforms

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -138,8 +138,8 @@ patches
 scarves
 *****/
 /obj/item/clothing/accessory/solgov/ec_scarf
-	name = "expeditionary dress scarf"
-	desc = "An SCG blue silk scarf, meant to be worn with the Expeditionary Corps dress uniform."
+	name = "expeditionary scarf"
+	desc = "An SCG blue silk scarf, meant to be worn with Expeditionary Corps uniforms."
 	icon = 'icons/obj/clothing/obj_accessories.dmi'
 	accessory_icons = list(slot_w_uniform_str = 'icons/mob/onmob/onmob_accessories.dmi', slot_wear_suit_str = 'icons/mob/onmob/onmob_accessories.dmi')
 	icon_state = "whitescarf"
@@ -148,13 +148,13 @@ scarves
 	check_codex_val = FACTION_EXPEDITIONARY
 
 /obj/item/clothing/accessory/solgov/ec_scarf/observatory
-	name = "\improper Observatory dress scarf"
-	desc = "A silk scarf in Expeditionary Corps Observatory section colors, meant to be worn with the Expeditionary Corps dress uniform."
+	name = "\improper Observatory scarf"
+	desc = "A silk scarf in Expeditionary Corps Observatory section colors, meant to be worn with Expeditionary Corps uniforms."
 	color = "#58bb59"
 
 /obj/item/clothing/accessory/solgov/ec_scarf/fieldops
-	name = "\improper Field Operations dress scarf"
-	desc = "A silk scarf in Expeditionary Corps Field Operations section colors, meant to be worn with the Expeditionary Corps dress uniform."
+	name = "\improper Field Operations scarf"
+	desc = "A silk scarf in Expeditionary Corps Field Operations section colors, meant to be worn with Expeditionary Corps uniforms."
 	color = "#9f84b3"
 
 /******

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -39,9 +39,9 @@
 	path = /obj/item/clothing/accessory/badge/solgov/tags
 
 /datum/gear/accessory/ec_scarf
-	display_name = "Expeditionary Corps dress scarf"
+	display_name = "Expeditionary Corps scarf"
 	path = /obj/item/clothing/accessory/solgov/ec_scarf
-	description = "A section-specific scarf for Expeditionary Corps dress uniforms."
+	description = "A section-specific scarf for Expeditionary Corps uniforms."
 	flags = GEAR_HAS_TYPE_SELECTION
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl:
tweak: Made EC scarves for all uniforms, not just Dress.
/:cl:

The scarves are cool and go very well with the utility uniform, no sense having them be for the never-worn dress, honestly, they fit. The EC deserves a bit of panaché.