### PR TITLE
Fixes #27569 Gives alternate pen types their own names

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -28,23 +28,27 @@
 
 
 /obj/item/weapon/pen/blue
+	name = "blue pen"
 	desc = "It's a normal blue ink pen."
 	icon_state = "pen_blue"
 	colour = "blue"
 	color_description = "blue ink"
 
 /obj/item/weapon/pen/red
+	name = "red pen"
 	desc = "It's a normal red ink pen."
 	icon_state = "pen_red"
 	colour = "red"
 	color_description = "red ink"
 
 /obj/item/weapon/pen/green
+	name = "green pen"
 	desc = "It's a normal green ink pen."
 	icon_state = "pen_green"
 	colour = "green"
 
 /obj/item/weapon/pen/multi
+	name = "multicoloured pen"
 	desc = "It's a pen with multiple colors of ink!"
 	var/selectedColor = 1
 	var/colors = list("black","blue","red","green")


### PR DESCRIPTION
:cl:
bugfix: Different pen types (blue, red, multicoloured, black) now have different names. They will now appear as differently named items on the autolathe list.
/:cl:

Fixes #27569 