### PR TITLE
Fixes deleting warrants in the main warrant window

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -130,7 +130,7 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 	if(href_list["deletewarrant"])
 		. = 1
 		if(!activewarrant)
-			for(var/datum/computer_file/report/crew_record/W in GLOB.all_crew_records)
+			for(var/datum/computer_file/data/warrant/W in GLOB.all_warrants)
 				if(W.uid == text2num(href_list["deletewarrant"]))
 					activewarrant = W
 					break


### PR DESCRIPTION
:cl:
bugfix: The delete warrant button in the main window of the Warrant Assistant program will now properly do its job.
/:cl:

Fixes #27709 