### PR TITLE
Reshuffles overmap objects class tree

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2475,6 +2475,7 @@
 #include "code\modules\organs\internal\species\unathi.dm"
 #include "code\modules\organs\internal\species\vox.dm"
 #include "code\modules\overmap\_defines.dm"
+#include "code\modules\overmap\overmap_object.dm"
 #include "code\modules\overmap\overmap_shuttle.dm"
 #include "code\modules\overmap\sectors.dm"
 #include "code\modules\overmap\spacetravel.dm"

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -73,7 +73,7 @@ SUBSYSTEM_DEF(shuttle)
 		registered_shuttle_landmarks[shuttle_landmark_tag] = shuttle_landmark
 		last_landmark_registration_time = world.time
 
-		var/obj/effect/overmap/O = landmarks_still_needed[shuttle_landmark_tag]
+		var/obj/effect/overmap/visitable/O = landmarks_still_needed[shuttle_landmark_tag]
 		if(O) //These need to be added to sectors, which we handle.
 			try_add_landmark_tag(shuttle_landmark_tag, O)
 			landmarks_still_needed -= shuttle_landmark_tag
@@ -86,7 +86,7 @@ SUBSYSTEM_DEF(shuttle)
 
 //Checks if the given sector's landmarks have initialized; if so, registers them with the sector, if not, marks them for assignment after they come in.
 //Also adds automatic landmarks that were waiting on their sector to spawn.
-/datum/controller/subsystem/shuttle/proc/initialize_sector(obj/effect/overmap/given_sector)
+/datum/controller/subsystem/shuttle/proc/initialize_sector(obj/effect/overmap/visitable/given_sector)
 	given_sector.populate_sector_objects() // This is a late init operation that sets up the sector's map_z and does non-overmap-related init tasks.
 
 	for(var/landmark_tag in given_sector.initial_generic_waypoints)
@@ -105,7 +105,7 @@ SUBSYSTEM_DEF(shuttle)
 			given_sector.add_landmark(landmark, landmark.shuttle_restricted)
 			landmarks_awaiting_sector -= landmark
 
-/datum/controller/subsystem/shuttle/proc/try_add_landmark_tag(landmark_tag, obj/effect/overmap/given_sector)
+/datum/controller/subsystem/shuttle/proc/try_add_landmark_tag(landmark_tag, obj/effect/overmap/visitable/given_sector)
 	var/obj/effect/shuttle_landmark/landmark = get_landmark(landmark_tag)
 	if(!landmark)
 		return
@@ -140,7 +140,7 @@ SUBSYSTEM_DEF(shuttle)
 		return
 	overmap_halted = !overmap_halted
 	for(var/ship in ships)
-		var/obj/effect/overmap/ship/ship_effect = ship
+		var/obj/effect/overmap/visitable/ship/ship_effect = ship
 		overmap_halted ? ship_effect.halt() : ship_effect.unhalt()
 
 /datum/controller/subsystem/shuttle/stat_entry()

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(skybox)
 	if(!skybox_cache["[z]"])
 		skybox_cache["[z]"] = generate_skybox(z)
 		if(GLOB.using_map.use_overmap)
-			var/obj/effect/overmap/O = map_sectors["[z]"]
+			var/obj/effect/overmap/visitable/O = map_sectors["[z]"]
 			if(istype(O))
 				for(var/zlevel in O.map_z)
 					skybox_cache["[zlevel]"] = skybox_cache["[z]"]
@@ -44,11 +44,11 @@ SUBSYSTEM_DEF(skybox)
 	res.overlays += base
 
 	if(GLOB.using_map.use_overmap && use_overmap_details)
-		var/obj/effect/overmap/O = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/O = map_sectors["[z]"]
 		if(istype(O))
 			var/image/overmap = image(skybox_icon)
 			overmap.overlays += O.generate_skybox()
-			for(var/obj/effect/overmap/other in O.loc)
+			for(var/obj/effect/overmap/visitable/other in O.loc)
 				if(other != O)
 					overmap.overlays += other.get_skybox_representation()
 			overmap.appearance_flags = RESET_COLOR

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(statistics)
 		death.brainloss = dead.getBrainLoss()
 		death.oxyloss =   dead.getOxyLoss()
 		death.using_map_name = GLOB.using_map.full_name
-		var/obj/effect/overmap/cell = map_sectors ? map_sectors["[dead.z]"] : null
+		var/obj/effect/overmap/visitable/cell = map_sectors ? map_sectors["[dead.z]"] : null
 		death.overmap_location_name = cell ? cell.name : "Unknown"
 		LAZYADD(deaths, death)
 

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -83,7 +83,7 @@
 	if(state != AWAITING_ACTIVATION)
 		to_chat(user, "<span class='warning'>\The [src] won't activate again.</span>")
 		return
-	var/obj/effect/overmap/O = map_sectors["[get_z(src)]"]
+	var/obj/effect/overmap/visitable/O = map_sectors["[get_z(src)]"]
 	var/choice = alert(user, "This will only affect your current location[istype(O) ? " ([O])" : ""]. Proceed?","Confirmation", "Yes", "No")
 	if(choice != "Yes")
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -221,9 +221,9 @@
 
 	var/list/possible_locations = list()
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/O = map_sectors["[z]"]
-		for(var/obj/effect/overmap/OO in range(O,2))
-			if(OO.in_space || istype(OO,/obj/effect/overmap/sector/exoplanet))
+		var/obj/effect/overmap/visitable/O = map_sectors["[z]"]
+		for(var/obj/effect/overmap/visitable/OO in range(O,2))
+			if(OO.in_space || istype(OO,/obj/effect/overmap/visitable/sector/exoplanet))
 				possible_locations |= text2num(level)
 
 	var/newz = GLOB.using_map.get_empty_zlevel()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -105,7 +105,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 				var/zlevels = GetConnectedZlevels(z)
 				if(GLOB.using_map.use_overmap && holopadType == HOLOPAD_LONG_RANGE)
 					for(var/zlevel in map_sectors)
-						var/obj/effect/overmap/O = map_sectors["[zlevel]"]
+						var/obj/effect/overmap/visitable/O = map_sectors["[zlevel]"]
 						if(!isnull(O))
 							zlevels |= O.map_z
 				for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -236,7 +236,7 @@
 /obj/item/blueprints/outpost/get_area_type(var/area/A = get_area(src))
 	if(istype(A, /area/exoplanet))
 		return AREA_SPACE
-	var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 	if(istype(E))
 		return AREA_STATION
 	return AREA_SPECIAL

--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -52,7 +52,7 @@
 	if(grown_seed.mysterious && !grown_seed.scanned)
 		grown_seed.scanned = TRUE
 		var/area/map = locate(/area/overmap)
-		for(var/obj/effect/overmap/sector/exoplanet/P in map)
+		for(var/obj/effect/overmap/visitable/sector/exoplanet/P in map)
 			if(grown_seed in P.seeds)
 				SSstatistics.add_field(STAT_XENOPLANTS_SCANNED, 1)
 				break

--- a/code/game/objects/items/devices/scanners/xenobio.dm
+++ b/code/game/objects/items/devices/scanners/xenobio.dm
@@ -54,7 +54,7 @@
 		. += "Known toxins:\t[list_gases(A.max_gas)]"
 		. += "Temperature comfort zone:\t[A.minbodytemp] K to [A.maxbodytemp] K"
 		var/area/map = locate(/area/overmap)
-		for(var/obj/effect/overmap/sector/exoplanet/P in map)
+		for(var/obj/effect/overmap/visitable/sector/exoplanet/P in map)
 			if((A in P.animals) || is_type_in_list(A, P.repopulate_types))
 				var/list/discovered = SSstatistics.get_field(STAT_XENOFAUNA_SCANNED)
 				if(!discovered)

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -164,5 +164,5 @@
 	if(!GLOB.using_map.use_overmap)
 		return station_name()
 
-	var/obj/effect/overmap/O = map_sectors["[pick(affecting_z)]"]
+	var/obj/effect/overmap/visitable/O = map_sectors["[pick(affecting_z)]"]
 	return O ? O.name : "Unknown Location"

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -103,7 +103,7 @@
 	next_meteor_lower = 5
 	next_meteor_upper = 10
 	next_meteor = 0
-	var/obj/effect/overmap/ship/victim
+	var/obj/effect/overmap/visitable/ship/victim
 
 /datum/event/meteor_wave/overmap/Destroy()
 	victim = null

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -49,7 +49,7 @@
 	if(!CanInteract(usr, GLOB.conscious_state))
 		return
 
-	for(var/obj/effect/overmap/sector/exoplanet/E)
+	for(var/obj/effect/overmap/visitable/sector/exoplanet/E)
 		if(src in E.animals)
 			var/newname = input("What do you want to name this species?", "Species naming", E.get_random_species_name()) as text|null
 			newname = sanitizeName(newname, allow_numbers = TRUE, force_first_letter_uppercase = FALSE)

--- a/code/modules/overmap/README.dm
+++ b/code/modules/overmap/README.dm
@@ -8,18 +8,18 @@ Unless stated otherwise, you just need to place any of things below somewhere on
 # How to make new sector
 *************************************************************
 0. Map whatever.
-1. Make /obj/effect/overmap/sector/[whatever]
+1. Make /obj/effect/overmap/visitable/sector/[whatever]
 	If you want explorations shuttles be able to dock here, remember to set waypoints lists
-2. Put /obj/effect/overmap/sector/[whatever] on the map. Even if it's multiz, only one is needed, on any z.
+2. Put /obj/effect/overmap/visitable/sector/[whatever] on the map. Even if it's multiz, only one is needed, on any z.
 3. Done.
 
 *************************************************************
 # How to make new ship
 *************************************************************
 0. Map whatever.
-1. Make /obj/effect/overmap/ship/[whatever]
+1. Make /obj/effect/overmap/visitable/ship/[whatever]
 	If you want explorations shuttles be able to dock here, remember to set waypoints lists
-2. Put /obj/effect/overmap/ship/[whatever] on the map. If it's multiz, only one is needed, on any z.
+2. Put /obj/effect/overmap/visitable/ship/[whatever] on the map. If it's multiz, only one is needed, on any z.
 3. Put Helm Console anywhere on the map.
 4. Put Engines Control Console anywhere on the map.
 5. Put some engines hooked up to gas supply anywhere on the map.
