### PR TITLE
Remodel shield bay, leaving only one shield.

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -5213,16 +5213,15 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck - Stairwell";
+	dir = 4
+	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Stairwell";
-	dir = 4
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/center)
@@ -7183,6 +7182,10 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/engineering/storage)
+"qB" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/maintenance/seconddeck/foreport)
 "qC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -8169,6 +8172,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/storage)
+"sK" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/seconddeck/foreport)
 "sL" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8362,9 +8369,6 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/drone_fabrication)
-"tn" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/seconddeck/foreport)
 "to" = (
 /obj/structure/window/reinforced,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -8386,44 +8390,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
-"tp" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/shieldbay)
 "tq" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/shieldbay)
-"tr" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/hydrant{
-	pixel_x = 0;
-	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/engineering/shieldbay)
@@ -8985,14 +8957,13 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/wastetank)
 "uV" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/clothing/gloves/insulated,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Shield Bay";
-	dir = 1
+/obj/structure/cable/cyan,
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/engineering/shieldbay)
 "uY" = (
@@ -9194,6 +9165,15 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shuttle/escape_pod10/station)
+"vy" = (
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shieldbay)
 "vz" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -10022,6 +10002,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
+"yo" = (
+/obj/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/seconddeck/foreport)
 "yr" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12912,16 +12897,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
-"FK" = (
+"FJ" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/gloves/insulated,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Shield Bay";
+	dir = 1
+	},
+/obj/machinery/light/small,
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 21
-	},
 /turf/simulated/floor/plating,
 /area/engineering/shieldbay)
 "FL" = (
@@ -13170,6 +13155,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
+"GI" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/random/maintenance/solgov,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/seconddeck/foreport)
 "GJ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14317,6 +14309,15 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
+"KA" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shieldbay)
 "KE" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -15242,6 +15243,18 @@
 /obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/forestarboard)
+"NY" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shieldbay)
 "NZ" = (
 /obj/structure/table/steel,
 /obj/item/stack/cable_coil{
@@ -15507,11 +15520,9 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_bay)
 "OF" = (
-/obj/structure/catwalk,
-/obj/machinery/power/terminal,
-/obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
-/area/engineering/shieldbay)
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/seconddeck/foreport)
 "OG" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced/airless,
@@ -16084,13 +16095,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/storage)
-"Qq" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/seconddeck/foreport)
 "Qt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -16719,6 +16723,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"Sp" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/seconddeck/foreport)
 "Sr" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -16841,6 +16850,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck)
+"SR" = (
+/obj/structure/catwalk,
+/obj/machinery/power/terminal,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/shieldbay)
 "SU" = (
 /obj/structure/sign/warning/pods/east{
 	dir = 1;
@@ -17579,11 +17597,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
-"VQ" = (
-/obj/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/seconddeck/foreport)
 "VR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17807,6 +17820,10 @@
 /area/engineering/engineering_bay)
 "Wx" = (
 /obj/structure/catwalk,
+/obj/structure/closet/hydrant{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /obj/structure/cable,
 /obj/machinery/power/terminal,
 /turf/simulated/floor/plating,
@@ -17833,16 +17850,6 @@
 /area/maintenance/seconddeck/aftport)
 "Wz" = (
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/alarm{
 	frequency = 1439;
 	pixel_y = 23;
@@ -18397,24 +18404,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
-"Ym" = (
-/obj/structure/catwalk,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/engineering/shieldbay)
 "Yn" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -18695,11 +18684,6 @@
 /area/hallway/primary/seconddeck)
 "Zm" = (
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -34525,9 +34509,9 @@ ZS
 gn
 nc
 sG
-tn
-tn
-tn
+ZV
+ZV
+nc
 nc
 nc
 nc
@@ -34727,12 +34711,12 @@ va
 LK
 va
 va
-VQ
-tn
-Qq
-lr
+ZV
+yi
+nc
 ww
 xr
+pi
 yk
 zd
 nc
@@ -34927,14 +34911,14 @@ va
 AR
 oW
 SX
+Vv
 va
-va
-TJ
-RF
-no
-TJ
+ZV
+sK
+nc
 wx
 nc
+qB
 yl
 zb
 nc
@@ -35131,10 +35115,10 @@ tU
 SX
 SX
 va
-Ym
-tH
-PI
-TJ
+ZV
+GI
+nc
+lr
 zO
 zO
 zO
@@ -35332,11 +35316,11 @@ tU
 CI
 tU
 ro
-Vv
-tp
+va
+ZV
 OF
-PX
-Ua
+Sp
+lr
 Yp
 Yp
 Xz
@@ -35535,10 +35519,10 @@ mn
 HA
 Yd
 va
-FK
-tH
-PI
-TJ
+ZV
+ZV
+yo
+lr
 Iz
 Iz
 Xz
@@ -35737,9 +35721,9 @@ Ui
 Nx
 va
 va
-tr
-OF
-PX
+RF
+no
+TJ
 vF
 wy
 wy
@@ -35939,8 +35923,8 @@ lD
 mm
 va
 sL
-tq
 tH
+NY
 uV
 TJ
 wz
@@ -36141,9 +36125,9 @@ ZE
 va
 va
 QR
-tq
 tH
-PI
+tq
+vy
 TJ
 eg
 eg
@@ -36344,8 +36328,8 @@ xj
 PF
 jV
 Wz
-OF
-PX
+tq
+FJ
 TJ
 qo
 wC
@@ -36545,8 +36529,8 @@ pL
 rW
 rO
 sN
+KA
 tt
-tH
 PI
 Ua
 qo
@@ -36748,7 +36732,7 @@ rV
 rP
 Wm
 Zm
-OF
+SR
 PX
 TJ
 wB


### PR DESCRIPTION
:cl:
maptweak: Engineering shield bay now only contains one shield
/:cl:


## Pictures
### Before
![minishieldbay-before](https://user-images.githubusercontent.com/1807509/77388113-36fa9780-6d5d-11ea-9d76-b08fc38fb959.png)

### After
![minishieldbay-after](https://user-images.githubusercontent.com/1807509/77388122-3a8e1e80-6d5d-11ea-96e3-cd379b31ea60.png)

## Why?
- Why do we have five shields anyways?
  - In two hours you can get maybe three shields charged, but that requires a very powerful engine setup
  - It's better to have one shield with some capacitance coils thrown in than it is to have four or five separate shields charging
- See #28199

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->