### PR TITLE
Vox related map changes

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -241,6 +241,8 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 /datum/antagonist/raider/proc/equip_vox(var/mob/living/carbon/human/player)
 
 	var/uniform_type = pick(list(/obj/item/clothing/under/vox/vox_robes,/obj/item/clothing/under/vox/vox_casual))
+	var/new_glasses = pick(raider_glasses)
+	var/new_holster = pick(raider_holster)
 
 	player.equip_to_slot_or_del(new uniform_type(player), slot_w_uniform)
 	player.equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/vox(player), slot_shoes) // REPLACE THESE WITH CODED VOX ALTERNATIVES.
@@ -248,7 +250,16 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	player.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/swat/vox(player), slot_wear_mask)
 	player.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(player), slot_back)
 	player.equip_to_slot_or_del(new /obj/item/device/flashlight(player), slot_r_store)
-
+	player.equip_to_slot_or_del(new new_glasses(player),slot_glasses)
+	
+	var/obj/item/clothing/accessory/storage/holster/holster = new new_holster
+	if(holster)
+		var/obj/item/clothing/under/uniform = player.w_uniform
+		if(istype(uniform) && uniform.can_attach_accessory(holster))
+			uniform.attackby(holster, player)
+		else
+			player.put_in_any_hand_if_possible(holster)
+	
 	player.set_internals(locate(/obj/item/weapon/tank) in player.contents)
 	return 1
 

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -274,7 +274,8 @@
 	icon_state = "revolver"
 
 /obj/random/projectile/spawn_choices()
-	return list(/obj/item/weapon/gun/projectile/shotgun/pump = 3,
+	return list(/obj/item/weapon/gun/projectile/heavysniper/boltaction = 4,
+				/obj/item/weapon/gun/projectile/shotgun/pump = 3,
 				/obj/item/weapon/gun/projectile/automatic/merc_smg = 2,
 				/obj/item/weapon/gun/projectile/automatic/assault_rifle = 2,
 				/obj/item/weapon/gun/projectile/automatic/bullpup_rifle = 2,

--- a/maps/antag_spawn/heist/heist.dm
+++ b/maps/antag_spawn/heist/heist.dm
@@ -69,7 +69,6 @@
 			var/choice = input("Do you wish to become a true Vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")
 			if(choice && choice == "Yes")
 				var/mob/living/carbon/human/vox/vox = new(get_turf(src),SPECIES_VOX)
-				vox.gender = user.gender
 				GLOB.raiders.equip(vox)
 				if(user.mind)
 					user.mind.transfer_to(vox)

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -657,7 +657,11 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bA" = (
 /obj/structure/table/rack,
-/obj/item/weapon/rig/vox,
+/obj/item/clothing/suit/space/vox/carapace,
+/obj/item/clothing/head/helmet/space/vox/carapace,
+/obj/item/clothing/shoes/magboots/vox,
+/obj/item/clothing/gloves/vox,
+/obj/item/weapon/gun/launcher/alien/spikethrower,
 /obj/item/clothing/under/vox/vox_casual,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
@@ -665,14 +669,12 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bB" = (
 /obj/structure/table/rack,
+/obj/item/clothing/suit/space/vox/carapace,
+/obj/item/clothing/head/helmet/space/vox/carapace,
+/obj/item/clothing/shoes/magboots/vox,
+/obj/item/clothing/gloves/vox,
 /obj/item/weapon/gun/launcher/alien/spikethrower,
-/obj/item/weapon/gun/launcher/alien/spikethrower,
-/obj/item/weapon/gun/projectile/dartgun/vox/medical,
-/obj/item/weapon/gun/projectile/dartgun/vox/raider,
-/obj/item/weapon/gun/energy/sonic,
-/obj/item/weapon/gun/energy/sonic,
-/obj/item/weapon/gun/energy/darkmatter,
-/obj/item/weapon/gun/energy/darkmatter,
+/obj/item/clothing/under/vox/vox_robes,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -860,6 +862,7 @@
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/vox/vox_robes,
+/obj/item/weapon/gun/projectile/dartgun/vox/raider,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -879,22 +882,25 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bX" = (
 /obj/structure/table/rack,
-/obj/item/clothing/under/vox/vox_casual,
-/obj/item/clothing/suit/space/vox/carapace,
-/obj/item/clothing/head/helmet/space/vox/carapace,
+/obj/item/clothing/suit/space/vox/pressure,
+/obj/item/clothing/head/helmet/space/vox/pressure,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
+/obj/item/clothing/under/vox/vox_casual,
+/obj/item/weapon/gun/projectile/dartgun/vox/raider,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "bY" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/vox/pressure,
-/obj/item/clothing/head/helmet/space/vox/pressure,
+/obj/item/clothing/suit/space/vox/stealth,
+/obj/item/clothing/head/helmet/space/vox/stealth,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
-/obj/item/clothing/under/vox/vox_casual,
+/obj/item/clothing/glasses/thermal/plain/monocle,
+/obj/item/clothing/under/vox/vox_robes,
+/obj/item/weapon/gun/projectile/dartgun/vox/medical,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -1952,27 +1958,6 @@
 	name = "plating"
 	},
 /area/map_template/syndicate_mothership/raider_base)
-"eJ" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/vox/stealth,
-/obj/item/clothing/head/helmet/space/vox/stealth,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/gloves/vox,
-/obj/item/clothing/under/vox/vox_robes,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/syndicate_mothership/raider_base)
-"eK" = (
-/obj/item/weapon/storage/box/detergent,
-/turf/simulated/floor/plating,
-/area/map_template/skipjack_station/start)
-"eL" = (
-/obj/item/clothing/suit/armor/vox_scrap,
-/turf/unsimulated/floor{
-	icon_state = "asteroid"
-	},
-/area/map_template/syndicate_mothership/raider_base)
 
 (1,1,1) = {"
 aa
@@ -2867,7 +2852,7 @@ aq
 aq
 bA
 bU
-bY
+bX
 aq
 aq
 aq
@@ -2940,7 +2925,7 @@ bk
 aq
 aq
 aq
-eL
+aq
 aQ
 cp
 ab
@@ -3007,11 +2992,11 @@ aq
 aq
 aq
 aq
-eL
+aq
 aq
 bB
-bX
-eJ
+bA
+bY
 aq
 aq
 cq
@@ -5113,7 +5098,7 @@ cR
 di
 dr
 dx
-eK
+dm
 dP
 ed
 cw

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -657,11 +657,7 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bA" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/vox/carapace,
-/obj/item/clothing/head/helmet/space/vox/carapace,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/gloves/vox,
-/obj/item/weapon/gun/launcher/alien/spikethrower,
+/obj/item/weapon/rig/vox,
 /obj/item/clothing/under/vox/vox_casual,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
@@ -669,12 +665,14 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bB" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/vox/carapace,
-/obj/item/clothing/head/helmet/space/vox/carapace,
-/obj/item/clothing/shoes/magboots/vox,
-/obj/item/clothing/gloves/vox,
 /obj/item/weapon/gun/launcher/alien/spikethrower,
-/obj/item/clothing/under/vox/vox_robes,
+/obj/item/weapon/gun/launcher/alien/spikethrower,
+/obj/item/weapon/gun/projectile/dartgun/vox/medical,
+/obj/item/weapon/gun/projectile/dartgun/vox/raider,
+/obj/item/weapon/gun/energy/sonic,
+/obj/item/weapon/gun/energy/sonic,
+/obj/item/weapon/gun/energy/darkmatter,
+/obj/item/weapon/gun/energy/darkmatter,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -862,7 +860,6 @@
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/vox/vox_robes,
-/obj/item/weapon/gun/projectile/dartgun/vox/raider,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -882,25 +879,22 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bX" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/vox/pressure,
-/obj/item/clothing/head/helmet/space/vox/pressure,
+/obj/item/clothing/under/vox/vox_casual,
+/obj/item/clothing/suit/space/vox/carapace,
+/obj/item/clothing/head/helmet/space/vox/carapace,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
-/obj/item/clothing/under/vox/vox_casual,
-/obj/item/weapon/gun/projectile/dartgun/vox/raider,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "bY" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/vox/stealth,
-/obj/item/clothing/head/helmet/space/vox/stealth,
+/obj/item/clothing/suit/space/vox/pressure,
+/obj/item/clothing/head/helmet/space/vox/pressure,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
-/obj/item/clothing/glasses/thermal/plain/monocle,
-/obj/item/clothing/under/vox/vox_robes,
-/obj/item/weapon/gun/projectile/dartgun/vox/medical,
+/obj/item/clothing/under/vox/vox_casual,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -1958,6 +1952,27 @@
 	name = "plating"
 	},
 /area/map_template/syndicate_mothership/raider_base)
+"eJ" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/vox/stealth,
+/obj/item/clothing/head/helmet/space/vox/stealth,
+/obj/item/clothing/shoes/magboots/vox,
+/obj/item/clothing/gloves/vox,
+/obj/item/clothing/under/vox/vox_robes,
+/turf/unsimulated/floor{
+	icon_state = "asteroid"
+	},
+/area/map_template/syndicate_mothership/raider_base)
+"eK" = (
+/obj/item/weapon/storage/box/detergent,
+/turf/simulated/floor/plating,
+/area/map_template/skipjack_station/start)
+"eL" = (
+/obj/item/clothing/suit/armor/vox_scrap,
+/turf/unsimulated/floor{
+	icon_state = "asteroid"
+	},
+/area/map_template/syndicate_mothership/raider_base)
 
 (1,1,1) = {"
 aa
@@ -2852,7 +2867,7 @@ aq
 aq
 bA
 bU
-bX
+bY
 aq
 aq
 aq
@@ -2925,7 +2940,7 @@ bk
 aq
 aq
 aq
-aq
+eL
 aQ
 cp
 ab
@@ -2992,11 +3007,11 @@ aq
 aq
 aq
 aq
-aq
+eL
 aq
 bB
-bA
-bY
+bX
+eJ
 aq
 aq
 cq
@@ -5098,7 +5113,7 @@ cR
 di
 dr
 dx
-dm
+eK
 dP
 ed
 cw

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -151,6 +151,7 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/item/weapon/storage/firstaid/combat,
+/obj/item/weapon/storage/box/detergent,
 /obj/machinery/light/small{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Imienny
maptweak: Added detergent pods to vox scavenger base, warranty void if swallowed.
rscadd: Vox raiders now spawn with thermals and holsters.
rscadd: Bolt action rifle can now spawn in vox scavenger base, as well as in other places.
bugfix: Fixed bug with cracked mirror allowing vox to have gender.
/:cl: