### PR TITLE
Adds codex entries for all deity mode structures and spells

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1608,6 +1608,7 @@
 #include "code\modules\codex\entries\mobs.dm"
 #include "code\modules\codex\entries\paperwork.dm"
 #include "code\modules\codex\entries\psionics.dm"
+#include "code\modules\codex\entries\spells.dm"
 #include "code\modules\codex\entries\stacks.dm"
 #include "code\modules\codex\entries\structures.dm"
 #include "code\modules\codex\entries\tools.dm"

--- a/code/modules/codex/entries/spells.dm
+++ b/code/modules/codex/entries/spells.dm
@@ -1,0 +1,115 @@
+/datum/codex_entry/eternal_darkness
+	associated_paths = list(/spell/targeted/shatter)
+	antag_text = "Assaults the mind of the target with fear of the unknown, shattering their sanity and causing brain damage."
+
+/datum/codex_entry/torment
+	associated_paths = list(/spell/targeted/torment)
+	antag_text = "Darkness stabs at the bodies of those around you. All within a medium range will suffer significant pain."
+
+/datum/codex_entry/blood_shard
+	associated_paths = list(/spell/hand/charges/blood_shard)
+	antag_text = "Launches a blood-red shard directly infront of you. Anyone hit by this will have their blood explode out of them in a spray of smaller shards. Stores two charges."
+
+/datum/codex_entry/drain_blood
+	associated_paths = list(/spell/aoe_turf/drain_blood)
+	antag_text = "Allows you to drain the blood from any targets in a short range, restoring your own."
+
+/datum/codex_entry/starburst
+	associated_paths = list(/spell/targeted/genetic/blind/starburst)
+	antag_text = "Grants you the power to blind non-cultists nearby."
+
+/datum/codex_entry/exchange_wounds
+	associated_paths = list(/spell/aoe_turf/exchange_wounds)
+	antag_text = "Allows you to sacrifice your own well-being for that of those around you."
+
+/datum/codex_entry/starlight
+	associated_paths = list(/spell/radiant_aura/starlight)
+	antag_text = "This spell makes you immune to laser fire, for a short while at least."
+
+/datum/codex_entry/burning_hand
+	associated_paths = list(/spell/targeted/equip_item/burning_hand)
+	antag_text = "Sets your hand aflame, allowing you to burn people with an ever-increasing flame."
+
+/datum/codex_entry/burning_grip
+	associated_paths = list(/spell/hand/burning_grip)
+	antag_text = "Burns an item in someone's hand so badly it causes them to burn."
+
+/datum/codex_entry/blood_boil
+	associated_paths = list(/spell/targeted/blood_boil)
+	antag_text = "Allow you to concentrate so deeply on a target that their body temperature increases, eventually setting them on fire."
+
+/datum/codex_entry/fireball
+	associated_paths = list(/spell/targeted/projectile/dumbfire/fireball)
+	antag_text = "A classic spell, grants you the ability to throw an exploding ball of flame in any direction."
+
+/datum/codex_entry/starlight
+	associated_paths = list(/spell/aoe_turf/disable_tech/starlight)
+	antag_text = "Gives you a spell of disabling machinery, and mechanical hearts."
+
+/datum/codex_entry/heal_target
+	associated_paths = list(/spell/targeted/heal_target)
+	antag_text = "Grants you the ability to heal yourself or a nearby target slightly."
+
+/datum/codex_entry/create_air/tower
+	associated_paths = list(/spell/create_air/tower)
+	antag_text = "Allows you to generate a livable atmosphere in the area you are in."
+
+/datum/codex_entry/acid_spray/tower
+	associated_paths = list(/spell/acid_spray/tower)
+	antag_text = "The simplest form of aggressive conjuration: acid spray is quite effective in melting both man and object."
+
+/datum/codex_entry/forcewall/tower
+	associated_paths = list(/spell/aoe_turf/conjure/forcewall/tower)
+	antag_text = "A temporary invincible wall for you to summon."
+
+/datum/codex_entry/faithful_hound/tower
+	associated_paths = list(/spell/aoe_turf/conjure/faithful_hound/tower)
+	antag_text = "This spell allows you to summon a singular spectral dog that guards the nearby area. Anyone without the password is barked at or bitten."
+
+/datum/codex_entry/dyrnwyn/tower
+	associated_paths = list(/spell/targeted/equip_item/dyrnwyn/tower)
+	antag_text = "This spell allows you to summon a golden firey sword for a short duration."
+
+/datum/codex_entry/shield/tower
+	associated_paths = list(/spell/targeted/equip_item/shield/tower)
+	antag_text = "This spell allows you to summon a magical shield for a short duration."
+
+/datum/codex_entry/fireball/tower
+	associated_paths = list(/spell/targeted/projectile/dumbfire/fireball/tower)
+	antag_text = "Imbue yourself with the power of exploding fire."
+
+/datum/codex_entry/force_portal/tower
+	associated_paths = list(/spell/aoe_turf/conjure/force_portal/tower)
+	antag_text = "This spell allows you to summon a force portal. Anything that hits the portal gets sucked inside and is then thrown out when the portal explodes."
+
+/datum/codex_entry/slippery_surface/tower
+	associated_paths = list(/spell/hand/slippery_surface/tower)
+	antag_text = "Allows you to slicken a small patch of floor. Anyone without sure-footing will find it hard to stay upright."
+
+/datum/codex_entry/smoke/tower
+	associated_paths = list(/spell/aoe_turf/smoke/tower)
+	antag_text = "Allows you to distill the nearby air into smoke."
+
+/datum/codex_entry/knock/tower
+	associated_paths = list(/spell/aoe_turf/knock/tower)
+	antag_text = "Allows you to open nearby doors without the keys."
+
+/datum/codex_entry/burning_grip/tower
+	associated_paths = list(/spell/hand/burning_grip/tower)
+	antag_text = "Allows you cause an object to heat up intensly in someone's hand, making them drop it and whatever skin is attached."
+
+/datum/codex_entry/ethereal_jaunt/tower
+	associated_paths = list(/spell/targeted/ethereal_jaunt/tower)
+	antag_text = "Allows you to liquify for a short duration, letting them pass through all dense objects."
+
+/datum/codex_entry/heal_target/tower
+	associated_paths = list(/spell/targeted/heal_target/tower)
+	antag_text = "Allows you to heal yourself, or others, for a slight amount."
+
+/datum/codex_entry/heal_target/major/tower
+	associated_paths = list(/spell/targeted/heal_target/major/tower)
+	antag_text = "Allows you to heal others for a great amount."
+
+/datum/codex_entry/heal_target/area/tower
+	associated_paths = list(/spell/targeted/heal_target/area/tower)
+	antag_text = "Allows you to heal everyone in an area for minor damage."

--- a/code/modules/codex/entries/structures.dm
+++ b/code/modules/codex/entries/structures.dm
@@ -25,3 +25,36 @@
 	associated_paths = list(/obj/structure/barricade/spike)
 	lore_text = "The cheval de frise (Frisian horse) is an ancient anti-cavalry barricade so named because they were widely deployed by the Frisians, who lacked easy access to horses to field their own cavalry."
 	mechanics_text = "Constructed by adding rods of any material to a barricade constructed of any material, this structure will injure anyone who moves into it."
+
+/datum/codex_entry/deity/altar
+	associated_paths = list(/obj/structure/deity/altar)
+	mechanics_text = "To place someone upon the altar, first have them in an aggressive grab and click the altar while adjacent."
+	antag_text = "This structure anchors your deity within this realm, granting them additional power to influence it and empower their followers. Additionally, using it as a focus for their powers, they can convert someone laying on top of the altar.<br>"
+
+/datum/codex_entry/deity/blood_forge
+	associated_paths = list(/obj/structure/deity/blood_forge)
+	antag_text = "Allows creation of special items by feeding your blood into it. Only usable by cultists of the aligned deity."
+
+/datum/codex_entry/deity/blood_stone
+	associated_paths = list(/obj/structure/deity/blood_stone)
+	antag_text = "Allows the user to feed blood directly to the aligned deity, granting it power."
+
+/datum/codex_entry/deity/gateway
+	associated_paths = list(/obj/structure/deity/gateway)
+	antag_text = "Stand within the gateway to be transported to an unknown dimension and transformed into a flaming Starborn, a mysterious Blueforged or a subtle Shadowling."
+
+/datum/codex_entry/deity/radiant_statue
+	associated_paths = list(/obj/structure/deity/radiant_statue)
+	antag_text = "Allows storage of power if cultists are nearby. This stored power can be expended to charge Starlight items."
+
+/datum/codex_entry/deity/blood_forge/starlight
+	associated_paths = list(/obj/structure/deity/blood_forge/starlight)
+	antag_text = "Allows creation of special Starlight items. Only usable by cultists of the aligned deity. Use of this powerful forge will inflict burns."
+
+/datum/codex_entry/deity/wizard_recharger
+	associated_paths = list(/obj/structure/deity/wizard_recharger)
+	antag_text = "A well of arcane power. When charged, a cultist may absorb this power to refresh their spells."
+
+/datum/codex_entry/deity/pylon
+	associated_paths = list(/obj/structure/deity/pylon)
+	antag_text = "Serves as a conduit for a deity to speak through, making their will known in this dimension to any who hear it."

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -65,6 +65,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/mob/living/deity/connected_god //Do we have this spell based off a boon from a god?
 	var/obj/screen/connected_button
 
+	var/hidden_from_codex = FALSE
+
 ///////////////////////
 ///SETUP AND PROCESS///
 ///////////////////////


### PR DESCRIPTION
:cl:
rscadd: All Deity mode spells and structures now have a codex entry visible to the God Cultists that explains what they do, or how to use them.
/:cl:

Being a God Cultist is incredibly confusing, since you get zero indication on what anything does without pestering your deity to repeat its ability descriptions to you. Hopefully this will lessen the frequent 'how does this work' ahelps in deity mode. Assuming people actually use the codex.

Some things still need some explaination, but they're more suited to an updated wiki article than codex entries - e.g. Starlight Blueforged mechanics.