### PR TITLE
Changes to adjacency, more exo code

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -81,7 +81,7 @@ Quick adjacency (to turf):
 	This is not used in stock /tg/station currently.
 */
 /atom/movable/Adjacent(var/atom/neighbor)
-	if(neighbor == loc) return 1
+	if(neighbor == loc || (neighbor.loc == loc)) return 1
 	if(!isturf(loc)) return 0
 	for(var/turf/T in locs)
 		if(isnull(T)) continue

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -29,6 +29,12 @@
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
 	click_handler.OnDblClick(src, params)
 
+/atom/proc/allow_click_through(var/atom/A, var/params, var/mob/user)
+	return FALSE
+
+/turf/allow_click_through(var/atom/A, var/params, var/mob/user)
+	return TRUE
+	
 /*
 	Standard mob ClickOn()
 	Handles exceptions: middle click, modified clicks, exosuit actions
@@ -118,7 +124,7 @@
 		trigger_aiming(TARGET_CAN_CLICK)
 		return 1
 
-	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
+	if(!loc.allow_click_through(A, params, src)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
 		return
 
 	//Atoms on turfs (not on your person)

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -12,6 +12,14 @@
 		return 0
 	return ..()
 
+/obj/item/mech_equipment/clamp/attack_hand(mob/user)
+	if(owner && LAZYISIN(owner.pilots, user))
+		if(!owner.hatch_closed && carrying)
+			if(user.put_in_active_hand(carrying))
+				owner.visible_message(SPAN_NOTICE("\The [user] carefully grabs \the [carrying] from \the [src]."))
+				carrying = null
+	. = ..()
+
 /obj/item/mech_equipment/clamp/afterattack(var/atom/target, var/mob/living/user, var/inrange, var/params)
 	. = ..()
 

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -46,6 +46,11 @@
 /datum/click_handler/default/mech/OnDblClick(var/atom/A, var/params)
 	OnClick(A, params)
 
+/mob/living/exosuit/allow_click_through(atom/A, params, mob/user)
+	if(LAZYISIN(pilots, user) && !hatch_closed)
+		return TRUE
+	. = ..()
+	
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)
 
 	if(!user || incapacitated() || user.incapacitated())


### PR DESCRIPTION
Allows some more click interactions from inside open cockpit exosuits. Normal sanity checks still apply.

🆑CrimsonShrike
rscadd: Allow some more interactions from inside exosuits such as grabbing items from clamp if the cockpit is open.
/🆑