### PR TITLE
'Instruct' will now tell you exactly why you're a bad teacher

### DIFF
--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -83,8 +83,10 @@ Robots and antags can instruct.
 	if(!SV || !istype(target))
 		return
 	if(src == target)
+		to_chat(src, "<span class='notice'>Cannot instruct yourself.</span>")
 		return
 	if(incapacitated() || target.incapacitated())
+		to_chat(src, "<span class='notice'>[incapacitated() ? "You are in no state to teach right now!" : "\the [target] is in no state to be taught right now!"]</span>")
 		return
 
 	if(target.too_many_buffs(/datum/skill_buff/instruct))
@@ -95,6 +97,8 @@ Robots and antags can instruct.
 	for(var/decl/hierarchy/skill/S in GLOB.skills)
 		if(!target.skill_check(S.type, SKILL_BASIC) && skill_check(S.type, SKILL_EXPERT))
 			options[S.name] = S
+	if(!length(options))
+		to_chat(src, "<span class='notice'>There is nothing you can teach \the [target].</span>")
 	var/choice = input(src, "Select skill to instruct \the [target] in:", "Skill select") as null|anything in options
 	if(!(choice in options) || !(target in view(2)))
 		return
@@ -103,11 +107,15 @@ Robots and antags can instruct.
 	if(!do_skilled(6 SECONDS, skill.type, target))
 		return
 	if(incapacitated() || target.incapacitated())
+		to_chat(src, "<span class='notice'>[incapacitated() ? "You are in no state to teach right now!" : "\the [target] is in no state to be taught right now!"]</span>")
 		return
 	if(target.too_many_buffs(/datum/skill_buff/instruct))
 		to_chat(src, "<span class='notice'>\The [target] exhausted from all the training \he recieved.</span>")
 		return
-	if(target.skill_check(skill.type, SKILL_BASIC) || !skill_check(skill.type, SKILL_EXPERT))
+	if(target.skill_check(skill.type, SKILL_BASIC))
+		to_chat(src, "<span class='notice'>\The [target] is too skilled to gain any benefit from a short lesson.</span>")
+		return
+	if(!skill_check(skill.type, SKILL_EXPERT))
 		return
 
 	target.buff_skill(list(skill.type = 1), buff_type = /datum/skill_buff/instruct)


### PR DESCRIPTION
:cl:
tweak: Instruct verb will inform you better about why it fails, if it does.
/:cl:

Adds some more error messages to instruct, was confusing people who didn't know exactly what it does.

Some of them will show up very rarely, like if a target is being taught the same skill by two people at once... the main useful one is explaining why the Instruct list is empty.