@@ -28,7 +28,7 @@ Unless stated otherwise, you just need to place any of things below somewhere on
 *************************************************************
 # Overmap object
 *************************************************************
-/obj/effect/overmap
+/obj/effect/overmap/visitable
 ### WHAT IT DOES
 Lets overmap know this place should be represented on the map as a sector/ship.
 If this zlevel (or any of connected ones for multiz) doesn't have this object, you won't be able to travel there by ovemap means.

--- a/code/modules/overmap/disperser/disperser_fire.dm
+++ b/code/modules/overmap/disperser/disperser_fire.dm
@@ -58,21 +58,21 @@
 
 	var/list/candidates = list()
 
-	for(var/obj/effect/overmap_event/O in get_step(linked, overmapdir))
+	for(var/obj/effect/overmap/event/O in get_step(linked, overmapdir))
 		candidates += O
 
 	//Way to waste a charge
 	if(!length(candidates))
 		return TRUE
 
-	var/obj/effect/overmap/finaltarget = pick(candidates)
+	var/obj/effect/overmap/visitable/finaltarget = pick(candidates)
 	log_and_message_admins("A type [chargetype] disperser beam was launched at [finaltarget].", location=finaltarget)
 
 	fire_at_event(finaltarget, chargetype)
 	qdel(atomcharge)
 	return TRUE
 
-/obj/machinery/computer/ship/disperser/proc/fire_at_event(obj/effect/overmap_event/finaltarget, chargetype)
+/obj/machinery/computer/ship/disperser/proc/fire_at_event(obj/effect/overmap/event/finaltarget, chargetype)
 	if(chargetype & finaltarget.weaknesses)
 		var/turf/T = finaltarget.loc
 		qdel(finaltarget)

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet
+/obj/effect/overmap/visitable/sector/exoplanet
 	name = "exoplanet"
 	icon_state = "globe"
 	in_space = 0
@@ -47,7 +47,7 @@
 
 	var/habitability_class
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_habitability()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_habitability()
 	var/roll = rand(1,100)
 	switch(roll)
 		if(1 to 10)
@@ -57,7 +57,7 @@
 		else
 			habitability_class = HABITABILITY_BAD
 
-/obj/effect/overmap/sector/exoplanet/New(nloc, max_x, max_y)
+/obj/effect/overmap/visitable/sector/exoplanet/New(nloc, max_x, max_y)
 	if(!GLOB.using_map.use_overmap)
 		return
 
@@ -83,7 +83,7 @@
 		possible_features += new ruin
 	..()
 
-/obj/effect/overmap/sector/exoplanet/proc/build_level()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/build_level()
 	generate_habitability()
 	generate_atmosphere()
 	generate_map()
@@ -95,7 +95,7 @@
 	START_PROCESSING(SSobj, src)
 
 //attempt at more consistent history generation for xenoarch finds.
-/obj/effect/overmap/sector/exoplanet/proc/get_engravings()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_engravings()
 	if(!actors.len)
 		actors += pick("alien humanoid","an amorphic blob","a short, hairy being","a rodent-like creature","a robot","a primate","a reptilian alien","an unidentifiable object","a statue","a starship","unusual devices","a structure")
 		actors += pick("alien humanoids","amorphic blobs","short, hairy beings","rodent-like creatures","robots","primates","reptilian aliens")
@@ -108,7 +108,7 @@
 	engravings += "."
 	return engravings
 
-/obj/effect/overmap/sector/exoplanet/Process(wait, tick)
+/obj/effect/overmap/visitable/sector/exoplanet/Process(wait, tick)
 	if(animals.len < 0.5*max_animal_count && !repopulating)
 		repopulating = 1
 		max_animal_count = round(max_animal_count * 0.5)
@@ -120,8 +120,8 @@
 					var/mob_type = pick(repopulate_types)
 					var/mob/S = new mob_type(T)
 					animals += S
-					GLOB.death_event.register(S, src, /obj/effect/overmap/sector/exoplanet/proc/remove_animal)
-					GLOB.destroyed_event.register(S, src, /obj/effect/overmap/sector/exoplanet/proc/remove_animal)
+					GLOB.death_event.register(S, src, /obj/effect/overmap/visitable/sector/exoplanet/proc/remove_animal)
+					GLOB.destroyed_event.register(S, src, /obj/effect/overmap/visitable/sector/exoplanet/proc/remove_animal)
 					adapt_animal(S)
 			if(animals.len >= max_animal_count)
 				repopulating = 0
@@ -147,7 +147,7 @@
 		if(daycolumn && tick % round(daycycle_column_delay / wait) == 0)
 			update_daynight()
 
-/obj/effect/overmap/sector/exoplanet/proc/update_daynight()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/update_daynight()
 	var/light = 0.1
 	if(!night)
 		light = lightlevel
@@ -157,13 +157,13 @@
 	if(daycolumn > maxx)
 		daycolumn = 0
 
-/obj/effect/overmap/sector/exoplanet/proc/remove_animal(var/mob/M)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/remove_animal(var/mob/M)
 	animals -= M
 	GLOB.death_event.unregister(M, src)
 	GLOB.destroyed_event.unregister(M, src)
 	repopulate_types |= M.type
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_map()
 	var/list/grasscolors = plant_colors.Copy()
 	grasscolors -= "RANDOM"
 	if(length(grasscolors))
@@ -187,10 +187,10 @@
 			else
 				new map_type(null,1,1,zlevel,maxx,maxy,0,1,1)
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_features()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_features()
 	spawned_features = seedRuins(map_z, features_budget, /area/exoplanet, possible_features, maxx, maxy)
 
-/obj/effect/overmap/sector/exoplanet/proc/get_biostuff(var/datum/random_map/noise/exoplanet/random_map)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_biostuff(var/datum/random_map/noise/exoplanet/random_map)
 	if(!istype(random_map))
 		return
 	seeds += random_map.small_flora_types
@@ -199,18 +199,18 @@
 	for(var/mob/living/simple_animal/A in GLOB.living_mob_list_)
 		if(A.z in map_z)
 			animals += A
-			GLOB.death_event.register(A, src, /obj/effect/overmap/sector/exoplanet/proc/remove_animal)
-			GLOB.destroyed_event.register(A, src, /obj/effect/overmap/sector/exoplanet/proc/remove_animal)
+			GLOB.death_event.register(A, src, /obj/effect/overmap/visitable/sector/exoplanet/proc/remove_animal)
+			GLOB.destroyed_event.register(A, src, /obj/effect/overmap/visitable/sector/exoplanet/proc/remove_animal)
 	max_animal_count = animals.len
 
-/obj/effect/overmap/sector/exoplanet/proc/update_biome()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/update_biome()
 	for(var/datum/seed/S in seeds)
 		adapt_seed(S)
 
 	for(var/mob/living/simple_animal/A in animals)
 		adapt_animal(A)
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_daycycle()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_daycycle()
 	if(lightlevel)
 		night = FALSE //we start with a day if we have light.
 
@@ -218,7 +218,7 @@
 		//Otherwise the right side of the exoplanet can get stuck in a forever day.
 		daycycle = rand(10 MINUTES, 40 MINUTES)
 
-/obj/effect/overmap/sector/exoplanet/proc/adapt_seed(var/datum/seed/S)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/adapt_seed(var/datum/seed/S)
 	S.set_trait(TRAIT_IDEAL_HEAT,          atmosphere.temperature + rand(-5,5),800,70)
 	S.set_trait(TRAIT_HEAT_TOLERANCE,      S.get_trait(TRAIT_HEAT_TOLERANCE) + rand(-5,5),800,70)
 	S.set_trait(TRAIT_LOWKPA_TOLERANCE,    atmosphere.return_pressure() + rand(-5,-50),80,0)
@@ -239,7 +239,7 @@
 			S.chems[/datum/reagent/nutriment] = nutriment
 			S.chems[chem_type] = list(rand(1,10),rand(10,20))
 
-/obj/effect/overmap/sector/exoplanet/proc/adapt_animal(var/mob/living/simple_animal/A)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/adapt_animal(var/mob/living/simple_animal/A)
 	if(species[A.type])
 		A.SetName(species[A.type])
 		A.real_name = species[A.type]
@@ -273,10 +273,10 @@
 		A.min_gas = null
 		A.max_gas = null
 
-/obj/effect/overmap/sector/exoplanet/proc/get_random_species_name()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_random_species_name()
 	return pick("nol","shan","can","fel","xor")+pick("a","e","o","t","ar")+pick("ian","oid","ac","ese","inian","rd")
 
-/obj/effect/overmap/sector/exoplanet/proc/rename_species(var/species_type, var/newname, var/force = FALSE)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/rename_species(var/species_type, var/newname, var/force = FALSE)
 	if(species[species_type] && !force)
 		return FALSE
 
@@ -290,7 +290,7 @@
 	return TRUE
 
 //Tries to generate num landmarks, but avoids repeats.
-/obj/effect/overmap/sector/exoplanet/proc/generate_landing(num = 1)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing(num = 1)
 	var/places = list()
 	var/attempts = 10*num
 	var/new_type = landmark_type
@@ -319,7 +319,7 @@
 		places += T
 		new new_type(T)
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_atmosphere()
 	atmosphere = new
 	if(habitability_class == HABITABILITY_IDEAL)
 		atmosphere.adjust_gas(GAS_OXYGEN, MOLES_O2STANDARD, 0)
@@ -364,7 +364,7 @@
 			total_moles = max(total_moles - part, 0)
 			i++
 
-/obj/effect/overmap/sector/exoplanet/get_scan_data(mob/user)
+/obj/effect/overmap/visitable/sector/exoplanet/get_scan_data(mob/user)
 	. = ..()
 	var/list/extra_data = list("<hr>")
 	if(atmosphere)
@@ -396,15 +396,15 @@
 
 	. += jointext(extra_data, "<br>")
 
-/obj/effect/overmap/sector/exoplanet/get_skybox_representation()
+/obj/effect/overmap/visitable/sector/exoplanet/get_skybox_representation()
 	return skybox_image
 
-/obj/effect/overmap/sector/exoplanet/proc/get_base_image()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_base_image()
 	var/image/base = image('icons/skybox/planet.dmi', "base")
 	base.color = get_surface_color()
 	return base
 
-/obj/effect/overmap/sector/exoplanet/proc/generate_planet_image()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_planet_image()
 	skybox_image = image('icons/skybox/planet.dmi', "")
 
 	skybox_image.overlays += get_base_image()
@@ -455,10 +455,10 @@
 	skybox_image.pixel_y = rand(128,256)
 	skybox_image.appearance_flags = RESET_COLOR
 
-/obj/effect/overmap/sector/exoplanet/proc/get_surface_color()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_surface_color()
 	return surface_color
 
-/obj/effect/overmap/sector/exoplanet/proc/get_atmosphere_color()
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_atmosphere_color()
 	var/list/colors = list()
 	for(var/g in atmosphere.gas)
 		if(gas_data.tile_overlay_color[g])

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/barren
+/obj/effect/overmap/visitable/sector/exoplanet/barren
 	name = "barren exoplanet"
 	desc = "An exoplanet that couldn't hold its atmosphere."
 	color = "#847c6f"
@@ -11,10 +11,10 @@
 	surface_color = "#847c6f"
 	water_color = null
 
-/obj/effect/overmap/sector/exoplanet/barren/generate_habitability()
+/obj/effect/overmap/visitable/sector/exoplanet/barren/generate_habitability()
 	return HABITABILITY_BAD
 
-/obj/effect/overmap/sector/exoplanet/barren/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/barren/generate_atmosphere()
 	..()
 	atmosphere.remove_ratio(0.9)
 

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/chlorine
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine
 	name = "chlorine exoplanet"
 	desc = "An exoplanet with a chlorine based ecosystem. Large quantities of liquid chlorine are present."
 	color = "#efff7c"
@@ -10,20 +10,20 @@
 	surface_color = "#a3b879"
 	water_color = COLOR_BOTTLE_GREEN
 
-/obj/effect/overmap/sector/exoplanet/chlorine/generate_habitability()
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_habitability()
 	return HABITABILITY_BAD
 
-/obj/effect/overmap/sector/exoplanet/chlorine/get_atmosphere_color()
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine/get_atmosphere_color()
 	return "#e5f2bd"
 
-/obj/effect/overmap/sector/exoplanet/chlorine/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_map()
 	if(prob(50))
 		lightlevel = rand(7,10)/10 //It could be night.
 	else
 		lightlevel = 0.1
 	..()
 
-/obj/effect/overmap/sector/exoplanet/chlorine/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_atmosphere()
 	..()
 	if(atmosphere)
 		atmosphere.adjust_gas(GAS_CHLORINE, MOLES_O2STANDARD)

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/desert
+/obj/effect/overmap/visitable/sector/exoplanet/desert
 	name = "desert exoplanet"
 	desc = "An arid exoplanet with sparse biological resources but rich mineral deposits underground."
 	color = "#d6cca4"
@@ -9,12 +9,12 @@
 	surface_color = "#d6cca4"
 	water_color = null
 
-/obj/effect/overmap/sector/exoplanet/desert/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/desert/generate_map()
 	if(prob(70))
 		lightlevel = rand(5,10)/10	//deserts are usually :lit:
 	..()
 
-/obj/effect/overmap/sector/exoplanet/desert/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/desert/generate_atmosphere()
 	..()
 	if(atmosphere)
 		var/limit = 1000
@@ -24,7 +24,7 @@
 		atmosphere.temperature = min(T20C + rand(20, 100), limit)
 		atmosphere.update_values()
 
-/obj/effect/overmap/sector/exoplanet/desert/adapt_seed(var/datum/seed/S)
+/obj/effect/overmap/visitable/sector/exoplanet/desert/adapt_seed(var/datum/seed/S)
 	..()
 	if(prob(90))
 		S.set_trait(TRAIT_REQUIRES_WATER,0)

--- a/code/modules/overmap/exoplanets/planet_types/garbage.dm
+++ b/code/modules/overmap/exoplanets/planet_types/garbage.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/garbage
+/obj/effect/overmap/visitable/sector/exoplanet/garbage
 	name = "ruined exoplanet"
 	desc = "An arid exoplanet with unnatural formations covering the surface. Hotspots of radiation detected."
 	color = "#a5a18b"
@@ -9,18 +9,18 @@
 	surface_color = "#a5a18b"
 	water_color = null
 
-/obj/effect/overmap/sector/exoplanet/garbage/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/garbage/generate_map()
 	if(prob(50))
 		lightlevel = rand(5,10)/10	//deserts are usually :lit:
 	..()
 
-/obj/effect/overmap/sector/exoplanet/garbage/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/garbage/generate_atmosphere()
 	..()
 	if(atmosphere)
 		atmosphere.temperature = T20C + rand(20, 100)
 		atmosphere.update_values()
 
-/obj/effect/overmap/sector/exoplanet/garbage/update_biome()
+/obj/effect/overmap/visitable/sector/exoplanet/garbage/update_biome()
 	..()
 	for(var/datum/seed/S in seeds)
 		if(prob(90))
@@ -31,11 +31,11 @@
 		if(prob(40))
 			S.set_trait(TRAIT_STINGS,1)
 
-/obj/effect/overmap/sector/exoplanet/garbage/adapt_animal(var/mob/living/simple_animal/A)
+/obj/effect/overmap/visitable/sector/exoplanet/garbage/adapt_animal(var/mob/living/simple_animal/A)
 	..()
 	A.faction = "Guardian" //stops bots form hitting each other
 
-/obj/effect/overmap/sector/exoplanet/garbage/get_base_image()
+/obj/effect/overmap/visitable/sector/exoplanet/garbage/get_base_image()
 	var/image/I = ..()
 	I.overlays += image('icons/skybox/planet.dmi', "ruins")
 	return I

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/grass
+/obj/effect/overmap/visitable/sector/exoplanet/grass
 	name = "lush exoplanet"
 	desc = "Planet with abundant flora and fauna."
 	color = "#538224"
@@ -7,21 +7,21 @@
 	plant_colors = list("#0e1e14","#1a3e38","#5a7467","#9eab88","#6e7248", "RANDOM")
 	map_generators = list(/datum/random_map/noise/exoplanet/grass)
 
-/obj/effect/overmap/sector/exoplanet/grass/generate_map()
+/obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
 	if(prob(40))
 		lightlevel = rand(1,7)/10	//give a chance of twilight jungle
 	..()
 
-/obj/effect/overmap/sector/exoplanet/grass/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/grass/generate_atmosphere()
 	..()
 	if(atmosphere)
 		atmosphere.temperature = T20C + rand(10, 30)
 		atmosphere.update_values()
 
-/obj/effect/overmap/sector/exoplanet/grass/get_surface_color()
+/obj/effect/overmap/visitable/sector/exoplanet/grass/get_surface_color()
 	return grass_color
 
-/obj/effect/overmap/sector/exoplanet/grass/adapt_seed(var/datum/seed/S)
+/obj/effect/overmap/visitable/sector/exoplanet/grass/adapt_seed(var/datum/seed/S)
 	..()
 	var/carnivore_prob = rand(100)
 	if(carnivore_prob < 30)
@@ -77,7 +77,7 @@
 /turf/simulated/floor/exoplanet/grass/Initialize()
 	. = ..()
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E) && E.grass_color)
 			color = E.grass_color
 	if(!resources)

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/shrouded
+/obj/effect/overmap/visitable/sector/exoplanet/shrouded
 	name = "shrouded exoplanet"
 	desc = "An exoplanet shrouded in a perpetual storm of bizzare, light absorbing particles."
 	color = "#3e3960"
@@ -11,13 +11,13 @@
 	surface_color = "#3e3960"
 	water_color = "#2b2840"
 
-/obj/effect/overmap/sector/exoplanet/shrouded/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/shrouded/generate_atmosphere()
 	..()
 	if(atmosphere)
 		atmosphere.temperature = T20C - rand(10, 20)
 		atmosphere.update_values()
 
-/obj/effect/overmap/sector/exoplanet/shrouded/get_atmosphere_color()
+/obj/effect/overmap/visitable/sector/exoplanet/shrouded/get_atmosphere_color()
 	return COLOR_BLACK
 
 /datum/random_map/noise/exoplanet/shrouded

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/snow
+/obj/effect/overmap/visitable/sector/exoplanet/snow
 	name = "snow exoplanet"
 	desc = "Cold planet with limited plant life."
 	color = "#e8faff"
@@ -9,7 +9,7 @@
 	surface_color = "#e8faff"
 	water_color = "#b5dfeb"
 
-/obj/effect/overmap/sector/exoplanet/snow/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/snow/generate_atmosphere()
 	..()
 	if(atmosphere)
 		var/limit = 0

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/sector/exoplanet/volcanic
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic
 	name = "volcanic exoplanet"
 	desc = "A tectonically unstable planet, extremely rich in minerals."
 	color = "#8e3900"
@@ -11,24 +11,24 @@
 	surface_color = "#261e19"
 	water_color = "#c74d00"
 
-/obj/effect/overmap/sector/exoplanet/volcanic/get_atmosphere_color()
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic/get_atmosphere_color()
 	return COLOR_GRAY20
 
-/obj/effect/overmap/sector/exoplanet/volcanic/generate_habitability()
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_habitability()
 	return HABITABILITY_BAD
 
-/obj/effect/overmap/sector/exoplanet/volcanic/generate_atmosphere()
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_atmosphere()
 	..()
 	if(atmosphere)
 		atmosphere.temperature = T20C + rand(220, 800)
 		atmosphere.update_values()
 
-/obj/effect/overmap/sector/exoplanet/volcanic/adapt_seed(var/datum/seed/S)
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic/adapt_seed(var/datum/seed/S)
 	..()
 	S.set_trait(TRAIT_REQUIRES_WATER,0)
 	S.set_trait(TRAIT_HEAT_TOLERANCE, 1000 + S.get_trait(TRAIT_HEAT_TOLERANCE))
 
-/obj/effect/overmap/sector/exoplanet/volcanic/adapt_animal(var/mob/living/simple_animal/A)
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic/adapt_animal(var/mob/living/simple_animal/A)
 	..()
 	A.heat_damage_per_tick = 0 //animals not hot, no burning in lava
 

--- a/code/modules/overmap/exoplanets/theme.dm
+++ b/code/modules/overmap/exoplanets/theme.dm
@@ -1,7 +1,7 @@
 /datum/exoplanet_theme
 	var/name = "Nothing Special"
 
-/datum/exoplanet_theme/proc/before_map_generation(obj/effect/overmap/sector/exoplanet/E)
+/datum/exoplanet_theme/proc/before_map_generation(obj/effect/overmap/visitable/sector/exoplanet/E)
 
 /datum/exoplanet_theme/proc/get_planet_image_extra()
 
@@ -9,7 +9,7 @@
 	name = "Mountains"
 	var/rock_color
 
-/datum/exoplanet_theme/mountains/before_map_generation(obj/effect/overmap/sector/exoplanet/E)
+/datum/exoplanet_theme/mountains/before_map_generation(obj/effect/overmap/visitable/sector/exoplanet/E)
 	rock_color = pick(E.rock_colors)
 	for(var/zlevel in E.map_z)
 		new /datum/random_map/automata/cave_system/mountains(null,TRANSITIONEDGE,TRANSITIONEDGE,zlevel,E.maxx-TRANSITIONEDGE,E.maxy-TRANSITIONEDGE,0,1,1, E.planetary_area, rock_color)

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -13,7 +13,7 @@
 
 /turf/simulated/floor/exoplanet/New()
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E))
 			if(E.atmosphere)
 				initial_gas = E.atmosphere.gas.Copy()
@@ -114,7 +114,7 @@
 
 /turf/simulated/planet_edge/Initialize()
 	. = ..()
-	var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 	if(!istype(E))
 		return
 	var/nx = x
@@ -141,7 +141,7 @@
 
 /turf/simulated/planet_edge/Bumped(atom/movable/A)
 	. = ..()
-	var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 	if(!istype(E))
 		return
 	if(E.planetary_area && istype(loc, world.area))

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -1,0 +1,36 @@
+/obj/effect/overmap
+	name = "map object"
+	icon = 'icons/obj/overmap.dmi'
+	icon_state = "object"
+
+	var/known = 1		//shows up on nav computers automatically
+	var/scannable       //if set to TRUE will show up on ship sensors for detailed scans
+
+//Overlay of how this object should look on other skyboxes
+/obj/effect/overmap/proc/get_skybox_representation()
+	return
+
+/obj/effect/overmap/proc/get_scan_data(mob/user)
+	return desc
+
+/obj/effect/overmap/Initialize()
+	. = ..()
+	if(!GLOB.using_map.use_overmap)
+		return INITIALIZE_HINT_QDEL
+	
+	if(known)
+		layer = ABOVE_LIGHTING_LAYER
+		plane = EFFECTS_ABOVE_LIGHTING_PLANE
+		for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
+			H.get_known_sectors()
+
+/obj/effect/overmap/Crossed(var/obj/effect/overmap/visitable/other)
+	if(istype(other))
+		for(var/obj/effect/overmap/visitable/O in loc)
+			SSskybox.rebuild_skyboxes(O.map_z)
+
+/obj/effect/overmap/Uncrossed(var/obj/effect/overmap/visitable/other)
+	if(istype(other))
+		SSskybox.rebuild_skyboxes(other.map_z)
+		for(var/obj/effect/overmap/visitable/O in loc)
+			SSskybox.rebuild_skyboxes(O.map_z)

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -62,7 +62,7 @@
 
 /datum/shuttle/autodock/overmap/proc/get_possible_destinations()
 	var/list/res = list()
-	for (var/obj/effect/overmap/S in range(get_turf(waypoint_sector(current_location)), range))
+	for (var/obj/effect/overmap/visitable/S in range(get_turf(waypoint_sector(current_location)), range))
 		var/list/waypoints = S.get_waypoints(name)
 		for(var/obj/effect/shuttle_landmark/LZ in waypoints)
 			if(LZ.is_valid(src))

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -19,7 +19,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 /obj/machinery/computer/ship/helm/proc/get_known_sectors()
 	var/area/overmap/map = locate() in world
-	for(var/obj/effect/overmap/sector/S in map)
+	for(var/obj/effect/overmap/visitable/sector/S in map)
 		if (S.known)
 			var/datum/computer_file/data/waypoint/R = new()
 			R.fields["name"] = S.name
@@ -70,7 +70,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		display_reconnect_dialog(user, "helm")
 	else
 		var/turf/T = get_turf(linked)
-		var/obj/effect/overmap/sector/current_sector = locate() in T
+		var/obj/effect/overmap/visitable/sector/current_sector = locate() in T
 
 		data["sector"] = current_sector ? current_sector.name : "Deep Space"
 		data["sector_info"] = current_sector ? current_sector.desc : "Not Available"
@@ -222,7 +222,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 
 	var/turf/T = get_turf(linked)
-	var/obj/effect/overmap/sector/current_sector = locate() in T
+	var/obj/effect/overmap/visitable/sector/current_sector = locate() in T
 
 	data["sector"] = current_sector ? current_sector.name : "Deep Space"
 	data["sector_info"] = current_sector ? current_sector.desc : "Not Available"

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -6,7 +6,7 @@
 	extra_view = 4
 	var/obj/machinery/shipsensors/sensors
 
-/obj/machinery/computer/ship/sensors/attempt_hook_up(obj/effect/overmap/ship/sector)
+/obj/machinery/computer/ship/sensors/attempt_hook_up(obj/effect/overmap/visitable/ship/sector)
 	if(!(. = ..()))
 		return
 	find_sensors()
@@ -45,6 +45,8 @@
 		var/list/contacts = list()
 		for(var/obj/effect/overmap/O in view(7,linked))
 			if(linked == O)
+				continue
+			if(!O.scannable)
 				continue
 			var/bearing = round(90 - Atan2(O.x - linked.x, O.y - linked.y),5)
 			if(bearing < 0)

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -1,15 +1,15 @@
 /*
 While these computers can be placed anywhere, they will only function if placed on either a non-space, non-shuttle turf
-with an /obj/effect/overmap/ship present elsewhere on that z level, or else placed in a shuttle area with an /obj/effect/overmap/ship
+with an /obj/effect/overmap/visitable/ship present elsewhere on that z level, or else placed in a shuttle area with an /obj/effect/overmap/visitable/ship
 somewhere on that shuttle. Subtypes of these can be then used to perform ship overmap movement functions.
 */
 /obj/machinery/computer/ship
-	var/obj/effect/overmap/ship/linked
+	var/obj/effect/overmap/visitable/ship/linked
 	var/list/viewers // Weakrefs to mobs in direct-view mode.
 	var/extra_view = 0 // how much the view is increased by when the mob is in overmap mode.
 
 // A late init operation called in SSshuttle, used to attach the thing to the right ship.
-/obj/machinery/computer/ship/proc/attempt_hook_up(obj/effect/overmap/ship/sector)
+/obj/machinery/computer/ship/proc/attempt_hook_up(obj/effect/overmap/visitable/ship/sector)
 	if(!istype(sector))
 		return
 	if(sector.check_ownership(src))
@@ -17,15 +17,15 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		return 1
 
 /obj/machinery/computer/ship/proc/sync_linked()
-	var/obj/effect/overmap/ship/sector = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/ship/sector = map_sectors["[z]"]
 	if(!sector)
 		return
 	return attempt_hook_up_recursive(sector)
 
-/obj/machinery/computer/ship/proc/attempt_hook_up_recursive(obj/effect/overmap/ship/sector)
+/obj/machinery/computer/ship/proc/attempt_hook_up_recursive(obj/effect/overmap/visitable/ship/sector)
 	if(attempt_hook_up(sector))
 		return sector
-	for(var/obj/effect/overmap/ship/candidate in sector)
+	for(var/obj/effect/overmap/visitable/ship/candidate in sector)
 		if((. = .(candidate)))
 			return
 

--- a/code/modules/overmap/ships/engines/engine.dm
+++ b/code/modules/overmap/ships/engines/engine.dm
@@ -39,7 +39,7 @@ var/list/ship_engines = list()
 
 /datum/ship_engine/Destroy()
 	ship_engines -= src
-	for(var/obj/effect/overmap/ship/S in SSshuttle.ships)
+	for(var/obj/effect/overmap/visitable/ship/S in SSshuttle.ships)
 		S.engines -= src
 	holder = null
 	. = ..()

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -87,7 +87,7 @@
 	update_nearby_tiles(need_rebuild=1)
 
 	for(var/ship in SSshuttle.ships)
-		var/obj/effect/overmap/ship/S = ship
+		var/obj/effect/overmap/visitable/ship/S = ship
 		if(S.check_ownership(src))
 			S.engines |= controller
 			if(dir != S.fore_dir)

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -2,7 +2,7 @@
 // Mapping location doesn't matter, so long as on a map loaded at the same time as the shuttle areas.
 // Multiz shuttles currently not supported. Non-autodock shuttles currently not supported.
 
-/obj/effect/overmap/ship/landable
+/obj/effect/overmap/visitable/ship/landable
 	var/shuttle                                         // Name of associated shuttle. Must be autodock.
 	var/obj/effect/shuttle_landmark/ship/landmark       // Record our open space landmark for easy reference.
 	var/multiz = 0										// Index of multi-z levels, starts at 0
@@ -10,21 +10,21 @@
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
 
-/obj/effect/overmap/ship/landable/Destroy()
+/obj/effect/overmap/visitable/ship/landable/Destroy()
 	GLOB.shuttle_moved_event.unregister(SSshuttle.shuttles[shuttle], src)
 	return ..()
 
-/obj/effect/overmap/ship/landable/can_burn()
+/obj/effect/overmap/visitable/ship/landable/can_burn()
 	if(status != SHIP_STATUS_OVERMAP)
 		return 0
 	return ..()
 
-/obj/effect/overmap/ship/landable/burn()
+/obj/effect/overmap/visitable/ship/landable/burn()
 	if(status != SHIP_STATUS_OVERMAP)
 		return 0
 	return ..()
 
