### PR TITLE
Makes output atmos tank controller work again

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -410,7 +410,7 @@
 /decl/public_access/public_variable/pressure_bound/write_var(obj/machinery/atmospherics/unary/vent_pump/machine, new_value)
 	if(new_value == "default")
 		new_value = machine.internal_pressure_bound_default
-	new_value = Clamp(new_value, 0, MAX_PUMP_PRESSURE)
+	new_value = Clamp(text2num(new_value), 0, MAX_PUMP_PRESSURE)
 	. = ..()
 	if(.)
 		machine.internal_pressure_bound = new_value
@@ -471,6 +471,7 @@
 
 /decl/stock_part_preset/radio/receiver/vent_pump/tank
 	frequency = ATMOS_TANK_FREQ
+	filter = RADIO_ATMOSIA
 
 /decl/stock_part_preset/radio/event_transmitter/vent_pump/tank
 	frequency = ATMOS_TANK_FREQ


### PR DESCRIPTION
:cl:
bugfix: Atmospherics' tank controllers work again when controlling the output vent.
/:cl:

Fixes #27975  -- Had the wrong `filter`

Also fixes a runtime to do with trying to Clamp a string in `/decl/public_access/public_variable/pressure_bound/write_var`