### PR TITLE
Surg borg fixes

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -6,7 +6,8 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, list(
 	/obj/item/weapon/reagent_containers/hypospray,
 	/obj/item/modular_computer,
 	/obj/item/weapon/reagent_containers/syringe,
-	/obj/item/device/antibody_scanner
+	/obj/item/device/antibody_scanner,
+	/obj/item/weapon/reagent_containers/borghypo
 ))
 GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 


### PR DESCRIPTION
:cl:
bugfix: Surgical borgs can now use their hypospray on targets that are on an operating table.
/:cl:
