### PR TITLE
Add visible emote for swallowing pills and initiating a give

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -11,36 +11,36 @@
 	if(!I)
 		I = usr.get_inactive_hand()
 	if(!I)
-		to_chat(usr, "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>")
+		to_chat(usr, SPAN_WARNING("You don't have anything in your hands to give to \the [target]."))
 		return
 
 	if(istype(I, /obj/item/grab))
-		to_chat(usr, "<span class='warning'>You can't give someone a grab.</span>")
+		to_chat(usr, SPAN_WARNING("You can't give someone a grab."))
 		return
 
+	usr.visible_message(SPAN_NOTICE("\The [usr] holds out \the [I] to \the [target]."), SPAN_NOTICE("You hold out \the [I] to \the [target], waiting for them to accept it."))
 
 	if(alert(target,"[usr] wants to give you \a [I]. Will you accept it?",,"Yes","No") == "No")
-		target.visible_message("<span class='notice'>\The [usr] tried to hand \the [I] to \the [target], \
-		but \the [target] didn't want it.</span>")
+		target.visible_message(SPAN_NOTICE("\The [usr] tried to hand \the [I] to \the [target], but \the [target] didn't want it."))
 		return
 
 	if(!I) return
 
 	if(!Adjacent(target))
-		to_chat(usr, "<span class='warning'>You need to stay in reaching distance while giving an object.</span>")
-		to_chat(target, "<span class='warning'>\The [usr] moved too far away.</span>")
+		to_chat(usr, SPAN_WARNING("You need to stay in reaching distance while giving an object."))
+		to_chat(target, SPAN_WARNING("\The [usr] moved too far away."))
 		return
 
 	if(I.loc != usr || (usr.l_hand != I && usr.r_hand != I))
-		to_chat(usr, "<span class='warning'>You need to keep the item in your hands.</span>")
-		to_chat(target, "<span class='warning'>\The [usr] seems to have given up on passing \the [I] to you.</span>")
+		to_chat(usr, SPAN_WARNING("You need to keep the item in your hands."))
+		to_chat(target, SPAN_WARNING("\The [usr] seems to have given up on passing \the [I] to you."))
 		return
 
 	if(target.r_hand != null && target.l_hand != null)
-		to_chat(target, "<span class='warning'>Your hands are full.</span>")
-		to_chat(usr, "<span class='warning'>Their hands are full.</span>")
+		to_chat(target, SPAN_WARNING("Your hands are full."))
+		to_chat(usr, SPAN_WARNING("Their hands are full."))
 		return
 
 	if(usr.unEquip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-		target.visible_message("<span class='notice'>\The [usr] handed \the [I] to \the [target].</span>")
+		target.visible_message(SPAN_NOTICE("\The [usr] handed \the [I] to \the [target]."), SPAN_NOTICE("You give \the [I] to \the [target]."))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -25,7 +25,7 @@
 		if(!M.can_eat(src))
 			return
 
-		to_chat(M, "<span class='notice'>You swallow \the [src].</span>")
+		M.visible_message(SPAN_NOTICE("[M] swallows a pill."), SPAN_NOTICE("You swallow \the [src]."), null, 2)
 		if(reagents.total_volume)
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		qdel(src)
@@ -35,11 +35,11 @@
 		if(!M.can_force_feed(user, src))
 			return
 
-		user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>")
+		user.visible_message(SPAN_WARNING("[user] attempts to force [M] to swallow \the [src]."))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(!do_mob(user, M))
 			return
-		user.visible_message("<span class='warning'>[user] forces [M] to swallow \the [src].</span>")
+		user.visible_message(SPAN_WARNING("[user] forces [M] to swallow \the [src]."))
 		var/contained = reagentlist()
 		admin_attack_log(user, M, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
 		if(reagents.total_volume)
@@ -358,7 +358,7 @@ obj/item/weapon/reagent_containers/pill/noexcutite/New()
 
 /obj/item/weapon/reagent_containers/pill/pod/cream
 	name = "creamer pod"
-	
+
 /obj/item/weapon/reagent_containers/pill/pod/cream/New()
 	..()
 	reagents.add_reagent(/datum/reagent/drink/milk, 5)
@@ -366,7 +366,7 @@ obj/item/weapon/reagent_containers/pill/noexcutite/New()
 
 /obj/item/weapon/reagent_containers/pill/pod/cream_soy
 	name = "non-dairy creamer pod"
-	
+
 /obj/item/weapon/reagent_containers/pill/pod/cream_soy/New()
 	..()
 	reagents.add_reagent(/datum/reagent/drink/milk/soymilk, 5)
@@ -374,7 +374,7 @@ obj/item/weapon/reagent_containers/pill/noexcutite/New()
 
 /obj/item/weapon/reagent_containers/pill/pod/orange
 	name = "orange flavorpod"
-	
+
 /obj/item/weapon/reagent_containers/pill/pod/orange/New()
 	..()
 	reagents.add_reagent(/datum/reagent/drink/juice/orange, 5)
@@ -382,7 +382,7 @@ obj/item/weapon/reagent_containers/pill/noexcutite/New()
 
 /obj/item/weapon/reagent_containers/pill/pod/mint
 	name = "mint flavorpod"
-	
+
 /obj/item/weapon/reagent_containers/pill/pod/mint/New()
 	..()
 	reagents.add_reagent(/datum/reagent/nutriment/mint, 1) //mint is used as a catalyst in all reactions as of writing


### PR DESCRIPTION
Also replaced hardcoded spans with the `SPAN_*()` defines.

:cl: SierraKomodo
tweak: Swallowing pills now displays a message to people within a 2 tile radius. This message does not tell them what pill you swallowed.
tweak: Initiating a give (Right click > Give) now displays a message that you 'hold out an item' to the target.
/:cl: