### PR TITLE
Joining as an explorer now requires a pathfinder to be awake, similar to Ascent

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -342,9 +342,7 @@ SUBSYSTEM_DEF(jobs)
 			// Loop through all jobs
 			for(var/datum/job/job in shuffledoccupations) // SHUFFLE ME BABY
 				if(job && !mode.disabled_jobs.Find(job.title) )
-					if(job.defer_roundstart_spawn)
-						deferred_jobs[job] = TRUE
-					else if(attempt_role_assignment(player, job, level, mode))
+					if(attempt_role_assignment(player, job, level, mode))
 						unassigned_roundstart -= player
 						break
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -47,7 +47,7 @@
 	var/min_goals = 1
 	var/max_goals = 3
 
-	var/defer_roundstart_spawn = FALSE // If true, the job will be put off until all other jobs have been populated.
+	var/requires_supervisor = FALSE
 	var/list/species_branch_rank_cache_ = list()
 	var/list/psi_faculties                // Starting psi faculties, if any.
 	var/psi_latency_chance = 0            // Chance of an additional psi latency, if any.
@@ -188,6 +188,11 @@
 			apply_fingerprints_to_item(holder, sub_item)
 
 /datum/job/proc/is_position_available()
+	if (((current_positions < total_positions) || (total_positions == -1)) && requires_supervisor)
+		for(var/mob/M in GLOB.player_list)
+			if(M.client && M.mind && M.mind.assigned_job && M.mind.assigned_job.title == requires_supervisor)
+				return TRUE
+		return FALSE // The job requires supervisors but supervisors were not found
 	return (current_positions < total_positions) || (total_positions == -1)
 
 /datum/job/proc/has_alt_title(var/mob/H, var/supplied_title, var/desired_title)

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -87,7 +87,7 @@
 	whitelisted_species = null
 	loadout_allowed = FALSE
 	is_semi_antagonist = TRUE
-	var/requires_supervisor = FALSE
+	requires_supervisor = FALSE
 	var/set_species_on_join = SPECIES_MANTID_GYNE
 	min_skill = list(SKILL_EVA = SKILL_ADEPT,
 					SKILL_PILOT = SKILL_ADEPT,
@@ -96,17 +96,6 @@
 					SKILL_WEAPONS = SKILL_ADEPT,
 					SKILL_SCIENCE = SKILL_ADEPT,
 					SKILL_MEDICAL = SKILL_BASIC)
-
-/datum/job/submap/ascent/is_position_available()
-	. = ..()
-	if(. && requires_supervisor)
-		for(var/mob/M in GLOB.player_list)
-			if(!M.client || !M.mind || !M.mind.assigned_job || M.mind.assigned_job.title != requires_supervisor)
-				continue
-			var/datum/job/submap/ascent/ascent_job = M.mind.assigned_job
-			if(istype(ascent_job) && ascent_job.owner == owner)
-				return TRUE
-		return FALSE
 
 /datum/job/submap/ascent/is_available(client/caller)
 	. = ..()

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -52,6 +52,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/corporate_bodyguard
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	requires_supervisor = "Workplace Liaison"
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
 	                    SKILL_COMBAT      = SKILL_BASIC,
@@ -71,14 +72,6 @@
 						access_cargo, access_solgov_crew, access_hangar,
 						access_nanotrasen, access_commissary, access_petrov,
 						access_sec_guard)
-	defer_roundstart_spawn = TRUE
-
-/datum/job/bodyguard/is_position_available()
-	if(..())
-		for(var/mob/M in GLOB.player_list)
-			if(M.client && M.mind && M.mind.assigned_role == "Workplace Liaison")
-				return TRUE
-	return FALSE
 
 /datum/job/bodyguard/get_description_blurb()
 	return "You are the Loss Prevention Associate. You are an employee of one of the corporations that make up the Expeditionary Corps Organisation, and your job is to prevent the loss of the Liason's life - even at the cost of your own. Good luck."

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -88,6 +88,7 @@
 	ideal_character_age = 20
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/exploration/explorer
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
+	requires_supervisor = "Pathfinder"
 
 	allowed_ranks = list(
 		/datum/mil_rank/ec/e3,


### PR DESCRIPTION
🆑 
tweak: Explorers can no longer join if there is no awake pathfinder
/🆑 

This change is aimed at reducing the number of explorers going off doing their own thing. They now have to have a supervisor present who can take responsability of their actions. The goal here is to bring a more serious tone to exploration, shifting them away from "Loot all the guns" mentality.