### PR TITLE
Fix issues with custom item mugs

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -27,6 +27,9 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	temperature_coefficient = 4
 
+	var/custom_name
+	var/custom_desc
+
 /obj/item/weapon/reagent_containers/food/drinks/glass2/examine(mob/M)
 	. = ..()
 
@@ -103,7 +106,7 @@
 	if (reagents.reagent_list.len > 0)
 		var/datum/reagent/R = reagents.get_master_reagent()
 		SetName("[base_name] of [R.glass_name ? R.glass_name : "something"]")
-		desc = R.glass_desc ? R.glass_desc : initial(desc)
+		desc = R.glass_desc || custom_desc || initial(desc)
 
 		var/list/under_liquid = list()
 		var/list/over_liquid = list()
@@ -138,8 +141,8 @@
 		for(var/k in over_liquid)
 			overlays += image(icon, src, k, -1)
 	else
-		SetName(initial(name))
-		desc = initial(desc)
+		SetName(custom_name || initial(name))
+		desc = custom_desc || initial(desc)
 
 	var/side = "left"
 	for(var/item in extras)

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
@@ -163,7 +163,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/punitelli
 	name = "#1 monkey coffee cup"
-	desc = "A white coffee cup, prominently featuring a \"#1 monkey\"."
+	desc = "A white coffee cup, prominently featuring a \"#1 monkey\" decal."
 	icon_state = "coffeecup_punitelli"
 	base_name = "#1 monkey cup"
 
@@ -238,3 +238,10 @@
 	filling_states = "100"
 	base_name = "teacup"
 	base_icon = "teacup"
+
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/custom/inherit_custom_item_data(var/datum/custom_item/citem)
+	. = ..()
+	if(citem.additional_data["base_name"])
+		base_name = citem.additional_data["base_name"] || base_name
+	custom_name = citem.item_name
+	custom_desc = citem.item_desc


### PR DESCRIPTION
Should fix a few issues with custom mugs.

1) fixes name being replaced after filling and emptying
2) fixes desc for the same
3) adds missing base_name implementation
4) on custom-items side, adds missing liquid overlay to the objs dmi

I don't have an easy way of testing this but the only thing I'm not certain about is the additional_data, but it should work based on the existing one I looked at.