### PR TITLE
Borg alt click only shocks doors on harm

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -141,7 +141,10 @@
 	return
 
 /obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
-	AICtrlAltClick()
+	if (usr.a_intent != I_HELP)
+		AICtrlAltClick()
+	else
+		..()
 
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()


### PR DESCRIPTION
Allows borgs to open the tile tab on tiles that have airlocks on them now.

:cl: SierraKomodo
tweak: Borgs can now alt-click doors to access the tile tab instead of shocking them. To shock a door, use harm intent when alt-clicking.
/:cl: