### PR TITLE
Cleans up airlock icon updating, fixes unpowered icons

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -695,66 +695,41 @@ About the new airlock wires panel:
 				stripe_filling_overlay.Blend(stripe_color, ICON_MULTIPLY)
 				airlock_icon_cache["[ikey2]"] = stripe_filling_overlay
 
-	switch(state)
-		if(AIRLOCK_CLOSED)
-			if(p_open)
-				panel_overlay = panel_file
-			if(welded)
-				weld_overlay = welded_file
-			if(stat & BROKEN)
-				damage_overlay = sparks_broken_file
-			else if(health < maxhealth * 3/4)
-				damage_overlay = sparks_damaged_file
-			if(lights && src.arePowerSystemsOn())
-				if(locked)
+	if(arePowerSystemsOn())
+		switch(state)
+			if(AIRLOCK_CLOSED)
+				if(lights && locked)
 					lights_overlay = bolts_file
 					set_light(0.25, 0.1, 1, 2, COLOR_RED_LIGHT)
 
-		if(AIRLOCK_DENY)
-			if(!src.arePowerSystemsOn())
-				return
-			if(p_open)
-				panel_overlay = panel_file
-			if(stat & BROKEN)
-				damage_overlay = sparks_broken_file
-			else if(health < maxhealth * 3/4)
-				damage_overlay = sparks_damaged_file
-			if(welded)
-				weld_overlay = welded_file
-			if(lights && src.arePowerSystemsOn())
-				lights_overlay = deny_file
-				set_light(0.25, 0.1, 1, 2, COLOR_RED_LIGHT)
+			if(AIRLOCK_DENY)
+				if(lights)
+					lights_overlay = deny_file
+					set_light(0.25, 0.1, 1, 2, COLOR_RED_LIGHT)
 
-		if(AIRLOCK_EMAG)
-			sparks_overlay = emag_file
-			if(p_open)
-				panel_overlay = panel_file
-			if(stat & BROKEN)
-				damage_overlay = sparks_broken_file
-			else if(health < maxhealth * 3/4)
-				damage_overlay = sparks_damaged_file
-			if(welded)
-				weld_overlay = welded_file
+			if(AIRLOCK_EMAG)
+				sparks_overlay = emag_file
 
-		if(AIRLOCK_CLOSING)
-			if(lights && src.arePowerSystemsOn())
-				lights_overlay = lights_file
-				set_light(0.25, 0.1, 1, 2, COLOR_LIME)
-			if(p_open)
-				panel_overlay = panel_file
+			if(AIRLOCK_CLOSING)
+				if(lights)
+					lights_overlay = lights_file
+					set_light(0.25, 0.1, 1, 2, COLOR_LIME)
 
-		if(AIRLOCK_OPEN)
-			if(stat & BROKEN)
-				damage_overlay = sparks_broken_file
-			else if(health < maxhealth * 3/4)
-				damage_overlay = sparks_damaged_file
+			if(AIRLOCK_OPENING)
+				if(lights)
+					lights_overlay = lights_file
+					set_light(0.25, 0.1, 1, 2, COLOR_LIME)
 
-		if(AIRLOCK_OPENING)
-			if(lights && src.arePowerSystemsOn())
-				lights_overlay = lights_file
-				set_light(0.25, 0.1, 1, 2, COLOR_LIME)
-			if(p_open)
-				panel_overlay = panel_file
+		if(stat & BROKEN)
+			damage_overlay = sparks_broken_file
+		else if(health < maxhealth * 3/4)
+			damage_overlay = sparks_damaged_file
+
+	if(welded)
+		weld_overlay = welded_file
+
+	if(p_open)
+		panel_overlay = panel_file
 
 	if(brace)
 		brace.update_icon()
@@ -787,15 +762,15 @@ About the new airlock wires panel:
 			flick("closing", src)
 			update_icon(AIRLOCK_CLOSED)
 		if("deny")
-			if(density && src.arePowerSystemsOn())
-				set_airlock_overlays(AIRLOCK_DENY)
+			set_airlock_overlays(AIRLOCK_DENY)
+			if(density && arePowerSystemsOn())
 				flick("deny", src)
 				if(secured_wires)
-					playsound(src.loc, open_failure_access_denied, 50, 0)
-				update_icon(AIRLOCK_CLOSED)
+					playsound(loc, open_failure_access_denied, 50, 0)
+			update_icon(AIRLOCK_CLOSED)
 		if("emag")
-			if(density && src.arePowerSystemsOn())
-				set_airlock_overlays(AIRLOCK_EMAG)
+			set_airlock_overlays(AIRLOCK_EMAG)
+			if(density && arePowerSystemsOn())
 				flick("deny", src)
 		else
 			update_icon()


### PR DESCRIPTION
:cl: Cakey
bugfix: Fixed airlock paint vanishing when interacting with unpowered airlocks.
/:cl:

Also cleaned up some unnecessary copy-paste.

Fixes #24102