### PR TITLE
Refactor Overmap Hazards (To prep for moving hazards) [Despaghettified/READY]

### DIFF
--- a/code/modules/overmap/disperser/disperser_fire.dm
+++ b/code/modules/overmap/disperser/disperser_fire.dm
@@ -73,10 +73,10 @@
 	return TRUE
 
 /obj/machinery/computer/ship/disperser/proc/fire_at_event(obj/effect/overmap_event/finaltarget, chargetype)
-	var/list/events_by_turf = overmap_event_handler.get_event_turfs_by_z_level(linked.z)
-	var/datum/overmap_event/tokill = events_by_turf[get_turf(finaltarget)]
-	if(chargetype & tokill.weaknesses)
+	if(chargetype & finaltarget.weaknesses)
+		var/turf/T = finaltarget.loc
 		qdel(finaltarget)
+		overmap_event_handler.update_hazards(T)
 
 /obj/machinery/computer/ship/disperser/proc/handle_beam(turf/start, direction)
 	set waitfor = FALSE

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -1,44 +1,33 @@
 /var/decl/overmap_event_handler/overmap_event_handler = new()
 
 /decl/overmap_event_handler
-	var/list/event_turfs_by_z_level
+	var/list/hazard_by_turf
+	var/list/ship_events
 
 /decl/overmap_event_handler/New()
 	..()
-	event_turfs_by_z_level = list()
+	hazard_by_turf = list()
+	ship_events = list()
 
 /decl/overmap_event_handler/proc/create_events(var/z_level, var/overmap_size, var/number_of_events)
 	// Acquire the list of not-yet utilized overmap turfs on this Z-level
-	var/list/events_by_turf = get_event_turfs_by_z_level(z_level)
 	var/list/candidate_turfs = block(locate(OVERMAP_EDGE, OVERMAP_EDGE, z_level),locate(overmap_size - OVERMAP_EDGE, overmap_size - OVERMAP_EDGE,z_level))
-	candidate_turfs -= events_by_turf
 	candidate_turfs = where(candidate_turfs, /proc/can_not_locate, /obj/effect/overmap)
 
 	for(var/i = 1 to number_of_events)
 		if(!candidate_turfs.len)
 			break
 		var/overmap_event_type = pick(subtypesof(/datum/overmap_event))
-		var/datum/overmap_event/overmap_event = new overmap_event_type
+		var/datum/overmap_event/datum_spawn = new overmap_event_type
 
-		var/list/event_turfs = acquire_event_turfs(overmap_event.count, overmap_event.radius, candidate_turfs, overmap_event.continuous)
+		var/list/event_turfs = acquire_event_turfs(datum_spawn.count, datum_spawn.radius, candidate_turfs, datum_spawn.continuous)
 		candidate_turfs -= event_turfs
 
 		for(var/event_turf in event_turfs)
-			events_by_turf[event_turf] = overmap_event
-			GLOB.entered_event.register(event_turf, src, /decl/overmap_event_handler/proc/on_turf_entered)
-			GLOB.exited_event.register(event_turf, src, /decl/overmap_event_handler/proc/on_turf_exited)
+			var/type = pick(datum_spawn.hazards)
+			new type(event_turf)
 
-			var/obj/effect/overmap_event/event = new(event_turf)
-			event.SetName(overmap_event.name)
-			event.icon_state = pick(overmap_event.event_icon_states)
-			event.opacity =  overmap_event.opacity
-
-/decl/overmap_event_handler/proc/get_event_turfs_by_z_level(var/z_level)
-	var/z_level_text = num2text(z_level)
-	. = event_turfs_by_z_level[z_level_text]
-	if(!.)
-		. = list()
-		event_turfs_by_z_level[z_level_text] = .
+		qdel(datum_spawn)//idk help how do I do this better?
 
 /decl/overmap_event_handler/proc/acquire_event_turfs(var/number_of_turfs, var/distance_from_origin, var/list/candidate_turfs, var/continuous = TRUE)
 	number_of_turfs = min(number_of_turfs, candidate_turfs.len)
@@ -74,39 +63,102 @@
 		if(T in candidate_turfs)
 			return T
 
-/decl/overmap_event_handler/proc/on_turf_exited(var/turf/old_loc, var/obj/effect/overmap/ship/entering_ship, var/new_loc)
-	if(!istype(entering_ship))
+/decl/overmap_event_handler/proc/start_hazard(var/obj/effect/overmap/ship/ship, var/obj/effect/overmap_event/hazard)//make these accept both hazards or events
+	if(!ship in ship_events)
+		ship_events += ship
+
+	for(var/event_type in hazard.events)
+		if(is_event_active(ship,event_type, hazard.difficulty))//event's already active, don't bother
+			continue
+		var/datum/event_meta/EM = new(hazard.difficulty, "Overmap event - [hazard.name]", event_type, add_to_queue = FALSE, is_one_shot = TRUE)
+		var/datum/event/E = new event_type(EM)
+		E.startWhen = 0
+		E.endWhen = INFINITY
+		E.affecting_z = ship.map_z
+		if("victim" in E.vars)//for meteors and other overmap events that uses ships//might need a better solution
+			E.vars["victim"] = ship
+		LAZYADD(ship_events[ship], E)
+
+/decl/overmap_event_handler/proc/stop_hazard(var/obj/effect/overmap/ship/ship, var/obj/effect/overmap_event/hazard)
+	for(var/event_type in hazard.events)
+		var/datum/event/E = is_event_active(ship,event_type,hazard.difficulty)
+		if(E)
+			E.kill()
+			LAZYREMOVE(ship_events[ship], E)
+
+/decl/overmap_event_handler/proc/is_event_active(var/ship, var/event_type, var/severity)
+	if(!ship_events[ship])	return
+	for(var/datum/event/E in ship_events[ship])
+		if(E.type == event_type && E.severity == severity)
+			return E
+
+/decl/overmap_event_handler/proc/on_turf_entered(var/turf/new_loc, var/obj/effect/overmap/ship/ship, var/old_loc)
+	if(!istype(ship))
 		return
 	if(new_loc == old_loc)
 		return
 
-	var/list/events_by_turf = get_event_turfs_by_z_level(old_loc.z)
-	var/datum/overmap_event/old_event = events_by_turf[old_loc]
-	var/datum/overmap_event/new_event = events_by_turf[new_loc]
+	for(var/obj/effect/overmap_event/E in hazard_by_turf[new_loc])
+		start_hazard(ship, E)
 
-	if(old_event == new_event)
-		return
-	if(old_event)
-		if(new_event && old_event.difficulty == new_event.difficulty && same_entries(old_event.events, new_event.events))
-			return
-		old_event.leave(entering_ship)
-
-/decl/overmap_event_handler/proc/on_turf_entered(var/turf/new_loc, var/obj/effect/overmap/ship/entering_ship, var/old_loc)
-	if(!istype(entering_ship))
+/decl/overmap_event_handler/proc/on_turf_exited(var/turf/old_loc, var/obj/effect/overmap/ship/ship, var/new_loc)
+	if(!istype(ship))
 		return
 	if(new_loc == old_loc)
 		return
 
-	var/list/events_by_turf = get_event_turfs_by_z_level(new_loc.z)
-	var/datum/overmap_event/old_event = events_by_turf[old_loc]
-	var/datum/overmap_event/new_event = events_by_turf[new_loc]
+	for(var/obj/effect/overmap_event/E in hazard_by_turf[old_loc])
+		if(is_event_included(hazard_by_turf[new_loc],E))
+			continue
+		stop_hazard(ship,E)
 
-	if(old_event == new_event)
+/decl/overmap_event_handler/proc/update_hazards(var/turf/T)//catch all updater
+	if(!istype(T))
 		return
-	if(new_event)
-		if(old_event && old_event.difficulty == new_event.difficulty && same_entries(old_event.events, new_event.events))
-			return
-		new_event.enter(entering_ship)
+
+	var/list/active_hazards = list()
+	for(var/obj/effect/overmap_event/E in T)
+		if(is_event_included(active_hazards, E, TRUE))
+			continue
+		active_hazards += E
+
+	if(!active_hazards.len)
+		hazard_by_turf -= T
+		GLOB.entered_event.unregister(T, src, /decl/overmap_event_handler/proc/on_turf_entered)
+		GLOB.exited_event.unregister(T, src, /decl/overmap_event_handler/proc/on_turf_exited)
+	else
+		hazard_by_turf |= T
+		hazard_by_turf[T] = active_hazards
+		GLOB.entered_event.register(T, src,/decl/overmap_event_handler/proc/on_turf_entered)
+		GLOB.exited_event.register(T, src, /decl/overmap_event_handler/proc/on_turf_exited)
+
+	for(var/obj/effect/overmap/ship/ship in T)
+		for(var/datum/event/E in ship_events[ship])
+			if(is_event_in_turf(E,T))
+				continue
+			E.kill()
+			LAZYREMOVE(ship_events[ship], E)
+
+		for(var/obj/effect/overmap_event/E in active_hazards)
+			start_hazard(ship,E)
+
+/decl/overmap_event_handler/proc/is_event_in_turf(var/datum/event/E, var/turf/T)
+	for(var/obj/effect/overmap_event/hazard in hazard_by_turf[T])
+		if(E in hazard.events && E.severity == hazard.difficulty)
+			return TRUE
+
+/decl/overmap_event_handler/proc/is_event_included(var/list/hazards, var/obj/effect/overmap_event/E, var/equal_or_better)//this proc is only used so it can break out of 2 loops cleanly
+	for(var/obj/effect/overmap_event/A in hazards)
+		if(istype(A,E.type) || istype(E,A.type))
+			if(same_entries(A.events, E.events))
+				if(equal_or_better)
+					if(A.difficulty >= E.difficulty)
+						return TRUE
+					else
+						hazards -= A
+				else
+					if(A.difficulty == E.difficulty)
+						return TRUE
 
 // We don't subtype /obj/effect/overmap because that'll create sections one can travel to
 //  And with them "existing" on the overmap Z-level things quickly get odd.
@@ -115,107 +167,124 @@
 	icon = 'icons/obj/overmap.dmi'
 	icon_state = "event"
 	opacity = 1
-
-/obj/effect/overmap_event/Destroy()
-	var/list/events_by_turf = overmap_event_handler.get_event_turfs_by_z_level(z)
-	var/datum/overmap_event/tokill = events_by_turf[get_turf(src)]
-	GLOB.entered_event.unregister(get_turf(src), overmap_event_handler, /decl/overmap_event_handler/proc/on_turf_entered)
-	GLOB.exited_event.unregister(get_turf(src), overmap_event_handler, /decl/overmap_event_handler/proc/on_turf_exited)
-	for(var/obj/effect/overmap/ship/leaver in get_turf(src))
-		tokill.leave(leaver)
-	events_by_turf -= get_turf(src)
-	. = ..()
-
-/datum/overmap_event
-	var/name = "map event"
-	var/radius = 2
-	var/count = 6
 	var/list/events
-	var/list/event_icon_states = list("event")
-	var/opacity = 1
+	var/list/event_icon_states
 	var/difficulty = EVENT_LEVEL_MODERATE
-	var/list/victims
-	var/continuous = TRUE //if it should form continous blob, or can have gaps
 	var/weaknesses //if the BSA can destroy them and with what
+	var/list/victims //basically cached events on which Z level
 
-/datum/overmap_event/proc/enter(var/obj/effect/overmap/ship/victim)
-	if(victim in victims)
-		log_error("Multiple attempts to trigger the same event by [victim] detected.")
-		return
-	LAZYADD(victims, victim)
-	for(var/event in events)
-		var/datum/event_meta/EM = new(difficulty, "Overmap event - [name]", event, add_to_queue = FALSE, is_one_shot = TRUE)
-		var/datum/event/E = new event(EM)
-		E.startWhen = 0
-		E.endWhen = INFINITY
-		E.affecting_z = victim.map_z
-		LAZYADD(victims[victim], E)
+/obj/effect/overmap_event/Initialize()
+	. = ..()
+	icon_state = pick(event_icon_states)
+	overmap_event_handler.update_hazards(loc)
 
-/datum/overmap_event/proc/leave(victim)
-	if(victims && victims[victim])
-		for(var/datum/event/E in victims[victim])
-			E.kill()
-		LAZYREMOVE(victims, victim)
+/obj/effect/overmap_event/Move()
+	var/turf/old_loc = loc
+	. = ..()
+	if(.)
+		overmap_event_handler.update_hazards(old_loc)
+		overmap_event_handler.update_hazards(loc)
 
-/datum/overmap_event/meteor
+/obj/effect/overmap_event/forceMove(atom/destination)
+	var/old_loc = loc
+	. = ..()
+	if(.)
+		overmap_event_handler.update_hazards(old_loc)
+		overmap_event_handler.update_hazards(loc)
+
+/obj/effect/overmap_event/Destroy()//takes a look at this one as well, make sure everything is A-OK
+	var/turf/T = loc
+	. = ..()
+	overmap_event_handler.update_hazards(T)
+
+/obj/effect/overmap_event/meteor
 	name = "asteroid field"
 	events = list(/datum/event/meteor_wave/overmap)
-	count = 15
-	radius = 4
-	continuous = FALSE
 	event_icon_states = list("meteor1", "meteor2", "meteor3", "meteor4")
 	difficulty = EVENT_LEVEL_MAJOR
 	weaknesses = OVERMAP_WEAKNESS_MINING | OVERMAP_WEAKNESS_EXPLOSIVE
 
-/datum/overmap_event/meteor/enter(var/obj/effect/overmap/ship/victim)
-	..()
-	if(victims[victim])
-		var/datum/event/meteor_wave/overmap/E = locate() in victims[victim]
-		if(E)
-			E.victim = victim
-
-/datum/overmap_event/electric
+/obj/effect/overmap_event/electric
 	name = "electrical storm"
 	events = list(/datum/event/electrical_storm)
-	count = 11
-	radius = 3
 	opacity = 0
 	event_icon_states = list("electrical1", "electrical2", "electrical3", "electrical4")
 	difficulty = EVENT_LEVEL_MAJOR
 	weaknesses = OVERMAP_WEAKNESS_EMP
 
-/datum/overmap_event/dust
+/obj/effect/overmap_event/dust
 	name = "dust cloud"
 	events = list(/datum/event/dust)
-	count = 16
-	radius = 4
 	event_icon_states = list("dust1", "dust2", "dust3", "dust4")
 	weaknesses = OVERMAP_WEAKNESS_MINING | OVERMAP_WEAKNESS_EXPLOSIVE | OVERMAP_WEAKNESS_FIRE
 
-/datum/overmap_event/ion
+/obj/effect/overmap_event/ion
 	name = "ion cloud"
 	events = list(/datum/event/ionstorm, /datum/event/computer_damage)
-	count = 8
-	radius = 3
 	opacity = 0
 	event_icon_states = list("ion1", "ion2", "ion3", "ion4")
 	difficulty = EVENT_LEVEL_MAJOR
 	weaknesses = OVERMAP_WEAKNESS_EMP
 
-/datum/overmap_event/carp
+/obj/effect/overmap_event/carp
 	name = "carp shoal"
 	events = list(/datum/event/carp_migration)
+	opacity = 0
+	difficulty = EVENT_LEVEL_MODERATE
+	event_icon_states = list("carp1", "carp2")
+	weaknesses = OVERMAP_WEAKNESS_EXPLOSIVE | OVERMAP_WEAKNESS_FIRE
+
+/obj/effect/overmap_event/carp/major
+	name = "carp school"
+	difficulty = EVENT_LEVEL_MAJOR
+	event_icon_states = list("carp3", "carp4")
+
+//These now are basically only used to spawn hazards. Will be useful when we need to spawn group of moving hazards
+/datum/overmap_event
+	var/name = "map event"
+	var/radius = 2
+	var/count = 6
+	var/hazards
+	var/opacity = 1
+	var/continuous = TRUE //if it should form continous blob, or can have gaps
+
+/datum/overmap_event/meteor
+	name = "asteroid field"
+	count = 15
+	radius = 4
+	continuous = FALSE
+	hazards = /obj/effect/overmap_event/meteor
+
+/datum/overmap_event/electric
+	name = "electrical storm"
+	count = 11
+	radius = 3
+	opacity = 0
+	hazards = /obj/effect/overmap_event/electric
+
+/datum/overmap_event/dust
+	name = "dust cloud"
+	count = 16
+	radius = 4
+	hazards = /obj/effect/overmap_event/dust
+
+/datum/overmap_event/ion
+	name = "ion cloud"
 	count = 8
 	radius = 3
 	opacity = 0
-	difficulty = EVENT_LEVEL_MODERATE
+	hazards = /obj/effect/overmap_event/ion
+
+/datum/overmap_event/carp
+	name = "carp shoal"
+	count = 8
+	radius = 3
+	opacity = 0
 	continuous = FALSE
-	event_icon_states = list("carp1", "carp2")
-	weaknesses = OVERMAP_WEAKNESS_EXPLOSIVE | OVERMAP_WEAKNESS_FIRE
+	hazards = /obj/effect/overmap_event/carp
 
 /datum/overmap_event/carp/major
 	name = "carp school"
 	count = 5
 	radius = 4
-	difficulty = EVENT_LEVEL_MAJOR
-	event_icon_states = list("carp3", "carp4")
+	hazards = /obj/effect/overmap_event/carp/major

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -17,11 +17,6 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	. = ..()
 	get_known_sectors()
 
-/obj/machinery/computer/ship/helm/attempt_hook_up(obj/effect/overmap/ship/sector)
-	if(!(. = ..()))
-		return
-	sector.nav_control = src
-
 /obj/machinery/computer/ship/helm/proc/get_known_sectors()
 	var/area/overmap/map = locate() in world
 	for(var/obj/effect/overmap/sector/S in map)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -26,7 +26,6 @@
 	var/list/last_movement = list(0,0)  //worldtime when ship last moved in x,y direction
 	var/fore_dir = NORTH                //what dir ship flies towards for purpose of moving stars effect procs
 
-	var/obj/machinery/computer/ship/helm/nav_control
 	var/list/engines = list()
 	var/engines_state = 0 //global on/off toggle for all engines
 	var/thrust_limit = 1  //global thrust limit for all engines, 0..1


### PR DESCRIPTION
Overmap hazard refactor is here!
Now supporting multiple hazards on the same turf, (if they're two of the same type, the one with the biggest severity is active)
Supporting /obj/effect/overmap_event moving.
And making all /obj/effect/overmap_event into different subtype so they can have different interaction and proc calls

https://i.imgur.com/qvtzujx.gif

It is ready!