### PR TITLE
Fixes a runtime when using an atmos analyzer on a pit

### DIFF
--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -60,7 +60,10 @@
 	update_icon()
 
 /obj/structure/pit/return_air()
-	return open
+	if(open && loc)
+		return loc.return_air()
+	else
+		return null
 
 /obj/structure/pit/proc/digout(mob/escapee)
 	var/breakout_time = 1 //2 minutes by default


### PR DESCRIPTION
:cl:
bugfix: Fixes a runtime when using an atmos analyzer on a pit
/:cl:

Fixes #27934

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->