### PR TITLE
Virus Event Retweak

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -5,6 +5,7 @@
 #define ASSIGNMENT_GARDENER "Gardener"
 #define ASSIGNMENT_JANITOR "Janitor"
 #define ASSIGNMENT_MEDICAL "Medical"
+#define ASSIGNMENT_VIROLOGY "Virology"
 #define ASSIGNMENT_SCIENTIST "Scientist"
 #define ASSIGNMENT_SECURITY "Security"
 
@@ -144,7 +145,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",			/datum/event/infestation, 			100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",						/datum/event/wallrot, 				0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MUNDANE, "Electrical Storm",	/datum/event/electrical_storm, 		20,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Cold Outbreak",			/datum/event/space_cold,			100,	list(ASSIGNMENT_MEDICAL = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Toilet Clog",					/datum/event/toilet_clog,			50, 	list(ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Drone Malfunction",				/datum/event/rogue_maint_drones/,	10,		list(ASSIGNMENT_ENGINEER = 30)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disposals Explosion",			/datum/event/disposals_explosion/,	50,		list(ASSIGNMENT_ENGINEER = 40)),
@@ -175,7 +175,8 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",						/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",					/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Cold Outbreak",					/datum/event/space_cold,				25,		list(ASSIGNMENT_VIROLOGY = 20), 1)
 	)
 
 /datum/event_container/major
@@ -199,5 +200,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 #undef ASSIGNMENT_GARDENER
 #undef ASSIGNMENT_JANITOR
 #undef ASSIGNMENT_MEDICAL
+#undef ASSIGNMENT_VIROLOGY
 #undef ASSIGNMENT_SCIENTIST
 #undef ASSIGNMENT_SECURITY

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -54,6 +54,9 @@ var/list/event_last_fired = list()
 		possibleEvents[/datum/event/radiation_storm] = active_with_role["Medical"] * 10
 		possibleEvents[/datum/event/spontaneous_appendicitis] = active_with_role["Medical"] * 10
 
+	if(active_with_role["Surgical"] > 0)
+		possibleEvents[/datum/event/space_cold] = active_with_role["Surgical"] * 20
+
 	possibleEvents[/datum/event/prison_break] = active_with_role["Security"] * 50
 	if(active_with_role["Security"] > 0)
 		if(!sent_spiders_to_station)
@@ -95,6 +98,7 @@ var/list/event_last_fired = list()
 	var/list/active_with_role = list()
 	active_with_role["Engineer"] = 0
 	active_with_role["Medical"] = 0
+	active_with_role["Virology"] = 0
 	active_with_role["Security"] = 0
 	active_with_role["Scientist"] = 0
 	active_with_role["AI"] = 0
@@ -125,6 +129,9 @@ var/list/event_last_fired = list()
 
 		if(M.mind.assigned_role in SSjobs.titles_by_department(MED))
 			active_with_role["Medical"]++
+
+		if(M.mind.assigned_role == ("Physician" || "Chief Medical Officer"))
+			active_with_role["Virology"]++
 
 		if(M.mind.assigned_role in SSjobs.titles_by_department(SEC))
 			active_with_role["Security"]++

--- a/code/modules/events/space_cold.dm
+++ b/code/modules/events/space_cold.dm
@@ -8,9 +8,30 @@ datum/event/space_cold/start()
 		return
 
 	var/datum/disease2/disease/sniffle = new
