### PR TITLE
Nerfs burn damage from radiation by 75%

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -10,7 +10,7 @@ Specifically made to do radiation burns.
 	if(species && !isSynthetic())
 		if(species.name == SPECIES_DIONA)
 			return FALSE
-		damage = damage * species.get_radiation_mod(src)
+		damage = 0.25 * damage * species.get_radiation_mod(src)
 		adjustFireLoss(damage)
 
 	updatehealth()


### PR DESCRIPTION
:cl:
tweak: Burn damage from radiation exposure is nerfed by 75%.
/:cl:

Radiation storm event could kill people solely with the burn damage if someone was exposed for even half the duration.

Can still cause burn damage that requires medical attention.

Worst affected victim, amongst 20+ victims, from one complete radiation storm:
Pre-Nerf - Brain-death from burns part-way through the storm. Face melted off, irreparable burns over most of the body.
Post-Nerf - Severe, significant and moderate burns, some blood loss, pain, passing out. Requires immediate medical attention (and the normal surgery due to radiation exposure messing up organs).