-/obj/effect/overmap/ship/landable/check_ownership(obj/object)
+/obj/effect/overmap/visitable/ship/landable/check_ownership(obj/object)
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	if(!shuttle_datum)
 		return
@@ -33,7 +33,7 @@
 		return 1
 
 // We autobuild our z levels.
-/obj/effect/overmap/ship/landable/find_z_levels()
+/obj/effect/overmap/visitable/ship/landable/find_z_levels()
 	for(var/i = 0 to multiz)
 		world.maxz++
 		map_z += world.maxz
@@ -62,13 +62,13 @@
 	name ="carpspawn"
 	movable_flags = MOVABLE_FLAG_DEL_SHUTTLE
 
-/obj/effect/overmap/ship/landable/get_areas()
+/obj/effect/overmap/visitable/ship/landable/get_areas()
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	if(!shuttle_datum)
 		return list()
 	return shuttle_datum.find_childfree_areas()
 
-/obj/effect/overmap/ship/landable/populate_sector_objects()
+/obj/effect/overmap/visitable/ship/landable/populate_sector_objects()
 	..()
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	GLOB.shuttle_moved_event.register(shuttle_datum, src, .proc/on_shuttle_jump)
@@ -87,7 +87,7 @@
 	. = ..()
 
 /obj/effect/shuttle_landmark/ship/Destroy()
-	var/obj/effect/overmap/ship/landable/ship = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/ship/landable/ship = map_sectors["[z]"]
 	if(istype(ship) && ship.landmark == src)
 		ship.landmark = null
 	. = ..()
@@ -132,7 +132,7 @@
 		GLOB.shuttle_moved_event.unregister(shuttle, src)
 		LAZYREMOVE(core_landmark.visitors, src)
 
-/obj/effect/overmap/ship/landable/proc/on_shuttle_jump(datum/shuttle/given_shuttle, obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
+/obj/effect/overmap/visitable/ship/landable/proc/on_shuttle_jump(datum/shuttle/given_shuttle, obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
 	if(given_shuttle != SSshuttle.shuttles[shuttle])
 		return
 	var/datum/shuttle/autodock/auto = given_shuttle
@@ -147,11 +147,11 @@
 	status = SHIP_STATUS_LANDED
 	on_landing(from, into)
 
-/obj/effect/overmap/ship/landable/proc/on_landing(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
-	var/obj/effect/overmap/target = map_sectors["[into.z]"]
+/obj/effect/overmap/visitable/ship/landable/proc/on_landing(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
+	var/obj/effect/overmap/visitable/target = map_sectors["[into.z]"]
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	if(into.landmark_tag == shuttle_datum.motherdock) // If our motherdock is a landable ship, it won't be found properly here so we need to find it manually.
-		for(var/obj/effect/overmap/ship/landable/landable in SSshuttle.ships)
+		for(var/obj/effect/overmap/visitable/ship/landable/landable in SSshuttle.ships)
 			if(landable.shuttle == shuttle_datum.mothershuttle)
 				target = landable
 				break
@@ -160,18 +160,18 @@
 	forceMove(target)
 	halt()
 
-/obj/effect/overmap/ship/landable/proc/on_takeoff(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
+/obj/effect/overmap/visitable/ship/landable/proc/on_takeoff(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
 	if(!isturf(loc))
 		forceMove(get_turf(loc))
 		unhalt()
 
-/obj/effect/overmap/ship/landable/get_landed_info()
+/obj/effect/overmap/visitable/ship/landable/get_landed_info()
 	switch(status)
 		if(SHIP_STATUS_LANDED)
-			var/obj/effect/overmap/location = loc
-			if(istype(loc, /obj/effect/overmap/sector))
+			var/obj/effect/overmap/visitable/location = loc
+			if(istype(loc, /obj/effect/overmap/visitable/sector))
 				return "Landed on \the [location.name]. Use secondary thrust to get clear before activating primary engines."
-			if(istype(loc, /obj/effect/overmap/ship))
+			if(istype(loc, /obj/effect/overmap/visitable/ship))
 				return "Docked with \the [location.name]. Use secondary thrust to get clear before activating primary engines."
 			return "Docked with an unknown object."
 		if(SHIP_STATUS_TRANSIT)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -3,12 +3,12 @@ var/list/cached_space = list()
 
 //Space stragglers go here
 
-/obj/effect/overmap/sector/temporary
+/obj/effect/overmap/visitable/sector/temporary
 	name = "Deep Space"
 	invisibility = 101
 	known = 0
 
-/obj/effect/overmap/sector/temporary/New(var/nx, var/ny, var/nz)
+/obj/effect/overmap/visitable/sector/temporary/New(var/nx, var/ny, var/nz)
 	loc = locate(nx, ny, GLOB.using_map.overmap_z)
 	x = nx
 	y = ny
@@ -16,11 +16,11 @@ var/list/cached_space = list()
 	map_sectors["[nz]"] = src
 	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [nz].")
 
-/obj/effect/overmap/sector/temporary/Destroy()
+/obj/effect/overmap/visitable/sector/temporary/Destroy()
 	map_sectors["[map_z]"] = null
 	testing("Temporary sector at [x],[y] was deleted.")
 
-/obj/effect/overmap/sector/temporary/proc/can_die(var/mob/observer)
+/obj/effect/overmap/visitable/sector/temporary/proc/can_die(var/mob/observer)
 	testing("Checking if sector at [map_z[1]] can die.")
 	for(var/mob/M in GLOB.player_list)
 		if(M != observer && M.z in map_z)
@@ -29,7 +29,7 @@ var/list/cached_space = list()
 	return 1
 
 proc/get_deepspace(x,y)
-	var/obj/effect/overmap/sector/temporary/res = locate(x,y,GLOB.using_map.overmap_z)
+	var/obj/effect/overmap/visitable/sector/temporary/res = locate(x,y,GLOB.using_map.overmap_z)
 	if(istype(res))
 		return res
 	else if(cached_space.len)
@@ -39,7 +39,7 @@ proc/get_deepspace(x,y)
 		res.y = y
 		return res
 	else
-		return new /obj/effect/overmap/sector/temporary(x, y, GLOB.using_map.get_empty_zlevel())
+		return new /obj/effect/overmap/visitable/sector/temporary(x, y, GLOB.using_map.get_empty_zlevel())
 
 /atom/movable/proc/lost_in_space()
 	for(var/atom/movable/AM in contents)
@@ -54,7 +54,7 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	if (!T || !A)
 		return
 
-	var/obj/effect/overmap/M = map_sectors["[T.z]"]
+	var/obj/effect/overmap/visitable/M = map_sectors["[T.z]"]
 	if (!M)
 		return
 
@@ -86,8 +86,8 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	testing("[A] spacemoving from [M] ([M.x], [M.y]).")
 
 	var/turf/map = locate(M.x,M.y,GLOB.using_map.overmap_z)
-	var/obj/effect/overmap/TM
-	for(var/obj/effect/overmap/O in map)
+	var/obj/effect/overmap/visitable/TM
+	for(var/obj/effect/overmap/visitable/O in map)
 		if(O != M && O.in_space && prob(50))
 			TM = O
 			break
@@ -103,8 +103,8 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 			if(D.pulling)
 				D.pulling.forceMove(dest)
 
-	if(istype(M, /obj/effect/overmap/sector/temporary))
-		var/obj/effect/overmap/sector/temporary/source = M
+	if(istype(M, /obj/effect/overmap/visitable/sector/temporary))
+		var/obj/effect/overmap/visitable/sector/temporary/source = M
 		if (source.can_die())
 			testing("Caching [M] for future use")
 			source.forceMove(null)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -182,7 +182,7 @@ var/list/solars_list = list()
 	// On planets, we take fewer steps because the light is mostly up
 	// Also, many planets barely have any spots with enough clear space around
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E))
 			steps = 5
 

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -47,14 +47,14 @@
 	if(!istype(docking_controller))
 		log_error("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/location = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/location = map_sectors["[z]"]
 		if(location && location.docking_codes)
 			docking_controller.docking_codes = location.docking_codes
 
 /obj/effect/shuttle_landmark/forceMove()
-	var/obj/effect/overmap/map_origin = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/map_origin = map_sectors["[z]"]
 	. = ..()
-	var/obj/effect/overmap/map_destination = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/map_destination = map_sectors["[z]"]
 	if(map_origin != map_destination)
 		if(map_origin)
 			map_origin.remove_landmark(src, shuttle_restricted)
@@ -62,7 +62,7 @@
 			map_destination.add_landmark(src, shuttle_restricted)
 
 //Called when the landmark is added to an overmap sector.
-/obj/effect/shuttle_landmark/proc/sector_set(var/obj/effect/overmap/O, shuttle_name)
+/obj/effect/shuttle_landmark/proc/sector_set(var/obj/effect/overmap/visitable/O, shuttle_name)
 	shuttle_restricted = shuttle_name
 
 /obj/effect/shuttle_landmark/proc/is_valid(var/datum/shuttle/shuttle)
@@ -104,7 +104,7 @@
 	landmark_tag += "-[x]-[y]-[z]-[random_id("landmarks",1,9999)]"
 	return ..()
 
-/obj/effect/shuttle_landmark/automatic/sector_set(var/obj/effect/overmap/O)
+/obj/effect/shuttle_landmark/automatic/sector_set(var/obj/effect/overmap/visitable/O)
 	..()
 	SetName("[O.name] - [initial(name)] ([x],[y])")
 

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -27,7 +27,7 @@
 	if(active_docking_controller)
 		set_docking_codes(active_docking_controller.docking_codes)
 	else if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/location = map_sectors["[current_location.z]"]
+		var/obj/effect/overmap/visitable/location = map_sectors["[current_location.z]"]
 		if(location && location.docking_codes)
 			set_docking_codes(location.docking_codes)
 	dock()

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -64,7 +64,7 @@
 		qdel(src)
 		return
 
-	var/obj/effect/overmap/cell = map_sectors["[associated_z]"]
+	var/obj/effect/overmap/visitable/cell = map_sectors["[associated_z]"]
 	if(istype(cell))
 		sync_cell(cell)
 
@@ -86,7 +86,7 @@
 	if(archetype && archetype.call_webhook)
 		SSwebhooks.send(archetype.call_webhook, list("name" = name))
 
-/datum/submap/proc/sync_cell(var/obj/effect/overmap/cell)
+/datum/submap/proc/sync_cell(var/obj/effect/overmap/visitable/cell)
 	name = cell.name
 
 /datum/submap/proc/available()

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -59,7 +59,7 @@
 
 	var/engravings = ""
 	if(apply_image_decorations)
-		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		engravings = "[pick("Engraved","Carved","Etched")] on the item is [pick("an image of","a frieze of","a depiction of")] "
 		if(istype(E))
 			engravings += E.get_engravings()

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -4,7 +4,7 @@
 /datum/unit_test/generic_shuttle_landmarks_shall_not_appear_in_restricted_list/start_test()
 	var/fail = FALSE
 
-	for(var/obj/effect/overmap/sector in world)
+	for(var/obj/effect/overmap/visitable/sector in world)
 		var/list/failures = list()
 		for(var/generic in sector.initial_generic_waypoints)
 			for(var/shuttle in sector.initial_restricted_waypoints)

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -355,7 +355,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/effect/overmap/ship/ascent_seedship,
+/obj/effect/overmap/visitable/ship/ascent_seedship,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
 "bl" = (
@@ -3666,7 +3666,7 @@
 /obj/machinery/computer/shuttle_control/explore/ascent{
 	dir = 1
 	},
-/obj/effect/overmap/ship/landable/ascent,
+/obj/effect/overmap/visitable/ship/landable/ascent,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "iD" = (
@@ -4529,7 +4529,7 @@
 /area/ship/ascent/fore_starboard_prow)
 "vF" = (
 /obj/machinery/computer/ship/engines/ascent,
-/obj/effect/overmap/ship/landable/ascent/two,
+/obj/effect/overmap/visitable/ship/landable/ascent/two,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_starboard)
 "vY" = (

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -17,7 +17,7 @@
 	)
 
 // Overmap objects.
-/obj/effect/overmap/ship/ascent_seedship
+/obj/effect/overmap/visitable/ship/ascent_seedship
 	name = ASCENT_COLONY_SHIP_NAME
 	desc = "Wake signature indicates a small to medium sized vessel of unknown design."
 	vessel_mass = 6500

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -22,7 +22,7 @@
 /datum/submap/ascent
 	var/gyne_name
 
-/datum/submap/ascent/sync_cell(obj/effect/overmap/cell)
+/datum/submap/ascent/sync_cell(obj/effect/overmap/visitable/cell)
 	return
 
 /datum/submap/ascent/check_general_join_blockers(var/mob/new_player/joining, var/datum/job/submap/job)

--- a/maps/away/ascent/ascent_shuttles.dm
+++ b/maps/away/ascent/ascent_shuttles.dm
@@ -1,7 +1,7 @@
 // Submap shuttles.
 // Trichoptera - Shuttle One, Port Side
 // Lepidoptera - Shuttle Two, Starboard Side
-/obj/effect/overmap/ship/landable/ascent
+/obj/effect/overmap/visitable/ship/landable/ascent
 	name = "Trichoptera"
 	shuttle = "Trichoptera"
 	moving_state = "ship_moving"
@@ -12,7 +12,7 @@
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_SMALL
 
-/obj/effect/overmap/ship/landable/ascent/two
+/obj/effect/overmap/visitable/ship/landable/ascent/two
 	name = "Lepidoptera"
 	shuttle = "Lepidoptera"
 	fore_dir = NORTH

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -110,7 +110,7 @@
 /turf/space,
 /area/space)
 "aq" = (
-/obj/effect/overmap/ship/bearcat,
+/obj/effect/overmap/visitable/ship/bearcat,
 /turf/space,
 /area/space)
 "ar" = (

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -14,14 +14,14 @@
 		/datum/job/submap/bearcat_crewman
 	)
 
-/obj/effect/overmap/ship/bearcat
+/obj/effect/overmap/visitable/ship/bearcat
 	name = "light freighter"
 	color = "#00ffff"
 	vessel_mass = 60
 	max_speed = 1/(10 SECONDS)
 	burn_delay = 10 SECONDS
 
-/obj/effect/overmap/ship/bearcat/New()
+/obj/effect/overmap/visitable/ship/bearcat/New()
 	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")]"
 	for(var/area/ship/scrap/A)
 		A.name = "\improper [name] - [A.name]"

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -64,7 +64,7 @@
 	},
 /area/bluespaceriver/ground)
 "al" = (
-/obj/effect/overmap/sector/arcticplanet{
+/obj/effect/overmap/visitable/sector/arcticplanet{
 	desc = "Sensor array an arctic planet with a small vessle on the surface. The vessle is located in the western region of a plateu surrounded by mineral rich mountains on all four sides. Scans further indicate strange energy levels below the planet's surface. Sunrise expected in 56 hours."
 	},
 /turf/simulated/floor/exoplanet/snow{

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -1,6 +1,6 @@
 //quality code theft
 #include "blueriver_areas.dm"
-/obj/effect/overmap/sector/arcticplanet
+/obj/effect/overmap/visitable/sector/arcticplanet
 	name = "arctic planetoid"
 	desc = "Sensor array detects an arctic planet with a small vessle on the planet's surface. Scans further indicate strange energy levels below the planet's surface."
 	in_space = 0
@@ -12,7 +12,7 @@
 		"nav_blueriv_antag"
 	)
 
-/obj/effect/overmap/sector/arcticplanet/New(nloc, max_x, max_y)
+/obj/effect/overmap/visitable/sector/arcticplanet/New(nloc, max_x, max_y)
 	name = "[generate_planet_name()], \a [name]"
 	..()
 

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -1,7 +1,7 @@
 #include "casino_areas.dm"
 #include "../mining/mining_areas.dm"
 
-/obj/effect/overmap/ship/casino
+/obj/effect/overmap/visitable/ship/casino
 	name = "passenger liner"
 	desc = "Sensors detect an undamaged vessel without any signs of activity."
 	color = "#bd6100"
@@ -20,7 +20,7 @@
 		"Casino Cutter" = list("nav_casino_hangar"),
 	)
 
-/obj/effect/overmap/ship/casino/New(nloc, max_x, max_y)
+/obj/effect/overmap/visitable/ship/casino/New(nloc, max_x, max_y)
 	name = "IPV [pick("Fortuna","Gold Rush","Ebisu","Lucky Paw","Four Leaves")], \a [name]"
 	..()
 

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -1483,7 +1483,7 @@
 /turf/simulated/floor/shuttle/yellow,
 /area/casino/casino_cutter)
 "eb" = (
-/obj/effect/overmap/ship/casino,
+/obj/effect/overmap/visitable/ship/casino,
 /turf/space,
 /area/space)
 "ec" = (

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1921,7 +1921,7 @@
 /turf/simulated/floor/tiled/dark/airless,
 /area/constructionsite/hallway/fore)
 "fT" = (
-/obj/effect/overmap/sector/derelict,
+/obj/effect/overmap/visitable/sector/derelict,
 /turf/simulated/floor/airless,
 /area/constructionsite/solar)
 "fU" = (
@@ -2574,7 +2574,7 @@
 	pressure_setting = 2000;
 	sensor_tag = "d_air_sensor";
 	sensor_name = "Air Supply Tank";
-
+	
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -1,6 +1,6 @@
 #include "derelict_areas.dm"
 
-/obj/effect/overmap/sector/derelict
+/obj/effect/overmap/visitable/sector/derelict
 	name = "debris field"
 	desc = "A large field of miscellanious debris."
 	icon_state = "object"

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -1,6 +1,6 @@
 #include "errant_pisces_areas.dm"
 
-/obj/effect/overmap/ship/errant_pisces
+/obj/effect/overmap/visitable/ship/errant_pisces
 	name = "XCV Ahab's Harpoon"
 	desc = "Sensors detect civilian vessel with unusual signs of life aboard."
 	color = "#bd6100"

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -6415,7 +6415,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "pz" = (
-/obj/effect/overmap/ship/errant_pisces,
+/obj/effect/overmap/visitable/ship/errant_pisces,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "pA" = (

--- a/maps/away/icarus/icarus-2.dmm
+++ b/maps/away/icarus/icarus-2.dmm
@@ -125,7 +125,7 @@
 /area/icarus/vessel)
 "aB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/overmap/sector/icarus,
+/obj/effect/overmap/visitable/sector/icarus,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "aD" = (

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -1,6 +1,6 @@
 #include "icarus_areas.dm"
 
-/obj/effect/overmap/sector/icarus
+/obj/effect/overmap/visitable/sector/icarus
 	name = "forest planetoid"
 	desc = "Sensors detect anomalous radiation area with the presence of artificial structures."
 	icon_state = "globe"
@@ -12,7 +12,7 @@
 		"nav_icarus_antag"
 	)
 
-/obj/effect/overmap/sector/icarus/New(nloc, max_x, max_y)
+/obj/effect/overmap/visitable/sector/icarus/New(nloc, max_x, max_y)
 	name = "[generate_planet_name()], \a [name]"
 	..()
 

--- a/maps/away/lar_maria/lar_maria-2.dmm
+++ b/maps/away/lar_maria/lar_maria-2.dmm
@@ -21,7 +21,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "af" = (
-/obj/effect/overmap/sector/lar_maria,
+/obj/effect/overmap/visitable/sector/lar_maria,
 /turf/simulated/floor/reinforced,
 /area/space)
 "ag" = (

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -1,6 +1,6 @@
 #include "lar_maria_areas.dm"
 
-/obj/effect/overmap/sector/lar_maria
+/obj/effect/overmap/visitable/sector/lar_maria
 	name = "Lar Maria space station"
 	desc = "Sensors detect an orbital station with low energy profile and sporadic life signs."
 	icon_state = "object"

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -1,7 +1,7 @@
 #include "lost_supply_base_areas.dm"
 #include "../mining/mining_areas.dm"
 
-/obj/effect/overmap/sector/lost_supply_base
+/obj/effect/overmap/visitable/sector/lost_supply_base
 	name = "supply station"
 	desc = "This looks like abandoned and heavy damaged supply station."
 	icon_state = "object"

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -589,7 +589,7 @@
 /turf/space,
 /area/space)
 "bp" = (
-/obj/effect/overmap/sector/lost_supply_base,
+/obj/effect/overmap/visitable/sector/lost_supply_base,
 /turf/space,
 /area/space)
 "bq" = (

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -1,6 +1,6 @@
 #include "magshield_areas.dm"
 
-/obj/effect/overmap/sector/magshield
+/obj/effect/overmap/visitable/sector/magshield
 	name = "orbital station"
 	desc = "Sensors detect an orbital station above the exoplanet. Sporadic magentic impulses are registred inside it. Planet landing is impossible due to lower orbits being cluttered with chaotically moving metal chunks."
 	icon_state = "object"

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -2279,7 +2279,7 @@
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "fH" = (
-/obj/effect/overmap/sector/magshield,
+/obj/effect/overmap/visitable/sector/magshield,
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "fI" = (

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -207,7 +207,7 @@
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
 "bf" = (
-/obj/effect/overmap/sector/cluster,
+/obj/effect/overmap/visitable/sector/cluster,
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
 "cb" = (

--- a/maps/away/mining/mining-orb.dmm
+++ b/maps/away/mining/mining-orb.dmm
@@ -128,7 +128,7 @@
 /turf/simulated/mineral,
 /area/mine/explored)
 "aT" = (
-/obj/effect/overmap/sector/orb,
+/obj/effect/overmap/visitable/sector/orb,
 /turf/simulated/wall/alium,
 /area/mine/explored)
 "aU" = (

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -2546,7 +2546,7 @@
 /area/outpost/abandoned)
 "hL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/overmap/sector/away,
+/obj/effect/overmap/visitable/sector/away,
 /turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "ib" = (

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -1,7 +1,7 @@
 #include "mining_areas.dm"
 
 //MINING-1 // CLUSTER
-/obj/effect/overmap/sector/cluster
+/obj/effect/overmap/visitable/sector/cluster
 	name = "asteroid cluster"
 	desc = "Large group of asteroids. Mineral content detected."
 	icon_state = "sector"
@@ -16,10 +16,10 @@
 	)
 	known = 0
 
-/obj/effect/overmap/sector/cluster/generate_skybox()
+/obj/effect/overmap/visitable/sector/cluster/generate_skybox()
 	return overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
 
-/obj/effect/overmap/sector/cluster/get_skybox_representation()
+/obj/effect/overmap/visitable/sector/cluster/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
 	res.transform *= 0.5
 	return res
@@ -72,7 +72,7 @@
 	base_area = /area/mine/explored
 
 //MINING-2 // SIGNAL
-/obj/effect/overmap/sector/away
+/obj/effect/overmap/visitable/sector/away
 	name = "faint signal from an asteroid"
 	desc = "Faint signal detected, originating from the human-made structures on the site's surface."
 	icon_state = "sector"
@@ -87,10 +87,10 @@
 	)
 	known = 0
 
-/obj/effect/overmap/sector/away/generate_skybox()
+/obj/effect/overmap/visitable/sector/away/generate_skybox()
 	return overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
 
-/obj/effect/overmap/sector/away/get_skybox_representation()
+/obj/effect/overmap/visitable/sector/away/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
 	res.transform *= 0.3
 	return res
@@ -142,7 +142,7 @@
 	landmark_tag = "nav_away_7"
 
 //MINING-3 // THE ORB
-/obj/effect/overmap/sector/orb
+/obj/effect/overmap/visitable/sector/orb
 	name = "monolithic asteroid"
 	desc = "Substantial mineral resources detected."
 	icon_state = "sector"
@@ -157,7 +157,7 @@
 	)
 	known = 0
 
-/obj/effect/overmap/sector/orb/get_skybox_representation()
+/obj/effect/overmap/visitable/sector/orb/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/skybox_rock_128.dmi', "bigrock", COLOR_ASTEROID_ROCK, RESET_COLOR)
 	res.pixel_x = rand(256,512)
 	res.pixel_y = rand(256,512)

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -1,6 +1,6 @@
 #include "mobius_rift_areas.dm"
 
-/obj/effect/overmap/sector/mobius_rift
+/obj/effect/overmap/visitable/sector/mobius_rift
 	name = "unusual asteroid"
 	desc = "Sensors error: ERROR #E0x003141592: recursive stack overflow for CALCULATE_APPROXIMATE_SIZE()."
 	icon_state = "object"

--- a/maps/away/mobius_rift/mobius_rift.dmm
+++ b/maps/away/mobius_rift/mobius_rift.dmm
@@ -62,7 +62,7 @@
 /area/mobius_rift)
 "r" = (
 /obj/effect/mobius_rift/portals_setup,
-/obj/effect/overmap/sector/mobius_rift,
+/obj/effect/overmap/visitable/sector/mobius_rift,
 /obj/effect/shuttle_landmark/automatic,
 /turf/unsimulated/beach/sand,
 /area/mobius_rift)

--- a/maps/away/skrellscoutship/skrellscoutship-1.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-1.dmm
@@ -642,7 +642,7 @@
 	icon_state = "computer";
 	dir = 4
 	},
-/obj/effect/overmap/ship/landable/skrellscoutshuttle,
+/obj/effect/overmap/visitable/ship/landable/skrellscoutshuttle,
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutshuttle)
 "bM" = (

--- a/maps/away/skrellscoutship/skrellscoutship-2.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship-2.dmm
@@ -499,7 +499,7 @@
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/command/bridge)
 "bu" = (
-/obj/effect/overmap/ship/landable/skrellscoutship,
+/obj/effect/overmap/visitable/ship/landable/skrellscoutship,
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
@@ -1474,7 +1474,7 @@
 /obj/effect/landmark/map_data{
 	height = 2
 	},
-/obj/effect/overmap/sector/skrellscoutspace,
+/obj/effect/overmap/visitable/sector/skrellscoutspace,
 /turf/space,
 /area/space)
 "dj" = (

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -17,7 +17,7 @@
 		/area/ship/skrellscoutship/solars =            NO_SCRUBBER|NO_VENT|NO_APC
 	)
 
-/obj/effect/overmap/sector/skrellscoutspace
+/obj/effect/overmap/visitable/sector/skrellscoutspace
 	name = "Empty Sector"
 	desc = "Slight traces of a cloaking device are present. Unable to determine exact location."
 	in_space = 1

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -8,7 +8,7 @@
 	req_access = list(access_skrellscoutship)
 	shuttle_tag = "Skrellian Shuttle"
 
-/obj/effect/overmap/ship/landable/skrellscoutship
+/obj/effect/overmap/visitable/ship/landable/skrellscoutship
 	name = "light skrellian vessel"
 	shuttle = "Skrellian Scout"
 	multiz = 1
@@ -23,11 +23,11 @@
 	)
 
 
-/obj/effect/overmap/ship/landable/skrellscoutship/New()
+/obj/effect/overmap/visitable/ship/landable/skrellscoutship/New()
 	name = "SSV [pick("Xilvuxix", "Zuuvixix", "Quizuu", "Vulzxixvuu","Quumzoox","Quuvuzxuu")]"
 	..()
 
-/obj/effect/overmap/ship/landable/skrellscoutshuttle
+/obj/effect/overmap/visitable/ship/landable/skrellscoutshuttle
 	name = "SSV-S"
 	shuttle = "Skrellian Shuttle"
 	fore_dir = WEST

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -1,7 +1,7 @@
 #include "slavers_base_areas.dm"
 #include "../mining/mining_areas.dm"
 
-/obj/effect/overmap/sector/slavers_base
+/obj/effect/overmap/visitable/sector/slavers_base
 	name = "large asteroid"
 	desc = "Sensor array is reading an artificial structure inside the asteroid."
 	icon_state = "object"

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -4313,7 +4313,7 @@
 /turf/space,
 /area/slavers_base/maint)
 "kW" = (
-/obj/effect/overmap/sector/slavers_base,
+/obj/effect/overmap/visitable/sector/slavers_base,
 /turf/space,
 /area/space)
 "kX" = (

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -1,7 +1,7 @@
 #include "smugglers_areas.dm"
 #include "../mining/mining_areas.dm"
 
-/obj/effect/overmap/sector/smugglers
+/obj/effect/overmap/visitable/sector/smugglers
 	name = "asteroid station"
 	desc = "A small station built into an asteroid. No radio traffic detected."
 	icon_state = "object"

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -13,7 +13,7 @@
 /turf/space,
 /area/space)
 "ae" = (
-/obj/effect/overmap/sector/smugglers,
+/obj/effect/overmap/visitable/sector/smugglers,
 /turf/space,
 /area/space)
 "af" = (
@@ -447,6 +447,7 @@
 "aX" = (
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor,
@@ -499,6 +500,7 @@
 "bf" = (
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/item/weapon/tank/air{
 	pixel_x = 5
@@ -547,6 +549,7 @@
 "bm" = (
 /obj/structure/table/rack{
 	dir = 8;
+	
 	},
 /obj/random/voidsuit,
 /obj/random/voidhelmet,

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/effect/overmap/ship/unishi{
+/obj/effect/overmap/visitable/ship/unishi{
 	color = "green"
 	},
 /turf/space,

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -13,7 +13,7 @@
 		/datum/job/submap/unishi_researcher
 	)
 
-/obj/effect/overmap/ship/unishi
+/obj/effect/overmap/visitable/ship/unishi
 	name = "SRV Verne"
 	desc = "Sensor array detects unknown class medium size vessel. The vessel appears unarmed.\
 	A small amount of radiation has been detected at the aft of the ship"

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -1844,11 +1844,11 @@
 	},
 /area/voxship/base)
 "eY" = (
-/obj/effect/overmap/sector/vox_base,
+/obj/effect/overmap/visitable/sector/vox_base,
 /turf/space,
 /area/space)
 "eZ" = (
-/obj/effect/overmap/ship/landable/vox,
+/obj/effect/overmap/visitable/ship/landable/vox,
 /turf/space,
 /area/space)
 "fa" = (

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -12,7 +12,7 @@
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 
-/obj/effect/overmap/sector/vox_base
+/obj/effect/overmap/visitable/sector/vox_base
 	name = "large asteroid"
 	desc = "Sensor array detects a large asteroid."
 	in_space = 1
@@ -50,7 +50,7 @@
 	name = "shuttle control console"
 	shuttle_tag = "Vox Shuttle"
 
-/obj/effect/overmap/ship/landable/vox
+/obj/effect/overmap/visitable/ship/landable/vox
 	name = "Unknown Signature"
 	shuttle = "Vox Shuttle"
 	fore_dir = NORTH

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -1,6 +1,6 @@
 #include "yacht_areas.dm"
 
-/obj/effect/overmap/ship/yacht
+/obj/effect/overmap/visitable/ship/yacht
 	name = "private yacht"
 	desc = "Sensor array is detecting a small vessel with unknown lifeforms on board"
 	color = "#ffc966"
@@ -13,7 +13,7 @@
 		"nav_yacht_antag"
 	)
 
-/obj/effect/overmap/ship/yacht/New(nloc, max_x, max_y)
+/obj/effect/overmap/visitable/ship/yacht/New(nloc, max_x, max_y)
 	name = "IPV [pick("Razorshark", "Aurora", "Lighting", "Pequod", "Anansi")], \a [name]"
 	..()
 

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/effect/overmap/ship/yacht,
+/obj/effect/overmap/visitable/ship/yacht,
 /turf/space,
 /area/space)
 "ac" = (

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -51,7 +51,7 @@
 /turf/space,
 /area/space)
 "ak" = (
-/obj/effect/overmap/ship/bearcat,
+/obj/effect/overmap/visitable/ship/bearcat,
 /turf/space,
 /area/space)
 "ar" = (

--- a/maps/bearcat/bearcat_jobs.dm
+++ b/maps/bearcat/bearcat_jobs.dm
@@ -30,7 +30,7 @@
 		return
 	GLOB.using_map.station_short = ship
 	GLOB.using_map.station_name = "FTV [ship]"
-	var/obj/effect/overmap/ship/bearcat/B = locate() in world
+	var/obj/effect/overmap/visitable/ship/bearcat/B = locate() in world
 	if(B)
 		B.SetName(GLOB.using_map.station_name)
 	command_announcement.Announce("Attention all hands on [GLOB.using_map.station_name]! Thank you for your attention.", "Ship re-christened")

--- a/maps/bearcat/bearcat_overmap.dm
+++ b/maps/bearcat/bearcat_overmap.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/ship/bearcat
+/obj/effect/overmap/visitable/ship/bearcat
 	name = "FTV Bearcat"
 	color = "#00ffff"
 	start_x = 4

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	descriptor = "crashed survival pod"
 	crew_jobs = list(/datum/job/submap/pod)
 
-/datum/submap/crashed_pod/sync_cell(var/obj/effect/overmap/cell)
+/datum/submap/crashed_pod/sync_cell(var/obj/effect/overmap/visitable/cell)
 	cell.has_distress_beacon = name
 
 /datum/job/submap/pod

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -24,7 +24,7 @@
 	if(A)
 		color = A.icon_colour
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E))
 			desc += "\nThere are images on it: [E.get_engravings()]"
 	update_icon()
@@ -48,7 +48,7 @@
 /obj/structure/monolith/attack_hand(mob/user)
 	visible_message("[user] touches \the [src].")
 	if(GLOB.using_map.use_overmap && istype(user,/mob/living/carbon/human))
-		var/obj/effect/overmap/sector/exoplanet/E = map_sectors["[z]"]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E))
 			var/mob/living/carbon/human/H = user
 			if(!H.isSynthetic())

--- a/maps/torch/datums/department_exploration.dm
+++ b/maps/torch/datums/department_exploration.dm
@@ -20,7 +20,7 @@
 /datum/goal/department/plant_samples/New()
 	var/total_seeds = 0
 	var/area/map = locate(/area/overmap)
-	for(var/obj/effect/overmap/sector/exoplanet/P in map)
+	for(var/obj/effect/overmap/visitable/sector/exoplanet/P in map)
 		total_seeds += P.seeds.len
 	if(total_seeds)
 		seeds = max(1, round(0.5 * total_seeds))
@@ -42,7 +42,7 @@
 /datum/goal/department/fauna_samples/New()
 	var/list/total_species = list()
 	var/area/map = locate(/area/overmap)
-	for(var/obj/effect/overmap/sector/exoplanet/P in map)
+	for(var/obj/effect/overmap/visitable/sector/exoplanet/P in map)
 		for(var/mob/living/simple_animal/A in P.animals)
 			total_species |= A.type
 	species = rand(length(total_species))

--- a/maps/torch/items/manuals.dm
+++ b/maps/torch/items/manuals.dm
@@ -83,7 +83,7 @@
 
 /obj/item/weapon/folder/envelope/captain/LateInitialize()
 	..()
-	var/obj/effect/overmap/torch = map_sectors["[z]"]
+	var/obj/effect/overmap/visitable/torch = map_sectors["[z]"]
 	var/memo = {"
 	<tt><center><b><font color='red'>SECRET - CODE WORDS: TORCH</font></b>
 	<h3>SOL CENTRAL GOVERNMENT EXPEDITIONARY COMMAND</h3>

--- a/maps/torch/items/solbanner.dm
+++ b/maps/torch/items/solbanner.dm
@@ -45,7 +45,7 @@
 	if(user.unEquip(src))
 		forceMove(T)
 		if(GLOB.using_map.use_overmap)
-			var/obj/effect/overmap/sector/exoplanet/P = map_sectors["[z]"]
+			var/obj/effect/overmap/visitable/sector/exoplanet/P = map_sectors["[z]"]
 			if(istype(P))
 				SSstatistics.add_field(STAT_FLAGS_PLANTED, 1)
 		qdel(src)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -1128,7 +1128,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "cA" = (
-/obj/effect/overmap/ship/landable/guppy,
+/obj/effect/overmap/visitable/ship/landable/guppy,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
@@ -2120,7 +2120,7 @@
 	dir = 4
 	},
 /obj/effect/shuttle_landmark/torch/hangar/exploration_shuttle,
-/obj/effect/overmap/ship/landable/exploration_shuttle,
+/obj/effect/overmap/visitable/ship/landable/exploration_shuttle,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/airlock)
 "el" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -6687,7 +6687,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/overmap/ship/landable/aquila,
+/obj/effect/overmap/visitable/ship/landable/aquila,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/airlock)
 "nn" = (
@@ -13451,7 +13451,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "HK" = (
-/obj/effect/overmap/ship/torch,
+/obj/effect/overmap/visitable/ship/torch,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "HP" = (

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -1,4 +1,4 @@
-/obj/effect/overmap/ship/torch
+/obj/effect/overmap/visitable/ship/torch
 	name = "SEV Torch"
 	desc = "A bluespace-capable corvette bearing markings of the SCG Expeditionary Corps."
 	fore_dir = WEST
@@ -68,7 +68,7 @@
 		"nav_ert_dock"
 	)
 
-/obj/effect/overmap/ship/landable/exploration_shuttle
+/obj/effect/overmap/visitable/ship/landable/exploration_shuttle
 	name = "Charon"
 	desc = "A medium-sized long-range shuttle. It bears markings of the SCG Expeditionary Corps."
 	shuttle = "Charon"
@@ -79,7 +79,7 @@
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_SMALL
 
-/obj/effect/overmap/ship/landable/aquila
+/obj/effect/overmap/visitable/ship/landable/aquila
 	name = "Aquila"
 	desc = "A vessel escort gunship. It bears markings of the SCG Fleet."
 	shuttle = "Aquila"
@@ -89,7 +89,7 @@
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL
 
-/obj/effect/overmap/ship/landable/guppy
+/obj/effect/overmap/visitable/ship/landable/guppy
 	name = "Guppy"
 	desc = "A small general utility pod. It's capable of limited independant space travel. It's marked as TORCH GUP #1"
 	shuttle = "Guppy"

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -16,7 +16,7 @@
 	welcome_text += "<hr>Current system:<br /><b>[system_name()]</b><br /><br>"
 
 	var/list/space_things = list()
-	var/obj/effect/overmap/torch = map_sectors["1"]
+	var/obj/effect/overmap/visitable/torch = map_sectors["1"]
 
 	welcome_text += "Current Coordinates:<br /><b>[torch.x]:[torch.y]</b><br /><br>"
 	welcome_text += "Next system targeted for jump:<br /><b>[generate_system_name()]</b><br /><br>"
@@ -25,15 +25,15 @@
 	welcome_text += "Scan results show the following points of interest:<br />"
 	
 	for(var/zlevel in map_sectors)
-		var/obj/effect/overmap/O = map_sectors[zlevel]
+		var/obj/effect/overmap/visitable/O = map_sectors[zlevel]
 		if(O.name == torch.name)
 			continue
-		if(istype(O, /obj/effect/overmap/ship/landable)) //Don't show shuttles
+		if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles
 			continue
 		space_things |= O
 
 	var/list/distress_calls
-	for(var/obj/effect/overmap/O in space_things)
+	for(var/obj/effect/overmap/visitable/O in space_things)
 		var/location_desc = " at present co-ordinates."
 		if(O.loc != torch.loc)
 			var/bearing = round(90 - Atan2(O.x - torch.x, O.y - torch.y),5) //fucking triangles how do they work

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -271,8 +271,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		return
 
 	for(var/i = 0, i < num_exoplanets, i++)
-		var/exoplanet_type = pick(subtypesof(/obj/effect/overmap/sector/exoplanet))
-		var/obj/effect/overmap/sector/exoplanet/new_planet = new exoplanet_type(null, planet_size[1], planet_size[2])
+		var/exoplanet_type = pick(subtypesof(/obj/effect/overmap/visitable/sector/exoplanet))
+		var/obj/effect/overmap/visitable/sector/exoplanet/new_planet = new exoplanet_type(null, planet_size[1], planet_size[2])
 		new_planet.build_level()
 
 // Used to apply various post-compile procedural effects to the map.


### PR DESCRIPTION
Now basic overmap object is just an object, like an event. It can be scanned, it gives skybox overlay, that's about it. Overmap events use it now (set to non-scannable for now to prevent sensors spam)

Proper overmap objects are repathed to /visitable

No actual changes.

Idea is to make sure there's common root for all things you see on overmap, and to provide ability to create non-visitable objects that can still be scanned / looked at in skybox / otherwise interacted with.