### PR TITLE
Dionaea can be cured of viruses through radiation exposure

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -74,7 +74,9 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 		return
 
 	if(mob.radiation > 50)
-		if(prob(1))
+		if((mob.species.name == SPECIES_DIONA) && prob(mob.radiation/25))
+			cure(mob)
+		else if(prob(1))
 			majormutate()
 
 	if(prob(mob.virus_immunity()) && prob(stage)) // Increasing chance of curing as the virus progresses


### PR DESCRIPTION
:cl:
tweak: Dionaea can be cured of viruses by receiving a middling dose of radiation. Exposure to a radiation storm or standing outside the supermatter containment window for a short time should be sufficient.
/:cl:

Currently diona players can get viruses but not have them cured, so they walk around infecting everyone else. Most of the virus symptoms don't affect them, but the ones that do tend to make it very difficult or impossible to continue playing, especially the ones that make you fall over constantly.

Chance of a cure per tick is dependent upon mob radiation level. Current value in testing showed a removal time of around a minute for twenty separate viruses on one mob, while standing outside the SM containment on a normal crystal EER of ~500.