### PR TITLE
psi events cannot affect mobs not derived from carbon/human

### DIFF
--- a/code/modules/psionics/events/_psi.dm
+++ b/code/modules/psionics/events/_psi.dm
@@ -21,4 +21,4 @@
 		apply_psi_effect(thing)
 
 /datum/event/psi/proc/apply_psi_effect(var/datum/psi_complexus/psi)
-	return
+	return psi && ishuman(psi.owner)

--- a/code/modules/psionics/events/psi_balm.dm
+++ b/code/modules/psionics/events/psi_balm.dm
@@ -6,6 +6,8 @@
 		)
 
 /datum/event/psi/balm/apply_psi_effect(var/datum/psi_complexus/psi)
+	if (!..())
+		return
 	var/soothed
 	if(psi.stun > 1)
 		psi.stun--

--- a/code/modules/psionics/events/psi_wail.dm
+++ b/code/modules/psionics/events/psi_wail.dm
@@ -6,6 +6,8 @@
 		)
 
 /datum/event/psi/wail/apply_psi_effect(var/datum/psi_complexus/psi)
+	if (!..())
+		return
 	var/annoyed
 	if(prob(1))
 		psi.stunned(1)


### PR DESCRIPTION
:cl:
tweak: Psi events cannot affect inappropriate mobs.
/:cl:

Alternate to #27882 - This way, non-human mobs can only get psi by being granted it by admins. isanimal doesn't even begin to cover the full set of things that shouldn't normally have powers and locking them out in the set proc is a weak bandaid.