### PR TITLE
EVA skill tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -10,7 +10,8 @@
 
 	tally += species.handle_movement_delay_special(src)
 
-	if (istype(loc, /turf/space))
+	var/area/a = get_area(src)
+	if(a && !a.has_gravity())
 		if(skill_check(SKILL_EVA, SKILL_PROF))
 			tally -= 2
 		tally -= 1


### PR DESCRIPTION
🆑 
tweak: EVA skills speed boost now checks if the area has gravity or not, instead if it was a space turf. Basically master EVA gets to zoom around on shuttles, on some away maps or when the torch's gravity fails.
🆑 

time to watch the server burn from a two lines code change