### PR TITLE
Pen / Retractable Pen tweaks

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -280,11 +280,6 @@
 			to_chat(usr, "<span class='info'>There isn't enough space left on \the [src] to write anything.</span>")
 			return
 
-		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
-
-		if(!t)
-			return
-
 		var/obj/item/I = usr.get_active_hand() // Check to see if he still got that darn pen, also check what type of pen
 		var/iscrayon = 0
 		var/isfancy = 0
@@ -300,15 +295,19 @@
 				return
 		
 		var/obj/item/weapon/pen/P = I
-		if(!P.pen_usable(usr))
-			return
+		if(!P.active)
+			P.toggle()
 
 		if(P.iscrayon)
-			iscrayon = 1
+			iscrayon = TRUE
 
 		if(P.isfancy)
-			isfancy = 1
+			isfancy = TRUE
 
+		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
+
+		if(!t)
+			return
 
 		// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
 		if(src.loc != usr && !src.Adjacent(usr) && !((istype(src.loc, /obj/item/weapon/material/clipboard) || istype(src.loc, /obj/item/weapon/folder)) && (src.loc.loc == usr || src.loc.Adjacent(usr)) ) )

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -13,6 +13,7 @@
 	var/colour = "black"	//what colour the ink is!
 	var/color_description = "black ink"
 
+	var/active = TRUE
 	var/iscrayon = FALSE
 	var/isfancy = FALSE
 
@@ -42,20 +43,20 @@
 	colour = "white"
 	color_description = "transluscent ink"
 
-/obj/item/weapon/pen/attack(atom/A, mob/user as mob, target_zone)
+/obj/item/weapon/pen/attack(atom/A, mob/user, target_zone)
 	if(ismob(A))
 		var/mob/M = A
 		if(ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
 			if(istype(head))
-				head.write_on(user, src.color_description)
+				head.write_on(user, color_description)
 		else
-			to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
+			to_chat(user, SPAN_WARNING("You stab [M] with \the [src]."))
 			admin_attack_log(user, M, "Stabbed using \a [src]", "Was stabbed with \a [src]", "used \a [src] to stab")
 	else if(istype(A, /obj/item/organ/external/head))
 		var/obj/item/organ/external/head/head = A
-		head.write_on(user, src.color_description)
+		head.write_on(user, color_description)
 
-/obj/item/weapon/pen/proc/pen_usable()
-	return TRUE
+/obj/item/weapon/pen/proc/toggle()
+	return

--- a/code/modules/paperwork/pen/retractable_pen.dm
+++ b/code/modules/paperwork/pen/retractable_pen.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/pen/retractable
 	desc = "It's a retractable pen."
 	icon_state = "pen" //for map visibility
-	var/active = FALSE
+	active = FALSE
 	var/base_state = "ret_black"
 
 /obj/item/weapon/pen/retractable/blue
@@ -34,17 +34,13 @@
 
 /obj/item/weapon/pen/retractable/attack(atom/A, mob/user, target_zone)
 	if(!active)
-		to_chat(user, SPAN_NOTICE("You'll have to activate \the [src] if you wish to use it."))
-		return
+		toggle()
 	..()
 
 /obj/item/weapon/pen/retractable/attack_self(mob/user)
+	toggle()
+
+/obj/item/weapon/pen/retractable/toggle()
 	active = !active
 	playsound(src, 'sound/items/penclick.ogg', 5, 0, -4)
 	update_icon()
-
-/obj/item/weapon/pen/retractable/pen_usable(var/mob/living/user)
-	if(active)
-		return TRUE
-	else
-		to_chat(user, SPAN_NOTICE("You'll have to activate \the [src] if you wish to write with it."))


### PR DESCRIPTION
:cl:
tweak: Paper will now check if your pen works before you start writing instead of after you've written your text.
tweak: If your retractable pen isn't in its active state when you start writing on something, your character will automatically click it.
tweak: Retractable pens will now toggle to their active state when you write on anything (union cards, people, the wall) instead of only paper.
/:cl:

Since retractable pens are not opt-in (they spawn in PDAs, rather than being a loadout choice), I don't think they should cause annoyance to the player relative to normal pens. 

Also characters should be smart enough to click a pen when you start to write on something.

These changes preserve the important annoy-other-people-with-pen-clicks RP while removing the self-annoyance.