### PR TITLE
Changes mag capacities for ARs and SMGs a little bit.

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -83,7 +83,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	matter = list(MATERIAL_STEEL = 1200)
 	caliber = CALIBER_PISTOL
-	max_ammo = 16
+	max_ammo = 20
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/machine_pistol/empty
@@ -96,7 +96,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol/small
 	matter = list(MATERIAL_STEEL = 1200)
 	caliber = CALIBER_PISTOL_SMALL
-	max_ammo = 20
+	max_ammo = 30
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/smg_top/empty
@@ -118,7 +118,7 @@
 	caliber = CALIBER_PISTOL
 	matter = list(MATERIAL_STEEL = 1500)
 	ammo_type = /obj/item/ammo_casing/pistol
-	max_ammo = 20
+	max_ammo = 30
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/smg/empty
@@ -253,7 +253,7 @@
 	caliber = CALIBER_RIFLE
 	matter = list(MATERIAL_STEEL = 4500)
 	ammo_type = /obj/item/ammo_casing/rifle
-	max_ammo = 50
+	max_ammo = 100
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/box/machinegun/empty
@@ -266,7 +266,7 @@
 	caliber = CALIBER_RIFLE
 	matter = list(MATERIAL_STEEL = 1800)
 	ammo_type = /obj/item/ammo_casing/rifle
-	max_ammo = 20
+	max_ammo = 30
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/mil_rifle
@@ -277,7 +277,7 @@
 	caliber = CALIBER_RIFLE_MILITARY
 	matter = list(MATERIAL_STEEL = 1800)
 	ammo_type = /obj/item/ammo_casing/rifle/military
-	max_ammo = 15 //if we lived in a world where normal mags had 30 rounds, this would be a 20 round mag
+	max_ammo = 20
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/mil_rifle/empty


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 
tweak: Magazine capacities for assault rifles and SMGs have been increased to reasonable amounts.
/🆑

• Machine pistol: 16 -> 20 
• Merc SMG: 20 -> 30
• Topmounted SMG: 20 -> 30
• Assault rifle: 20 -> 30
• Bullpup rifle: 15 -> 20
• LMG: 50 -> 100

This change will not affect traitors at all because they don't get to buy any of those via uplink.

With this change I want to encourage more spray-and-pray kind of gameplay due to how the general accuracy of all guns is lowered and get rid of an eyesore that is the 20 round AR mag. Shoutouts to whoever left that comment under bullpup.