### PR TITLE
Buildable radio components; air sensor changes.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -717,6 +717,7 @@
 #include "code\game\machinery\_machines_base\machine_construction\computer.dm"
 #include "code\game\machinery\_machines_base\machine_construction\default.dm"
 #include "code\game\machinery\_machines_base\machine_construction\frame.dm"
+#include "code\game\machinery\_machines_base\machine_construction\item_chassis.dm"
 #include "code\game\machinery\_machines_base\machine_construction\tcomms.dm"
 #include "code\game\machinery\_machines_base\stock_parts\_stock_parts.dm"
 #include "code\game\machinery\_machines_base\stock_parts\building_material.dm"

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -130,6 +130,7 @@ var/const/SEC_I_FREQ = 1475
 var/const/ATMOS_ENGINE_FREQ = 1438 // Used by atmos monitoring in the engine.
 var/const/FUEL_FREQ         = 1447 // Used by fuel atmos stuff, and currently default for digital valves
 var/const/ATMOS_TANK_FREQ   = 1441 // Used for gas tank sensors and monitoring.
+var/const/ATMOS_DIST_FREQ   = 1443 // Alternative atmos frequency.
 var/const/BUTTON_FREQ       = 1301 // Used by generic buttons controlling stuff
 var/const/BLAST_DOORS_FREQ  = 1303 // Used by blast doors, buttons controlling them, and mass drivers.
 var/const/AIRLOCK_FREQ      = 1305 // Used by airlocks and buttons controlling them.

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -127,7 +127,9 @@ var/const/MED_I_FREQ = 1485
 var/const/SEC_I_FREQ = 1475
 
 // Device signal frequencies
+var/const/ATMOS_ENGINE_FREQ = 1438 // Used by atmos monitoring in the engine.
 var/const/FUEL_FREQ         = 1447 // Used by fuel atmos stuff, and currently default for digital valves
+var/const/ATMOS_TANK_FREQ   = 1441 // Used for gas tank sensors and monitoring.
 var/const/BUTTON_FREQ       = 1301 // Used by generic buttons controlling stuff
 var/const/BLAST_DOORS_FREQ  = 1303 // Used by blast doors, buttons controlling them, and mass drivers.
 var/const/AIRLOCK_FREQ      = 1305 // Used by airlocks and buttons controlling them.

--- a/code/datums/extensions/multitool/items/stock_parts_radio.dm
+++ b/code/datums/extensions/multitool/items/stock_parts_radio.dm
@@ -35,7 +35,9 @@
 	var/list/dat = list()
 
 	dat += "<a href='?src=\ref[src];unlink=1'>Unlink Machine</a><br>"
-
+	var/obj/machinery/actual_machine = machine && machine.resolve()
+	if(actual_machine && actual_machine.can_apply_preset_to(radio))
+		dat += "<a href='?src=\ref[src];stockreset=1'>Reset to Machine Defaults</a><br>"
 	dat += "<b>Configuration for \the [radio].</b><br>"
 	dat += "Frequency: <a href='?src=\ref[src];frequency=1'>[radio.frequency || "none"]</a><br>"
 	dat += "ID: <a href='?src=\ref[src];id_tag=1'>[radio.id_tag || "none"]</a><br>"
@@ -82,6 +84,12 @@
 		if(new_encryption == radio.encryption)
 			return MT_NOACTION
 		radio.encryption = new_encryption
+		return MT_REFRESH
+	if(href_list["stockreset"])
+		var/obj/machinery/actual_machine = machine && machine.resolve()
+		if(!actual_machine)
+			return MT_CLOSE
+		actual_machine.apply_preset_to(radio)
 		return MT_REFRESH
 
 // Helper.

--- a/code/game/machinery/_machines_base/machine_construction/item_chassis.dm
+++ b/code/game/machinery/_machines_base/machine_construction/item_chassis.dm
@@ -1,0 +1,9 @@
+// Identical to default behavior, but does not require circuit boards.
+
+/decl/machine_construction/default/panel_closed/item_chassis
+	needs_board = null
+	down_state = /decl/machine_construction/default/panel_open/item_chassis
+
+/decl/machine_construction/default/panel_open/item_chassis
+	needs_board = null
+	up_state = /decl/machine_construction/default/panel_closed/item_chassis

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -59,6 +59,22 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 				if(number == 0)
 					break
 
+// Returns the first valid preset decl for a given part, or null
+/obj/machinery/proc/can_apply_preset_to(var/obj/item/weapon/stock_parts/part)
+	if(!stock_part_presets)
+		return
+	for(var/path in stock_part_presets)
+		var/decl/stock_part_preset/preset = decls_repository.get_decl(path)
+		if(istype(part, preset.expected_part_type))
+			return preset
+
+// Applies the first valid preset to the given part. Returns preset applied, or null.
+/obj/machinery/proc/apply_preset_to(var/obj/item/weapon/stock_parts/part)
+	var/decl/stock_part_preset/preset = can_apply_preset_to(part)
+	if(preset)
+		preset.apply(null, part)
+		return preset
+
 // Returns a list of subtypes of the given component type, with associated value = number of that component.
 /obj/machinery/proc/types_of_component(var/part_type)
 	. = list()

--- a/code/game/machinery/_machines_base/stock_parts/radio/receiver.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/receiver.dm
@@ -41,3 +41,6 @@
 		if(!isnull(signal.data[thing]))
 			var/decl/public_access/public_method/method = receive_and_call[thing]
 			method.perform(machine)
+
+/obj/item/weapon/stock_parts/radio/receiver/buildable
+	part_flags = PART_FLAG_HAND_REMOVE

--- a/code/game/machinery/_machines_base/stock_parts/radio/receiver.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/receiver.dm
@@ -44,3 +44,4 @@
 
 /obj/item/weapon/stock_parts/radio/receiver/buildable
 	part_flags = PART_FLAG_HAND_REMOVE
+	matter = list(MATERIAL_STEEL = 400)

--- a/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
@@ -104,6 +104,14 @@
 
 /obj/item/weapon/stock_parts/radio/transmitter/basic/buildable
 	part_flags = PART_FLAG_HAND_REMOVE
+	name = "basic radio transmitter"
+	desc = "A stock radio transmitter machine component. Can transmit updates regularly or on change."
+	color = COLOR_RED
+	matter = list(MATERIAL_STEEL = 400)
 
 /obj/item/weapon/stock_parts/radio/transmitter/on_event/buildable
 	part_flags = PART_FLAG_HAND_REMOVE
+	name = "event radio transmitter"
+	desc = "A radio transmitter machine component which transmits when activated by an event."
+	color = COLOR_ORANGE
+	matter = list(MATERIAL_STEEL = 400)

--- a/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
@@ -101,3 +101,9 @@
 		var/decl/public_access/public_variable/check_variable = transmit_on_event[thing]
 		dat[thing] = check_variable.access_var(machine)
 	queue_transmit(dat)
+
+/obj/item/weapon/stock_parts/radio/transmitter/basic/buildable
+	part_flags = PART_FLAG_HAND_REMOVE
+
+/obj/item/weapon/stock_parts/radio/transmitter/on_event/buildable
+	part_flags = PART_FLAG_HAND_REMOVE

--- a/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
+++ b/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
@@ -11,8 +11,10 @@ Do not work with lazy-initialized parts.
 	var/expected_part_type
 
 /decl/stock_part_preset/proc/apply(obj/machinery/machine, obj/item/weapon/stock_parts/part)
-	part.on_uninstall(machine, TRUE) // don't delete
+	if(machine)
+		part.on_uninstall(machine, TRUE) // don't delete
 	do_apply(machine, part)
-	part.on_install(machine)
+	if(machine)
+		part.on_install(machine)
 
 /decl/stock_part_preset/proc/do_apply(obj/machinery/machine, obj/item/weapon/stock_parts/part)

--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -90,3 +90,9 @@
 
 /decl/stock_part_preset/radio/basic_transmitter/air_sensor/engine
 	frequency = ATMOS_ENGINE_FREQ
+
+/obj/machinery/air_sensor/dist
+	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/air_sensor/engine = 1)
+
+/decl/stock_part_preset/radio/basic_transmitter/air_sensor/engine
+	frequency = ATMOS_DIST_FREQ

--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -51,7 +51,7 @@
 	for(var/gas in air_sample.gas)				
 		var/gaspercent = round(air_sample.gas["[gas]"]*100/total_moles,0.01)
 		var/gas_list = list("symbol" = gas_data.symbol_html["[gas]"], "percent" = gaspercent)
-		.["gas"] += list(gas_list)
+		. += list(gas_list)
 
 /decl/public_access/public_variable/pressure
 	expected_type = /obj/machinery/air_sensor
