### PR TITLE
Makes alarms always get signals.

### DIFF
--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -6,8 +6,7 @@
 SUBSYSTEM_DEF(throwing)
 	name = "Throwing"
 	wait = 1
-	flags = SS_NO_INIT|SS_KEEP_TIMING|SS_TICKER
-	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	flags = SS_NO_INIT|SS_KEEP_TIMING
 
 	var/list/currentrun
 	var/list/processing = list()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -177,17 +177,6 @@
 		return list()
 	return ..()
 
-// Request updates for air vents and scrubbers which appear to have been added.
-/obj/machinery/alarm/power_change()
-	. = ..()
-	if(. && !(stat & NOPOWER) && alarm_area)
-		for(var/id_tag in alarm_area.air_vent_names)
-			if(!alarm_area.air_vent_info[id_tag])
-				send_signal(id_tag, list("status" = TRUE))
-		for(var/id_tag in alarm_area.air_scrub_names)
-			if(!alarm_area.air_scrub_info[id_tag])
-				send_signal(id_tag, list("status" = TRUE))
-
 /obj/machinery/alarm/Process()
 	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)
 		return
@@ -382,8 +371,6 @@
 	set_light(0.25, 0.1, 1, 2, new_color)
 
 /obj/machinery/alarm/receive_signal(datum/signal/signal)
-	if(stat & (NOPOWER|BROKEN))
-		return
 	if (alarm_area.master_air_alarm != src)
 		if (master_is_operating())
 			return
@@ -420,10 +407,7 @@
 	else if (device_type=="AScr")
 		new_name = "[alarm_area.name] Air Scrubber #[alarm_area.air_scrub_names.len+1]"
 		alarm_area.air_scrub_names[m_id] = new_name
-	else
-		return
-	spawn (10)
-		send_signal(m_id, list("init" = new_name) )
+	send_signal(m_id, list("init" = new_name) )
 
 /obj/machinery/alarm/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -68,8 +68,15 @@
 
 /datum/unit_test/air_alarm_connectivity
 	name = "MAP: Air alarms shall receive updates."
+	async = TRUE // Waits for SStimers to finish one full run before testing
 
 /datum/unit_test/air_alarm_connectivity/start_test()
+	return 1
+
+/datum/unit_test/air_alarm_connectivity/subsystems_to_await()
+	return list(SStimer)
+
+/datum/unit_test/air_alarm_connectivity/check_result()
 	var/failed = FALSE
 	for(var/area/A in world)
 		if(!A.z)
@@ -84,11 +91,11 @@
 
 		for(var/tag in A.air_vent_names) // The point of this test is that while the names list is registered at init, the info is transmitted by radio.
 			if(!A.air_vent_info[tag])
-				log_bad("[log_info_line(A.air_vent_names[tag])] with id_tag [tag] did not update the air alarm in area [A].")
+				log_bad("Vent [A.air_vent_names[tag]] with id_tag [tag] did not update the air alarm in area [A].")
 				failed = TRUE
 		for(var/tag in A.air_scrub_names)
 			if(!A.air_scrub_info[tag])
-				log_bad("[log_info_line(A.air_vent_names[tag])] with id_tag [tag] did not update the air alarm in area [A].")
+				log_bad("Scrubber [A.air_scrub_names[tag]] with id_tag [tag] did not update the air alarm in area [A].")
 				failed = TRUE
 
 	if(failed)

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -50,7 +50,7 @@ var/ascii_reset = "[ascii_esc]\[0m"
 // We list these here so we can remove them from the for loop running this.
 // Templates aren't intended to be ran but just serve as a way to create child objects of it with inheritable tests for quick test creation.
 
-datum/unit_test
+/datum/unit_test
 	var/name = "template - should not be ran."
 	var/template        // Treat the unit test as a template if its type is the same as the value of this var
 	var/disabled = 0    // If we want to keep a unit test in the codebase but not run it for some reason.
