### PR TITLE
Tweaks solar arrays on planetary surfaces to require less clear space

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -174,12 +174,20 @@ var/list/solars_list = list()
 //trace towards sun to see if we're in shadow
 /obj/machinery/power/solar/proc/occlusion()
 
+	var/steps = 20	// 20 steps is enough
 	var/ax = x		// start at the solar panel
 	var/ay = y
 	var/turf/T = null
 
-	for(var/i = 1 to 20)		// 20 steps is enough
-		ax += GLOB.sun.dx	// do step
+	// On planets, we take fewer steps because the light is mostly up
+	// Also, many planets barely have any spots with enough clear space around
+	if(GLOB.using_map.use_overmap)
+		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		if(istype(E))
+			steps = 5
+
+	for(var/i = 1 to steps)
+		ax += GLOB.sun.dx
 		ay += GLOB.sun.dy
 
 		T = locate( round(ax,0.5),round(ay,0.5),z)
@@ -191,7 +199,7 @@ var/list/solars_list = list()
 			obscured = 1
 			return
 
-	obscured = 0		// if hit the edge or stepped 20 times, not obscured
+	obscured = 0		// if hit the edge or stepped max times, not obscured
 	update_solar_exposure()
 
 
@@ -347,7 +355,6 @@ var/list/solars_list = list()
 
 	set_panels(cdir)
 	updateDialog()
-
 
 /obj/machinery/power/solar_control/Initialize()
 	. = ..()

--- a/html/changelogs/Ithalan-solartweak.yml
+++ b/html/changelogs/Ithalan-solartweak.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Ithalan
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Solar arrays on planetary surfaces now only require 5 tiles of clear space around them to work at all, instead of 20. Solar arrays in space are unchanged."


### PR DESCRIPTION
Solar arrays normally require a clear line-of-sight twenty tiles out from their position, in the direction of the sun, to generate any power at all. This much clear space can be hard to achieve on many randomly generated planets, leading to solar arrays becoming useless there without a lot of time spent mining away every rock in the vicinity.

This PR reduces the distance required on planetary surfaces only to five tiles instead.