### PR TITLE
Personal closets and runtime fix

### DIFF
--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -11,7 +11,7 @@
 	desc = "A soft cotton towel."
 
 /obj/item/weapon/towel/attack_self(mob/living/user as mob)
-	user.visible_message(text("<span class='notice'>[] uses [] to towel themselves off.</span>", user, src))
+	user.visible_message("<span class='notice'>[user] uses [src] to towel themselves off.</span>")
 	playsound(user, 'sound/weapons/towelwipe.ogg', 25, 1)
 
 /obj/item/weapon/towel/random/New()

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -554,3 +554,6 @@
 	locked = FALSE
 	desc += " It appears to be broken."
 	return TRUE
+
+/obj/structure/closet/CanUseTopicPhysical(mob/user)
+	return CanUseTopic(user, GLOB.physical_no_access_state)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -28,7 +28,7 @@
 	return ..() || (istype(id_card) && id_card.registered_name && (!registered_name || (registered_name == id_card.registered_name)))
 
 /obj/structure/closet/secure_closet/personal/togglelock(var/mob/user, var/obj/item/weapon/card/id/id_card)
-	if (..() && !src.registered_name)
+	if (..() && !registered_name)
 		id_card = istype(id_card) ? id_card : user.GetIdCard()
 		if (id_card)
 			set_owner(id_card.registered_name)

--- a/code/modules/augment/simple.dm
+++ b/code/modules/augment/simple.dm
@@ -67,7 +67,7 @@
 /obj/item/organ/internal/augment/active/simple/can_activate()
 	if(..())
 		if(!holding)
-			owner.visible_message(owner, SPAN_WARNING("The device is damaged and fails to deploy"))
+			to_chat(owner, SPAN_WARNING("The device is damaged and fails to deploy"))
 			return FALSE
 		return TRUE
 	return FALSE

--- a/code/modules/nano/interaction/physical.dm
+++ b/code/modules/nano/interaction/physical.dm
@@ -16,3 +16,8 @@ GLOBAL_DATUM_INIT(physical_state, /datum/topic_state/physical, new)
 
 /mob/living/silicon/ai/check_physical_distance(var/src_object)
 	return max(STATUS_UPDATE, shared_living_nano_distance(src_object))
+
+GLOBAL_DATUM_INIT(physical_no_access_state, /datum/topic_state/physical/no_access, new)
+
+/datum/topic_state/physical/no_access
+	check_access = FALSE


### PR DESCRIPTION
Fixes #25955 
Fixes #26312 
Fixes #26849

Added a new topic_state which is necessary because the one that is being used checks for access and therefore broke the closets. This one does not check for access by setting the flag. This also fixes other closets that didn't have their feedback shown, such as "Access denied".

🆑 Nirnael
bugfix: Fixes personal closets.
/ 🆑 

