### PR TITLE
Removes corpsec beret from loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -9,10 +9,6 @@
 	flags = GEAR_HAS_COLOR_SELECTION
 	description = "A simple, solid color beret. This one has no emblems or insignia on it."
 
-/datum/gear/head/whitentberet
-	display_name = "beret, corporate security"
-	path = /obj/item/clothing/head/beret/guard
-
 /datum/gear/head/bandana
 	display_name = "bandana selection"
 	path = /obj/item/clothing


### PR DESCRIPTION
:cl: Rain7x
rscdel: The Corporate Security Beret has been removed from the loadout.
/:cl:

We don't have corporate security anymore, and the onmob sprite is missing. I tried searching for it for ages, but couldn't find it anywhere.