-	sniffle.max_stage = 3
-	sniffle.makerandom(1)
-	sniffle.spreadtype = "Airborne"
+	if(prob(60))
+		sniffle.max_stage = 3
+		sniffle.makerandom(VIRUS_MILD)
+		sniffle.spreadtype = "Airborne"
+	else
+		if(prob(75))
+			sniffle.max_stage = 3
+			sniffle.makerandom(VIRUS_COMMON)
+			sniffle.spreadtype = "Airborne"
+		else
+			if(prob(75))
+				sniffle.max_stage = 3
+				sniffle.makerandom(VIRUS_ENGINEERED)
+				if(prob(50))
+					sniffle.spreadtype = "Airborne"
+				else
+					sniffle.spreadtype = "Contact"
+			else
+				sniffle.max_stage = 4
+				sniffle.makerandom(VIRUS_ENGINEERED)
+				if(prob(25))
+					sniffle.spreadtype = "Airborne"
+				else
+					sniffle.spreadtype = "Contact"
 
 	var/victims = min(rand(1,3), candidates.len)
 	while(victims)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -312,6 +312,7 @@
 	delay = 25 SECONDS
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.emote("shiver")
+		mob.bodytemperature = min(mob.bodytemperature, 220)
 
 /datum/disease2/effect/hair
 	name = "Hair Loss"

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -128,6 +128,18 @@ proc/infection_chance(var/mob/living/carbon/M, var/vector = "Airborne")
 	D.makerandom(VIRUS_COMMON)
 	infect_virus2(M, D, 1)
 
+/proc/infect_mob_random_severe(var/mob/living/carbon/M)
+	var/datum/disease2/disease/D = new /datum/disease2/disease
+
+	D.makerandom(VIRUS_ENGINEERED)
+	infect_virus2(M, D, 1)
+
+/proc/infect_mob_random_exotic(var/mob/living/carbon/M)
+	var/datum/disease2/disease/D = new /datum/disease2/disease
+
+	D.makerandom(VIRUS_EXOTIC)
+	infect_virus2(M, D, 1)
+
 //Fancy prob() function.
 /proc/dprob(var/p)
 	return(prob(sqrt(p)) && prob(sqrt(p)))


### PR DESCRIPTION
:cl:
tweak: Virus outbreaks now occur less frequently and with a much wider variety of possible symptoms including those previously restricted from appearing in-game.
tweak: Viruses will now only appear in the presence of people able to work on them.
tweak: More severe random viruses have a decreasing chance of spreading through airborne contact to limit their ability to snowball out of control.
/:cl:
_"But why?"_

1. _Doesn't this add more obnoxious interruptions to the game?_
Nope. The event occurs less frequently and with a greater possible severity when it does.
The more an event can possibly influence a round, the more tension it adds. You can choose to ignore the virus, but will you get away with it? This change forces you to ask this question even if most viruses will still only spawn with minor to moderate symptoms. You'll spend less time dealing with viruses and have to place a lot more weight on the decision to deal with them when they appear.

2. _Won't this steer players' focus away from antagonism and its consequences?_
Nope. This change opens doors for antagonism. The more windows of opportunity we offer to antagonists, the more likely they can effectively antagonize for the round. Too often targets are in public, have numerous people around them, and don't move (especially true with objects.)  
Viruses you might not be able to afford having out in the open pull varied actors from the round away from what they're doing and into a secluded area - virology. This creates opportunities for all kinds of antagonists to act on targets isolated, trapped, or left unprotected by the virus - not to mention the tools it might drop into the hands of an antagonist working on the virus itself.

3. _Yeah, but what if you have a GBS outbreak and nobody takes care of it?_
GBS and 2% Syndrome (monkification) are still locked behind VIRUS_EXOTIC. 
However, a wider variety of possible outcomes in the game makes it much more replayable, novel, and dynamic. They broaden the number of roles players can choose to take in response - a paranoid maintenance-dweller who creates a plague fort to sit out the danger? A responder going into harm's way to keep up quarantine and bring the sick people in? Or perhaps a sick prisoner who doesn't know if they've really been brought into medical for a necessary treatment or not? 
Destructive and highly-dangerous symptoms only appear very rarely; virus outbreaks will happen less overall. Although they may tear down a round or two (not unlike spiders and blob,) I think the added sense of meaningfulness to the choices around addressing a virus make them a lot more fun. Viruses have to have teeth for those choices to have meaning. 