### PR TITLE
Editing the bridge, I guess

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -646,9 +646,6 @@
 /area/maintenance/bridge/aftstarboard)
 "bn" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/structure/flora/pottedplant/deskleaf{
-	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
 "bo" = (
@@ -802,8 +799,8 @@
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/weapon/material/ashtray/plastic,
-/obj/item/weapon/storage/fancy/cigar,
-/obj/item/weapon/flame/lighter/zippo/bronze,
+/obj/random/smokes,
+/obj/item/weapon/flame/lighter/random,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl)
 "bA" = (
@@ -946,16 +943,16 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "bM" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/starboard)
 "bN" = (
 /obj/effect/floor_decal/spline/plain/beige{
@@ -1010,7 +1007,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/starboard)
 "bS" = (
 /obj/machinery/camera/network/command{
@@ -1023,10 +1020,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/starboard)
 "bT" = (
 /turf/simulated/floor/tiled,
@@ -1052,12 +1046,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cl)
-"bW" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/bridge/hallway/starboard)
 "bX" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -1111,9 +1099,6 @@
 /obj/machinery/atmospherics/valve/shutoff{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -1121,6 +1106,9 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
@@ -1455,13 +1443,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
+/obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
 "cB" = (
@@ -1793,11 +1775,8 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
@@ -1853,11 +1832,12 @@
 	},
 /obj/item/weapon/pen,
 /obj/item/weapon/hand_labeler,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/item/sticky_pad/random,
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/structure/sign/warning/smoking{
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
@@ -1971,17 +1951,17 @@
 	department = "Bridge"
 	},
 /obj/machinery/button/alternate/door{
-	id_tag = "meetindstarboard";
+	id_tag = "meetingstarboard";
 	name = "Bridge Meeting Starboard Door Control";
 	pixel_x = 34;
-	pixel_y = -6;
+	pixel_y = 6;
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/machinery/button/alternate/door{
 	id_tag = "meetingport";
 	name = "Bridge Meeting Port Door Control";
 	pixel_x = 34;
-	pixel_y = 6;
+	pixel_y = -6;
 	req_access = list("ACCESS_BRIDGE")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -2439,23 +2419,8 @@
 	c_tag = "Bridge";
 	dir = 1
 	},
-/obj/item/weapon/book/manual/sol_sop,
-/obj/item/weapon/book/manual/solgov_law,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"dX" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/sign/ecplaque{
-	pixel_x = 29
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/meeting_room)
 "dY" = (
 /turf/simulated/wall/r_wall/hull,
 /area/shield/bridge)
@@ -2699,20 +2664,13 @@
 	pixel_y = -24
 	},
 /obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/item/weapon/pen/red,
-/obj/item/weapon/pen/blue,
+/obj/item/weapon/book/manual/solgov_law,
+/obj/item/weapon/book/manual/sol_sop,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "ew" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/flashlight,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "ex" = (
@@ -2731,11 +2689,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
@@ -2850,13 +2805,7 @@
 /area/security/bridgecheck)
 "eG" = (
 /obj/machinery/light,
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
+/obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "eH" = (
@@ -2892,6 +2841,7 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "eM" = (
@@ -2905,15 +2855,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/hull,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/bridge/storage)
 "eN" = (
@@ -2928,6 +2869,7 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
 "eP" = (
@@ -2951,18 +2893,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
 "eR" = (
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/sign/ecplaque{
+	pixel_x = 29
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
@@ -3436,13 +3376,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/airlock_sensor{
-	command = null;
-	id_tag = "bridge_safe_exterior_sensor";
-	master_tag = "bridge_safe";
-	pixel_x = 26;
-	pixel_y = -35
-	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
 	},
@@ -3518,13 +3451,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
+/obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fN" = (
@@ -3626,15 +3553,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fU" = (
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
 /obj/machinery/atmospherics/valve/shutoff{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 10
+	},
+/obj/machinery/airlock_sensor{
+	command = null;
+	id_tag = "bridge_safe_exterior_sensor";
+	master_tag = "bridge_safe";
+	pixel_x = 26;
+	pixel_y = -35
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
@@ -4942,11 +4876,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/item/weapon/storage/secure/briefcase{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "jz" = (
@@ -5150,19 +5079,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
-"ka" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "bridge sensors";
-	name = "Sensor Shroud"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/bridge/storage)
 "kb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -8455,7 +8371,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/command{
-	id_tag = "meetingport";
+	id_tag = "meetingstarboard";
 	name = "Conference Room"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -8935,6 +8851,25 @@
 /obj/item/weapon/book/manual/military_law,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
+"sF" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "sH" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -9068,7 +9003,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/command{
-	id_tag = "meetingstarboard";
+	id_tag = "meetingport";
 	name = "Conference Room"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -9790,10 +9725,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "uM" = (
-/obj/effect/floor_decal/spline/plain/brown{
-	icon_state = "spline_plain";
-	dir = 1
-	},
 /obj/machinery/camera/network/command{
 	c_tag = "Sol Government Representative - Office";
 	dir = 4;
@@ -9803,10 +9734,6 @@
 /area/crew_quarters/heads/office/sgr)
 "uN" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/effect/floor_decal/spline/plain/brown{
-	icon_state = "spline_plain";
-	dir = 1
-	},
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -9819,10 +9746,6 @@
 /area/crew_quarters/heads/office/sgr)
 "uO" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/effect/floor_decal/spline/plain/brown{
-	icon_state = "spline_plain";
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12102,7 +12025,6 @@
 	pixel_y = 0;
 	id_tag = "bridge blast"
 	},
-/obj/item/weapon/storage/box/donut,
 /obj/machinery/light/spot{
 	dir = 8
 	},
@@ -12766,6 +12688,22 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
+"Es" = (
+/obj/structure/cable/green,
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "bridge blast";
+	name = "Bridge Blast Doors"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge)
 "Ey" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -13214,6 +13152,10 @@
 	pixel_y = 32;
 	products = list(/obj/item/stack/medical/bruise_pack = 6, /obj/item/stack/medical/ointment = 6, /obj/item/weapon/reagent_containers/pill/paracetamol = 8, /obj/item/weapon/storage/med_pouch/trauma = 4, /obj/item/weapon/storage/med_pouch/burn = 2, /obj/item/weapon/storage/med_pouch/oxyloss = 2, /obj/item/weapon/storage/med_pouch/toxin = 2)
 	},
+/obj/machinery/pointdefense_control{
+	initial_id_tag = "torch_primary_pd";
+	name = "Point Defense Controller"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "GY" = (
@@ -13443,6 +13385,11 @@
 	id_tag = "bridge blast";
 	name = "Bridge Blast Doors"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/bridge)
 "HC" = (
@@ -13505,9 +13452,6 @@
 /area/bridge)
 "HK" = (
 /obj/effect/overmap/ship/torch,
-/obj/machinery/pointdefense_control{
-	initial_id_tag = "torch_primary_pd"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HP" = (
@@ -13923,7 +13867,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/item/sticky_pad/random,
 /obj/item/device/destTagger,
 /obj/item/stack/package_wrap/twenty_five,
 /obj/structure/cable/green{
@@ -14014,11 +13957,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"Js" = (
-/obj/structure/lattice,
-/obj/machinery/light/navigation/delay2,
-/turf/space,
-/area/space)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14245,6 +14183,11 @@
 	dir = 4;
 	id_tag = "bridge blast";
 	name = "Bridge Blast Doors"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -15072,13 +15015,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Oz" = (
-/obj/structure/sign/warning/smoking{
-	icon_state = "smoking";
-	dir = 8
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/meeting_room)
 "OD" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -15480,6 +15416,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
+"Qw" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "Qz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15769,6 +15717,11 @@
 /obj/item/device/flash,
 /obj/item/device/flash,
 /obj/item/device/megaphone,
+/obj/item/weapon/storage/secure/briefcase{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "Rx" = (
@@ -15889,15 +15842,6 @@
 	dir = 4;
 	id_tag = "cap_window";
 	name = "CO's Quarters Shutters"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/co)
@@ -16050,6 +15994,11 @@
 	id_tag = "bridge blast";
 	name = "Bridge Blast Doors"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/bridge)
 "SG" = (
@@ -16074,10 +16023,6 @@
 /area/bridge)
 "SL" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/effect/floor_decal/spline/plain/brown{
-	icon_state = "spline_plain";
-	dir = 1
-	},
 /obj/item/weapon/material/ashtray/bronze,
 /obj/item/weapon/flame/lighter/zippo/random,
 /obj/random/smokes,
@@ -16311,11 +16256,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
 "TB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/reinforced/airless,
 /area/bridge/storage)
 "TI" = (
@@ -17046,6 +16986,16 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
+"WW" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/bridge)
 "WX" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -24756,17 +24706,17 @@ aa
 ae
 aa
 aa
-aa
+zx
 aa
 aa
 kE
 aa
 aa
 aa
-Js
+kE
 aa
 aa
-aa
+zx
 aa
 aa
 ae
@@ -24956,9 +24906,9 @@ af
 af
 af
 oA
-zx
 aa
 aa
+vA
 aa
 aa
 hH
@@ -24968,9 +24918,9 @@ aa
 ae
 aa
 aa
+vA
 aa
 aa
-zx
 ae
 tg
 tg
@@ -25158,9 +25108,9 @@ af
 af
 af
 fu
-ka
 XQ
-wM
+XQ
+sF
 Hz
 SE
 Aw
@@ -25170,9 +25120,9 @@ mc
 Aw
 KG
 Hz
-mc
+Es
 aa
-vA
+aa
 sx
 tg
 tg
@@ -25370,7 +25320,7 @@ QW
 Rq
 GV
 dU
-CE
+WW
 FE
 HE
 BI
@@ -25571,7 +25521,7 @@ lt
 vg
 zg
 zN
-lt
+Qw
 TK
 cV
 Ie
@@ -27380,7 +27330,7 @@ aO
 eq
 aO
 yg
-bW
+bY
 cl
 cw
 cD
@@ -28803,7 +28753,7 @@ jH
 Sn
 dQ
 dS
-dX
+jH
 es
 eR
 id
@@ -29001,7 +28951,7 @@ cs
 hs
 hs
 hs
-Oz
+hs
 hs
 hs
 hs

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1247,7 +1247,7 @@
 // Command
 
 /area/bridge
-	name = "\improper Bridge"
+	name = "\improper SEV Torch Bridge"
 	icon_state = "bridge"
 	req_access = list(access_bridge)
 


### PR DESCRIPTION
Editing the Bridge again. Never thought I'd have to but.
:cl: Albens
tweak: Bridge Holopad is now named SEV Torch Bridge
/:cl: 
Just a bunch of small shit that got missed with the last edits. Layering, object shifting, deleting stupid shit, renaming, etc.
<details>
  <summary>Spoiler warning</summary>

Fixes some overlap issues, properly uses some floor_decals.
Fixes the meeting room door buttons
Moves the fire assist mainframe. 
Renames it to Point Defense Controller. That's all it does for right now, so people stop thinking it does anything else.
Renames Bridge to SEV Torch Bridge for holocall purposes, fixes an (?) unreport bug involving two places having the same Long-range pad named "Bridge".
Moves some items back to being random spawn.
Deletes a snowflake plant from the wrong office.
Shifts the Bridge point defense battery
Deletes a bunch of duplicated bridge crap. Six pens, Dozen donuts, etc.
Moves some bridge crap back to where it belongs; the storage room
I don't think I missed anything.
</details>
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->