### PR TITLE
Fixes modular computer icons not updating automatically for some programs

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -56,9 +56,9 @@
 
 // Relays icon update to the computer.
 /datum/computer_file/program/proc/update_computer_icon()
-	if(computer)
+	if(istype(computer))
+		computer.update_host_icon()
 		return
-		// computer.update_icon()
 
 // Attempts to create a log in global ntnet datum. Returns 1 on success, 0 on fail.
 /datum/computer_file/program/proc/generate_network_log(var/text)

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -22,8 +22,7 @@
 		last_status = new_status
 		ui_header = "smmon_[last_status].gif"
 		program_icon_state = "smmon_[last_status]"
-		if(istype(computer))
-			computer.update_host_icon()
+		update_computer_icon()
 
 /datum/nano_module/supermatter_monitor
 	name = "Supermatter monitor"

--- a/html/changelogs/Ithalan-mciconfix.yml
+++ b/html/changelogs/Ithalan-mciconfix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Ithalan
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes modular computer icons not updating automatically for certain monitoring program events."


### PR DESCRIPTION
Many programs that update the computer icon based on state changes or events (such as crew sensors when a monitored crew member becomes injured) weren't working since #26929 

As far as I could tell, only the supermatter monitor program worked as it should because it called the icon update function directly on the computer instead of going through the non-working function for it that all programs share. This fixes the function and makes the SM program use it too.