### PR TITLE
Replaces all holdover references to `calypso` with `charon`

### DIFF
--- a/maps/away/icarus/icarus-2.dmm
+++ b/maps/away/icarus/icarus-2.dmm
@@ -1795,7 +1795,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump"
+	id_tag = "charon_shuttle_pump"
 	},
 /turf/simulated/floor/plating,
 /area/icarus/vessel)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -410,7 +410,7 @@
 	density = 0;
 	dir = 1;
 	icon_state = "pdoor0";
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters";
 	opacity = 0
 	},
@@ -434,7 +434,7 @@
 	density = 0;
 	dir = 1;
 	icon_state = "pdoor0";
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters";
 	opacity = 0
 	},
@@ -530,7 +530,7 @@
 	density = 0;
 	dir = 4;
 	icon_state = "pdoor0";
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters";
 	opacity = 0
 	},
@@ -761,7 +761,7 @@
 /area/exploration_shuttle/cockpit)
 "bT" = (
 /obj/machinery/button/blast_door{
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters Control";
 	pixel_x = -32
 	},
@@ -877,7 +877,7 @@
 	density = 0;
 	dir = 4;
 	icon_state = "pdoor0";
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters";
 	opacity = 0
 	},
@@ -997,7 +997,7 @@
 /obj/machinery/computer/air_control{
 	dir = 8;
 	name = "Atmospheric Sensors";
-	sensor_tag = "calypso_out"
+	sensor_tag = "charon_out"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
@@ -1230,7 +1230,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump_out_external"
+	id_tag = "charon_shuttle_pump_out_external"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -1243,7 +1243,7 @@
 	},
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1331;
-	master_tag = "calypso_shuttle";
+	master_tag = "charon_shuttle";
 	pixel_x = 20;
 	pixel_y = 20
 	},
@@ -1257,7 +1257,7 @@
 	density = 0;
 	dir = 4;
 	icon_state = "pdoor0";
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters";
 	opacity = 0
 	},
@@ -1269,7 +1269,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump_out_internal"
+	id_tag = "charon_shuttle_pump_out_internal"
 	},
 /obj/structure/handrai,
 /obj/machinery/oxygen_pump{
@@ -1285,11 +1285,11 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle";
+	id_tag = "charon_shuttle";
 	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list("ACCESS_TORCH_EXPLO");
-	tag_exterior_sensor = "calypso_shuttle_sensor_external"
+	tag_exterior_sensor = "charon_shuttle_sensor_external"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1298,7 +1298,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump"
+	id_tag = "charon_shuttle_pump"
 	},
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
@@ -1310,11 +1310,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump"
+	id_tag = "charon_shuttle_pump"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
-	id_tag = "calypso_shuttle_sensor";
+	id_tag = "charon_shuttle_sensor";
 	pixel_x = 0;
 	pixel_y = 24
 	},
@@ -1339,7 +1339,7 @@
 /obj/machinery/camera/network/exploration_shuttle,
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1331;
-	master_tag = "calypso_shuttle";
+	master_tag = "charon_shuttle";
 	pixel_x = -20;
 	pixel_y = 20
 	},
@@ -1495,7 +1495,7 @@
 	dir = 8
 	},
 /obj/machinery/air_sensor{
-	id_tag = "calypso_out"
+	id_tag = "charon_out"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -1513,7 +1513,7 @@
 	autoset_access = 0;
 	density = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_outer";
+	id_tag = "charon_shuttle_outer";
 	name = "Charon External Access"
 	},
 /obj/machinery/shield_diffuser,
@@ -1562,7 +1562,7 @@
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_inner";
+	id_tag = "charon_shuttle_inner";
 	name = "Charon External Access"
 	},
 /obj/structure/cable/cyan{
@@ -1674,11 +1674,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump_out_external"
+	id_tag = "charon_shuttle_pump_out_external"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
-	id_tag = "calypso_shuttle_sensor_external";
+	id_tag = "charon_shuttle_sensor_external";
 	pixel_x = 25;
 	pixel_y = -25
 	},
@@ -1696,7 +1696,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump_out_internal"
+	id_tag = "charon_shuttle_pump_out_internal"
 	},
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -1717,7 +1717,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump"
+	id_tag = "charon_shuttle_pump"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1726,7 +1726,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_shuttle_pump"
+	id_tag = "charon_shuttle_pump"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -2325,7 +2325,7 @@
 	},
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1331;
-	master_tag = "calypso_cargo";
+	master_tag = "charon_cargo";
 	pixel_x = 20;
 	pixel_y = -15
 	},
@@ -2378,7 +2378,7 @@
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1331;
-	id_tag = "calypso_cargo_inner";
+	id_tag = "charon_cargo_inner";
 	name = "Charon Cargo Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2444,7 +2444,7 @@
 	controlled = 0;
 	dir = 4;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump"
+	id_tag = "charon_cargo_pump"
 	},
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
@@ -2522,7 +2522,7 @@
 	controlled = 0;
 	dir = 8;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump"
+	id_tag = "charon_cargo_pump"
 	},
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloor_edges";
@@ -2591,7 +2591,7 @@
 	controlled = 0;
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump"
+	id_tag = "charon_cargo_pump"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -2606,7 +2606,7 @@
 	controlled = 0;
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump"
+	id_tag = "charon_cargo_pump"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -2615,7 +2615,7 @@
 	controlled = 0;
 	dir = 2;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump_out_internal"
+	id_tag = "charon_cargo_pump_out_internal"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -2658,7 +2658,7 @@
 	density = 0;
 	dir = 4;
 	icon_state = "pdoor0";
-	id_tag = "calypso_shutters";
+	id_tag = "charon_shutters";
 	name = "Protective Shutters";
 	opacity = 0
 	},
@@ -2753,7 +2753,7 @@
 	controlled = 0;
 	dir = 4;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump_out_internal"
+	id_tag = "charon_cargo_pump_out_internal"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -2787,7 +2787,7 @@
 	controlled = 0;
 	dir = 8;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump_out_internal"
+	id_tag = "charon_cargo_pump_out_internal"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -2858,7 +2858,7 @@
 "fZ" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
-	id_tag = "calypso_cargo_sensor";
+	id_tag = "charon_cargo_sensor";
 	pixel_x = 24;
 	pixel_y = -24
 	},
@@ -2920,7 +2920,7 @@
 	autoset_access = 0;
 	density = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo_outer";
+	id_tag = "charon_cargo_outer";
 	name = "Charon External Access"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2931,7 +2931,7 @@
 	autoset_access = 0;
 	density = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo_outer";
+	id_tag = "charon_cargo_outer";
 	name = "Charon External Access"
 	},
 /obj/machinery/light_switch{
@@ -3206,7 +3206,7 @@
 	},
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1331;
-	master_tag = "calypso_cargo";
+	master_tag = "charon_cargo";
 	pixel_x = 20;
 	pixel_y = 20
 	},
@@ -3214,7 +3214,7 @@
 	controlled = 0;
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump_out_external"
+	id_tag = "charon_cargo_pump_out_external"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -10671,7 +10671,7 @@
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1331;
-	id_tag = "calypso_cargo_inner";
+	id_tag = "charon_cargo_inner";
 	name = "Charon Cargo Bay"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -10794,7 +10794,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	alarm_id = "calypso_cargo_alarm";
+	alarm_id = "charon_cargo_alarm";
 	dir = 2;
 	frequency = 1331;
 	icon_state = "alarm0";
@@ -13590,7 +13590,7 @@
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	cycle_to_external_air = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo";
+	id_tag = "charon_cargo";
 	pixel_y = 24;
 	req_access = list("ACCESS_TORCH_EXPLO");
 	tag_exterior_sensor = null
@@ -15145,7 +15145,7 @@
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
-	id_tag = "calypso_cargo_exterior_sensor";
+	id_tag = "charon_cargo_exterior_sensor";
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -15153,7 +15153,7 @@
 	controlled = 0;
 	dir = 1;
 	frequency = 1331;
-	id_tag = "calypso_cargo_pump_out_external"
+	id_tag = "charon_cargo_pump_out_external"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
@@ -15302,7 +15302,7 @@
 "OZ" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
-	id_tag = "calypso_cargo_sensor";
+	id_tag = "charon_cargo_sensor";
 	pixel_x = 24;
 	pixel_y = 0
 	},

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -7,7 +7,7 @@
 	base = TRUE
 
 	initial_restricted_waypoints = list(
-		"Charon" = list("nav_hangar_calypso"), 	//can't have random shuttles popping inside the ship
+		"Charon" = list("nav_hangar_charon"), 	//can't have random shuttles popping inside the ship
 		"Guppy" = list("nav_hangar_guppy"),
 		"Aquila" = list("nav_hangar_aquila")
 	)
@@ -18,7 +18,7 @@
 		"nav_ninja_deck5",
 		"nav_skipjack_deck5",
 		"nav_ert_deck5",
-		"nav_bridge_calypso",
+		"nav_bridge_charon",
 		"nav_bridge_guppy",
 		"nav_bridge_aquila",
 
@@ -27,7 +27,7 @@
 		"nav_ninja_deck1",
 		"nav_skipjack_deck1",
 		"nav_ert_deck4",
-		"nav_deck4_calypso",
+		"nav_deck4_charon",
 		"nav_deck4_guppy",
 		"nav_deck4_aquila",
 
@@ -36,7 +36,7 @@
 		"nav_ninja_deck2",
 		"nav_skipjack_deck2",
 		"nav_ert_deck3",
-		"nav_deck3_calypso",
+		"nav_deck3_charon",
 		"nav_deck3_guppy",
 		"nav_deck3_aquila",
 
@@ -45,7 +45,7 @@
 		"nav_ninja_deck3",
 		"nav_skipjack_deck3",
 		"nav_ert_deck2",
-		"nav_deck2_calypso",
+		"nav_deck2_charon",
 		"nav_deck2_guppy",
 		"nav_deck2_aquila",
 
@@ -54,7 +54,7 @@
 		"nav_ninja_deck4",
 		"nav_skipjack_deck4",
 		"nav_ert_deck1",
-		"nav_deck1_calypso",
+		"nav_deck1_charon",
 		"nav_deck1_guppy",
 		"nav_deck1_aquila",
 

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -1,6 +1,6 @@
 var/const/NETWORK_AQUILA      = "Aquila"
 var/const/NETWORK_BRIDGE      = "Bridge"
-var/const/NETWORK_CALYPSO     = "Charon"
+var/const/NETWORK_CHARON      = "Charon"
 var/const/NETWORK_EXPEDITION  = "Expedition"
 var/const/NETWORK_FIRST_DECK  = "First Deck"
 var/const/NETWORK_FOURTH_DECK = "Fourth Deck"
@@ -19,7 +19,7 @@ var/const/NETWORK_NANOTRASEN  = "Petrov"
 			return access_aquila
 		if(NETWORK_BRIDGE)
 			return access_heads
-		if(NETWORK_CALYPSO)
+		if(NETWORK_CHARON)
 			return access_expedition_shuttle
 		if(NETWORK_POD)
 			return access_guppy
@@ -54,7 +54,7 @@ var/const/NETWORK_NANOTRASEN  = "Petrov"
 		NETWORK_EXPLO,
 		NETWORK_HANGAR,
 		NETWORK_AQUILA,
-		NETWORK_CALYPSO,
+		NETWORK_CHARON,
 		NETWORK_POD,
 		NETWORK_NANOTRASEN,
 		NETWORK_ALARM_ATMOS,
@@ -77,7 +77,7 @@ var/const/NETWORK_NANOTRASEN  = "Petrov"
 	network = list(NETWORK_BRIDGE)
 
 /obj/machinery/camera/network/exploration_shuttle
-	network = list(NETWORK_CALYPSO)
+	network = list(NETWORK_CHARON)
 
 /obj/machinery/camera/network/expedition
 	network = list(NETWORK_EXPEDITION)

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -370,44 +370,44 @@ TORCH_ESCAPE_POD(17)
 	name = "Charon"
 	move_time = 90
 	shuttle_area = list(/area/exploration_shuttle/cockpit, /area/exploration_shuttle/atmos, /area/exploration_shuttle/power, /area/exploration_shuttle/crew, /area/exploration_shuttle/cargo, /area/exploration_shuttle/airlock)
-	dock_target = "calypso_shuttle"
-	current_location = "nav_hangar_calypso"
-	landmark_transition = "nav_transit_calypso"
+	dock_target = "charon_shuttle"
+	current_location = "nav_hangar_charon"
+	landmark_transition = "nav_transit_charon"
 	range = 1
 	fuel_consumption = 4
-	logging_home_tag = "nav_hangar_calypso"
+	logging_home_tag = "nav_hangar_charon"
 	logging_access = access_expedition_shuttle_helm
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/torch
 
 /obj/effect/shuttle_landmark/torch/hangar/exploration_shuttle
 	name = "Charon Hangar"
-	landmark_tag = "nav_hangar_calypso"
+	landmark_tag = "nav_hangar_charon"
 	base_area = /area/quartermaster/hangar
 	base_turf = /turf/simulated/floor/plating
 
 /obj/effect/shuttle_landmark/torch/deck1/exploration_shuttle
 	name = "Space near Forth Deck"
-	landmark_tag = "nav_deck1_calypso"
+	landmark_tag = "nav_deck1_charon"
 
 /obj/effect/shuttle_landmark/torch/deck2/exploration_shuttle
 	name = "Space near Third Deck"
-	landmark_tag = "nav_deck2_calypso"
+	landmark_tag = "nav_deck2_charon"
 
 /obj/effect/shuttle_landmark/torch/deck3/exploration_shuttle
 	name = "Space near Second Deck"
-	landmark_tag = "nav_deck3_calypso"
+	landmark_tag = "nav_deck3_charon"
 
 /obj/effect/shuttle_landmark/torch/deck4/exploration_shuttle
 	name = "Space near First Deck"
-	landmark_tag = "nav_deck4_calypso"
+	landmark_tag = "nav_deck4_charon"
 
 /obj/effect/shuttle_landmark/torch/deck5/exploration_shuttle
 	name = "Space near Bridge"
-	landmark_tag = "nav_bridge_calypso"
+	landmark_tag = "nav_bridge_charon"
 
 /obj/effect/shuttle_landmark/transit/torch/exploration_shuttle
 	name = "In transit"
-	landmark_tag = "nav_transit_calypso"
+	landmark_tag = "nav_transit_charon"
 
 /datum/shuttle/autodock/overmap/guppy
 	name = "Guppy"


### PR DESCRIPTION
Makes the code consistent with the shuttle's current name, and fixes the random references to 'Calypso' seen in certain UIs in game