### PR TITLE
Sec HUD goggles description grammar fix

### DIFF
--- a/code/modules/clothing/glasses/sunglasses.dm
+++ b/code/modules/clothing/glasses/sunglasses.dm
@@ -27,7 +27,7 @@
 
 /obj/item/clothing/glasses/sunglasses/sechud/goggles //now just a more "military" set of HUDglasses for the Torch
 	name = "HUD goggles"
-	desc = "A pair of relatively goggles with an inbuilt heads up display. The lenses provide some flash protection."
+	desc = "A pair of goggles with an inbuilt heads up display. The lenses provide some flash protection."
 	icon_state = "goggles"
 
 /obj/item/clothing/glasses/sunglasses/sechud/toggle


### PR DESCRIPTION
# A pair of relatively goggles

I don't think a changelog is necessary for this one... but seeing as there's a tag for it...

:cl:
spellcheck: Sec HUD goggles description grammar fix
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->