### PR TITLE
Makes bullets etc less likely to blow off limbs

### DIFF
--- a/code/modules/organs/_organ_setup.dm
+++ b/code/modules/organs/_organ_setup.dm
@@ -1,6 +1,6 @@
 //These control the damage thresholds for the various ways of removing limbs
 #define DROPLIMB_THRESHOLD_EDGE 5
-#define DROPLIMB_THRESHOLD_TEAROFF 2
+#define DROPLIMB_THRESHOLD_TEAROFF 1.5
 #define DROPLIMB_THRESHOLD_DESTROY 1
 
 #define ORGAN_RECOVERY_THRESHOLD (5 MINUTES)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -49,7 +49,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			var/total_damage = brute_dam + burn_dam + brute + burn + spillover
 			var/threshold = max_damage * config.organ_health_multiplier
 			if(total_damage > threshold)
-				if(attempt_dismemberment(pure_brute, burn, edge, used_weapon, spillover, total_damage > threshold*6))
+				if(attempt_dismemberment(pure_brute, burn, sharp, edge, used_weapon, spillover, total_damage > threshold*6))
 					return
 
 	//blunt damage is gud at fracturing
@@ -351,7 +351,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 //2. If the damage amount dealt exceeds the disintegrate threshold, the organ is completely obliterated.
 //3. If the organ has already reached or would be put over it's max damage amount (currently redundant),
 //   and the brute damage dealt exceeds the tearoff threshold, the organ is torn off.
-/obj/item/organ/external/proc/attempt_dismemberment(brute, burn, edge, used_weapon, spillover, force_droplimb)
+/obj/item/organ/external/proc/attempt_dismemberment(brute, burn, sharp, edge, used_weapon, spillover, force_droplimb)
 	//Check edge eligibility
 	var/edge_eligible = 0
 	if(edge)
@@ -361,7 +361,8 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 				edge_eligible = 1
 		else
 			edge_eligible = 1
-
+	else if(sharp)
+		brute = 0.5 * brute
 	if(force_droplimb)
 		if(burn)
 			droplimb(0, DROPLIMB_BURN)


### PR DESCRIPTION
Sharp, but not edged, attacks now have halved effective damage for purposes of checking if they can remove a limb.
Thresholds for non-edged attacks tearing off things raised a bit in general.
