### PR TITLE
Make uplinks other than PDA/headset less awful

### DIFF
--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 	if(!P.hard_drive.try_store_file(program))
 		return SETUP_FAILED	//Not enough space or other issues.
 	P.hard_drive.store_file(program)
-	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [P.name]. Simply enter the code \"[pda_pass]\" in your new program to unlock its hidden features.</span>")
+	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [P.name]. Simply enter the code \"[pda_pass]\" in TaxQuickly program to unlock its hidden features.</span>")
 	M.StoreMemory("<B>Uplink passcode:</B> [pda_pass] ([P.name]).", /decl/memory_options/system)
 
 /decl/uplink_source/radio
@@ -62,7 +62,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 
 /decl/uplink_source/implant
 	name = "Implant"
-	desc = "Teleports an uplink implant into your head. Costs at least half the initial TC amount."
+	desc = "Teleports an uplink implant into your head. Costs 20% of the initial TC amount."
 
 /decl/uplink_source/implant/setup_uplink_source(var/mob/living/carbon/human/H, var/amount)
 	if(!istype(H))
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 	if(!head)
 		return SETUP_FAILED
 
-	var/obj/item/weapon/implant/uplink/U = new(H, IMPLANT_TELECRYSTAL_AMOUNT(amount))
+	var/obj/item/weapon/implant/uplink/U = new(H, round(amount * 0.8))
 	U.imp_in = H
 	U.implanted = TRUE
 	U.part = head
@@ -82,17 +82,18 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 
 /decl/uplink_source/unit
 	name = "Uplink Unit"
-	desc = "Teleports an uplink unit to your location. Costs 10% of the initial TC amount."
+	desc = "Teleports an uplink unit to your location. Gives extra 30% of the initial TC amount."
 
 /decl/uplink_source/unit/setup_uplink_source(var/mob/M, var/amount)
-	var/obj/item/device/radio/uplink/U = new(M, M.mind, round(amount * 0.9))
+	var/obj/item/device/radio/uplink/U = new(M, M.mind, round(amount * 1.3))
 	put_on_mob(M, U, "\A [U]")
 
 /decl/uplink_source/telecrystals
 	name = "Telecrystals"
-	desc = "Get your telecrystals in pure form, without the means to trade them for goods."
+	desc = "Get your telecrystals in pure form, without the means to trade them for goods, Gives 150% of initial TC amout"
 
 /decl/uplink_source/telecrystals/setup_uplink_source(var/mob/M, var/amount)
+	amount = round(amount * 1.5)
 	var/obj/item/stack/telecrystal/TC = new(M, amount)
 	put_on_mob(M, TC, "[amount] telecrystal\s")
 

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 
 /decl/uplink_source/unit
 	name = "Uplink Unit"
-	desc = "Teleports an uplink unit to your location. Gives extra 30% of the initial TC amount."
+	desc = "Teleports an uplink unit to your location. Has 30% more TC."
 
 /decl/uplink_source/unit/setup_uplink_source(var/mob/M, var/amount)
 	var/obj/item/device/radio/uplink/U = new(M, M.mind, round(amount * 1.3))
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 
 /decl/uplink_source/telecrystals
 	name = "Telecrystals"
-	desc = "Get your telecrystals in pure form, without the means to trade them for goods, Gives 150% of initial TC amout"
+	desc = "Get your telecrystals in pure form, without the means to trade them for goods, Gives 150% of initial TC amount"
 
 /decl/uplink_source/telecrystals/setup_uplink_source(var/mob/M, var/amount)
 	amount = round(amount * 1.5)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Imienny
tweak: Tweaked TC cost of uplinks in Character Setup menu, radio uplink now gives you 30% more TC, uplink Implant cost only 20% of total TC and taking TC without uplink gives you 50% more TC.
tweak: Message shown after receiving PDA uplink now should explain better how to access uplink.
/:cl:
based on Colfer idea

Option to choose what type of uplink you want is cool, but evey option other than headset/PDA is awful and not worth taking,
radio uplink is big red "VALID" to everyone who see it, and in addition to that, it cost 10% of your TC,
uplink implant is completely pointless and its always better to take PDA/headset uplink and just buy two uplink implants.