### PR TITLE
Supermatter now checks for all sources of meson vision

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -338,3 +338,9 @@
 	if(isSynthetic())
 		return // Can't cure disabilites, so don't give them.
 	..()
+
+/mob/living/carbon/human/proc/has_meson_effect()
+	. = FALSE
+	for(var/obj/screen/equipment_screen in equipment_overlays) // check through our overlays to see if we have any source of the meson overlay
+		if (equipment_screen.icon_state == "meson_hud")
+			return TRUE

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -397,10 +397,8 @@
 			continue
 		if (BP_IS_ROBOTIC(eyes))
 			continue
-		if (istype(subject.glasses, /obj/item/clothing/glasses/meson))
-			var/obj/item/clothing/glasses/meson/mesons = subject.glasses
-			if (mesons.active)
-				continue
+		if(subject.has_meson_effect())
+			continue
 		var/effect = max(0, min(200, power * config_hallucination_power * sqrt( 1 / max(1,get_dist(subject, src)))) )
 		subject.adjust_hallucination(effect, 0.25 * effect)
 


### PR DESCRIPTION
:cl:
bugfix: Supermatter hallucination effect now checks for any source of meson vision, rather than just meson glasses. Other sources of meson vision, e.g. the hardsuit module will now properly stop hallucinations from developing when active.
/:cl:

Fixes #27574 