### PR TITLE
Timer SS Update

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -85,26 +85,13 @@ if(Datum.is_processing) {\
 #define SS_POST_FIRE_TIMING 64
 
 // -- SStimer stuff --
-//Don't run if there is an identical unique timer active
-#define TIMER_UNIQUE		0x1
 
-//For unique timers: Replace the old timer rather then not start this one
-#define TIMER_OVERRIDE		0x2
-
-//Timing should be based on how timing progresses on clients, not the sever.
-//	tracking this is more expensive,
-//	should only be used in conjuction with things that have to progress client side, such as animate() or sound()
-#define TIMER_CLIENT_TIME	0x4
-
-//Timer can be stopped using deltimer()
-#define TIMER_STOPPABLE		0x8
-
-//To be used with TIMER_UNIQUE
-//prevents distinguishing identical timers with the wait variable
-#define TIMER_NO_HASH_WAIT  0x10
-
-//number of byond ticks that are allowed to pass before the timer subsystem thinks it hung on something
-#define TIMER_NO_INVOKE_WARNING 600
+#define TIMER_UNIQUE       (1 << 0) // Don't run if there is an identical unique timer active
+#define TIMER_OVERRIDE     (1 << 1) // For unique timers: Replace the old timer rather then not start this one
+#define TIMER_CLIENT_TIME  (1 << 2) // Timing should be based on how timing progresses on clients, not the server - this is more expensive, so should only be used with things that need to progress client-side (like animate or sound)
+#define TIMER_STOPPABLE    (1 << 3) // Timer can be stopped using deltimer()
+#define TIMER_NO_HASH_WAIT (1 << 4) // For unique timers: don't distinguish timers by wait
+#define TIMER_LOOP         (1 << 5) // Repeat the timer until it's deleted.
 
 #define TIMER_ID_NULL -1
 

--- a/code/__defines/lists.dm
+++ b/code/__defines/lists.dm
@@ -1,1 +1,59 @@
 #define subtypesof(prototype) (typesof(prototype) - prototype)
+
+// Helper macros to aid in optimizing lazy instantiation of lists.
+// All of these are null-safe, you can use them without knowing if the list var is initialized yet
+
+//Picks from the list, with some safeties, and returns the "default" arg if it fails
+#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+// Ensures L is initailized after this point
+#define LAZYINITLIST(L) if (!L) L = list()
+// Sets a L back to null iff it is empty
+#define UNSETEMPTY(L) if (L && !L.len) L = null
+// Removes I from list L, and sets I to null if it is now empty
+#define LAZYREMOVE(L, I) if(L) { L -= I; if(!length(L)) { L = null; } }
+// Adds I to L, initalizing L if necessary
+#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
+// Insert I into L at position X, initalizing L if necessary
+#define LAZYINSERT(L, I, X) if(!L) { L = list(); } L.Insert(X, I);
+// Adds I to L, initalizing L if necessary, if I is not already in L
+#define LAZYDISTINCTADD(L, I) if(!L) { L = list(); } L |= I;
+// Sets L[A] to I, initalizing L if necessary
+#define LAZYSET(L, A, I) if(!L) { L = list(); } L[A] = I;
+// Reads I from L safely - Works with both associative and traditional lists.
+#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
+// Reads the length of L, returning 0 if null
+#define LAZYLEN(L) length(L)
+// Safely checks if I is in L
+#define LAZYISIN(L, I) (L ? (I in L) : FALSE)
+// Null-safe L.Cut()
+#define LAZYCLEARLIST(L) if(L) { L.Cut(); L = null; }
+// Reads L or an empty list if L is not a list.  Note: Does NOT assign, L may be an expression.
+#define SANITIZE_LIST(L) ( islist(L) ? L : list() )
+
+// binary search sorted insert
+// IN: Object to be inserted
+// LIST: List to insert object into
+// TYPECONT: The typepath of the contents of the list
+// COMPARE: The variable on the objects to compare
+#define BINARY_INSERT(IN, LIST, TYPECONT, COMPARE) \
+	var/__BIN_CTTL = length(LIST);\
+	if(!__BIN_CTTL) {\
+		LIST += IN;\
+	} else {\
+		var/__BIN_LEFT = 1;\
+		var/__BIN_RIGHT = __BIN_CTTL;\
+		var/__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
+		var/##TYPECONT/__BIN_ITEM;\
+		while(__BIN_LEFT < __BIN_RIGHT) {\
+			__BIN_ITEM = LIST[__BIN_MID];\
+			if(__BIN_ITEM.##COMPARE <= IN.##COMPARE) {\
+				__BIN_LEFT = __BIN_MID + 1;\
+			} else {\
+				__BIN_RIGHT = __BIN_MID;\
+			};\
+			__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
+		};\
+		__BIN_ITEM = LIST[__BIN_MID];\
+		__BIN_MID = __BIN_ITEM.##COMPARE > IN.##COMPARE ? __BIN_MID : __BIN_MID + 1;\
+		LIST.Insert(__BIN_MID, IN);\
+	}

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -6,6 +6,7 @@
 #define SS_PRIORITY_DEFAULT 50          // Default priority for all processes levels
 
 // SS_TICKER
+#define SS_PRIORITY_TIMER          20
 #define SS_PRIORITY_ICON_UPDATE    20	// Queued icon updates. Mostly used by APCs and tables.
 
 // Normal

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -12,6 +12,12 @@
 
 #define TimeOfGame (get_game_time())
 #define TimeOfTick (world.tick_usage*0.01*world.tick_lag)
+
+#define TICKS *world.tick_lag
+
+#define DS2TICKS(DS) ((DS)/world.tick_lag)
+#define TICKS2DS(T) ((T) TICKS)
+
 /proc/get_game_time()
 	var/global/time_offset = 0
 	var/global/last_time = 0

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -133,36 +133,6 @@
 
 #define ARGS_DEBUG log_debug("[__FILE__] - [__LINE__]") ; for(var/arg in args) { log_debug("\t[log_info_line(arg)]") }
 
-// Helper macros to aid in optimizing lazy instantiation of lists.
-// All of these are null-safe, you can use them without knowing if the list var is initialized yet
-
-//Picks from the list, with some safeties, and returns the "default" arg if it fails
-#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
-// Ensures L is initailized after this point
-#define LAZYINITLIST(L) if (!L) L = list()
-// Sets a L back to null iff it is empty
-#define UNSETEMPTY(L) if (L && !L.len) L = null
-// Removes I from list L, and sets I to null if it is now empty
-#define LAZYREMOVE(L, I) if(L) { L -= I; if(!length(L)) { L = null; } }
-// Adds I to L, initalizing L if necessary
-#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
-// Insert I into L at position X, initalizing L if necessary
-#define LAZYINSERT(L, I, X) if(!L) { L = list(); } L.Insert(X, I);
-// Adds I to L, initalizing L if necessary, if I is not already in L
-#define LAZYDISTINCTADD(L, I) if(!L) { L = list(); } L |= I;
-// Sets L[A] to I, initalizing L if necessary
-#define LAZYSET(L, A, I) if(!L) { L = list(); } L[A] = I;
-// Reads I from L safely - Works with both associative and traditional lists.
-#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
-// Reads the length of L, returning 0 if null
-#define LAZYLEN(L) length(L)
-// Safely checks if I is in L
-#define LAZYISIN(L, I) (L ? (I in L) : FALSE)
-// Null-safe L.Cut()
-#define LAZYCLEARLIST(L) if(L) { L.Cut(); L = null; }
-// Reads L or an empty list if L is not a list.  Note: Does NOT assign, L may be an expression.
-#define SANITIZE_LIST(L) ( islist(L) ? L : list() )
-
 // Insert an object A into a sorted list using cmp_proc (/code/_helpers/cmp.dm) for comparison.
 #define ADD_SORTED(list, A, cmp_proc) if(!list.len) {list.Add(A)} else {list.Insert(FindElementIndex(A, list, cmp_proc), A)}
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -1,19 +1,20 @@
 #define BUCKET_LEN (round(10*(60/world.tick_lag), 1)) //how many ticks should we keep in the bucket. (1 minutes worth)
-#define BUCKET_POS(timer) (round((timer.timeToRun - SStimer.head_offset) / world.tick_lag) + 1)
+#define BUCKET_POS(timer) (((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define TIMER_MAX (world.time + TICKS2DS(min(BUCKET_LEN-(SStimer.practical_offset-DS2TICKS(world.time - SStimer.head_offset))-1, BUCKET_LEN-1)))
 #define TIMER_ID_MAX (2**24) //max float with integer precision
 
 SUBSYSTEM_DEF(timer)
 	name = "Timer"
 	wait = 1 //SS_TICKER subsystem, so wait is in ticks
-	init_order = 1
+	priority = SS_PRIORITY_TIMER
 
 	flags = SS_TICKER|SS_NO_INIT
 
-	var/list/datum/timedevent/processing = list()
+	var/list/datum/timedevent/second_queue = list() //awe, yes, you've had first queue, but what about second queue?
 	var/list/hashes = list()
 
 	var/head_offset = 0 //world.time of the first entry in the the bucket.
-	var/practical_offset = 0 //index of the first non-empty item in the bucket.
+	var/practical_offset = 1 //index of the first non-empty item in the bucket.
 	var/bucket_resolution = 0 //world.tick_lag the bucket was designed for
 	var/bucket_count = 0 //how many timers are in the buckets
 
@@ -27,31 +28,31 @@ SUBSYSTEM_DEF(timer)
 	var/static/last_invoke_warning = 0
 	var/static/bucket_auto_reset = TRUE
 
-	var/static/times_flushed = 0
-	var/static/times_crashed = 0
+/datum/controller/subsystem/timer/PreInit()
+	bucket_list.len = BUCKET_LEN
+	head_offset = world.time
+	bucket_resolution = world.tick_lag
 
 /datum/controller/subsystem/timer/stat_entry(msg)
-	..("B:[bucket_count] P:[length(processing)] H:[length(hashes)] C:[length(clienttime_timers)][times_crashed ? " F:[times_crashed]" : ""]")
+	..("B:[bucket_count] P:[length(second_queue)] H:[length(hashes)] C:[length(clienttime_timers)] S:[length(timer_id_dict)]")
 
 /datum/controller/subsystem/timer/fire(resumed = FALSE)
 	var/lit = last_invoke_tick
-	var/last_check = world.time - TIMER_NO_INVOKE_WARNING
+	var/last_check = world.time - TICKS2DS(BUCKET_LEN*1.5)
 	var/list/bucket_list = src.bucket_list
-	var/static/list/spent = list()
 
 	if(!bucket_count)
 		last_invoke_tick = world.time
 
-	if(lit && lit < last_check && last_invoke_warning < last_check)
+	if(lit && lit < last_check && head_offset < last_check && last_invoke_warning < last_check)
 		last_invoke_warning = world.time
-		var/msg = "No regular timers processed in the last [TIMER_NO_INVOKE_WARNING] ticks[bucket_auto_reset ? ", resetting buckets" : ""]!"
-		times_crashed++
+		var/msg = "No regular timers processed in the last [BUCKET_LEN*1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""]!"
 		message_admins(msg)
 		WARNING(msg)
 		if(bucket_auto_reset)
 			bucket_resolution = 0
 
-		log_ss(name, "Timer bucket reset. world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset], times_flushed: [times_flushed], length(spent): [length(spent)]")
+		log_ss(name, "Timer bucket reset. world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
 		for (var/i in 1 to length(bucket_list))
 			var/datum/timedevent/bucket_head = bucket_list[i]
 			if (!bucket_head)
@@ -66,85 +67,173 @@ SUBSYSTEM_DEF(timer)
 				bucket_node = bucket_node.next
 				anti_loop_check--
 			while(bucket_node && bucket_node != bucket_head && anti_loop_check)
-		log_ss(name, "Active timers in the processing queue:")
-		for(var/I in processing)
+		log_ss(name, "Active timers in the second_queue queue:")
+		for(var/I in second_queue)
 			log_ss(name, get_timer_debug_string(I))
 
-	while(length(clienttime_timers))
-		var/datum/timedevent/ctime_timer = clienttime_timers[clienttime_timers.len]
-		if (ctime_timer.timeToRun <= REALTIMEOFDAY)
-			--clienttime_timers.len
-			var/datum/callback/callBack = ctime_timer.callBack
-			ctime_timer.spent = TRUE
-			callBack.InvokeAsync()
-			qdel(ctime_timer)
-		else
-			break	//None of the rest are ready to run
+	var/next_clienttime_timer_index = 0
+	var/len = length(clienttime_timers)
+
+	for (next_clienttime_timer_index in 1 to len)
 		if (MC_TICK_CHECK)
-			return
+			next_clienttime_timer_index--
+			break
+		var/datum/timedevent/ctime_timer = clienttime_timers[next_clienttime_timer_index]
+		if (ctime_timer.timeToRun > REALTIMEOFDAY)
+			next_clienttime_timer_index--
+			break
 
+		var/datum/callback/callBack = ctime_timer.callBack
+		if (!callBack)
+			clienttime_timers.Cut(next_clienttime_timer_index,next_clienttime_timer_index+1)
+			CRASH("Invalid timer: [get_timer_debug_string(ctime_timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset], REALTIMEOFDAY: [REALTIMEOFDAY]")
+
+		ctime_timer.spent = REALTIMEOFDAY
+		callBack.InvokeAsync()
+
+		if(ctime_timer.flags & TIMER_LOOP)
+			ctime_timer.spent = 0
+			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
+			BINARY_INSERT(ctime_timer, clienttime_timers, datum/timedevent, timeToRun)
+		else
+			qdel(ctime_timer)
+
+
+	if (next_clienttime_timer_index)
+		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
+
+	if (MC_TICK_CHECK)
+		return
+
+	var/static/list/spent = list()
 	var/static/datum/timedevent/timer
-	var/static/datum/timedevent/head
+	if (practical_offset > BUCKET_LEN)
+		head_offset += TICKS2DS(BUCKET_LEN)
+		practical_offset = 1
+		resumed = FALSE
 
-	if (practical_offset > BUCKET_LEN || (!resumed  && length(bucket_list) != BUCKET_LEN || world.tick_lag != bucket_resolution))
-		shift_buckets()
+	if ((length(bucket_list) != BUCKET_LEN) || (world.tick_lag != bucket_resolution))
+		reset_buckets()
 		bucket_list = src.bucket_list
 		resumed = FALSE
 
+
 	if (!resumed)
 		timer = null
-		head = null
 
-	while (practical_offset <= BUCKET_LEN && head_offset + (practical_offset*world.tick_lag) <= world.time && !MC_TICK_CHECK)
+	while (practical_offset <= BUCKET_LEN && head_offset + ((practical_offset-1)*world.tick_lag) <= world.time)
+		var/datum/timedevent/head = bucket_list[practical_offset]
 		if (!timer || !head || timer == head)
 			head = bucket_list[practical_offset]
-			if (!head)
-				practical_offset++
-				if (MC_TICK_CHECK)
-					break
-				continue
 			timer = head
-		do
+		while (timer)
 			var/datum/callback/callBack = timer.callBack
 			if (!callBack)
-				qdel(timer)
 				bucket_resolution = null //force bucket recreation
-				CRASH("Invalid timer: [timer] timer.timeToRun=[timer.timeToRun]||QDELETED(timer)=[QDELETED(timer)]||world.time=[world.time]||head_offset=[head_offset]||practical_offset=[practical_offset]||timer.spent=[timer.spent]")
+				CRASH("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
 
 			if (!timer.spent)
 				spent += timer
-				timer.spent = TRUE
+				timer.spent = world.time
 				callBack.InvokeAsync()
 				last_invoke_tick = world.time
 
-			timer = timer.next
-
 			if (MC_TICK_CHECK)
 				return
-		while (timer && timer != head)
-		timer = null
-		bucket_list[practical_offset++] = null
-		if (MC_TICK_CHECK)
-			return
 
-	times_flushed++
+			timer = timer.next
+			if (timer == head)
+				break
+
+
+		bucket_list[practical_offset++] = null
+
+		//we freed up a bucket, lets see if anything in second_queue needs to be shifted to that bucket.
+		var/i = 0
+		var/L = length(second_queue)
+		for (i in 1 to L)
+			timer = second_queue[i]
+			if (timer.timeToRun >= TIMER_MAX)
+				i--
+				break
+
+			if (timer.timeToRun < head_offset)
+				bucket_resolution = null //force bucket recreation
+				CRASH("[i] Invalid timer state: Timer in long run queue with a time to run less then head_offset. [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
+
+				if (timer.callBack && !timer.spent)
+					timer.callBack.InvokeAsync()
+					spent += timer
+					bucket_count++
+				else if(!QDELETED(timer))
+					qdel(timer)
+				continue
+
+			if (timer.timeToRun < head_offset + TICKS2DS(practical_offset-1))
+				bucket_resolution = null //force bucket recreation
+				CRASH("[i] Invalid timer state: Timer in long run queue that would require a backtrack to transfer to short run queue. [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
+				if (timer.callBack && !timer.spent)
+					timer.callBack.InvokeAsync()
+					spent += timer
+					bucket_count++
+				else if(!QDELETED(timer))
+					qdel(timer)
+				continue
+
+			bucket_count++
+			var/bucket_pos = max(1, BUCKET_POS(timer))
+
+			var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
+			if (!bucket_head)
+				bucket_list[bucket_pos] = timer
+				timer.next = null
+				timer.prev = null
+				continue
+
+			if (!bucket_head.prev)
+				bucket_head.prev = bucket_head
+			timer.next = bucket_head
+			timer.prev = bucket_head.prev
+			timer.next.prev = timer
+			timer.prev.next = timer
+		if (i)
+			second_queue.Cut(1, i+1)
+
+		timer = null
 
 	bucket_count -= length(spent)
 
-	for (var/spent_timer in spent)
-		qdel(spent_timer)
+	for (var/i in spent)
+		var/datum/timedevent/qtimer = i
+		if(QDELETED(qtimer))
+			bucket_count++
+			continue
+		if(!(qtimer.flags & TIMER_LOOP))
+			qdel(qtimer)
+		else
+			bucket_count++
+			qtimer.spent = 0
+			qtimer.bucketEject()
+			if(qtimer.flags & TIMER_CLIENT_TIME)
+				qtimer.timeToRun = REALTIMEOFDAY + qtimer.wait
+			else
+				qtimer.timeToRun = world.time + qtimer.wait
+			qtimer.bucketJoin()
 
 	spent.len = 0
 
+//formated this way to be runtime resistant
 /datum/controller/subsystem/timer/proc/get_timer_debug_string(datum/timedevent/TE)
 	. = "Timer: [TE]"
 	. += "Prev: [TE.prev ? TE.prev : "NULL"], Next: [TE.next ? TE.next : "NULL"]"
 	if(TE.spent)
-		. += ", SPENT"
+		. += ", SPENT([TE.spent])"
 	if(QDELETED(TE))
 		. += ", QDELETED"
+	if(!TE.callBack)
+		. += ", NO CALLBACK"
 
-/datum/controller/subsystem/timer/proc/shift_buckets()
+/datum/controller/subsystem/timer/proc/reset_buckets()
 	var/list/bucket_list = src.bucket_list
 	var/list/alltimers = list()
 	//collect the timers currently in the bucket
@@ -165,7 +254,7 @@ SUBSYSTEM_DEF(timer)
 	head_offset = world.time
 	bucket_resolution = world.tick_lag
 
-	alltimers += processing
+	alltimers += second_queue
 	if (!length(alltimers))
 		return
 
@@ -176,22 +265,26 @@ SUBSYSTEM_DEF(timer)
 	if (head.timeToRun < head_offset)
 		head_offset = head.timeToRun
 
-	var/list/timers_to_remove = list()
-
-	for (var/thing in alltimers)
-		var/datum/timedevent/timer = thing
+	var/new_bucket_count
+	var/i = 1
+	for (i in 1 to length(alltimers))
+		var/datum/timedevent/timer = alltimers[i]
 		if (!timer)
-			timers_to_remove += timer
 			continue
 
 		var/bucket_pos = BUCKET_POS(timer)
-		if (bucket_pos > BUCKET_LEN)
+		if (timer.timeToRun >= TIMER_MAX)
+			i--
 			break
 
-		timers_to_remove += timer //remove it from the big list once we are done
+
 		if (!timer.callBack || timer.spent)
+			WARNING("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
+			if (timer.callBack)
+				qdel(timer)
 			continue
-		bucket_count++
+
+		new_bucket_count++
 		var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
 		if (!bucket_head)
 			bucket_list[bucket_pos] = timer
@@ -205,12 +298,14 @@ SUBSYSTEM_DEF(timer)
 		timer.prev = bucket_head.prev
 		timer.next.prev = timer
 		timer.prev.next = timer
-
-	processing = (alltimers - timers_to_remove)
+	if (i)
+		alltimers.Cut(1, i+1)
+	second_queue = alltimers
+	bucket_count = new_bucket_count
 
 
 /datum/controller/subsystem/timer/Recover()
-	processing |= SStimer.processing
+	second_queue |= SStimer.second_queue
 	hashes |= SStimer.hashes
 	timer_id_dict |= SStimer.timer_id_dict
 	bucket_list |= SStimer.bucket_list
@@ -219,87 +314,53 @@ SUBSYSTEM_DEF(timer)
 	var/id
 	var/datum/callback/callBack
 	var/timeToRun
+	var/wait
 	var/hash
 	var/list/flags
-	var/spent = FALSE //set to true right before running.
+	var/spent = 0 //time we ran the timer.
 	var/name //for easy debugging.
-
 	//cicular doublely linked list
 	var/datum/timedevent/next
 	var/datum/timedevent/prev
 
+/datum/timedevent/New(datum/callback/callBack, wait, flags, hash)
 	var/static/nextid = 1
-
-/datum/timedevent/New(datum/callback/callBack, timeToRun, flags, hash)
 	id = TIMER_ID_NULL
 	src.callBack = callBack
-	src.timeToRun = timeToRun
+	src.wait = wait
 	src.flags = flags
 	src.hash = hash
 
+	if (flags & TIMER_CLIENT_TIME)
+		timeToRun = REALTIMEOFDAY + wait
+	else
+		timeToRun = world.time + wait
+
 	if (flags & TIMER_UNIQUE)
 		SStimer.hashes[hash] = src
+
 	if (flags & TIMER_STOPPABLE)
-		do
-			if (nextid >= TIMER_ID_MAX)
-				nextid = 1
-			id = nextid++
-		while(SStimer.timer_id_dict["timerid" + num2text(id, 8)])
-		SStimer.timer_id_dict["timerid" + num2text(id, 8)] = src
+		id = num2text(nextid, 100)
+		if (nextid >= TIMER_ID_MAX)
+			nextid += min(1, 2**round(nextid/TIMER_ID_MAX))
+		else
+			nextid++
+		SStimer.timer_id_dict[id] = src
 
-	name = "Timer: " + num2text(id, 8) + ", TTR: [timeToRun], Flags: [jointext(bitfield2list(flags, list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT")), ", ")], callBack: \ref[callBack], callBack.object: [callBack.object]\ref[callBack.object]([getcallingtype()]), callBack.delegate:[callBack.delegate]([callBack.arguments ? callBack.arguments.Join(", ") : ""])"
+	name = "Timer: [id] (\ref[src]), TTR: [timeToRun], Flags: [jointext(bitfield2list(flags, list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT", "TIMER_LOOP")), ", ")], callBack: \ref[callBack], callBack.object: [callBack.object]\ref[callBack.object]([getcallingtype()]), callBack.delegate:[callBack.delegate]([callBack.arguments ? callBack.arguments.Join(", ") : ""])"
 
-	if (callBack.object != GLOBAL_PROC)
+	if ((timeToRun < world.time || timeToRun < SStimer.head_offset) && !(flags & TIMER_CLIENT_TIME))
+		CRASH("Invalid timer state: Timer created that would require a backtrack to run (addtimer would never let this happen): [SStimer.get_timer_debug_string(src)]")
+
+	if (callBack.object != GLOBAL_PROC && !QDESTROYING(callBack.object))
 		LAZYADD(callBack.object.active_timers, src)
 
-	if (flags & TIMER_CLIENT_TIME)
-		//sorted insert
-		var/list/ctts = SStimer.clienttime_timers
-		var/cttl = length(ctts)
-		if(cttl)
-			var/datum/timedevent/Last = ctts[cttl]
-			if(Last.timeToRun >= timeToRun)
-				ctts += src
-			else if(cttl > 1)
-				for(var/I in cttl to 1)
-					var/datum/timedevent/E = ctts[I]
-					if(E.timeToRun <= timeToRun)
-						ctts.Insert(src, I)
-						break
-		else
-			ctts += src
-		return
-
-	//get the list of buckets
-	var/list/bucket_list = SStimer.bucket_list
-	//calculate our place in the bucket list
-	var/bucket_pos = BUCKET_POS(src)
-	//we are too far aways from needing to run to be in the bucket list, shift_buckets() will handle us.
-	if (bucket_pos > length(bucket_list))
-		SStimer.processing += src
-		return
-	//get the bucket for our tick
-	var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
-	SStimer.bucket_count++
-	//empty bucket, we will just add ourselves
-	if (!bucket_head)
-		bucket_list[bucket_pos] = src
-		if (bucket_pos < SStimer.practical_offset)
-			SStimer.practical_offset = bucket_pos
-		return
-	//other wise, lets do a simplified linked list add.
-	if (!bucket_head.prev)
-		bucket_head.prev = bucket_head
-	next = bucket_head
-	prev = bucket_head.prev
-	next.prev = src
-	prev.next = src
+	bucketJoin()
 
 /datum/timedevent/Destroy()
 	..()