@@ -59,7 +59,7 @@
 	desc = "The pressure of the gas at the sensor."
 	can_write = FALSE
 	has_updates = FALSE
-	var_type = IC_FORMAT_NUMBER
+	var_type = IC_FORMAT_STRING
 
 /decl/public_access/public_variable/pressure/access_var(obj/machinery/air_sensor/sensor)
 	var/datum/gas_mixture/air_sample = sensor.return_air()
@@ -73,9 +73,9 @@
 	has_updates = FALSE
 	var_type = IC_FORMAT_NUMBER
 
-/decl/public_access/public_variable/pressure/access_var(obj/machinery/air_sensor/sensor)
+/decl/public_access/public_variable/temperature/access_var(obj/machinery/air_sensor/sensor)
 	var/datum/gas_mixture/air_sample = sensor.return_air()
-	return air_sample && num2text(round(air_sample.temperature,0.1))
+	return air_sample && round(air_sample.temperature,0.1)
 
 /decl/stock_part_preset/radio/basic_transmitter/air_sensor
 	transmit_on_tick = list(

--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -4,15 +4,26 @@
 	name = "Gas Sensor"
 
 	anchored = 1
-	var/state = 0
-	var/frequency = 1441
 
-	var/datum/radio_frequency/radio_connection
-	var/datum/gas_mixture/sample
-
-	var/constructed_path = /obj/machinery/air_sensor
-
+	uncreated_component_parts = list(
+		/obj/item/weapon/stock_parts/radio/transmitter/basic/buildable,
+		/obj/item/weapon/stock_parts/power/apc/buildable
+	)
+	public_variables = list(
+		/decl/public_access/public_variable/gas,
+		/decl/public_access/public_variable/pressure,
+		/decl/public_access/public_variable/temperature		
+	)
+	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/air_sensor = 1)
 	use_power = POWER_USE_IDLE
+
+	frame_type = /obj/item/machine_chassis/air_sensor
+	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
+	base_type = /obj/machinery/air_sensor/buildable
+
+// Have to install components on your own.
+/obj/machinery/air_sensor/buildable
+	uncreated_component_parts = null
 
 /obj/machinery/air_sensor/on_update_icon()
 	if(!powered())
@@ -20,92 +31,62 @@
 	else
 		icon_state = "gsensor[use_power]"
 
-/obj/machinery/air_sensor/Process()
-	if(powered() && use_power)
-		var/datum/signal/signal = new
-		signal.transmission_method = 1 //radio signal
-		signal.data["tag"] = id_tag
-		signal.data["timestamp"] = world.time
-		signal.data["gas"] = list()
+/decl/public_access/public_variable/gas
+	expected_type = /obj/machinery/air_sensor
+	name = "gas data"
+	desc = "A list of gas data from the sensor location; the list entries are two-entry lists with \"symbol\" and \"percent\" fields."
+	can_write = FALSE
+	has_updates = FALSE
+	var_type = IC_FORMAT_LIST
 
-		var/datum/gas_mixture/air_sample = return_air()
-		sample = air_sample
-		
-		signal.data["pressure"] = num2text(round(air_sample.return_pressure(),0.1),)
-		
-		signal.data["temperature"] = round(air_sample.temperature,0.1)
+/decl/public_access/public_variable/gas/access_var(obj/machinery/air_sensor/sensor)
+	var/datum/gas_mixture/air_sample = sensor.return_air()
+	if(!air_sample)
+		return
+	var/total_moles = air_sample.total_moles
+	if(total_moles <= 0)
+		return
 
-		var/total_moles = air_sample.total_moles
-
-		if(total_moles > 0)
-			for(var/gas in air_sample.gas)				
-				var/gaspercent = round(air_sample.gas["[gas]"]*100/total_moles,0.01)
-				var/gas_list = list("symbol" = gas_data.symbol_html["[gas]"], "percent" = gaspercent)
-				signal.data["gas"] += list(gas_list)
-
-		signal.data["sigtype"] = "status"
-		radio_connection.post_signal(src, signal, radio_filter = RADIO_ATMOSIA)
-
-/obj/machinery/air_sensor/proc/set_frequency(new_frequency)
-	radio_controller.remove_object(src, frequency)
-	frequency = new_frequency
-	radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
-
-/obj/machinery/air_sensor/Initialize()
-	set_frequency(frequency)	
-	. = ..()
-
-obj/machinery/air_sensor/Destroy()
-	if(radio_controller)
-		radio_controller.remove_object(src,frequency)
-	. = ..()
-
-/obj/machinery/air_sensor/proc/get_console_data()
 	. = list()
