### PR TITLE
Meteor remix for Torch

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -1,5 +1,4 @@
 // The following four defines can be used to tweak the difficulty of the gamemode
-#define METEOR_DELAY 15 MINUTES			// This should be enough for crew to set up.
 #define METEOR_FAILSAFE_THRESHOLD 45 MINUTES	// Failsafe that guarantees Severity will be at least 15 when the round hits this time.
 
 // In general, a PVE oriented game mode. A middle ground between Extended and actual antagonist based rounds.
@@ -20,6 +19,7 @@
 	var/start_text
 	var/maximal_severity = 40
 	var/meteor_wave_delay = 30 SECONDS //minimum wait between waves in tenths of seconds
+	var/meteor_grace_period = 15 MINUTES //waves will not arrive until this far into round
 
 	// Moved these from defines to variables, to allow for in-round tweaking via varedit:
 	var/escalation_probability = 45
@@ -47,22 +47,32 @@
 /datum/game_mode/meteor/post_setup()
 	..()
 	alert_title = "Automated Beacon AB-[rand(10, 99)]"
-	alert_text = "This is an automatic warning. Your facility: [GLOB.using_map.full_name] is on a collision course with a nearby asteroid belt. Estimated time until impact is: [METEOR_DELAY / 1200] MINUTES. Please perform necessary actions to secure your ship or station from the threat. Have a nice day."
+	alert_text = "This is an automatic warning. Your facility: [GLOB.using_map.full_name] is on a collision course with a nearby asteroid belt. Estimated time until impact is: [meteor_grace_period / 1200] MINUTES. Please perform necessary actions to secure your ship or station from the threat. Have a nice day."
 	start_text = "This is an automatic warning. Your facility: [GLOB.using_map.full_name] has entered an asteroid belt. Estimated time until you leave the belt is: [rand(20,30)] HOURS and [rand(1, 59)] MINUTES. For your safety, please consider changing course or using protective equipment. Have a nice day."
-	next_wave = round_duration_in_ticks + METEOR_DELAY
+	next_wave = round_duration_in_ticks + meteor_grace_period
+
+/datum/game_mode/meteor/proc/on_meteor_warn()
+	alert_sent = 1
+	command_announcement.Announce(alert_text, alert_title)
+
+/datum/game_mode/meteor/proc/on_enter_field()
+	alert_sent = 2
+	command_announcement.Announce(start_text, alert_title)
+	for(var/obj/machinery/shield_diffuser/SD in SSmachines.machinery)
+		SD.meteor_alarm(INFINITY)
+	if(GLOB.using_map.use_overmap)
+		var/area/map = locate(/area/overmap)
+		for(var/turf/T in map)
+			T.overlays += image('icons/obj/overmap.dmi', "meteor[rand(1,4)]")
+	next_wave = round_duration_in_ticks + meteor_wave_delay
 
 /datum/game_mode/meteor/process()
 	// Send an alert halfway through the round.
 	if((round_duration_in_ticks >= (next_wave / 2)) && !alert_sent)
-		alert_sent = 1
-		command_announcement.Announce(alert_text, alert_title)
+		on_meteor_warn()
 	// And then another one when the meteors start flying around.
 	if((round_duration_in_ticks >= next_wave) && (alert_sent == 1))
-		alert_sent = 2
-		command_announcement.Announce(start_text, alert_title)
-		for(var/obj/machinery/shield_diffuser/SD in SSmachines.machinery)
-			SD.meteor_alarm(INFINITY)
-		next_wave = round_duration_in_ticks + meteor_wave_delay
+		on_enter_field()
 	if((round_duration_in_ticks >= METEOR_FAILSAFE_THRESHOLD) && (meteor_severity < 15) && !failsafe_triggered)
 		log_and_message_admins("Meteor mode severity failsafe triggered: Severity forced to 15.")
 		meteor_severity = 15
@@ -98,5 +108,4 @@
 	return meteors_normal
 
 
-#undef METEOR_DELAY
 #undef METEOR_FAILSAFE_THRESHOLD

--- a/maps/torch/datums/game_modes/torch_meteor.dm
+++ b/maps/torch/datums/game_modes/torch_meteor.dm
@@ -1,0 +1,63 @@
+//Torch override for it, auto-calls long-delayed jump automatically so round duration is hard capped.
+/datum/game_mode/meteor
+	name = "Meteor"
+	round_description = "Suddenly the rocks, thousands of them!"
+	extended_round_description = "We are on an unavoidable collision course with an asteroid field. You have only a moment to prepare before you are barraged by dust and meteors. Emergency BS drive spoolup has been initiated, but you need to survive until it's done."
+	shuttle_delay = 5	//40ish minutes round
+	meteor_grace_period = 10 MINUTES
+	meteor_severity = 10   //Since Torch is pretty sturdy and time is of essence, jumpstart things a bit
+	escalation_probability = 70
+
+/datum/game_mode/meteor/post_setup()
+	..()
+	alert_title = "[GLOB.using_map.full_name] Short Range Sensors"
+	alert_text = "[GLOB.using_map.full_name] is on a collision course with an ultradense asteroid field. Estimated time until impact is: [meteor_grace_period / 1200] MINUTES. Emegency random jump procedure initiated."
+	start_text = "Asteroid field imminent. All hands brace for multiple impacts. May %DEITY_NAME% be with you."
+
+	GLOB.using_map.shuttle_called_message = "Attention all hands: Emergency Bluespace Drive spool up initiated. It will be ready for jump in %ETA%."
+	GLOB.using_map.shuttle_docked_message = "Attention all hands: Bluespace Drive spooled up. Emergency bluespace jump in %ETD%."
+	GLOB.using_map.shuttle_leaving_dock = "Attention all hands: Emergency bluespace jump initiated, emerging in %ETA%."
+
+/datum/game_mode/meteor/on_meteor_warn()
+	..()
+	var/datum/evacuation_option/meteor_bluespace_jump/auto_evac = new()
+	auto_evac.execute()
+
+/datum/game_mode/meteor/declare_completion()
+	var/eng_status = 0
+	for(var/obj/machinery/atmospherics/unary/engine/E in SSmachines.machinery)
+		if((get_z(E) in GLOB.using_map.station_levels) && !(E.stat & BROKEN))
+			eng_status++
+	var/nav_status = FALSE
+	for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
+		if((get_z(H) in GLOB.using_map.station_levels) && !(H.stat & BROKEN))
+			nav_status = TRUE
+	var/bsd_status = FALSE
+	var/area/A = locate(/area/engineering/bluespace/containment) in world
+	if(A && A.powered(EQUIP)) //There's no actual machines to check
+		bsd_status = TRUE
+
+	to_world("<h3>Damage report</h3>")
+	if(eng_status)
+		to_world("<span class='good'>At least [eng_status] thrusters remained operational.</span>")
+	else
+		to_world("<span class='bad'>All propulsion was lost, leaving \the [GLOB.using_map.full_name] drifting.</span>")
+	if(nav_status)
+		to_world("<span class='good'>Navigation and helm remained operational.</span>")
+	else
+		to_world("<span class='bad'>The navigation systems were lost on [GLOB.using_map.full_name].</span>")
+	if(bsd_status)
+		to_world("<span class='good'>Bluespace drive stayed powered.</span>")
+	else
+		to_world("<span class='bad'>Bluespace drive lost power during the jump, causing dangerous anomalies in the local time-space.</span>")
+
+
+//Bluespace jump but ignoring cooldowns and done at roundstart basically
+/datum/evacuation_option/meteor_bluespace_jump
+	option_text = "Initiate emergency bluespace jump"
+	option_desc = "initiate automated emergency bluespace jump"
+
+/datum/evacuation_option/meteor_bluespace_jump/execute(mob/user)
+	if (!evacuation_controller)
+		return
+	evacuation_controller.call_evacuation(user, 0, forced = TRUE)

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -24,6 +24,7 @@
 	#include "datums/uniforms_expedition.dm"
 	#include "datums/uniforms_fleet.dm"
 	#include "datums/game_modes/torch_revolution.dm"
+	#include "datums/game_modes/torch_meteor.dm"
 	#include "datums/reports/command.dm"
 	#include "datums/reports/corporate.dm"
 	#include "datums/reports/exploration.dm"


### PR DESCRIPTION
Auto-calls evac on roundstart, but it takes 45 minutes to arrive. Basically caps max duration.
Also it jump starts meteors a bit because Torch turned out to be /very/ resillent even without shields, thanks to thicc hull and PD. Now things get dangerous halfway to evac timer.
Also adds some greentext in the end - checking if you have helm, thrusters and BSD, to give people something to do aside from just waiting for sweet release of death.

Reason is because while nerfing shields into the ground curbed the 'extended but with lag' rounds, I think more definite cap is needed so it's not relying on engineering systems not being abused one way or another.

:cl: Chinsky
tweak: During the metor rounds, evacuation jump will be called automatically after announcement that rocks are coming. It will take 30ish minutes to arrive
tweak: Since there's less time and Torch is /very/ sturdy (thicc hull and PD), initial intensity is bumped a bit and escalation is going faster, so will hit max intensity at around 30 minutes mark.
tweak: After the jump mode will check for some important things and will print red/green text about them:  helm console (need to have at least one and powered), thrusters (ditto), bluespace drive (the room must be powered).
/:cl: