### PR TITLE
Fixes launchers

### DIFF
--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -66,7 +66,7 @@ SUBSYSTEM_DEF(throwing)
 	src.thrownthing = thrownthing
 	src.target = target
 	src.target_turf = get_turf(target)
-	src.init_dir = get_dir(src, target)
+	src.init_dir = get_dir(thrownthing, target)
 	src.maxrange = range
 	src.speed = speed
 	src.thrower = thrower

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -303,11 +303,13 @@ var/const/enterloopsanity = 100
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, TT.speed)
-		else
-			var/intial_dir = TT.init_dir
-			spawn(2)
-				step(AM, turn(intial_dir, 180))
+			if(M.pinned.len)
+				return
 
+		var/intial_dir = TT.init_dir
+		spawn(2)
+			step(AM, turn(intial_dir, 180))
+				
 /turf/proc/can_engrave()
 	return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -303,6 +303,10 @@ var/const/enterloopsanity = 100
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, TT.speed)
+		else
+			var/intial_dir = TT.init_dir
+			spawn(2)
+				step(AM, turn(intial_dir, 180))
 
 /turf/proc/can_engrave()
 	return FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -303,9 +303,6 @@ var/const/enterloopsanity = 100
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, TT.speed)
-		var/intial_dir = TT.init_dir
-		spawn(2)
-			step(AM, turn(intial_dir, 180))
 
 /turf/proc/can_engrave()
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -360,9 +360,11 @@ meteor_act
 
 		if(momentum >= THROWNOBJ_KNOCKBACK_SPEED)
 			var/dir = TT.init_dir
-
+			
 			visible_message("<span class='warning'>\The [src] staggers under the impact!</span>","<span class='warning'>You stagger under the impact!</span>")
-			src.throw_at(get_edge_target_turf(src,dir),1,momentum)
+
+			if(!src.isinspace())
+				src.throw_at(get_edge_target_turf(src,dir),1,momentum)
 
 			if(!O || !src) return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -339,7 +339,7 @@ meteor_act
 			if (!is_robot_module(I))
 				var/sharp = I.can_embed()
 				var/damage = throw_damage //the effective damage used for embedding purposes, no actual damage is dealt here
-				damage *= (1 - get_blocked_ratio(zone, BRUTE, O.damage_flags(), O.armor_penetration, I.force))
+				damage *= (1 - get_blocked_ratio(zone, BRUTE, O.damage_flags(), O.armor_penetration, throw_damage))
 
 				//blunt objects should really not be embedding in things unless a huge amount of force is involved
 				var/embed_chance = sharp? damage/I.w_class : damage/(I.w_class*3)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -360,7 +360,7 @@ meteor_act
 
 		if(momentum >= THROWNOBJ_KNOCKBACK_SPEED)
 			var/dir = TT.init_dir
-			
+
 			visible_message("<span class='warning'>\The [src] staggers under the impact!</span>","<span class='warning'>You stagger under the impact!</span>")
 
 			if(!src.isinspace())

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -364,7 +364,7 @@ meteor_act
 			visible_message("<span class='warning'>\The [src] staggers under the impact!</span>","<span class='warning'>You stagger under the impact!</span>")
 
 			if(!src.isinspace())
-				src.throw_at(get_edge_target_turf(src,dir),1,momentum)
+				src.throw_at(get_edge_target_turf(src,dir),1,momentum - THROWNOBJ_KNOCKBACK_SPEED)
 
 			if(!O || !src) return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -194,7 +194,7 @@
 /mob/living/proc/turf_collision(var/turf/T, var/speed)
 	visible_message("<span class='danger'>[src] slams into \the [T]!</span>")
 	playsound(T, 'sound/effects/bangtaper.ogg', 50, 1, 1)//so it plays sounds on the turf instead, makes for awesome carps to hull collision and such
-	apply_damage(speed*5, BRUTE)
+	apply_damage(speed*2, BRUTE)
 
 /mob/living/proc/near_wall(var/direction,var/distance=1)
 	var/turf/T = get_step(get_turf(src),direction)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 502 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 501 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 501 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 502 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
:cl: Imienny
bugfix: Fixed crossbow & spike thrower wall pins.
bugfix: Probably fixed some thrown objects being able to pass through obstacles.
bugfix: Thrown objects now correctly use throw force instead of force for effect tests like embed.
tweak: Significantly reduced damage to thrown mobs from hitting walls.
tweak: Disabled thrown object knock-back in space.
/:cl:

Fixes https://github.com/Baystation12/Baystation12/issues/27849