### PR TITLE
Bump and monospace BYOND version in SECURITY.md

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-This repository is built and tested against BYOND version 512.1483 at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [.travis.yml](https://github.com/Baystation12/Baystation12/blob/dev/.travis.yml#L8) in the repository root folder, the Travis configuration should be considered authoritative and this document should be noted as out of date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
+This repository is built and tested against BYOND version `512.1485` at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [.travis.yml](https://github.com/Baystation12/Baystation12/blob/dev/.travis.yml#L8) in the repository root folder, the Travis configuration should be considered authoritative and this document should be noted as out of date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Bump (and `monospace`) BYOND version in SECURITY.md, per `travis.yml`

Housekeeping