### PR TITLE
Adds more stuff to uplink + small MRE coffee and tea changes

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -11,6 +11,12 @@
 	item_cost = 3
 	path = /obj/item/ammo_magazine/pistol/small
 
+/datum/uplink_item/item/ammo/empslug
+	name = "Haywire Slug"
+	desc = "Single 12-gauge shotgun slug fitted with a single-use ion pulse generator"
+	item_cost = 1
+	path = /obj/item/ammo_casing/shotgun/emp
+
 /datum/uplink_item/item/ammo/holdout_speedloader
 	name = "Small Speedloader"
 	desc = "A speedloader for small revolvers. Contains 6 rounds."
@@ -33,8 +39,13 @@
 	desc = "A magazine for assault rifles. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
-	antag_roles = list(MODE_MERCENARY)
-
+	
+/datum/uplink_item/item/ammo/bullpup //for zipguns
+	name = "Bullpup Rifle Magazine"
+	desc = "A magazine for bullpup assault rifles. Contains 15 rounds."
+	item_cost = 8
+	path = /obj/item/ammo_magazine/mil_rifle
+	
 /datum/uplink_item/item/ammo/sniperammo
 	name = "Ammobox of Sniper Rounds"
 	desc = "A container of rounds for the anti-materiel rifle. Contains 7 rounds."

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -23,6 +23,12 @@
 	var/obj/item/I = new balloon_type(loc)
 	return I
 
+/datum/uplink_item/item/badassery/crayonmre
+	name = "Crayon MRE"
+	desc = "Exceptionally robust MRE"
+	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	path = /obj/item/weapon/storage/mre/menu11/special
+
 /**************
 * Random Item *
 **************/

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -11,6 +11,12 @@
 	item_cost = 8
 	path = /obj/item/weapon/storage/toolbox/syndicate
 
+/datum/uplink_item/item/tools/ductape
+	name = "Duct Tape"
+	desc = "A roll of duct tape. changes \"HELP\" in to sexy \"mmm\"."
+	item_cost = 8
+	path = /obj/item/weapon/tape_roll
+
 /datum/uplink_item/item/tools/money
 	name = "Operations Funding"
 	item_cost = 8

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -13,7 +13,7 @@
 
 /datum/uplink_item/item/tools/ductape
 	name = "Duct Tape"
-	desc = "A roll of duct tape. changes \"HELP\" in to sexy \"mmm\"."
+	desc = "A roll of duct tape. changes \"HELP\" into sexy \"mmm\"."
 	item_cost = 8
 	path = /obj/item/weapon/tape_roll
 

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -14,7 +14,7 @@
 /datum/uplink_item/item/tools/ductape
 	name = "Duct Tape"
 	desc = "A roll of duct tape. changes \"HELP\" into sexy \"mmm\"."
-	item_cost = 8
+	item_cost = 2
 	path = /obj/item/weapon/tape_roll
 
 /datum/uplink_item/item/tools/money

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -4,6 +4,24 @@
 /datum/uplink_item/item/visible_weapons
 	category = /datum/uplink_category/visible_weapons
 
+/datum/uplink_item/item/visible_weapons/zipgun
+	name = "Zip Gun"
+	desc = "A pipe attached to crude wooden stock with firing mechanism, holds one round."
+	item_cost = 8
+	path = /obj/item/weapon/gun/projectile/pirate
+
+/datum/uplink_item/item/visible_weapons/smallenergy_gun
+	name = "Small Energy Gun"
+	desc = "A pocket-sized energy based sidearm with three different lethality settings."
+	item_cost = 16
+	path = /obj/item/weapon/gun/energy/gun/small
+
+/datum/uplink_item/item/visible_weapons/ancient
+	name = "Replica Pistol"
+	desc = "Cheap replica of some earth handgun"
+	item_cost = 16
+	path = /obj/item/weapon/gun/projectile/pistol/throwback
+	
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
 	desc = "A gas-powered dart gun capable of delivering chemical payloads across short distances. \
@@ -42,6 +60,12 @@
 	desc = "A energy based sidearm with three different lethality settings."
 	item_cost = 32
 	path = /obj/item/weapon/gun/energy/gun
