### PR TITLE
Surgery Borg grippers can now perform transplants properly

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -3,6 +3,10 @@
 
 //Returns the thing in our active hand (whatever is in our active module-slot, in this case)
 /mob/living/silicon/robot/get_active_hand()
+	if(istype(module_active,/obj/item/weapon/gripper)) //or if we have a gripper, return the thing inside the gripper instead
+		var/obj/item/weapon/gripper/G = module_active
+		if(G.wrapped)
+			return G.wrapped
 	return module_active
 
 /*-------TODOOOOOOOOOO--------*/

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -180,6 +180,13 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 		to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		return TRUE
 
+	// Check for robot grippers that do not themselves contain a tool
+	if(istype(src,/obj/item/weapon/gripper))
+		var/obj/item/weapon/gripper/G = src
+		if(!istype(G.wrapped,/obj/item/weapon))
+			src = G.wrapped
+			return FALSE
+
 	// What surgeries does our tool/target enable?
 	var/list/possible_surgeries
 	var/list/all_surgeries = decls_repository.get_decls_of_subtype(/decl/surgery_step)


### PR DESCRIPTION
:cl:
bugfix: Surgery borg grippers can now implant organs properly.
/:cl:

Fixes #25693

Instead of returning the gripper when a robot's hand is looked in, it will return the contents of the gripper (if it exists). 

This was causing this check to fail when starting surgery:
```
	// Otherwise we can make a start on surgery!
	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
```