### PR TITLE
Changes planet skybox image offsets

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -443,8 +443,8 @@
 	var/image/light = image('icons/skybox/planet.dmi', "lightrim")
 	skybox_image.overlays += light
 
-	skybox_image.pixel_x = rand(0,256)
-	skybox_image.pixel_y = rand(0,256)
+	skybox_image.pixel_x = rand(0,64)
+	skybox_image.pixel_y = rand(128,256)
 	skybox_image.appearance_flags = RESET_COLOR
 
 /obj/effect/overmap/sector/exoplanet/proc/get_surface_color()


### PR DESCRIPTION
They sohuld be actually visible now from like windows, instead of only when you're in empty space above them.


https://a.uguu.se/f2HboCu8k03p_2019-10-08_23-07-26.mp4