### PR TITLE
Improve Vox neck markings

### DIFF
--- a/code/modules/client/preference_setup/general/04_flavor.dm
+++ b/code/modules/client/preference_setup/general/04_flavor.dm
@@ -1,6 +1,7 @@
 /datum/preferences
 	var/list/flavor_texts        = list()
 	var/list/flavour_texts_robot = list()
+	var/neck_markings_description = ""
 
 /datum/category_item/player_setup_item/physical/flavor
 	name = "Flavor"
@@ -21,6 +22,8 @@
 	S["flavour_texts_robot_Default"] >> pref.flavour_texts_robot["Default"]
 	for(var/module in SSrobots.all_module_names)
 		S["flavour_texts_robot_[module]"] >> pref.flavour_texts_robot[module]
+	
+	from_file(S["neck_markings_description"], pref.neck_markings_description)
 
 /datum/category_item/player_setup_item/physical/flavor/save_character(var/savefile/S)
 	S["flavor_texts_general"]	<< pref.flavor_texts["general"]
@@ -36,15 +39,19 @@
 	S["flavour_texts_robot_Default"] << pref.flavour_texts_robot["Default"]
 	for(var/module in SSrobots.all_module_names)
 		S["flavour_texts_robot_[module]"] << pref.flavour_texts_robot[module]
+		
+	to_file(S["neck_markings_description"], pref.neck_markings_description)
 
 /datum/category_item/player_setup_item/physical/flavor/sanitize_character()
 	if(!istype(pref.flavor_texts))        pref.flavor_texts = list()
 	if(!istype(pref.flavour_texts_robot)) pref.flavour_texts_robot = list()
-
+	
 /datum/category_item/player_setup_item/physical/flavor/content(var/mob/user)
 	. += "<b>Flavor:</b><br>"
 	. += "<a href='?src=\ref[src];flavor_text=open'>Set Flavor Text</a><br/>"
 	. += "<a href='?src=\ref[src];flavour_text_robot=open'>Set Robot Flavor Text</a><br/>"
+	if((pref.species == SPECIES_VOX) || (pref.species == SPECIES_VOX_ARMALIS))
+		. += "<a href='?src=\ref[src];neck_markings=open'>Set Stack Lineage Descriptor</a><br/>"
 
 /datum/category_item/player_setup_item/physical/flavor/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["flavor_text"])
@@ -74,7 +81,15 @@
 					pref.flavour_texts_robot[href_list["flavour_text_robot"]] = msg
 		SetFlavourTextRobot(user)
 		return TOPIC_HANDLED
-
+	
+	else if(href_list["neck_markings"])
+		switch(href_list["neck_markings"])
+			if("open")
+				var/msg = sanitize(input(usr,"Stack Lineage description.","Stack Lineage description",html_decode(pref.neck_markings_description)) as message, extra = 0)
+				if(CanUseTopic(user))
+					pref.neck_markings_description = msg
+		return TOPIC_HANDLED
+	
 	return ..()
 
 /datum/category_item/player_setup_item/physical/flavor/proc/SetFlavorText(mob/user)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -290,6 +290,9 @@ datum/preferences
 	character.flavor_texts["legs"] = flavor_texts["legs"]
 	character.flavor_texts["feet"] = flavor_texts["feet"]
 
+	if(isspecies(character, SPECIES_VOX) || isspecies(character, SPECIES_VOX_ARMALIS))
+		character.neck_markings_text = neck_markings_description
+
 	character.public_record = public_record
 	character.med_record = med_record
 	character.sec_record = sec_record

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -309,7 +309,11 @@
 
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
-
+	
+	var/are_vox = (isspecies(user, SPECIES_VOX) || isspecies(user, SPECIES_VOX_ARMALIS)) && (isspecies(src, SPECIES_VOX) || isspecies(src, SPECIES_VOX_ARMALIS))
+	if(are_vox && (neck_markings_text && neck_markings_text != ""))
+		msg += "<span class='notice'>[T.His] neck markings <a href='byond://?src=\ref[src];neck_markings_description_more=1'>indicate...</a></span>\n"
+	
 	if(mind && user.mind && name == real_name)
 		var/list/relations = matchmaker.get_relationships_between(user.mind, mind, TRUE)
 		if(length(relations))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -454,6 +454,10 @@
 		show_browser(user, "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY><TT>[replacetext(flavor_text, "\n", "<BR>")]</TT></BODY></HTML>", "window=[name];size=500x200")
 		onclose(user, "[name]")
 		return TOPIC_HANDLED
+	else if(href_list["neck_markings_description_more"])
+		show_browser(user, "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY><TT>[replacetext(neck_markings_text, "\n", "<BR>")]</TT></BODY></HTML>", "window=[name];size=500x200")
+		onclose(user, "[name]")
+		return TOPIC_HANDLED
 
 // You probably do not need to override this proc. Use one of the two above.
 /mob/Topic(href, href_list, datum/topic_state/state)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -187,7 +187,8 @@
 	var/drowsyness = 0.0//Carbon
 
 	var/flavor_text = ""
-
+	var/neck_markings_text = ""
+	
 	var/datum/skillset/skillset = /datum/skillset
 
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Imienny
rscadd: Adds the ability for Vox to set what their neck markings indicate in character setup, Description of neck markings is visible on examination only to other vox
/:cl: