### PR TITLE
Bump Surgical borg medicine skill (without microwaves this time)

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -51,7 +51,7 @@
 	emag = /obj/item/weapon/reagent_containers/spray
 	skills = list(
 		SKILL_ANATOMY     = SKILL_PROF,
-		SKILL_MEDICAL     = SKILL_ADEPT,
+		SKILL_MEDICAL     = SKILL_EXPERT,
 		SKILL_CHEMISTRY   = SKILL_ADEPT,
 		SKILL_BUREAUCRACY = SKILL_ADEPT,
 		SKILL_DEVICES     = SKILL_EXPERT


### PR DESCRIPTION
:cl: 
tweak: Bumps medborg medicine skill from Adept to Expert
/:cl:


Right now, Surgical borg module, with its current medical skill, has an rather high chance to fail steps like sawing bones, which pretty much makes the module rather obsolete as attempting the one job you are supposed to do can result in your harming your patient.