### PR TITLE
Fixes Drill Head Requiring no construction

### DIFF
--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -263,7 +263,7 @@
 	result_type = /obj/item/weapon/material/drill_head
 	req_amount = 3
 	send_material_data = 1
-	difficulty = 0
+	difficulty = 3
 
 /datum/stack_recipe/cross
 	title = "cross"


### PR DESCRIPTION
:cl: Rain7x, MikoMyazaki
bugfix: The Drill Head now requires trained construction to create
/:cl:

Should fix #26681 , credit to Myazaki, they closed their PR and I'm just re-opening.