### PR TITLE
Makes robotic limb reattachment consistently use robotic skills.

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -44,6 +44,14 @@
 	else
 		. = TRUE
 
+/decl/surgery_step/limb/attach/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/organ/external/tool)
+	if(istype(tool) && BP_IS_ROBOTIC(tool))
+		if(target.isSynthetic())
+			return SURGERY_SKILLS_ROBOTIC
+		else
+			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+	return ..()
+
 /decl/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
 		var/obj/item/organ/external/E = tool
@@ -85,6 +93,15 @@
 	can_infect = 1
 	min_duration = 100
 	max_duration = 120
+
+/decl/surgery_step/limb/connect/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	var/obj/item/organ/external/E = target && target.get_organ(target_zone)
+	if(istype(E) && BP_IS_ROBOTIC(E))
+		if(target.isSynthetic())
+			return SURGERY_SKILLS_ROBOTIC
+		else
+			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+	return ..()
 
 /decl/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 	return 1
 
-/decl/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	if(delicate)
 		return SURGERY_SKILLS_DELICATE
 	else
@@ -124,12 +124,12 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 /decl/surgery_step/proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return null
 
-/decl/surgery_step/proc/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/proc/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	. = tool_quality(tool)
 	if(user == target)
 		. -= 10
 
-	var/skill_reqs = get_skill_reqs(user, target, tool)
+	var/skill_reqs = get_skill_reqs(user, target, tool, target_zone)
 	for(var/skill in skill_reqs)
 		var/penalty = delicate ? 40 : 20
 		. -= max(0, penalty * (skill_reqs[skill] - user.get_skill_value(skill)))
@@ -196,7 +196,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	else if(LAZYLEN(possible_surgeries) >= 1)
 		if(user.client) // In case of future autodocs.
 			S = input(user, "Which surgery would you like to perform?", "Surgery") as null|anything in possible_surgeries
-		if(S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src)))
+		if(S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src, zone)))
 			S = pick(possible_surgeries)
 
 	// We didn't find a surgery, or decided not to perform one.
@@ -223,9 +223,9 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			if(operation_data)
 				LAZYSET(M.surgeries_in_progress, zone, operation_data)
 				S.begin_step(user, M, zone, src)
-				var/skill_reqs = S.get_skill_reqs(user, M, src)
+				var/skill_reqs = S.get_skill_reqs(user, M, src, zone)
 				var/duration = user.skill_delay_mult(skill_reqs[1]) * rand(S.min_duration, S.max_duration)
-				if(prob(S.success_chance(user, M, src)) && do_mob(user, M, duration))
+				if(prob(S.success_chance(user, M, src, zone)) && do_mob(user, M, duration))
 					S.end_step(user, M, zone, src)
 					handle_post_surgery()
 				else if ((src in user.contents) && user.Adjacent(M))


### PR DESCRIPTION
:cl:
bugfix: Robotic limb attachment and connection surgery now consistently checks robotic skills (complex devices, also anatomy if on flesh target).
/:cl:

Fixes #27697