### PR TITLE
Allows AI to set standard alerts

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -62,8 +62,9 @@
 	data["message_line1"] = msg_line1
 	data["message_line2"] = msg_line2
 	data["state"] = current_status
-	data["isAI"] = issilicon(usr)
-	data["authenticated"] = is_autenthicated(user)
+	data["isAI"] = isAI(usr)
+	data["issilicon"] = issilicon(usr)
+	data["authenticated"] = is_authenticated(user)
 	data["boss_short"] = GLOB.using_map.boss_short
 
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
@@ -107,7 +108,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/program/comm/proc/is_autenthicated(var/mob/user)
+/datum/nano_module/program/comm/proc/is_authenticated(var/mob/user)
 	if(program)
 		return program.can_run(user)
 	return 1
@@ -131,7 +132,7 @@
 			current_status = text2num(href_list["target"])
 		if("announce")
 			. = 1
-			if(is_autenthicated(user) && !issilicon(usr) && ntn_comm)
+			if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 				if(user)
 					var/obj/item/weapon/card/id/id_card = user.GetIdCard()
 					crew_announcement.announcer = GetNameAndAssignmentFromId(id_card)
@@ -152,12 +153,12 @@
 			. = 1
 			if(href_list["target"] == "emagged")
 				if(program)
-					if(is_autenthicated(user) && program.computer.emagged() && !issilicon(usr) && ntn_comm)
+					if(is_authenticated(user) && program.computer.emagged() && !issilicon(usr) && ntn_comm)
 						if(centcomm_message_cooldown)
 							to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 							SSnano.update_uis(src)
 							return
-						var/input = sanitize(input(usr, "Please choose a message to transmit to \[ABNORMAL ROUTING CORDINATES\] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination. Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
+						var/input = sanitize(input(usr, "Please choose a message to transmit to \[ABNORMAL ROUTING COORDINATES\] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination. Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
 						if(!input || !can_still_topic())
 							return 1
 						Syndicate_announce(input, usr)
@@ -167,7 +168,7 @@
 						spawn(300)//30 second cooldown
 							centcomm_message_cooldown = 0
 			else if(href_list["target"] == "regular")
-				if(is_autenthicated(user) && !issilicon(usr) && ntn_comm)
+				if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 					if(centcomm_message_cooldown)
 						to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 						SSnano.update_uis(src)
@@ -186,7 +187,7 @@
 						centcomm_message_cooldown = 0
 		if("evac")
 			. = 1
-			if(is_autenthicated(user))
+			if(is_authenticated(user))
 				var/datum/evacuation_option/selected_evac_option = evacuation_controller.evacuation_options[href_list["target"]]
 				if (isnull(selected_evac_option) || !istype(selected_evac_option))
 					return
@@ -199,7 +200,7 @@
 					evacuation_controller.handle_evac_option(selected_evac_option.option_target, user)
 		if("setstatus")
 			. = 1
-			if(is_autenthicated(user) && ntn_cont)
+			if(is_authenticated(user) && ntn_cont)
 				switch(href_list["target"])
 					if("line1")
 						var/linput = reject_bad_text(sanitize(input("Line 1", "Enter Message Text", msg_line1) as text|null, 40), 40)
@@ -217,7 +218,7 @@
 						post_status(href_list["target"])
 		if("setalert")
 			. = 1
-			if(is_autenthicated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
+			if(is_authenticated(user) && (!issilicon(usr) || isAI(usr)) && ntn_cont && ntn_comm)
 				var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 				var/decl/security_level/target_level = locate(href_list["target"]) in security_state.comm_console_security_levels
 				if(target_level && security_state.can_switch_to(target_level))
@@ -231,7 +232,7 @@
 			current_status = STATE_DEFAULT
 		if("viewmessage")
 			. = 1
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				current_viewing_message_id = text2num(href_list["target"])
 				for(var/list/m in l.messages)
 					if(m["id"] == current_viewing_message_id)
@@ -239,12 +240,12 @@
 				current_status = STATE_VIEWMESSAGE
 		if("delmessage")
 			. = 1
-			if(is_autenthicated(user) && ntn_comm && l != global_message_listener)
+			if(is_authenticated(user) && ntn_comm && l != global_message_listener)
 				l.Remove(current_viewing_message)
 			current_status = STATE_MESSAGELIST
 		if("printmessage")
 			. = 1
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				if(!program.computer.print_paper(current_viewing_message["contents"],current_viewing_message["title"]))
 					to_chat(usr, "<span class='notice'>Hardware Error: Printer was unable to print the selected file.</span>")
 		if("unbolt_doors")

--- a/nano/templates/communication.tmpl
+++ b/nano/templates/communication.tmpl
@@ -3,8 +3,8 @@
 
 		<h4>Command</h4>
 		<div class=itemGroup>
-			<div class=item>{{:helper.link('Make an announcement', null, {'action' : 'announce'}, data.isAI || !data.net_comms ? 'disabled' : null)}} </div>
-			<div class=item>{{:helper.link('Change alert level', null, {'action' : 'sw_menu', 'target' : 5}, data.isAI || !data.net_syscont || !data.net_comms ? 'disabled' : null)}} </div>
+			<div class=item>{{:helper.link('Make an announcement', null, {'action' : 'announce'}, data.issilicon || !data.net_comms ? 'disabled' : null)}} </div>
+			<div class=item>{{:helper.link('Change alert level', null, {'action' : 'sw_menu', 'target' : 5}, (data.issilicon && !data.isAI) || !data.net_syscont || !data.net_comms ? 'disabled' : null)}} </div>
 			<div class=item>{{:helper.link('Set status display', null, {'action' : 'sw_menu', 'target' : 4}, !data.net_syscont ? 'disabled' : null)}} </div>
 		</div>
 
@@ -12,19 +12,19 @@
 		<div class=itemGroup>
 			<div class=item>{{:helper.link('Message list', null, {'action' : 'sw_menu', 'target' : 2}, !data.net_comms ? 'disabled' : null)}} </div>
 			<div class=item>{{if data.emagged}}
-				{{:helper.link('Send an emergency message to [UNKNOWN]', null, {'action' : 'message', 'target' : 'emagged'}, data.isAI || !data.net_comms ? 'disabled' : null)}}
+				{{:helper.link('Send an emergency message to [UNKNOWN]', null, {'action' : 'message', 'target' : 'emagged'}, data.issilicon || !data.net_comms ? 'disabled' : null)}}
 			{{else}}
-				{{:helper.link('Send an emergency message to ' + data.boss_short, null, {'action' : 'message', 'target' : 'regular'}, data.isAI || !data.net_comms ? 'disabled' : null)}}
+				{{:helper.link('Send an emergency message to ' + data.boss_short, null, {'action' : 'message', 'target' : 'regular'}, data.issilicon || !data.net_comms ? 'disabled' : null)}}
 			{{/if}} </div>
 		</div>
 
 		<h4>Additional</h4>
 		<div class=itemGroup>
 			<div class="item">{{:helper.link('Unbolt saferoom doors', null, {'action' : 'unbolt_doors'})}}</div>
-			<div class="item">{{:helper.link('Bolt saferoom doors', null, {'action' : 'bolt_doors'})}}</div>		
+			<div class="item">{{:helper.link('Bolt saferoom doors', null, {'action' : 'bolt_doors'})}}</div>
 			{{for data.evac_options}}
 				<div class="item">
-					{{:helper.link(value.option_text, null, {'action' : 'evac', 'target' : value.option_target}, ((value.needs_syscontrol && !data.net_syscont) || (!value.silicon_allowed && data.isAI)) ? 'disabled' : null, 'redButton')}}
+					{{:helper.link(value.option_text, null, {'action' : 'evac', 'target' : value.option_target}, ((value.needs_syscontrol && !data.net_syscont) || (!value.silicon_allowed && data.issilicon)) ? 'disabled' : null, 'redButton')}}
 				</div>
 			{{empty}}
 				<div class=bad>No further options currently available.</div>
@@ -77,7 +77,7 @@
                 {{:helper.link(data.message_line2 ? data.message_line2 : '(none)', null, {'action' : 'setstatus', 'target' : 'line2'})}}
             </div>
         </div>
-        
+
         <div class="item">
             <div class="itemLabel">
                 <b>Alert:</b>
@@ -102,7 +102,7 @@
 				<div class=itemGroup>
 				{{for data.security_levels}}
 					<div class="item">
-						<div class=item>{{:helper.link(value.title, null, {'action' : 'setalert', 'target' : value.ref}, data.current_security_level_ref === value.ref || data.isAI ? 'disabled' : null)}} </div>
+						<div class=item>{{:helper.link(value.title, null, {'action' : 'setalert', 'target' : value.ref}, data.current_security_level_ref === value.ref || (data.issilicon && !data.isAI) ? 'disabled' : null)}} </div>
 					</div>
 				{{/for}}
 			{{/if}}


### PR DESCRIPTION
Also fixes some typos in proc names and displayed text.

Borgs, maint drones, and other silicon do not get access to set alerts, only the AI (Or anything that passes the `isAI()` check).

:cl:
add: AI can now set standard alerts (Green, Blue, Orange, Violet) using the Command and Communications software or subsystem like other bridge staff. Borgs do not get this ability.
/:cl: