### PR TITLE
Adds food coloring/food dye, used to change the color of food, drinks, and reagents

### DIFF
--- a/code/datums/supplypacks/galley.dm
+++ b/code/datums/supplypacks/galley.dm
@@ -9,7 +9,8 @@
 					/obj/item/weapon/storage/fancy/egg_box = 2,
 					/obj/item/weapon/reagent_containers/food/snacks/tofu = 4,
 					/obj/item/weapon/reagent_containers/food/snacks/meat = 4,
-					/obj/item/weapon/reagent_containers/food/condiment/enzyme = 1
+					/obj/item/weapon/reagent_containers/food/condiment/enzyme = 1,
+					/obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic = 1
 					)
 	cost = 10
 	containertype = /obj/structure/closet/crate/freezer

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -161,3 +161,11 @@
 	path = /obj/effect/spawner/newbomb/traitor
 	desc = "A remote-activated phoron-oxygen bomb assembly with an included signaler. \
 			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"
+
+/datum/uplink_item/item/tools/polychromic_dye_bottle
+	name = "Polychromic Dye Bottle"
+	item_cost = 10
+	path = /obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic
+	desc = "A small bottle containing tasteless coloring that causes any chemical mix or food it's added to take on the color of the dye itself. \
+			Very useful for disguising poisons to the untrained eye; even large amounts of reagents will be completely recolored by only a drop or two of dye. \
+			Comes with the ability to freely choose the dye's coloration by using the bottle while it's in your hand."

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -163,9 +163,9 @@
 			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"
 
 /datum/uplink_item/item/tools/polychromic_dye_bottle
-	name = "Polychromic Dye Bottle"
+	name = "Extra-Strength Polychromic Dye"
 	item_cost = 10
-	path = /obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic
-	desc = "A small bottle containing tasteless coloring that causes any chemical mix or food it's added to take on the color of the dye itself. \
-			Very useful for disguising poisons to the untrained eye; even large amounts of reagents will be completely recolored by only a drop or two of dye. \
-			Comes with the ability to freely choose the dye's coloration by using the bottle while it's in your hand."
+	path = /obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic/strong
+	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
+			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
+			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -99,6 +99,9 @@
 /atom/proc/on_reagent_change()
 	return
 
+/atom/proc/on_color_transfer_reagent_change()
+	return
+
 /atom/proc/Bumped(AM as mob|obj)
 	return
 

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -75,6 +75,7 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/powersink, 10, 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/ai_module, 25, 0)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/teleporter, 10, 0)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/polychromic_dye_bottle)
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_freedom)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_compress)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -6,7 +6,8 @@
 	return list(
 		/obj/item/weapon/reagent_containers/food/condiment/salt = 1,
 		/obj/item/weapon/reagent_containers/food/condiment/flour = 7,
-		/obj/item/weapon/reagent_containers/food/condiment/sugar = 2
+		/obj/item/weapon/reagent_containers/food/condiment/sugar = 2,
+		/obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic = 2
 	)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -325,9 +325,8 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 			if (added)
 				added.color = current.color
 				if (target.my_atom)
+					target.my_atom.on_color_transfer_reagent_change()
 					target.my_atom.update_icon()
-		if (target.my_atom)
-			target.my_atom.on_reagent_change()
 
 	if(!copy)
 		HANDLE_REACTIONS(src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -248,6 +248,12 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 		del_reagent(current.type)
 	return
 
+/datum/reagents/proc/get_reagent(var/reagent_type)
+	for(var/datum/reagent/current in reagent_list)
+		if(current.type == reagent_type)
+			return current
+	return
+
 /datum/reagents/proc/get_reagent_amount(var/reagent_type)
 	for(var/datum/reagent/current in reagent_list)
 		if(current.type == reagent_type)
@@ -314,6 +320,13 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 		target.add_reagent(current.type, amount_to_transfer * multiplier, current.get_data(), safety = 1) // We don't react until everything is in place
 		if(!copy)
 			remove_reagent(current.type, amount_to_transfer, 1)
+		if (current.color_transfer)
+			var/datum/reagent/added = target.get_reagent(current.type)
+			if (added)
+				added.color = current.color
+				if (target.my_atom)
+					target.my_atom.update_icon()
+		target.my_atom.on_reagent_change()
 
 	if(!copy)
 		HANDLE_REACTIONS(src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -326,7 +326,8 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 				added.color = current.color
 				if (target.my_atom)
 					target.my_atom.update_icon()
-		target.my_atom.on_reagent_change()
+		if (target.my_atom)
+			target.my_atom.on_reagent_change()
 
 	if(!copy)
 		HANDLE_REACTIONS(src)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -14,6 +14,14 @@
 	var/scannable = 0 // Shows up on health analyzers.
 	var/color = "#000000"
 	var/color_weight = 1
+	var/color_foods = FALSE // If TRUE, this reagent affects the color of food items it's added to
+
+	// If TRUE, this reagent transfers changes to its 'color' var when moving to other containers
+	// Of note: Mixing two reagents of the same type with this var that have different colors
+	// will cause them both to take on the color of the form being added into the holder.
+	// i.e. if you add red to blue, all of the reagent turns red and vice-versa.
+	var/color_transfer = FALSE
+
 	var/alpha = 255
 	var/flags = 0
 	var/hidden_from_codex

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -514,7 +514,12 @@
 	name = "Dye"
 	description = "Non-toxic artificial coloration used for food and drinks. When mixed with reagents, the compound will take on the dye's coloration."
 	color = "#FFFFFF"
-	color_weight = 150
+	color_weight = 40
 	color_transfer = TRUE
 	color_foods = TRUE
 	taste_mult = 0
+
+/datum/reagent/dye/strong
+	name = "Strong Dye"
+	description = "An extra-strength dye. Used for tinting food, but is especially effective with drinks and other fluids."
+	color_weight = 100

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -509,3 +509,12 @@
 	description = "Ammonia Nitrate Fuel Oil, with aluminium powder, an explosive compound known for centuries. Safe to handle, can be set off with a small explosion."
 	color = "#ffe8e8"
 	boompower = 2
+
+/datum/reagent/dye
+	name = "Dye"
+	description = "Non-toxic artificial coloration used for food and drinks. When mixed with reagents, the compound will take on the dye's coloration."
+	color = "#FFFFFF"
+	color_weight = 150
+	color_transfer = TRUE
+	color_foods = TRUE
+	taste_mult = 0

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -513,7 +513,7 @@
 /datum/reagent/dye
 	name = "Dye"
 	description = "Non-toxic artificial coloration used for food and drinks. When mixed with reagents, the compound will take on the dye's coloration."
-	color = "#FFFFFF"
+	color = "#ffffff"
 	color_weight = 40
 	color_transfer = TRUE
 	color_foods = TRUE

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -8,3 +8,9 @@
 	volume = 50 //Sets the default container amount for all food items.
 	var/filling_color = "#ffffff" //Used by sandwiches.
 	var/trash = null
+
+/obj/item/weapon/reagent_containers/food/on_reagent_change()
+	for(var/datum/reagent/R in reagents.reagent_list)
+		if (!R.color_foods)
+			continue
+		color = R.color //Possible todo: Mixing of food-coloring reagents for final result?

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -9,7 +9,7 @@
 	var/filling_color = "#ffffff" //Used by sandwiches.
 	var/trash = null
 
-/obj/item/weapon/reagent_containers/food/on_reagent_change()
+/obj/item/weapon/reagent_containers/food/on_color_transfer_reagent_change()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		if (!R.color_foods)
 			continue

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -17,6 +17,9 @@
 	update_icon()
 	return
 
+/obj/item/weapon/reagent_containers/food/drinks/on_color_transfer_reagent_change()
+	return
+
 /obj/item/weapon/reagent_containers/food/drinks/attack_self(mob/user as mob)
 	if(!is_open_container())
 		open(user)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -286,6 +286,5 @@
 	update_icon()
 
 /obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic/strong
-	desc = "A bottle filled with extra-strength polychromic dye, for making bottles of \"tramadol\" using horrible poisons. Activate it in-hand to choose its color freely."
 	starting_reagent = /datum/reagent/dye/strong
 	starting_vol = 15

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -251,3 +251,34 @@
 	..()
 	reagents.add_reagent(/datum/reagent/frostoil, 60)
 	update_icon()
+
+/obj/item/weapon/reagent_containers/glass/bottle/dye
+	name = "dye bottle"
+	desc = "A little bottle used to hold dye or food coloring, with a narrow bottleneck for handling small amounts."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle-1"
+	amount_per_transfer_from_this = 1
+	possible_transfer_amounts = "1;2;5;10;15;25;30;60"
+
+/obj/item/weapon/reagent_containers/glass/bottle/dye/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/dye, 60)
+	update_icon()
+
+
+/obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic
+	name = "polychromic dye bottle"
+	desc = "A little bottle used to hold dye or food coloring, with a narrow bottleneck for handling small amounts. \
+			Outfitted with a tiny mechanism that can change the color of its contained dye, opening up infinite possibilities."
+
+/obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic/attack_self(mob/living/user)
+	var/datum/reagent/dye/heldDye = reagents.get_reagent(/datum/reagent/dye)
+	if (!heldDye)
+		to_chat(user, "<span class='warning'>\The [src] isn't holding any dye!</span>")
+		return
+	var/new_color = input(user, "Choose the dye's new color.", "[name]") as color|null
+	if (!new_color || !Adjacent(user))
+		return
+	to_chat(user, "<span class='notice'>The dye in \the [src] swirls and takes on a new color.</span>")
+	heldDye.color = new_color
+	update_icon()

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -259,10 +259,12 @@
 	icon_state = "bottle-1"
 	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = "1;2;5;10;15;25;30;60"
+	var/datum/reagent/starting_reagent = /datum/reagent/dye
+	var/starting_vol = 60
 
 /obj/item/weapon/reagent_containers/glass/bottle/dye/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/dye, 60)
+	reagents.add_reagent(starting_reagent, starting_vol)
 	update_icon()
 
 
@@ -272,13 +274,18 @@
 			Outfitted with a tiny mechanism that can change the color of its contained dye, opening up infinite possibilities."
 
 /obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic/attack_self(mob/living/user)
-	var/datum/reagent/dye/heldDye = reagents.get_reagent(/datum/reagent/dye)
+	var/datum/reagent/heldDye = reagents.get_reagent(starting_reagent)
 	if (!heldDye)
 		to_chat(user, "<span class='warning'>\The [src] isn't holding any dye!</span>")
 		return
 	var/new_color = input(user, "Choose the dye's new color.", "[name]") as color|null
 	if (!new_color || !Adjacent(user))
 		return
-	to_chat(user, "<span class='notice'>The dye in \the [src] swirls and takes on a new color.</span>")
+	to_chat(user, SPAN_NOTICE("The dye in \the [src] swirls and takes on a new color."))
 	heldDye.color = new_color
 	update_icon()
+
+/obj/item/weapon/reagent_containers/glass/bottle/dye/polychromic/strong
+	desc = "A bottle filled with extra-strength polychromic dye, for making bottles of \"tramadol\" using horrible poisons. Activate it in-hand to choose its color freely."
+	starting_reagent = /datum/reagent/dye/strong
+	starting_vol = 15


### PR DESCRIPTION
:cl: Ilysen
rscadd: Added polychromic dye, which can be used to change the appearance of food and drinks! Find bottles in the galley backroom and from kitchen supply crates. You can also buy a small bottle of extra-strength dye with a greater color-changing effect using an uplink.
/:cl:

I spitballed this idea after I was playing as cook and wanted to have a visual way to portray ways I've modified my dishes that can't actually be otherwise seen with current sprites or taste. It got some support on the official discord, and so I figured I'd give it a shot.

This adds a new reagent called Dye. Dye doesn't do anything on its own, but it has an extreme color weight, meaning that its color will massively contribute to what reagent mixes will look like. A few drops of dye into a pitcher of coffee can turn it a completely different color - or putting some into a bottle of poison and labeling it as medicine can fool an untrained eye.

More usefully, dye can be added to any food to cause the food to take on the color of that dye. It's tasteless, so it won't spoil the taste of the food you color it with.

Dye can be found in polychromic dye bottles. The galley's backroom starts with two in the kitchen cabinet, each with 60 units, and kitchen supply crates contain one more as well. You can also get it from the Syndicate uplink for 10 telecrystals, for sneaky poison disguising. Note that dye doesn't actually do anything to disguise individual reagents, so someone with a reagent-scanning tool or high Chemistry might be able to tell something's wrong if they look closely!

Possible roleplaying opportunities might include:
* Tinting a haunch of meat slightly yellow after glazing it in honey.
* Serving up some green eggs and ham.
* Making coffee a very light brown to show extra milk.
* Turning a steak slightly reddish to represent being cooked rare.

Green eggs and ham, with green space cola.

![image](https://user-images.githubusercontent.com/47678781/78491197-8904cb00-7716-11ea-916d-9916b541437f.png)


### Technical Stuff

`/datum/reagent` has been given two new attributes:
* `color_transfer`, set to FALSE by default. If TRUE, then any time this reagent transfers containers, the newly-added reagent in that container will be given the color of the original.
* `color_foods`, set to FALSE by default. If TRUE, food objects will take on the color of this reagent when the reagent is added.

`/atom` has a new empty proc called `on_color_transfer_reagent_change()`, called whenever a color-transferring reagent is transferred to a new holder. Right now, this is used by food objects to change their color to match that of applied dye.

It's possible I did this in a yucky way. If so, please let me know how to touch it up and I'll gladly fix what I can.