### PR TITLE
Lab Tech Skill Fixes

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -150,9 +150,10 @@
 						SKILL_VIROLOGY  = HAS_PERK,
 	                    SKILL_CHEMISTRY = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
+	max_skill = list(   SKILL_MEDICAL     = SKILL_ADEPT,
+						SKILL_ANATOMY	  = SKILL_ADEPT,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
-	skill_points = 26
+	skill_points = 16
 
 	access = list(access_medical, access_maint_tunnels, access_emergency_storage, access_medical_equip, access_solgov_crew, access_chemistry,
 	 						access_virology, access_morgue, access_crematorium)


### PR DESCRIPTION
:cl:
tweak: The Lab Tech now only has 16 skill points, and is restricted to trained medicine and anatomy.
/:cl:

This job has way too many skill points, and to reinforce that they aren't a corpsman/doctor, their ability to do surgery / medicine has been cut.