### PR TITLE
Fixes #27997

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -29,6 +29,8 @@
 	..()
 
 /obj/structure/bed/chair/wheelchair/relaymove(mob/user, direction)
+	if(direction & (UP|DOWN))
+		return
 	// Redundant check?
 	if(user.stat || user.stunned || user.weakened || user.paralysis || user.lying || user.restrained())
 		if(user==pulling)

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -139,6 +139,8 @@
 		unload(user)
 		visible_message("<span class='warning'>\The [user] falls off \the [src]!</span>")
 		return
+	if(direction & (UP|DOWN))
+		return
 	return Move(get_step(src, direction))
 
 /obj/vehicle/bike/Move(var/turf/destination)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -177,6 +177,8 @@
 // Interaction procs
 //-------------------------------------------
 /obj/vehicle/train/cargo/engine/relaymove(mob/user, direction)
+	if(direction & (UP|DOWN))
+		return 0 
 	if(user != load || user.incapacitated())
 		return 0
 

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -74,6 +74,9 @@
 // Interaction procs
 //-------------------------------------------
 /obj/vehicle/train/relaymove(mob/user, direction)
+	if(direction & (UP|DOWN))
+		return 0
+		
 	if(user.incapacitated())
 		return 0
 


### PR DESCRIPTION
:cl:
bugfix: Prevented being able to move through floors with wheelchairs, trains & similar.
/:cl:

Wheelchairs should maybe be refactored into a vehicle, along with some multiz movement handlers for vehicles.

Until someone decides to write that... this PR prevents relaymove procs from allowing players to move through floors to connected z-levels, when they are able to move between z-levels due to a mob flight ability.

Fixes #27997 