### PR TITLE
Adding inflatables dispenser to surveyor 

### DIFF
--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -39,7 +39,8 @@
 		/obj/item/weapon/crowbar,
 		/obj/item/weapon/wirecutters,
 		/obj/item/device/multitool,
-		/obj/item/bioreactor
+		/obj/item/bioreactor,
+		/obj/item/weapon/inflatable_dispenser/robot
 	)
 
 	emag = /obj/item/weapon/melee/energy/machete


### PR DESCRIPTION
The surveyor often gets the task of disassembling doors and walls on away missions but has no way to prevent breaches on it's own.

:cl: Soviet Swede
rscadd: Added the inflatables dispenser to the surveyor 
/:cl: