### PR TITLE
Sets minimal character ages for jobs

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -19,7 +19,7 @@
 	var/minimal_player_age = 0            // If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/department = null                 // Does this position have a department tag?
 	var/head_position = 0                 // Is this position Command?
-	var/minimum_character_age = 0
+	var/minimum_character_age			  // List of species = age, if species is not here, it's auto-pass
 	var/ideal_character_age = 30
 	var/create_record = 1                 // Do we announce/make records for people who spawn on this job?
 	var/is_semi_antagonist = FALSE        // Whether or not this job is given semi-antagonist status.
@@ -195,9 +195,6 @@
 
 /datum/job/proc/is_restricted(var/datum/preferences/prefs, var/feedback)
 
-	if(minimum_character_age && (prefs.age < minimum_character_age))
-		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age].</span>")
-		return TRUE
 
 	if(!isnull(allowed_branches) && (!prefs.branches[title] || !is_branch_allowed(prefs.branches[title])))
 		to_chat(feedback, "<span class='boldannounce'>Wrong branch of service for [title]. Valid branches are: [get_branches()].</span>")
@@ -212,6 +209,10 @@
 		to_chat(feedback, "<span class='boldannounce'>Restricted species, [S], for [title].</span>")
 		return TRUE
 
+	if(LAZYACCESS(minimum_character_age, S.get_bodytype()) && (prefs.age < minimum_character_age[S.get_bodytype()]))
+		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_bodytype()]].</span>")
+		return TRUE
+	
 	if(!S.check_background(src, prefs))
 		to_chat(feedback, "<span class='boldannounce'>Incompatible background for [title].</span>")
 		return TRUE

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -150,6 +150,7 @@
 				var/help_link = "</td><td width = '10%' align = 'center'><a href='?src=\ref[src];job_info=[title]'>?</a></td>"
 				lastJob = job
 
+				var/bodytype = S.get_bodytype()
 				var/bad_message = ""
 				if(job.total_positions == 0 && job.spawn_positions == 0)
 					bad_message = "<b>\[UNAVAILABLE]</b>"
@@ -158,8 +159,8 @@
 				else if(!job.player_old_enough(user.client))
 					var/available_in_days = job.available_in_days(user.client)
 					bad_message = "\[IN [(available_in_days)] DAYS]"
-				else if(job.minimum_character_age && user.client && (user.client.prefs.age < job.minimum_character_age))
-					bad_message = "\[MINIMUM CHARACTER AGE: [job.minimum_character_age]]"
+				else if(LAZYACCESS(job.minimum_character_age, bodytype) && user.client && (user.client.prefs.age < job.minimum_character_age[bodytype]))
+					bad_message = "\[MIN CHAR AGE: [job.minimum_character_age[bodytype]]]"
 				else if(!job.is_species_allowed(S))
 					bad_message = "<b>\[SPECIES RESTRICTED]</b>"
 				else if(!S.check_background(job, user.client.prefs))

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -63,8 +63,9 @@
 	return TRUE
 
 /datum/job/submap/is_restricted(var/datum/preferences/prefs, var/feedback)
-	if(minimum_character_age && (prefs.age < minimum_character_age))
-		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age].</span>")
+	var/datum/species/S = all_species[prefs.species]
+	if(LAZYACCESS(minimum_character_age, S.get_bodytype()) && (prefs.age < minimum_character_age[S.get_bodytype()]))
+		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_bodytype()]].</span>")
 		return TRUE
 	if(LAZYLEN(whitelisted_species) && !(prefs.species in whitelisted_species))
 		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.descriptor].</span>")

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -3,6 +3,7 @@
 	supervisors = "the Sol Central Government and the Sol Code of Military Justice"
 	minimal_player_age = 7
 	economic_power = 15
+	minimum_character_age = list(SPECIES_HUMAN = 40)
 	ideal_character_age = 50
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/CO
 	allowed_branches = list(
@@ -39,6 +40,7 @@
 	department_flag = COM
 	minimal_player_age = 7
 	economic_power = 10
+	minimum_character_age = list(SPECIES_HUMAN = 35)
 	ideal_character_age = 45
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/XO
 	allowed_branches = list(
@@ -96,6 +98,7 @@
 	supervisors = "the Commanding Officer"
 	economic_power = 20
 	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 35)
 	ideal_character_age = 60
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/cso
 	allowed_branches = list(
@@ -142,6 +145,7 @@
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 10
 	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 35)
 	ideal_character_age = 48
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/cmo
 	allowed_branches = list(
@@ -184,6 +188,7 @@
 	title = "Chief Engineer"
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 9
+	minimum_character_age = list(SPECIES_HUMAN = 27)
 	ideal_character_age = 40
 	minimal_player_age = 7
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer
@@ -240,6 +245,7 @@
 	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 8
 	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/cos
 	allowed_branches = list(
@@ -293,6 +299,7 @@
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_EXPERT,
 	                    SKILL_FINANCE     = SKILL_BASIC)
 	skill_points = 20
+	minimum_character_age = list(SPECIES_HUMAN = 27)
 
 	access = list(access_representative, access_security, access_medical,
 			            access_bridge, access_cargo, access_solgov_crew, access_hangar)
@@ -312,6 +319,7 @@
 	selection_color = "#2f2f7f"
 	minimal_player_age = 7
 	economic_power = 8
+	minimum_character_age = list(SPECIES_HUMAN = 35)
 	ideal_character_age = 45
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/sea/fleet
 	allowed_branches = list(
@@ -357,6 +365,7 @@
 	selection_color = "#2f2f7f"
 	minimal_player_age = 0
 	economic_power = 7
+	minimum_character_age = list(SPECIES_HUMAN = 22)
 	ideal_character_age = 24
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
 	allowed_branches = list(

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -8,6 +8,7 @@
 	selection_color = "#2f2f7f"
 	economic_power = 15
 	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	alt_titles = list(
 		"Corporate Liaison",
 		"Union Representative" = /decl/hierarchy/outfit/job/torch/passenger/workplace_liaison/union_rep,
@@ -47,6 +48,7 @@
 	selection_color = "#3d3d7f"
 	economic_power = 12
 	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 19)
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/corporate_bodyguard
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -8,6 +8,7 @@
 	selection_color = "#5b4d20"
 	economic_power = 6
 	minimal_player_age = 3
+	minimum_character_age = list(SPECIES_HUMAN = 27)
 	ideal_character_age = 40
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer
 	allowed_branches = list(
@@ -55,6 +56,7 @@
 	supervisors = "the Chief Engineer"
 	economic_power = 5
 	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 19)
 	ideal_character_age = 30
 	alt_titles = list(
 		"Maintenance Technician",
@@ -116,6 +118,7 @@
 	spawn_positions = 2
 	supervisors = "the Chief Engineer and Engineering Personnel"
 	selection_color = "#5b4d20"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
@@ -167,6 +170,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	supervisors = "the Chief Engineer and the Corporate Liaison."
 	selection_color = "#5b4d20"
 	economic_power = 6

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -8,6 +8,7 @@
 	selection_color = "#68099e"
 	minimal_player_age = 1
 	economic_power = 7
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/pathfinder
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
@@ -49,6 +50,7 @@
 	selection_color = "#68099e"
 	economic_power = 10
 	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 24)
 	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/pilot
 	allowed_branches = list(
@@ -84,6 +86,7 @@
 	spawn_positions = 5
 	supervisors = "the Commanding Officer, Executive Officer, and Pathfinder"
 	selection_color = "#68099e"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/explorer
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -3,6 +3,7 @@
 	department = "Medical"
 	department_flag = MED
 	minimal_player_age = 2
+	minimum_character_age = list(SPECIES_HUMAN = 29)
 	ideal_character_age = 45
 	total_positions = 2
 	spawn_positions = 2
@@ -49,6 +50,7 @@
 	spawn_positions = 3
 	supervisors = "Physicians and the Chief Medical Officer"
 	economic_power = 7
+	minimum_character_age = list(SPECIES_HUMAN = 19)
 	ideal_character_age = 40
 	minimal_player_age = 0
 	alt_titles = list(
@@ -94,6 +96,7 @@
 	spawn_positions = 1
 	supervisors = "Medical personnel, and the Chief Medical Officer"
 	selection_color = "#013d3b"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 	alt_titles = list(
 		"Corpsman Trainee")
@@ -139,6 +142,7 @@
 	supervisors = "the Chief Medical Officer, the Corporate Liaison and Medical Personnel"
 	selection_color = "#013d3b"
 	economic_power = 4
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 30
 	minimal_player_age = 0
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -9,6 +9,7 @@
 	selection_color = "#633d63"
 	economic_power = 12
 	minimal_player_age = 3
+	minimum_character_age = list(SPECIES_HUMAN = 30)
 	ideal_character_age = 50
 	alt_titles = list(
 		"Research Supervisor")
@@ -44,6 +45,7 @@
 	spawn_positions = 6
 	supervisors = "the Chief Science Officer and the Workplace Liaison"
 	economic_power = 10
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 45
 	minimal_player_age = 0
 	alt_titles = list(
@@ -90,6 +92,7 @@
 	supervisors = "the Chief Science Officer, the Workplace Liaison and science personnel"
 	selection_color = "#633d63"
 	economic_power = 3
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 30
 	alt_titles = list(
 		"Custodian" = /decl/hierarchy/outfit/job/torch/passenger/research/assist/janitor,

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -6,6 +6,7 @@
 	economic_power = 5
 	minimal_player_age = 7
 	ideal_character_age = 35
+	minimum_character_age = list(SPECIES_HUMAN = 27)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/brig_chief
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
@@ -43,6 +44,7 @@
 	supervisors = "the Chief of Security"
 	economic_power = 5
 	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 35
 	skill_points = 14
 	alt_titles = list(
@@ -91,6 +93,7 @@
 	supervisors = "the Chief of Security"
 	economic_power = 4
 	minimal_player_age = 7
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 25
 	alt_titles = list() // This is a hack. Overriding a list var with null does not actually override it due to the particulars of dm list init. Do not "clean up" without testing.
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/security/maa

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -4,6 +4,7 @@
 	department_flag = SRV
 	total_positions = 1
 	spawn_positions = 1
+	minimum_character_age = list(SPECIES_HUMAN = 24)
 	ideal_character_age = 40
 	economic_power = 5
 	minimal_player_age = 0
@@ -29,6 +30,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Executive Officer"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 	alt_titles = list(
 		"Janitor")
@@ -56,6 +58,7 @@
 	department_flag = SRV
 	total_positions = 1
 	spawn_positions = 1
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	supervisors = "the Executive Officer"
 	alt_titles = list(
 		"Chef",
@@ -84,6 +87,7 @@
 	department = "Service"
 	department_flag = SRV
 	supervisors = "the Executive Officer and the Corporate Liaison"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/bartender
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -102,6 +106,7 @@
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "the Executive Officer and SolGov Personnel"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -7,6 +7,7 @@
 	supervisors = "the Executive Officer"
 	economic_power = 5
 	minimal_player_age = 0
+	minimum_character_age = list(SPECIES_HUMAN = 27)
 	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer
 	allowed_branches = list(
@@ -43,6 +44,7 @@
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Deck Chief and Executive Officer"
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 24
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/supply/tech
 	allowed_branches = list(
@@ -79,6 +81,7 @@
 	spawn_positions = 2
 	supervisors = "the Deck Chief, the Corporate Liaison and the Executive Officer"
 	economic_power = 7
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 25
 	alt_titles = list(
 		"Drill Technician",


### PR DESCRIPTION
Replacing bwoinks with cold uncaring machine.
Adjusted min age thing to only care about certain species, so snowflakes aren't affected, only humans are.

:cl: Chinsky
rscadd: Minimum character age for jobs is now code-enforced. You may have to adjust your chars to be able to join as your preferred job. 
/:cl:
```
Job | Age
-- | --
Commanding Officer | 40
Executive Officer | 40
Senior Enlisted Advisor | 36
Chief Science Officer | 35
Chief Medical Officer | 35
Senior Engineer | 30
Senior Researcher | 30
Physician | 29
Brig Chief | 28
Deck Chief | 28
Chief Engineer | 27
SolGov Representative | 27
Pathfinder | 25
Scientist | 25
Chief of Security | 25
Workplace Liaison | 25
Roboticist | 25
Forensic Technician | 25
Chemist | 25
Shuttle Pilot | 24
Counselor | 24
Chaplain | 24
Bridge Officer | 22
Loss Prevention Associate | 20
Engineer | 19
Medical Technician | 19
Research Assistant | 18
Explorer | 18
Engineer Trainee | 18
Master at Arms | 18
Trainee Medical Technician | 18
Deck Technician | 18
Prospector | 18
Sanitation Technician | 18
Cook | 18
Bartender | 18
Crewman | 18
```
