### PR TITLE
Taping paper to windows will now put it above the window

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -140,6 +140,8 @@
 		return
 	playsound(src, 'sound/effects/tape.ogg',25)
 
+	layer = ABOVE_WINDOW_LAYER
+	
 	if(params)
 		var/list/mouse_control = params2list(params)
 		if(mouse_control["icon-x"])


### PR DESCRIPTION
:cl:
bugfix: Taping paper to windows will no longer put it below the window.
/:cl:

Fixes #27739 