### PR TITLE
qdel cards on card_slot Destroy()

### DIFF
--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -123,5 +123,5 @@
 /obj/item/weapon/stock_parts/computer/card_slot/Destroy()
 	loc.verbs -= /obj/item/weapon/stock_parts/computer/card_slot/verb/verb_eject_id
 	if(stored_card)
-		stored_card.dropInto(loc)
+		QDEL_NULL(stored_card)
 	return ..()


### PR DESCRIPTION
Closes #27198

Fixes ID cards persisting after the slot itself has been Destroyed. The other part of #27198 regarding double reports is already reported as an issue.