### PR TITLE
HUD icon refactoring

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -32,16 +32,21 @@
 #define PROCESS_KILL 26 // Used to trigger removal from a processing list.
 
 // For secHUDs and medHUDs and variants. The number is the location of the image on the list hud_list of humans.
-#define      HEALTH_HUD 1 // A simple line rounding the mob's number health.
-#define      STATUS_HUD 2 // Alive, dead, diseased, etc.
-#define          ID_HUD 3 // The job asigned to your ID.
-#define      WANTED_HUD 4 // Wanted, released, paroled, security status.
-#define    IMPLOYAL_HUD 5 // Loyality implant.
-#define     IMPCHEM_HUD 6 // Chemical implant.
-#define    IMPTRACK_HUD 7 // Tracking implant.
-#define SPECIALROLE_HUD 8 // AntagHUD image.
-#define  STATUS_HUD_OOC 9 // STATUS_HUD without virus DB check for someone being ill.
-#define 	  LIFE_HUD 10 // STATUS_HUD that only reports dead or alive
+#define      HEALTH_HUD 1  // A simple line rounding the mob's number health.
+#define      STATUS_HUD 2  // Alive, dead, diseased, etc.
+#define          ID_HUD 3  // The job asigned to your ID.
+#define      WANTED_HUD 4  // Wanted, released, paroled, security status.
+#define    IMPLOYAL_HUD 5  // Loyality implant.
+#define     IMPCHEM_HUD 6  // Chemical implant.
+#define    IMPTRACK_HUD 7  // Tracking implant.
+#define SPECIALROLE_HUD 8  // AntagHUD image.
+#define        LIFE_HUD 9  // STATUS_HUD that only reports dead or alive
+
+#define HUD_COUNT 9 // Must be the total number of HUDs listed above
+#define HUD_ALL (~0)
+
+#define HUDBIT(idx) (1 << ((idx) - 1))
+#define MEDICAL_HUDS HUDBIT(HEALTH_HUD) | HUDBIT(STATUS_HUD) | HUDBIT(LIFE_HUD)
 
 // Shuttle moving status.
 #define SHUTTLE_IDLE      0

--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -1,6 +1,7 @@
 GLOBAL_LIST_EMPTY(med_hud_users)          // List of all entities using a medical HUD.
 GLOBAL_LIST_EMPTY(sec_hud_users)          // List of all entities using a security HUD.
 GLOBAL_LIST_EMPTY(jani_hud_users)
+GLOBAL_LIST_EMPTY(antag_hud_users)
 GLOBAL_LIST_EMPTY(hud_icon_reference)
 
 GLOBAL_LIST_EMPTY(listening_objects) // List of objects that need to be able to hear, used to avoid recursive searching through contents.

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -556,9 +556,7 @@ SUBSYSTEM_DEF(jobs)
 			var/obj/item/clothing/glasses/G = H.glasses
 			G.prescription = 7
 
-	BITSET(H.hud_updateflag, ID_HUD)
-	BITSET(H.hud_updateflag, IMPLOYAL_HUD)
-	BITSET(H.hud_updateflag, SPECIALROLE_HUD)
+	H.hud_updateflag |= HUDBIT(ID_HUD) | HUDBIT(SPECIALROLE_HUD)
 
 	job.post_equip_rank(H, alt_title || rank)
 

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -390,9 +390,6 @@
 
 	else if(href_list["implant"])
 		var/mob/living/carbon/human/H = current
-
-		BITSET(H.hud_updateflag, IMPLOYAL_HUD)   // updates that players HUD images so secHUD's pick up they are implanted or not.
-
 		switch(href_list["implant"])
 			if("remove")
 				for(var/obj/item/weapon/implant/loyalty/I in H.contents)
@@ -402,13 +399,14 @@
 							break
 				to_chat(H, "<span class='notice'><font size =3><B>Your loyalty implant has been deactivated.</B></font></span>")
 				log_admin("[key_name_admin(usr)] has de-loyalty implanted [current].")
+
 			if("add")
 				to_chat(H, "<span class='danger'><font size =3>You somehow have become the recepient of a loyalty transplant, and it just activated!</font></span>")
 				H.implant_loyalty(H, override = TRUE)
 				log_admin("[key_name_admin(usr)] has loyalty implanted [current].")
-			else
+
 	else if (href_list["silicon"])
-		BITSET(current.hud_updateflag, SPECIALROLE_HUD)
+		current.hud_updateflag |= HUDBIT(SPECIALROLE_HUD)
 		switch(href_list["silicon"])
 
 			if("unemag")

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -64,6 +64,10 @@
 		if(nonstandard_role_msg)
 			to_chat(player.current, "<span class='notice'>[nonstandard_role_msg]</span>")
 		update_icons_added(player)
+
+	if(player.current)
+		player.current.create_hud_overlay(SPECIALROLE_HUD)
+
 	return 1
 
 /datum/antagonist/proc/remove_antagonist(var/datum/mind/player, var/show_message, var/implanted)
@@ -81,7 +85,7 @@
 		update_icons_removed(player)
 
 		if(player.current)
-			BITSET(player.current.hud_updateflag, SPECIALROLE_HUD)
+			player.current.hud_updateflag |= HUDBIT(SPECIALROLE_HUD)
 			player.current.reset_skillset() //Reset their skills to be job-appropriate.
 
 		if(!is_special_character(player))

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -60,8 +60,6 @@
 			affected.implants += src
 			part = affected
 
-		BITSET(H.hud_updateflag, IMPLOYAL_HUD)
-
 	forceMove(M)
 	imp_in = M
 	implanted = 1
@@ -120,4 +118,5 @@
 /obj/item/weapon/implant/Destroy()
 	if(part)
 		part.implants.Remove(src)
+	removed()
 	return ..()

--- a/code/game/objects/items/weapons/implants/implants/chem.dm
+++ b/code/game/objects/items/weapons/implants/implants/chem.dm
@@ -4,6 +4,12 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2)
 	known = 1
 
+/obj/item/weapon/implant/chem/removed()
+	if (implanted && istype(imp_in, /mob/living))
+		var/mob/living/H = imp_in
+		H.hud_updateflag |= HUDBIT(IMPCHEM_HUD)
+	. = ..()
+
 /obj/item/weapon/implant/chem/get_data()
 	return {"
 	<b>Implant Specifications:</b><BR>
@@ -43,6 +49,12 @@
 				to_chat(user, "<span class='notice'>You inject 5 units of the solution. The syringe now contains [I.reagents.total_volume] units.</span>")
 	else
 		..()
+
+/obj/item/weapon/implant/chem/implanted(mob/M)
+	if (istype(M, /mob/living))
+		var/mob/living/H = M
+		H.create_hud_overlay(IMPCHEM_HUD)
+	. = ..()
 
 /obj/item/weapon/implantcase/chem
 	name = "glass case - 'chem'"

--- a/code/game/objects/items/weapons/implants/implants/loyalty.dm
+++ b/code/game/objects/items/weapons/implants/implants/loyalty.dm
@@ -4,6 +4,12 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ESOTERIC = 3)
 	known = 1
 
+/obj/item/weapon/implant/loyalty/removed()
+	if (implanted && istype(imp_in, /mob/living))
+		var/mob/living/H = imp_in
+		H.hud_updateflag |= HUDBIT(IMPLOYAL_HUD)
+	. = ..()
+
 /obj/item/weapon/implant/loyalty/get_data()
 	return {"
 	<b>Implant Specifications:</b><BR>
@@ -23,9 +29,9 @@
 	if(antag_data && (antag_data.flags & ANTAG_IMPLANT_IMMUNE))
 		H.visible_message("[H] seems to resist the implant!", "You feel the corporate tendrils of [GLOB.using_map.company_name] try to invade your mind!")
 		return FALSE
-	else
-		clear_antag_roles(H.mind, 1)
-		to_chat(H, "<span class='notice'>You feel a surge of loyalty towards [GLOB.using_map.company_name].</span>")
+	clear_antag_roles(H.mind, 1)
+	to_chat(H, "<span class='notice'>You feel a surge of loyalty towards [GLOB.using_map.company_name].</span>")
+	H.create_hud_overlay(IMPLOYAL_HUD)
 	return TRUE
 
 /obj/item/weapon/implanter/loyalty

--- a/code/game/objects/items/weapons/implants/implants/tracking.dm
+++ b/code/game/objects/items/weapons/implants/implants/tracking.dm
@@ -5,6 +5,12 @@
 	known = 1
 	var/id = 1
 
+/obj/item/weapon/implant/tracking/removed()
+	if (implanted && istype(imp_in, /mob/living))
+		var/mob/living/H = imp_in
+		H.hud_updateflag |= HUDBIT(IMPTRACK_HUD)
+	. = ..()
+
 /obj/item/weapon/implant/tracking/get_data()
 	. = {"<b>Implant Specifications:</b><BR>
 	<b>Name:</b> Tracking Beacon<BR>
@@ -41,6 +47,12 @@
 		meltdown()
 	else if(prob(power * 40))
 		disable(rand(power*500,power*5000))//adds in extra time because this is the only other way to sabotage it
+
+/obj/item/weapon/implant/tracking/implanted(mob/M)
+	if (istype(M, /mob/living))
+		var/mob/living/H = M
+		H.create_hud_overlay(IMPTRACK_HUD)
+	. = ..()
 
 /obj/item/weapon/implantcase/tracking
 	name = "glass case - 'tracking'"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -966,6 +966,10 @@ BLIND     // can't see anything
 	else
 		user.visible_message("[user] adjusts the tracking sensor on [src]", "You adjust the sensor on [src].")
 
+	if (istype(loc, /mob/living))
+		var/mob/living/H = loc
+		H.hud_updateflag |= MEDICAL_HUDS
+
 /obj/item/clothing/under/emp_act(var/severity)
 	..()
 	var/new_mode
@@ -978,6 +982,10 @@ BLIND     // can't see anything
 			new_mode = pick(25;SUIT_SENSOR_OFF, 35;SUIT_SENSOR_BINARY, 30;SUIT_SENSOR_VITAL, 10;SUIT_SENSOR_TRACKING)
 
 	sensor_mode = new_mode
+
+	if (istype(loc, /mob/living))
+		var/mob/living/H = loc
+		H.hud_updateflag |= MEDICAL_HUDS
 
 /obj/item/clothing/under/verb/toggle()
 	set name = "Toggle Suit Sensors"

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -27,10 +27,8 @@
 
 	if(stat == DEAD) return
 
-	BITSET(hud_updateflag, HEALTH_HUD)
-	BITSET(hud_updateflag, STATUS_HUD)
-	BITSET(hud_updateflag, LIFE_HUD)
-	
+	hud_updateflag |= MEDICAL_HUDS
+
 	//Handle species-specific deaths.
 	species.handle_death(src)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
 
-	var/list/hud_list[10]
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 	var/obj/item/weapon/rig/wearing_rig // This is very not good, but it's much much better than calling get_rig() every update_canmove() call.
 	var/list/stance_limbs
@@ -34,16 +33,11 @@
 		if(mind)
 			mind.name = real_name
 
-	hud_list[HEALTH_HUD]      = new /image/hud_overlay('icons/mob/hud_med.dmi', src, "100")
-	hud_list[STATUS_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudhealthy")
-	hud_list[LIFE_HUD]	      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudhealthy")
-	hud_list[ID_HUD]          = new /image/hud_overlay(GLOB.using_map.id_hud_icons, src, "hudunknown")
-	hud_list[WANTED_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPLOYAL_HUD]    = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPCHEM_HUD]     = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPTRACK_HUD]    = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[SPECIALROLE_HUD] = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[STATUS_HUD_OOC]  = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudhealthy")
+	hud_list = new /list(HUD_COUNT)
+	create_hud_overlay(HEALTH_HUD, "100", 'icons/mob/hud_med.dmi')
+	create_hud_overlay(STATUS_HUD, "hudhealthy")
+	create_hud_overlay(LIFE_HUD, "hudhealthy")
+	create_hud_overlay(ID_HUD, "hudunknown", GLOB.using_map.id_hud_icons)
 
 	GLOB.human_mob_list |= src
 	..()
@@ -453,7 +447,7 @@
 					modified = 1
 
 					spawn()
-						BITSET(hud_updateflag, WANTED_HUD)
+						hud_updateflag |= HUDBIT(WANTED_HUD)
 						if(istype(user,/mob/living/carbon/human))
 							var/mob/living/carbon/human/U = user
 							U.handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -1,5 +1,6 @@
 //Updates the mob's health from organs and mob damage variables
 /mob/living/carbon/human/updatehealth()
+	hud_updateflag |= HUDBIT(HEALTH_HUD)
 
 	if(status_flags & GODMODE)
 		health = maxHealth
@@ -65,7 +66,7 @@
 			amount -= E.remove_pain(amount)
 		else
 			amount -= E.add_pain(amount)
-	BITSET(hud_updateflag, HEALTH_HUD)
+	hud_updateflag |= HUDBIT(HEALTH_HUD)
 
 //These procs fetch a cumulative total damage from all organs
 /mob/living/carbon/human/getBruteLoss()
@@ -89,14 +90,14 @@
 		take_overall_damage(amount, 0)
 	else
 		heal_overall_damage(-amount, 0)
-	BITSET(hud_updateflag, HEALTH_HUD)
+	hud_updateflag |= HUDBIT(HEALTH_HUD)
 
 /mob/living/carbon/human/adjustFireLoss(var/amount)
 	if(amount > 0)
 		take_overall_damage(0, amount)
 	else
 		heal_overall_damage(0, -amount)
-	BITSET(hud_updateflag, HEALTH_HUD)
+	hud_updateflag |= HUDBIT(HEALTH_HUD)
 
 /mob/living/carbon/human/Stun(amount)
 	amount *= species.stun_mod
@@ -137,7 +138,7 @@
 			amount -= E.remove_genetic_damage(amount)
 		else
 			amount -= E.add_genetic_damage(amount)
-	BITSET(hud_updateflag, HEALTH_HUD)
+	hud_updateflag |= HUDBIT(HEALTH_HUD)
 
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/getOxyLoss()
@@ -165,7 +166,7 @@
 			breathe_organ.remove_oxygen_deprivation(abs(amount))
 		else
 			breathe_organ.add_oxygen_deprivation(abs(amount*species.oxy_mod))
-	BITSET(hud_updateflag, HEALTH_HUD)
+	hud_updateflag |= HUDBIT(HEALTH_HUD)
 
 /mob/living/carbon/human/getToxLoss()
 	if((species.species_flags & SPECIES_FLAG_NO_POISON) || isSynthetic())
@@ -266,8 +267,7 @@
 	var/list/obj/item/organ/external/parts = get_damaged_organs(brute,burn)
 	if(!parts.len)	return
 	var/obj/item/organ/external/picked = pick(parts)
-	if(picked.heal_damage(brute,burn,robo_repair = affect_robo))
-		BITSET(hud_updateflag, HEALTH_HUD)
+	picked.heal_damage(brute,burn,robo_repair = affect_robo)
 	updatehealth()
 
 
@@ -286,10 +286,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 	var/obj/item/organ/external/picked = pick(parts)
 	var/damage_flags = (sharp? DAM_SHARP : 0)|(edge? DAM_EDGE : 0)
-
-	if(picked.take_external_damage(brute, burn, damage_flags))
-		BITSET(hud_updateflag, HEALTH_HUD)
-
+	picked.take_external_damage(brute, burn, damage_flags)
 	updatehealth()
 
 
@@ -310,7 +307,6 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 		parts -= picked
 	updatehealth()
-	BITSET(hud_updateflag, HEALTH_HUD)
 
 // damage MANY external organs, in random order
 /mob/living/carbon/human/take_overall_damage(var/brute, var/burn, var/sharp = 0, var/edge = 0, var/used_weapon = null)
@@ -333,7 +329,6 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 			apply_damage(damage = burn_avg, damagetype = BURN, damage_flags = dam_flags, used_weapon = used_weapon, silent = TRUE, given_organ = E)
 
 	updatehealth()
-	BITSET(hud_updateflag, HEALTH_HUD)
 
 
 ////////////////////////////////////////////
@@ -361,7 +356,7 @@ This function restores all organs.
 	var/obj/item/organ/external/E = get_organ(zone)
 	if(istype(E, /obj/item/organ/external))
 		if (E.heal_damage(brute, burn))
-			BITSET(hud_updateflag, HEALTH_HUD)
+			hud_updateflag |= HUDBIT(HEALTH_HUD)
 	else
 		return 0
 	return
@@ -423,7 +418,6 @@ This function restores all organs.
 
 	// Will set our damageoverlay icon to the next level, which will then be set back to the normal level the next mob.Life().
 	updatehealth()
-	BITSET(hud_updateflag, HEALTH_HUD)
 	return created_wound
 
 // Find out in how much pain the mob is at the moment.

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -517,8 +517,7 @@ var/global/list/damage_icon_parts = list()
 
 	overlays_standing[HO_ID_LAYER]	= id_overlay
 
-	BITSET(hud_updateflag, ID_HUD)
-	BITSET(hud_updateflag, WANTED_HUD)
+	hud_updateflag |= HUDBIT(ID_HUD) | HUDBIT(WANTED_HUD)
 
 	if(update_icons)
 		queue_icon_update()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -403,9 +403,6 @@ default behaviour is:
 		if (C.handcuffed && !initial(C.handcuffed))
 			C.drop_from_inventory(C.handcuffed)
 		C.handcuffed = initial(C.handcuffed)
-	BITSET(hud_updateflag, HEALTH_HUD)
-	BITSET(hud_updateflag, STATUS_HUD)
-	BITSET(hud_updateflag, LIFE_HUD)
 	ExtinguishMob()
 	fire_stacks = 0
 
@@ -455,9 +452,7 @@ default behaviour is:
 	// make the icons look correct
 	regenerate_icons()
 
-	BITSET(hud_updateflag, HEALTH_HUD)
-	BITSET(hud_updateflag, STATUS_HUD)
-	BITSET(hud_updateflag, LIFE_HUD)
+	hud_updateflag |= MEDICAL_HUDS
 
 	failed_last_breath = 0 //So mobs that died of oxyloss don't revive and have perpetual out of breath.
 	reload_fullscreen()
@@ -476,9 +471,7 @@ default behaviour is:
 	stat = CONSCIOUS
 	regenerate_icons()
 
-	BITSET(hud_updateflag, HEALTH_HUD)
-	BITSET(hud_updateflag, STATUS_HUD)
-	BITSET(hud_updateflag, LIFE_HUD)
+	hud_updateflag |= MEDICAL_HUDS
 
 	failed_last_breath = 0 //So mobs that died of oxyloss don't revive and have perpetual out of breath.
 	reload_fullscreen()
@@ -562,7 +555,7 @@ default behaviour is:
 	if(!can_pull())
 		stop_pulling()
 		return
-	
+
 	if (!isliving(pulling))
 		step(pulling, get_dir(pulling.loc, old_loc))
 	else
@@ -874,3 +867,24 @@ default behaviour is:
 
 /mob/living/proc/eyecheck()
 	return FLASH_PROTECTION_NONE
+
+/mob/living/proc/create_hud_overlay(index, default_state = "hudblank", icon_path = 'icons/mob/hud.dmi')
+	if (hud_list[index] == null)
+		hud_list[index] = new /image/hud_overlay(icon_path, src, default_state)
+	hud_updateflag |= HUDBIT(index)
+
+/mob/living/proc/update_hud_overlay(index, new_state)
+	if (hud_list[index] != null)
+		var/image/holder = hud_list[index]
+		holder.icon_state = new_state
+		hud_list[index] = holder
+
+/mob/living/proc/delete_hud_overlay(index)
+	QDEL_NULL(hud_list[index])
+	hud_updateflag |= HUDBIT(index)
+
+/mob/living/proc/check_hud_overlay_update(index, bypassExistsCheck = FALSE)
+	if (bypassExistsCheck)
+		return (hud_updateflag & HUDBIT(index))
+	else
+		return (hud_updateflag & HUDBIT(index)) && hud_list[index]

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -7,7 +7,8 @@
 	var/maxHealth = 100 //Maximum health that should be possible.
 	var/health = 100 	//A mob's health
 
-	var/hud_updateflag = 0
+	var/hud_updateflag = 0 // Bitflag
+	var/hud_list
 
 	//Damage related vars, NOTE: THESE SHOULD ONLY BE MODIFIED BY PROCS // what a joke
 	//var/bruteloss = 0 //Brutal damage caused by brute force (punching, being clubbed by a toolbox ect... this also accounts for pressure damage)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -173,15 +173,7 @@ var/list/ai_verbs_default = list(
 
 	create_powersupply()
 
-	hud_list[HEALTH_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[STATUS_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[LIFE_HUD] 		  = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[ID_HUD]          = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[WANTED_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPLOYAL_HUD]    = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPCHEM_HUD]     = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPTRACK_HUD]    = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[SPECIALROLE_HUD] = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
+	hud_list = new /list(HUD_COUNT)
 
 	ai_list += src
 	..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -145,15 +145,9 @@
 
 	add_robot_verbs()
 
-	hud_list[HEALTH_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[STATUS_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudhealth100")
-	hud_list[LIFE_HUD]        = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudhealth100")
-	hud_list[ID_HUD]          = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[WANTED_HUD]      = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPLOYAL_HUD]    = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPCHEM_HUD]     = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[IMPTRACK_HUD]    = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
-	hud_list[SPECIALROLE_HUD] = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
+	hud_list = new /list(HUD_COUNT)
+	create_hud_overlay(STATUS_HUD, "hudhealth100")
+	create_hud_overlay(LIFE_HUD, "hudhealth100")
 
 	AddMovementHandler(/datum/movement_handler/robot/use_power, /datum/movement_handler/mob/space)
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -16,7 +16,6 @@
 	var/list/stating_laws = list()// Channels laws are currently being stated on
 	var/obj/item/device/radio/silicon_radio
 
-	var/list/hud_list[10]
 	var/list/speech_synthesizer_langs = list()	//which languages can be vocalized by the speech synthesizer
 
 	//Used in say.dm.

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -112,29 +112,9 @@ Works together with spawning an observer, noted above.
 	handle_hud_glasses()
 
 	if(antagHUD)
-		var/list/target_list = list()
-		for(var/mob/living/target in oview(src, 14))
-			if(target.mind && target.mind.special_role)
-				target_list += target
-		if(target_list.len)
-			assess_targets(target_list, src)
+		process_antag_hud(src)
 	if(medHUD)
-		process_medHUD(src)
-
-
-/mob/observer/ghost/proc/process_medHUD(var/mob/M)
-	var/client/C = M.client
-	for(var/mob/living/carbon/human/patient in oview(M, 14))
-		C.images += patient.hud_list[HEALTH_HUD]
-		C.images += patient.hud_list[STATUS_HUD_OOC]
-
-/mob/observer/ghost/proc/assess_targets(list/target_list, mob/observer/ghost/U)
-	var/client/C = U.client
-	for(var/mob/living/carbon/human/target in target_list)
-		C.images += target.hud_list[SPECIALROLE_HUD]
-	for(var/mob/living/silicon/target in target_list)
-		C.images += target.hud_list[SPECIALROLE_HUD]
-	return 1
+		process_med_hud(src, TRUE)
 
 /mob/proc/ghostize(var/can_reenter_corpse = CORPSE_CAN_REENTER)
 	// Are we the body of an aghosted admin? If so, don't make a ghost.

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -104,9 +104,7 @@
 				var/obj/item/clothing/glasses/G = user_human.glasses
 				G.prescription = 7
 
-		BITSET(character.hud_updateflag, ID_HUD)
-		BITSET(character.hud_updateflag, IMPLOYAL_HUD)
-		BITSET(character.hud_updateflag, SPECIALROLE_HUD)
+		character.hud_updateflag |= HUDBIT(ID_HUD) | HUDBIT(SPECIALROLE_HUD)
 
 		SSticker.mode.handle_offsite_latejoin(character)
 		GLOB.universe.OnPlayerLatejoin(character)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -201,8 +201,6 @@
 			"<span class='notice'>You take \the [obj] out of incision on \the [target]'s [affected.name] with \the [tool].</span>" )
 			target.remove_implant(obj, TRUE, affected)
 
-			BITSET(target.hud_updateflag, IMPLOYAL_HUD)
-
 			//Handle possessive brain borers.
 			if(istype(obj,/mob/living/simple_animal/borer))
 				var/mob/living/simple_animal/borer/worm = obj
@@ -231,4 +229,3 @@
 			playsound(imp.loc, 'sound/items/countdown.ogg', 75, 1, -3)
 			spawn(25)
 				imp.activate()
-

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 43 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 476 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 477 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P


### PR DESCRIPTION
- Should fix null runtimes
- Fixes implant icons not always disappearing when implants are removed
- Antag hud now uses the same process as other huds
- Ghosts using huds now use the same procs as hud glasses
- hud_updateflag is now a more sensible bitwise var
- Removed redundant or unused HUD flags

:cl: SierraKomodo
tweak: Medical, Security, and Antag HUDs have been reworked. There should be no player-facing changes aside from some bug fixing. This does not affect cult, rev, etc antag icons that currently use a different system. Forward all HUD related bug reports to SierraKomodo.
bugfix: Implant icons in Security HUD overlays now disappear when the implant is removed.
bugfix: 'Non-local' Medical HUD overlay will now properly update when suit sensors are adjusted (Only affects AI and borgs using sensor augmentations. Does not affect people and borgs using the medical hud object)
bugfix: Ghost antag HUD should now show antags that were added mid-round
/:cl:

TODO
- [x] Get medical HUD overlays to work again
- [X] Fix implant HUD overlays (Tracking, loyalty, and chemical)
- [x] Fix ghost antag HUD overlays