+
+/datum/uplink_item/item/visible_weapons/ionpistol
+	name = "Ion Pistol"
+	desc = "Ion rifle in compact form."
+	item_cost = 40
+	path = /obj/item/weapon/gun/energy/ionrifle/small
 
 /datum/uplink_item/item/visible_weapons/revolver
 	name = "Magnum Revolver"

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -18,7 +18,7 @@
 
 /datum/uplink_item/item/visible_weapons/ancient
 	name = "Replica Pistol"
-	desc = "Cheap replica of some earth handgun"
+	desc = "A cheap replica of an earth handgun. To reload, buy another."
 	item_cost = 16
 	path = /obj/item/weapon/gun/projectile/pistol/throwback
 	

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -10,6 +10,24 @@
 	item_cost = 8
 	path = /obj/item/weapon/storage/box/sinpockets
 
+/datum/uplink_item/item/medical/stabilisation
+	name = "Stabilisation First Aid Kit"
+	desc = "Contains variety of emergency medical pouches."
+	item_cost = 16
+	path = /obj/item/weapon/storage/firstaid/stab
+
+/datum/uplink_item/item/medical/stasis
+	name = "Stasis Bag"
+	desc = "Reusable bag designed to slow down life functions of occupant, especially useful if short on time or in a hostile enviroment."
+	item_cost = 24
+	path = /obj/item/bodybag/cryobag
+
+/datum/uplink_item/item/medical/defib
+	name = "Combat Defibrillator"
+	desc = "A belt-equipped defibrillator that can be rapidly deployed. Does not have the restrictions or safeties of conventional defibrillators and can revive through space suits."
+	item_cost = 24
+	path = /obj/item/weapon/defibrillator/compact/combat/loaded
+
 /datum/uplink_item/item/medical/surgery
 	name = "Surgery Kit"
 	desc = "Contains all the tools needed for on the spot surgery, assuming you actually know what you're doing with them. Floor sterilization not included."

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -10,6 +10,11 @@
 	item_cost = 1
 	path = /obj/item/clothing/mask/fakemoustache
 
+/datum/uplink_item/item/stealth_items/balaclava
+	name = "Balaclava"
+	item_cost = 1
+	path = /obj/item/clothing/mask/balaclava
+
 /datum/uplink_item/item/stealth_items/syndigaloshes
 	name = "No-Slip Shoes"
 	desc = "These shoes have a non-slip grip on them, so those pesky janitors can't ruin your operations!"

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -70,7 +70,7 @@ MRE Stuff
 
 /obj/item/weapon/storage/mre/menu8
 	meal_desc = " This one is menu 8, hot chili."
-	main_meal = /obj/item/weapon/storage/mrebag/menu3
+	main_meal = /obj/item/weapon/storage/mrebag/menu8
 
 /obj/item/weapon/storage/mre/menu9
 	name = "vegan MRE"
@@ -109,6 +109,9 @@ MRE Stuff
 	/obj/random/mre/sauce/crayon,
 	/obj/random/mre/sauce/crayon
 	)
+
+/obj/item/weapon/storage/mre/menu11/special
+	meal_desc = "This one doesn't have a menu listing. How odd. It has the initials \"A.B.\" written on the back."
 
 /obj/item/weapon/storage/mre/random
 	meal_desc = "The menu label is faded out."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -160,6 +160,10 @@
 	nutriment_factor = 1
 	color = "#482000"
 
+/datum/reagent/nutriment/coffee/instant
+	name = "Instant Coffee Powder"
+	description = "A bitter powder made by processing coffee beans."
+
 /datum/reagent/nutriment/tea
 	name = "Tea Powder"
 	description = "A dark, tart powder made from black tea leaves."
@@ -167,6 +171,9 @@
 	taste_mult = 1.3
 	nutriment_factor = 1
 	color = "#101000"
+
+/datum/reagent/nutriment/tea/instant
+	name = "Instant Tea Powder"
 
 /datum/reagent/nutriment/coco
 	name = "Coco Powder"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1394,6 +1394,15 @@
 	result = /datum/reagent/drink/coffee
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/nutriment/coffee = 1)
 	result_amount = 5
