### PR TITLE
Removes the option for fleet mentalists/counselors to be O-2

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -177,7 +177,6 @@
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/fleet/o1,
-		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/ec/o1)
 	min_skill = list(
 		SKILL_BUREAUCRACY = SKILL_BASIC,


### PR DESCRIPTION
:cl:
tweak: Mentalists can now only be an O-1 (Ensign)
/:cl:

Someone who is not a doctor should not be able to outrank doctors in their own department. This is mostly to prevent SLT Mentalists being able to tell doctors what to do. It doesn't happen much, but I've seen it happen enough to make this PR.