### PR TITLE
Code Quality: Turf Sanity

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -49,10 +49,6 @@
 		holy = 1
 	levelupdate()
 
-/turf/simulated/Destroy()
-	deltimer(timer_id)
-	return ..()
-
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=COLOR_BLOOD_HUMAN)
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src
 	if(!tracks)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -47,7 +47,6 @@
 
 /turf/simulated/wall/Destroy()
 	STOP_PROCESSING(SSturf, src)
-	dismantle_wall(null,null,1)
 	. = ..()
 
 // Walls always hide the stuff below them.

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -6,11 +6,6 @@
 	var/tmp/ao_neighbors
 	var/ao_queued = AO_UPDATE_NONE
 
-/turf/Initialize(mapload)
-	. = ..()
-	if (mapload && permit_ao)
-		queue_ao()
-
 /turf/set_density(var/new_density)
 	var/last_density = density
 	..()

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -36,6 +36,7 @@
 
 //	log_debug("Replacing [src.type] with [N]")
 
+	changing_turf = TRUE
 
 	if(connections) connections.erase_all()
 
@@ -53,6 +54,9 @@
 	for(var/atom/movable/A in src)
 		old_contents += A
 		A.forceMove(null)
+
+	// Run the Destroy() chain.
+	qdel(src)
 
 	var/turf/simulated/W = new N( locate(src.x, src.y, src.z) )
 	for(var/atom/movable/A in old_contents)

--- a/code/modules/admin/verbs/SDQL.dm
+++ b/code/modules/admin/verbs/SDQL.dm
@@ -288,7 +288,12 @@
 	switch(lowertext(query_list[1]))
 		if("delete")
 			for(var/datum/t in objs)
-				qdel(t)
+				// turfs are special snowflakes that explode if qdeleted
+				if (isturf(t))
+					var/turf/T = t
+					T.ChangeTurf(world.turf)
+				else
+					qdel(t)
 
 		if("update")
 			for(var/datum/t in objs)

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -93,7 +93,12 @@
 
 				if("delete")
 					for(var/datum/d in objs)
-						qdel(d)
+						if (isturf(d))
+							// turfs are special snowflakes that explode if qdeleted
+							var/turf/T = d
+							T.ChangeTurf(world.turf)
+						else
+							qdel(d)
 						CHECK_TICK
 
 				if("select")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -124,14 +124,14 @@
 			)
 		if (!size)
 			return
-	
+
 	if (!message)
 		message = input("Message:", text("Enter the text you wish to appear to your target:")) as null|text
 		if (style != "unsafe")
 			message = sanitize(message)
 	if (!message)
 		return
-	
+
 	var/result = message
 	if (style != "unsafe")
 		switch (style)
@@ -149,7 +149,7 @@
 			if ("giant")  result = FONT_GIANT(result)
 
 	return list(result, style, size, message)
-	
+
 
 // Targetted narrate: will narrate to one specific mob
 /client/proc/cmd_admin_direct_narrate(var/mob/M)
@@ -164,14 +164,14 @@
 		M = input("Direct narrate to who?", "Active Players") as null|anything in get_mob_with_client_list()
 	if (!M)
 		return
-	
+
 	var/style
 	var/size
 
 	if (!check_rights(R_ADMIN, FALSE))
 		style = "subtle"
 		size = "normal"
-	
+
 	var/result = cmd_admin_narrate_helper(src, style, size)
 	if (!result)
 		return
@@ -188,7 +188,7 @@
 
 	if(!check_rights(R_ADMIN))
 		return
-	
+
 	var/result = cmd_admin_narrate_helper(src)
 	if (!result)
 		return
@@ -616,7 +616,13 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		log_admin("[key_name(usr)] deleted [O] at ([O.x],[O.y],[O.z])")
 		message_admins("[key_name_admin(usr)] deleted [O] at ([O.x],[O.y],[O.z])", 1)
 		SSstatistics.add_field_details("admin_verb","DEL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		qdel(O)
+
+		// turfs are special snowflakes that'll explode if qdel'd
+		if (isturf(O))
+			var/turf/T = O
+			T.ChangeTurf(world.turf)
+		else
+			qdel(O)
 
 /client/proc/cmd_admin_list_open_jobs()
 	set category = "Admin"

--- a/code/unit_tests/movement_tests.dm
+++ b/code/unit_tests/movement_tests.dm
@@ -22,7 +22,7 @@
 	else
 		pass("The target was crossed 1 time.")
 
-	qdel(target)
+	qdel(mover)
 	qdel(crossed)
 	return TRUE
 


### PR DESCRIPTION
Makes turfs Destroy() like most other atoms, which should make some things (like timers) better behaved on turfs. Also removes some invalid behavior in `turf/simulated/wall/Destroy` that was causing qdel loops.

Note: with this PR (though this was true already), **you must not directly qdel turfs.** The logic won't actually delete the turf, and you'll just end up with a turf in a deinited state.