### PR TITLE
Decreases difficulty for installing augments

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -224,7 +224,7 @@
 /decl/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	var/obj/item/organ/internal/O = tool
 	var/obj/item/organ/external/affected = target.get_organ(user.zone_sel.selecting)
-	if(BP_IS_ROBOTIC(O))
+	if(BP_IS_ROBOTIC(O) || istype(O, /obj/item/organ/internal/augment))
 		if(BP_IS_ROBOTIC(affected))
 			return SURGERY_SKILLS_ROBOTIC
 		else


### PR DESCRIPTION
:cl:
tweak: Decreased difficulty of installing augments to the same level as installing robotic organs.
/:cl:

Seems like an oversight from the 'increase surgery skill requirements' PRs. Augments should not be harder to install than robotic organs, and this makes it more possible for roboticists to do that part of their job.