@@ -61,35 +61,35 @@ datum/unit_test
 	var/safe_landmark
 	var/space_landmark
 
-datum/unit_test/proc/log_debug(var/message)
+/datum/unit_test/proc/log_debug(var/message)
 	log_unit_test("[ascii_yellow]---  DEBUG  --- \[[name]\]: [message][ascii_reset]")
 
-datum/unit_test/proc/log_bad(var/message)
+/datum/unit_test/proc/log_bad(var/message)
 	log_unit_test("[ascii_red]\[[name]\]: [message][ascii_reset]")
 
-datum/unit_test/proc/fail(var/message)
+/datum/unit_test/proc/fail(var/message)
 	all_unit_tests_passed = 0
 	failed_unit_tests++
 	reported = 1
 	log_unit_test("[ascii_red]!!! FAILURE !!! \[[name]\]: [message][ascii_reset]")
 
-datum/unit_test/proc/pass(var/message)
+/datum/unit_test/proc/pass(var/message)
 	reported = 1
 	log_unit_test("[ascii_green]*** SUCCESS *** \[[name]\]: [message][ascii_reset]")
 
-datum/unit_test/proc/skip(var/message)
+/datum/unit_test/proc/skip(var/message)
 	skipped_unit_tests++
 	reported = 1
 	log_unit_test("[ascii_yellow]--- SKIPPED --- \[[name]\]: [message][ascii_reset]")
 
-datum/unit_test/proc/start_test()
+/datum/unit_test/proc/start_test()
 	fail("No test proc - [type]")
 
-datum/unit_test/proc/check_result()
+/datum/unit_test/proc/check_result()
 	fail("No check results proc - [type]")
 	return 1
 
-datum/unit_test/proc/get_safe_turf()
+/datum/unit_test/proc/get_safe_turf()
 	if(!safe_landmark)
 		for(var/landmark in landmarks_list)
 			if(istype(landmark, /obj/effect/landmark/test/safe_turf))
@@ -97,7 +97,7 @@ datum/unit_test/proc/get_safe_turf()
 				break
 	return get_turf(safe_landmark)
 
-datum/unit_test/proc/get_space_turf()
+/datum/unit_test/proc/get_space_turf()
 	if(!space_landmark)
 		for(var/landmark in landmarks_list)
 			if(istype(landmark, /obj/effect/landmark/test/space_turf))
@@ -105,7 +105,11 @@ datum/unit_test/proc/get_space_turf()
 				break
 	return get_turf(space_landmark)
 
-proc/load_unit_test_changes()
+// Async unit tests will be delayed until the subsystems in this list have fired at least once.
+/datum/unit_test/proc/subsystems_to_await()
+	return list()
+
+/proc/load_unit_test_changes()
 /*
 	//This takes about 60 seconds to run on Travis and is only used for the ZAS vacume check on The Asteroid.
 	if(config.generate_map != 1)

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -95,6 +95,10 @@ SUBSYSTEM_DEF(unit_tests)
 	var/list/async = current_async
 	while (async.len)
 		var/datum/unit_test/test = current_async[async.len]
+		for(var/S in test.subsystems_to_await())
+			var/datum/controller/subsystem/subsystem = S
+			if(subsystem.times_fired < 1)
+				return
 		async.len--
 		if(check_unit_test(test, end_unit_tests))
 			async_tests -= test

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 503 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 502 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
I don't think that check is needed, and I think it's bad design vis a vis the overarching radio signal system. If you are unaware of who is listening to your signals, and you need them to get through to ensure consistent state tracking, you either have to keep sending them constantly (horrible and expensive) or you need to make sure they are guaranteed to arrive. The new radio components work on that principle, but this obj does not. May or may not resolve Travis issues. If not, it suggests some much more severely flawed initialization stuff is happening.

This does potentially change gameplay with alarms which are unpowered or broken, but in a way which will likely be more intuitive to the user anyway.