### PR TITLE
Rewrites food tray code, improves functionality

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -53,6 +53,7 @@ GLOBAL_LIST_INIT(switch_sound,list('sound/machines/switch1.ogg','sound/machines/
 GLOBAL_LIST_INIT(button_sound,list('sound/machines/button1.ogg','sound/machines/button2.ogg','sound/machines/button3.ogg','sound/machines/button4.ogg'))
 GLOBAL_LIST_INIT(chop_sound,list('sound/weapons/chop1.ogg','sound/weapons/chop2.ogg','sound/weapons/chop3.ogg'))
 GLOBAL_LIST_INIT(glasscrack_sound,list('sound/effects/glass_crack1.ogg','sound/effects/glass_crack2.ogg','sound/effects/glass_crack3.ogg','sound/effects/glass_crack4.ogg'))
+GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'))
 
 /proc/playsound(var/atom/source, soundin, vol as num, vary, extrarange as num, falloff, var/is_global, var/frequency, var/is_ambiance = 0)
 
@@ -188,4 +189,5 @@ var/const/FALLOFF_SOUNDS = 0.5
 			if ("button") soundin = pick(GLOB.button_sound)
 			if ("chop") soundin = pick(GLOB.chop_sound)
 			if ("glasscrack") soundin = pick(GLOB.glasscrack_sound)
+			if ("tray_hit") soundin = pick(GLOB.tray_hit_sound)
 	return soundin

--- a/code/modules/codex/entries/tools.dm
+++ b/code/modules/codex/entries/tools.dm
@@ -91,3 +91,11 @@
 	mechanics_text = "The toolbox is a general-purpose storage item with lots of space. With an item in your hand, click on it to store it inside."
 	lore_text = "No one remembers which company designed this particular toolbox. It's been mass-produced, retired, brought out of retirement, and counterfeited for decades."
 	antag_text = "Carrying one of these and being bald tends to instill a certain primal fear in most people."
+
+/datum/codex_entry/tray
+	associated_paths = list(/obj/item/weapon/tray)
+	mechanics_text = "A storage item for food; foodstuffs on the tray take up half as much space as they normally would, letting you carry ingredients or food easily.\
+	<br><br>Switch to Grab intent to scoop up items by hitting them, or add them to the tray directly. Hit a table with Grab intent active to unload the tray's contents onto it. \
+	You can also activate the tray in-hand to dump its contents onto whatever's beneath you.\
+	<br><br>Non-Grab intents can be used to put the tray down onto surfaces without dumping it out, or Harm intent can be used to hit people with the tray itself. \
+	If you're a cyborg, robot, or other non-human, Help intent replaces Grab intent for interactions that use it."

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -195,78 +195,8 @@
 	name = "RoboTray"
 	desc = "An autoloading tray specialized for carrying refreshments."
 
-/obj/item/weapon/tray/robotray/afterattack(atom/target, mob/user as mob, proximity)
-	if(!proximity)
-		return
-	if ( !target )
-		return
-	// pick up items, mostly copied from base tray pickup proc
-	// see code/game/objects/items/weapons/kitchen.dm line 241
-	if ( istype(target,/obj/item))
-		if ( !isturf(target.loc) ) // Don't load up stuff if it's inside a container or mob!
-			return
-		var turf/pickup = target.loc
-
-		var addedSomething = 0
-
-		for(var/obj/item/weapon/reagent_containers/food/I in pickup)
-
-
-			if( I != src && !I.anchored && !istype(I, /obj/item/clothing/under) && !istype(I, /obj/item/clothing/suit) && !istype(I, /obj/item/projectile) )
-				var/add = I.get_storage_cost()
-				if(calc_carry() + add >= max_carry)
-					break
-
-				I.forceMove(src)
-				carrying.Add(I)
-				overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = 30 + I.layer)
-				addedSomething = 1
-		if ( addedSomething )
-			user.visible_message("<span class='notice'>\The [user] load some items onto their service tray.</span>")
-
-		return
-
-	// Unloads the tray, copied from base item's proc dropped() and altered
-	// see code/game/objects/items/weapons/kitchen.dm line 263
-
-	if ( isturf(target) || istype(target,/obj/structure/table) )
-		var foundtable = istype(target,/obj/structure/table/)
-		if ( !foundtable ) //it must be a turf!
-			for(var/obj/structure/table/T in target)
-				foundtable = 1
-				break
-
-		var turf/dropspot
-		if ( !foundtable ) // don't unload things onto walls or other silly places.
-			dropspot = user.loc
-		else if ( isturf(target) ) // they clicked on a turf with a table in it
-			dropspot = target
-		else					// they clicked on a table
-			dropspot = target.loc
-
-
-		overlays.Cut()
-
-		var droppedSomething = 0
-
-		for(var/obj/item/I in carrying)
-			I.forceMove(dropspot)
-			carrying.Remove(I)
-			droppedSomething = 1
-			if(!foundtable && isturf(dropspot))
-				// if no table, presume that the person just shittily dropped the tray on the ground and made a mess everywhere!
-				spawn()
-					for(var/i = 1, i <= rand(1,2), i++)
-						if(I)
-							step(I, pick(NORTH,SOUTH,EAST,WEST))
-							sleep(rand(2,4))
-		if ( droppedSomething )
-			if ( foundtable )
-				user.visible_message("<span class='notice'>[user] unloads their service tray.</span>")
-			else
-				user.visible_message("<span class='notice'>[user] drops all the items on their tray.</span>")
-
-	return ..()
+/obj/item/weapon/tray/robotray/can_add_item(obj/item/I)
+	return ..() && istype(I, /obj/item/weapon/reagent_containers)
 
 
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 501 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 497 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
:cl: Ilysen
tweak: Changed the functionality of food trays to be much more flexible than before!
tweak: While on Grab intent, use a food tray on a tile or an item to scoop up what items you can.
tweak: Also while on Grab intent, hit a table with a food tray to dump out the tray's contents onto the table, or a fridge to dump in what you can from the tray.
tweak: Use any other intent to put the tray down without dumping out its contents.
tweak: Borgs can use Help intent in place of Grab intent!
/:cl:

Someone mentioned that food trays behave weirdly in-game right now, so I decided to take a look at their code, and ***holy hell*** was it awful. It was very, very old code. Archaeological code! And its functionality was really weird, too! So I remade them.

In an ideal world, trays would simply be storage items with custom logic, but I'm not sure how to migrate them to that, nor how to prevent them from breaking other stuff in the code by changing their path, so I think the best approach is to un-spaghettify their existing code.

Notable changes, in no particular order:
* Trays no longer use completely custom weapon logic. They now just use normal damage formulae and sane design.
* Trays can now be stored in backpacks. The previous reason for preventing its storage was that the trays... were too strong as weapons. This was stated by a comment in the code itself.
* To make up for trays being storable in backpacks, non-food items take up double the space on them. The default storage space of a tray is the equivalent of one large item, so this just means that normal objects take up the same effective space as putting them in normally.
* Turned checks to determine storage capacity and valid items on trays into reusable functions.
* RoboTrays no longer ***completely copy-paste the code of the entire normal tray instead of just using its base behaviour!***
* Previous trays updated their contents whenever they were picked up, and once items were on it, it was impossible to remove them without dropping the tray. This was very clunky and counter-intuitive, so I remade their functionality from the ground up in the following ways:
  * You can hit a tile that has items in it (or an item itself) to try to scoop up everything on that tile.
  * You can hit a table with a tray to offload the tray onto the table.
  * You can activate a tray in-hand to dump out its contents.
  * You can use an item on the tray to put the item onto the tray if you can.
* General tidying and rewriting of problematic portions of the code and cleanup of very old functions.

Tested as both a human and as a service robot on a local server. I'm sleepy at the time of this PR's making, so page me if I've missed anything or you have any thoughts about it. Stretch goals for the future may include simply turning these into normal storage objects, once I have the knowledge to do that.

Note: I unfortunately haven't tested the attack sound, as I'm too exhausted and forgot to try it when I was testing other aspects. If you could let me know how that goes when testing it locally, I'd really appreciate it.