### PR TITLE
Most Input calls now use text|null

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -292,7 +292,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		var/newname
 
 		for(var/i=1,i<=3,i++)	//we get 3 attempts to pick a suitable name.
-			newname = input(src,"You are \a [role]. Would you like to change your name to something else?", "Name change",oldname) as text
+			newname = input(src,"You are \a [role]. Would you like to change your name to something else?", "Name change",oldname) as text|null
 			if((world.time-time_passed)>3000)
 				return	//took too long
 			newname = sanitizeName(newname, ,allow_numbers)	//returns null if the name doesn't meet some basic requirements. Tidies up a few other things like bad-characters.

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -104,7 +104,7 @@
 	M.maptext = "Movable"
 	M.maptext_width = 64
 
-	var/screen_l = input(usr,"Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)","Spawn Movable UI Object") as text
+	var/screen_l = input(usr,"Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)","Spawn Movable UI Object") as text|null
 	if(!screen_l)
 		return
 
@@ -123,7 +123,7 @@
 	S.maptext = "Snap"
 	S.maptext_width = 64
 
-	var/screen_l = input(usr,"Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)","Spawn Snap UI Object") as text
+	var/screen_l = input(usr,"Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)","Spawn Snap UI Object") as text|null
 	if(!screen_l)
 		return
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -823,7 +823,7 @@ var/list/turret_icons
 				return
 
 	if(istype(I, /obj/item/weapon/pen))	//you can rename turrets like bots!
-		var/t = sanitizeSafe(input(user, "Enter new turret name", name, finish_name) as text, MAX_NAME_LEN)
+		var/t = sanitizeSafe(input(user, "Enter new turret name", name, finish_name) as text|null, MAX_NAME_LEN)
 		if(!t)
 			return
 		if(!in_range(src, usr) && loc != usr)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -43,6 +43,8 @@
 /obj/structure/closet/body_bag/attackby(var/obj/item/W, mob/user as mob)
 	if (istype(W, /obj/item/weapon/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text|null
+		if(isnull(t))
+			return
 		if (user.get_active_hand() != W)
 			return
 		if (!in_range(src, user) && src.loc != user)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -42,7 +42,7 @@
 
 /obj/structure/closet/body_bag/attackby(var/obj/item/W, mob/user as mob)
 	if (istype(W, /obj/item/weapon/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
+		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text|null
 		if (user.get_active_hand() != W)
 			return
 		if (!in_range(src, user) && src.loc != user)

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -46,7 +46,7 @@
 		H.attack_same = 0
 		H.friends += weakref(user)
 	L.desc += "<br><span class='notice'>It looks especially docile.</span>"
-	var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text
+	var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text|null
 	if(length(name))
 		L.real_name = name
 		L.SetName(name)

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -22,7 +22,7 @@
 		to_chat(user, "<span class='warning'>\The [src] needs to recharge!</span>")
 		return
 
-	var/message = sanitize(input(user, "Shout a message?", "Megaphone", null)  as text)
+	var/message = sanitize(input(user, "Shout a message?", "Megaphone", null)  as text|null)
 	if(!message)
 		return
 	message = capitalize(message)

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -20,7 +20,7 @@
 		return
 
 	var/new_message = input(usr, "Please enter new message (leave blank to reset).") as text|null
-	if(isnull(message))
+	if(isnull(new_message))
 		return
 	if(!new_message || new_message == "")
 		use_message = "Halt! Security!"

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -20,6 +20,8 @@
 		return
 
 	var/new_message = input(usr, "Please enter new message (leave blank to reset).") as text|null
+	if(isnull(message))
+		return
 	if(!new_message || new_message == "")
 		use_message = "Halt! Security!"
 	else

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -19,7 +19,7 @@
 		to_chat(usr, "The hailer is fried. The tiny input screen just shows a waving ASCII penis.")
 		return
 
-	var/new_message = input(usr, "Please enter new message (leave blank to reset).") as text
+	var/new_message = input(usr, "Please enter new message (leave blank to reset).") as text|null
 	if(!new_message || new_message == "")
 		use_message = "Halt! Security!"
 	else

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -37,7 +37,7 @@
 		if(signed_by)
 			to_chat(user, SPAN_WARNING("\The [src] has already been signed."))
 		else
-			var/signature = sanitizeSafe(input("What do you want to sign the card as?", "Union Card") as text, MAX_NAME_LEN)
+			var/signature = sanitizeSafe(input("What do you want to sign the card as?", "Union Card") as text|null, MAX_NAME_LEN)
 			if(signature && !signed_by && !user.incapacitated() && Adjacent(user))
 				signed_by = signature
 				user.visible_message(SPAN_NOTICE("\The [user] signs \the [src] with a flourish."))

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -110,13 +110,13 @@
 					to_chat(user, "<span class='notice'>Age has been set to '[age]'.</span>")
 					. = 1
 			if("Prefix")
-				var/new_prefix = sanitizeSafe(input(user,"What title prefix would you like to put on this card?","Agent Card Prefix", age) as text, MAX_NAME_LEN)
+				var/new_prefix = sanitizeSafe(input(user,"What title prefix would you like to put on this card?","Agent Card Prefix", age) as text|null, MAX_NAME_LEN)
 				if(!isnull(new_prefix) && CanUseTopic(user, state))
 					formal_name_prefix = new_prefix
 					to_chat(user, "<span class='notice'>Title prefix has been set to '[formal_name_prefix]'.</span>")
 					. = 1
 			if("Suffix")
-				var/new_suffix = sanitizeSafe(input(user,"What title suffix would you like to put on this card?","Agent Card Suffix", age) as text, MAX_NAME_LEN)
+				var/new_suffix = sanitizeSafe(input(user,"What title suffix would you like to put on this card?","Agent Card Suffix", age) as text|null, MAX_NAME_LEN)
 				if(!isnull(new_suffix) && CanUseTopic(user, state))
 					formal_name_suffix = new_suffix
 					to_chat(user, "<span class='notice'>Title suffix has been set to '[formal_name_suffix]'.</span>")

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -150,7 +150,7 @@
 	if(!elevel)
 		elevel = alert("What sort of explosion would you prefer?", "Implant Intent", "Localized Limb", "Destroy Body", "Full Explosion")
 	if(!phrase)
-		phrase = sanitize_phrase(input("Choose activation phrase:") as text)
+		phrase = sanitize_phrase(input("Choose activation phrase:") as text|null)
 	if(!phrase)
 		return
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -94,7 +94,7 @@
 
 /obj/structure/morgue/attackby(P as obj, mob/user as mob)
 	if (istype(P, /obj/item/weapon/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
+		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text|null
 		if (user.get_active_hand() != P)
 			return
 		if ((!in_range(src, usr) && src.loc != user))
@@ -258,7 +258,7 @@
 
 /obj/structure/crematorium/attackby(P as obj, mob/user as mob)
 	if(istype(P, /obj/item/weapon/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
+		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text|null
 		if(user.get_active_hand() != P)
 			return
 		if((!in_range(src, usr) > 1 && src.loc != user))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -95,6 +95,8 @@
 /obj/structure/morgue/attackby(P as obj, mob/user as mob)
 	if (istype(P, /obj/item/weapon/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text|null
+		if(isnull(t))
+			return
 		if (user.get_active_hand() != P)
 			return
 		if ((!in_range(src, usr) && src.loc != user))
@@ -259,6 +261,8 @@
 /obj/structure/crematorium/attackby(P as obj, mob/user as mob)
 	if(istype(P, /obj/item/weapon/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text|null
+		if(isnull(t))
+			return
 		if(user.get_active_hand() != P)
 			return
 		if((!in_range(src, usr) > 1 && src.loc != user))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -742,7 +742,7 @@ var/list/admin_verbs_mod = list(
 	switch(alert("Are you sure you wish to edit this mob's appearance? Skrell, Unathi and Vox can result in unintended consequences.",,"Yes","No"))
 		if("No")
 			return
-	var/new_facial = input("Please select facial hair color.", "Character Generation") as color
+	var/new_facial = input("Please select facial hair color.", "Character Generation") as color|null
 	if(new_facial)
 		M.r_facial = hex2num(copytext(new_facial, 2, 4))
 		M.g_facial = hex2num(copytext(new_facial, 4, 6))
@@ -767,7 +767,7 @@ var/list/admin_verbs_mod = list(
 		M.g_skin = hex2num(copytext(new_skin, 4, 6))
 		M.b_skin = hex2num(copytext(new_skin, 6, 8))
 
-	var/new_tone = input("Please select skin tone level: 1-220 (1=albino, 35=caucasian, 150=black, 220='very' black)", "Character Generation")  as text
+	var/new_tone = input("Please select skin tone level: 1-220 (1=albino, 35=caucasian, 150=black, 220='very' black)", "Character Generation")  as text|null
 
 	if (new_tone)
 		M.s_tone = max(min(round(text2num(new_tone)), 220), 1)

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -234,7 +234,7 @@ proc/get_open_ticket_by_client(var/datum/client_lite/owner)
 				if(!admin_found)
 					to_chat(usr, "<span class='warning'>Error: Private-Message: Client not found. They may have lost connection, so please be patient!</span>")
 			else
-				usr.client.adminhelp(input(usr,"", "adminhelp \"text\"") as text)
+				usr.client.adminhelp(input(usr,"", "adminhelp \"text\"") as text|null)
 
 /client/verb/view_tickets()
 	set name = "View Tickets"

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -260,13 +260,13 @@ var/list/debug_verbs = list (
 /client/proc/count_objects_on_z_level()
 	set category = "Mapping"
 	set name = "Count Objects On Level"
-	var/level = input("Which z-level?","Level?") as text
+	var/level = input("Which z-level?","Level?") as text|null
 	if(!level) return
 	var/num_level = text2num(level)
 	if(!num_level) return
 	if(!isnum(num_level)) return
 
-	var/type_text = input("Which type path?","Path?") as text
+	var/type_text = input("Which type path?","Path?") as text|null
 	if(!type_text) return
 	var/type_path = text2path(type_text)
 	if(!type_path) return
@@ -304,7 +304,7 @@ var/list/debug_verbs = list (
 	set category = "Mapping"
 	set name = "Count Objects All"
 
-	var/type_text = input("Which type path?","") as text
+	var/type_text = input("Which type path?","") as text|null
 	if(!type_text) return
 	var/type_path = text2path(type_text)
 	if(!type_path) return

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -1,4 +1,4 @@
-// This system is used to grab a ghost from observers with the required preferences 
+// This system is used to grab a ghost from observers with the required preferences
 // and lack of bans set. See posibrain.dm for an example of how they are called/used.
 
 var/list/ghost_traps
@@ -121,7 +121,7 @@ var/list/ghost_traps
 	if(!can_set_own_name)
 		return
 
-	var/newname = sanitizeSafe(input(target,"Enter a name, or leave blank for the default name.", "Name change",target.real_name) as text, MAX_NAME_LEN)
+	var/newname = sanitizeSafe(input(target,"Enter a name, or leave blank for the default name.", "Name change",target.real_name) as text|null, MAX_NAME_LEN)
 	if (newname && newname != "")
 		target.real_name = newname
 		target.SetName(target.real_name)

--- a/code/modules/integrated_electronics/core/special_pins/char_pin.dm
+++ b/code/modules/integrated_electronics/core/special_pins/char_pin.dm
@@ -3,7 +3,9 @@
 	name = "char pin"
 
 /datum/integrated_io/char/ask_for_pin_data(mob/user)
-	var/new_data = input(user, "Please type in one character.", "[src] char writing]") as text
+	var/new_data = input(user, "Please type in one character.", "[src] char writing]") as text|null
+	if(!new_data)
+		return //Canceling the window should not set the pin to null
 	new_data = sanitize(new_data, 1, trim=0)
 	if(holder.check_interactivity(user) )
 		to_chat(user, "<span class='notice'>You input [new_data ? "new_data" : "NULL"] into the pin.</span>")

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -143,7 +143,7 @@
 		return
 
 	to_chat(user, "<span class='notice'>The crate is locked with a Deca-code lock.</span>")
-	var/input = input(user, "Enter [codelen] digits.", "Deca-Code Lock", "") as text
+	var/input = input(user, "Enter [codelen] digits.", "Deca-Code Lock", "") as text|null
 	if(!Adjacent(user))
 		return
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -346,7 +346,7 @@
 	set desc = "Sets a description which will be shown when someone examines you."
 	set category = "IC"
 
-	pose =  sanitize(input(usr, "This is [src]. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"]...", "Pose", null)  as text)
+	pose =  sanitize(input(usr, "This is [src]. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"]...", "Pose", null)  as text|null)
 
 /mob/living/carbon/human/verb/set_flavor()
 	set name = "Set Flavour Text"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -346,7 +346,10 @@
 	set desc = "Sets a description which will be shown when someone examines you."
 	set category = "IC"
 
-	pose =  sanitize(input(usr, "This is [src]. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"]...", "Pose", null)  as text|null)
+	var/posetext = sanitize(input(usr, "This is [src]. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"]...", "Pose", null)  as text|null)
+	if(isnull(posetext))
+		return
+	pose = posetext
 
 /mob/living/carbon/human/verb/set_flavor()
 	set name = "Set Flavour Text"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -769,7 +769,7 @@
 		b_eyes = hex2num(copytext(new_eyes, 6, 8))
 		update_eyes()
 
-	var/new_tone = input("Please select skin tone level: 1-220 (1=albino, 35=caucasian, 150=black, 220='very' black)", "Character Generation", "[35-s_tone]")  as text|null
+	var/new_tone = input("Please select skin tone level: 1-220 (1=albino, 35=caucasian, 150=black, 220='very' black)", "Character Generation", "[35-s_tone]")  as text
 
 	if (!new_tone)
 		new_tone = 35

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -769,7 +769,7 @@
 		b_eyes = hex2num(copytext(new_eyes, 6, 8))
 		update_eyes()
 
-	var/new_tone = input("Please select skin tone level: 1-220 (1=albino, 35=caucasian, 150=black, 220='very' black)", "Character Generation", "[35-s_tone]")  as text
+	var/new_tone = input("Please select skin tone level: 1-220 (1=albino, 35=caucasian, 150=black, 220='very' black)", "Character Generation", "[35-s_tone]")  as text|null
 
 	if (!new_tone)
 		new_tone = 35

--- a/code/modules/mob/living/deity/deity.dm
+++ b/code/modules/mob/living/deity/deity.dm
@@ -97,7 +97,7 @@
 	to_chat(src, "<span class='notice'>You undergo a transformation into your new form!</span>")
 	spawn(1)
 		SetName(form.name)
-		var/newname = sanitize(input(src, "Choose a name for your new form.", "Name change", form.name) as text, MAX_NAME_LEN)
+		var/newname = sanitize(input(src, "Choose a name for your new form.", "Name change", form.name) as text|null, MAX_NAME_LEN)
 		if(newname)
 			fully_replace_character_name(newname)
 	src.verbs -= /mob/living/deity/verb/choose_form

--- a/code/modules/mob/living/deity/phenomena/communication.dm
+++ b/code/modules/mob/living/deity/phenomena/communication.dm
@@ -6,7 +6,7 @@
 	expected_type = /mob/living
 
 /datum/phenomena/communicate/activate(var/mob/living/L)
-	var/text_to_send = sanitize(input(linked, "Subjugate a member to your will", "Message a Believer") as text)
+	var/text_to_send = sanitize(input(linked, "Subjugate a member to your will", "Message a Believer") as text|null)
 	if(text_to_send)
 		var/text_size = 4
 		if(!linked.is_follower(L))

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -57,19 +57,19 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 
 		switch(option)
 			if("name")
-				t = sanitizeSafe(input("Enter a name for your pAI", "pAI Name", candidate.name) as text, MAX_NAME_LEN)
+				t = sanitizeSafe(input("Enter a name for your pAI", "pAI Name", candidate.name) as text|null, MAX_NAME_LEN)
 				if(t)
 					candidate.name = t
 			if("desc")
-				t = input("Enter a description for your pAI", "pAI Description", candidate.description) as message
+				t = input("Enter a description for your pAI", "pAI Description", candidate.description) as message|null
 				if(t)
 					candidate.description = sanitize(t)
 			if("role")
-				t = input("Enter a role for your pAI", "pAI Role", candidate.role) as text
+				t = input("Enter a role for your pAI", "pAI Role", candidate.role) as text|null
 				if(t)
 					candidate.role = sanitize(t)
 			if("ooc")
-				t = input("Enter any OOC comments", "pAI OOC Comments", candidate.comments) as message
+				t = input("Enter any OOC comments", "pAI OOC Comments", candidate.comments) as message|null
 				if(t)
 					candidate.comments = sanitize(t)
 			if("save")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -351,7 +351,7 @@
 
 	spawn(0)
 		var/newname
-		newname = sanitizeName(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN, allow_numbers = 1)
+		newname = sanitizeName(input(src,"You are a robot. Enter a name, or leave blank for the default name.", "Name change","") as text|null, MAX_NAME_LEN, allow_numbers = 1)
 		if (newname)
 			custom_name = newname
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -307,7 +307,7 @@
 /obj/item/weapon/pen/robopen/proc/RenamePaper(mob/user, obj/item/weapon/paper/paper)
 	if ( !user || !paper )
 		return
-	var/n_name = sanitizeSafe(input(user, "What would you like to label the paper?", "Paper Labelling", null)  as text, 32)
+	var/n_name = sanitizeSafe(input(user, "What would you like to label the paper?", "Paper Labelling", null)  as text|null, 32)
 	if ( !user || !paper )
 		return
 
@@ -573,7 +573,7 @@
 		if(istype(A, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			generating_power = base_power_generation
 			using_item = A
-		else 
+		else
 			for(var/fuel_type in fuel_types)
 				if(istype(A, fuel_type))
 					generating_power = fuel_types[fuel_type] * base_power_generation

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -308,7 +308,7 @@
 	if ( !user || !paper )
 		return
 	var/n_name = sanitizeSafe(input(user, "What would you like to label the paper?", "Paper Labelling", null)  as text|null, 32)
-	if ( !user || !paper )
+	if ( !user || !paper || isnull(paper))
 		return
 
 	//n_name = copytext(n_name, 1, 32)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -248,7 +248,10 @@
 	set desc = "Sets a description which will be shown when someone examines you."
 	set category = "IC"
 
-	pose =  sanitize(input(usr, "This is [src]. It...", "Pose", null)  as text|null)
+	var/posetext = sanitize(input(usr, "This is [src]. It...", "Pose", null)  as text|null)
+	if(isnull(posetext))
+		return
+	pose =  posetext
 
 /mob/living/silicon/verb/set_flavor()
 	set name = "Set Flavour Text"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -248,14 +248,14 @@
 	set desc = "Sets a description which will be shown when someone examines you."
 	set category = "IC"
 
-	pose =  sanitize(input(usr, "This is [src]. It...", "Pose", null)  as text)
+	pose =  sanitize(input(usr, "This is [src]. It...", "Pose", null)  as text|null)
 
 /mob/living/silicon/verb/set_flavor()
 	set name = "Set Flavour Text"
 	set desc = "Sets an extended description of your character's features."
 	set category = "IC"
 
-	flavor_text =  sanitize(input(usr, "Please enter your new flavour text.", "Flavour text", null)  as text)
+	flavor_text =  sanitize(input(usr, "Please enter your new flavour text.", "Flavour text", null)  as text|null)
 
 /mob/living/silicon/binarycheck()
 	return 1

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -41,14 +41,14 @@ I IS TYPIN'!'
 
 /mob/Logout()
 	remove_typing_indicator()
-	. = ..()	
+	. = ..()
 
 /mob/verb/say_wrapper()
 	set name = ".Say"
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","say (text)") as text
+	var/message = input("","say (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		say_verb(message)
@@ -58,7 +58,7 @@ I IS TYPIN'!'
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","me (text)") as text
+	var/message = input("","me (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		me_verb(message)

--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -31,7 +31,7 @@
 			to_chat(user, "<span class='warning'>Nonstandard names are not subject to real-time modification under [PROTOCOL_ARTICLE].</span>")
 			return
 
-		var/newname = sanitizeSafe(input(user, "Enter a new ident.", "Reset Ident") as text, MAX_NAME_LEN)
+		var/newname = sanitizeSafe(input(user, "Enter a new ident.", "Reset Ident") as text|null, MAX_NAME_LEN)
 		if(newname)
 			var/confirm = input(user, "Are you sure you wish your name to become [newname] [res]?","Reset Ident") as anything in list("No", "Yes")
 			if(confirm == "Yes" && owner && user == owner && !owner.incapacitated() && world.time >= next_rename)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -128,6 +128,8 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	if (href_list["add"])
 		var/datum/computer_file/data/waypoint/R = new()
 		var/sec_name = input("Input naviation entry name", "New navigation entry", "Sector #[known_sectors.len]") as text|null
+		if(isnull(sec_name))
+			return
 		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(!sec_name)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -127,7 +127,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 	if (href_list["add"])
 		var/datum/computer_file/data/waypoint/R = new()
-		var/sec_name = input("Input naviation entry name", "New navigation entry", "Sector #[known_sectors.len]") as text
+		var/sec_name = input("Input naviation entry name", "New navigation entry", "Sector #[known_sectors.len]") as text|null
 		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(!sec_name)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -38,7 +38,7 @@
 		to_chat(user, "<span class='notice'>You put the [W] into \the [src].</span>")
 		update_icon()
 	else if(istype(W, /obj/item/weapon/pen))
-		var/n_name = sanitizeSafe(input(usr, "What would you like to label the folder?", "Folder Labelling", null)  as text, MAX_NAME_LEN)
+		var/n_name = sanitizeSafe(input(usr, "What would you like to label the folder?", "Folder Labelling", null)  as text|null, MAX_NAME_LEN)
 		if((loc == usr && usr.stat == 0))
 			SetName("folder[(n_name ? text("- '[n_name]'") : null)]")
 	return
@@ -68,7 +68,7 @@
 			if(P && (P.loc == src) && istype(P))
 				usr.put_in_hands(P)
 
-		else if(href_list["read"])			
+		else if(href_list["read"])
 			var/obj/item/weapon/paper/P = locate(href_list["read"])
 			if(P && (P.loc == src) && istype(P))
 				if(!(istype(usr, /mob/living/carbon/human) || isghost(usr) || istype(usr, /mob/living/silicon)))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -95,7 +95,7 @@
 	if((MUTATION_CLUMSY in usr.mutations) && prob(50))
 		to_chat(usr, "<span class='warning'>You cut yourself on the paper.</span>")
 		return
-	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null)  as text, MAX_NAME_LEN)
+	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null)  as text|null, MAX_NAME_LEN)
 
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/weapon/photo/rename()
 	if(!n_name || !CanInteract(usr, GLOB.deep_inventory_state))
@@ -293,7 +293,7 @@
 					return
 			else
 				return
-		
+
 		var/obj/item/weapon/pen/P = I
 		if(!P.active)
 			P.toggle()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -65,7 +65,7 @@
 	var/sheet_name = istype(sheet, /obj/item/weapon/photo) ? "photo" : "sheet of paper"
 	bundle_name = (bundle_name == name) ? "the [bundle_name]" : name
 	sheet_name = (sheet_name == sheet.name) ? "the [sheet_name]" : sheet.name
-	
+
 	to_chat(user, "<span class='notice'>You add [sheet_name] to [bundle_name].</span>")
 	pages.Insert(index, sheet)
 	if(index <= page)
@@ -187,7 +187,7 @@
 	set category = "Object"
 	set src in usr
 
-	var/n_name = sanitizeSafe(input(usr, "What would you like to label the bundle?", "Bundle Labelling", null)  as text, MAX_NAME_LEN)
+	var/n_name = sanitizeSafe(input(usr, "What would you like to label the bundle?", "Bundle Labelling", null)  as text|null, MAX_NAME_LEN)
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
 		SetName("[(n_name ? text("[n_name]") : "paper")]")
 	add_fingerprint(usr)

--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -33,7 +33,7 @@
 		if(writing_space <= 0)
 			to_chat(user, SPAN_WARNING("There is no room left on \the [src]."))
 			return
-		var/text = sanitizeSafe(input("What would you like to write?") as text, writing_space)
+		var/text = sanitizeSafe(input("What would you like to write?") as text|null, writing_space)
 		if(!text || thing.loc != user || (!Adjacent(user) && loc != user) || user.incapacitated())
 			return
 		user.visible_message(SPAN_NOTICE("\The [user] jots a note down on \the [src]."))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -59,7 +59,7 @@ var/global/photo_count = 0
 
 /obj/item/weapon/photo/attackby(obj/item/weapon/P as obj, mob/user as mob)
 	if(istype(P, /obj/item/weapon/pen))
-		var/txt = sanitize(input(user, "What would you like to write on the back?", "Photo Writing", null)  as text, 128)
+		var/txt = sanitize(input(user, "What would you like to write on the back?", "Photo Writing", null)  as text|null, 128)
 		if(loc == user && user.stat == 0)
 			scribble = txt
 	..()
@@ -90,7 +90,7 @@ var/global/photo_count = 0
 	set category = "Object"
 	set src in usr
 
-	var/n_name = sanitizeSafe(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text, MAX_NAME_LEN)
+	var/n_name = sanitizeSafe(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text|null, MAX_NAME_LEN)
 	//loc.loc check is for making possible renaming photos in clipboards
 	if(!n_name || !CanInteract(usr, GLOB.deep_inventory_state))
 		return

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -86,7 +86,7 @@
 
 /obj/machinery/power/breakerbox/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(isMultitool(W))
-		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
+		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text|null
 		if(newtag)
 			RCon_tag = newtag
 			to_chat(user, "<span class='notice'>You changed the RCON tag to: [newtag]</span>")

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -347,7 +347,7 @@
 
 		// Multitool - change RCON tag
 		if(isMultitool(W))
-			var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
+			var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text|null
 			if(newtag)
 				RCon_tag = newtag
 				to_chat(user, "<span class='notice'>You changed the RCON tag to: [newtag]</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2800,7 +2800,7 @@
 		if( src.open )
 			return
 
-		var/t = sanitize(input("Enter what you want to add to the tag:", "Write", null, null) as text, 30)
+		var/t = sanitize(input("Enter what you want to add to the tag:", "Write", null, null) as text|null, 30)
 
 		var/obj/item/pizzabox/boxtotagto = src
 		if( boxes.len > 0 )

--- a/maps/antag_spawn/heist/heist.dm
+++ b/maps/antag_spawn/heist/heist.dm
@@ -73,7 +73,7 @@
 				if(user.mind)
 					user.mind.transfer_to(vox)
 				spawn(1)
-					var/newname = sanitizeSafe(input(vox,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
+					var/newname = sanitizeSafe(input(vox,"Enter a name, or leave blank for the default name.", "Name change","") as text|null, MAX_NAME_LEN)
 					if(!newname || newname == "")
 						var/decl/cultural_info/voxculture = SSculture.get_culture(CULTURE_VOX_RAIDER)
 						newname = voxculture.get_random_name()


### PR DESCRIPTION
This adds a cancel button to them which is very useful if someone needs to stop speaking or otherwise back out of the window quickly. Most of them have fallbacks for if no input is given anyway, so this shouldn't cause any errors. However, a few cases were intentionally left unmodified since it wouldn't make sense for them to be cancelable.

:cl:
tweak: Most input boxes now have a cancel button. Now you don't have to erase your whole message if you decide not to say anything.
/:cl: