### PR TITLE
Allow cyborg materials to be used in machine construction

### DIFF
--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		LAZYREMOVE(uncreated_component_parts, path)
 	return install_component(path, TRUE)
 
-// Can be given a path or an instance. False will guarantee part creation. 
+// Can be given a path or an instance. False will guarantee part creation.
 // If an instance is given or created, it is returned, otherwise null is returned.
 /obj/machinery/proc/install_component(var/obj/item/weapon/stock_parts/part, force = FALSE, refresh_parts = TRUE)
 	if(ispath(part))
@@ -251,14 +251,14 @@ Standard helpers for users interacting with machinery parts.
 					return TRUE
 
 /obj/machinery/proc/part_insertion(mob/user, obj/item/weapon/stock_parts/part) // Second argument may actually be an arbitrary item.
-	if(!user.canUnEquip(part))
+	if(!user.canUnEquip(part) && !isstack(part))
 		return FALSE
 	var/number = can_add_component(part, user)
 	if(!number)
 		return istype(part) // If it's not a stock part, we don't block further interactions; presumably the user meant to do something else.
 	if(isstack(part))
 		var/obj/item/stack/stack = part
-		install_component(stack.split(number))
+		install_component(stack.split(number, TRUE))
 	else
 		user.unEquip(part, src)
 		install_component(part)


### PR DESCRIPTION
Fixes #27484

:cl: SierraKomodo
bugfix: Cyborg cable coil can now be used to build machines
/:cl: