### PR TITLE
Allow borgs to access console terminals

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -12,6 +12,9 @@
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
+	if (modifiers["ctrl"] && modifiers["alt"])
+		CtrlAltClickOn(A)
+		return
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
@@ -112,6 +115,9 @@
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
 	A.BorgAltClick(src)
 
+/mob/living/silicon/robot/CtrlAltClickOn(atom/A)
+	A.BorgCtrlAltClick(src)
+
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlShiftClick(user)
 
@@ -151,6 +157,9 @@
 
 /obj/machinery/atmospherics/binary/pump/BorgAltClick()
 	return AltClick()
+
+/atom/proc/BorgCtrlAltClick(var/mob/living/silicon/robot/user)
+	CtrlAltClick(user)
 
 /*
 	As with AI, these are not used in click code,


### PR DESCRIPTION
- Only usable when adjacent to a console and still not usable by AI for balancing reasons
- Still requires the proper skill level to actually be useful

:cl: SierraKomodo
tweak: Borgs with the proper skills can now use console terminals with ctrl+alt+click. You must be adjacent to the console to use this.
/:cl:

Really all I did was let borgs use the ctrl+alt+click macros that already exist.