### PR TITLE
Implant tweaks and Ion nerf

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -102,6 +102,18 @@
 		to_chat(imp_in,"<span class='warning'>A wave of nausea comes over you.</span><br><span class='good'> You are no longer so sure of those beliefs you've had...</span>")
 	. = ..()
 
+/obj/item/weapon/implant/imprinting/can_implant(mob/M, mob/user, target_zone)
+	var/mob/living/carbon/human/H = M	
+	if(istype(H))
+		var/obj/item/organ/internal/B = H.internal_organs_by_name[BP_BRAIN]
+		if(!B || H.isSynthetic())
+			to_chat(user, "<span class='warning'>\The [M] cannot be imprinted.</span>")
+			return FALSE
+		if(!(B.parent_organ == check_zone(target_zone)))
+			to_chat(user, "<span class='warning'>\The [src] must be implanted in [H.get_organ(B.parent_organ)].</span>")
+			return FALSE
+	return TRUE
+
 /obj/item/weapon/implanter/imprinting
 	name = "imprinting implanter"
 	imp = /obj/item/weapon/implant/imprinting

--- a/code/game/objects/items/weapons/implants/implants/uplink.dm
+++ b/code/game/objects/items/weapons/implants/implants/uplink.dm
@@ -24,7 +24,7 @@
 
 /obj/item/weapon/implant/uplink/emp_act(severity)
 	var/power = 4 - severity
-	if(prob(power * 15))
+	if(prob(power))
 		meltdown()
 	else if(prob(power * 40))
 		disable(rand(power*100,power*1000))

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -11,7 +11,8 @@
 	slot_flags = SLOT_BACK
 	one_hand_penalty = 4
 	charge_cost = 30
-	max_shots = 10
+	max_shots = 8
+	fire_delay = 30
 	projectile_type = /obj/item/projectile/ion
 	wielded_item_state = "ionrifle-wielded"
 	combustion = 0
@@ -31,7 +32,7 @@
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	one_hand_penalty = 0
 	charge_cost = 20
-	max_shots = 6
+	max_shots = 4
 	projectile_type = /obj/item/projectile/ion/small
 
 /obj/item/weapon/gun/energy/decloner


### PR DESCRIPTION
🆑 
tweak: Ion rifle and pistol has its capacity reduce to 8/4 shots respective and had their delay between shots increased to 3 seconds.
tweak: Uplink implant is now more EMP resistant, it can still be disabled by an EMP but its chance of permanently breaking is significantly lowered.
tweak: Imprinting implant cannot be implanted into synthetic being and must now be imprinted where the brain organ is eg. For a GAS that would be their thorax; for humans, their head. 
/🆑

EMP are plenty strong already, they would  one shot, disable any thing with robo-limbs ever since stun/shock changes

Uplink is more EMP resistant to make traitor role a little bit more forgiving.

Mindbreaker toxin cannot be injected into synthetic being so naturally neither should the imprinting implant.

Also imprinting implant being next to the brain organ is a must! You can't just control someone's mind for their pinky toe! (Also this would increase the opportunity for more random implant failure by a chance shock beam to the head)