### PR TITLE
Medical skill rebalance

### DIFF
--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -74,6 +74,15 @@ GLOBAL_LIST_EMPTY(skills)
 	ID	 = "medical"
 	difficulty = SKILL_HARD
 
+/decl/hierarchy/skill/medical/get_cost(var/level)
+	switch(level)
+		if(SKILL_BASIC, SKILL_ADEPT)
+			return difficulty
+		if(SKILL_EXPERT, SKILL_PROF)
+			return 0.5*difficulty
+		else
+			return 0
+
 // ONLY SKILL DEFINITIONS BELOW THIS LINE
 // Category: Organizational
 

--- a/maps/bearcat/bearcat_jobs.dm
+++ b/maps/bearcat/bearcat_jobs.dm
@@ -82,17 +82,17 @@
 	total_positions = 1
 	spawn_positions = 1
 	hud_icon = "hudmedicaldoctor"
-	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
-	                    SKILL_MEDICAL     = SKILL_EXPERT,
-	                    SKILL_ANATOMY     = SKILL_EXPERT,
-	                    SKILL_CHEMISTRY   = SKILL_BASIC,
-	                    SKILL_VIROLOGY    = SKILL_BASIC)
+	min_skill = list(	SKILL_BUREAUCRACY = SKILL_BASIC,
+						SKILL_MEDICAL     = SKILL_EXPERT,
+						SKILL_ANATOMY     = SKILL_EXPERT,
+						SKILL_CHEMISTRY   = SKILL_BASIC,
+						SKILL_VIROLOGY    = SKILL_BASIC)
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX,
 	                    SKILL_VIROLOGY    = SKILL_MAX)
-	skill_points = 28
+	skill_points = 20
 
 /datum/job/hop
 	title = "First Mate"

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -167,7 +167,7 @@
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX,
 	                    SKILL_VIROLOGY    = SKILL_MAX)
-	skill_points = 32
+	skill_points = 20
 
 	access = list(access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_bridge, access_heads,

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -4,7 +4,7 @@
 	department_flag = MED
 	minimal_player_age = 2
 	minimum_character_age = list(SPECIES_HUMAN = 29)
-	ideal_character_age = 45
+	ideal_character_age = 35
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Chief Medical Officer"
@@ -35,7 +35,6 @@
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX,
 	                    SKILL_VIROLOGY    = SKILL_MAX)
-	skill_points = 28
 
 	access = list(access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
 			            access_crematorium, access_chemistry, access_surgery,
@@ -51,7 +50,7 @@
 	supervisors = "Physicians and the Chief Medical Officer"
 	economic_power = 7
 	minimum_character_age = list(SPECIES_HUMAN = 19)
-	ideal_character_age = 40
+	ideal_character_age = 25
 	minimal_player_age = 0
 	alt_titles = list(
 		"Paramedic",
@@ -85,7 +84,6 @@
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
-	skill_points = 26
 
 /datum/job/medical_trainee
 	title = "Trainee Medical Technician"
@@ -152,7 +150,6 @@
 
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
-	skill_points = 26
 
 	access = list(access_medical, access_maint_tunnels, access_emergency_storage, access_medical_equip, access_solgov_crew, access_chemistry)
 	minimal_access = list()
@@ -161,7 +158,7 @@
 	title = "Counselor"
 	total_positions = 1
 	spawn_positions = 1
-	ideal_character_age = 40
+	ideal_character_age = 30
 	economic_power = 5
 	minimal_player_age = 0
 	supervisors = "the Chief Medical Officer"


### PR DESCRIPTION
🆑 
tweak: All medical skill has their experienced and master cost reduced to 2. The cost of medical skill will be 4/4/2/2 respectively for their tier. 
tweak: All medical crew has their skill points and starting skill set reduced to account for the previous change, please adjust your characters accordingly.
🆑
### Why?
this is to fix the huge amount of skill points medical staff is given to stat into their medical skills. basically anti mary sues
Currently doctors will have 36 (28 base + 8 age) skill points. which is just ridiculous.Example: 
https://i.imgur.com/dQqs8kH.png
^in case your doctor was a trained martial artist, riflemen, engineer, exosuit operator,roboticsist and pilot while having the skills to be decent at their job.

This way it's still expensive to stat into medical skills however it's cheaper for medical staff who has access to the higher tiers.

Second commit coming soon making virology a sub-skill perk of medicine

### Changes:
**Corpsman**
Skills: 26 -> 16 (before -> after) (16 is the base skill points for most role)
points left over after decent starting skills:
(Experienced med) 14 -> 10
(Master med) 6 -> 8

**Doctor**
Skill: 28 -> 16 (They're usually older than 31 so there should atleast +4 points ontop of 28; min age: 29)
points left over after decent starting skills:
(Master med & anat) 12 -> 12

**CMO**
Skill: 32 -> 20 (atleast +4 more after 32/20; min age: 35)
points left over after decent starting skills:
(Master med & anat) 16 -> 16

**Chemist**
Skill: 26 -> 16
(Master chem) 10 -> 12