### PR TITLE
Fix Disappearing First Aid Kit

### DIFF
--- a/code/controllers/subsystems/initialization/fabrication.dm
+++ b/code/controllers/subsystems/initialization/fabrication.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(fabrication)
 
 /datum/controller/subsystem/fabrication/proc/try_craft_with(var/obj/item/target, var/obj/item/thing, var/mob/user)
 	for(var/decl/crafting_stage/initial_stage in SSfabrication.find_crafting_recipes(target.type))
-		if(initial_stage.can_begin_with(target))
+		if(initial_stage.can_begin_with(target) && initial_stage.is_appropriate_tool(thing))
 			var/obj/item/crafting_holder/H = new /obj/item/crafting_holder(get_turf(target), initial_stage, target, thing, user)
 			if(initial_stage.progress_to(thing, user, H))
 				return H


### PR DESCRIPTION
:cl: WezYo
bugfix: Clicking on first aid kits (or other crafting objects) with certain items will no longer delete the first aid kit.
/:cl:

Fixes #27631