### PR TITLE
Fixes restart logic so players can call restart or transfer

### DIFF
--- a/code/datums/vote/restart.dm
+++ b/code/datums/vote/restart.dm
@@ -6,7 +6,7 @@
 	results_length = 1
 
 /datum/vote/restart/can_run(mob/creator, automatic)
-	if(!automatic && (!config.allow_vote_restart || !is_admin(creator)))
+	if(!automatic && !config.allow_vote_restart && !is_admin(creator))
 		return FALSE // Admins and autovotes bypass the config setting.
 	return ..()
 

--- a/code/datums/vote/transfer.dm
+++ b/code/datums/vote/transfer.dm
@@ -7,7 +7,7 @@
 		return
 	if(!evacuation_controller || !evacuation_controller.should_call_autotransfer_vote())
 		return FALSE
-	if(!automatic && (!config.allow_vote_restart || !is_admin(creator)))
+	if(!automatic && !config.allow_vote_restart && !is_admin(creator))
 		return FALSE // Admins and autovotes bypass the config setting.
 	if(check_rights(R_INVESTIGATE, 0, creator))
 		return //Mods bypass further checks.
@@ -16,7 +16,7 @@
 		to_chat(creator, "The current alert status is too high to call for a crew transfer!")
 		return FALSE
 	if(GAME_STATE <= RUNLEVEL_SETUP)
-		to_chat(creator, "The crew transfer button has been disabled!")	
+		to_chat(creator, "The crew transfer button has been disabled!")
 		return FALSE
 
 /datum/vote/transfer/setup_vote(mob/creator, automatic)


### PR DESCRIPTION
Only when config is valid -- unlikely to apply to BS12 but will be useful for downstream branches

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->