### PR TITLE
Fix health scanner centering text for 513 clients

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -55,7 +55,9 @@
 		return
 
 	. = medical_scan_results(scan_subject, verbose, user.get_skill_value(SKILL_MEDICAL))
-	to_chat(user, "<hr>[.]<hr>")
+	to_chat(user, "<hr>")
+	to_chat(user, .)
+	to_chat(user, "<hr>")
 
 /proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose, var/skill_level = SKILL_DEFAULT)
 	. = list()


### PR DESCRIPTION
For unknown reasons, printing `<hr>` to chat after a non-tag cause all following text to be centered in 513
Fixes #27418