### PR TITLE
Drones can't open windoors fix

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -83,7 +83,7 @@
 	var/mob/M = AM // we've returned by here if M is not a mob
 	if (src.operating)
 		return
-	if (src.density && (!issmall(M) || ishuman(M)) && src.allowed(AM))
+	if (src.density && (!issmall(M) || ishuman(M) || issilicon(M)) && src.allowed(AM))
 		open()
 		if(src.check_access(null))
 			sleep(50)


### PR DESCRIPTION
🆑 WezYo
bugfix: Flying drones can now open windoors
/🆑 

From Babydoll's #24998

Fixes #28012
Fixes #24908