### PR TITLE
Peridaxon side effects fix

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -455,10 +455,12 @@
 		for(var/obj/item/organ/internal/I in H.internal_organs)
 			if(!BP_IS_ROBOTIC(I))
 				if(I.organ_tag == BP_BRAIN)
-					if(I.damage >= I.min_bruised_damage)
-						continue
+					// if we have located an organic brain, apply side effects
 					H.confused++
 					H.drowsyness++
+					// peridaxon only heals minor brain damage
+					if(I.damage >= I.min_bruised_damage)
+						continue
 				I.heal_damage(removed)
 
 /datum/reagent/ryetalyn


### PR DESCRIPTION
:cl:
bugfix: Having more than 10 brain damage no longer grants immunity to peridaxon's side effects (confusion and drowsiness)
/:cl:

### Justification
- The current side effect behavior looks unintentional, so I'm pretty sure this is a bug
- Even if this was intentional, I'm not sure why having more than 10 brain damage would merit granting immunity to the confusion and drowsiness effects
