### PR TITLE
NTNet Downloads no longer download the file too early

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -59,7 +59,7 @@
 	if(PRG.available_on_syndinet && !computer.emagged())
 		return 0
 
-	if(!computer || !computer.store_file(PRG))
+	if(!computer || !computer.try_store_file(PRG))
 		return 0
 
 	return 1

--- a/code/modules/modular_computers/ntos/files.dm
+++ b/code/modules/modular_computers/ntos/files.dm
@@ -34,6 +34,11 @@
 	else
 		return TRUE
 
+/datum/extension/interactive/ntos/proc/try_store_file(var/datum/computer_file/file, var/obj/item/weapon/stock_parts/computer/hard_drive/disk = get_component(PART_HDD))
+	if(!disk)
+		return FALSE
+	return disk.try_store_file(file)
+
 /datum/extension/interactive/ntos/proc/save_file(var/newname, var/data, var/file_type = /datum/computer_file/data, var/list/metadata, var/obj/item/weapon/stock_parts/computer/hard_drive/disk = get_component(PART_HDD))
 	if(!disk)
 		return FALSE


### PR DESCRIPTION
Fixes #27250 

The file was being downloaded when `check_file_download` was called (right after you tell the NT Downloader to start downloading a program), and then again when the download actually completed. 

So I changed that part to use the hard drive function try_store_file() rather than store_file() 

:cl:
bugfix: NTNet downloads will no longer download the file at the beginning of the download sequence, instead only adding the new program at the end of the download timer.
/:cl: