### PR TITLE
Most pipe-dispenser'd atmos machines no longer require components to be installed

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/item_chassis.dm
+++ b/code/game/machinery/_machines_base/machine_construction/item_chassis.dm
@@ -1,9 +1,25 @@
 // Identical to default behavior, but does not require circuit boards.
 
-/decl/machine_construction/default/panel_closed/item_chassis
+/decl/machine_construction/default/item_chassis
 	needs_board = null
-	down_state = /decl/machine_construction/default/panel_open/item_chassis
+	down_state = /decl/machine_construction/default/deconstructed
 
-/decl/machine_construction/default/panel_open/item_chassis
-	needs_board = null
-	up_state = /decl/machine_construction/default/panel_closed/item_chassis
+/decl/machine_construction/default/item_chassis/attackby(obj/item/I, mob/user, obj/machinery/machine)
+	if((. = ..()))
+		return
+	if(isWrench(I))
+		TRANSFER_STATE(down_state)
+		machine.dismantle()
+		return
+
+/decl/machine_construction/default/item_chassis/state_is_valid(obj/machinery/machine)
+	return TRUE
+
+/decl/machine_construction/default/item_chassis/validate_state(obj/machinery/machine)
+	. = ..()
+	if(!.)
+		try_change_state(machine, down_state)
+
+/decl/machine_construction/default/panel_closed/mechanics_info()
+	. = list()
+	. += "Use a wrench to deconstruct the machine"

