### PR TITLE
Nymphs, Golems can no longer be auto-traitor'd

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/_nymph.dm
@@ -13,6 +13,7 @@
 	health = 60
 	maxHealth = 60
 	available_maneuvers = list(/decl/maneuver/leap)
+	status_flags = NO_ANTAG
 
 	language = LANGUAGE_ROOTLOCAL
 	species_language = LANGUAGE_ROOTLOCAL

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -49,6 +49,7 @@
 		H.mind.special_role = "Golem"
 	H.real_name = "golem ([rand(1, 1000)])"
 	H.SetName(H.real_name)
+	H.status_flags |= NO_ANTAG
 	..()
 
 /datum/species/golem/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)


### PR DESCRIPTION
:cl:
bugfix: Nymphs and Golems are no longer valid targets for auto-traitor.
/:cl:

Fixes #27769