### PR TITLE
Makes adherent fast again

### DIFF
--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -132,6 +132,9 @@
 /datum/species/adherent/can_fall(var/mob/living/carbon/human/H)
 	. = !can_overcome_gravity(H)
 
+/datum/species/adherent/get_slowdown(var/mob/living/carbon/human/H)
+    return slowdown
+
 /datum/species/adherent/handle_fall_special(var/mob/living/carbon/human/H, var/turf/landing)
 
 	if(can_overcome_gravity(H))

--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -133,7 +133,7 @@
 	. = !can_overcome_gravity(H)
 
 /datum/species/adherent/get_slowdown(var/mob/living/carbon/human/H)
-    return slowdown
+	return slowdown
 
 /datum/species/adherent/handle_fall_special(var/mob/living/carbon/human/H, var/turf/landing)
 


### PR DESCRIPTION
Adherent were getting their -1 slowdown bonus unintentionally removed due to being synthetic
This fixes that

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->