### PR TITLE
Virus capping

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -127,6 +127,7 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		H.cure_virus(uniqueID)
+		H.immunity = min(H.immunity + 25, H.immunity_norm) // On virus cure, give a small boost to immunity to help prevent instant reinfection with another virus
 
 	if (mob_gains_antigens)
 		mob.antibodies |= antigen

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -88,6 +88,8 @@ proc/infection_chance(var/mob/living/carbon/M, var/vector = "Airborne")
 		return
 	if ("[disease.uniqueID]" in M.virus2)
 		return
+	if(M.virus2.len >= 2) // cap the number of viruses a mob can have to two
+		return
 	// if one of the antibodies in the mob's body matches one of the disease's antigens, don't infect
 	var/list/antibodies_in_common = M.antibodies & disease.antigen
 	if(antibodies_in_common.len)


### PR DESCRIPTION
:cl:
tweak: A mob can now have a maximum of two viruses concurrently.
tweak: Curing a mob of a virus will provide a small boost to immunity to help prevent instant reinfection with a different virus if their immune system is low. It is recommended to use immunobooster drugs as well on the patient, especially if they have recently been irradiated.
/:cl:

This should prevent the recent server slowdown + crashes due to mobs having too many viruses. Plus the situations that have been happening with medical having an impossible quantity of instantly replaced viruses.

I think this is a good temporary fix at least.