### PR TITLE
Gives Head Revs traitor uplinks

### DIFF
--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -45,3 +45,12 @@ GLOBAL_DATUM_INIT(revs, /datum/antagonist/revolutionary, new)
 		rev_obj.target = player.mind
 		rev_obj.explanation_text = "Assassinate, capture or convert [player.real_name], the [player.mind.assigned_role]."
 		global_objectives += rev_obj
+
+/datum/antagonist/revolutionary/equip(var/mob/living/carbon/human/revolutionary_mob)
+	spawn_uplink(revolutionary_mob)
+	. = ..()
+	if(!.)
+		return
+
+/datum/antagonist/revolutionary/proc/spawn_uplink(var/mob/living/carbon/human/revolutionary_mob)
+	setup_uplink_source(revolutionary_mob, DEFAULT_TELECRYSTAL_AMOUNT)


### PR DESCRIPTION
:cl:
tweak: Radicals rejoice! Head Revolutionaries once again get traitor uplinks.
/:cl:

_"But why?"_

Because it too often falls solely on revs to move rounds along, and they could use some tools to do so.
Loyalists too often just keep the status quo. Without re-implementing the old mechanical "bar closed, non-humans banned/fired" announcements, this gives our authoritarian friends more reason to fear the lurking forces of sedition and crack down (probably creating more revolutionaries in the process.)
Also, cosmetic/fluff traitor tools + exploitable info open a lot of doors for revs to use in play.

Disclaimer: Conversions don't give free uplinks.