### PR TITLE
Lets goals check if they're impossible before adding them

### DIFF
--- a/code/modules/goals/_goal.dm
+++ b/code/modules/goals/_goal.dm
@@ -50,3 +50,6 @@
 		if(istype(owner, /datum/mind))
 			var/datum/mind/mind = owner
 			to_chat(mind.current, "<font color='green'><b>[completion_message]</b></font>")
+
+/datum/goal/proc/is_valid()
+	return TRUE

--- a/code/modules/goals/goal_department.dm
+++ b/code/modules/goals/goal_department.dm
@@ -10,9 +10,15 @@
 		return
 	var/list/possible_goals = goals.Copy()
 	goals.Cut()
-	for(var/i = 1 to min(LAZYLEN(possible_goals), rand(min_goals, max_goals)))
+	var/goals_to_pick = min(LAZYLEN(possible_goals), rand(min_goals, max_goals))
+	while(goals_to_pick && LAZYLEN(possible_goals))
 		var/goal = pick_n_take(possible_goals)
-		LAZYADD(goals, new goal(src))
+		var/datum/goal/deptgoal = new goal(src)
+		if(deptgoal.is_valid())
+			LAZYADD(goals, deptgoal)
+			goals_to_pick--
+		else
+			qdel(deptgoal)
 
 /datum/department/proc/summarize_goals(var/show_success = FALSE)
 	. = list()

--- a/maps/torch/datums/department_exploration.dm
+++ b/maps/torch/datums/department_exploration.dm
@@ -26,6 +26,9 @@
 		seeds = max(1, round(0.5 * total_seeds))
 	..()
 
+/datum/goal/department/plant_samples/is_valid()
+	return seeds > 0
+
 /datum/goal/department/plant_samples/update_strings()
 	description = "Scan at least [seeds] different plant\s native to exoplanets."
 	
@@ -47,6 +50,9 @@
 			total_species |= A.type
 	species = rand(length(total_species))
 	..()
+
+/datum/goal/department/fauna_samples/is_valid()
+	return species > 0
 
 /datum/goal/department/fauna_samples/update_strings()
 	description = "Scan at least [species] different creature\s native to exoplanets."


### PR DESCRIPTION
Department goals will not check if they're not dumb before being added.
Mostly used for exploration goals, so no more 'scan 0 plants' goals.

Fixes #27610