### PR TITLE
Fixes improper loadout item blacklisting due to skill checks.

### DIFF
--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -15,7 +15,7 @@
 
 /datum/preferences/proc/get_total_skill_value(datum/job/job, decl/hierarchy/skill/req_skill)
 	if(!(job in skills_allocated))
-		return 0
+		return get_min_skill(job, req_skill)
 	var/allocated = skills_allocated[job]
 	if(req_skill in allocated)
 		return allocated[req_skill] + get_min_skill(job, req_skill)


### PR DESCRIPTION
This proc returns an incorrect value if the first check failed (i.e. no skills were changed from default for the given job).