+	minimum_temperature = 70 CELSIUS
+	maximum_temperature = (70 CELSIUS) + 100
+	mix_message = "The solution thickens into a steaming dark brown beverage."
+
+/datum/chemical_reaction/coffee/instant
+	name = "Instant Coffee"
+	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/nutriment/coffee/instant = 1)
+	maximum_temperature = INFINITY
+	minimum_temperature = 0
 	mix_message = "The solution thickens into dark brown beverage."
 
 /datum/chemical_reaction/tea
@@ -1401,8 +1410,17 @@
 	result = /datum/reagent/drink/tea
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/nutriment/tea = 1)
 	result_amount = 5
-	mix_message = "The solution thickens into black beverage."
+	minimum_temperature = 70 CELSIUS
+	maximum_temperature = (70 CELSIUS) + 100
+	mix_message = "The solution thickens into a steaming black beverage."
 
+/datum/chemical_reaction/tea/instant
+	name = "Instant Black tea"
+	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/nutriment/tea/instant = 1)
+	maximum_temperature = INFINITY
+	minimum_temperature = 0
+	mix_message = "The solution thickens into black beverage."
+	
 /datum/chemical_reaction/hot_coco
 	name = "Hot Coco"
 	result = /datum/reagent/drink/hot_coco

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1394,18 +1394,14 @@
 	result = /datum/reagent/drink/coffee
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/nutriment/coffee = 1)
 	result_amount = 5
-	minimum_temperature = 70 CELSIUS
-	maximum_temperature = (70 CELSIUS) + 100
-	mix_message = "The solution thickens into a steaming dark brown beverage."
+	mix_message = "The solution thickens into dark brown beverage."
 
 /datum/chemical_reaction/tea
 	name = "Black tea"
 	result = /datum/reagent/drink/tea
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/nutriment/tea = 1)
 	result_amount = 5
-	minimum_temperature = 70 CELSIUS
-	maximum_temperature = (70 CELSIUS) + 100
-	mix_message = "The solution thickens into a steaming black beverage."
+	mix_message = "The solution thickens into black beverage."
 
 /datum/chemical_reaction/hot_coco
 	name = "Hot Coco"

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -256,13 +256,13 @@
 	starting_reagents = list(/datum/reagent/nutriment/soysauce = 5)
 
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee
-	name = "coffee powder packet"
-	desc = "Contains 5u of coffee powder. Mix with 25u of water and heat."
+	name = "instant coffee powder packet"
+	desc = "Contains 5u of instant coffee powder. Mix with 25u of water."
 	starting_reagents = list(/datum/reagent/nutriment/coffee = 5)
 
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/tea
-	name = "tea powder packet"
-	desc = "Contains 5u of black tea powder. Mix with 25u of water and heat."
+	name = "instant tea powder packet"
+	desc = "Contains 5u of instant black tea powder. Mix with 25u of water."
 	starting_reagents = list(/datum/reagent/nutriment/tea = 5)
 
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/cocoa

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -258,12 +258,12 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee
 	name = "instant coffee powder packet"
 	desc = "Contains 5u of instant coffee powder. Mix with 25u of water."
-	starting_reagents = list(/datum/reagent/nutriment/coffee = 5)
+	starting_reagents = list(/datum/reagent/nutriment/coffee/instant = 5)
 
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/tea
 	name = "instant tea powder packet"
 	desc = "Contains 5u of instant black tea powder. Mix with 25u of water."
-	starting_reagents = list(/datum/reagent/nutriment/tea = 5)
+	starting_reagents = list(/datum/reagent/nutriment/tea/instant = 5)
 
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/cocoa
 	name = "cocoa powder packet"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
as in title, this PR will probably need some spelling error fixes which im unable to do

:cl: Imienny
rscadd: adds zipgun, knock-off pistol, small energy gun, ion pistol, ion slug, duct tape, combat defibrillator, stasis bag, stabilisation kit, balaclava and "exceptionally robust MRE" to uplink
tweak: MRE coffee and tea powder no longer require heating
bugfix: fixed MRE menu 8 (chilli) spawning with pizza instead of chilli
/:cl: