### PR TITLE
Makes chameleon behavior an extension

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -266,6 +266,7 @@
 #include "code\datums\communication\pray.dm"
 #include "code\datums\communication\~defines.dm"
 #include "code\datums\extensions\_defines.dm"
+#include "code\datums\extensions\chameleon.dm"
 #include "code\datums\extensions\deity_be_near.dm"
 #include "code\datums\extensions\event_registration.dm"
 #include "code\datums\extensions\extensions.dm"

--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -1,0 +1,181 @@
+/datum/extension/chameleon
+	base_type = /datum/extension/chameleon
+	expected_type = /obj/item
+	flags = EXTENSION_FLAG_IMMEDIATE
+	var/list/chameleon_choices
+	var/static/list/chameleon_choices_by_type
+	var/atom/atom_holder
+	var/chameleon_type = null //if we want an item to have chameleon changes not of its parent_type or base_type
+	var/chameleon_verb
+
+/datum/extension/chameleon/New(datum/holder, base_type)
+	..()
+
+	if(!chameleon_choices)
+		var/chameleon_type = base_type || holder.parent_type
+		chameleon_choices = LAZYACCESS(chameleon_choices_by_type, chameleon_type)
+		if(!chameleon_choices)
+			chameleon_choices = generate_chameleon_choices(chameleon_type)
+			LAZYSET(chameleon_choices_by_type, chameleon_type, chameleon_choices)	
+
+	atom_holder = holder
+	chameleon_verb += new/atom/proc/chameleon_appearance(atom_holder,"Change [atom_holder.name] Appearance")
+
+/datum/extension/chameleon/Destroy()
+	. = ..()
+	atom_holder.verbs -= chameleon_verb
+	atom_holder = null
+
+/datum/extension/chameleon/proc/disguise(var/newtype, var/mob/user)
+	//this is necessary, unfortunately, as initial() does not play well with list vars
+	var/obj/item/copy = new newtype(null)
+	var/obj/item/C = atom_holder
+
+	C.name = copy.name
+	C.desc = copy.desc
+	C.icon = copy.icon
+	C.color = copy.color
+	C.icon_state = copy.icon_state
+	C.flags_inv = copy.flags_inv
+	C.item_state = copy.item_state
+	C.body_parts_covered = copy.body_parts_covered
+
+	if(copy.item_icons)
+		C.item_icons = copy.item_icons.Copy()
+	if(copy.item_state_slots)
+		C.item_state_slots = copy.item_state_slots.Copy()
+	if(copy.sprite_sheets)
+		C.sprite_sheets = copy.sprite_sheets.Copy()
+
+	OnDisguise(copy)
+	qdel(copy)
+
+/datum/extension/chameleon/proc/OnDisguise(var/obj/item/copy)
+
+/datum/extension/chameleon/clothing
+	expected_type = /obj/item/clothing
+
+/datum/extension/chameleon/clothing/accessory
+	expected_type = /obj/item/clothing/accessory
+
+/datum/extension/chameleon/clothing/accessory/OnDisguise(var/obj/item/clothing/accessory/copy)
+	..()
+	var/obj/item/clothing/accessory/A = holder
+
+	A.slot = copy.slot
+	A.has_suit = copy.has_suit
+	A.inv_overlay = copy.inv_overlay
+	A.mob_overlay = copy.mob_overlay
+	A.overlay_state = copy.overlay_state
+	A.accessory_icons = copy.accessory_icons
+	A.on_rolled = copy.on_rolled
+	A.high_visibility = copy.high_visibility
+
+/datum/extension/chameleon/proc/generate_chameleon_choices(var/basetype)
+	. = list()
+
+	var/types = islist(basetype) ? basetype : typesof(basetype)
+	var/i = 1 //in case there is a collision with both name AND icon_state
+	for(var/typepath in types)
+		var/obj/item/I = typepath
+		if(initial(I.icon) && initial(I.icon_state) && !(initial(I.item_flags) & ITEM_FLAG_INVALID_FOR_CHAMELEON))
+			var/name = initial(I.name)
+			if(name in .)
+				name += " ([initial(I.icon_state)])"
+			if(name in .)
+				name += " \[[i++]\]"
+			.[name] = typepath
+	return sortAssoc(.)
+
+/atom/proc/chameleon_appearance()
+	set name = "Change Appearance"
+	set desc = "Activate the holographic appearance changing module."
+	set category = "Chameleon Items"
+
+	if(!CanPhysicallyInteract(usr))
+		return
+	if(has_extension(src,/datum/extension/chameleon))
+		var/datum/extension/chameleon/C = get_extension(src, /datum/extension/chameleon)
+		C.change(usr)
+	else
+		src.verbs -= /atom/proc/chameleon_appearance
+
+/datum/extension/chameleon/proc/change(mob/user)
+	var/choice = input(user, "Select a new appearance", "Select appearance") as null|anything in chameleon_choices
+	if(choice)
+		disguise(chameleon_choices[choice], user)
+		OnChange(user,holder)
+
+/datum/extension/chameleon/proc/OnChange(mob/user, var/obj/item/clothing/C) //contains icon updates
+	if(istype(C))
+		C.update_clothing_icon()
+
+/datum/extension/chameleon/backpack
+	expected_type = /obj/item/weapon/storage/backpack
+
+/datum/extension/chameleon/backpack/OnChange(mob/user,var/obj/item/weapon/storage/backpack/C)
+	if(ismob(C.loc))
+		var/mob/M = C.loc
+		M.update_inv_back()
+
+/datum/extension/chameleon/headset
+	expected_type = /obj/item/device/radio/headset
+
+/datum/extension/chameleon/headset/OnChange(mob/user,var/obj/item/device/radio/headset/C)
+	if(ismob(C.loc))
+		var/mob/M = C.loc
+		M.update_inv_ears()
+
+/datum/extension/chameleon/gun
+	expected_type = /obj/item/weapon/gun
+	var/obj/item/projectile/copy_projectile = null
+
+/datum/extension/chameleon/gun/OnChange(mob/user,var/obj/item/weapon/gun/C)
+	if(ismob(C.loc))
+		var/mob/M = C.loc
+		M.update_inv_r_hand()
+		M.update_inv_l_hand()
+
+/datum/extension/chameleon/gun/proc/consume_next_projectile()
+	var/obj/item/projectile/P = ..()
+	if(P && ispath(copy_projectile))
+		P.SetName(initial(copy_projectile.name))
+		P.icon = initial(copy_projectile.icon)
+		P.icon_state = initial(copy_projectile.icon_state)
+		P.pass_flags = initial(copy_projectile.pass_flags)
+		P.hitscan = initial(copy_projectile.hitscan)
+		P.step_delay = initial(copy_projectile.step_delay)
+		P.muzzle_type = initial(copy_projectile.muzzle_type)
+		P.tracer_type = initial(copy_projectile.tracer_type)
+		P.impact_type = initial(copy_projectile.impact_type)
+	return P
+
+/datum/extension/chameleon/gun/OnDisguise(var/obj/item/weapon/gun/copy)
+	var/obj/item/weapon/gun/G = src
+
+	G.flags_inv = copy.flags_inv
+	G.fire_sound = copy.fire_sound
+	G.fire_sound_text = copy.fire_sound_text
+	G.icon = copy.icon
+
+	var/obj/item/weapon/gun/energy/E = copy
+	if(istype(E))
+		copy_projectile = E.projectile_type
+	else
+		copy_projectile = null
+
+/datum/extension/chameleon/emag
+	expected_type = /obj/item/weapon/card
+	chameleon_choices = list(
+							/obj/item/weapon/card/emag,
+							/obj/item/weapon/card/union,
+							/obj/item/weapon/card/data,
+							/obj/item/weapon/card/data/full_color,
+							/obj/item/weapon/card/data/disk,
+							/obj/item/weapon/card/id,
+						) //Should be enough of a selection for most purposes
+
+/datum/extension/chameleon/emag/proc/examine(mob/user)
+	. = ..()
+	if(user.skill_check(SKILL_DEVICES,SKILL_ADEPT))
+		to_chat(user, SPAN_WARNING("This ID card has some form of non-standard modifications."))

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -107,15 +107,6 @@
 	origin_tech = list(TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 	var/uses = 10
 
-	var/static/list/card_choices = list(
-							/obj/item/weapon/card/emag,
-							/obj/item/weapon/card/union,
-							/obj/item/weapon/card/data,
-							/obj/item/weapon/card/data/full_color,
-							/obj/item/weapon/card/data/disk,
-							/obj/item/weapon/card/id,
-						) //Should be enough of a selection for most purposes
-
 var/const/NO_EMAG_ACT = -50
 /obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)
 	var/used_uses = A.emag_act(uses, user, src)
@@ -137,24 +128,7 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/weapon/card/emag/Initialize()
 	. = ..()
-	if(length(card_choices) && !card_choices[card_choices[1]])
-		card_choices = generate_chameleon_choices(card_choices)
-
-/obj/item/weapon/card/emag/verb/change(picked in card_choices)
-	set name = "Change Cryptographic Sequencer Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(card_choices[picked]))
-			return
-
-		disguise(card_choices[picked], usr)
-
-/obj/item/weapon/card/emag/examine(mob/user)
-	. = ..()
-	if(user.skill_check(SKILL_DEVICES,SKILL_ADEPT))
-		to_chat(user, SPAN_WARNING("This ID card has some form of non-standard modifications."))
+	set_extension(src,/datum/extension/chameleon/emag)
 
 /obj/item/weapon/card/id
 	name = "identification card"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -1,55 +1,3 @@
-//*****************
-//**Cham Jumpsuit**
-//*****************
-
-/obj/item/proc/disguise(var/newtype, var/mob/user)
-	if(!user || !CanPhysicallyInteract(user))
-		return
-	//this is necessary, unfortunately, as initial() does not play well with list vars
-	var/obj/item/copy = new newtype(null)
-
-	desc = copy.desc
-	name = copy.name
-	icon = copy.icon
-	color = copy.color
-	icon_state = copy.icon_state
-	item_state = copy.item_state
-	body_parts_covered = copy.body_parts_covered
-	flags_inv = copy.flags_inv
-	gender = copy.gender
-
-	if(copy.item_icons)
-		item_icons = copy.item_icons.Copy()
-	if(copy.item_state_slots)
-		item_state_slots = copy.item_state_slots.Copy()
-	if(copy.sprite_sheets)
-		sprite_sheets = copy.sprite_sheets.Copy()
-	//copying sprite_sheets_obj should be unnecessary as chameleon items are not refittable.
-
-	OnDisguise(copy, user)
-	qdel(copy)
-
-// Subtypes shall override this, not /disguise()
-/obj/item/proc/OnDisguise(var/obj/item/copy, var/mob/user)
-	return
-
-/proc/generate_chameleon_choices(var/basetype)
-	. = list()
-
-	var/types = islist(basetype) ? basetype : typesof(basetype)
-	var/i = 1 //in case there is a collision with both name AND icon_state
-	for(var/typepath in types)
-		var/obj/item/I = typepath
-		if(initial(I.icon) && initial(I.icon_state) && !(initial(I.item_flags) & ITEM_FLAG_INVALID_FOR_CHAMELEON))
-			var/name = initial(I.name)
-			if(name in .)
-				name += " ([initial(I.icon_state)])"
-			if(name in .)
-				name += " \[[i++]\]"
-			.[name] = typepath
-	return sortAssoc(.)
-
-//starts off as a jumpsuit
 /obj/item/clothing/under/chameleon
 	name = "jumpsuit"
 	icon_state = "jumpsuit"
@@ -58,58 +6,22 @@
 	desc = "It's a plain jumpsuit. It seems to have a small dial on the wrist."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/under/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/under)
-
-/obj/item/clothing/under/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Jumpsuit Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//*****************
-//**Chameleon Hat**
-//*****************
+	set_extension(src,/datum/extension/chameleon/clothing)
 
 /obj/item/clothing/head/chameleon
-	name = "grey cap"
+	name = "cap"
 	icon_state = "greysoft"
 	desc = "It looks like a plain hat, but upon closer inspection, there's an advanced holographic array installed inside. It seems to have a small dial inside."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	body_parts_covered = 0
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/head/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head)
-
-/obj/item/clothing/head/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Hat/Helmet Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//******************
-//**Chameleon Suit**
-//******************
+	set_extension(src,/datum/extension/chameleon/clothing)
 
 /obj/item/clothing/suit/chameleon
 	name = "armor"
@@ -118,57 +30,23 @@
 	desc = "It appears to be a vest of standard armor, except this is embedded with a hidden holographic cloaker, allowing it to change it's appearance, but offering no protection.. It seems to have a small dial inside."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/suit/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit)
+	set_extension(src,/datum/extension/chameleon/clothing)
 
-/obj/item/clothing/suit/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Oversuit Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//*******************
-//**Chameleon Shoes**
-//*******************
 /obj/item/clothing/shoes/chameleon
-	name = "black shoes"
+	name = "shoes"
 	icon_state = "black"
 	item_state = "black"
 	desc = "They're comfy black shoes, with clever cloaking technology built in. It seems to have a small dial on the back of each shoe."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/shoes/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes)
+	set_extension(src,/datum/extension/chameleon/clothing)
 
-/obj/item/clothing/shoes/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Footwear Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//**********************
-//**Chameleon Backpack**
-//**********************
 /obj/item/weapon/storage/backpack/chameleon
 	name = "backpack"
 	icon_state = "backpack"
@@ -176,122 +54,46 @@
 	desc = "A backpack outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/weapon/storage/backpack/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/weapon/storage/backpack)
-
-/obj/item/weapon/storage/backpack/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Backpack Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-
-	//so our overlays update.
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_back()
-
-//********************
-//**Chameleon Gloves**
-//********************
+	set_extension(src,/datum/extension/chameleon/backpack,/obj/item/weapon/storage/backpack)
 
 /obj/item/clothing/gloves/chameleon
-	name = "black gloves"
+	name = "gloves"
 	icon_state = "black"
 	item_state = "bgloves"
 	desc = "It looks like a pair of gloves, but it seems to have a small dial inside."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
-/obj/item/clothing/gloves/chameleon/New()
-	..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves)
-
-/obj/item/clothing/gloves/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Gloves Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//******************
-//**Chameleon Mask**
-//******************
+/obj/item/clothing/gloves/chameleon/Initialize()
+	. = ..()
+	set_extension(src,/datum/extension/chameleon/clothing)
 
 /obj/item/clothing/mask/chameleon
-	name = "gas mask"
+	name = "mask"
 	icon_state = "fullgas"
 	item_state = "gas_alt"
 	desc = "It looks like a plain gask mask, but on closer inspection, it seems to have a small dial inside."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/mask/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask)
-
-/obj/item/clothing/mask/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Mask Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//*********************
-//**Chameleon Glasses**
-//*********************
+	set_extension(src,/datum/extension/chameleon/clothing)
 
 /obj/item/clothing/glasses/chameleon
-	name = "Optical Meson Scanner"
+	name = "goggles"
 	icon_state = "meson"
 	item_state = "glasses"
 	desc = "It looks like a plain set of mesons, but on closer inspection, it seems to have a small dial inside."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/glasses/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses)
-
-/obj/item/clothing/glasses/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Glasses Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-//*********************
-//**Chameleon Headset**
-//*********************
+	set_extension(src,/datum/extension/chameleon/clothing)
 
 /obj/item/device/radio/headset/chameleon
 	name = "radio headset"
@@ -300,30 +102,10 @@
 	desc = "An updated, modular intercom that fits over the head. This one seems to have a small dial on it."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/list/global/clothing_choices
 
 /obj/item/device/radio/headset/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/device/radio/headset)
-
-/obj/item/device/radio/headset/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Headset Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		if (ismob(src.loc))
-			var/mob/M = src.loc
-			M.update_inv_ears()
-
-//***********************
-//**Chameleon Accessory**
-//***********************
+	set_extension(src,/datum/extension/chameleon/headset)
 
 /obj/item/clothing/accessory/chameleon
 	name = "tie"
@@ -332,43 +114,11 @@
 	desc = "A neosilk clip-on tie. It seems to have a small dial on its back."
 	origin_tech = list(TECH_ESOTERIC = 3)
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
-	var/global/list/clothing_choices
 
 /obj/item/clothing/accessory/chameleon/Initialize()
 	. = ..()
-	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/accessory)
+	set_extension(src,/datum/extension/chameleon/clothing/accessory)
 
-/obj/item/clothing/accessory/chameleon/verb/change(picked in clothing_choices)
-	set name = "Change Accessory Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(clothing_choices[picked]))
-			return
-
-		disguise(clothing_choices[picked], usr)
-		update_clothing_icon()	//so our overlays update.
-
-/obj/item/clothing/accessory/chameleon/disguise(var/newtype, var/mob/user)
-	var/obj/item/clothing/accessory/copy = ..()
-	if (!copy)
-		return
-
-	slot = copy.slot
-	has_suit = copy.has_suit
-	inv_overlay = copy.inv_overlay
-	mob_overlay = copy.mob_overlay
-	overlay_state = copy.overlay_state
-	accessory_icons = copy.accessory_icons
-	on_rolled = copy.on_rolled
-	high_visibility = copy.high_visibility
-	return copy
-
-//*****************
-//**Chameleon Gun**
-//*****************
 /obj/item/weapon/gun/energy/chameleon
 	name = "chameleon gun"
 	desc = "A hologram projector in the shape of a gun. There is a dial on the side to change the gun's disguise."
@@ -385,58 +135,6 @@
 	charge_cost = 20 //uses next to no power, since it's just holograms
 	max_shots = 50
 
-	var/obj/item/projectile/copy_projectile
-	var/global/list/gun_choices
-
 /obj/item/weapon/gun/energy/chameleon/Initialize()
 	. = ..()
-	if(!gun_choices)
-		gun_choices = generate_chameleon_choices(/obj/item/weapon/gun)
-
-/obj/item/weapon/gun/energy/chameleon/consume_next_projectile()
-	var/obj/item/projectile/P = ..()
-	if(P && ispath(copy_projectile))
-		P.SetName(initial(copy_projectile.name))
-		P.icon = initial(copy_projectile.icon)
-		P.icon_state = initial(copy_projectile.icon_state)
-		P.pass_flags = initial(copy_projectile.pass_flags)
-		P.hitscan = initial(copy_projectile.hitscan)
-		P.step_delay = initial(copy_projectile.step_delay)
-		P.muzzle_type = initial(copy_projectile.muzzle_type)
-		P.tracer_type = initial(copy_projectile.tracer_type)
-		P.impact_type = initial(copy_projectile.impact_type)
-	return P
-
-/obj/item/weapon/gun/energy/chameleon/OnDisguise(var/obj/item/weapon/gun/copy)
-	if(!istype(copy))
-		return
-
-	flags_inv = copy.flags_inv
-	fire_sound = copy.fire_sound
-	fire_sound_text = copy.fire_sound_text
-	icon = copy.icon
-
-	var/obj/item/weapon/gun/energy/E = copy
-	if(istype(E))
-		copy_projectile = E.projectile_type
-		//charge_meter = E.charge_meter //does not work very well with icon_state changes, ATM
-	else
-		copy_projectile = null
-		//charge_meter = 0
-
-/obj/item/weapon/gun/energy/chameleon/verb/change(picked in gun_choices)
-	set name = "Change Gun Appearance"
-	set category = "Chameleon Items"
-	set src in usr
-
-	if (!(usr.incapacitated()))
-		if(!ispath(gun_choices[picked]))
-			return
-
-		disguise(gun_choices[picked], usr)
-
-	//so our overlays update.
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_r_hand()
-		M.update_inv_l_hand()
+	set_extension(src,/datum/extension/chameleon/gun)


### PR DESCRIPTION
No player-facing changes that require a changelog.

Eventually, I want to add some additional chameleon items or things that provide chameleon behavior to their container (e.g an integrated electronics component). So I decided to see if I could tidy up the chameleon code, by stuffing it all into an extension. I'd also like to generalize it for any /obj, but this current implementation doesn't quite do that.

Putting it up to get some advice on a problem, which is that the verb `/atom/proc/change()` does not show up on items that have the extension. After that's solved it should work 