### PR TITLE
Adherent can pass over tables when floating

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -4,7 +4,7 @@
 	icon_state = "repairbot"
 
 	emote_type = 2		// pAIs emotes are heard, not seen, so they can be seen through a container (eg. person)
-	pass_flags = 1
+	pass_flags = PASS_FLAG_TABLE
 	mob_size = MOB_SMALL
 
 	can_pull_size = ITEM_SIZE_SMALL

--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -100,8 +100,13 @@
 
 /obj/item/organ/internal/powered/float/Process()
 	. = ..()
-	if(active && owner && owner.floatiness <= 5)
-		owner.make_floating(5)
+	if(owner)
+		if(active)
+			owner.pass_flags |= PASS_FLAG_TABLE
+			if(owner.floatiness <= 5)
+				owner.make_floating(5)
+		else
+			owner.pass_flags &= ~PASS_FLAG_TABLE
 
 /obj/item/organ/internal/eyes/adherent
 	name = "receptor prism"


### PR DESCRIPTION
:cl:
rscadd: Adherent can now float over tables
/:cl:

Fixes #22774

Adherent should have the ability to pass over tables. I have implemented this, using a mechanism similar to that of flying robots.

During my research I also noticed and fixed a magic number in pai.dm regarding their `pass_flags`. This does not change the value of their `pass_flags`, as `PASS_FLAG_TABLE` = 1.

I have tested this locally and it works as intended.

### Why I think this is a good (or at the very least not-bad) idea
- Brings Adherent functionality in line with the author's intent. To quote MistakeNot4892's [original adherent addition PR](https://github.com/Baystation12/Baystation12/pull/22286#issue-201508942)
  > They fly under their own power, which means they can go straight over tables and open space, maneuver during EVA, and move under zero gravity.
  
  and [a later issue](https://github.com/Baystation12/Baystation12/issues/22774#issuecomment-415244186) where the table-passing discrepancy is called-out:
  > [Adherent's inability to fly over tables] is me forgetting to implement something rather than a bug. I am aware and will get around to it eventually.
- While normally a movement buff would also be a combat buff, this should not be, as adherent are protocol-bound to avoid violence
- Adherent movement (only when using the powered float) now matches that of flying robots, adding consistency between the mob with the anti-gravity levitation plate and the mob with the anti-gravity hover unit.
- While Adherent are large and flying robots are small, I believe being able to move over tables makes sense in-universe given that much of their size is comprised of tendrils and they can literally fly.