### PR TITLE
Limit some Topic calls

### DIFF
--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -239,6 +239,9 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	var/mob/pref_mob = preference_mob()
 	if(!pref_mob || !pref_mob.client)
 		return 1
+	// If the usr isn't trying to alter their own mob then they must instead be an admin
+	if(usr != pref_mob || !check_rights(R_ADMIN, 0, usr))
+		return 1
 
 	. = OnTopic(href, href_list, usr)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -96,7 +96,11 @@
 				if(player.ready)totalPlayersReady++
 
 /mob/new_player/Topic(href, href_list[])
-	if(!client)	return 0
+	// These return values are 0 as to not interfere with ..() calls in unexpected ways
+	if(!client)
+		return 0
+	if(usr != src)
+		return 0
 
 	if(href_list["show_preferences"])
 		client.prefs.ShowChoices(src)


### PR DESCRIPTION
Only the preference "owner" or an admin may edit character preferences
`new_player`-Topic now requires that `usr` and `src` is the same