### PR TITLE
Boiling a giant spider leg no longer keeps the name the same

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -470,8 +470,7 @@
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/spider/Initialize()
-	.=..()
-	name = "giant spider leg" //since most mobs use a generic meat type and append the name of the mob onto it ('parrot meat')
+	. = ..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 9)
 
 /obj/item/weapon/reagent_containers/food/snacks/spider/cooked


### PR DESCRIPTION
:cl:
bugfix: The 'boiled spider meat' recipe now correctly produces an item called 'boiled spider meat' rather than 'giant spider leg'.
/:cl:

Fixes #27579 