### PR TITLE
Show server profiler to admins with R_DEBUG

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -64,6 +64,10 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		C.holder = null
 	GLOB.admins.Cut()
 
+	// Flush profiler access.
+	for (var/admin in world.GetConfig("admin"))
+		world.SetConfig("APP/admin", admin, null)
+
 	if(config.admin_legacy_system)
 		load_admin_ranks()
 

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -30,6 +30,8 @@ var/list/admin_datums = list()
 	rank = initial_rank
 	rights = initial_rights
 	admin_datums[ckey] = src
+	if (rights & R_DEBUG)
+		world.SetConfig("APP/admin", ckey, "role=admin")
 
 /datum/admins/proc/associate(client/C)
 	if(istype(C))


### PR DESCRIPTION
Does what it says on the tin.

As noted on discord, this also means that users with R_DEBUG can reboot the server via Seeker as well.

---

By request of Xales.