### PR TITLE
Z-Mimic / AO / Observ Fixes

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -51,6 +51,9 @@ SUBSYSTEM_DEF(lighting)
 		if (T.dynamic_lighting && T.loc:dynamic_lighting)
 			T.lighting_build_overlay()
 
+		// If this isn't here, BYOND will set-background us.
+		CHECK_TICK
+
 /datum/controller/subsystem/lighting/fire(resumed = FALSE, no_mc_tick = FALSE)
 	if (!resumed)
 		stats_queues["Source"] += processed_lights

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -73,15 +73,15 @@
 
 	// Return whether anything is listening to a source, if no listener is given.
 	if (!listener)
-		return global_listeners.len || (event_source in event_sources)
+		return global_listeners.len || event_sources[event_source]
 
 	// Return false if nothing is associated with that source.
-	if (!(event_source in event_sources))
+	if (!event_sources[event_source])
 		return FALSE
 
 	// Get and check the listeners for the reuqested event.
 	var/listeners = event_sources[event_source]
-	if (!(listener in listeners))
+	if (!listeners[listener])
 		return FALSE
 
 	// Return true unless a specific callback needs checked.
@@ -131,7 +131,7 @@
 
 /decl/observ/proc/unregister(var/event_source, var/datum/listener, var/proc_call)
 	// Sanity.
-	if (!(event_source && listener && (event_source in event_sources)))
+	if (!event_source || !listener || !event_sources[event_source])
 		return FALSE
 
 	// Return false if nothing is listening for this event.
@@ -180,7 +180,7 @@
 
 /decl/observ/proc/unregister_global(var/datum/listener, var/proc_call)
 	// Return false unless the listener is set as a global listener.
-	if (!(listener && (listener in global_listeners)))
+	if (!(listener && global_listeners[listener]))
 		return FALSE
 
 	// Remove all callbacks if no specific one is given.
@@ -206,24 +206,25 @@
 	if (!args.len)
 		return FALSE
 
-	// Call the global listeners.
-	for (var/datum/listener in global_listeners)
-		var/list/callbacks = global_listeners[listener]
-		for (var/proc_call in callbacks)
+	if (global_listeners.len)
+		// Call the global listeners.
+		for (var/listener in global_listeners)
+			var/list/callbacks = global_listeners[listener]
+			for (var/proc_call in callbacks)
 
-			// If the callback crashes, record the error and remove it.
-			try
-				call(listener, proc_call)(arglist(args))
-			catch (var/exception/e)
-				error("[e.name] - [e.file] - [e.line]")
-				error(e.desc)
-				unregister_global(listener, proc_call)
+				// If the callback crashes, record the error and remove it.
+				try
+					call(listener, proc_call)(arglist(args))
+				catch (var/exception/e)
+					error("[e.name] - [e.file] - [e.line]")
+					error(e.desc)
+					unregister_global(listener, proc_call)
 
 	// Call the listeners for this specific event source, if they exist.
 	var/source = args[1]
-	if (source in event_sources)
+	if (source && event_sources[source])
 		var/list/listeners = event_sources[source]
-		for (var/datum/listener in listeners)
+		for (var/listener in listeners)
 			var/list/callbacks = listeners[listener]
 			for (var/proc_call in callbacks)
 

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -9,12 +9,6 @@
 	var/tmp/ao_neighbors_mimic
 	var/ao_queued = AO_UPDATE_NONE
 
-/turf/set_density(var/new_density)
-	var/last_density = density
-	..()
-	if(density != last_density && permit_ao)
-		regenerate_ao()
-
 /turf/proc/regenerate_ao()
 	for (var/thing in RANGE_TURFS(src, 1))
 		var/turf/T = thing

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -49,18 +49,13 @@
 		var/turf/simulated/S = src
 		if(S.zone) S.zone.rebuild()
 
-	// Closest we can do as far as giving sane alerts to listeners. In particular, this calls Exited and moved events in a self-consistent way.
-	var/list/old_contents = list()
-	for(var/atom/movable/A in src)
-		old_contents += A
-		A.forceMove(null)
-
 	// Run the Destroy() chain.
 	qdel(src)
 
-	var/turf/simulated/W = new N( locate(src.x, src.y, src.z) )
-	for(var/atom/movable/A in old_contents)
-		A.forceMove(W)
+	var/turf/simulated/W = new N(src)
+
+	if (permit_ao)
+		regenerate_ao()
 
 	W.opaque_counter = opaque_counter
 

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -4481,7 +4481,6 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;


### PR DESCRIPTION
- Resolves Z-M GC thrashing due to unexpected forceMove(null) events.
- Removes forceMove dance from CT, ~~replaces with Entered event trigger in turf/Initialize()~~.
- Fixes AO not properly updating in lifts.
- Significantly reduces CPU usage of Observ. Probably still works.
- Fixes an issue where movables weren't on a turf during `turf/Destroy()` (decals like wallrot should clean up properly).
- Fixes an issue where `InitializeTurfs` in lighting would runtime due to a suspected infinite loop.
- Deleted one (1) dirt from bearcat.