### PR TITLE
sensor readout can ignore overmap visitables

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -20,6 +20,8 @@
 	var/base = 0		//starting sector, counts as station_levels
 	var/in_space = 1	//can be accessed via lucky EVA
 
+	var/hide_from_reports = FALSE
+
 	var/has_distress_beacon
 
 /obj/effect/overmap/visitable/Initialize()

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -8,6 +8,7 @@
 	desc = "Sensor array detects a medium cargo vessel with high structural damage."
 	in_space = 1
 	icon_state = "ship"
+	hide_from_reports = TRUE
 	initial_generic_waypoints = list(
 		"nav_merc_1",
 		"nav_merc_2",

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -23,6 +23,7 @@
 	vessel_mass = 6500
 	fore_dir = WEST
 	max_speed = 1/(1 SECOND)
+	hide_from_reports = TRUE
 	initial_restricted_waypoints = list(
 		"Trichoptera" = list("nav_hangar_ascent_one"),
 		"Lepidoptera" = list("nav_hangar_ascent_two")

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -22,6 +22,7 @@
 	desc = "Slight traces of a cloaking device are present. Unable to determine exact location."
 	in_space = 1
 	icon_state = "event"
+	hide_from_reports = TRUE
 
 /obj/effect/submap_landmark/joinable_submap/skrellscoutship
 	name = "Xilvuxix"

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -17,6 +17,7 @@
 	desc = "Sensor array detects a large asteroid."
 	in_space = 1
 	icon_state = "meteor4"
+	hide_from_reports = TRUE
 	initial_generic_waypoints = list(
 		"nav_voxbase_1",
 	)

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -30,6 +30,8 @@
 			continue
 		if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles
 			continue
+		if (O.hide_from_reports)
+			continue
 		space_things |= O
 
 	var/list/distress_calls


### PR DESCRIPTION
:cl:
tweak: Mercenary and Provocateur starting points are hidden from the Torch's roundstart sensor message.
/:cl:
