### PR TITLE
Z-Mimic Fixes Pack 1

### DIFF
--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -96,9 +96,9 @@ SUBSYSTEM_DEF(zcopy)
 	while (qt_idex <= curr_turfs.len)
 		var/turf/T = curr_turfs[qt_idex]
 		curr_turfs[qt_idex] = null
-		qt_idex++
+		qt_idex += 1
 
-		if (!istype(T) || !T.below)
+		if (!isturf(T) || !T.below || !(T.z_flags & ZM_MIMIC_BELOW))
 			if (no_mc_tick)
 				CHECK_TICK
 			else if (MC_TICK_CHECK)
@@ -107,6 +107,14 @@ SUBSYSTEM_DEF(zcopy)
 
 		if (!T.shadower)	// If we don't have a shadower yet, something has gone horribly wrong.
 			WARNING("Turf [T] at [T.x],[T.y],[T.z] was queued, but had no shadower.")
+			continue
+
+		if (T.z_queued > 1)
+			T.z_queued -= 1
+			if (no_mc_tick)
+				CHECK_TICK
+			else if (MC_TICK_CHECK)
+				break
 			continue
 
 		// Figure out how many z-levels down we are.
@@ -197,7 +205,7 @@ SUBSYSTEM_DEF(zcopy)
 		else if (MC_TICK_CHECK)
 			break
 
-	if (qt_idex > 1 && qt_idex <= curr_turfs.len)
+	if (qt_idex > 1)
 		curr_turfs.Cut(1, qt_idex)
 		qt_idex = 1
 
@@ -207,7 +215,7 @@ SUBSYSTEM_DEF(zcopy)
 	while (qo_idex <= curr_ov.len)
 		var/atom/movable/openspace/overlay/OO = curr_ov[qo_idex]
 		curr_ov[qo_idex] = null
-		qo_idex++
+		qo_idex += 1
 
 		if (QDELETED(OO))
 			if (no_mc_tick)
@@ -241,9 +249,9 @@ SUBSYSTEM_DEF(zcopy)
 		else if (MC_TICK_CHECK)
 			break
 
-		if (qo_idex > 1 && qo_idex <= curr_ov.len)
-			curr_ov.Cut(1, qo_idex)
-			qo_idex = 1
+	if (qo_idex > 1)
+		curr_ov.Cut(1, qo_idex)
+		qo_idex = 1
 
 /client/proc/analyze_openturf(turf/T)
 	set name = "Analyze Openturf"

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -109,14 +109,6 @@ SUBSYSTEM_DEF(zcopy)
 			WARNING("Turf [T] at [T.x],[T.y],[T.z] was queued, but had no shadower.")
 			continue
 
-		if (T.z_queued > 1)
-			T.z_queued -= 1
-			if (no_mc_tick)
-				CHECK_TICK
-			else if (MC_TICK_CHECK)
-				break
-			continue
-
 		// Figure out how many z-levels down we are.
 		var/depth = 0
 		var/turf/Td = T

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -125,9 +125,7 @@ SUBSYSTEM_DEF(zcopy)
 		// Handle space parallax.
 		if (T.below.z_eventually_space)
 			T.z_eventually_space = TRUE
-
-			if (istype(T.below, /turf/space))
-				t_target = SPACE_PLANE
+			t_target = SPACE_PLANE
 
 		if (!(T.z_flags & ZM_MIMIC_OVERWRITE))
 			// Some openturfs have icons, so we can't overwrite their appearance.

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -43,6 +43,14 @@
 
 	return INITIALIZE_HINT_LATELOAD // oh no! we need to switch to being a different kind of turf!
 
+/turf/space/Destroy()
+	// Cleanup cached z_eventually_space values above us.
+	if (above)
+		var/turf/T = src
+		while ((T = GetAbove(T)))
+			T.z_eventually_space = FALSE
+	return ..()
+
 /turf/space/LateInitialize()
 	if(GLOB.using_map.base_floor_area)
 		var/area/new_area = locate(GLOB.using_map.base_floor_area) || new GLOB.using_map.base_floor_area

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -75,6 +75,9 @@
 		SSao.queue -= src
 		ao_queued = 0
 
+	if (z_flags & ZM_MIMIC_BELOW)
+		cleanup_zmimic()
+
 	if (bound_overlay)
 		QDEL_NULL(bound_overlay)
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -10,9 +10,8 @@
 // Called after turf replaces old one
 /turf/proc/post_change()
 	levelupdate()
-	var/turf/simulated/open/T = GetAbove(src)
-	if(istype(T))
-		T.update_icon()
+	if (above)
+		above.update_mimic()
 
 //Creates a new turf
 /turf/proc/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -60,6 +60,7 @@
 /turf/proc/cleanup_zmimic()
 	SSzcopy.openspace_turfs -= 1
 	// Don't remove ourselves from the queue, the subsystem will explode. We'll naturally fall out of the queue.
+	z_queued = 0
 
 	QDEL_NULL(shadower)
 

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -59,10 +59,7 @@
 // Cleans up Z-mimic objects for this turf. You shouldn't call this directly 99% of the time.
 /turf/proc/cleanup_zmimic()
 	SSzcopy.openspace_turfs -= 1
-	if (z_queued)
-		while (z_queued)
-			SSzcopy.queued_turfs -= src
-			z_queued -= 1
+	// Don't remove ourselves from the queue, the subsystem will explode. We'll naturally fall out of the queue.
 
 	QDEL_NULL(shadower)
 


### PR DESCRIPTION
Fixes:
- OTs getting into an invalid state after mimicing a space tile, and that space tile being removed.
- OOs being created on elevator move, but not cleaned up.
- Update queueing in SSzcopy being generally wack.
- Space not working with recursive mimic (only single-level mimic).

Does not fix issues with elevators turning black.