### PR TITLE
Wide Medical Visor now protects your eyeballs

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -37,6 +37,7 @@
 	desc = "A medical HUD integrated with a wide visor."
 	icon_state = "medhud_visor"
 	item_state = "medhud_visor"
+	body_parts_covered = EYES
 
 /obj/item/clothing/glasses/hud/security
 	name = "security HUD"


### PR DESCRIPTION
🆑
tweak: Medical Visor is more tightly secured, protecting the Corpsmen's sensitive eyeballs
/🆑
Just added a flag to the visor so it covers the eyes so MTs don't get fucked when patients spray a fresh supply of blood all over their eyeballs.