-	if (flags & TIMER_UNIQUE)
+	if (flags & TIMER_UNIQUE && hash)
 		SStimer.hashes -= hash
-
 
 	if (callBack && callBack.object && callBack.object != GLOBAL_PROC && callBack.object.active_timers)
 		callBack.object.active_timers -= src
@@ -308,34 +369,17 @@ SUBSYSTEM_DEF(timer)
 	callBack = null
 
 	if (flags & TIMER_STOPPABLE)
-		SStimer.timer_id_dict -= "timerid[id]"
+		SStimer.timer_id_dict -= id
 
 	if (flags & TIMER_CLIENT_TIME)
-		SStimer.clienttime_timers -= src
+		if (!spent)
+			spent = world.time
+			SStimer.clienttime_timers -= src
 		return QDEL_HINT_IWILLGC
 
 	if (!spent)
-		if (prev == next && next)
-			next.prev = null
-			prev.next = null
-		else
-			if (prev)
-				prev.next = next
-			if (next)
-				next.prev = prev
-
-		var/bucketpos = BUCKET_POS(src)
-		var/datum/timedevent/buckethead
-		var/list/bucket_list = SStimer.bucket_list
-
-		if (bucketpos > 0 && bucketpos <= length(bucket_list))
-			buckethead = bucket_list[bucketpos]
-			SStimer.bucket_count--
-		else
-			SStimer.processing -= src
-
-		if (buckethead == src)
-			bucket_list[bucketpos] = next
+		spent = world.time
+		bucketEject()
 	else
 		if (prev && prev.next == src)
 			prev.next = next
@@ -345,18 +389,85 @@ SUBSYSTEM_DEF(timer)
 	prev = null
 	return QDEL_HINT_IWILLGC
 
+/datum/timedevent/proc/bucketEject()
+	var/bucketpos = BUCKET_POS(src)
+	var/list/bucket_list = SStimer.bucket_list
+	var/list/second_queue = SStimer.second_queue
+	var/datum/timedevent/buckethead
+	if(bucketpos > 0)
+		buckethead = bucket_list[bucketpos]
+	if(buckethead == src)
+		bucket_list[bucketpos] = next
+		SStimer.bucket_count--
+	else if(timeToRun < TIMER_MAX || next || prev)
+		SStimer.bucket_count--
+	else
+		var/l = length(second_queue)
+		second_queue -= src
+		if(l == length(second_queue))
+			SStimer.bucket_count--
+	if(prev != next)
+		prev.next = next
+		next.prev = prev
+	else
+		prev?.next = null
+		next?.prev = null
+	prev = next = null
+
+/datum/timedevent/proc/bucketJoin()
+	var/list/L
+
+	if (flags & TIMER_CLIENT_TIME)
+		L = SStimer.clienttime_timers
+	else if (timeToRun >= TIMER_MAX)
+		L = SStimer.second_queue
+
+	if(L)
+		BINARY_INSERT(src, L, datum/timedevent, timeToRun)
+		return
+
+	//get the list of buckets
+	var/list/bucket_list = SStimer.bucket_list
+
+	//calculate our place in the bucket list
+	var/bucket_pos = BUCKET_POS(src)
+
+	//get the bucket for our tick
+	var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
+	SStimer.bucket_count++
+	//empty bucket, we will just add ourselves
+	if (!bucket_head)
+		bucket_list[bucket_pos] = src
+		return
+	//other wise, lets do a simplified linked list add.
+	if (!bucket_head.prev)
+		bucket_head.prev = bucket_head
+	next = bucket_head
+	prev = bucket_head.prev
+	next.prev = src
+	prev.next = src
+
 /datum/timedevent/proc/getcallingtype()
 	. = "ERROR"
 	if (callBack.object == GLOBAL_PROC)
