### PR TITLE
Prevents mobs that can't use psionics properly (due to lack of UI) from gaining psionics

### DIFF
--- a/code/modules/psionics/mob/mob.dm
+++ b/code/modules/psionics/mob/mob.dm
@@ -13,6 +13,9 @@
 	. = ..()
 
 /mob/living/proc/set_psi_rank(var/faculty, var/rank, var/take_larger, var/defer_update, var/temporary)
+	if(!src.zone_sel)
+		to_chat(src, SPAN_NOTICE("You feel something strange brush against your mind... but your brain is not able to grasp it."))
+		return
 	if(!psi)
 		psi = new(src)
 	var/current_rank = psi.get_rank(faculty)


### PR DESCRIPTION
:cl:
admin: Mobs without the UI elements to use psionics can no longer be granted psionics. e.g. simple animals.
/:cl:

Only applies to admins granting simple animals psionics on purpose, I think, hence the admin changelog.

Many psionic powers rely on UI elements e.g. targeting locations that simple animals do not have. So they probably shouldn't be able to gain psionic powers. 

Also they ignore the downsides of psionic powers that rely on 'backblast', since they don't have brains. Possibly abusable.

Fixes #27799
Fixes #27800
Fixes #28004
