### PR TITLE
Tweaks geiger counter thresholds and volume

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -206,9 +206,9 @@
 #define ERROR_USEFUL_LEN 2
 
 #define RAD_LEVEL_LOW 1 // Around the level at which radiation starts to become harmful
-#define RAD_LEVEL_MODERATE 5
-#define RAD_LEVEL_HIGH 20
-#define RAD_LEVEL_VERY_HIGH 40
+#define RAD_LEVEL_MODERATE 25
+#define RAD_LEVEL_HIGH 40
+#define RAD_LEVEL_VERY_HIGH 100
 
 #define RADIATION_THRESHOLD_CUTOFF 0.1	// Radiation will not affect a tile when below this value.
 

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -71,7 +71,7 @@
 			sound_token.SetVolume(geiger_volume)
 		if(RAD_LEVEL_LOW + 0.01 to RAD_LEVEL_MODERATE)
 			icon_state = "geiger_on_2"
-			geiger_volume = 16
+			geiger_volume = 10
 			sound_token.SetVolume(geiger_volume)
 		if(RAD_LEVEL_MODERATE + 0.1 to RAD_LEVEL_HIGH)
 			icon_state = "geiger_on_3"


### PR DESCRIPTION
Easier on ears when exploring rad planets.
it now mirrors armor value defines more or less, 'moderate' is rads that are above 'small' armor value, high above 'resistant', very high is VERY HIGH YOURE FUCKED WITHOUT RADPROOF SUIT.
Lowers volume for low-level rad a bit.

:cl: Chinsky
tweak: Geiger counter thresholds have been tweaked upwards, 'high' is now for rads that will breach most non-radproof suits, 'very high' is dangerous even to 'radproof' suits.
/:cl: