### PR TITLE
Fix round-start webhook duplicate triggers

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -220,7 +220,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	if(delay)
 		sleep(delay)
 	report_progress("Master starting processing")
-	SSwebhooks.send(WEBHOOK_ROUNDSTART, list("url" = get_world_url()))
 	var/rtn = Loop()
 	if (rtn > 0 || processing < 0)
 		return //this was suppose to happen.

--- a/code/controllers/subsystems/initialization/webhooks.dm
+++ b/code/controllers/subsystems/initialization/webhooks.dm
@@ -81,3 +81,7 @@ SUBSYSTEM_DEF(webhooks)
 		log_and_message_admins("has pinged webhook [choice].", usr)
 		to_world_log("[usr.key] has pinged webhook [choice].")
 		webhook.send()
+
+/hook/roundstart/proc/run_webhook()
+	SSwebhooks.send(WEBHOOK_ROUNDSTART, list("url" = get_world_url()))
+	return 1


### PR DESCRIPTION
Moves the round-start webhook to be triggered from `/hook/roundstart` instead of directly by the MC. Fixes the round-start webhook being triggered by MC restarts.