### PR TITLE
Medical window nerf

### DIFF
--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -136,18 +136,22 @@
 
 
 /obj/effect/wallframe_spawn/reinforced/polarized
-	name = "polarized wall frame window spawner"
+	name = "polarized reinforced wall frame window spawner"
 	color = "#444444"
 	win_path = /obj/structure/window/reinforced/polarized/full
 	var/id
 
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille
-	name = "polarized wall frame window spawner (no grille)"
+	name = "polarized reinforced wall frame window spawner (no grille)"
 	grille_path = null
 
-/obj/effect/wallframe_spawn/reinforced/polarized/full
-	name = "polarized wall frame window spawner - full tile"
+/obj/effect/wallframe_spawn/reinforced/polarized/full//wtf it's the same as the other one, not gonna touch this cause I don't wanna remap a million things
+	name = "polarized reinforced wall frame window spawner - full tile"
 	win_path = /obj/structure/window/reinforced/polarized/full
+
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular
+	name = "polarized wall frame window spawner (no grille) (non reinforced)"
+	win_path = /obj/structure/window/basic/full/polarized
 
 /obj/effect/wallframe_spawn/reinforced/polarized/handle_window_spawn(var/obj/structure/window/reinforced/polarized/P)
 	if(id)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -258,7 +258,7 @@
 				S.update_strings()
 				S.update_icon()
 			qdel(src)
-	else if(isCoil(W) && reinf_material && !polarized)
+	else if(isCoil(W) && !polarized && is_fulltile())
 		var/obj/item/stack/cable_coil/C = W
 		if (C.use(1))
 			playsound(src.loc, 'sound/effects/sparks1.ogg', 75, 1)
@@ -414,6 +414,9 @@
 /obj/structure/window/basic/full
 	dir = 5
 	icon_state = "window_full"
+
+/obj/structure/window/basic/full/polarized
+	polarized = 1
 
 /obj/structure/window/phoronbasic
 	name = "phoron window"

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2884,7 +2884,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
 "agg" = (
-/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "surgery_windows"
 	},
 /turf/simulated/floor/plating,
@@ -4919,7 +4919,7 @@
 /turf/simulated/floor/plating,
 /area/medical/sleeper)
 "anN" = (
-/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "recov_windows"
 	},
 /turf/simulated/floor/plating,
@@ -18694,6 +18694,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"fYD" = (
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
+	id = "robotics_surg"
+	},
+/turf/simulated/floor/plating,
+/area/assembly/robotics/surgery)
 "fZn" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -22806,7 +22812,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "robotics_surg"
 	},
 /turf/simulated/floor/plating,
@@ -23709,6 +23715,12 @@
 "lHb" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/counselor)
+"lHO" = (
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
+	id = "exam_windows"
+	},
+/turf/simulated/floor/plating,
+/area/medical/exam_room)
 "lJb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/luminol,
@@ -24730,7 +24742,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/firstdeck/fore)
 "ncM" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 2;
@@ -24739,6 +24750,7 @@
 	name = "Counselor's Office Shutters";
 	opacity = 0
 	},
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/counselor)
 "ndb" = (
@@ -26270,6 +26282,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary/annex)
+"oMi" = (
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
+	id = "robotics_windows"
+	},
+/turf/simulated/floor/plating,
+/area/medical/surgery2)
 "oMq" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 4
@@ -27250,6 +27268,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary/annex)
+"pWW" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "mhealthshutters";
+	name = "Counselor's Office Shutters";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/turf/simulated/floor/plating,
+/area/medical/counselor)
 "pXm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/sol{
@@ -30657,7 +30687,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "uiY" = (
-/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/medical/infirmary)
 "ujx" = (
@@ -49138,7 +49168,7 @@ oMq
 lYA
 kEb
 kMb
-kUb
+fYD
 lYA
 lgb
 bHp
@@ -50547,7 +50577,7 @@ tCw
 tCw
 tCw
 ghb
-iGb
+oMi
 mbb
 arH
 kHb
@@ -53377,7 +53407,7 @@ anN
 fdb
 fub
 mob
-anH
+lHO
 ofb
 gzb
 ovb
@@ -53579,7 +53609,7 @@ anN
 gPb
 aqJ
 fLb
-anH
+lHO
 okb
 orb
 owb
@@ -57219,7 +57249,7 @@ sHb
 vZK
 sIb
 vii
-ncM
+pWW
 usl
 sLb
 azM
@@ -57421,7 +57451,7 @@ nMb
 sIg
 ovZ
 dnr
-ncM
+pWW
 hiD
 ayB
 azN
@@ -57623,7 +57653,7 @@ asi
 ati
 ovZ
 aug
-ncM
+pWW
 aGx
 hnN
 uZi


### PR DESCRIPTION
🆑 
maptweak: Most interior windows inside medical are now non-reinforced windows
tweak: Full-tile glass are now tintable whereas border windows are not.
/🆑

Salt PR: Had a gun fight in medical and no one was shot...

Gimme a second lemme check if single layer windows panes should be tintable
Answer: no