### PR TITLE
Adds text redaction tags for paperwork.

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -429,6 +429,7 @@ proc/TextPreview(var/string,var/len=40)
 	text = replacetext(text, "\[fontblue\]", "<font color=\"blue\">")//</font> to pass travis html tag integrity check
 	text = replacetext(text, "\[fontgreen\]", "<font color=\"green\">")
 	text = replacetext(text, "\[/font\]", "</font>")
+	text = replacetext(text, "\[redacted\]", "<span class=\"redacted\">R E D A C T E D</span>")
 	return pencode2html(text)
 
 //Will kill most formatting; not recommended.
@@ -473,6 +474,7 @@ proc/TextPreview(var/string,var/len=40)
 	t = replacetext(t, "<img src = xynlogo.png>", "\[xynlogo\]")
 	t = replacetext(t, "<img src = sfplogo.png>", "\[sfplogo\]")
 	t = replacetext(t, "<span class=\"paper_field\"></span>", "\[field\]")
+	t = replacetext(t, "<span class=\"redacted\">R E D A C T E D</span>", "\[redacted\]")
 	t = strip_html_properly(t)
 	return t
 

--- a/code/modules/codex/entries/paperwork.dm
+++ b/code/modules/codex/entries/paperwork.dm
@@ -36,4 +36,5 @@
 \[pre\] - \[/pre\] : Adds preformatted text, forcing the text to be fixed width.<br>
 \[fontred\] - \[/font\] : Makes the text red.<br>
 \[fontblue\] - \[/font\] : Makes the text blue.<br>
-\[fontgreen\] - \[/font\] : Makes the text green.<br><br>"}
+\[fontgreen\] - \[/font\] : Makes the text green.<br>
+\[redacted\] : Adds R E D A C T E D in black font on a black background.<br><br>"}

--- a/html/changelogs/SomeoneStoleMyNickname-2.yml
+++ b/html/changelogs/SomeoneStoleMyNickname-2.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: SomeoneStoleMyNickname
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a new digital pencode tag. [redacted] creates the string R E D A C E D in black lettes on black background to give the illusion of redacted contend in reports."

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -705,3 +705,8 @@ th.bot {
 .candystripe:nth-child(odd) {
 	background-color: rgba(0, 0, 0, 0.16);
 }
+
+.redacted {
+	background-color: black;
+	color: black;
+}


### PR DESCRIPTION
:cl:
rscadd: Added redacted tags to text formatting. Use adds a set of font boxes to simulate classic stencil redactions.
/:cl:

The tag in action. (Screenshot taken from [this suggestion](https://forums.baystation12.net/threads/persistent-ingame-reports.8742/) I'm working on.
![redacted](https://user-images.githubusercontent.com/3452002/74100349-449dea00-4b2e-11ea-96b8-980342d055c0.png)