### PR TITLE
Tweaks atmosprogram. Fixes Atmos alarm environmental modes

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -421,13 +421,13 @@
 
 		if(AALARM_MODE_PANIC, AALARM_MODE_CYCLE)
 			for(var/device_id in alarm_area.air_scrub_names)
-				send_signal(device_id, list("set_power"= 1, "panic_siphon"= 1) )
+				send_signal(device_id, list("set_power"= 1, "set_scrubbing"= SCRUBBER_SIPHON, "panic_siphon"= 1) )
 			for(var/device_id in alarm_area.air_vent_names)
 				send_signal(device_id, list("set_power"= 0) )
 
 		if(AALARM_MODE_REPLACEMENT)
 			for(var/device_id in alarm_area.air_scrub_names)
-				send_signal(device_id, list("set_power"= 1, "panic_siphon"= 1) )
+				send_signal(device_id, list("set_power"= 1, "set_scrubbing"= SCRUBBER_SIPHON, "panic_siphon"= 1) )
 			for(var/device_id in alarm_area.air_vent_names)
 				send_signal(device_id, list("set_power"= 1, "set_checks"= "default", "set_external_pressure"= "default") )
 

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -51,11 +51,22 @@
 /datum/nano_module/atmos_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/master_ui = null, var/datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 	var/alarms[0]
+	var/alarmsAlert[0]
+	var/alarmsDanger[0]
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : SSmachines.machinery))
-		alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = max(alarm.danger_level, alarm.alarm_area.atmosalm))
+		var/danger_level = max(alarm.danger_level, alarm.alarm_area.atmosalm)
+		if(danger_level == 2)
+			alarmsAlert[++alarmsAlert.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
+		else if(danger_level == 1)
+			alarmsDanger[++alarmsDanger.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
+		else
+			alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
+	
 	data["alarms"] = alarms
+	data["alarmsAlert"] = alarmsAlert
+	data["alarmsDanger"] = alarmsDanger
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)

--- a/nano/templates/atmos_control.tmpl
+++ b/nano/templates/atmos_control.tmpl
@@ -1,5 +1,15 @@
 <div class='item'>
+	{{for data.alarmsAlert}}
+        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, 'redButton')}}
+    {{/for}}
+</div>
+<div class='item'>
+    {{for data.alarmsDanger}}
+        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, 'yellowButton'))}}
+    {{/for}}
+</div>
+<div class='item'>
     {{for data.alarms}}
-        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, value.danger == 2 ? 'redButton' : (value.danger == 1 ? 'yellowButton' : null))}}
+        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, null)}}
     {{/for}}
 </div>


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: YodaDoge
tweak: Atmosphere Control Program now shows alarms with alerts on top
bugfix: Air Alarm environmental modes will now set scrubbers to siphoning correctly
/:cl:

