### PR TITLE
Autopilot Tweaks & Improvements

### DIFF
--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -3,7 +3,7 @@
 
 <div style="float:left;width:45%;">
 	<fieldset style="min-height:180px;background-color: #202020;">
-		<legend style="text-align:center">Flight data</legend> 
+		<legend style="text-align:center">Flight data</legend>
 		<div class='item'>
 			<div class="itemLabelWider">
 				ETA to next grid:
@@ -35,7 +35,7 @@
 			<div style="float:right">
 				{{:data.heading}}&deg;
 			</div>
-		</div> 
+		</div>
 		<div class='item'>
 			<div class="itemLabelWider">
 				Acceleration limiter:
@@ -43,10 +43,10 @@
 			<div style="float:right">
 				{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}} Gm/h
 			</div>
-		</div> 
+		</div>
 	</fieldset>
 </div>
-	
+
 <div style="float:left;width:25%">
 <fieldset style="min-height:180px;background-color: #202020;">
 	<legend style="text-align:center">Manual control</legend>
@@ -75,7 +75,7 @@
 	</div>
 </fieldset>
 </div>
-	
+
 <div style="float:left;width:30%">
 <fieldset style="min-height:180px;background-color: #202020;">
 	<legend style="text-align:center">Autopilot</legend>
@@ -90,7 +90,19 @@
 				{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
 			{{/if}}
 		</div>
-	</div> 
+	</div>
+	<div class='item'>
+		<div class="itemLabelWide">
+			Next:
+		</div>
+		<div class="itemContent">
+			{{if data.next_dest}}
+				{{:helper.link(data.next_d_x, null, { 'setnextx' : 1 }, null, null)}} {{:helper.link(data.next_d_y, null, { 'setnexty' : 1 }, null, null)}}
+			{{else}}
+				{{:helper.link('None', null, { 'setnexty' : 1, 'setnextx' : 1 }, null, null)}}
+			{{/if}}
+		</div>
+	</div>
 	<div class='item'>
 		<div class="itemLabelWide">
 			Speed limit:
@@ -98,13 +110,13 @@
 		<div class="itemContent">
 			{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}} Gm/h
 		</div>
-	</div> 
+	</div>
 	<div class="item">
 		{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
 	</div>
 </fieldset>
 </div>
-	
+
 	<div class='block' style='clear: both;'>
 		<h3>Navigation data</h3>
 		<div class='item'>
@@ -155,5 +167,3 @@
 		</table>
 	</div>
 	</div>
-	
-	


### PR DESCRIPTION
:cl: SierraKomodo
add: Autopilot now has a 'next target' field that acts as the next waypoint to travel to upon reaching the current coordinates. Target coordinates are automatically changed on reaching the previous grid.
tweak: Autopilot's heading corrections have been tweaked to be more intelligent about when and how to fire the engines to adjust course.
/:cl:

TODO:
- [X] Add secondary autopilot waypoints
- [x] (SELFREMINDER TO FULLY TEST THIS) Tweak heading calculations to be less wasteful of fuel and smarter of 'which way do I burn'
- [ ] Have autopilot automatically split horizontal and vertical movement evenly when destinations are diagonal
- [ ] Let autopilot reduce acceleration limit temporarily to perfectly reach the assigned speedlimit
- [ ] Add 'Emergency Stop' button (Requested by Albens)
- [ ] (Maybe) Have untrained piloting skill result in randomized autopilot coordinates
- [ ] (Maybe) have piloting skill affect what autopilot buttons are available