### PR TITLE
Adds header to codex entries

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(codex)
 
 /datum/controller/subsystem/codex/proc/present_codex_entry(var/mob/presenting_to, var/datum/codex_entry/entry)
 	if(entry && istype(presenting_to) && presenting_to.client)
-		var/datum/browser/popup = new(presenting_to, "codex", "Codex - [entry.display_name]")
+		var/datum/browser/popup = new(presenting_to, "codex", "Codex", nheight=425)
 		popup.set_content(parse_links(entry.get_text(presenting_to), presenting_to))
 		popup.open()
 

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -31,8 +31,17 @@
 		display_name = associated_strings[1]
 	..()
 
-/datum/codex_entry/proc/get_text(var/mob/presenting_to)
+/datum/codex_entry/proc/get_header(var/mob/presenting_to)
 	var/list/dat = list()
+	var/datum/codex_entry/linked_entry = SScodex.get_entry_by_string("nexus")
+	dat += "<a href='?src=\ref[SScodex];show_examined_info=\ref[linked_entry];show_to=\ref[presenting_to]'>Home</a>"
+	dat += "<a href='?src=\ref[presenting_to.client];codex_search=1'>Search Codex</a>"
+	dat += "<a href='?src=\ref[presenting_to.client];codex_index=1'>List All Entries</a>"
+	dat += "<hr><h2>[display_name]</h2>"
+	return jointext(dat, null)
+
+/datum/codex_entry/proc/get_text(var/mob/presenting_to)
+	var/list/dat = list(get_header(presenting_to))
 	if(lore_text)
 		dat += "<font color = '[CODEX_COLOR_LORE]'>[lore_text]</font>"
 	if(mechanics_text)

--- a/code/modules/codex/entries/codex.dm
+++ b/code/modules/codex/entries/codex.dm
@@ -23,10 +23,8 @@
 	mechanics_text = "The place to start with <span codexlink='codex'>The Codex</span><br>" 
 
 /datum/codex_entry/nexus/get_text(var/mob/presenting_to)
-	var/list/dat = list("<h3>CODEX NEXUS</h3>")
+	var/list/dat = list(get_header(presenting_to))
 	dat += "[mechanics_text]"
-	dat += "You can use <a href='?src=\ref[presenting_to.client];codex_search=1'><b>Search-Codex <i>topic</i></b></a> to look something up, or you can click the links provided when examining some objects.<br>"
-	dat += "You can also use <a href='?src=\ref[presenting_to.client];codex_index=1'><b>List-Codex-Entries</b></a> to get a comprehensive index of all entries.<br><br>"
 	dat += "<h3>Categories</h3>"
 	var/list/categories = list()
 	for(var/type in subtypesof(/datum/codex_category))
@@ -34,7 +32,7 @@
 		var/key = "[initial(C.name)] (category)"
 		var/datum/codex_entry/entry = SScodex.get_codex_entry(key)
 		if(entry)
-			categories += "<span codexlink='[key]'>[initial(C.name)]</span>"
+			categories += "<li><span codexlink='[key]'>[initial(C.name)]</span> - [initial(C.desc)]"
 	dat += jointext(categories, " ")
 	return "<font color = '[CODEX_COLOR_MECHANICS]'>[jointext(dat, null)]</font>"
 


### PR DESCRIPTION
It has links to home / search / list all for easier navigation
Reshuffles home page too ot list categories more distinctly, and removed help stuff since there's buttons for it now right there.
:cl: Chinsky
tweak: Codex now has navigation bar to get to home page quickly, or search or list all stuff.
/:cl: