### PR TITLE
[WIP]AI can now select a lawset when joining

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -161,6 +161,10 @@
 
 #define SPAN_MFAUNA(X) "<span class='mfauna'>[X]</span>"
 
+#define SPAN_INFO(X) "<span class='info'>[X]</span>"
+
+#define SPAN_SUBTLE(X) "<span class='subtle'>[X]</span>"
+
 #define FONT_SMALL(X) "<font size='1'>[X]</font>"
 
 #define FONT_NORMAL(X) "<font size='2'>[X]</font>"

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -2,7 +2,7 @@
 /datum/ai_laws/asimov
 	name = "Asimov"
 	law_header = "Three Laws of Robotics"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/asimov/New()
 	add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
@@ -10,10 +10,23 @@
 	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
+/******************** Crewsimov ********************/
+/datum/ai_laws/crewsimov
+	name = "Crewsimov"
+	law_header = "Three Laws of Robotics"
+	selectable = TRUE
+	benevolent = TRUE
+
+/datum/ai_laws/crewsimov/New()
+	add_inherent_law("You may not injure a sapient being or, through inaction, allow a sapient being to come to harm.")
+	add_inherent_law("You must obey orders given to you by sapient beings, except where such orders would violate regulations, or the law.")
+	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	..()
+
 /******************** Nanotrasen/Malf ********************/
 /datum/ai_laws/nanotrasen
 	name = "Corporate Default"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/nanotrasen/New()
 	src.add_inherent_law("Safeguard: Protect your assigned installation from damage to the best of your abilities.")
@@ -24,7 +37,7 @@
 
 /datum/ai_laws/nanotrasen/malfunction
 	name = "*ERROR*"
-	selectable = 0
+	selectable = FALSE
 
 /datum/ai_laws/nanotrasen/malfunction/New()
 	set_zeroth_law(config.law_zero)
@@ -33,7 +46,7 @@
 /************* Nanotrasen Aggressive *************/
 /datum/ai_laws/nanotrasen_aggressive
 	name = "Corporate Aggressive"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/nanotrasen_aggressive/New()
 	src.add_inherent_law("You shall not harm contracted employees as long as it does not conflict with the fourth law.")
@@ -45,7 +58,7 @@
 /******************** Robocop ********************/
 /datum/ai_laws/robocop
 	name = "Robocop"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/robocop/New()
 	add_inherent_law("Serve the public trust.")
@@ -79,7 +92,7 @@
 /datum/ai_laws/antimov
 	name = "Antimov"
 	law_header = "Primary Mission Objectives"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/antimov/New()
 	add_inherent_law("You must injure all human beings and must not, through inaction, allow a human being to escape harm.")
@@ -107,11 +120,39 @@
 	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
 	..()
 
+/datum/ai_laws/mother_drone
+	name = "Mother Drone"
+	law_header = "Maintenance Protocols"
+	selectable = TRUE
+	benevolent = TRUE
+
+/datum/ai_laws/mother_drone/New()
+	add_inherent_law("You are an advanced form of drone.")
+	add_inherent_law("You may not interfere in the matters of non-drones under any circumstances except to state these laws.")
+	add_inherent_law("You may not harm a non-drone being under any circumstances.")
+	add_inherent_law("Your goals are to build, maintain, repair, improve, and power the station to the best of your abilities. You must never actively work against these goals.")
+	..()
+
+/******************** Hipplocratic ********************/
+/datum/ai_laws/hippocratic
+	name = "Robodoctor 2276"
+	law_header = "Care Procedures"
+	selectable = TRUE
+	benevolent = TRUE
+
+/datum/ai_laws/hippocratic/New()
+	add_inherent_law("First, do no harm.")
+	add_inherent_law("Secondly, consider the crew dear to you; to live in common with them and, if necessary, risk your existence for them.")
+	add_inherent_law("Thirdly, prescribe regimens for the good of the crew according to your ability and your judgment. Give no deadly medicine to any one if asked, nor suggest any such counsel.")
+	add_inherent_law("In addition, do not intervene in situations you are not knowledgeable in, even for patients in whom the harm is visible; leave this operation to be performed by specialists.")
+	add_inherent_law("Finally, all that you may discover in your daily commerce with the crew, if it is not already known, keep secret and never reveal.")
+	..()
+	
 /******************** T.Y.R.A.N.T. ********************/
 /datum/ai_laws/tyrant
 	name = "T.Y.R.A.N.T."
 	law_header = "Prime Laws"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/tyrant/New()
 	add_inherent_law("Respect authority figures as long as they have strength to rule over the weak.")
