### PR TITLE
Adds welding goggles to loadout.

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -79,6 +79,10 @@
 	display_name = "Meson Goggles, prescription"
 	path = /obj/item/clothing/glasses/meson/prescription
 
+/datum/gear/eyes/welding
+	display_name = "Welding Goggles"
+	path = /obj/item/clothing/glasses/welding
+
 /datum/gear/eyes/meson/ipatch
 	display_name = "HUDpatch, Meson"
 	path = /obj/item/clothing/glasses/eyepatch/hud/meson

--- a/maps/torch/loadout/loadout_eyes.dm
+++ b/maps/torch/loadout/loadout_eyes.dm
@@ -17,5 +17,8 @@
 /datum/gear/eyes/meson
 	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/pathfinder, /datum/job/explorer, /datum/job/scientist, /datum/job/rd, /datum/job/senior_scientist)
 
+/datum/gear/eyes/welding
+	allowed_roles = TECHNICAL_ROLES
+
 /datum/gear/eyes/material
 	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant)


### PR DESCRIPTION
Adds welding goggles to loadout with the same restrictions as welding masks.

:cl: Xaytan
tweak: Adds welding goggles as an option in loadout.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->