### PR TITLE
Modular consoles now have a forced shutdown verb

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -111,3 +111,16 @@
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		os.open_terminal(user)
+
+/obj/machinery/computer/modular/verb/emergency_shutdown()
+	set name = "Forced Shutdown"
+	set category = "Object"
+	set src in view(1)
+
+	if(!CanPhysicallyInteract(usr))
+		return
+
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os && os.on)
+		to_chat(usr, "You press a hard-reset button on \the [src].")
+		os.system_shutdown()


### PR DESCRIPTION
:cl:
bugfix: Stationary consoles now have a 'Forced Shutdown' verb, just like other kinds of modular computer.
/:cl:

Fixes #27376 