### PR TITLE
Fixes misused proc in psi debug code.

### DIFF
--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -37,7 +37,7 @@
 /datum/psi_complexus/proc/get_aura_image()
 	if(_aura_image && !istype(_aura_image))
 		var/atom/A = _aura_image
-		debug_print("Non-image found in psi complexus: \ref[A] - \the [A] - [istype(A) ? A.type : "non-atom"]")
+		log_debug("Non-image found in psi complexus: \ref[A] - \the [A] - [istype(A) ? A.type : "non-atom"]")
 		destroy_aura_image(_aura_image)
 		_aura_image = null
 	if(!_aura_image)


### PR DESCRIPTION
If this was called, the uplink repository would print a list of all purchases. Oops.