### PR TITLE
Tweaks to internal organ violent damage

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -10,9 +10,8 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	take_external_damage(amount)
 
 /obj/item/organ/external/proc/take_external_damage(brute, burn, damage_flags, used_weapon = null)
-
-	brute = round(brute * get_brute_mod(), 0.1)
-	burn = round(burn * get_burn_mod(), 0.1)
+	brute = round(brute * get_brute_mod(damage_flags), 0.1)
+	burn = round(burn * get_burn_mod(damage_flags), 0.1)
 
 	if((brute <= 0) && (burn <= 0))
 		return 0
@@ -20,27 +19,20 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	var/sharp = (damage_flags & DAM_SHARP)
 	var/edge  = (damage_flags & DAM_EDGE)
 	var/laser = (damage_flags & DAM_LASER)
-	var/blunt = brute && !sharp && !edge
+	var/blunt = !!(brute && !sharp && !edge)
 
 	// Handle some status-based damage multipliers.
-	if(blunt)
-		if(BP_IS_BRITTLE(src))
-			brute = Floor(brute * 1.5)
-	else if(BP_IS_CRYSTAL(src))
-		if(burn && laser)
-			burn = Floor(burn * 0.1)
-			if(burn)
-				brute += burn // Stress fracturing from heat!
-				owner.bodytemperature += burn
-				burn = 0
-			if(prob(25))
-				owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
-		if(brute)
-			brute = Floor(brute * 0.8)
+	if(BP_IS_CRYSTAL(src) && burn && laser)
+		brute += burn // Stress fracturing from heat!
+		owner.bodytemperature += burn
+		burn = 0
+		if(prob(25))
+			owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
 
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
-	var/can_cut = (!BP_IS_ROBOTIC(src) && (sharp || prob(brute*2)))
+
+	var/can_cut = !BP_IS_ROBOTIC(src) && (sharp || prob(brute*2))
 	var/spillover = 0
 	var/pure_brute = brute
 	if(!is_damageable(brute + burn))
@@ -66,36 +58,11 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		fracture()
 
 	// High brute damage or sharp objects may damage internal organs
-	if(internal_organs && internal_organs.len)
-		var/damage_amt = brute
-		var/cur_damage = brute_dam
-		if(laser || BP_IS_ROBOTIC(src))
-			damage_amt += burn
-			cur_damage += burn_dam
-		var/organ_damage_threshold = 5
-		if(sharp)
-			organ_damage_threshold *= 0.5
-		var/organ_damage_prob = 10 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
-		if(encased && !(status & ORGAN_BROKEN)) //ribs protect
-			if(!laser)
-				organ_damage_prob *= 0.2
-			else
-				organ_damage_prob *= 0.5
-		if ((cur_damage + damage_amt >= max_damage || damage_amt >= organ_damage_threshold) && prob(organ_damage_prob))
-			// Damage an internal organ
-			var/list/victims = list()
-			for(var/obj/item/organ/internal/I in internal_organs)
-				if(I.damage < I.max_damage && prob(I.relative_size))
-					victims += I
-			if(!victims.len)
-				victims += pick(internal_organs)
-			for(var/v in victims)
-				var/obj/item/organ/internal/victim = v
-				brute /= 2
-				if(laser)
-					burn /= 2
-				damage_amt -= max(damage_amt*victim.damage_reduction, 0)
-				victim.take_internal_damage(damage_amt)
+	if(LAZYLEN(internal_organs))
+		var/taken_damage_divisor = damage_internal_organs(brute, burn, damage_flags)
+		brute /= taken_damage_divisor
+		if(laser)
+			burn /= taken_damage_divisor
 
 	if(status & ORGAN_BROKEN && brute)
 		jostle_bone(brute)
@@ -153,6 +120,45 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		owner.UpdateDamageIcon()
 
 	return created_wound
