### PR TITLE
Fixes unathi horn rotation bug

### DIFF
--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -227,8 +227,7 @@
 	var/list/base_auras
 
 	var/sexybits_location	//organ tag where they are located if they can be kicked for increased pain
-
-	var/list/prone_overlay_offset = list(0, 0) // amount to shift overlays when lying
+	
 	var/job_skill_buffs = list()				// A list containing jobs (/datum/job), with values the extra points that job recieves.
 
 	var/list/descriptors = list(

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -83,8 +83,6 @@
 		/mob/living/carbon/human/proc/diona_heal_toggle
 		)
 
-	prone_overlay_offset = list(-4, -4)
-
 	override_organ_types = list(
 		BP_EYES = /obj/item/organ/internal/eyes/unathi,
 		BP_BRAIN = /obj/item/organ/internal/brain/unathi


### PR DESCRIPTION
:cl:
bugfix: Unathi horn icons will no longer rotate incorrectly when lying down.
/:cl:

Fixes #27956 

Was applying a constant shift to the images, which caused problems if there was no shift (i.e. in the case where the unathi body and horn graphics are both 32x40.)