### PR TITLE
Fix Scrubber Siphon

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -279,7 +279,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		machine.scrubbing = new_value
+		machine.panic = new_value
 		if(machine.panic)
 			machine.update_use_power(POWER_USE_IDLE)
 			machine.scrubbing = SCRUBBER_SIPHON


### PR DESCRIPTION
credit to @afterthought2
🆑 afterthought2
bugfix: Air Alarm environmental modes will now set scrubbers to siphoning correctly
/🆑