-		. = "GLOBAL PROC"
+		. = "GLOBAL_PROC"
 	else
 		. = "[callBack.object.type]"
 
-/proc/addtimer(datum/callback/callback, wait, flags)
+/proc/addtimer(datum/callback/callback, wait = 0, flags = 0)
 	if (!callback)
-		return
+		CRASH("addtimer called without a callback")
 
-	wait = max(wait, 0)
+	if (wait < 0)
+		crash_with("addtimer called with a negative wait. Converting to [world.tick_lag]")
+
+	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
+		crash_with("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not be supported and may refuse to run or run with a 0 wait")
+
+	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
+
+	if(wait >= INFINITY)
+		CRASH("Attempted to create timer with INFINITY delay")
 
 	var/hash
 
@@ -372,36 +483,32 @@ SUBSYSTEM_DEF(timer)
 		var/datum/timedevent/hash_timer = SStimer.hashes[hash]
 		if(hash_timer)
 			if (hash_timer.spent) //it's pending deletion, pretend it doesn't exist.
-				hash_timer.hash = null
-				SStimer.hashes -= hash
+				hash_timer.hash = null //but keep it from accidentally deleting us
 			else
-
 				if (flags & TIMER_OVERRIDE)
+					hash_timer.hash = null //no need having it delete it's hash if we are going to replace it
 					qdel(hash_timer)
 				else
 					if (hash_timer.flags & TIMER_STOPPABLE)
 						. = hash_timer.id
 					return
