### PR TITLE
Combining stacks from an inventory no longer leaves bugged sprites

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -107,8 +107,12 @@
 		m.drop_from_inventory(src)
 	var/obj/item/weapon/storage/storage = loc
 	if(istype(storage))
-		storage.on_item_deletion()
-	return ..()
+		// some ui cleanup needs to be done
+		storage.on_item_pre_deletion(src) // must be done before deletion
+		. = ..()
+		storage.on_item_post_deletion(src) // must be done after deletion
+	else
+		return ..()
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -243,9 +243,13 @@
 	return 1
 
 // Only do ui functions for now; the obj is responsible for anything else.
-/obj/item/weapon/storage/proc/on_item_deletion(obj/item/W)
+/obj/item/weapon/storage/proc/on_item_pre_deletion(obj/item/W)
 	if(storage_ui)
 		storage_ui.on_pre_remove(null, W) // Supposed to be able to handle null user.
+
+// Only do ui functions for now; the obj is responsible for anything else.
+/obj/item/weapon/storage/proc/on_item_post_deletion(obj/item/W)
+	if(storage_ui)
 		update_ui_after_item_removal()
 	queue_icon_update()
 


### PR DESCRIPTION
:cl:
bugfix: Combining stacks from an inventory no longer leaves bugged sprites
/:cl:

Fixes #27059

Tested this locally by tossing some stacks around and it seems like it works as intended.

## So, here's my understanding of what's happening currently

First, `/obj/item/stack/proc/transfer_to(obj/item/stack/S, var/tamount=null, var/type_verified)` is called.

This calls `/obj/item/stack/proc/use(var/used)`, which contains this snippet:
```
if (amount <= 0)
	qdel(src)
```

`qdel` eventually hooks into `/obj/item/Destroy()`, which contains this snippet:
```
var/obj/item/weapon/storage/storage = loc
if(istype(storage))
	storage.on_item_deletion(src)
```

`/obj/item/weapon/storage/proc/on_item_deletion(obj/item/W)` makes calls to the following:
```
/datum/storage_ui/default/on_pre_remove(var/mob/user, var/obj/item/W)
/datum/storage_ui/default/prepare_ui()
/datum/storage_ui/default/on_post_remove(var/mob/user)
```

- `on_pre_remove` removes the item from the screen
- `prepare_ui` iterates over `storage.contents`, rendering each item, _including the item which we are in the process of removing, and still exists in `contents`._ At this point, the (now empty) stack item get shoved right back onto `screen`, because the storage ui thinks it's still in the storage.
- finally, `on_post_remove` does nothing of interest.

After all this, the Destroy() continues to travel back up the `..()` chain until garbage collection eventually does whatever it does.

## How to fix it

~~Given my understanding of this bug, it seems like the simple fix is simply doing a `contents -= W` in `/obj/item/weapon/storage/proc/on_item_deletion(obj/item/W)`~~

Hot take: the secret sauce is that `on_pre_remove` needs to be called before `qdel` and `prepare_ui` needs to be called after.
- `on_pre_remove` needs the item to still exist so that it can be referenced and removed from the screen
- `prepare_ui` needs the item to be deleted, which apparently removes it from the storage's contents. I don't know _where_ this is happening, but it's definitely happening.
