### PR TITLE
Adds some sounds for exosuit's utility equipment

### DIFF
--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -15,7 +15,7 @@
 /obj/item/mech_equipment/clamp/attack_hand(mob/user)
 	if(owner && LAZYISIN(owner.pilots, user))
 		if(!owner.hatch_closed && carrying)
-			if(!do_after(user, 30, owner)) return
+			if(!do_after(user, 20, owner)) return
 			if(user.put_in_active_hand(carrying))
 				owner.visible_message(SPAN_NOTICE("\The [user] carefully grabs \the [carrying] from \the [src]."))
 				playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
@@ -72,7 +72,6 @@
 		if(!carrying)
 			to_chat(user, SPAN_WARNING("You are not carrying anything in \the [src]."))
 		else
-			if(!do_after(user, 20, owner)) return
 			owner.visible_message(SPAN_NOTICE("\The [owner] unloads \the [carrying]."))
 			playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
 			carrying.forceMove(get_turf(src))
@@ -88,7 +87,7 @@
 		carrying.dropInto(loc)
 		carrying = null
 	. = ..()
-	
+
 // A lot of this is copied from floodlights.
 /obj/item/mech_equipment/light
 	name = "floodlight"
@@ -124,7 +123,7 @@
 	on = FALSE
 	update_icon()
 	. = ..()
-	
+
 #define CATAPULT_SINGLE 1
 #define CATAPULT_AREA   2
 
@@ -186,7 +185,7 @@
 						locked = null
 						to_chat(user, SPAN_NOTICE("Lock on [locked] disengaged."))
 			if(CATAPULT_AREA)
-				
+
 				var/list/atoms = list()
 				if(isturf(target))
 					atoms = range(target,3)
@@ -230,9 +229,9 @@
 		descriptor = "shows some signs of wear"
 	if(percentage > 95)
 		descriptor = "shows no wear"
-		
+
 	to_chat(user, "It [descriptor].")
-	
+
 /obj/item/weapon/material/drill_head/Initialize()
 	. = ..()
 	durability = 2 * material.integrity
@@ -248,7 +247,7 @@
 	//Drill can have a head
 	var/obj/item/weapon/material/drill_head/drill_head
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	
+
 
 
 /obj/item/mech_equipment/drill/Initialize()
@@ -281,7 +280,7 @@
 		visible_message(SPAN_NOTICE("\The [user] mounts the [drill_head] on the [src]."))
 		return
 	. = ..()
-	
+
 /obj/item/mech_equipment/drill/afterattack(var/atom/target, var/mob/living/user, var/inrange, var/params)
 	. = ..()
 	if(.)
@@ -303,7 +302,7 @@
 		if(drill_head == null)
 			to_chat(user, SPAN_WARNING("Your drill doesn't have a head!"))
 			return
-		
+
 		var/obj/item/weapon/cell/C = owner.get_cell()
 		if(istype(C))
 			C.use(active_power_use * CELLRATE)
@@ -312,7 +311,7 @@
 
 		var/T = target.loc
 
-		//Better materials = faster drill! 
+		//Better materials = faster drill!
 		var/delay = max(5, 20 - drill_head.material.brute_armor)
 		owner.setClickCooldown(delay) //Don't spamclick!
 		if(do_after(owner, delay, target) && drill_head)
@@ -343,9 +342,9 @@
 					drill_head.durability -= 1
 					log_and_message_admins("[src] used to drill [target].", user, owner.loc)
 
-				
 
-	
+
+
 				if(owner.hardpoints.len) //if this isn't true the drill should not be working to be fair
 					for(var/hardpoint in owner.hardpoints)
 						var/obj/item/I = owner.hardpoints[hardpoint]
@@ -358,11 +357,11 @@
 									ore.Move(ore_box)
 
 		else
-			to_chat(user, "You must stay still while the drill is engaged!")		
+			to_chat(user, "You must stay still while the drill is engaged!")
 
-				
+
 		return 1
-		
+
 
 
 
@@ -378,5 +377,5 @@
 /obj/item/weapon/gun/energy/plasmacutter/mounted/mech
 	use_external_power = TRUE
 	has_safety = FALSE
-	
+
 

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -15,8 +15,10 @@
 /obj/item/mech_equipment/clamp/attack_hand(mob/user)
 	if(owner && LAZYISIN(owner.pilots, user))
 		if(!owner.hatch_closed && carrying)
+			if(!do_after(user, 30, owner)) return
 			if(user.put_in_active_hand(carrying))
 				owner.visible_message(SPAN_NOTICE("\The [user] carefully grabs \the [carrying] from \the [src]."))
+				playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
 				carrying = null
 	. = ..()
 
@@ -44,7 +46,7 @@
 				O.forceMove(src)
 				carrying = O
 				owner.visible_message(SPAN_NOTICE("\The [owner] loads \the [O] into its cargo compartment."))
-
+				playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
 
 		//attacking - Cannot be carrying something, cause then your clamp would be full
 		else if(istype(target,/mob/living))
@@ -70,7 +72,9 @@
 		if(!carrying)
 			to_chat(user, SPAN_WARNING("You are not carrying anything in \the [src]."))
 		else
+			if(!do_after(user, 20, owner)) return
 			owner.visible_message(SPAN_NOTICE("\The [owner] unloads \the [carrying]."))
+			playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
 			carrying.forceMove(get_turf(src))
 			carrying = null
 
@@ -256,7 +260,7 @@
 	if(.)
 		if(drill_head)
 			owner.visible_message(SPAN_WARNING("[owner] revs the [drill_head], menancingly."))
-			playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)
+			playsound(src, 'sound/mecha/mechdrill.ogg', 50, 1)
 
 /obj/item/mech_equipment/drill/get_hardpoint_maptext()
 	if(drill_head)
@@ -293,6 +297,7 @@
 			DH.forceMove(src)
 			drill_head = DH
 			owner.visible_message(SPAN_NOTICE("\The [owner] mounts the [drill_head] on the [src]."))
+			playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)
 			return
 
 		if(drill_head == null)
@@ -303,6 +308,7 @@
 		if(istype(C))
 			C.use(active_power_use * CELLRATE)
 		owner.visible_message("<span class='danger'>\The [owner] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
+		playsound(src, 'sound/mecha/mechdrill.ogg', 50, 1)
 
 		var/T = target.loc
 
@@ -351,8 +357,6 @@
 								if(get_dir(owner,ore)&owner.dir)
 									ore.Move(ore_box)
 
-				playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)
-		
 		else
 			to_chat(user, "You must stay still while the drill is engaged!")		
 


### PR DESCRIPTION
🆑 quardbreak
:soundadd: The mounted clamp and drill for exosuits now have sounds! Replacing drill head now have a sound as well.
:tweak: Added two seconds to unloading process for mounted clamp and three seconds to manually eject item from module.
/🆑

Greetings! 👋
After the exosuit refactor I notice what someone added new sounds, which sadly, almost never been used in code. Since they are just laying here without use I code two sounds for two utility modules: mounted clamp and drill.

Also added two do_after procs to make a 'process is going' effect. 
I would like to replace all `owner` arguments in this proc with user to fix progress bars, but don't know if it can broke something :S