### PR TITLE
Adherent with usable levitation plates can now feather-fall

### DIFF
--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -135,12 +135,19 @@
 	return slowdown
 
 /datum/species/adherent/handle_fall_special(var/mob/living/carbon/human/H, var/turf/landing)
-
-	if(can_overcome_gravity(H))
+	var/float_is_usable = FALSE
+	if(H && H.stat == CONSCIOUS)
+		for(var/obj/item/organ/internal/powered/float/float in H.internal_organs)
+			if(float.is_usable())
+				float_is_usable = TRUE
+				break
+	if(float_is_usable)
 		if(istype(landing, /turf/simulated/open))
 			H.visible_message("\The [H] descends from \the [landing].", "You descend regally.")
 		else
 			H.visible_message("\The [H] floats gracefully down from \the [landing].", "You land gently on \the [landing].")
+		return TRUE
+	return FALSE
 
 /datum/species/adherent/get_blood_name()
 	return "coolant"


### PR DESCRIPTION
:cl:
bugfix: Adherent with usable levitation plates can now feather-fall, avoiding damage
/:cl:

I noticed that Adherent have a partial `handle_fall_special` implementation, but it had two problems with it:
- It would only trigger if you were floating, which prevents falling in the first place
- Even if it did trigger, it doesn't return TRUE, meaning it will show the flavor text and then offer no fall protection

I've tested this locally by jumping down the stairwell, and it works as intended.

### Why I think this is a good idea
- GAS can [already do this](https://github.com/Baystation12/Baystation12/blob/741a65c429d40d8a3eff5a4c74b36a769a81c2fa/code/modules/species/station/nabber.dm#L194), floating above 80kPa and feather-falling above 50kPa.
- Adherent possess an anti-gravity levitation plate they use to bring their true 250-300kg mass within the 20-30kg range _passively_. Actively, at the cost of power usage, they can increase their levitation plate's output, achieving flight. I don't think it makes sense for something with that sort of functionality from an internal organ to accidentally take a damaging fall without catching itself.
- A broken, unreachable fall handler is already in place, indicating the original author of the Adherent intended for them to be able to feather-fall. Strings such as `You land gently on the [landing].` currently exist in the code, and were intended to print when Adherent landed after a feather-fall. This is why I've marked this as a bugfix, over a tweak.


