### PR TITLE
adds character email prefs

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -146,7 +146,7 @@
 			if(48 to 57)	//0-9
 				dat += ascii2text(ascii_char)
 				last_was_space = 0
-			if(32)			//space
+			if(32, 46)	//space or .
 				if(last_was_space)
 					continue
 				dat += "."		//We turn these into ., but avoid repeats or . at start.

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -470,13 +470,19 @@ SUBSYSTEM_DEF(jobs)
 		// EMAIL GENERATION
 		if(rank != "Robot" && rank != "AI")		//These guys get their emails later.
 			var/domain
+			var/addr = H.real_name
+			var/pass
 			if(H.char_branch)
 				if(H.char_branch.email_domain)
 					domain = H.char_branch.email_domain
+				if (H.char_branch.allow_custom_email && H.client.prefs.email_addr)
+					addr = H.client.prefs.email_addr
 			else
 				domain = "freemail.net"
+			if (H.client.prefs.email_pass)
+				pass = H.client.prefs.email_pass
 			if(domain)
-				ntnet_global.create_email(H, H.real_name, domain, rank)
+				ntnet_global.create_email(H, addr, domain, rank, pass)
 		// END EMAIL GENERATION
 
 		job.equip(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)

--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -111,6 +111,8 @@ var/datum/mil_branches/mil_branches = new()
 	// Email addresses will be created under this domain name. Mostly for the looks.
 	var/email_domain = "freemail.net"
 
+	var/allow_custom_email = FALSE
+
 	var/list/min_skill
 
 /datum/mil_branch/New()

--- a/code/modules/client/preference_setup/_defines.dm
+++ b/code/modules/client/preference_setup/_defines.dm
@@ -14,3 +14,8 @@ if(!decls_by_name) \
 		decls_by_name[decl_instance.name] = decl_instance;\
 	}\
 }
+
+#define UIBUTTON(key, label, title) "[title ? title + ": " : ""]<a href='?src=\ref[src];[key]=1'>[label]</a>"
+
+#define UI_FONT_GOOD(X) "<font color='55cc55'>[X]</font>"
+#define UI_FONT_BAD(X) "<font color='cc5555'>[X]</font>"

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -248,7 +248,7 @@ var/global/datum/ntnet/ntnet_global = new()
 			my_client.stored_login = new_login
 
 //Used for initial email generation.
-/datum/ntnet/proc/create_email(mob/user, desired_name, domain, assignment)
+/datum/ntnet/proc/create_email(mob/user, desired_name, domain, assignment, desired_password)
 	desired_name = sanitize_for_email(desired_name)
 	var/login = "[desired_name]@[domain]"
 	// It is VERY unlikely that we'll have two players, in the same round, with the same name and branch, but still, this is here.
@@ -261,7 +261,7 @@ var/global/datum/ntnet/ntnet_global = new()
 		user.StoreMemory("You were not assigned an email address.", /decl/memory_options/system)
 	else
 		var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account(login, user.real_name, assignment)
-		EA.password = GenerateKey()
+		EA.password = desired_password ? desired_password : GenerateKey()
 		if(user.mind)
 			user.mind.initial_email_login["login"] = EA.login
 			user.mind.initial_email_login["password"] = EA.password

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -222,6 +222,7 @@
 	name = "Civilian"
 	name_short = "Civ"
 	email_domain = "freemail.net"
+	allow_custom_email = TRUE
 
 	rank_types = list(
 		/datum/mil_rank/civ/civ,


### PR DESCRIPTION
:cl:
rscadd: You can set a character email address and password preference. Email addresses are only applied to civilians.
/:cl:

Allows players to do fun stuff like have a non-random password that they share in their antag record.

Ed: Also now adds:

preferences procs for calling callbacks or groups of callbacks against selected jobs or branches by priority (or if you're sneaky, by passing in a custom job list).

A UI button define, because too much inline markup.