### PR TITLE
Updates prison break events

### DIFF
--- a/code/controllers/subsystems/event.dm
+++ b/code/controllers/subsystems/event.dm
@@ -36,6 +36,9 @@ SUBSYSTEM_DEF(event)
 			)
 	if(GLOB.using_map.use_overmap)
 		overmap_event_handler.create_events(GLOB.using_map.overmap_z, GLOB.using_map.overmap_size, GLOB.using_map.overmap_event_areas)
+	GLOB.using_map.setup_events()
+	for(var/event_level in GLOB.using_map.map_event_container)
+		event_containers[text2num(event_level)].available_events += GLOB.using_map.map_event_container[event_level].available_events
 	. = ..()
 
 /datum/controller/subsystem/event/Recover()

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -171,8 +171,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",							/datum/event/solar_storm, 				10,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust	, 					30, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",					/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",						/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",					/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30))
 	)
@@ -183,7 +181,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",							/datum/event/nothing,				1320),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",							/datum/event/blob, 					0,	list(ASSIGNMENT_ENGINEER = 40), 1),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,		0,	list(ASSIGNMENT_SECURITY =  5), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",				/datum/event/prison_break/station,	0,	list(ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,			0,	list(ASSIGNMENT_ENGINEER = 10),	1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",						/datum/event/spacevine, 			0,	list(ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Electrical Storm",		/datum/event/electrical_storm, 		0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 5)),

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -10,24 +10,6 @@
 	var/list/areaType = list(/area/security/prison, /area/security/brig)	//Area types to include.
 	var/list/areaNotType = list()		//Area types to specifically exclude.
 
-/datum/event/prison_break/virology
-	eventDept = "Medical"
-	areaName = list("Virology")
-	areaType = list(/area/medical/virology, /area/medical/virologyaccess)
-
-/datum/event/prison_break/xenobiology
-	eventDept = "Science"
-	areaName = list("Xenobiology")
-	areaType = list(/area/rnd/xenobiology)
-	areaNotType = list(/area/rnd/xenobiology/xenoflora, /area/rnd/xenobiology/xenoflora_storage)
-
-/datum/event/prison_break/station
-	eventDept = "Local"
-	areaName = list("Brig","Virology","Xenobiology")
-	areaType = list(/area/security/prison, /area/security/brig, /area/medical/virology, /area/medical/virologyaccess, /area/rnd/xenobiology)
-	areaNotType = list(/area/rnd/xenobiology/xenoflora, /area/rnd/xenobiology/xenoflora_storage)
-
-
 /datum/event/prison_break/setup()
 	announceWhen = rand(75, 105)
 	releaseWhen = rand(60, 90)

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -4,6 +4,7 @@
 	#include "torch_antagonism.dm"
 	#include "torch_areas.dm"
 	#include "torch_elevator.dm"
+	#include "torch_events.dm"
 	#include "torch_holodecks.dm"
 	#include "torch_lobby.dm"
 	#include "torch_machinery.dm"

--- a/maps/torch/torch_events.dm
+++ b/maps/torch/torch_events.dm
@@ -1,0 +1,55 @@
+#define ASSIGNMENT_ENGINEER "Engineer"
+#define ASSIGNMENT_SUPPLY "Supply"
+#define ASSIGNMENT_SECURITY "Security"
+
+/datum/map/torch/setup_events()
+	map_event_container = list(
+				num2text(EVENT_LEVEL_MODERATE)	= new/datum/event_container/moderate/torch,
+				num2text(EVENT_LEVEL_MAJOR) 	= new/datum/event_container/major/torch
+			)
+
+/datum/event/prison_break/xenobiology
+	eventDept = "Science"
+	areaName = list("Xenobiology")
+	areaType = list(/area/rnd/xenobiology)
+	areaNotType = list(/area/rnd/xenobiology/xenoflora, /area/rnd/xenobiology/xenoflora_storage)
+
+/datum/event/prison_break/station
+	eventDept = "Local"
+	areaName = list("Brig","Supply Warehouse","Xenobiology","Engineering Hard Storage")
+	areaType = list(/area/security/prison, /area/security/brig, /area/quartermaster/storage, /area/rnd/xenobiology, /area/engineering/hardstorage)
+	areaNotType = list(/area/rnd/xenobiology/xenoflora, /area/rnd/xenobiology/xenoflora_storage, /area/quartermaster/storage/upper)
+
+/datum/event/prison_break/warehouse
+	eventDept = "Supply"
+	areaName = list("Supply Warehouse")
+	areaType = list(/area/quartermaster/storage)
+	areaNotType = list(/area/quartermaster/storage/upper)
+
+/datum/event/prison_break/hardstorage
+	eventDept = "Engineering"
+	areaName = list("Engineering Hard Storage")
+	areaType = list(/area/engineering/hardstorage)
+
+/datum/event/prison_break/armory
+	eventDept = "Security"
+	areaName = list("Emergency Armory")
+	areaType = list(/area/command/armoury)
+	areaNotType = list(/area/command/armoury/tactical)
+
+/datum/event_container/moderate/torch
+	available_events = list(
+		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",					/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
+		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Warehouse Breach",						/datum/event/prison_break/warehouse,	0,		list(ASSIGNMENT_SUPPLY = 100)),
+		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Hard Storage Breach",					/datum/event/prison_break/hardstorage,	0,		list(ASSIGNMENT_ENGINEER = 100)),		
+		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Armory Breach",						/datum/event/prison_break/armory,		0,		list(ASSIGNMENT_SECURITY = 100))
+		)
+
+/datum/event_container/major/torch
+	available_events = list(
+		new/datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",				/datum/event/prison_break/station,	0,	list(ASSIGNMENT_ANY = 5))
+		)
+
+#undef ASSIGNMENT_ENGINEER
+#undef ASSIGNMENT_SUPPLY
+#undef ASSIGNMENT_SECURITY

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -206,6 +206,9 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	// List of /datum/department types to instantiate at roundstart.
 	var/list/departments
 
+	// List of events specific to a map
+	var/list/map_event_container = list()
+
 /datum/map/New()
 	if(!map_levels)
 		map_levels = station_levels.Copy()
@@ -230,6 +233,10 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 /datum/map/proc/setup_map()
 	lobby_track = get_lobby_track()
 	world.update_status()
+	setup_events()
+
+/datum/map/proc/setup_events()
+	return
 
 /datum/map/proc/setup_job_lists()
 	return


### PR DESCRIPTION
:cl:
rscdel: Virology prison break event is removed.
rscadd: Adds prison break events for the Warehouse, Engineering Hard Storage and the Emergency Armoury (but not the room with weaponry).
/:cl:

Updates the prison break events. I tried to pick some areas that contain useful items for antagonists to steal, that aren't main department offices or extremely busy areas.

Note that the Emergency Armoury event does not open the room with the weapons, only the the central room and entryway.

---

Also adds the ability to make events map-dependent.