### PR TITLE
Ports pull rotations

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -131,6 +131,7 @@ default behaviour is:
 		now_pushing = 0
 		spawn(0)
 			..()
+			var/saved_dir = AM.dir
 			if (!istype(AM, /atom/movable) || AM.anchored)
 				if(confused && prob(50) && !MOVING_DELIBERATELY(src))
 					Weaken(2)
@@ -157,6 +158,8 @@ default behaviour is:
 					for(var/obj/item/grab/G in M.grabbed_by)
 						step(G.assailant, get_dir(G.assailant, AM))
 						G.adjust_position()
+				if(saved_dir)
+					AM.set_dir(saved_dir)
 				now_pushing = 0
 
 /proc/swap_density_check(var/mob/swapper, var/mob/swapee)
@@ -170,7 +173,8 @@ default behaviour is:
 			return 1
 
 /mob/living/proc/can_swap_with(var/mob/living/tmob)
-	if(tmob.buckled || buckled)
+	if(!tmob) return
+	if(tmob.buckled || buckled || tmob.anchored)
 		return 0
 	//BubbleWrap: people in handcuffs are always switched around as if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
 	if(!(tmob.mob_always_swap || (tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || src.restrained())))
@@ -562,7 +566,10 @@ default behaviour is:
 	if(!can_pull())
 		stop_pulling()
 		return
-	
+
+	if(pulling.loc == loc || pulling.loc == old_loc)
+		return
+
 	if (!isliving(pulling))
 		step(pulling, get_dir(pulling.loc, old_loc))
 	else
@@ -582,6 +589,23 @@ default behaviour is:
 			if(t)
 				M.start_pulling(t)
 
+	handle_dir_after_pull()
+
+/mob/living/proc/handle_dir_after_pull()
+	if(pulling)
+		if(isobj(pulling))
+			var/obj/O = pulling
+			// Hacky check to know if you can pass through the closet
+			if(istype(O, /obj/structure/closet) && !O.density)
+				return set_dir(get_dir(src, pulling))
+			if(O.w_class >= ITEM_SIZE_HUGE || O.density)
+				return set_dir(get_dir(src, pulling))
+		if(isliving(pulling))
+			var/mob/living/L = pulling
+			// If pulled mob was bigger than us, we morelike will turn
+			// I made additional check in case if someone want a hand walk
+			if(L.mob_size > mob_size || L.lying || a_intent != I_HELP)
+				return set_dir(get_dir(src, pulling))
 
 /mob/living/proc/handle_pull_damage(mob/living/puller)
 	var/area/A = get_area(src)


### PR DESCRIPTION
Hello! In this PR I would like to suggest some visual changes in pull mechanic which I made on my fork.
Since last changes to pull make pull looks dorky, I made some changes to make it looks like before, with some checks to avoid unnecessary movement.

1. First, I want to let you compare changes, before and after:
![2020-02-09_20-02-08](https://user-images.githubusercontent.com/44920739/74106910-eef02e80-4b7b-11ea-8625-22b6a2ba7bd1.gif) ![2020-02-09_20-18-51](https://user-images.githubusercontent.com/44920739/74106988-bef55b00-4b7c-11ea-8f5f-4e3ce8dfe2f0.gif)

So this fixes "swaps" with pulling objects, like paper, open crates, etc...

2. And adds some direction rotations for pull. It will automatically reverse your face direction to pulled object. Don't worry, this works only with huge objects like big guns, crates, chairs, etc
![2020-02-09_20-24-19](https://user-images.githubusercontent.com/44920739/74107034-18f62080-4b7d-11ea-9cf4-56a7b39abeaa.gif)
You still can hand walk with help intent like in old times, just set your intent on help!

3. All Bumps now save initial object direction. I made this for visual realism.. I doubt what pushing objects make them rotating self in 180 degree.

4. Fixes AI pull swap. You unable swap places with it if AI anchored self.


 