### PR TITLE
Changes Counselor title to no longer be Psionic

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -196,12 +196,10 @@
 	give_psionic_implant_on_join = FALSE
 
 /datum/job/psychiatrist/equip(var/mob/living/carbon/human/H)
-	if(H.mind.role_alt_title == "Counselor")
-		psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT)
 	if(H.mind.role_alt_title == "Mentalist")
 		psi_faculties = list("[PSI_COERCION]" = PSI_RANK_OPERANT)
 	return ..()
 
 
 /datum/job/psychiatrist/get_description_blurb()
-	return "You are the Counselor. You are psionically awakened, part of a tiny minority, and you are the first and only exposure most of the crew will have to the mentally gifted. Your main responsibility is the mental health and wellbeing of the crew. You are subordinate to the Chief Medical Officer."
+	return "You are the Counselor. Your main responsibility is the mental health and wellbeing of the crew. You are subordinate to the Chief Medical Officer."


### PR DESCRIPTION
Being psionic as a counselor is now a choice. You can either be a counselor with no psi abilities or a psionic mentalist.

This is mostly me figuring out how baycode works and how the github system works.

:cl: Deadmon
tweak: Changes Counselor to no longer have psionics. Mentalists still get psionics. You now have a choice whether you want psionics or not.
/:cl: