### PR TITLE
Can recycle organs in the bioprinters to recover part of their cost

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -163,6 +163,8 @@
 
 #define SPAN_SUBTLE(X) "<span class='subtle'>[X]</span>"
 
+#define SPAN_INFO(X) "<span class='info'>[X]</span>"
+
 #define FONT_SMALL(X) "<font size='1'>[X]</font>"
 
 #define FONT_NORMAL(X) "<font size='2'>[X]</font>"

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -37,7 +37,7 @@
 
 /obj/machinery/organ_printer/examine(mob/user)
 	. = ..()
-	to_chat(user, "<span class='notice'>It is loaded with [stored_matter]/[max_stored_matter] matter units.</span>")
+	to_chat(user, SPAN_NOTICE("It is loaded with [stored_matter]/[max_stored_matter] matter units."))
 
 /obj/machinery/organ_printer/RefreshParts()
 	print_delay = initial(print_delay)
@@ -88,7 +88,7 @@
 
 /obj/machinery/organ_printer/proc/can_print(var/choice)
 	if(stored_matter < products[choice][2])
-		visible_message("<span class='notice'>\The [src] displays a warning: 'Not enough matter. [stored_matter] stored and [products[choice][2]] needed.'</span>")
+		visible_message(SPAN_NOTICE("\The [src] displays a warning: 'Not enough matter. [stored_matter] stored and [products[choice][2]] needed.'"))
 		return 0
 	return 1
 
@@ -140,24 +140,44 @@
 	var/obj/item/organ/O = ..()
 	O.robotize()
 	O.status |= ORGAN_CUT_AWAY  // robotize() resets status to 0
-	visible_message("<span class='info'>\The [src] churns for a moment, then spits out \a [O].</span>")
+	visible_message(SPAN_INFO("\The [src] churns for a moment, then spits out \a [O]."))
+	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 	return O
 
 /obj/machinery/organ_printer/robot/attackby(var/obj/item/weapon/W, var/mob/user)
+	var/add_matter = 0
+	var/object_name = "[W]"
+
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == matter_type)
-		if((max_stored_matter-stored_matter) < matter_amount_per_sheet)
-			to_chat(user, "<span class='warning'>\The [src] is too full.</span>")
+		if((max_stored_matter-stored_matter) >= matter_amount_per_sheet)
+			var/obj/item/stack/S = W
+			var/space_left = max_stored_matter - stored_matter
+			var/sheets_to_take = min(S.amount, Floor(space_left/matter_amount_per_sheet))
+			if(sheets_to_take > 0)
+				add_matter = min(max_stored_matter - stored_matter, sheets_to_take*matter_amount_per_sheet)
+				S.use(sheets_to_take)
+
+	else if(istype(W,/obj/item/organ))
+		var/obj/item/organ/O = W
+		if((O.organ_tag in products) && istype(O, products[O.organ_tag][1]))
+			if(!BP_IS_ROBOTIC(O))
+				to_chat(user, SPAN_WARNING("\The [src] only accepts robotic organs."))
+				return
+			var/recycle_worth = Floor(products[O.organ_tag][2] * 0.5)
+			if((max_stored_matter-stored_matter) >= recycle_worth)
+				add_matter = recycle_worth
+				qdel(O)
+		else
+			to_chat(user, SPAN_WARNING("\The [src] does not know how to recycle \the [O]."))
 			return
-		var/obj/item/stack/S = W
-		var/space_left = max_stored_matter - stored_matter
-		var/sheets_to_take = min(S.amount, Floor(space_left/matter_amount_per_sheet))
-		if(sheets_to_take <= 0)
-			to_chat(user, "<span class='warning'>\The [src] is too full.</span>")
-			return
-		stored_matter = min(max_stored_matter, stored_matter + (sheets_to_take*matter_amount_per_sheet))
-		to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored matter now: [stored_matter]</span>")
-		S.use(sheets_to_take)
-		return
+
+	stored_matter += add_matter
+
+	if(add_matter)
+		to_chat(user, SPAN_INFO("\The [src] processes \the [object_name]. Levels of stored matter now: [stored_matter]"))
+	else
+		to_chat(user, SPAN_WARNING("\The [src] is too full."))
+
 	return ..()
 // END ROBOT ORGAN PRINTER
 
@@ -167,9 +187,11 @@
 	desc = "It's a machine that prints replacement organs."
 	icon_state = "bioprinter"
 	base_type = /obj/machinery/organ_printer/flesh
+	// null amount means it will calculate the cost based on get_organ_cost()
 	var/list/amount_list = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat = 50,
-		/obj/item/weapon/reagent_containers/food/snacks/rawcutlet = 15
+		/obj/item/weapon/reagent_containers/food/snacks/rawcutlet = 15,
+		/obj/item/organ = null
 		)
 	var/datum/dna/loaded_dna_datum
 	var/datum/species/loaded_species //For quick refrencing
@@ -202,12 +224,13 @@
 		// This is a very hacky way of doing of what organ/New() does if it has an owner
 		O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)
 
-	visible_message("<span class='info'>\The [src] churns for a moment, injects its stored DNA into the biomass, then spits out \a [O].</span>")
+	visible_message(SPAN_INFO("\The [src] churns for a moment, injects its stored DNA into the biomass, then spits out \a [O]."))
+	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 	return O
 
 /obj/machinery/organ_printer/flesh/physical_attack_hand(mob/user)
 	if(!loaded_dna_datum || !loaded_species)
-		visible_message("<span class='info'>\The [src] displays a warning: 'No DNA saved. Insert a blood sample.'</span>")
+		visible_message(SPAN_INFO("\The [src] displays a warning: 'No DNA saved. Insert a blood sample.'"))
 		return
 
 	var/choice = input("What [loaded_species.name] organ would you like to print?") as null|anything in products
@@ -222,12 +245,13 @@
 	for(var/path in amount_list)
 		if(istype(W, path))
 			if(max_stored_matter == stored_matter)
-				to_chat(user, "<span class='warning'>\The [src] is too full.</span>")
+				to_chat(user, SPAN_WARNING("\The [src] is too full."))
 				return
 			if(!user.unEquip(W))
 				return
-			stored_matter += min(amount_list[path], max_stored_matter - stored_matter)
-			to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]</span>")
+			var/add_matter = amount_list[path] ? amount_list[path] : 0.5*get_organ_cost(W)
+			stored_matter += min(add_matter, max_stored_matter - stored_matter)
+			to_chat(user, SPAN_INFO("\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]"))
 			qdel(W)
 
 	// DNA sample from syringe.
@@ -242,7 +266,7 @@
 				loaded_species = H.species
 				loaded_dna_datum = H.dna && H.dna.Clone()
 				products = get_possible_products()
-				to_chat(user, "<span class='info'>You inject the blood sample into the bioprinter.</span>")
+				to_chat(user, SPAN_INFO("You inject the blood sample into the bioprinter."))
 				return TRUE
 		to_chat(user, SPAN_NOTICE("\The [src] displays an error: no viable blood sample could be obtained from \the [W]."))
 	return ..()
@@ -259,10 +283,12 @@
 	for(var/organ in organs)
 		var/obj/item/organ/O = organ
 		if(check_printable(organ))
-			var/cost = initial(O.print_cost)
-			if(!cost)
-				cost = round(0.75 * initial(O.max_damage))
-			.[initial(O.organ_tag)] = list(O, cost)
+			.[initial(O.organ_tag)] = list(O, get_organ_cost(O))
+
+/obj/machinery/organ_printer/flesh/proc/get_organ_cost(var/obj/item/organ/O)
+	. = initial(O.print_cost)
+	if(!.)
+		. = round(0.75 * initial(O.max_damage))
 
 /obj/machinery/organ_printer/flesh/proc/check_printable(var/organtype)
 	var/obj/item/organ/O = organtype


### PR DESCRIPTION
:cl:
tweak: Can now insert organs (external and internal) into the bioprinters (robotic and organic) to recover part of their cost in materials.
/:cl:

Since virology is a bit of a mess, this adds another way for medics to dispose of extracted or removed organs from patients without sending it through disposals for supply to deal with.

Recycled organs are worth about half the materials, relative to printing a shiny new one.

Also bioprinters now ding when they're done.