### PR TITLE
implements species exertion

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1695,6 +1695,7 @@
 #include "code\modules\emotes\definitions\adherent.dm"
 #include "code\modules\emotes\definitions\ascent.dm"
 #include "code\modules\emotes\definitions\audible.dm"
+#include "code\modules\emotes\definitions\exertion.dm"
 #include "code\modules\emotes\definitions\human.dm"
 #include "code\modules\emotes\definitions\slime.dm"
 #include "code\modules\emotes\definitions\synthetics.dm"

--- a/code/modules/emotes/definitions/exertion.dm
+++ b/code/modules/emotes/definitions/exertion.dm
@@ -1,0 +1,41 @@
+
+/decl/emote/exertion/biological
+	key = "esweat"
+	emote_range = 4
+	emote_message_1p = "You are sweating heavily."
+	emote_message_3p = "USER is sweating heavily."
+
+/decl/emote/exertion/biological/check_user(mob/living/user)
+	if(istype(user) && !user.isSynthetic())
+		return ..()
+	return FALSE
+
+/decl/emote/exertion/biological/breath
+	key = "ebreath"
+	emote_message_1p = "You feel out of breath."
+	emote_message_3p = "USER looks out of breath."
+
+/decl/emote/exertion/biological/pant
+	key = "epant"
+	emote_range = 3
+	message_type = AUDIBLE_MESSAGE
+	emote_message_1p = "You pant to catch your breath."
+	emote_message_3p = "USER pants for air."
+	emote_message_impaired = "You can see USER breathing heavily."
+
+/decl/emote/exertion/synthetic
+	key = "ewhine"
+	emote_range = 3
+	message_type = AUDIBLE_MESSAGE
+	emote_message_1p = "You overstress your actuators."
+	emote_message_3p = "USER's actuators whine with strain."
+
+/decl/emote/exertion/synthetic/check_user(mob/living/user)
+	if(istype(user) && user.isSynthetic())
+		return ..()
+	return FALSE
+
+/decl/emote/exertion/synthetic/creak
+	key = "ecreak"
+	emote_message_1p = "Your chassis stress indicators spike."
+	emote_message_3p = "USER's joints creak with stress."

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -18,6 +18,7 @@
 	var/targetted_emote                // Whether or not this emote needs a target.
 	var/check_restraints               // Can this emote be used while restrained?
 	var/conscious = 1				   // Do we need to be awake to emote this?
+	var/emote_range = 0                // If >0, restricts emote visibility to viewers within range.
 
 /decl/emote/proc/get_emote_message_1p(var/atom/user, var/atom/target, var/extra_params)
 	if(target)
@@ -78,12 +79,16 @@
 		use_3p = replacetext(use_3p, "USER", "<b>\the [user]</b>")
 		use_3p = capitalize(use_3p)
 
+	var/use_range = emote_range
+	if (!use_range)
+		use_range = world.view
+
 	if(ismob(user))
 		var/mob/M = user
 		if(message_type == AUDIBLE_MESSAGE)
-			M.audible_message(message = use_3p, self_message = use_1p, deaf_message = emote_message_impaired, checkghosts = /datum/client_preference/ghost_sight)
+			M.audible_message(message = use_3p, self_message = use_1p, deaf_message = emote_message_impaired, hearing_distance = use_range, checkghosts = /datum/client_preference/ghost_sight)
 		else
-			M.visible_message(message = use_3p, self_message = use_1p, blind_message = emote_message_impaired, checkghosts = /datum/client_preference/ghost_sight)
+			M.visible_message(message = use_3p, self_message = use_1p, blind_message = emote_message_impaired, range = use_range, checkghosts = /datum/client_preference/ghost_sight)
 
 	do_extra(user, target)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -134,22 +134,8 @@
 /mob/living/carbon/human/Move()
 	. = ..()
 	if(.) //We moved
-		handle_exertion()
+		species.handle_exertion(src)
 		handle_leg_damage()
-
-/mob/living/carbon/human/proc/handle_exertion()
-	if(isSynthetic() || (species.species_flags & (SPECIES_FLAG_IS_PLANT|SPECIES_FLAG_NO_PAIN)))
-		return
-	
-	var/lac_chance =  10 * encumbrance()
-	if(lac_chance && prob(skill_fail_chance(SKILL_HAULING, lac_chance)))
-		make_reagent(1, /datum/reagent/lactate)
-		adjust_hydration(-DEFAULT_THIRST_FACTOR)
-		switch(rand(1,20))
-			if(1)
-				visible_message("<span class='notice'>\The [src] is sweating heavily!</span>", "<span class='notice'>You are sweating heavily!</span>")
-			if(2)
-				visible_message("<span class='notice'>\The [src] looks out of breath!</span>", "<span class='notice'>You are out of breath!</span>")
 
 /mob/living/carbon/human/proc/handle_leg_damage()
 	if(!can_feel_pain())

--- a/code/modules/species/mantid/mantid.dm
+++ b/code/modules/species/mantid/mantid.dm
@@ -111,6 +111,16 @@
 			list(/decl/emote/visible/ascent_flicker, /decl/emote/visible/ascent_glint) = 20,
 		)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+
 /datum/species/mantid/handle_sleeping(var/mob/living/carbon/human/H)
 	return
 

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -17,6 +17,16 @@
 		TAG_CULTURE = CULTURE_ALIUM
 	)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+
 /datum/species/alium/New()
 	//Coloring
 	blood_color = RANDOM_RGB

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -106,6 +106,21 @@
 		)
 	)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_charge_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+	exertion_emotes_synthetic = list(
+		/decl/emote/exertion/synthetic,
+		/decl/emote/exertion/synthetic/creak
+	)
+
 /datum/species/vox/equip_survival_gear(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vox(H), slot_wear_mask)
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -255,6 +255,17 @@
 		list(/decl/emote/audible/grunt, /decl/emote/audible/groan, /decl/emote/audible/moan) = 40,
 		list(/decl/emote/audible/grunt, /decl/emote/audible/groan) = 10,
 	)
+
+	
+	var/exertion_effect_chance = 0
+	var/exertion_hydration_scale = 0
+	var/exertion_nutrition_scale = 0
+	var/exertion_charge_scale = 0
+	var/exertion_reagent_scale = 0
+	var/exertion_reagent_path = null
+	var/list/exertion_emotes_biological = null
+	var/list/exertion_emotes_synthetic = null
+
 /*
 These are all the things that can be adjusted for equipping stuff and
 each one can be in the NORTH, SOUTH, EAST, and WEST direction. Specify
@@ -805,3 +816,27 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			// This assumes that if a pain-level has been defined it also has a list of emotes to go with it
 			var/decl/emote/E = decls_repository.get_decl(pick(pain_emotes))
 			return E.key
+
+/datum/species/proc/handle_exertion(mob/living/carbon/human/H)
+	if (!exertion_effect_chance)
+		return
+	var/chance = exertion_effect_chance * H.encumbrance()
+	if (chance && prob(H.skill_fail_chance(SKILL_HAULING, chance)))
+		var/synthetic = H.isSynthetic()
+		if (synthetic)
+			if (exertion_charge_scale)
+				var/obj/item/organ/internal/cell/cell = locate() in H.internal_organs
+				if (cell)
+					cell.use(cell.get_power_drain() * exertion_charge_scale)
+		else
+			if (exertion_hydration_scale)
+				H.adjust_hydration(-DEFAULT_THIRST_FACTOR * exertion_hydration_scale)
+			if (exertion_nutrition_scale)
+				H.adjust_nutrition(-DEFAULT_HUNGER_FACTOR * exertion_nutrition_scale)
+			if (exertion_reagent_scale && !isnull(exertion_reagent_path))
+				H.make_reagent(REM * exertion_reagent_scale, exertion_reagent_path)
+		if (prob(10))
+			var/list/active_emotes = synthetic ? exertion_emotes_synthetic : exertion_emotes_biological
+			var/decl/emote/exertion_emote = decls_repository.get_decl(pick(active_emotes))
+			if (exertion_emote)
+				exertion_emote.do_emote(H)

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -120,7 +120,17 @@
 			list(/decl/emote/audible/grunt, /decl/emote/audible/groan, /decl/emote/audible/wheeze, /decl/emote/audible/hiss) = 50,
 			list(/decl/emote/audible/grunt, /decl/emote/audible/groan, /decl/emote/audible/hiss) = 20,
 		)
-		
+
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+
 /datum/species/unathi/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)

--- a/code/modules/species/station/machine.dm
+++ b/code/modules/species/station/machine.dm
@@ -83,6 +83,13 @@
 		TAG_FACTION = FACTION_POSITRONICS
 	)
 
+	exertion_effect_chance = 10
+	exertion_charge_scale = 1
+	exertion_emotes_synthetic = list(
+		/decl/emote/exertion/synthetic,
+		/decl/emote/exertion/synthetic/creak
+	)
+
 /datum/species/machine/handle_death(var/mob/living/carbon/human/H)
 	..()
 	if(istype(H.wear_mask,/obj/item/clothing/mask/monitor))

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -144,6 +144,16 @@
 			list(/decl/emote/audible/bug_hiss) = 40
 	)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+
 /datum/species/nabber/New()
 	equip_adjust = list(
 		slot_head_str =    list("[NORTH]" = list("x" = 0, "y" = 7),  "[EAST]" = list("x" = 0, "y" = 8),  "[SOUTH]" = list("x" = 0, "y" = 8),  "[WEST]" = list("x" = 0, "y" = 8)),

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -40,6 +40,21 @@
 		)
 	)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_charge_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+	exertion_emotes_synthetic = list(
+		/decl/emote/exertion/synthetic,
+		/decl/emote/exertion/synthetic/creak
+	)
+
 /datum/species/human/get_bodytype(var/mob/living/carbon/human/H)
 	return SPECIES_HUMAN
 
@@ -204,6 +219,21 @@
 		BP_BRAIN =    /obj/item/organ/internal/brain,
 		BP_EYES =     /obj/item/organ/internal/eyes/skrell
 		)
+
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_charge_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /datum/reagent/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+	exertion_emotes_synthetic = list(
+		/decl/emote/exertion/synthetic,
+		/decl/emote/exertion/synthetic/creak
+	)
 
 /datum/species/skrell/get_sex(var/mob/living/carbon/human/H)
 	return istype(H) && (H.descriptors["headtail length"] == 1 ? MALE : FEMALE)


### PR DESCRIPTION
:cl:
tweak: IPCs and FBPs cost cell charge as exertion to move heavy objects.
/:cl:

Moves exertion off mobs and onto species. Configurable without proc overrides:
- Proc chance
- Messages, including visible/audible parts
- Hydration / hunger / charge cost
- Generated reagent type & amount

Initial version applies prior universal values to humans, skrell, unathi, vox, serpentids, mantids, and subspecies.

Adds charge cost to IPCs and species that can be FBPs.

Exempt: Trees, rock squids, golems, starborn, slimes, shadows.

resolves #28188 
