### PR TITLE
Allows labeling of storage items with intent check

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -142,6 +142,10 @@
 				to_chat(user, "<span class='notice'>\The [src] has no more space specifically for \the [W].</span>")
 			return 0
 
+	//If attempting to lable the storage item, silently fail to allow it
+	if(istype(W, /obj/item/weapon/hand_labeler) && user.a_intent != I_HELP)
+		return FALSE
+
 	// Don't allow insertion of unsafed compressed matter implants
 	// Since they are sucking something up now, their afterattack will delete the storage
 	if(istype(W, /obj/item/weapon/implanter/compressed))


### PR DESCRIPTION
Allows you to label storage items instead of inserting the labeler if you use a non-help intent.

:cl:
tweak: Allows hand-labeler to label storage items when used with non-help intent.
/:cl: