### PR TITLE
Malfunctioning AI Mode Fixes

### DIFF
--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -66,7 +66,7 @@ GLOBAL_DATUM_INIT(malf, /datum/antagonist/rogue_ai, new)
 		sleep(10)
 		to_chat(malf, "<B>running MEMCHCK</B>")
 		sleep(50)
-		to_chat(malf, "<B>MEMCHCK</B> Corrupted sectors confirmed. Reccomended solution: Delete. Proceed? Y/N: Y")
+		to_chat(malf, "<B>MEMCHCK</B> Corrupted sectors confirmed. Recommended solution: Delete. Proceed? Y/N: Y")
 		sleep(10)
 		// this is so Travis doesn't complain about the backslash-B. Fixed at compile time (or should be).
 		to_chat(malf, "<span class='notice'>Corrupted files deleted: sys\\core\\users.dat sys\\core\\laws.dat sys\\core\\" + "backups.dat</span>")

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -2,8 +2,8 @@ GLOBAL_DATUM_INIT(malf, /datum/antagonist/rogue_ai, new)
 
 /datum/antagonist/rogue_ai
 	id = MODE_MALFUNCTION
-	role_text = "Rampant AI"
-	role_text_plural = "Rampant AIs"
+	role_text = "Malfunctioning AI"
+	role_text_plural = "Malfunctioning AIs"
 	mob_path = /mob/living/silicon/ai
 	landmark_id = "AI"
 	welcome_text = "You are malfunctioning! You do not have to follow any laws."

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -1,5 +1,5 @@
 /datum/game_mode/malfunction
-	name = "AI Malfunction"
+	name = "Malfunctioning AI"
 	round_description = "The AI is behaving abnormally and must be stopped."
 	extended_round_description = "The AI will attempt to hack the APCs in order to gain as much control as possible."
 	config_tag = "malfunction"
@@ -20,7 +20,7 @@
 	var/mob/living/silicon/ai/master
 
 	for(var/mob/living/silicon/ai/ai in GLOB.player_list)
-		if(ai.check_special_role("Rampant AI"))
+		if(ai.check_special_role("Malfunctioning AI"))
 			master = ai
 			break
 

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -10,14 +10,14 @@
 	hacked_apcs = list()
 	recalc_cpu()
 
-	verbs += new/datum/game_mode/malfunction/verb/ai_select_hardware()
-	verbs += new/datum/game_mode/malfunction/verb/ai_select_research()
-	verbs += new/datum/game_mode/malfunction/verb/ai_help()
+	verbs += /datum/game_mode/malfunction/verb/ai_select_hardware
+	verbs += /datum/game_mode/malfunction/verb/ai_select_research
+	verbs += /datum/game_mode/malfunction/verb/ai_help
 
 	log_ability_use(src, "became malfunctioning AI")
 	// And greet user with some OOC info.
 	to_chat(user, "You are malfunctioning, you do not have to follow any laws.")
-	to_chat(user, "Use ai-help command to view relevant information about your abilities")
+	to_chat(user, "Use the display-help command to view relevant information about your abilities")
 
 // Safely remove malfunction status, fixing hacked APCs and resetting variables.
 /mob/living/silicon/ai/proc/stop_malf(var/loud = 1)


### PR DESCRIPTION
:cl:
bugfix: Malfunctioning AIs will now properly get the ai-select-hardware, ai-select-research and display-help and set-ambition verbs.
tweak: Malfunctioning AI is now consistently called Malfunctioning AI everywhere. (This will not affect your character role settings.)
/:cl:

Was deleting/overwriting its own verbs. 

Also being called 'Rampant AI', 'AI malfunction' and 'Malfunction AI' in different places bothered me so I made it all the same.

Fixes  #14546 and fixes #25939