### PR TITLE
Fixes #27841- vox cold_level var should not be zero

### DIFF
--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -39,7 +39,7 @@
 
 	cold_level_1 = 80
 	cold_level_2 = 50
-	cold_level_3 = 0
+	cold_level_3 = -1
 	
 	min_age = 1
 	max_age = 100


### PR DESCRIPTION
Fixes #27841 

cold_level vars should not be zero. Other races that do not have cold_levels 2/3 have this set to -1 so that `getCryogenicFactor` will return a maximum of 20 due to line 154 of human_helpers.dm, e.g. see Diona on line 283 of station.dm