### PR TITLE
Couple fixes and tweaks

### DIFF
--- a/code/game/objects/items/weapons/grenades/light.dm
+++ b/code/game/objects/items/weapons/grenades/light.dm
@@ -7,13 +7,10 @@
 
 /obj/item/weapon/grenade/light/detonate()
 	..()
-	if(active)
-		return
 	var/lifetime = rand(2 MINUTES, 4 MINUTES)
 	var/light_colour = pick("#49f37c", "#fc0f29", "#599dff", "#fa7c0b", "#fef923")
 
 	playsound(src, 'sound/effects/snap.ogg', 80, 1)
 	audible_message("<span class='warning'>\The [src] detonates with a sharp crack!</span>")
-	active = TRUE
 	set_light(1, 1, 12, 2, light_colour)
 	QDEL_IN(src, lifetime)

--- a/code/game/objects/structures/stasis_cage.dm
+++ b/code/game/objects/structures/stasis_cage.dm
@@ -16,10 +16,19 @@
 		contain(A)
 
 /obj/structure/stasis_cage/attack_hand(var/mob/user)
-	release()
+	try_release(user)
 
 /obj/structure/stasis_cage/attack_robot(var/mob/user)
 	if(Adjacent(user))
+		try_release(user)
+
+/obj/structure/stasis_cage/proc/try_release(mob/user)
+	if(!contained)
+		to_chat(user, SPAN_NOTICE("There's no animals inside \the [src]"))
+		return
+	user.visible_message("[user] begins undoing the locks and latches on \the [src].")
+	if(do_after(user, 20, src))
+		user.visible_message("[user] releases \the [contained] from \the [src]!")
 		release()
 
 /obj/structure/stasis_cage/on_update_icon()
@@ -58,7 +67,7 @@
 /mob/living/simple_animal/MouseDrop(var/obj/structure/stasis_cage/over_object)
 	if(istype(over_object) && Adjacent(over_object) && CanMouseDrop(over_object, usr))
 
-		if(!src.buckled || !istype(src.buckled, /obj/effect/energy_net))
+		if(!stat && !istype(src.buckled, /obj/effect/energy_net))
 			to_chat(usr, "It's going to be difficult to convince \the [src] to move into \the [over_object] without capturing it in a net.")
 			return
 

--- a/code/modules/modular_computers/file_system/reports/report_field.dm
+++ b/code/modules/modular_computers/file_system/reports/report_field.dm
@@ -94,7 +94,7 @@ Basic field subtypes.
 
 //For information between fields.
 /datum/report_field/text_label/instruction/generate_row_pencode(access, with_fields)
-	return "\[small\]\[i\][display_name()]\[i\]\[/small\]"
+	return "\[small\]\[i\][display_name()]\[/i\]\[/small\]"
 
 /datum/report_field/text_label/instruction/generate_nano_data(list/given_access)
 	var/dat = ..()
@@ -103,7 +103,7 @@ Basic field subtypes.
 
 //For headers between fields.
 /datum/report_field/text_label/header/generate_row_pencode(access, with_fields)
-	return "\[h3][display_name()]\[h3]"
+	return "\[h3][display_name()]\[/h3]"
 
 /datum/report_field/text_label/header/generate_nano_data(list/given_access)
 	var/dat = ..()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -25,13 +25,6 @@
 		list(mode_name="long bursts",   burst=8, fire_delay=null, move_delay=4,    one_hand_penalty=2, burst_accuracy=list(0,0,-1,-1,-1,-1,-2,-2), dispersion=list(0.0, 0.0, 0.5, 0.6, 0.8, 1.0, 1.0, 1.2)),
 		)
 
-/obj/item/weapon/gun/projectile/automatic/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "prototype"
-	else
-		icon_state = "prototype-empty"
-
 /obj/item/weapon/gun/projectile/automatic/machine_pistol
 	name = "machine pistol"
 	desc = "The Hephaestus Industries MP6 Vesper, A fairly common machine pistol. Sometimes refered to as an 'uzi' by the backwater spacers it is often associated with."
@@ -168,7 +161,7 @@
 /obj/item/weapon/gun/projectile/automatic/sec_smg/on_update_icon()
 	..()
 	if(ammo_magazine)
-		overlays += image(icon, "mag-[round(ammo_magazine.stored_ammo.len,4)]")
+		overlays += image(icon, "mag-[round(ammo_magazine.stored_ammo.len,5)]")
 	if(ammo_magazine && LAZYLEN(ammo_magazine.stored_ammo))
 		overlays += image(icon, "ammo-ok")
 	else


### PR DESCRIPTION
Fixes light grenades not exploding, and some SMG icons
Fixes unclosed tags in some report fields.
Makes stasis cages do 2 second do_after to release beasties (to help against misclicks).
Stasis cages will now accept KO'd or dead animals without requiring them to be net'd first.