### PR TITLE
Nerfs girders

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -5,7 +5,7 @@
 	layer = BELOW_OBJ_LAYER
 	w_class = ITEM_SIZE_NO_CONTAINER
 	var/state = 0
-	var/health = 200
+	var/health = 100
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0
@@ -40,12 +40,14 @@
 	if(!istype(Proj, /obj/item/projectile/beam))
 		damage *= 0.4 //non beams do reduced damage
 
+	..()
+	take_damage(damage)
+
+/obj/structure/girder/take_damage(damage)
 	health -= damage
 	..()
 	if(health <= 0)
 		dismantle()
-
-	return
 
 /obj/structure/girder/CanFluidPass(var/coming_from)
 	return TRUE
@@ -139,6 +141,7 @@
 				return ..()
 
 	else
+		take_damage(W.force)
 		return ..()
 
 /obj/structure/girder/proc/construct_wall(obj/item/stack/material/S, mob/user)


### PR DESCRIPTION
:cl:
tweak: Wall girders are now easier to take down using brute force
/:cl:

Slashes their health and makes them take damage from melee attacks.
Getting indestructible grider after smashing a wall down with melee wapon is super frustrating.
