### PR TITLE
Fixes mercenary radio channel

### DIFF
--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1949,6 +1949,15 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
+"eI" = (
+/obj/machinery/telecomms/allinone{
+	intercept = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "plating";
+	name = "plating"
+	},
+/area/map_template/syndicate_mothership/raider_base)
 
 (1,1,1) = {"
 aa
@@ -5282,7 +5291,7 @@ ab
 ab
 ab
 ae
-aj
+eI
 aj
 av
 av

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -127,6 +127,17 @@
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/map_template/merc_shuttle)
+"al" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central6,
+/obj/machinery/telecomms/allinone{
+	intercept = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/merc_spawn)
 "am" = (
 /obj/effect/paint/black,
 /turf/simulated/wall/r_titanium,
@@ -2570,14 +2581,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/airless,
-/area/map_template/merc_spawn)
-"wC" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6,
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_spawn)
 "wG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -10104,7 +10107,7 @@ aa
 aa
 XS
 vO
-wC
+al
 XS
 aa
 aa

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -12,6 +12,17 @@
 "aad" = (
 /turf/space,
 /area/shuttle/syndicate_elite/mothership)
+"aae" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/telecomms/allinone{
+	intercept = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/control)
 "aao" = (
 /turf/space,
 /area/shuttle/escape_pod1/centcom)
@@ -23701,7 +23712,7 @@ avN
 avm
 avU
 awa
-awC
+aae
 awG
 awG
 axy


### PR DESCRIPTION
:cl:
bugfix: Mercenary radio channel now works again for mercs, raiders, traitors etc.
/:cl:

Added the appropriate telecomms machine to Merc base, Raider base, Admin level since it got forgotten in the merc overmapping.

Fixes #27929