### PR TITLE
Couple external damage tweaks

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -176,3 +176,6 @@
 
 	set_dir(turn(dir, 90))
 	update_icon() 
+
+//For things to apply special effects after damaging an organ, called by organ's take_damage
+/obj/proc/after_wounding(obj/item/organ/external/organ, datum/wound)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -32,7 +32,6 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
 
-	var/can_cut = !BP_IS_ROBOTIC(src) && (sharp || prob(brute*2))
 	var/spillover = 0
 	var/pure_brute = brute
 	if(!is_damageable(brute + burn))
@@ -70,13 +69,13 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
 	var/datum/wound/created_wound
-	var/block_cut = !(brute > 15 || !(species.species_flags & SPECIES_FLAG_NO_MINOR_CUT))
+	var/block_cut = (species.species_flags & SPECIES_FLAG_NO_MINOR_CUT) && brute <= 15
+	var/can_cut = !block_cut && !BP_IS_ROBOTIC(src) && (sharp || prob(brute))
 
 	if(brute)
 		var/to_create = BRUISE
 		if(can_cut)
-			if(!block_cut)
-				to_create = CUT
+			to_create = CUT
 			//need to check sharp again here so that blunt damage that was strong enough to break skin doesn't give puncture wounds
 			if(sharp && !edge)
 				to_create = PIERCE

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -117,6 +117,10 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	if(owner && update_damstate())
 		owner.UpdateDamageIcon()
 
+	if(created_wound && isobj(used_weapon))
+		var/obj/O = used_weapon
+		O.after_wounding(src, created_wound)
+
 	return created_wound
 
 /obj/item/organ/external/proc/damage_internal_organs(brute, burn, damage_flags)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -485,4 +485,28 @@
 	qdel(trace) //No need for it anymore
 	return output //Send it back to the gun!
 
+/obj/item/projectile/after_wounding(obj/item/organ/external/organ, datum/wound/wound)
+	//Check if we even broke skin in first place
+	if(!wound || !(wound.damage_type == CUT || wound.damage_type == PIERCE))
+		return
+	//Check if we can do nasty stuff inside
+	if(!can_embed() || (organ.species.species_flags & SPECIES_FLAG_NO_EMBED))
+		return
+	//Embed or sever artery
+	var/damage_prob = 0.5 * wound.damage * penetration_modifier
+	if(prob(damage_prob))
+		var/obj/item/shrapnel = get_shrapnel()
+		if(shrapnel)
+			shrapnel.forceMove(organ)
+			organ.embed(shrapnel)
+	else if(prob(2 * damage_prob))
+		organ.sever_artery()
 
+	organ.owner.projectile_hit_bloody(src, wound.damage*5, null, organ)
+
+/obj/item/projectile/proc/get_shrapnel()
+	if(shrapnel_type)
+		var/obj/item/SP = new shrapnel_type()
+		SP.SetName((name != "shrapnel")? "[name] shrapnel" : "shrapnel")
+		SP.desc += " It looks like it was fired from [shot_from]."
+		return SP


### PR DESCRIPTION
Cutting parts from another WIP branch so it's less noisy.

- Now if organ took damage and a wound was created, it will check whether the weapon passed to damage proc is an object, and if so will call a special proc on that object for any on-wounding effects. Bullets now use that instead of going around entire damage handling chain. In effect that means now armor actually affects chance of getting IB.

- Now you can get large bruises. Currently any brute damage above 15 created a cut, even if damage was blunt. Put a prob on that check, so while brute above 15 can create cuts, itll not be guaranteed.