### PR TITLE
Default aim mode tweak

### DIFF
--- a/code/_onclick/hud/gun_mode.dm
+++ b/code/_onclick/hud/gun_mode.dm
@@ -11,7 +11,7 @@
 
 /obj/screen/gun/move
 	name = "Allow Movement"
-	icon_state = "no_walk0"
+	icon_state = "no_walk1"
 	screen_loc = ui_gun2
 
 /obj/screen/gun/move/Click(location, control, params)
@@ -25,7 +25,7 @@
 
 /obj/screen/gun/item
 	name = "Allow Item Use"
-	icon_state = "no_item0"
+	icon_state = "no_item1"
 	screen_loc = ui_gun1
 
 /obj/screen/gun/item/Click(location, control, params)

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -16,7 +16,7 @@
 	var/locked =    0          // Have we locked on?
 	var/lock_time = 0          // When -will- we lock on?
 	var/active =    0          // Is our owner intending to take hostages?
-	var/target_permissions = TARGET_CAN_RADIO // Permission bitflags.
+	var/target_permissions = TARGET_CAN_MOVE | TARGET_CAN_CLICK | TARGET_CAN_RADIO	// Permission bitflags.
 
 /obj/aiming_overlay/New(var/newowner)
 	..()


### PR DESCRIPTION
🆑 
tweak: Default aim mode allows all movement, items an radio uses.
/🆑 

ideally this should stops unrobust people from just straight up getting shot every time they're held at gunpoint.
You can still change it back but if you do it mid aim, the target should receive the big flashing YOU ARE NOW NOT PERMITTED TO X, which should hopefully help