--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -6,8 +6,8 @@
 	anchored = 1
 
 	uncreated_component_parts = list(
-		/obj/item/weapon/stock_parts/radio/transmitter/basic/buildable,
-		/obj/item/weapon/stock_parts/power/apc/buildable
+		/obj/item/weapon/stock_parts/radio/transmitter/basic,
+		/obj/item/weapon/stock_parts/power/apc
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/gas,
@@ -18,12 +18,8 @@
 	use_power = POWER_USE_IDLE
 
 	frame_type = /obj/item/machine_chassis/air_sensor
-	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/air_sensor/buildable
-
-// Have to install components on your own.
-/obj/machinery/air_sensor/buildable
-	uncreated_component_parts = null
+	construct_state = /decl/machine_construction/default/item_chassis
+	base_type = /obj/machinery/air_sensor
 
 /obj/machinery/air_sensor/on_update_icon()
 	if(!powered())

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 15
 
 	uncreated_component_parts = list(
-		/obj/item/weapon/stock_parts/power/apc/buildable
+		/obj/item/weapon/stock_parts/power/apc
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/gas,
@@ -19,8 +19,8 @@
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/meter = 1)
 
 	frame_type = /obj/item/machine_chassis/pipe_meter
-	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/meter/buildable
+	construct_state = /decl/machine_construction/default/item_chassis
+	base_type = /obj/machinery/meter
 
 /obj/machinery/meter/Initialize()
 	. = ..()
@@ -102,9 +102,6 @@
 	if (!target)
 		set_target(loc)
 	. = ..()
-
-/obj/machinery/meter/buildable
-	uncreated_component_parts = null
 
 /obj/machinery/meter/starts_with_radio
 	uncreated_component_parts = list(

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -229,7 +229,7 @@ Buildable meters
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
 	w_class = ITEM_SIZE_LARGE
-	build_type = /obj/machinery/air_sensor/buildable
+	build_type = /obj/machinery/air_sensor
 
 /obj/item/machine_chassis/pipe_meter
 	name = "meter"
@@ -238,4 +238,4 @@ Buildable meters
 	icon_state = "meter"
 	item_state = "buildpipe"
 	w_class = ITEM_SIZE_LARGE
-	build_type = /obj/machinery/meter/buildable
+	build_type = /obj/machinery/meter

--- a/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/device_pipe_datums.dm
@@ -43,7 +43,7 @@
 	build_path = /obj/item/pipe
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "pump"
-	constructed_path = /obj/machinery/atmospherics/binary/pump/buildable
+	constructed_path = /obj/machinery/atmospherics/binary/pump
 	pipe_class = PIPE_CLASS_BINARY
 
 /datum/pipe/pipe_dispenser/device/pressureregulator
@@ -61,7 +61,7 @@
 	build_path = /obj/item/pipe
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "volumepump"
-	constructed_path = /obj/machinery/atmospherics/binary/pump/high_power/buildable
+	constructed_path = /obj/machinery/atmospherics/binary/pump/high_power
 	pipe_class = PIPE_CLASS_BINARY
 
 /datum/pipe/pipe_dispenser/device/scrubber
@@ -70,7 +70,7 @@
 	build_path = /obj/item/pipe
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER
 	build_icon_state = "scrubber"
-	constructed_path = /obj/machinery/atmospherics/unary/vent_scrubber/buildable
+	constructed_path = /obj/machinery/atmospherics/unary/vent_scrubber
 	pipe_class = PIPE_CLASS_UNARY
 
 /datum/pipe/pipe_dispenser/device/meter
@@ -172,7 +172,7 @@
 	pipe_color = null
 	connect_types = null
 	colorable = FALSE
-	constructed_path = /obj/machinery/air_sensor/buildable
+	constructed_path = /obj/machinery/air_sensor
 	pipe_class = PIPE_CLASS_OTHER
 
 /datum/pipe/pipe_dispenser/device/outlet_injector

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -35,7 +35,7 @@ Thus, the two variables affect pump operation are set in New():
 	build_icon_state = "pump"
 
 	uncreated_component_parts = list(
-		/obj/item/weapon/stock_parts/power/apc/buildable
+		/obj/item/weapon/stock_parts/power/apc
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/input_toggle,
@@ -53,11 +53,8 @@ Thus, the two variables affect pump operation are set in New():
 	)
 
 	frame_type = /obj/item/pipe
-	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/atmospherics/binary/pump/buildable
-
-/obj/machinery/atmospherics/binary/pump/buildable
-	uncreated_component_parts = null
+	construct_state = /decl/machine_construction/default/item_chassis
+	base_type = /obj/machinery/atmospherics/binary/pump
 
 /obj/machinery/atmospherics/binary/pump/Initialize()
 	. = ..()
@@ -116,6 +113,12 @@ Thus, the two variables affect pump operation are set in New():
 			network2.update = 1
 
 	return 1
+
+/obj/machinery/atmospherics/binary/pump/return_air()
+	if(air1.return_pressure() > air2.return_pressure())
+		return air1
+	else
+		return air2
 
 /obj/machinery/atmospherics/binary/pump/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -43,9 +43,9 @@
 	build_icon_state = "uvent"
 
 	uncreated_component_parts = list(
-		/obj/item/weapon/stock_parts/power/apc/buildable,
-		/obj/item/weapon/stock_parts/radio/receiver/buildable,
-		/obj/item/weapon/stock_parts/radio/transmitter/on_event/buildable,
+		/obj/item/weapon/stock_parts/power/apc,
+		/obj/item/weapon/stock_parts/radio/receiver,
+		/obj/item/weapon/stock_parts/radio/transmitter/on_event,
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/input_toggle,
@@ -71,11 +71,8 @@
 	)
 
 	frame_type = /obj/item/pipe
-	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/atmospherics/unary/vent_pump/buildable
-
-/obj/machinery/atmospherics/unary/vent_pump/buildable
-	uncreated_component_parts = null
+	construct_state = /decl/machine_construction/default/item_chassis
+	base_type = /obj/machinery/atmospherics/unary/vent_pump
 
 /obj/machinery/atmospherics/unary/vent_pump/on
 	use_power = POWER_USE_IDLE

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -24,9 +24,9 @@
 	build_icon_state = "scrubber"
 
 	uncreated_component_parts = list(
-		/obj/item/weapon/stock_parts/power/apc/buildable,
-		/obj/item/weapon/stock_parts/radio/receiver/buildable,
-		/obj/item/weapon/stock_parts/radio/transmitter/on_event/buildable,
+		/obj/item/weapon/stock_parts/power/apc,
+		/obj/item/weapon/stock_parts/radio/receiver,
+		/obj/item/weapon/stock_parts/radio/transmitter/on_event,
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/input_toggle,
@@ -50,11 +50,8 @@
 	)
 
 	frame_type = /obj/item/pipe
-	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/atmospherics/unary/vent_scrubber/buildable
-
-/obj/machinery/atmospherics/unary/vent_scrubber/buildable
-	uncreated_component_parts = null
+	construct_state = /decl/machine_construction/default/item_chassis
+	base_type = /obj/machinery/atmospherics/unary/vent_scrubber
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on
 	use_power = POWER_USE_IDLE


### PR DESCRIPTION
:cl:
tweak: Air Sensors, Meters, Pumps, Scrubbers, Vents and subtypes no longer have normal machinery construction steps requiring components. They are built or removed in one step with a wrench.
bugfix: Pumps will now properly prevent deconstruction if their internal pressure is too different from the environment pressure.
/:cl:

Makes building basic atmos machinery components less annoying for Engineering.

Pumps were returning their loc's pressure instead of their internal pressure for the pressure check. Now they return the highest of their input/output pressures.