+	else if(flags & TIMER_OVERRIDE)
+		crash_with("TIMER_OVERRIDE used without TIMER_UNIQUE")
 
-
-	var/timeToRun = world.time + wait
-	if (flags & TIMER_CLIENT_TIME)
-		timeToRun = REALTIMEOFDAY + wait
-
-	var/datum/timedevent/timer = new(callback, timeToRun, flags, hash)
-	if (flags & TIMER_STOPPABLE)
-		return timer.id
+	var/datum/timedevent/timer = new(callback, wait, flags, hash)
+	return timer.id
 
 /proc/deltimer(id)
 	if (!id)
 		return FALSE
 	if (id == TIMER_ID_NULL)
-		CRASH("Tried to delete a null timerid. Use the TIMER_STOPPABLE flag.")
+		CRASH("Tried to delete a null timerid. Use TIMER_STOPPABLE flag")
 	if (!istext(id))
 		if (istype(id, /datum/timedevent))
 			qdel(id)
 			return TRUE
-	var/datum/timedevent/timer = SStimer.timer_id_dict["timerid[id]"]
+	//id is string
+	var/datum/timedevent/timer = SStimer.timer_id_dict[id]
 	if (timer && !timer.spent)
 		qdel(timer)
 		return TRUE
@@ -410,4 +517,5 @@ SUBSYSTEM_DEF(timer)
 
 #undef BUCKET_LEN
 #undef BUCKET_POS
+#undef TIMER_MAX
 #undef TIMER_ID_MAX

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 43 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 477 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 483 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 1 "update_icon() override" '/update_icon\((.*)\)'  -P


### PR DESCRIPTION
Updates the timer SS from O7/tg as well as rearranging some timer and list defines. This makes the timer SS use binary insert to queue new timers (no more sorted bucket shifts), as well as adds support for TIMER_LOOP (timers are re-queued on fire instead of deleted).

Done at spookerton's request.