### PR TITLE
Moves the chemistry subsystem's wait interval from 20 ds to 5 ds

### DIFF
--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -2,6 +2,7 @@ SUBSYSTEM_DEF(chemistry)
 	name = "Chemistry"
 	priority = SS_PRIORITY_CHEMISTRY
 	init_order = SS_INIT_CHEMISTRY
+	wait = 5
 
 	var/list/active_holders =               list()
 	var/list/chemical_reactions =           list()


### PR DESCRIPTION
:cl: Ava
tweak: The chemistry subsystem now processes every 5 deciseconds instead of 20 deciseconds, meaning that reagents in containers will mix together more quickly. This doesn't affect mob metabolization - it only affects the delay when mixing stuff.
/:cl:

Hi! First time contributing here. I'm not sure if there's any offlimits or other restrictions regarding subsystems, or any problems with this change in general, so page me in the bay Discord if that's the case - my tag is **Ava#1866**. If I've crossed some cardinal line, feel free to close this and let me know why.

### Code Changes

Changes the `wait` period of SSchemistry from `20` (the default) to `5`, which makes it process twice per second instead of once per two seconds. As far as I can tell, the chemistry subsystem's processing is currently only used to handle reactions in reagent containers.

### Goal

For anyone concerned about performance, I can say with confidence that the performance impact of this change is very likely zero due to the structure of the subsystem. There's a period of a second or two at the start of the round while roundstart chems react with themselves and their environment, but it still consumes far less processing time than the atmospherics SS does while idle at any given time.

Mixing reagents (via chemistry, bartending, cooking, and the like) currently feels a little sluggish due to the slowness that reactions happen at. This is amplified with coolers and heaters, because they run at the same time interval as reactions but happen after reactions are processed - meaning one has to wait nearly four full seconds even after they've hit their target temperature.

This is a pet peeve, but when playing a shift as a role that mixes a lot of reagents, it adds up to feel awkward overall, especially if it's a reagent you're trying to mix quickly (for instance, oxycodone for a critical patient, which takes several steps, or trying to perfect your Allies Cocktail speedrun technique.)

This change is very small, but I feel that it makes mixing much more responsive. A cursory test of making compound reagents that use several steps (such as dexalin plus or peridaxon) shows a much smoother flow when reagent reactions happen quickly as opposed to comparatively slowly. It's true that this is also a bit less realistic, but I'm not sure of how much of a problem that is or if ultra-realism is a goal for whatever reason in a game with space wizards and sapient robots with TV heads.

Obviously, instant reactions could be attained by just manually processing reactions whenever reagents were added or removed from a container, but that feels like a regression when they already have their own dedicated subsystem that's probably more efficient than that. I think making the system process a little faster strikes a nice compromise without decreasing efficiency.