### PR TITLE
Catches nulled lists when making food in microwaves

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -108,10 +108,14 @@
 /datum/recipe/proc/make_food(var/obj/container as obj)
 	if(!result)
 		log_error("<span class='danger'>Recipe [type] is defined without a result, please bug this.</span>")
-
 		return
 	var/obj/result_obj = new result(container)
-	for (var/obj/O in (container.InsertedContents()-result_obj))
+	container.reagents.clear_reagents()
+	//Checked here in case LAZYCLEARLIST nulls and no more physical ingredients are added
+	var/list/container_contents = container.InsertedContents()
+	if(!container_contents)
+		return result_obj
+	for (var/obj/O in (container_contents-result_obj))
 		if (O.reagents)
 			O.reagents.del_reagent(/datum/reagent/nutriment)
 			O.reagents.update_total()
@@ -120,7 +124,6 @@
 			var/obj/item/weapon/holder/H = O
 			H.destroy_all()
 		qdel(O)
-	container.reagents.clear_reagents()
 	return result_obj
 
 /proc/select_recipe(var/list/datum/recipe/avaiable_recipes, var/obj/obj as obj, var/exact)


### PR DESCRIPTION
Fixes #27035
Fixes #27259 
Fixes #27292

Remaining items not fixed in #27292 are not bugs, merely wiki corrections/preferences

:cl:
bugfix: Microwaves now properly handle non-item based recipes all the time
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->