### PR TITLE
Add release publish Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Build Release
+
+on:
+  push:
+    branches:
+    - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Login Docker Registry
+      run: docker login -u $REG_USER -p $REG_PASS $REG_URL
+      env:
+        REG_USER: ${{ secrets.REG_USER }}
+        REG_PASS: ${{ secrets.REG_PASS }}
+        REG_URL: ${{ secrets.REG_URL }}
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg BUILD_ARGS=-Icustom-items/inc.dm
+      env:
+        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+    - name: Push the Docker image
+      run: docker push $IMAGE_NAME
+      env:
+        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}


### PR DESCRIPTION
This has been done on Azure previously, before Actions, but I don't see a compelling reason not to manage everything centrally any more.

cc @mloc @afterthought2 
Should be safe to run this alongside Azure for now; though with Azure having spurious weird issues with the registry connection, makes sense to at least try this now.

nb: I've already configured the `secrets` being used.