### PR TITLE
Hardsuit pieces can no longer be retracted while the hardsuit is active

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -728,6 +728,9 @@
 			if(use_obj)
 				holder = use_obj.loc
 				if(istype(holder))
+					if (!canremove)
+						to_chat(wearer, "<span class='warning'>You cannot disengage your [use_obj.name] while your hardsuit is active.")
+						return
 					if(use_obj && check_slot == use_obj)
 						to_chat(wearer, "<font color='blue'><b>Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.</b></font>")
 						use_obj.canremove = 1

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -729,7 +729,7 @@
 				holder = use_obj.loc
 				if(istype(holder))
 					if (!canremove)
-						to_chat(wearer, "<span class='warning'>You cannot disengage your [use_obj.name] while your hardsuit is active.")
+						to_chat(wearer, "<span class='warning'>You cannot disengage your [use_obj.name] while your hardsuit is active.</span>")
 						return
 					if(use_obj && check_slot == use_obj)
 						to_chat(wearer, "<font color='blue'><b>Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.</b></font>")


### PR DESCRIPTION
This makes it so that, if a hardsuit is active, you cannot toggle any of the individual pieces. Since the hardsuit is meant to create an airtight seal around your person by adjusting each component in a lengthy sequence (as shown when you deploy it), it makes little sense to be able to break that seal and retract a piece, and then be able to deploy that piece and re-establish that seal on a whim. At least not without an additional progress bar.

Voidsuits are not included in this since they are fundamentally different and do not have initialization procedures.

:cl:
tweak: You can no longer remove individual pieces from your hardsuit while it's active. Disengage it first.
/:cl: