### PR TITLE
Nerf to immunobooster.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -986,11 +986,20 @@
 	reagent_state = LIQUID
 	color = "#ffc0cb"
 	metabolism = REM
-	overdose = REAGENTS_OVERDOSE * 2
+	overdose = REAGENTS_OVERDOSE
 	value = 1.5
 	scannable = 1
 
 /datum/reagent/immunobooster/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.immunity = min(M.immunity_norm * 0.5, removed + M.immunity) // Rapidly brings someone up to half immunity.
+	if(volume < REAGENTS_OVERDOSE && !M.chem_effects[CE_ANTIVIRAL])
+		M.immunity = min(M.immunity_norm * 0.5, removed + M.immunity) // Rapidly brings someone up to half immunity.
+	if(M.chem_effects[CE_ANTIVIRAL]) //don't take with 'cillin
+		M.add_chemical_effect(CE_TOXIN, 4) // as strong as taking vanilla 'toxin'
+
+
+/datum/reagent/immunobooster/overdose(var/mob/living/carbon/M, var/alien)
+	..()
+	M.add_chemical_effect(CE_TOXIN, 1)
+	M.immunity -= 0.5 //inverse effects when abused


### PR DESCRIPTION
Adds some minor negative effects to misusing immunobooster. Prevents 'stuff a bunch of it in a pill lol' memes.

🆑 Technetium
tweak: Immunobooster now has overdose effects and a lower OD threshold (60u -> 30u).
tweak: Immunobooster now has strong negative interaction with spaceacillin. Do not mix.
/🆑

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->