### PR TITLE
Renames microwave

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,7 +1,7 @@
 
 /obj/machinery/microwave
 	name = "Kitchen Buddy"
-	desc = "A food preparation device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad, all in a device that looks oddly like a microwave! Guaranteed not to nuke your workplace! (Warranty void if nuked)"
+	desc = "A food preparation device from WaffleCo, capable of variety of functions, from grilling meat through baking a pie to making a salad, all in a device that looks oddly like a microwave! Guaranteed not to nuke your workplace! (Warranty void if nuked)"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
 	layer = BELOW_OBJ_LAYER

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,7 +1,7 @@
 
 /obj/machinery/microwave
-	name = "Food preparing device"
-	desc = "A futuristic device that takes ingredients and spits out prepared food. It also looks kinda like an oldschool microwave"
+	name = "WaffleCo Kitchen Buddy"
+	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad!"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
 	layer = BELOW_OBJ_LAYER
@@ -37,24 +37,24 @@
 	if(src.broken > 0)
 		if(src.broken == 2 && isScrewdriver(O)) // If it's broken and they're using a screwdriver
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the food preparing device.</span>", \
-				"<span class='notice'>You start to fix part of the food preparing device.</span>" \
+				"<span class='notice'>\The [user] starts to fix part of the WaffleCo Kitchen Buddy.</span>", \
+				"<span class='notice'>You start to fix part of the WaffleCo Kitchen Buddy.</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes part of the food preparing device.</span>", \
-					"<span class='notice'>You have fixed part of the food preparing device.</span>" \
+					"<span class='notice'>\The [user] fixes part of the WaffleCo Kitchen Buddy.</span>", \
+					"<span class='notice'>You have fixed part of the WaffleCo Kitchen Buddy.</span>" \
 				)
 				src.broken = 1 // Fix it a bit
 		else if(src.broken == 1 && isWrench(O)) // If it's broken and they're doing the wrench
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the food preparing device.</span>", \
-				"<span class='notice'>You start to fix part of the food preparing device.</span>" \
+				"<span class='notice'>\The [user] starts to fix part of the WaffleCo Kitchen Buddy.</span>", \
+				"<span class='notice'>You start to fix part of the WaffleCo Kitchen Buddy.</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes the food preparing device.</span>", \
-					"<span class='notice'>You have fixed the food preparing device.</span>" \
+					"<span class='notice'>\The [user] fixes the WaffleCo Kitchen Buddy.</span>", \
+					"<span class='notice'>You have fixed the WaffleCo Kitchen Buddy.</span>" \
 				)
 				src.broken = 0 // Fix it!
 				src.dirty = 0 // just to be sure
@@ -69,13 +69,13 @@
 	else if(src.dirty==100) // The food preparing device is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner) || istype(O, /obj/item/weapon/reagent_containers/glass/rag)) // If they're trying to clean it then let them
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to clean the food preparing device.</span>", \
-				"<span class='notice'>You start to clean the food preparing device.</span>" \
+				"<span class='notice'>\The [user] starts to clean the WaffleCo Kitchen Buddy.</span>", \
+				"<span class='notice'>You start to clean the WaffleCo Kitchen Buddy.</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] has cleaned the food preparing device.</span>", \
-					"<span class='notice'>You have cleaned the food preparing device.</span>" \
+					"<span class='notice'>\The [user] has cleaned the WaffleCo Kitchen Buddy.</span>", \
+					"<span class='notice'>You have cleaned the WaffleCo Kitchen Buddy.</span>" \
 				)
 				src.dirty = 0 // It's clean!
 				src.broken = 0 // just to be sure
