### PR TITLE
Converts becquerels to roentgen in the code.

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -177,7 +177,7 @@ SUBSYSTEM_DEF(jobs)
 	if(airstatus || radlevel > 0)
 		var/reply = alert(spawner, "Warning. Your selected spawn location seems to have unfavorable conditions. \
 		You may die shortly after spawning. \
-		Spawn anyway? More information: [airstatus] Radiation: [radlevel] Gy", "Atmosphere warning", "Abort", "Spawn anyway")
+		Spawn anyway? More information: [airstatus] Radiation: [radlevel] Roentgen", "Atmosphere warning", "Abort", "Spawn anyway")
 		if(reply == "Abort")
 			return FALSE
 		else

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -177,7 +177,7 @@ SUBSYSTEM_DEF(jobs)
 	if(airstatus || radlevel > 0)
 		var/reply = alert(spawner, "Warning. Your selected spawn location seems to have unfavorable conditions. \
 		You may die shortly after spawning. \
-		Spawn anyway? More information: [airstatus] Radiation: [radlevel] Bq", "Atmosphere warning", "Abort", "Spawn anyway")
+		Spawn anyway? More information: [airstatus] Radiation: [radlevel] Gy", "Atmosphere warning", "Abort", "Spawn anyway")
 		if(reply == "Abort")
 			return FALSE
 		else

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -40,7 +40,7 @@
 
 /obj/item/device/geiger/examine(mob/user)
 	. = ..()
-	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: .[radiation_count ? radiation_count : "0"] Roentgen."
+	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: [radiation_count ? radiation_count : "0"] Roentgen."
 	if(radiation_count > RAD_LEVEL_LOW)
 		to_chat(user, "<span class='warning'>[msg]</span>")
 	else

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -40,7 +40,7 @@
 
 /obj/item/device/geiger/examine(mob/user)
 	. = ..()
-	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: .[radiation_count ? radiation_count : "0"] Gy."
+	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: .[radiation_count ? radiation_count : "0"] Roentgen."
 	if(radiation_count > RAD_LEVEL_LOW)
 		to_chat(user, "<span class='warning'>[msg]</span>")
 	else

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -40,7 +40,7 @@
 
 /obj/item/device/geiger/examine(mob/user)
 	. = ..()
-	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: [radiation_count ? radiation_count : "0"] Bq."
+	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: .[radiation_count ? radiation_count : "0"] Gy."
 	if(radiation_count > RAD_LEVEL_LOW)
 		to_chat(user, "<span class='warning'>[msg]</span>")
 	else

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -350,7 +350,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/turf/t = get_turf(src)
 	if(t)
 		var/rads = SSradiation.get_rads_at_turf(t)
-		to_chat(src, "<span class='notice'>Radiation level: [rads ? rads : "0"] Gy.</span>")
+		to_chat(src, "<span class='notice'>Radiation level: [rads ? rads : "0"] Roentgen.</span>")
 
 /mob/observer/ghost/proc/scan_target()
 	set name = "Scan Target"

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -350,7 +350,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/turf/t = get_turf(src)
 	if(t)
 		var/rads = SSradiation.get_rads_at_turf(t)
-		to_chat(src, "<span class='notice'>Radiation level: [rads ? rads : "0"] Bq.</span>")
+		to_chat(src, "<span class='notice'>Radiation level: [rads ? rads : "0"] Gy.</span>")
 
 /mob/observer/ghost/proc/scan_target()
 	set name = "Scan Target"


### PR DESCRIPTION
A becquerel is a unit of activity, instead of exposure. Roentgen makes more sense as a unit for geiger counters to have.

_if you make a 3.6R meme IC i'll personally ban you_
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->