### PR TITLE
Tweaks space-adapted species mods

### DIFF
--- a/code/__defines/species.dm
+++ b/code/__defines/species.dm
@@ -9,6 +9,7 @@
 #define SPECIES_FLAG_NO_TANGLE                  0x0080  // This species wont get tangled up in weeds
 #define SPECIES_FLAG_NO_BLOCK                   0x0100  // Unable to block or defend itself from attackers.
 #define SPECIES_FLAG_NEED_DIRECT_ABSORB         0x0200  // This species can only have their DNA taken by direct absorption.
+#define SPECIES_FLAG_LOW_GRAV_ADAPTED           0x0400  // This species is used to lower than standard gravity, affecting stamina in high-grav
 
 // unused: 0x8000 - higher than this will overflow
 

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -272,6 +272,12 @@
 
 /mob/living/carbon/human/get_stamina_used_per_step()
 	var/mod = (1-((get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)))
+	if(species && (species.species_flags & SPECIES_FLAG_LOW_GRAV_ADAPTED))
+		if(has_gravity(src))
+			mod *= 1.2
+		else
+			mod *= 0.8
+
 	return config.minimum_sprint_cost + (config.skill_sprint_cost_range * mod)
 
 /datum/movement_handler/mob/movement/proc/HandleGrabs(var/direction, var/old_turf)

--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -49,6 +49,12 @@
 		)
 
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_SPCR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
+	species_flags = SPECIES_FLAG_LOW_GRAV_ADAPTED
+
+	hazard_high_pressure = HAZARD_HIGH_PRESSURE * 0.8            // Dangerously high pressure.
+	warning_high_pressure = WARNING_HIGH_PRESSURE * 0.8          // High pressure warning.
+	warning_low_pressure = WARNING_LOW_PRESSURE * 0.8            // Low pressure warning.
+	hazard_low_pressure = HAZARD_LOW_PRESSURE * 0.8              // Dangerously low pressure.
 
 /datum/species/human/vatgrown
 	name = SPECIES_VATGROWN


### PR DESCRIPTION
:cl:
tweak: Space-Adapted humans' stamina now depends slightly upon gravity levels, with better stamina than baseline humans in low-gravity, worse in standard gravity.
tweak: Space-Adapted humans are adapted for lower-pressure environments, but suffer in higher pressure environments faster relative to baseline humans.
/:cl:

Most human subspecies modifiers are largely not noticeable to the player. This tweaks space-adapted humans to have some more noticable species traits.

There's also a new sprite in the works and some other adjustments maybe coming in future PRs to spacies to make them stand out a bit more from the homogeneous blob of subspecies.
