### PR TITLE
Restricts SCG organization berets to civilian branches.

### DIFF
--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -2,7 +2,7 @@
 	display_name = "SolGov beret selection"
 	description = "A beret denoting service in an organization within SolGov."
 	path = /obj/item/clothing/head/beret/solgov
-	allowed_branches = SOLGOV_BRANCHES
+	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/head/solberet/New()
 	..()


### PR DESCRIPTION
:cl: Flying_loulou
tweak: SCG organization berets are now restricted to civilian branches.
/:cl:

Well, you shouldn't be wearing those with your uniform (according to lore master), so it makes no sense to restric them to people who shouldn't be wearing them in first place.