+
+/obj/item/organ/external/proc/damage_internal_organs(brute, burn, damage_flags)
+	if(!LAZYLEN(internal_organs))
+		return
+
+	var/laser = (damage_flags & DAM_LASER)
+
+	var/damage_amt = brute
+	var/cur_damage = brute_dam
+	if(laser || BP_IS_ROBOTIC(src))
+		damage_amt += burn
+		cur_damage += burn_dam
+	
+	var/organ_damage_threshold = 5
+	if(damage_flags & DAM_SHARP)
+		organ_damage_threshold *= 0.5
+
+	var/organ_damage_prob = 10 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
+	if(encased && !(status & ORGAN_BROKEN)) //ribs protect
+		if(!laser)
+			organ_damage_prob *= 0.2
+		else
+			organ_damage_prob *= 0.5
+
+	var/taken_damage_divisor = 1
+	if((cur_damage + damage_amt >= max_damage || damage_amt >= organ_damage_threshold) && prob(organ_damage_prob))
+		// Damage an internal organ
+		var/list/victims = list()
+		for(var/obj/item/organ/internal/I in internal_organs)
+			if(I.damage < I.max_damage && prob(I.relative_size))
+				victims += I
+		if(!victims.len)
+			victims += pick(internal_organs)
+		for(var/v in victims)
+			var/obj/item/organ/internal/victim = v
+			damage_amt -= max(damage_amt*victim.damage_reduction, 0)
+			victim.take_internal_damage(damage_amt)
+			taken_damage_divisor *= 2
+	return taken_damage_divisor
 
 /obj/item/organ/external/heal_damage(brute, burn, internal = 0, robo_repair = 0)
 	if(BP_IS_ROBOTIC(src) && !robo_repair)
@@ -305,22 +311,29 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		return TRUE
 	return FALSE
 
-/obj/item/organ/external/proc/get_brute_mod()
+/obj/item/organ/external/proc/get_brute_mod(var/damage_flags)
 	var/obj/item/organ/internal/augment/armor/A = owner && owner.internal_organs_by_name[BP_AUGMENT_CHEST_ARMOUR]
 	var/B = 1
 	if(A && istype(A))
 		B = A.brute_mult
 	if(!BP_IS_ROBOTIC(src))
 		B *= species.get_brute_mod(owner)
+	var/blunt = !(damage_flags & DAM_EDGE|DAM_SHARP)
+	if(blunt && BP_IS_BRITTLE(src))
+		B *= 1.5
+	if(BP_IS_CRYSTAL(src))
+		B *= 0.8
 	return B + (0.2 * burn_dam/max_damage) //burns make you take more brute damage
 
-/obj/item/organ/external/proc/get_burn_mod()
+/obj/item/organ/external/proc/get_burn_mod(var/damage_flags)
 	var/obj/item/organ/internal/augment/armor/A = owner && owner.internal_organs_by_name[BP_AUGMENT_CHEST_ARMOUR]
 	var/B = 1
 	if(A && istype(A))
 		B = A.burn_mult
 	if(!BP_IS_ROBOTIC(src))
 		B *= species.get_burn_mod(owner)
+	if(BP_IS_CRYSTAL(src))
+		B *= 0.1
 	return B
 
 //organs can come off in three cases

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -6,7 +6,7 @@
 	organ_tag = BP_EYES
 	parent_organ = BP_HEAD
 	surface_accessible = TRUE
-	relative_size = 10
+	relative_size = 5
 	var/phoron_guard = 0
 	var/list/eye_colour = list(0,0,0)
 	var/innate_flash_protection = FLASH_PROTECTION_NONE

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -8,7 +8,8 @@
 	var/heartbeat = 0
 	var/beat_sound = 'sound/effects/singlebeat.ogg'
 	var/tmp/next_blood_squirt = 0
-	relative_size = 15
+	damage_reduction = 0.7
+	relative_size = 5
 	max_damage = 45
 	var/open
 	var/list/external_pump

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -7,6 +7,7 @@
 	min_bruised_damage = 25
 	min_broken_damage = 45
 	max_damage = 70
+	relative_size = 10
 
 /obj/item/organ/internal/kidneys/robotize()
 	. = ..()


### PR DESCRIPTION
:cl:
tweak: Larger internal organs are now more likely to get hit than larger ones
tweak: Energy-based weapons are now in many cases less likely to cause internal organ damage than ballistic weapons (based on damage output)
/:cl:

First off, made organs picked weighted, based on their relative size. Decreased some sizes, heart's size was radically reduced due to how instantly-lethal heart hits are.
As a side effect, headshots are more dangerous now because pretty much every shot will deal brain damage. I think it's ok because those have fairly harsh penalties and headshots are very underwhelming right now.

Chance to hit organs no longer depends solely on damage dealt, but rather on summary area of damageable organs present. Damage still affects it.

Lasers get increased damage threshold to beat before they can damage the organs. It affects the chance to hit them too.

In practice it works out like this:
- Pretty much any ballistic gun can still damage organs. In fact headshots are now viable, so close up executinos are doable.
- Weak lasguns (like smol one) don't really damage organs much
- Fullsize lasgun shreks lungs on naked victim, on a victim in merc voidsuit it damages them to nasty but survivable degree.