### PR TITLE
Prevent the mini spasm event from giving synthetics disabilities

### DIFF
--- a/code/modules/psionics/events/mini_spasm.dm
+++ b/code/modules/psionics/events/mini_spasm.dm
@@ -33,7 +33,7 @@
 /datum/event/minispasm/proc/do_spasm(var/mob/living/victim, var/obj/item/device/radio/source)
 	set waitfor = 0
 
-	if(iscarbon(victim))
+	if(iscarbon(victim) && !victim.isSynthetic())
 		var/list/disabilities = list(NEARSIGHTED, EPILEPSY, TOURETTES, NERVOUS)
 		for(var/disability in disabilities)
 			if(victim.disabilities & disability)


### PR DESCRIPTION
:cl:
bugfix: The psionic signal event can no longer give synthetics genetic disabilities
/:cl:

The mini spasm event currently forces any carbon mob to take one of {NEARSIGHTED, EPILEPSY, TOURETTES, NERVOUS}. It does not make sense for synthetics to have any of these.