### PR TITLE
Add IT Technician to Engineer alt titles

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -63,6 +63,7 @@
 		"Damage Control Technician",
 		"Electrician",
 		"Atmospheric Technician",
+		"IT Technician",
 		)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/engineer
 	allowed_branches = list(


### PR DESCRIPTION
Computers can randomly break down and someone might want to RP a technologically-illiterate person who needs help using their PDA. Or you might just want to be a cyberhacker. Given IT has its own skill, it makes sense to make an alt title for it as well.

:cl:
add: You can now choose "IT Technician" as an alternate title for Engineer.
/:cl: