### PR TITLE
R-UST QoL tweaks

### DIFF
--- a/code/modules/power/fusion/consoles/core_control.dm
+++ b/code/modules/power/fusion/consoles/core_control.dm
@@ -18,6 +18,9 @@
 
 		if(href_list["toggle_active"])
 			if(!C.Startup()) //Startup() whilst the device is active will return null.
+				if(!C.owned_field.is_shutdown_safe())
+					if(alert(user, "Shutting down this fusion core without proper safety procedures will cause serious damage, do you wish to continue?", "Shut Down?", "Yes", "No") == "No")
+						return TOPIC_NOACTION
 				C.Shutdown()
 			return TOPIC_REFRESH
 

--- a/code/modules/power/fusion/consoles/injector_control.dm
+++ b/code/modules/power/fusion/consoles/injector_control.dm
@@ -5,18 +5,39 @@
 	ui_template = "fusion_injector_control.tmpl"
 
 /obj/machinery/computer/fusion/fuel_control/OnTopic(var/mob/user, var/href_list, var/datum/topic_state/state)
-	if(href_list["toggle_injecting"])
-		var/obj/machinery/fusion_fuel_injector/I = locate(href_list["toggle_injecting"])
-		if(!istype(I))
+	var/datum/local_network/lan = get_local_network()
+	var/list/fuel_injectors = lan.get_devices(/obj/machinery/fusion_fuel_injector)
+
+	if(href_list["global_toggle"])
+		if(!lan || !fuel_injectors)
 			return TOPIC_NOACTION
-		var/datum/local_network/lan = get_local_network()
-		var/list/fuel_injectors = lan.get_devices(/obj/machinery/fusion_fuel_injector)
-		if(!lan || !fuel_injectors || !fuel_injectors[I])
+			
+		for(var/obj/machinery/fusion_fuel_injector/F in fuel_injectors)
+			if(F.injecting)
+				F.StopInjecting()
+			else
+				F.BeginInjecting()
+		return TOPIC_REFRESH
+
+	if(href_list["toggle_injecting"] || href_list["injection_rate"])
+		var/obj/machinery/fusion_fuel_injector/I = locate((href_list["toggle_injecting"] || href_list["machine"]))
+		if(!istype(I) || !lan || !fuel_injectors || !fuel_injectors[I])
 			return TOPIC_NOACTION
-		if(I.injecting)
-			I.StopInjecting()
-		else
-			I.BeginInjecting()
+
+		if(href_list["toggle_injecting"])
+			if(I.injecting)
+				I.StopInjecting()
+			else
+				I.BeginInjecting()
+
+		if(href_list["injection_rate"])
+			var/new_injection_rate = input("Enter a new injection rate between 0 and 100", "Modifying injection rate", I.injection_rate) as num
+			if(!istype(I))
+				return TOPIC_NOACTION
+			if(!new_injection_rate)
+				to_chat(user, SPAN_WARNING("That's not a valid injection rate."))
+				return TOPIC_NOACTION
+			I.injection_rate = Clamp(new_injection_rate, 0, 100) / 100
 		return TOPIC_REFRESH
 
 /obj/machinery/computer/fusion/fuel_control/build_ui_data()
@@ -32,7 +53,8 @@
 			injector["id"] =       "#[i]"
 			injector["ref"] =       "\ref[I]"
 			injector["injecting"] =  I.injecting
-			injector["fueltype"] =  "[I.cur_assembly ? I.cur_assembly.fuel_type : "no fuel inserted"]"
+			injector["fueltype"] =  "[I.cur_assembly ? I.cur_assembly.fuel_type : "No Fuel Inserted"]"
 			injector["depletion"] = "[I.cur_assembly ? (I.cur_assembly.percent_depleted * 100) : 100]%"
+			injector["injection_rate"] = "[I.injection_rate * 100]%"
 			injectors += list(injector)
 	.["injectors"] = injectors

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -203,6 +203,9 @@
 					Radiate()
 	return
 
+/obj/effect/fusion_em_field/proc/is_shutdown_safe()
+	return plasma_temperature < 1000
+
 /obj/effect/fusion_em_field/proc/Rupture()
 	visible_message("<span class='danger'>\The [src] shudders like a dying animal before flaring to eye-searing brightness and rupturing!</span>")
 	set_light(1, 0.1, 15, 2, "#ccccff")

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -16,6 +16,7 @@
 	var/initial_id_tag
 	var/injecting = 0
 	var/obj/item/weapon/fuel_assembly/cur_assembly
+	var/injection_rate = 1
 
 /obj/machinery/fusion_fuel_injector/Initialize()
 	set_extension(src, /datum/extension/local_network_member)
@@ -112,7 +113,7 @@
 		var/amount_left = 0
 		for(var/reagent in cur_assembly.rod_quantities)
 			if(cur_assembly.rod_quantities[reagent] > 0)
-				var/amount = cur_assembly.rod_quantities[reagent] * fuel_usage
+				var/amount = cur_assembly.rod_quantities[reagent] * fuel_usage * injection_rate
 				if(amount < 1)
 					amount = 1
 				var/obj/effect/accelerated_particle/A = new/obj/effect/accelerated_particle(get_turf(src), dir)

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -18,6 +18,7 @@
 		/obj/item/weapon/stock_parts/radio/receiver,
 	)
 	stat_immune = 0
+	base_type = /obj/machinery/power/emitter/gyrotron
 
 /obj/machinery/power/emitter/gyrotron/anchored
 	anchored = 1

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -40,6 +40,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod11/station)
+"ad" = (
+/obj/machinery/fusion_fuel_injector/mapped{
+	initial_id_tag = "aux_fusion_plant"
+	},
+/turf/simulated/floor/reinforced,
+/area/vacant/prototype/engine)
 "ae" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2238,7 +2244,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/emitter/gyrotron{
+/obj/machinery/power/emitter/gyrotron/anchored{
 	dir = 8;
 	initial_id_tag = "aux_fusion_plant"
 	},
@@ -2271,6 +2277,16 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/aftstarboard)
+"ew" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman/mrs{
+	anchored = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/vacant/prototype/engine)
 "ex" = (
 /obj/random/torchcloset,
 /turf/simulated/floor/plating,
@@ -2371,6 +2387,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/central)
+"eH" = (
+/obj/machinery/fusion_fuel_injector/mapped{
+	dir = 1;
+	icon_state = "injector0";
+	initial_id_tag = "aux_fusion_plant"
+	},
+/turf/simulated/floor/reinforced,
+/area/vacant/prototype/engine)
 "eI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14452,13 +14476,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/seconddeck/forestarboard)
-"Lg" = (
-/obj/machinery/fusion_fuel_injector/mapped{
-	anchored = 0;
-	initial_id_tag = "aux_fusion_plant"
-	},
-/turf/simulated/floor/reinforced,
-/area/vacant/prototype/engine)
 "Lh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16903,14 +16920,6 @@
 	},
 /turf/space,
 /area/space)
-"Tg" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/port_gen/pacman/mrs,
-/turf/simulated/floor/reinforced/airless,
-/area/vacant/prototype/engine)
 "Th" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -18110,15 +18119,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/vacant/prototype/control)
-"Xj" = (
-/obj/machinery/fusion_fuel_injector/mapped{
-	anchored = 0;
-	dir = 1;
-	icon_state = "injector0";
-	initial_id_tag = "aux_fusion_plant"
-	},
-/turf/simulated/floor/reinforced,
-/area/vacant/prototype/engine)
 "Xk" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
@@ -27676,7 +27676,7 @@ aa
 aa
 qw
 Lc
-Lg
+ad
 Ej
 Kf
 Fg
@@ -27684,7 +27684,7 @@ Xg
 Oh
 Kf
 Ej
-Xj
+eH
 qj
 qw
 aa
@@ -27878,7 +27878,7 @@ aa
 aa
 qw
 md
-Lg
+ad
 Ej
 Kf
 Gg
@@ -27886,7 +27886,7 @@ eh
 Ph
 Kf
 Ej
-Xj
+eH
 rj
 qw
 aa
@@ -28080,7 +28080,7 @@ aa
 aa
 qw
 Lc
-Lg
+ad
 Ej
 Kf
 Hg
@@ -28088,7 +28088,7 @@ mh
 Qh
 Kf
 Ej
-Xj
+eH
 qj
 qw
 aa
@@ -29495,7 +29495,7 @@ fU
 JX
 OY
 mb
-Tg
+ew
 Qf
 Ng
 Vi

--- a/nano/templates/fusion_injector_control.tmpl
+++ b/nano/templates/fusion_injector_control.tmpl
@@ -1,4 +1,12 @@
 <h3>Fusion plant: {{:data.id}}</h3>
+<div class="item">
+	<div class="itemLabel">
+		Injector Control:
+	</div>
+	<div class="itemContent">
+		{{:helper.link('Toggle All', null, {'global_toggle' : 1})}}
+	</div>
+</div>
 {{for data.injectors}}
 	<h3>{{:value.id}}</h3>
 	<div class="item">
@@ -11,6 +19,14 @@
 			 {{else}}
 				Offline.<br/>{{:helper.link('Start up.', null, {'toggle_injecting': value.ref})}}
 			 {{/if}}
+		</div>
+	</div>
+	<div class="item">
+		<div class="itemLabel">
+			Injection rate
+		</div>
+		<div class="itemContent">
+			{{:helper.link(value.injection_rate, null, {'machine': value.ref, 'injection_rate': 1})}}
 		</div>
 	</div>
 	<div class="item">


### PR DESCRIPTION
:cl:
tweak: R-UST now has a prompt to tell you when hitting the shutdown button will cause an instant explosion, asking whether you're sure.
maptweak: R-UST room machinery starts the round anchored.
tweak: Improves the fuel injector controller UI, with injection rate and toggle all injectors controls.
/:cl:

Tweaks some simple quality of life things for the R-UST. 

Intending to use the R-UST for an away map, so... doing a bit of tweaking first to make it more usable as a main power source. This PR contains the non-controversial changes I want to make -- More to come with changing instability rates, fuels and power outputs in a future PR that will require a bit more time + testing. 