### PR TITLE
Adds debug trace to catch all instances where program is deleted

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -32,6 +32,7 @@
 		computer.kill_program(src)
 	computer = null
 	. = ..()
+	crash_with("Something is deleting a program")
 
 /datum/computer_file/program/nano_host()
 	return computer && computer.nano_host()


### PR DESCRIPTION
There's some bug happening right now where ntnet's repository programs are getting qdel'd but I can't find /who/ does it.
This will let me get at least a pool of suspects.
