### PR TITLE
Made inflamed appendix harder to miss on scan + fixed riot helmets

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -82,6 +82,9 @@
 		O["is_bruised"] = I.is_bruised()
 		O["is_damaged"] = I.is_damaged()
 		O["scan_results"] = I.get_scan_results(tag)
+		if (istype(I, /obj/item/organ/internal/appendix))
+			var/obj/item/organ/internal/appendix/A = I
+			O["inflamed"] = A.inflamed
 
 		scan["internal_organs"] += list(O)
 
@@ -342,7 +345,8 @@
 		dat += "<tr><th colspan='3'><center>Internal Organs</center></th></tr>"
 		for(var/list/I in scan["internal_organs"])
 			var/row = list()
-			row += "<tr><td>[I["name"]]</td>"
+			var/inflamed = I["inflamed"] || FALSE
+			row += "<tr><td><span[inflamed ? " class='bad'" : ""]>[I["name"]]</span></td>"
 			if(I["is_broken"])
 				row += "<td><span class='bad'>Severe</span></td>"
 			else if(I["is_bruised"])

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -80,8 +80,12 @@
 
 /obj/item/clothing/head/helmet/riot/attack_self(mob/user)
 	body_parts_covered ^= EYES|FACE
-	icon_state = "[initial(icon_state)][(body_parts_covered & EYES) ? "" : "_up"]"
-	visible_message(SPAN_ITALIC("\The [user] [(body_parts_covered & EYES) ? "lowers" : "raises"] the visor on \the [src]."), range = 3)
+	icon_state = initial(icon_state)
+	var/action = "lowers"
+	if (~body_parts_covered & EYES)
+		icon_state += "_up"
+		action = "raises"
+	visible_message(SPAN_ITALIC("\The [user] [action] the visor on \the [src]."), range = 3)
 	update_clothing_icon()
 
 /obj/item/clothing/head/helmet/ablative

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -78,13 +78,10 @@
 	siemens_coefficient = 0.7
 	action_button_name = "Toggle Visor"
 
-/obj/item/clothing/head/helmet/riot/attack_self(mob/user as mob)
-	if(src.icon_state == initial(icon_state))
-		src.icon_state = "[icon_state]_up"
-		to_chat(user, "You raise the visor on the [src].")
-	else
-		src.icon_state = initial(icon_state)
-		to_chat(user, "You lower the visor on the [src].")
+/obj/item/clothing/head/helmet/riot/attack_self(mob/user)
+	body_parts_covered ^= EYES|FACE
+	icon_state = "[initial(icon_state)][(body_parts_covered & EYES) ? "" : "_up"]"
+	visible_message(SPAN_ITALIC("\The [user] [(body_parts_covered & EYES) ? "lowers" : "raises"] the visor on \the [src]."), range = 3)
 	update_clothing_icon()
 
 /obj/item/clothing/head/helmet/ablative


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Imienny
tweak: Inflamed appendix is now harder to miss on medical scan
bugfix: Fixed riots helmets not uncovering face after raising visor
/:cl: