### PR TITLE
Auto-assign a developer to pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+# By default developer team gets assigned
+* @Baystation12/Developers
 # Require reviews from Core team for changes to CI or infra stuff
 .github/ @Baystation12/Core
 .azure-pipelines.yml @Baystation12/Core


### PR DESCRIPTION
This uses the following org settings and results in a developer being auto-assigned to each PR; opting out is possible by setting yourself in the org to "busy".

Opinions welcome.

![](https://cdn.discordapp.com/attachments/256853514624434177/644373784807079938/unknown.png)