### PR TITLE
Revert #28215

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -148,16 +148,13 @@
 	"\The [src]", "Yes, [density ? "open" : "close"]", "No")
 	if(answer == "No")
 		return
-	var/mob/living/carbon/human/H = locate() in get_turf(src)
-	if(H)
-		user.visible_message("Someone is blocking the [src]")
-		return
 	if(user.incapacitated() || (get_dist(src, user) > 1  && !issilicon(user)))
 		to_chat(user, "Sorry, you must remain able bodied and close to \the [src] in order to use it.")
 		return
 	if(density && (stat & (BROKEN|NOPOWER))) //can still close without power
 		to_chat(user, "\The [src] is not functioning, you'll have to force it open manually.")
 		return
+
 	if(alarmed && density && lockdown && !allowed(user))
 		to_chat(user, "<span class='warning'>Access denied. Please wait for authorities to arrive, or for the alert to clear.</span>")
 		return
@@ -348,11 +345,6 @@
 	return
 
 /obj/machinery/door/firedoor/close()
-	// if there are humans on the tile, don't close
-	var/mob/living/carbon/human/H = locate() in get_turf(src)
-	if(H)
-		return
-
 	latetoggle()
 	return ..()
 

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -80,14 +80,6 @@
 /obj/machinery/door/unpowered/simple/close(var/forced = 0)
 	if(!can_close(forced))
 		return
-	
-	// If the door is blocked, don't close
-	for(var/turf/A in locs)
-		var/turf/T = A
-		var/obstruction = T.get_obstruction()
-		if (obstruction)
-			return
-	
 	playsound(src.loc, material.dooropen_noise, 100, 1)
 	..()
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -7,24 +7,15 @@
 
 	atmos_canpass = CANPASS_DENSITY
 
-/obj/item/inflatable/afterattack(var/atom/A, var/mob/user)
-	..(A, user)
+/obj/item/inflatable/attack_self(mob/user)
 	if(!deploy_path)
 		return
-	if(!user.Adjacent(A))
-		return
-	if (isturf(A))
-		var/turf/T = A
-		var/obstruction = T.get_obstruction()
-		if (obstruction)
-			to_chat(user, "\The [english_list(obstruction)] is blocking that spot.")
-			return
 	user.visible_message("[user] starts inflating \the [src].", "You start inflating \the [src].")
-	if(!do_after(user, 1 SECOND))
+	if(!do_after(user, 1 SECOND, src))
 		return
 	playsound(loc, 'sound/items/zip.ogg', 75, 1)
 	user.visible_message(SPAN_NOTICE("[user] inflates \the [src]."), SPAN_NOTICE("You inflate \the [src]."))
-	var/obj/structure/inflatable/R = new deploy_path(get_turf(A))
+	var/obj/structure/inflatable/R = new deploy_path(get_turf(src))
 	transfer_fingerprints_to(R)
 	R.add_fingerprint(user)
 	if(inflatable_health)
@@ -269,13 +260,6 @@
 	isSwitchingStates = 0
 
 /obj/structure/inflatable/door/proc/Close()
-	// If the inflatable is blocked, don't close
-	for(var/turf/A in locs)
-		var/turf/T = A
-		var/obstruction = T.get_obstruction()
-		if (obstruction)
-			return
-
 	isSwitchingStates = 1
 	flick("door_closing",src)
 	sleep(10)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -360,13 +360,3 @@ var/const/enterloopsanity = 100
 
 /turf/proc/is_floor()
 	return FALSE
-
-/turf/proc/get_obstruction()
-	if (density)
-		LAZYADD(., src)
-	if (contents.len > 100 || contents.len <= !!lighting_overlay)
-		return    // fuck it, too/not-enough much shit here
-	for (var/thing in src)
-		var/atom/movable/AM = thing
-		if (AM.simulated && AM.blocks_airlock())
-			LAZYADD(., AM)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -402,13 +402,9 @@
 	if(!user)
 		return
 	if(!user.Adjacent(A))
+		to_chat(user, "You can't reach!")
 		return
-	if (isturf(A))
-		var/turf/T = A
-		var/obstruction = T.get_obstruction()
-		if (obstruction)
-			to_chat(user, "\The [english_list(obstruction)] is blocking that spot.")
-			return
+	if(istype(A, /turf))
 		try_deploy_inflatable(A, user)
 	if(istype(A, /obj/item/inflatable) || istype(A, /obj/structure/inflatable))
 		pick_up(A, user)


### PR DESCRIPTION
:cl: lorwp
rscdel: #28215 has been reverted, with the main player-facing change being that firelocks now close again on people, and inflatables close on them as well
/:cl:

Reverts #28215

A bit of discussion in in-game channels has shown that this change in practice in actual rounds was unpopular. this PR is on request.