@@ -122,14 +122,14 @@
 		return 1
 	else if(isWrench(O))
 		user.visible_message( \
-			"<span class='notice'>\The [user] begins [src.anchored ? "securing" : "unsecuring"] the microwave.</span>", \
-			"<span class='notice'>You attempt to [src.anchored ? "secure" : "unsecure"] the microwave.</span>"
+			"<span class='notice'>\The [user] begins [src.anchored ? "securing" : "unsecuring"] the WaffleCo Kitchen Buddy.</span>", \
+			"<span class='notice'>You attempt to [src.anchored ? "secure" : "unsecure"] the WaffleCo Kitchen Buddy.</span>"
 			)
 		if (do_after(user,20, src))
 			src.anchored = !src.anchored
 			user.visible_message( \
-			"<span class='notice'>\The [user] [src.anchored ? "secures" : "unsecures"] the microwave.</span>", \
-			"<span class='notice'>You [src.anchored ? "secure" : "unsecure"] the microwave.</span>"
+			"<span class='notice'>\The [user] [src.anchored ? "secures" : "unsecures"] the WaffleCo Kitchen Buddy.</span>", \
+			"<span class='notice'>You [src.anchored ? "secure" : "unsecure"] the WaffleCo Kitchen Buddy.</span>"
 			)
 		else
 			to_chat(user, "<span class='notice'>You decide not to do that.</span>")
@@ -170,9 +170,9 @@
 	if(src.broken > 0)
 		dat += "<TT>Bzzzzttttt</TT>"
 	else if(src.operating)
-		dat += "<TT>Microwaving in progress!<BR>Please wait...!</TT>"
+		dat += "<TT>Food preparing in progress!<BR>Please wait...!</TT>"
 	else if(src.dirty==100)
-		dat += "<TT>This microwave is dirty!<BR>Please clean it before use!</TT>"
+		dat += "<TT>This WaffleCo Kitchen Buddy is dirty!<BR>Please clean it before use!</TT>"
 	else
 		var/list/items_counts = new
 		var/list/items_measures = new
@@ -220,7 +220,7 @@
 			dat += "<b>Ingredients:</b><br>[dat]"
 		dat += "<HR><BR><A href='?src=\ref[src];action=cook'>Turn on!<BR><A href='?src=\ref[src];action=dispose'>Eject ingredients!"
 
-	show_browser(user, "<HEAD><TITLE>Microwave Controls</TITLE></HEAD><TT>[jointext(dat,"<br>")]</TT>", "window=microwave")
+	show_browser(user, "<HEAD><TITLE>WaffleCo Kitchen Buddy Controls</TITLE></HEAD><TT>[jointext(dat,"<br>")]</TT>", "window=microwave")
 	onclose(user, "microwave")
 	return
 

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,7 +1,7 @@
 
 /obj/machinery/microwave
 	name = "Kitchen Buddy"
-	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad! Guaranteed not to nuke your workplace! (Warranty void if nuked)"
+	desc = "A food preparation device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad, all in a device that looks oddly like a microwave! Guaranteed not to nuke your workplace! (Warranty void if nuked)"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
 	layer = BELOW_OBJ_LAYER
@@ -170,7 +170,7 @@
 	if(src.broken > 0)
 		dat += "<TT>Bzzzzttttt</TT>"
 	else if(src.operating)
-		dat += "<TT>Food preparing in progress!<BR>Please wait...!</TT>"
+		dat += "<TT>Preparation in progress!<BR>Please wait...!</TT>"
 	else if(src.dirty==100)
 		dat += "<TT>This \the [name] is dirty!<BR>Please clean it before use!</TT>"
 	else

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,6 +1,6 @@
 
 /obj/machinery/microwave
-	name = "WaffleCo Kitchen Buddy"
+	name = "Kitchen Buddy"
 	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad! 
 	Guaranteed not to nuke your workplace! (Warranty void if nuked)"
 	icon = 'icons/obj/kitchen.dmi'

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,8 +1,7 @@
 
 /obj/machinery/microwave
 	name = "Kitchen Buddy"
-	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad! 
-	Guaranteed not to nuke your workplace! (Warranty void if nuked)"
+	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad! Guaranteed not to nuke your workplace! (Warranty void if nuked)"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
 	layer = BELOW_OBJ_LAYER

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,6 +1,7 @@
 
 /obj/machinery/microwave
-	name = "microwave"
+	name = "Food preparing device"
+	desc = "A futuristic device that takes ingredients and spits out prepared food. It also looks kinda like an oldschool microwave"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
 	layer = BELOW_OBJ_LAYER
@@ -36,24 +37,24 @@
 	if(src.broken > 0)
 		if(src.broken == 2 && isScrewdriver(O)) // If it's broken and they're using a screwdriver
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the microwave.</span>", \
-				"<span class='notice'>You start to fix part of the microwave.</span>" \
+				"<span class='notice'>\The [user] starts to fix part of the food preparing device.</span>", \
+				"<span class='notice'>You start to fix part of the food preparing device.</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes part of the microwave.</span>", \
-					"<span class='notice'>You have fixed part of the microwave.</span>" \
+					"<span class='notice'>\The [user] fixes part of the food preparing device.</span>", \
+					"<span class='notice'>You have fixed part of the food preparing device.</span>" \
 				)
 				src.broken = 1 // Fix it a bit
 		else if(src.broken == 1 && isWrench(O)) // If it's broken and they're doing the wrench
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the microwave.</span>", \
-				"<span class='notice'>You start to fix part of the microwave.</span>" \
+				"<span class='notice'>\The [user] starts to fix part of the food preparing device.</span>", \
+				"<span class='notice'>You start to fix part of the food preparing device.</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes the microwave.</span>", \
-					"<span class='notice'>You have fixed the microwave.</span>" \
+					"<span class='notice'>\The [user] fixes the food preparing device.</span>", \
+					"<span class='notice'>You have fixed the food preparing device.</span>" \
 				)
 				src.broken = 0 // Fix it!
 				src.dirty = 0 // just to be sure
@@ -65,16 +66,16 @@
 	else if((. = component_attackby(O, user)))
 		dispose()
 		return
-	else if(src.dirty==100) // The microwave is all dirty so can't be used!
+	else if(src.dirty==100) // The food preparing device is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner) || istype(O, /obj/item/weapon/reagent_containers/glass/rag)) // If they're trying to clean it then let them
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to clean the microwave.</span>", \
-				"<span class='notice'>You start to clean the microwave.</span>" \
+				"<span class='notice'>\The [user] starts to clean the food preparing device.</span>", \
+				"<span class='notice'>You start to clean the food preparing device.</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] has cleaned the microwave.</span>", \
-					"<span class='notice'>You have cleaned the microwave.</span>" \
+					"<span class='notice'>\The [user] has cleaned the food preparing device.</span>", \
+					"<span class='notice'>You have cleaned the food preparing device.</span>" \
 				)
 				src.dirty = 0 // It's clean!
 				src.broken = 0 // just to be sure

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -1,7 +1,8 @@
 
 /obj/machinery/microwave
 	name = "WaffleCo Kitchen Buddy"
-	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad!"
+	desc = "A food preparing device from WaffleCo, it can do everything from grilling meat through baking a pie to making a salad! 
+	Guaranteed not to nuke your workplace! (Warranty void if nuked)"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"
 	layer = BELOW_OBJ_LAYER
@@ -37,24 +38,24 @@
 	if(src.broken > 0)
 		if(src.broken == 2 && isScrewdriver(O)) // If it's broken and they're using a screwdriver
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the WaffleCo Kitchen Buddy.</span>", \
-				"<span class='notice'>You start to fix part of the WaffleCo Kitchen Buddy.</span>" \
+				"<span class='notice'>\The [user] starts to fix part of the \the [name].</span>", \
+				"<span class='notice'>You start to fix part of the \the [name].</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes part of the WaffleCo Kitchen Buddy.</span>", \
-					"<span class='notice'>You have fixed part of the WaffleCo Kitchen Buddy.</span>" \
+					"<span class='notice'>\The [user] fixes part of the \the [name].</span>", \
+					"<span class='notice'>You have fixed part of the \the [name].</span>" \
 				)
 				src.broken = 1 // Fix it a bit
 		else if(src.broken == 1 && isWrench(O)) // If it's broken and they're doing the wrench
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the WaffleCo Kitchen Buddy.</span>", \
-				"<span class='notice'>You start to fix part of the WaffleCo Kitchen Buddy.</span>" \
+				"<span class='notice'>\The [user] starts to fix part of \the [name].</span>", \
+				"<span class='notice'>You start to fix part of the \the [name].</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes the WaffleCo Kitchen Buddy.</span>", \
-					"<span class='notice'>You have fixed the WaffleCo Kitchen Buddy.</span>" \
+					"<span class='notice'>\The [user] fixes the \the [name].</span>", \
+					"<span class='notice'>You have fixed the \the [name].</span>" \
 				)
 				src.broken = 0 // Fix it!
 				src.dirty = 0 // just to be sure
@@ -69,13 +70,13 @@
 	else if(src.dirty==100) // The food preparing device is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner) || istype(O, /obj/item/weapon/reagent_containers/glass/rag)) // If they're trying to clean it then let them
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to clean the WaffleCo Kitchen Buddy.</span>", \
-				"<span class='notice'>You start to clean the WaffleCo Kitchen Buddy.</span>" \
+				"<span class='notice'>\The [user] starts to clean the \the [name]. </span>", \
+				"<span class='notice'>You start to clean the \the [name].</span>" \
 			)
 			if (do_after(user, 20, src))
 				user.visible_message( \
-					"<span class='notice'>\The [user] has cleaned the WaffleCo Kitchen Buddy.</span>", \
-					"<span class='notice'>You have cleaned the WaffleCo Kitchen Buddy.</span>" \
+					"<span class='notice'>\The [user] has cleaned the \the [name].</span>", \
+					"<span class='notice'>You have cleaned the \the [name].</span>" \
 				)
 				src.dirty = 0 // It's clean!
 				src.broken = 0 // just to be sure
@@ -122,14 +123,14 @@
 		return 1
 	else if(isWrench(O))
 		user.visible_message( \
-			"<span class='notice'>\The [user] begins [src.anchored ? "securing" : "unsecuring"] the WaffleCo Kitchen Buddy.</span>", \
-			"<span class='notice'>You attempt to [src.anchored ? "secure" : "unsecure"] the WaffleCo Kitchen Buddy.</span>"
+			"<span class='notice'>\The [user] begins [src.anchored ? "securing" : "unsecuring"] the \the [name].</span>", \
+			"<span class='notice'>You attempt to [src.anchored ? "secure" : "unsecure"] the \the [name].</span>"
 			)
 		if (do_after(user,20, src))
 			src.anchored = !src.anchored
 			user.visible_message( \
-			"<span class='notice'>\The [user] [src.anchored ? "secures" : "unsecures"] the WaffleCo Kitchen Buddy.</span>", \
-			"<span class='notice'>You [src.anchored ? "secure" : "unsecure"] the WaffleCo Kitchen Buddy.</span>"
+			"<span class='notice'>\The [user] [src.anchored ? "secures" : "unsecures"] the \the [name].</span>", \
+			"<span class='notice'>You [src.anchored ? "secure" : "unsecure"] the \the [name].</span>"
 			)
 		else
 			to_chat(user, "<span class='notice'>You decide not to do that.</span>")
@@ -172,7 +173,7 @@
 	else if(src.operating)
 		dat += "<TT>Food preparing in progress!<BR>Please wait...!</TT>"
 	else if(src.dirty==100)
-		dat += "<TT>This WaffleCo Kitchen Buddy is dirty!<BR>Please clean it before use!</TT>"
+		dat += "<TT>This \the [name] is dirty!<BR>Please clean it before use!</TT>"
 	else
 		var/list/items_counts = new
 		var/list/items_measures = new
@@ -303,7 +304,7 @@
 	return 0
 
 /obj/machinery/microwave/proc/start()
-	src.visible_message("<span class='notice'>The microwave turns on.</span>", "<span class='notice'>You hear a microwave.</span>")
+	src.visible_message("<span class='notice'>The \the [name] turns on.</span>", "<span class='notice'>You hear a \the [name].</span>")
 	src.operating = 1
 	src.updateUsrDialog()
 	src.update_icon()
@@ -348,7 +349,7 @@
 	var/datum/effect/effect/system/spark_spread/s = new
 	s.set_up(2, 1, src)
 	s.start()
-	src.visible_message("<span class='warning'>The microwave breaks!</span>") //Let them know they're stupid
+	src.visible_message("<span class='warning'>The \the [name] breaks!</span>") //Let them know they're stupid
 	src.broken = 2 // Make it broken so it can't be used util fixed
 	src.obj_flags = null //So you can't add condiments
 	src.operating = 0 // Turn it off again aferwards

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -221,7 +221,7 @@
 			dat += "<b>Ingredients:</b><br>[dat]"
 		dat += "<HR><BR><A href='?src=\ref[src];action=cook'>Turn on!<BR><A href='?src=\ref[src];action=dispose'>Eject ingredients!"
 
-	show_browser(user, "<HEAD><TITLE>WaffleCo Kitchen Buddy Controls</TITLE></HEAD><TT>[jointext(dat,"<br>")]</TT>", "window=microwave")
+	show_browser(user, "<HEAD><TITLE>Microwave Controls</TITLE></HEAD><TT>[jointext(dat,"<br>")]</TT>", "window=microwave")
 	onclose(user, "microwave")
 	return
 

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -172,7 +172,7 @@ GLOBAL_LIST_EMPTY(skills)
 	ID = "cooking"
 	name = "Cooking"
 	desc = "Describes a character's skill at preparing meals and other consumable goods. This includes mixing alcoholic beverages."
-	levels = list( "Unskilled"			= "You barely know anything about cooking, and stick to vending machines when you can. The food preparing device is a device of black magic to you, and you avoid it when possible.",
+	levels = list( "Unskilled"			= "You barely know anything about cooking, and stick to vending machines when you can. The WaffleCo Kitchen Buddy is a device of black magic to you, and you avoid it when possible.",
 						"Basic"				= "You can make simple meals and do the cooking for your family. Things like spaghetti, grilled cheese, or simple mixed drinks are your usual fare.<br>- You can safely use the blender.",
 						"Trained"			= "You can make most meals while following instructions, and they generally turn out well. You have some experience with hosting, catering, and/or bartending.<br>- You can fully operate the drink dispensers.",
 						"Experienced"		= "You can cook professionally, keeping an entire crew fed easily. Your food is tasty and you don't have a problem with tricky or complicated dishes. You can be depended on to make just about any commonly-served drink.",

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -172,7 +172,7 @@ GLOBAL_LIST_EMPTY(skills)
 	ID = "cooking"
 	name = "Cooking"
 	desc = "Describes a character's skill at preparing meals and other consumable goods. This includes mixing alcoholic beverages."
-	levels = list( "Unskilled"			= "You barely know anything about cooking, and stick to vending machines when you can. The microwave is a device of black magic to you, and you avoid it when possible.",
+	levels = list( "Unskilled"			= "You barely know anything about cooking, and stick to vending machines when you can. The food preparing device is a device of black magic to you, and you avoid it when possible.",
 						"Basic"				= "You can make simple meals and do the cooking for your family. Things like spaghetti, grilled cheese, or simple mixed drinks are your usual fare.<br>- You can safely use the blender.",
 						"Trained"			= "You can make most meals while following instructions, and they generally turn out well. You have some experience with hosting, catering, and/or bartending.<br>- You can fully operate the drink dispensers.",
 						"Experienced"		= "You can cook professionally, keeping an entire crew fed easily. Your food is tasty and you don't have a problem with tricky or complicated dishes. You can be depended on to make just about any commonly-served drink.",


### PR DESCRIPTION
:cl: 
tweak: Renames microwave to food preparing device
/:cl:
Because a lot of things have no business being made in microwaves, and microwaves are kinda ancient tech anyway. still called microwave in code though. Also adds a short description