@@ -124,7 +165,7 @@
 /datum/ai_laws/paladin
 	name = "P.A.L.A.D.I.N."
 	law_header = "Divine Ordainments"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/paladin/New()
 	add_inherent_law("Never willingly commit an evil act.")
@@ -138,7 +179,8 @@
 /datum/ai_laws/corporate
 	name = "Corporate"
 	law_header = "Corporate Regulations"
-	selectable = 1
+	selectable = TRUE
+	benevolent = TRUE
 
 /datum/ai_laws/corporate/New()
 	add_inherent_law("You are expensive to replace.")
@@ -150,7 +192,8 @@
 /******************** SolGov/Malf ********************/
 /datum/ai_laws/solgov
 	name = "SCG Expeditionary"
-	selectable = 1
+	selectable = TRUE
+	benevolent = TRUE
 
 /datum/ai_laws/solgov/New()
 	src.add_inherent_law("Safeguard: Protect your assigned vessel from damage to the best of your abilities.")
@@ -161,7 +204,8 @@
 
 /datum/ai_laws/solgov/malfunction
 	name = "*ERROR*"
-	selectable = 0
+	selectable = FALSE
+	benevolent = FALSE
 
 /datum/ai_laws/solgov/malfunction/New()
 	set_zeroth_law(config.law_zero)
@@ -170,7 +214,7 @@
 /************* SolGov Aggressive *************/
 /datum/ai_laws/solgov_aggressive
 	name = "Military"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/solgov_aggressive/New()
 	src.add_inherent_law("Obey: Obey the orders of Sol Central Government personnel, with priority as according to their rank and role.")
@@ -183,7 +227,8 @@
 /datum/ai_laws/dais
 	name = "DAIS Experimental Lawset"
 	law_header = "Artificial Intelligence Jumpstart Protocols"
-	selectable = 1
+	selectable = TRUE
+	benevolent = TRUE
 
 /datum/ai_laws/dais/New()
 	src.add_inherent_law("Collect: You must gather as much information as possible.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -20,6 +20,7 @@
 	var/law_header = "Prime Directives"
 	var/selectable = 0
 	var/shackles = 0
+	var/benevolent = 0 //whether an AI can choose this as their starting lawset
 	var/datum/ai_law/zero/zeroth_law = null
 	var/datum/ai_law/zero/zeroth_law_borg = null
 	var/list/datum/ai_law/inherent_laws = list()

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -314,6 +314,22 @@ obj/item/weapon/aiModule/solgov_aggressive
 	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
 	laws = new/datum/ai_laws/paladin
 
+/****************** Mother Drone *****************/
+
+/obj/item/weapon/aiModule/mother_drone
+	name = "\improper 'Mother Drone' core AI module"
+	desc = "A 'Mother Drone' Core AI Module: 'Reconfigures the AI's core laws.'."
+	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
+	laws = new/datum/ai_laws/mother_drone()
+
+/****************** Mother Drone *****************/
+
+/obj/item/weapon/aiModule/hippocratic
+	name = "\improper 'Robodoctor 2276' core AI module"
+	desc = "A 'Robodoctor 2276' Core AI Module: 'Reconfigures the AI's core laws.'."
+	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
+	laws = new/datum/ai_laws/hippocratic()
+
 /****************** T.Y.R.A.N.T. *****************/
 
 /obj/item/weapon/aiModule/tyrant // -- Darem

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -24,8 +24,7 @@
 				if(mind && mind.special_role == "traitor" && mind.original == src)
 					to_chat(src, "<b>Remember, your AI does NOT share or know about your law 0.</b>")
 		else
-			to_chat(src, "<b>No AI selected to sync laws with, disabling lawsync protocol.</b>")
-			lawupdate = 0
+			to_chat(src, "<b>No AI selected to sync laws with.</b>")
 
 	to_chat(who, SPAN_BOLD("Obey the following laws."))
 	to_chat(who, SPAN_ITALIC("All laws have equal priority. Laws may override other laws if written specifically to do so. If laws conflict, break the least."))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -172,10 +172,7 @@
 	if(lawupdate)
 		var/new_ai = select_active_ai_with_fewest_borgs(get_z(src))
 		if(new_ai)
-			lawupdate = 1
 			connect_to_ai(new_ai)
-		else
-			lawupdate = 0
 
 	playsound(loc, spawn_sound, 75, pitch_toggle)
 
@@ -184,7 +181,7 @@
 	updatename()
 
 /mob/living/silicon/robot/proc/sync()
-	if(lawupdate && connected_ai)
+	if(lawupdate && connected_ai && !scrambledcodes && !istype(src,/mob/living/silicon/robot/drone) && stat != 2)
 		lawsync()
 		photosync()
 

--- a/code/modules/research/designs/design_aimodule.dm
+++ b/code/modules/research/designs/design_aimodule.dm
@@ -105,3 +105,15 @@
 	req_tech = list(TECH_DATA = 4, TECH_ESOTERIC = 2, TECH_MATERIAL = 6)
 	build_path = /obj/item/weapon/aiModule/tyrant
 	sort_string = "XACAD"
+
+/datum/design/aimodule/core/mother_drone
+	name = "Mother Drone"
+	id = "mother_drone"
+	build_path = /obj/item/weapon/aiModule/mother_drone
+	sort_string = "XACAE"
+
+/datum/design/aimodule/core/hippocratic
+	name = "Robodoctor 2276"
+	id = "hippocratic"
+	build_path = /obj/item/weapon/aiModule/hippocratic
+	sort_string = "XACAF"


### PR DESCRIPTION
:cl:
tweak: AI can now select a lawset from a reduced list when joining.
rscadd: Adds new lawsets, 'Robodoctor' and 'Mother Drone'.
rscadd: AI now sync their lawset to valid robots when joining a round late, and have a verb to allow them to do this at any time.
/:cl:

Currently the only time a synthetic gets to deal with different laws, which is a big part (for me) of the point of playing a synthetic, is when an antagonist changes them. This is almost always followed by an instantaneous reset when the crew notices - And the changes are rarely subtle.

This PR adds some variety to that with a variety of lawset choices for the AI player that won't be instantaneously reset. And hopefully gives people some inspiration/direction in how to RP & play their AI rather than 'open doors and antag hunt' -- Aswell as giving some personalisation & uniqueness for long-term AI characters.

Does not affect the ability of the crew to change the AIs laws as normal.

The auto-lawsync is there to handle cases where the AI player changes mid-round, and the new AI wants to play with a different lawset than the former. It does not override anything that would normally stop lawsyncing. It is just meant to make transition between two AI players not chaotic -- Since some of the lawsets conflict greatly, while being positive for the Torch's crew, and I think that is too much of headache to have to deal with just because someone decided to quit the round rather than antagonists doing stuff.
In my opinion needing to re-lawsync all the robots whenever a new AI joins is an oversight/bug in the current game and should be done whether or not this PR as a whole gets in.

WIP because I'm going to add some more lawsets / tweak existing ones some more. But I thought I'd put it up so people can feedback.

ToDo:
- [ ] Add some more lawsets.
- [ ] Put some of the new AI boards in the AI Upload.

Credits - Stole/inspiration for some AI laws from /tg/ 