### PR TITLE
revises redaction mending to work closer to apparent intent

### DIFF
--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -121,6 +121,7 @@
 
 	var/heal_general =  FALSE
 	var/heal_poison =   FALSE
+	var/heal_internal = FALSE
 	var/heal_bleeding = FALSE
 	var/heal_rate =     0
 	var/mend_prob =     0
@@ -129,20 +130,24 @@
 	if(use_rank >= PSI_RANK_PARAMOUNT)
 		heal_general = TRUE
 		heal_poison = TRUE
+		heal_internal = TRUE
 		heal_bleeding = TRUE
 		mend_prob = 50
 		heal_rate = 7
 	else if(use_rank == PSI_RANK_GRANDMASTER)
-		heal_bleeding = TRUE
 		heal_poison = TRUE
+		heal_internal = TRUE
+		heal_bleeding = TRUE
 		mend_prob = 20
 		heal_rate = 5
 	else if(use_rank == PSI_RANK_MASTER)
+		heal_internal = TRUE
 		heal_bleeding = TRUE
 		mend_prob = 10
 		heal_rate = 3
 	else if(use_rank == PSI_RANK_OPERANT)
 		heal_bleeding = TRUE
+		mend_prob = 5
 		heal_rate = 1
 	else
 		return
@@ -166,16 +171,17 @@
 				H.resuscitate()
 
 			// Heal organ damage.
-			for(var/obj/item/organ/I in H.internal_organs)
+			if(heal_internal)
+				for(var/obj/item/organ/I in H.internal_organs)
 
-				if(BP_IS_ROBOTIC(I) || BP_IS_CRYSTAL(I))
-					continue
+					if(BP_IS_ROBOTIC(I) || BP_IS_CRYSTAL(I))
+						continue
 
-				if(I.damage > 0 && spend_power(heal_rate))
-					I.damage = max(I.damage - heal_rate, 0)
-					if(prob(25))
-						to_chat(H, SPAN_NOTICE("Your innards itch as your autoredactive faculty mends your [I.name]."))
-					return
+					if(I.damage > 0 && spend_power(heal_rate))
+						I.damage = max(I.damage - heal_rate, 0)
+						if(prob(25))
+							to_chat(H, SPAN_NOTICE("Your innards itch as your autoredactive faculty mends your [I.name]."))
+						return
 
 			// Heal broken bones.
 			if(H.bad_external_organs.len)
@@ -184,7 +190,7 @@
 					if(BP_IS_ROBOTIC(E))
 						continue
 
-					if ((E.status & ORGAN_BROKEN) && E.damage < (E.min_broken_damage * config.organ_health_multiplier)) // So we don't mend and autobreak.
+					if(heal_internal && (E.status & ORGAN_BROKEN) && E.damage < (E.min_broken_damage * config.organ_health_multiplier)) // So we don't mend and autobreak.
 						if(spend_power(heal_rate))
 							if(E.mend_fracture())
 								to_chat(H, SPAN_NOTICE("Your autoredactive faculty coaxes together the shattered bones in your [E.name]."))

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -94,20 +94,21 @@
 				return TRUE
 
 		for(var/datum/wound/W in E.wounds)
-			if (W.bleeding() && (W.current_stage > 1 || redaction_rank >= PSI_RANK_MASTER)) 
-				to_chat(user, SPAN_NOTICE("You knit together severed veins and broken flesh, stemming the bleeding."))
-				W.bleed_timer = 0
-				W.clamped = TRUE
-				E.status &= ~ORGAN_BLEEDING
-				return TRUE
-			else if (W.current_stage == 1)
-				to_chat(user, SPAN_NOTICE("This [W.desc] is beyond your power to heal."))
+			if(W.bleeding())
+				if(redaction_rank >= PSI_RANK_MASTER || W.wound_damage() < 30)
+					to_chat(user, SPAN_NOTICE("You knit together severed veins and broken flesh, stemming the bleeding."))
+					W.bleed_timer = 0
+					W.clamped = TRUE
+					E.status &= ~ORGAN_BLEEDING
+					return TRUE
+				else
+					to_chat(user, SPAN_NOTICE("This [W.desc] is beyond your power to heal."))
 
 		if(redaction_rank >= PSI_RANK_GRANDMASTER)
 			for(var/obj/item/organ/internal/I in E.internal_organs)
 				if(!BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
 					to_chat(user, SPAN_NOTICE("You encourage the damaged tissue of \the [I] to repair itself."))
-					var/heal_rate = user.psi.get_rank(PSI_REDACTION)
+					var/heal_rate = redaction_rank
 					I.damage = max(0, I.damage - rand(heal_rate,heal_rate*2))
 					return TRUE
 


### PR DESCRIPTION
Fixes what seems to be a pair of oversights in how the mend power and autoredaction works for those with only Operant level in Redaction.

Mend was intended to be limited to only stop bleeding for less severe wounds when used by Operants, but the code checked for this in a counterintuitive way using wound stages where minor wounds could be considered too severe to mend, while other wounds representing greater actual damage would mend just fine. This turns it into a check against the actual damage the wound inflicts instead.

Autoredaction explicitly sets Operant-level up to heal bleeding, but the actual logic for this is placed within a block that depends on it also having a non-zero mend probability. This gives Operants a small probability to also mend so they can make use of this benefit, while making sure they don't get access to any of the benefits intended for higher levels.