### PR TITLE
tiny build mode tweaks

### DIFF
--- a/code/modules/admin/buildmode/areas.dm
+++ b/code/modules/admin/buildmode/areas.dm
@@ -82,6 +82,8 @@ Right Click       - List/Create Area
 			else
 				vision_colors[ref] = distinct_colors[used_colors]
 		I.color = vision_colors[ref]
+		I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+		I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM|NO_CLIENT_COLOR|KEEP_APART
 		vision_images.Add(I)
 	user.client.images += vision_images
 

--- a/code/modules/admin/buildmode/click_handler.dm
+++ b/code/modules/admin/buildmode/click_handler.dm
@@ -36,14 +36,13 @@
 	. = ..()
 
 /datum/click_handler/build_mode/proc/StartTimer()
-	timer_handle = addtimer(CALLBACK(src, .proc/TimerEvent), 1 SECOND, TIMER_UNIQUE | TIMER_STOPPABLE)
+	timer_handle = addtimer(CALLBACK(src, .proc/TimerEvent), 1 SECOND, TIMER_UNIQUE | TIMER_STOPPABLE | TIMER_LOOP)
 
 /datum/click_handler/build_mode/proc/StopTimer()
 	deltimer(timer_handle)
 
 /datum/click_handler/build_mode/proc/TimerEvent()
 	current_build_mode.TimerEvent()
-	StartTimer()
 
 /datum/click_handler/build_mode/Enter()
 	user.client.show_popup_menus = FALSE


### PR DESCRIPTION
build mode timer loops instead of self calls
area overlay clears color multipliers etc so that it is no longer affected by some turfs that apply them

I meant to do these months ago but I stalled on the larger change they were part of. May as well get them done now.