### PR TITLE
Forensics provides a larger bonus to incisions on dead targets

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -133,7 +133,9 @@
 /decl/surgery_step/generic/cut_open/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
 	if(user.skill_check(SKILL_FORENSICS, SKILL_ADEPT))
-		. += 10
+		. += 40
+		if(target.stat == DEAD)
+			. += 40
 
 //////////////////////////////////////////////////////////////////
 //	 bleeder clamping surgery step


### PR DESCRIPTION
:cl:
tweak: Trained Forensics now provides a much larger bonus to making simple incisions on dead targets for autopsies.
/:cl:

Recent surgery skill changes made it very difficult for a Forensics Tech to perform autopsies, even with the +10 chance bonus from Trained Forensics. 

Trained Forensics now gives a +40 bonus so long as their target is dead. This should make it fairly easy for a Forensics Tech with Trained Forensics and Basic/Trained Anatomy to make simple incisions successfully.

This does not apply to any other surgical steps, it does not make the Forensics Tech into a surgeon, and it only applies to dead targets.