### PR TITLE
Sort teleport-to-location lists numerically by zlevel

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -38,8 +38,9 @@
 
 /proc/group_areas_by_z_level(var/list/predicates)
 	. = list()
+	var/enough_digits_to_contain_all_zlevels = 3
 	for(var/area/A in get_filtered_areas(predicates))
-		group_by(., num2text(A.z), A)
+		group_by(., add_zero(num2text(A.z), enough_digits_to_contain_all_zlevels), A)
 
 /*
 	Pick helpers


### PR DESCRIPTION
Currently, `/proc/group_areas_by_z_level` returns areas grouped by their zlevel in the form of `"1" -> list`, `"2" -> list`, `"15" -> list`, and so on. However, since the consumers of these areas then sort by the zlevel alphanumerically, we end up with it being sorted to `"1", "15", "2"`, which isn't what we want - we want `"1", "2", "15"`.

Adding a bit of zero padding sorts that out. The sort now sees `"001", "002", "015"`, which alphanumerically sorts correctly. Presentation to the user is unchanged except that the areas are now correctly sorted (they don't see the additional zeros).

I'm assuming padding to three digits will be enough. If not, at worst it'll revert back to how it currently works, so no biggy - all areas will be present in the list.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->