### PR TITLE
Xenobotany Atmospheric Chamber Fix

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -26614,7 +26614,8 @@
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 1;
+	id_tag = null
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
@@ -27234,7 +27235,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "qab" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 2;
+	frequency = 1441;
+	icon_state = "map_injector";
+	id = "xenobot_in";
+	use_power = 1
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -27269,7 +27276,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "qcb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/unary/vent_pump/tank{
+	dir = 2;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	id_tag = "xenobot_out";
+	initialize_directions = 2;
+	internal_pressure_bound = 2000;
+	internal_pressure_bound_default = 2000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 0
+	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qdb" = (
@@ -28014,9 +28034,11 @@
 /area/rnd/xenobiology/xenoflora)
 "rab" = (
 /obj/machinery/computer/air_control{
+	input_tag = "xenobot_in";
 	name = "Xenoflora Gas Monitor";
-	sensor_tag = "xenobot_sensor";
-	sensor_name = "Xenoflora Environment"
+	output_tag = "xenobot_out";
+	sensor_name = "Xenoflora Environment";
+	sensor_tag = "xenobot_sensor"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	icon_state = "intact";


### PR DESCRIPTION
:cl: Lindhrive
maptweak: The atmospheric chamber in Xenobotany works now. The console outside can be used to pump gasses in or out.
/:cl:

The atmospheric chamber in Xenobotany was not working as intended. The vent has been replaced with an injector and the scrubber with a tank-vent, and the console has been configured to speak with them. It now works like the chamber in the Miscellaneous lab, only with the vent defaulted to off so as not to pop any unsuspecting scientist lungs.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->