### PR TITLE
Add fleet cap to loadout, rename existing 'fleet cap' to utility cover

### DIFF
--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -27,9 +27,15 @@
 	path = /obj/item/clothing/head/soft/solgov
 	allowed_branches = SOLGOV_BRANCHES
 
-/datum/gear/head/fleethat
-	display_name = "fleet cap"
+/datum/gear/head/fleetcover
+	display_name = "fleet utilty cover"
 	path = /obj/item/clothing/head/solgov/utility/fleet
+	cost = 0
+	allowed_branches = list(/datum/mil_branch/fleet)
+
+/datum/gear/head/fleetcap
+	display_name = "fleet cap"
+	path = /obj/item/clothing/head/soft/solgov/fleet
 	cost = 0
 	allowed_branches = list(/datum/mil_branch/fleet)
 


### PR DESCRIPTION
:cl: lorwp
tweak: In loadout hats 'Fleet Cap' is now 'fleet utility cover' and is still the utility cover, 'fleet cap' is now the fleet ballcap.
/:cl:

~~Per changelog~~

[Now, where's my trucker hat?](https://youtu.be/jJHEQ8g1Yms)