### PR TITLE
Vox can now return to their hangar landmark properly

### DIFF
--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -22,6 +22,10 @@
 		"nav_voxbase_1",
 	)
 
+	initial_restricted_waypoints = list(
+		"Vox Shuttle" = list("nav_hangar_vox"),
+	)
+
 /obj/effect/shuttle_landmark/nav_voxbase/nav1
 	name = "Northest of Large Asteroid"
 	landmark_tag = "nav_voxbase_1"


### PR DESCRIPTION
:cl:
bugfix: The Vox shuttle can now return to its hangar properly.
/:cl:

Fixes #27920