### PR TITLE
Fixes issue with polytools not working

### DIFF
--- a/code/modules/augment/active/polytool.dm
+++ b/code/modules/augment/active/polytool.dm
@@ -51,7 +51,7 @@
 			to_chat(owner, SPAN_WARNING("You must drop [I] before tool can be extend."))
 	else
 		var/obj/item = input(owner, "Select item for deploy") as null|anything in src
-		if(!item || !(src.loc in owner.organs))
+		if(!item || !(src in owner.internal_organs))
 			return
 		if(owner.equip_to_slot_if_possible(item, slot))
 			items -= item


### PR DESCRIPTION
:cl:
bugfix: Polytools now allow you to extend tools again.
/:cl:

Fixes #28056 

Problem caused / revealed by #28035 with a `!src.loc in owner.organs` -> `!(src.loc in owner.organs)`
The implant was never in `owner.organs`, it lives in the `internal_organs` list.

Previously this check did nothing.