-	. += "<table>"
-	. += "<tr><td><b>Name:</b></td><td>[name]</td>"
-	. += "<tr><td><b>ID Tag:</b></td><td>[id_tag]</td><td><a href='?src=\ref[src];settag=\ref[id_tag]'>Set ID Tag</a></td></td></tr>"
-	if(frequency%10)
-		. += "<tr><td><b>Frequency:</b></td><td>[frequency/10]</td><td><a href='?src=\ref[src];setfreq=\ref[frequency]'>Set Frequency</a></td></td></tr>"
-	else
-		. += "<tr><td><b>Frequency:</b></td><td>[frequency/10].0</td><td><a href='?src=\ref[src];setfreq=\ref[frequency]'>Set Frequency</a></td></td></tr>"
-	.+= "</table>"
-	. = JOINTEXT(.)
+	for(var/gas in air_sample.gas)				
+		var/gaspercent = round(air_sample.gas["[gas]"]*100/total_moles,0.01)
+		var/gas_list = list("symbol" = gas_data.symbol_html["[gas]"], "percent" = gaspercent)
+		.["gas"] += list(gas_list)
 
-/obj/machinery/air_sensor/OnTopic(mob/user, href_list, datum/topic_state/state)
-	if((. = ..()))
-		return
-	if(href_list["settag"])	
-		var/t = sanitizeSafe(input(user, "Enter the ID tag for [src.name]", src.name, id_tag), MAX_NAME_LEN)
-		if(t && CanInteract(user, state))
-			id_tag = t
-			return TOPIC_REFRESH
-		return TOPIC_HANDLED
-	if(href_list["setfreq"])
-		var/freq = input(user, "Enter the Frequency for [src.name]. Decimal will automatically be inserted", src.name, frequency) as num|null
-		if(CanInteract(user, state))
-			set_frequency(freq)
-			return TOPIC_REFRESH
-		return TOPIC_HANDLED
+/decl/public_access/public_variable/pressure
+	expected_type = /obj/machinery/air_sensor
+	name = "pressure data"
+	desc = "The pressure of the gas at the sensor."
+	can_write = FALSE
+	has_updates = FALSE
+	var_type = IC_FORMAT_NUMBER
 
-/obj/machinery/air_sensor/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(isMultitool(O))
-		var/datum/browser/popup = new (user, "Vent Configuration Utility", "[src] Configuration Panel", 600, 200)
-		popup.set_content(jointext(get_console_data(),"<br>"))
-		popup.open()
-		return
-	else if(isWrench(O))
-		var/obj/item/air_sensor/sensor = new /obj/item/air_sensor(src.loc)
-		sensor.frequency = frequency
-		sensor.id_tag = id_tag
-		qdel(src)
-	else if(isScrewdriver(O))
-		var/F = input("What frequency would you like to set this to?", "Adjust Frequency", frequency) as num|null
-		if(CanPhysicallyInteract(user))
-			return
-		if(user.get_active_hand() != O)
-			return
-		if(F)
-			frequency = F
-			set_frequency(F)
-			to_chat(user, "<span class='notice'>The frequency of the sensor is now [frequency]</span>")
+/decl/public_access/public_variable/pressure/access_var(obj/machinery/air_sensor/sensor)
+	var/datum/gas_mixture/air_sample = sensor.return_air()
+	return air_sample && num2text(round(air_sample.return_pressure(),0.1))
+
+/decl/public_access/public_variable/temperature
+	expected_type = /obj/machinery/air_sensor
+	name = "temperature data"
+	desc = "The temperature of the gas at the sensor."
+	can_write = FALSE
+	has_updates = FALSE
+	var_type = IC_FORMAT_NUMBER
+
+/decl/public_access/public_variable/pressure/access_var(obj/machinery/air_sensor/sensor)
+	var/datum/gas_mixture/air_sample = sensor.return_air()
+	return air_sample && num2text(round(air_sample.temperature,0.1))
+
+/decl/stock_part_preset/radio/basic_transmitter/air_sensor
+	transmit_on_tick = list(
+		"gas" = /decl/public_access/public_variable/gas,
+		"pressure" = /decl/public_access/public_variable/pressure,
+		"temperature" = /decl/public_access/public_variable/temperature
+	)
+	frequency = ATMOS_TANK_FREQ
+
+/obj/machinery/air_sensor/engine
+	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/air_sensor/engine = 1)
+
+/decl/stock_part_preset/radio/basic_transmitter/air_sensor/engine
+	frequency = ATMOS_ENGINE_FREQ

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -232,23 +232,25 @@ Buildable meters
 		
 	qdel(src)
 
-/obj/item/air_sensor
+/obj/item/machine_chassis
+	var/build_type
+
+/obj/item/machine_chassis/attackby(var/obj/item/weapon/W, var/mob/user)
+	if(!isWrench(W))
+		return ..()
+	var/obj/machinery/machine = new build_type(get_turf(src), dir, FALSE)
+	machine.apply_component_presets()
+	machine.RefreshParts()
+	if(machine.construct_state)
+		machine.construct_state.post_construct(machine)
+	playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+	to_chat(user, "<span class='notice'>You have fastened the [src].</span>")
+	qdel(src)
+
+/obj/item/machine_chassis/air_sensor
 	name = "gas sensor"
 	desc = "A sensor. It detects gasses."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
 	w_class = ITEM_SIZE_LARGE
-	var/frequency = 1441
-	var/output = 3
-	var/id_tag
-
-/obj/item/air_sensor/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	..()
-	if(!isWrench(W))
-		return ..()
-	var/obj/machinery/air_sensor/sensor = new /obj/machinery/air_sensor(src.loc)
-	sensor.frequency = frequency
-	sensor.set_frequency(frequency)
-	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-	to_chat(user, "<span class='notice'>You have fastened the [src].</span>")
-	qdel(src)
+	build_type = /obj/machinery/air_sensor/buildable

--- a/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
@@ -166,13 +166,13 @@
 /datum/pipe/pipe_dispenser/device/air_sensor
 	name = "gas sensor"
 	desc = "a sensor. It detects gasses."
-	build_path = /obj/item/air_sensor
+	build_path = /obj/item/machine_chassis/air_sensor
 	build_icon_state = "gsensor1"
 	build_icon = 'icons/obj/stationobjs.dmi'
 	pipe_color = null
 	connect_types = null
 	colorable = FALSE
-	constructed_path = /obj/machinery/air_sensor
+	constructed_path = /obj/machinery/air_sensor/buildable
 	pipe_class = PIPE_CLASS_OTHER
 
 /datum/pipe/pipe_dispenser/device/outlet_injector

--- a/code/modules/fabrication/designs/general/designs_devices_components.dm
+++ b/code/modules/fabrication/designs/general/designs_devices_components.dm
@@ -8,6 +8,15 @@
 /datum/fabricator_recipe/device_component/tesla_component
 	path = /obj/item/weapon/stock_parts/power/apc/buildable
 
+/datum/fabricator_recipe/device_component/radio_transmitter
+	path = /obj/item/weapon/stock_parts/radio/transmitter/basic/buildable
+
+/datum/fabricator_recipe/device_component/radio_transmitter_event
+	path = /obj/item/weapon/stock_parts/radio/transmitter/on_event/buildable
+
+/datum/fabricator_recipe/device_component/radio_receiver
+	path = /obj/item/weapon/stock_parts/radio/receiver/buildable
+
 /datum/fabricator_recipe/device_component/battery_backup_crap
 	name = "battery backup (weak)"
 	path = /obj/item/weapon/stock_parts/power/battery/buildable/crap

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2732,7 +2732,6 @@
 	dir = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d_o2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -2834,7 +2833,6 @@
 	dir = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d_n2_sensor"
 	},
 /turf/simulated/floor/reinforced/nitrogen,

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2620,8 +2620,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/air_sensor{
-	frequency = 1443;
+/obj/machinery/air_sensor/dist{
 	id_tag = "d_air_sensor"
 	},
 /turf/simulated/floor/reinforced/airmix,

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -873,7 +873,6 @@
 	dir = 10
 	},
 /obj/machinery/air_sensor{
-	frequency = 7664;
 	id_tag = "c1"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
@@ -940,7 +939,6 @@
 	dir = 10
 	},
 /obj/machinery/air_sensor{
-	frequency = 7663;
 	id_tag = "c2"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -964,7 +962,6 @@
 	dir = 10
 	},
 /obj/machinery/air_sensor{
-	frequency = 7662;
 	id_tag = "c3"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -1020,7 +1017,7 @@
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 7664;
+	frequency = 1441;
 	id = "cn2n"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
@@ -1052,7 +1049,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	frequency = 7664;
+	frequency = 1441;
 	id_tag = "cn2o"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
@@ -1230,7 +1227,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	frequency = 7663;
+	frequency = 1441;
 	id_tag = "co2o"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -1285,7 +1282,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 7663;
+	frequency = 1441;
 	id = "co2n"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -1302,7 +1299,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 7662;
+	frequency = 1441;
 	id = "cco2n"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -1458,7 +1455,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	frequency = 7662;
+	frequency = 1441;
 	id_tag = "cco2o"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -1898,7 +1895,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/air_control{
-	frequency = 7664;
+	frequency = 1441;
 	input_tag = "cn2n";
 	name = "Nitrogen Supply Control";
 	output_tag = "cn2o";
@@ -2722,7 +2719,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/air_control{
-	frequency = 7663;
+	frequency = 1441;
 	input_tag = "co2n";
 	name = "Oxygen Supply Control";
 	output_tag = "co2o";
@@ -2816,7 +2813,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/air_control{
-	frequency = 7662;
+	frequency = 1441;
 	input_tag = "cco2n";
 	name = "Carbon Dioxide Tank Control";
 	output_tag = "cco2o";
@@ -6385,7 +6382,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 7664;
+	frequency = 1441;
 	id = "cn2n"
 	},
 /turf/simulated/floor/reinforced/nitrogen,

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -241,7 +241,6 @@
 "az" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "toxins_sensor"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -13117,7 +13116,6 @@
 /area/shuttle/petrov/maint)
 "Ht" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "phoron_sensor"
 	},
 /turf/simulated/floor/reinforced,

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -8971,7 +8971,6 @@
 /area/hallway/primary/thirddeck/center)
 "si" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d3sh_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
@@ -10709,7 +10708,6 @@
 /area/hallway/primary/thirddeck/aft)
 "wm" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d3ph_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
@@ -16985,7 +16983,6 @@
 /area/storage/tools)
 "MR" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d3po2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -18875,7 +18872,6 @@
 /area/maintenance/thirddeck/port)
 "SJ" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d3so2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -8834,7 +8834,6 @@
 	use_power = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -10409,7 +10408,6 @@
 	use_power = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "n2o_sensor"
 	},
 /turf/simulated/floor/reinforced/n20,
@@ -12585,7 +12583,6 @@
 	use_power = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -12619,7 +12616,6 @@
 	dir = 6
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "waste_sensor"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -14154,7 +14150,6 @@
 /area/engineering/engineering_monitoring)
 "JR" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
@@ -15784,7 +15779,6 @@
 	use_power = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
@@ -16077,7 +16071,6 @@
 	use_power = 1
 	},
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "fuel_sensor"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -16967,8 +16960,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "To" = (
-/obj/machinery/air_sensor{
-	frequency = 1438;
+/obj/machinery/air_sensor/engine{
 	id_tag = "engine_sensor"
 	},
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -14035,7 +14035,6 @@
 /area/security/processing)
 "bdz" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d1po2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -15498,7 +15497,6 @@
 /area/security/bo)
 "cHm" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d1sh_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
@@ -19715,7 +19713,6 @@
 /area/security/oldopscheck)
 "hml" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d1so2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -23328,7 +23325,6 @@
 /area/security/opscheck)
 "lom" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "d1ph_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
@@ -27248,7 +27244,6 @@
 /area/rnd/xenobiology/xenoflora)
 "qbb" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "xenobot_sensor"
 	},
 /turf/simulated/floor/reinforced,
@@ -29247,7 +29242,6 @@
 /area/thruster/d1port)
 "sqb" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "testchamber_sensor"
 	},
 /obj/effect/landmark{


### PR DESCRIPTION
:cl:
rscadd: Buildable radio components for machines are now available. They will have limited use with machines currently.
tweak: When building air sensors, you now must also add a power component and a radio transmitter. You can use a multitool on the radio transmitter while standing near a machine to configure it.
/:cl:

Pretty experimental; will need to test and possibly expand scope somewhat. Do not merge. Opening to run Travis over nonstandard maps.