### PR TITLE
Experiment: partially disable Azure builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,15 +14,15 @@ steps:
     imageName: '$(imageName)'
     buildArguments: BUILD_ARGS=-Icustom-items/inc.dm
 
-- task: Docker@1
-  displayName: 'registry login'
-  inputs:
-    containerregistrytype: 'Container Registry'
-    dockerRegistryEndpoint: 'bs12_2'
-    command: login
-
-- task: Docker@1
-  displayName: 'push'
-  inputs:
-    command: 'push'
-    imageName: '$(imageName)'
+#- task: Docker@1
+#  displayName: 'registry login'
+#  inputs:
+#    containerregistrytype: 'Container Registry'
+#    dockerRegistryEndpoint: 'bs12_2'
+#    command: login
+#
+#- task: Docker@1
+#  displayName: 'push'
+#  inputs:
+#    command: 'push'
+#    imageName: '$(imageName)'


### PR DESCRIPTION
Github Actions are now generally available. As an experiment, this disables the push stage of the Azure version of the builds, to see if we can run solely with Actions.