### PR TITLE
Makes the labcoat only available to Scientists and Doctors

### DIFF
--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -12,6 +12,9 @@
 //For roles with no uniform or formal clothing requirements
 #define RESTRICTED_ROLES list(/datum/job/assistant, /datum/job/bartender, /datum/job/merchant)
 
+//For roles that would have a higher level of education, typically doctors and other scientists
+#define DOCTOR_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist)
+
 //For members of the medical department
 #define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/medical_trainee)
 

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -52,7 +52,7 @@
 	allowed_roles = RESTRICTED_ROLES
 
 /datum/gear/suit/labcoat
-	allowed_roles = STERILE_ROLES
+	allowed_roles = DOCTOR_ROLES
 
 /datum/gear/suit/labcoat_corp
 	allowed_roles = STERILE_ROLES

--- a/maps/torch/loadout/~defines.dm
+++ b/maps/torch/loadout/~defines.dm
@@ -8,6 +8,8 @@
 
 #undef RESTRICTED_ROLES
 
+#undef DOCTOR_ROLES
+
 #undef MEDICAL_ROLES
 
 #undef STERILE_ROLES

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -127,6 +127,5 @@
 		RANDOM_SCRUBS = 4,
 		/obj/item/clothing/suit/surgicalapron = 2,
 		/obj/item/clothing/shoes/white = 2,
-		/obj/item/clothing/suit/storage/toggle/labcoat = 2,
 		/obj/item/clothing/mask/surgical = 2
 	)


### PR DESCRIPTION
:cl: Rain7x
tweak: The labcoat can only be selected in loadout if your job would realistically require it. It has also been removed from the medical wardrobe.
/:cl:

Labcoats are heavy and gross, they're not meant to be worn for first responders as they would significantly slow them down. 

Also I added a new define, could be used elsewhere later.