### PR TITLE
Removes suit sensors from robotics console

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -17568,7 +17568,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "eRQ" = (
-/obj/machinery/computer/modular/preset/medical{
+/obj/machinery/computer/modular{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,


### PR DESCRIPTION
Fixes #27342

An alternative to #27451 that doesn't add access to roboticists (They don't really have a reason to have suit sensors anyway - They're not medical).

:cl: SierraKomodo
mapfix: The robotics console no longer has suit sensors loaded by default, fixing the 'Access Denied' spam error.
/:cl: