### PR TITLE
Inflatables, unpowered doors and firedoors can no longer be closed on people.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -148,13 +148,16 @@
 	"\The [src]", "Yes, [density ? "open" : "close"]", "No")
 	if(answer == "No")
 		return
+	var/mob/living/carbon/human/H = locate() in get_turf(src)
+	if(H)
+		user.visible_message("Someone is blocking the [src]")
+		return
 	if(user.incapacitated() || (get_dist(src, user) > 1  && !issilicon(user)))
 		to_chat(user, "Sorry, you must remain able bodied and close to \the [src] in order to use it.")
 		return
 	if(density && (stat & (BROKEN|NOPOWER))) //can still close without power
 		to_chat(user, "\The [src] is not functioning, you'll have to force it open manually.")
 		return
-
 	if(alarmed && density && lockdown && !allowed(user))
 		to_chat(user, "<span class='warning'>Access denied. Please wait for authorities to arrive, or for the alert to clear.</span>")
 		return
@@ -345,6 +348,11 @@
 	return
 
 /obj/machinery/door/firedoor/close()
+	// if there are humans on the tile, don't close
+	var/mob/living/carbon/human/H = locate() in get_turf(src)
+	if(H)
+		return
+
 	latetoggle()
 	return ..()
 

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -80,6 +80,14 @@
 /obj/machinery/door/unpowered/simple/close(var/forced = 0)
 	if(!can_close(forced))
 		return
+	
+	// If the door is blocked, don't close
+	for(var/turf/A in locs)
+		var/turf/T = A
+		var/obstruction = T.get_obstruction()
+		if (obstruction)
+			return
+	
 	playsound(src.loc, material.dooropen_noise, 100, 1)
 	..()
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -7,15 +7,24 @@
 
 	atmos_canpass = CANPASS_DENSITY
 
-/obj/item/inflatable/attack_self(mob/user)
+/obj/item/inflatable/afterattack(var/atom/A, var/mob/user)
+	..(A, user)
 	if(!deploy_path)
 		return
+	if(!user.Adjacent(A))
+		return
+	if (isturf(A))
+		var/turf/T = A
+		var/obstruction = T.get_obstruction()
+		if (obstruction)
+			to_chat(user, "\The [english_list(obstruction)] is blocking that spot.")
+			return
 	user.visible_message("[user] starts inflating \the [src].", "You start inflating \the [src].")
-	if(!do_after(user, 1 SECOND, src))
+	if(!do_after(user, 1 SECOND))
 		return
 	playsound(loc, 'sound/items/zip.ogg', 75, 1)
 	user.visible_message(SPAN_NOTICE("[user] inflates \the [src]."), SPAN_NOTICE("You inflate \the [src]."))
-	var/obj/structure/inflatable/R = new deploy_path(get_turf(src))
+	var/obj/structure/inflatable/R = new deploy_path(get_turf(A))
 	transfer_fingerprints_to(R)
 	R.add_fingerprint(user)
 	if(inflatable_health)
@@ -260,6 +269,13 @@
 	isSwitchingStates = 0
 
 /obj/structure/inflatable/door/proc/Close()
+	// If the inflatable is blocked, don't close
+	for(var/turf/A in locs)
+		var/turf/T = A
+		var/obstruction = T.get_obstruction()
+		if (obstruction)
+			return
+
 	isSwitchingStates = 1
 	flick("door_closing",src)
 	sleep(10)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -360,3 +360,13 @@ var/const/enterloopsanity = 100
 
 /turf/proc/is_floor()
 	return FALSE
+
+/turf/proc/get_obstruction()
+	if (density)
+		LAZYADD(., src)
+	if (contents.len > 100 || contents.len <= !!lighting_overlay)
+		return    // fuck it, too/not-enough much shit here
+	for (var/thing in src)
+		var/atom/movable/AM = thing
+		if (AM.simulated && AM.blocks_airlock())
+			LAZYADD(., AM)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -402,9 +402,13 @@
 	if(!user)
 		return
 	if(!user.Adjacent(A))
-		to_chat(user, "You can't reach!")
 		return
-	if(istype(A, /turf))
+	if (isturf(A))
+		var/turf/T = A
+		var/obstruction = T.get_obstruction()
+		if (obstruction)
+			to_chat(user, "\The [english_list(obstruction)] is blocking that spot.")
+			return
 		try_deploy_inflatable(A, user)
 	if(istype(A, /obj/item/inflatable) || istype(A, /obj/structure/inflatable))
 		pick_up(A, user)


### PR DESCRIPTION
🆑 
tweak: fire doors can no longer close on people, they will still close on all other objects
tweak: Inflatables are now deployed by clicking on your desired tile instead of with a self-attack/activate
tweak: Inflatable doors can no longer close on any object that prevents a standard powered airlock to close
tweak: Inflatables can no longer be deployed on any object that prevents a standard powered airlock to close
tweak: Unpowered doors can no longer close on any object that would prevent a standard powered airlock from closing.
/🆑

Now, you just read the changelog and you're flying over to ping me on discord (@Alex6511 by the way). STOP.
Remember:
![dreamseeker_2020-03-26_18-36-25](https://user-images.githubusercontent.com/7919184/77707265-a0172080-6f92-11ea-83b8-20cd8a64478e.png)
![dreamseeker_2020-03-26_18-38-08](https://user-images.githubusercontent.com/7919184/77707268-a2797a80-6f92-11ea-82db-4f1a04671477.png)
 These are both perfectly valid setups with this new system that will allow you to utilize inflatables with very little change before this mechanic. You just need to be mindful that now there will be _some amount_ of atmospheric mixing and leaking into both environments. 

This change is because inflatable airlocks are literally better than standard airlocks in almost every way currently. There is very little reason to use things like firelocks, charon and other various things when you can use the 2 inflatable door trick to completely negate any atmospheric mixing. Inflatable doors are meant to be a temporary solution, not a permanent one.