### PR TITLE
Emitter control button no longer goes invisible when clicked

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -91,11 +91,11 @@
 //alternate button with the same functionality, except has a door control sprite instead
 /obj/machinery/button/alternate
 	icon = 'icons/obj/stationobjs.dmi'
-	icon_state = "doorctrl0"
+	icon_state = "doorctrl"
 
 /obj/machinery/button/alternate/on_update_icon()
 	if(operating)
-		icon_state = "doorctrl0"
+		icon_state = "doorctrl"
 	else
 		icon_state = "doorctrl2"
 


### PR DESCRIPTION
:cl:
bugfix: Engine emitter control button (and other buttons of this type) no longer go invisible for a couple of seconds when clicked.
/:cl:

Icon name was wrong. Operating state will now be visible.