### PR TITLE
Fixes issue with being able to walk through closed double doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -81,12 +81,12 @@
 		set_extension(src, /datum/extension/turf_hand, turf_hand_priority)
 
 	health = maxhealth
+	update_connections(1)
 	update_icon()
 
 	update_nearby_tiles(need_rebuild=1)
 
 /obj/machinery/door/Initialize()
-	update_connections(1)
 	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
 	. = ..()
 	if(autoset_access)


### PR DESCRIPTION
:cl:
bugfix: Double doors are properly solid again.
/:cl:

Fixes #27879

Reverts part of #27716 which changed how doors worked. All doors on the mercenary starting area + ship still work. I think that change was made to correct the rotation of one door, however it messes up all the double doors on all other maps.