### PR TITLE
Lowered renegade amount, removed duplicate vars

### DIFF
--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -17,13 +17,11 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 
 	id = MODE_RENEGADE
 	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE | ANTAG_RANDSPAWN | ANTAG_VOTABLE
-	hard_cap = 5
-	hard_cap_round = 7
+	hard_cap = 3
+	hard_cap_round = 5
 
-	hard_cap = 8
-	hard_cap_round = 12
-	initial_spawn_req = 3
-	initial_spawn_target = 6
+	initial_spawn_req = 1
+	initial_spawn_target = 3
 	antaghud_indicator = "hud_renegade"
 	skill_setter = /datum/antag_skill_setter/station
 


### PR DESCRIPTION
Tweaked amount of renegades in a round. It was getting very silly how we would often have 5-6 renegades for one traitor. This has been brought down to a more reasonable amount of angry people with guns.

Also removed duplicate vars that were there for some reason.

:cl:
tweak: Adjusted renegade numbers.
bugfix: Removed duplicate vars.
/:cl:
