### PR TITLE
Allows robots to unwrench rechargers

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -16,9 +16,6 @@
 	var/portable = 1
 
 /obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
-	if(istype(user,/mob/living/silicon))
-		return
-
 	var/allowed = 0
 	for (var/allowed_type in allowed_devices)
 		if (istype(G, allowed_type)) allowed = 1


### PR DESCRIPTION
:cl:
bugfix: Robots can now wrench portable rechargers to move/anchor them.
/:cl:

So far as I can tell (with testing) this bit of code is unnecessary and all robot items that can be placed within rechargers are prevented from doing so by other means, such as the `canremove` var.

Fixes #17630