### PR TITLE
Space deletion tweak

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -50,6 +50,9 @@ proc/get_deepspace(x,y)
 /mob/lost_in_space()
 	return isnull(client)
 
+/mob/living/carbon/human/lost_in_space()
+	return isnull(client) && !last_ckey && stat == DEAD
+
 proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	if (!T || !A)
 		return


### PR DESCRIPTION
Made it so human bodies don't get deleted in space if they've had a client and is still alive.

Addresses the problem of people accidentally DCing in space and having their fully EVA prepped character deleted from the game