### PR TITLE
Adds Gender Announcement Preference Over Radio

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -128,6 +128,11 @@ var/list/_client_preferences_by_type
 	key = "LANGUAGE_DISPLAY"
 	options = list(GLOB.PREF_SHORTHAND, GLOB.PREF_FULL, GLOB.PREF_OFF)
 
+/datum/client_preference/gender_display
+	description = "Display Genders Over Radio"
+	key = "LANGUAGE_GENDER"
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+	
 /datum/client_preference/ghost_follow_link_length
 	description ="Ghost Follow Links"
 	key = "CHAT_GHOSTFOLLOWLINKLENGTH"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -223,6 +223,19 @@
 		formatted = language.format_message_radio(message, nverb)
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>"
+	if(speaker && istype(speaker, /mob/living) && !hard_to_hear) //Machines have no gender and you cannot discern the gender if you can't hear well
+		var/gender = speaker.get_gender()
+		var/gendertext
+		switch(gender)
+			if ("male")
+				gendertext = "M"
+			if ("female")
+				gendertext = "F"
+			if ("plural")
+				gendertext = "P"
+			if ("neuter")
+				gendertext = "N"
+		speaker_name += " \[[gendertext]\]"
 	if(sdisabilities & DEAFENED || ear_deaf)
 		var/mob/living/carbon/human/H = src
 		if(istype(H) && H.has_headset_in_ears() && prob(20))


### PR DESCRIPTION
Adds a "Display Gender Over Radio" preference. Whenever a mob speaks over the radio, its gender will appear after its name. [M] is male, [F] is female, [P] is plural, [N] is neuter. For example:

- Adam Smith [M] says, "..."
- Eve Smith [F] says, "..."
- The Leaves Falling On Snow [P] says, "..."
- Some Neuter Character IDK [N] says, "..."

If the speaker is not a mob (for example, the announcements machine), its gender will not appear. In addition, if the person speaking is Unknown, their gender will not appear (over the radio this is usually due to not being able to hear well).

In addition, this will not happen if they are speaking in person (subject to change), since you can examine them to find out their gender most of the time.
:cl:
rscadd: Added a new preference, "Display Gender Over Radio." When turned on, a mob's gender will be shown to you over the radio: [M] for male, [F] for female, [P] for plural, and [N] for neuter. No more guessing and offending people!
/:cl: