### PR TITLE
Adds an error message for trying to cut into spacesuits/thick clothes/armor with a scalpel

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -70,6 +70,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			// Check if clothing is blocking access
 			var/obj/item/I = target.get_covering_equipped_item_by_zone(target_zone)
 			if(I && (I.item_flags & ITEM_FLAG_THICKMATERIAL))
+				to_chat(user,SPAN_NOTICE("The material covering this area is too thick for you to do surgery through!"))
 				return FALSE
 			// Check various conditional flags.
 			if(((surgery_candidate_flags & SURGERY_NO_ROBOTIC) && BP_IS_ROBOTIC(affected)) || \


### PR DESCRIPTION
:cl:
tweak: Failing to do surgery due to thick material clothing items will now display an appropriate error message.
/:cl:

Was missing an error message and was confusing as to why the surgery was failing. Now will tell you what's wrong so you can strip whatever item off the patient.