### PR TITLE
Firing a gun will remove rig cloaks.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -317,6 +317,13 @@
 		if(curloc)
 			curloc.hotspot_expose(700, 5)
 
+	if(istype(user,/mob/living/carbon/human) && user.is_cloaked()) //shooting will disable a rig cloaking device
+		var/mob/living/carbon/human/H = user
+		if(istype(H.back,/obj/item/weapon/rig))
+			var/obj/item/weapon/rig/R = H.back
+			for(var/obj/item/rig_module/stealth_field/S in R.installed_modules)
+				S.deactivate()
+
 	update_icon()
 
 


### PR DESCRIPTION
:cl:
tweak: Firing a gun successfully will now switch off RIG-based cloaking devices.
/:cl:

There've been recent rounds with people robusting the whole of security while being constantly invisible, making it very difficult to click on and attack the cloaked person.

This has mostly been people using the stealth rig that is available in the heist game-mode 1/6th of the time. An alternative fix if this PR isn't liked is to remove that particular rig from the random spawn. But I personally like the idea of the stealthy rig being in the heist game-mode for its stealthy thievery potential. And, since this module is also available to RnD and therefore potentially every antagonist, I prefer this fix.

An alternative, alternative fix would be to have weapon shots under cloaks drain extra energy. Let me know if you prefer that option in feedback.

I have never rolled ninja, so I hope this does not affect that game-mode too much. It does not affect melee weaponry, and it doesn't affect single-target assassination with guns too much either as they still get one shot from stealth.

This does not affect the wizard cloaking ability, only rig-based cloaking.