### PR TITLE
Fire tweaks, chapter 1.

### DIFF
--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -37,7 +37,10 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 	if(air_contents.check_combustability(liquid))
 		igniting = 1
-
+		var/datum/effect/effect/system/smoke_spread/bad/smoke = new /datum/effect/effect/system/smoke_spread/bad()
+		smoke.attach(src)
+		smoke.set_up(10, 0, usr.loc)
+		smoke.start()
 		create_fire(exposed_temperature)
 	return igniting
 
@@ -314,6 +317,10 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		//calculate the energy produced by the reaction and then set the new temperature of the mix
 		temperature = (starting_energy + vsc.fire_fuel_energy_release * (used_gas_fuel + used_liquid_fuel)) / heat_capacity()
 		update_values()
+
+		if (temperature<273)
+			firelevel = 0
+			return firelevel
 
 		#ifdef FIREDBG
 		log_debug("used_gas_fuel = [used_gas_fuel]; used_liquid_fuel = [used_liquid_fuel]; total = [used_fuel]")


### PR DESCRIPTION
:cl: Flying_loulou
tweak: Law of physics, rejoice !!! A fire will now stop under 273 kelvins.
rscadd: Liquid combustion now produce smoke.
/:cl:

**A fire will now stop under 273 kelvins.**
This is to prevent this meme where you're in a room at -100°C with a hydrogen fire still going on. However if the temperature is close to 0°C (around -10 or so) the fire struggling (tiles will ignite and extinguish themselves repeatedly) will heat the room enough to make the fire great again (makes sense, if a room is filled with hydrogen, even if it's at -10°C I'd imagine it can still catch fire).

**Liquid fuel fires now create smoke.**
Well fire makes smoke, duh. I didn't add it to gazeous fire because they make much less smoke.