### PR TITLE
Enable partial understanding between the Unathi languages

### DIFF
--- a/code/modules/mob/language/alien/unathi.dm
+++ b/code/modules/mob/language/alien/unathi.dm
@@ -8,6 +8,9 @@
 	key = "o"
 	flags = WHITELISTED
 	space_chance = 40
+	partial_understanding = list(
+		LANGUAGE_UNATHI_YEOSA = 30
+		)
 	syllables = list(
 		"za", "az", "ze", "ez", "zi", "iz", "zo", "oz", "zu", "uz", "zs", "sz",
 		"ha", "ah", "he", "eh", "hi", "ih", "ho", "oh", "hu", "uh", "hs", "sh",
@@ -29,6 +32,9 @@
 	key = "h"
 	flags = WHITELISTED
 	space_chance = 40
+	partial_understanding = list(
+		LANGUAGE_UNATHI_SINTA = 30
+		)
 	syllables = list(
 		"azs","zis","zau","azua","skiu","zuakz","izo","aei","ki","kut","zo",
 		"za", "az", "ze", "ez", "zi", "iz", "zo", "oz", "zu", "uz", "zs", "sz",

--- a/code/modules/mob/language/alien/unathi.dm
+++ b/code/modules/mob/language/alien/unathi.dm
@@ -10,7 +10,7 @@
 	space_chance = 40
 	partial_understanding = list(
 		LANGUAGE_UNATHI_YEOSA = 30
-		)
+	)
 	syllables = list(
 		"za", "az", "ze", "ez", "zi", "iz", "zo", "oz", "zu", "uz", "zs", "sz",
 		"ha", "ah", "he", "eh", "hi", "ih", "ho", "oh", "hu", "uh", "hs", "sh",
@@ -34,7 +34,7 @@
 	space_chance = 40
 	partial_understanding = list(
 		LANGUAGE_UNATHI_SINTA = 30
-		)
+	)
 	syllables = list(
 		"azs","zis","zau","azua","skiu","zuakz","izo","aei","ki","kut","zo",
 		"za", "az", "ze", "ez", "zi", "iz", "zo", "oz", "zu", "uz", "zs", "sz",


### PR DESCRIPTION
Yeosa and Sinta are now cross-understanding compatable.

:cl: Draxtheros
tweak: The Yeosa and Sinta languages now have some level of partial understanding between each other.
/:cl: