### PR TITLE
Antagonist icons (e.g. cultist) no longer show up under the floor.

### DIFF
--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -32,7 +32,7 @@
 	if(!antag_indicator || !other.current || !recipient.current)
 		return
 	var/indicator = (faction_indicator && (other in faction_members)) ? faction_indicator : antag_indicator
-	var/image/I = image('icons/mob/hud.dmi', loc = other.current, icon_state = indicator, layer = LIGHTING_LAYER+0.1)
+	var/image/I = image('icons/mob/hud.dmi', loc = other.current, icon_state = indicator, layer = ABOVE_HUMAN_LAYER)
 	if(ishuman(other.current))
 		var/mob/living/carbon/human/H = other.current
 		I.pixel_x = H.species.antaghud_offset_x


### PR DESCRIPTION
:cl:
bugfix: Antagonist HUD markers e.g. Cultist indicators will now properly show up instead of being under the floor layer sometimes.
/:cl:

Fixes #25943 #20682