### PR TITLE
Revert "Replace spoon in MRE with spork"

### DIFF
--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -19,7 +19,7 @@ MRE Stuff
 	/obj/random/mre/spread,
 	/obj/random/mre/drink,
 	/obj/random/mre/sauce,
-	/obj/item/weapon/material/kitchen/utensil/spork/plastic
+	/obj/item/weapon/material/kitchen/utensil/spoon/plastic
 	)
 
 /obj/item/weapon/storage/mre/Initialize()


### PR DESCRIPTION
Reverts Baystation12/Baystation12#27936

MREs have spoons, not sporks. This is bothering me.