### PR TITLE
Camera, Airlock Name adjustments

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -12446,7 +12446,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/camera/network/fourth_deck{
-	c_tag = "Laundry Room";
+	c_tag = "Fourth Deck - Laundry Room";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -492,7 +492,7 @@
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/corner/green/mono,
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Hydro Storage"
+	c_tag = "Hydroponics -  Storage"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics/storage)
@@ -8189,7 +8189,7 @@
 	amount = 50
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "EVA- Center";
+	c_tag = "EVA - Center";
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -12542,7 +12542,7 @@
 "Bw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/uniform_vendor{
-	dir = 8;
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
@@ -13350,7 +13350,7 @@
 /area/maintenance/thirddeck/port)
 "DU" = (
 /obj/machinery/camera/network/command{
-	c_tag = "Bluespace Artillery - Storage";
+	c_tag = "Fire Control - Storage";
 	dir = 4;
 	network = list("Command")
 	},
@@ -14741,7 +14741,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "closed";
 	locked = 0;
-	name = "Bluespace Artillery Control"
+	name = "Fire Control"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/command/disperser)
@@ -14756,7 +14756,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "closed";
 	locked = 0;
-	name = "Bluespace Artillery Control"
+	name = "Fire Control"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/command/disperser)
@@ -14765,7 +14765,7 @@
 	dir = 9
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Bluespace Artillery - Access"
+	c_tag = "Fire Control - Access"
 	},
 /turf/simulated/floor/plating,
 /area/command/disperser)
@@ -14829,7 +14829,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "closed";
 	locked = 0;
-	name = "Bluespace Artillery Control"
+	name = "Fire Control"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/command/disperser)
@@ -14975,7 +14975,7 @@
 /area/hallway/primary/thirddeck/fore)
 "Ir" = (
 /obj/machinery/camera/network/command{
-	c_tag = "Bluespace Artillery - Control";
+	c_tag = "Fire Control - Controls";
 	dir = 4
 	},
 /obj/machinery/computer/ship/disperser{

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -16186,7 +16186,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "EVA- Command";
+	c_tag = "EVA - Command";
 	dir = 2
 	},
 /turf/simulated/floor/tiled/dark/monotile,


### PR DESCRIPTION
Some Camera names changed to reflect naming conventions or added spaces where there should be. Bluespace Arterillery Doors named to Fire Control

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->