### PR TITLE
Makes cyborg name use species bodytype instead of exact subspecie

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -50,8 +50,9 @@
 	if(!(skipjumpsuit && skipface))
 		var/species_name = "\improper "
 		if(is_synth && species.cyborg_noun)
-			species_name += "[species.cyborg_noun] "
-		species_name += "[species.name]"
+			species_name += "[species.cyborg_noun] [species.get_bodytype(src)]"
+		else
+			species_name += "[species.name]"
 		msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value())) ?  SPAN_NOTICE(" \[<a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
 
 	var/extra_species_text = species.get_additional_examine_text(src)


### PR DESCRIPTION
Seeing fully robotic boosters/spaceadapted/whatever was p jarring since the part that was modified is gone.
Now all such species will show up as just Cyborg Human
