### PR TITLE
Makes vat-grown early bloomers.

### DIFF
--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -76,12 +76,12 @@
 	default_cultural_info = list(
 		TAG_CULTURE = CULTURE_HUMAN_VATGROWN
 	)
-	/datum/species/human/vatgrown/skills_from_age(age)
-		switch(age)
-			if(17 to 19)	. = -4
-			if(20 to 25)	. = 0
-			if(26 to 35)	. = 4
-			else			. = 8
+/datum/species/human/vatgrown/skills_from_age(age)
+	switch(age)
+		if(17 to 19)	. = -4
+		if(20 to 25)	. = 0
+		if(26 to 35)	. = 4
+		else			. = 8
 			
 
 /datum/species/human/tritonian

--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -76,6 +76,13 @@
 	default_cultural_info = list(
 		TAG_CULTURE = CULTURE_HUMAN_VATGROWN
 	)
+	/datum/species/human/vatgrown/skills_from_age(age)
+		switch(age)
+			if(17 to 19)	. = -4
+			if(20 to 25)	. = 0
+			if(26 to 35)	. = 4
+			else			. = 8
+			
 
 /datum/species/human/tritonian
 	name = SPECIES_TRITONIAN


### PR DESCRIPTION
Causes vat-grown to gain their age based skillpoint increases earlier, without changing the final total. A small positive to balance out the increased toxmod and risk of major organ failure.

:cl:
tweak: Made vat-grown humans gain age-based skill points earlier than normal humans.
/:cl: