### PR TITLE
Corporate Liaison can now use the departmental audit form

### DIFF
--- a/maps/torch/datums/reports/solgov.dm
+++ b/maps/torch/datums/reports/solgov.dm
@@ -17,7 +17,8 @@
 	add_field(/datum/report_field/pencode_text, "Other Notes")
 	add_field(/datum/report_field/signature, "Signature")
 	add_field(/datum/report_field/options/yes_no, "Approved")
-	set_access(access_edit = access_representative)
+	set_access(access_edit = access_representative, override = 0)
+	set_access(access_edit = access_nanotrasen, override = 0)
 
 /datum/computer_file/report/recipient/sol/crewman_incident
 	form_name = "SCG-REP-4"


### PR DESCRIPTION
Since part of the CL's (theoretical) job is to make sure the research department is performing up to EXO's standards, it's possible that they want to audit the department and see how it's running. This lets them do that without having to draft a new report by hand.

:cl:
tweak: Corporate Liaisons (and equivalent) can now use SCG-REP-12, the departmental audit form.
/:cl: