### PR TITLE
Prevents unconscious people from 'seeing' with right-clicks

### DIFF
--- a/code/__defines/dna.dm
+++ b/code/__defines/dna.dm
@@ -35,9 +35,9 @@
 #define NERVOUS     0x10
 
 // sdisabilities
-#define BLIND 0x1
-#define MUTE  0x2
-#define DEAF  0x4
+#define BLINDED 0x1
+#define MUTED  0x2
+#define DEAFENED  0x4
 
 // The way blocks are handled badly needs a rewrite, this is horrible.
 // Too much of a project to handle at the moment, TODO for later.

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -90,7 +90,7 @@
 	for(var/organ_name in H.species.has_organ)
 		if(!locate(H.species.has_organ[organ_name]) in H.internal_organs)
 			scan["missing_organs"] += organ_name
-	if(H.sdisabilities & BLIND)
+	if(H.sdisabilities & BLINDED)
 		scan["blind"] = TRUE
 	if(H.sdisabilities & NEARSIGHTED)
 		scan["nearsight"] = TRUE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -75,7 +75,7 @@
 		CtrlClickOn(A)
 		return 1
 
-	if(stat || paralysis || stunned || weakened)
+	if(stat || paralysis || stunned || weakened || sleeping)
 		return
 
 	// Do not allow player facing change in fixed chairs

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -103,7 +103,7 @@
 /datum/dna/gene/disability/blindness
 	name="Blindness"
 	activation_message="You can't seem to see anything."
-	sdisability=BLIND
+	sdisability=BLINDED
 
 /datum/dna/gene/disability/blindness/New()
 	block=GLOB.BLINDBLOCK
@@ -111,7 +111,7 @@
 /datum/dna/gene/disability/deaf
 	name="Deafness"
 	activation_message="It's kinda quiet."
-	sdisability=DEAF
+	sdisability=DEAFENED
 
 /datum/dna/gene/disability/deaf/New()
 	block=GLOB.DEAFBLOCK

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -31,8 +31,8 @@
 	//testing("Assigning DNA blocks:")
 
 	// Standard muts, imported from older code above.
-	GLOB.BLINDBLOCK         = getAssignedBlock("BLIND",         numsToAssign)
-	GLOB.DEAFBLOCK          = getAssignedBlock("DEAF",          numsToAssign)
+	GLOB.BLINDBLOCK         = getAssignedBlock("BLINDED",         numsToAssign)
+	GLOB.DEAFBLOCK          = getAssignedBlock("DEAFENED",          numsToAssign)
 	GLOB.HULKBLOCK          = getAssignedBlock("HULK",          numsToAssign, DNA_HARD_BOUNDS)
 	GLOB.TELEBLOCK          = getAssignedBlock("TELE",          numsToAssign, DNA_HARD_BOUNDS)
 	GLOB.FIREBLOCK          = getAssignedBlock("FIRE",          numsToAssign, DNA_HARDER_BOUNDS)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -22,7 +22,7 @@
 			L.client.perspective = EYE_PERSPECTIVE
 			L.client.eye = src
 		L.forceMove(src)
-		L.set_sdisability(MUTE)
+		L.set_sdisability(MUTED)
 		health = L.health + 100 //stoning damaged mobs will result in easier to shatter statues
 		intialTox = L.getToxLoss()
 		intialFire = L.getFireLoss()
@@ -65,7 +65,7 @@
 
 	for(var/mob/living/M in src)
 		M.dropInto(loc)
-		M.unset_sdisability(MUTE)
+		M.unset_sdisability(MUTED)
 		M.take_overall_damage((M.health - health - 100),0) //any new damage the statue incurred is transfered to the mob
 		if(M.client)
 			M.client.eye = M.client.mob

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -31,7 +31,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & NONVERBAL))
-		if (!speaker || (src.sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
+		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
 			message = stars(message)
 
 	if(!(language && (language.flags & INNATE))) // skip understanding checks for INNATE languages
@@ -113,7 +113,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & NONVERBAL))
-		if (!speaker || (src.sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
+		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
 			message = stars(message)
 
 	if(!(language && (language.flags & INNATE))) // skip understanding checks for INNATE languages
@@ -223,7 +223,7 @@
 		formatted = language.format_message_radio(message, nverb)
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>"
-	if(sdisabilities & DEAF || ear_deaf)
+	if(sdisabilities & DEAFENED || ear_deaf)
 		var/mob/living/carbon/human/H = src
 		if(istype(H) && H.has_headset_in_ears() && prob(20))
 			to_chat(src, SPAN_WARNING("You feel your headset vibrate but can hear nothing from it!"))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -199,7 +199,7 @@
 		eye_blurry = 1
 	else
 		//blindness
-		if(!(sdisabilities & BLIND))
+		if(!(sdisabilities & BLINDED))
 			if(equipment_tint_total >= TINT_BLIND)	// Covered eyes, heal faster
 				eye_blurry = max(eye_blurry-2, 0)
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -146,7 +146,7 @@
 	return verb
 
 /mob/living/carbon/human/handle_speech_problems(var/list/message_data)
-	if(silent || (sdisabilities & MUTE))
+	if(silent || (sdisabilities & MUTED))
 		message_data[1] = ""
 		. = 1
 

--- a/code/modules/mob/living/carbon/xenobiological/life.dm
+++ b/code/modules/mob/living/carbon/xenobiological/life.dm
@@ -124,9 +124,9 @@
 
 	src.set_density(!src.lying)
 
-	if (src.sdisabilities & BLIND)
+	if (src.sdisabilities & BLINDED)
 		src.blinded = 1
-	if (src.sdisabilities & DEAF)
+	if (src.sdisabilities & DEAFENED)
 		src.ear_deaf = 1
 
 	if (src.eye_blurry > 0)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -134,7 +134,7 @@
 
 /mob/living/proc/handle_impaired_vision()
 	//Eyes
-	if(sdisabilities & BLIND || stat)	//blindness from disability or unconsciousness doesn't get better on its own
+	if(sdisabilities & BLINDED || stat)	//blindness from disability or unconsciousness doesn't get better on its own
 		eye_blind = max(eye_blind, 1)
 	else if(eye_blind)			//blindness, heals slowly over time
 		eye_blind = max(eye_blind-1,0)
@@ -143,7 +143,7 @@
 
 /mob/living/proc/handle_impaired_hearing()
 	//Ears
-	if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
+	if(sdisabilities & DEAFENED)	//disabled-deaf, doesn't get better on its own
 		setEarDamage(null, max(ear_deaf, 1))
 	else if(ear_damage < 25)
 		adjustEarDamage(-0.05, -1)	// having ear damage impairs the recovery of ear_deaf
@@ -201,7 +201,13 @@
 	set_see_invisible(max(vision[2], see_invisible))
 
 /mob/living/proc/update_living_sight()
-	set_sight(sight&(~(SEE_TURFS|SEE_MOBS|SEE_OBJS)))
+	var/set_sight_flags = sight & ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
+	if(stat & UNCONSCIOUS)
+		set_sight_flags |= BLIND
+	else
+		set_sight_flags &= ~BLIND
+
+	set_sight(set_sight_flags)
 	set_see_in_dark(initial(see_in_dark))
 	set_see_invisible(initial(see_invisible))
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -687,7 +687,7 @@ default behaviour is:
 
 //called when the mob receives a bright flash
 /mob/living/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
-	if(override_blindness_check || !(disabilities & BLIND))
+	if(override_blindness_check || !(disabilities & BLINDED))
 		..()
 		overlay_fullscreen("flash", type)
 		spawn(25)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -121,9 +121,9 @@
 
 	src.set_density(!src.lying)
 
-	if ((src.sdisabilities & BLIND))
+	if ((src.sdisabilities & BLINDED))
 		src.blinded = 1
-	if ((src.sdisabilities & DEAF))
+	if ((src.sdisabilities & DEAFENED))
 		src.ear_deaf = 1
 
 	if (src.eye_blurry > 0)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -132,10 +132,10 @@
 		blinded = host.blinded
 		eye_blind = host.eye_blind
 		eye_blurry = host.eye_blurry
-		if(host.sdisabilities & BLIND)
-			sdisabilities |= BLIND
-		if(host.sdisabilities & DEAF)
-			sdisabilities |= DEAF
+		if(host.sdisabilities & BLINDED)
+			sdisabilities |= BLINDED
+		if(host.sdisabilities & DEAFENED)
+			sdisabilities |= DEAFENED
 	else
 		blinded =    FALSE
 		eye_blind =  0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -227,10 +227,10 @@
 	return restrained() ? FULLY_BUCKLED : PARTIALLY_BUCKLED
 
 /mob/proc/is_blind()
-	return ((sdisabilities & BLIND) || blinded || incapacitated(INCAPACITATION_KNOCKOUT))
+	return ((sdisabilities & BLINDED) || blinded || incapacitated(INCAPACITATION_KNOCKOUT))
 
 /mob/proc/is_deaf()
-	return ((sdisabilities & DEAF) || ear_deaf || incapacitated(INCAPACITATION_KNOCKOUT))
+	return ((sdisabilities & DEAFENED) || ear_deaf || incapacitated(INCAPACITATION_KNOCKOUT))
 
 /mob/proc/is_physically_disabled()
 	return incapacitated(INCAPACITATION_DISABLED)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -42,7 +42,7 @@
 proc/isdeaf(A)
 	if(isliving(A))
 		var/mob/living/M = A
-		return (M.sdisabilities & DEAF) || M.ear_deaf
+		return (M.sdisabilities & DEAFENED) || M.ear_deaf
 	return 0
 
 proc/hasorgans(A) // Fucking really??
@@ -404,10 +404,10 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 			else
 				hud_used.action_intent.icon_state = I_HELP
 
-proc/is_blind(A)
+/proc/is_blind(A)
 	if(istype(A, /mob/living/carbon))
 		var/mob/living/carbon/C = A
-		if(C.sdisabilities & BLIND || C.blinded)
+		if(C.sdisabilities & BLINDED|| C.blinded)
 			return 1
 	return 0
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -163,7 +163,7 @@
 		to_chat(M, SPAN_DANGER("Your ears start to ring badly!"))
 		if(prob(M.ear_damage - 5))
 			to_chat(M, SPAN_DANGER("You can't hear anything!"))
-			M.set_sdisability(DEAF)
+			M.set_sdisability(DEAFENED)
 	else
 		if(M.ear_damage >= 5)
 			to_chat(M, SPAN_DANGER("Your ears start to ring!"))


### PR DESCRIPTION
:cl:
bugfix: Can no longer right-click darkness due to being unconscious to see what is on that turf.
/:cl:

I'd like this to also cover blindfolds, however they work with a different system and I don't know how to get the sight BLIND var's effect on the context menu without also automatically making the screen black.

Also changes the dna BLIND flag to BLINDED because it was overriding byond's BLIND flag (although they were the same value)