### PR TITLE
Hide End Credits Ckey pref now also applies to end of round special role listing too

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1127,3 +1127,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		M.start_pulling(t)
 	else
 		step(user.pulling, get_dir(user.pulling.loc, A))
+
+/proc/check_client_pref(var/mob/M, var/pref_key, var/pref_choice)
+	if(M.ckey && M.client)
+		if(M.client.get_preference_value(get_client_preference_by_key(pref_key)) == pref_choice)
+			return TRUE
+	return FALSE

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -400,19 +400,19 @@ Helpers
 					to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></font>")
 	to_world("<br>")
 
-	for (var/mob/living/silicon/ai/aiPlayer in SSmobs.mob_list)
-		if (aiPlayer.stat != 2)
-			to_world("<b>[aiPlayer.name] (Played by: [aiPlayer.key])'s laws at the end of the round were:</b>")
+	for(var/mob/living/silicon/ai/aiPlayer in SSmobs.mob_list)
+		if(aiPlayer.stat != 2)
+			to_world("<b>[aiPlayer.name] [check_client_pref(aiPlayer, "SHOW_CKEY_CREDITS", GLOB.PREF_SHOW) ? "(Played by: [aiPlayer.key])\'s" : ""] laws at the end of the round were:</b>")
 
 		else
-			to_world("<b>[aiPlayer.name] (Played by: [aiPlayer.key])'s laws when it was deactivated were:</b>")
+			to_world("<b>[aiPlayer.name] [check_client_pref(aiPlayer, "SHOW_CKEY_CREDITS", GLOB.PREF_SHOW) ? "(Played by: [aiPlayer.key])\'s" : ""] laws when it was deactivated were:</b>")
 
 		aiPlayer.show_laws(1)
 
 		if (aiPlayer.connected_robots.len)
 			var/robolist = "<b>The AI's loyal minions were:</b> "
 			for(var/mob/living/silicon/robot/robo in aiPlayer.connected_robots)
-				robolist += "[robo.name][robo.stat?" (Deactivated) (Played by: [robo.key]), ":" (Played by: [robo.key]), "]"
+				robolist += "[robo.name][robo.stat ? " (Deactivated)" : ""] [check_client_pref(robo, "SHOW_CKEY_CREDITS", GLOB.PREF_SHOW) ? "(Played by: [robo.key])" : ""],"
 			to_world("[robolist]")
 
 	var/dronecount = 0
@@ -422,13 +422,13 @@ Helpers
 		if(istype(robo,/mob/living/silicon/robot/drone))
 			dronecount++
 			continue
-
+			
 		if (!robo.connected_ai)
 			if (robo.stat != 2)
-				to_world("<b>[robo.name] (Played by: [robo.key]) survived as an AI-less synthetic! Its laws were:</b>")
+				to_world("<b>[robo.name] [check_client_pref(robo, "SHOW_CKEY_CREDITS", GLOB.PREF_SHOW) ? "(Played by: [robo.key])" : ""] survived as an AI-less synthetic! Its laws were:</b>")
 
 			else
-				to_world("<b>[robo.name] (Played by: [robo.key]) was unable to survive the rigors of being a synthetic without an AI. Its laws were:</b>")
+				to_world("<b>[robo.name] [check_client_pref(robo, "SHOW_CKEY_CREDITS", GLOB.PREF_SHOW) ? "(Played by: [robo.key])" : ""] was unable to survive the rigors of being a synthetic without an AI. Its laws were:</b>")
 
 
 			if(robo) //How the hell do we lose robo between here and the world messages directly above this?

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -35,7 +35,7 @@
 
 /datum/antagonist/proc/print_player(var/datum/mind/ply)
 	var/role = ply.assigned_role ? "\improper[ply.assigned_role]" : (ply.special_role ? "\improper[ply.special_role]" : "unknown role")
-	var/text = "<br><b>[ply.name]</b> (<b>[ply.key]</b>) as \a <b>[role]</b> ("
+	var/text = "<br><b>[ply.name]</b> [check_client_pref(ply.current, "SHOW_CKEY_CREDITS", GLOB.PREF_SHOW) ? "(<b>[ply.key]</b>)" : ""] as \a <b>[role]</b> ("
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += "died"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -196,7 +196,7 @@ var/list/_client_preferences_by_type
 	key = "SHOW_CREDITS"
 
 /datum/client_preference/show_ckey_credits
-	description = "Show Ckey in End Credits"
+	description = "Show Ckey in End Credits/Special Role List"
 	key = "SHOW_CKEY_CREDITS"
 	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
 


### PR DESCRIPTION
:cl:
tweak: 'Show Ckey in End Credits' pref now also applies to the end-of-round special role list that shows the ckeys of all antagonists, AI, robots and other special roles.
/:cl:

Seems sensible to me. People don't want their ckeys shown at round-end, it should apply to all the round-end ckey postings.