### PR TITLE
Fixes net shotgun shell runtime

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -84,17 +84,19 @@
 
 /obj/item/weapon/energy_net/throw_impact(atom/hit_atom)
 	..()
+	try_capture_mob(hit_atom)
 
-	var/mob/living/M = hit_atom
+// This will validate the hit_atom, then spawn an energy_net effect and qdel itself
+/obj/item/weapon/energy_net/proc/try_capture_mob(mob/living/M)
 
 	if(!istype(M) || locate(/obj/effect/energy_net) in M.loc)
 		qdel(src)
-		return 0
+		return FALSE
 
 	var/turf/T = get_turf(M)
 	if(T)
-		var/obj/effect/energy_net/net = new net_type(T)
-		net.capture_mob(M)
+		var/obj/effect/energy_net/net_effect = new net_type(T)
+		net_effect.capture_mob(M)
 		qdel(src)
 
 	// If we miss or hit an obstacle, we still want to delete the net.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -36,7 +36,7 @@
 		var/total_item_slowdown = -1
 		for(var/slot = slot_first to slot_last)
 			var/obj/item/I = get_equipped_item(slot)
-			if(I)
+			if(istype(I))
 				var/item_slowdown = 0
 				item_slowdown += I.slowdown_general
 				item_slowdown += I.slowdown_per_slot[slot]

--- a/maps/torch/items/explo_shotgun.dm
+++ b/maps/torch/items/explo_shotgun.dm
@@ -27,11 +27,11 @@
 		icon_state = "expshotgun[!!chambered]"
 	else
 		icon_state = "ghettexpshotgun[!!chambered]"
-	
+
 /obj/item/weapon/gun/projectile/shotgun/pump/exploration/Destroy()
 	QDEL_NULL(reinforced)
 	. = ..()
-	
+
 /obj/item/weapon/gun/projectile/shotgun/pump/exploration/free_fire()
 	var/my_z = get_z(src)
 	if(!GLOB.using_map.station_levels.Find(my_z))
@@ -102,7 +102,7 @@
 
 /obj/item/projectile/bullet/shotgun/beanbag/net/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
 	var/obj/item/weapon/energy_net/safari/net = new(loc)
-	net.throw_impact(target)
+	net.try_capture_mob(target)
 	return TRUE
 
 /obj/item/weapon/storage/box/ammo/explo_shells


### PR DESCRIPTION
Fixes #27894 

Shooting doors with a net shell would runtime - previously was creating a net obj and then throwing at the hit atom. I cut out the middle man and just netted the hit object, we don't need to throw it. It duplicates some code, but this way we don't need to deal with the throwing code when we don't have to.