### PR TITLE
add tracking for players vs admins in prometheus metrics

### DIFF
--- a/code/modules/prometheus_metrics/metrics/ss13.dm
+++ b/code/modules/prometheus_metrics/metrics/ss13.dm
@@ -69,3 +69,26 @@
 		out[++out.len] = list(list("type" = "del"), SSgarbage.totaldels)
 
 	return out
+
+
+/datum/metric_family/ss13_players
+	name = "ss13_players"
+	metric_type = PROMETHEUS_METRIC_GAUGE
+	help = "Count of players currently connected to the server"
+
+/datum/metric_family/ss13_players/collect()
+	var/players = 0
+	var/admins = 0
+
+	for(var/client/C)
+		if(!(C.connection == "seeker" || C.connection == "web"))
+			continue
+		if(C.holder && !C.is_stealthed())
+			admins++
+			continue
+		players++
+
+	return list(
+		list(list("admin" = "0"), players),
+		list(list("admin" = "1"), admins)
+	)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->