### PR TITLE
More masks now cover the face, making them suitable for disguises

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -34,6 +34,7 @@
 	item_state = "sterile"
 	w_class = ITEM_SIZE_SMALL
 	body_parts_covered = FACE
+	flags_inv = HIDEFACE
 	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.01


### PR DESCRIPTION
:cl:
tweak: More masks now cover the face, concealing your identity and making you appear as 'Unknown (ID Name). These include medical masks and any subtypes of those masks.
/:cl:

The voice-changer is fairly weak as a disguise item, if you want to impersonate someone and be seen by people. There are really only two options for disguising yourself with it, the fake mustache (not viable for women), and the face mask (not viable for many jobs, and not commonly seen). It isn't that cheap TC-wise, and I think it should have more viable disguise options.

I've made a bunch more of the commonly used masks cover your face, so antagonists will have an easier time doing disguise gimmicks with the voice-changer mask. They do not conceal your identity if pulled down.