### PR TITLE
allow setting IPC monitor state on alt-click

### DIFF
--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -92,3 +92,6 @@
 	icon_state = monitor_states[monitor_state_index]
 	var/mob/living/carbon/human/H = loc
 	if(istype(H)) H.update_inv_wear_mask()
+
+/obj/item/clothing/mask/monitor/AltClick(var/mob/user)
+	set_monitor_state(user)


### PR DESCRIPTION
:cl:
rscadd: IPC Monitors can now have what they display changed on a alt-click
/:cl:

changelog. Alt Click > dialog appears to change what's displayed. Made because right-clicking every time was crushing my metal *soul*