### PR TITLE
Fixes unathi suffocating in populated rooms

### DIFF
--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -20,7 +20,7 @@
 	darksight_tint = DARKTINT_MODERATE
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
-	breath_pressure = 20
+	breath_pressure = 18
 	slowdown = 0.5
 	brute_mod = 0.8
 	flash_mod = 1.2


### PR DESCRIPTION
Recent changes made to unathi breathing pressure resulted in them suffocating in rooms with anything less than a perfect ratio of oxygen (21% being default), in rooms with 2 or more people this will drop to 20.9% and start giving the unathi in the room suffocation warnings, and at lower amounts they will start suffocating. 

This fixes that.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->