### PR TITLE
Fixes powerloader torso not being printable

### DIFF
--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -294,7 +294,7 @@
 	build_path = /obj/item/mech_component/propulsion/tracks
 	req_tech = list(TECH_MATERIAL = 4)
 
-/datum/design/item/mechfab/exosuit/powerloader_torso
+/datum/design/item/mechfab/exosuit/sphere_torso
 	name = "spherical chassis"
 	id = "sphere_body"
 	build_path = /obj/item/mech_component/chassis/pod


### PR DESCRIPTION
I accidently redefined it as sphere torso.
