### PR TITLE
Update headset notice

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -243,10 +243,7 @@ proc/get_radio_key_from_channel(var/channel)
 			message_range = speaking.get_talkinto_msg_range(message)
 		var/msg
 		if(!speaking || !(speaking.flags & NO_TALK_MSG))
-			msg = "<span class='notice'>\The [src] talks into \the [used_radios[1]].</span>"
-		for(var/mob/living/M in hearers(5, src))
-			if((M != src) && msg)
-				M.show_message(msg)
+			src.visible_message("<span class='notice'>\The [src] talks into \the [used_radios[1]].</span>", null, "<span class='notice'>You hear someone talk into their headset.</span>", 5)
 			if (speech_sound)
 				sound_vol *= 0.5
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -241,7 +241,6 @@ proc/get_radio_key_from_channel(var/channel)
 		message_range = 1
 		if(speaking)
 			message_range = speaking.get_talkinto_msg_range(message)
-		var/msg
 		if(!speaking || !(speaking.flags & NO_TALK_MSG))
 			src.visible_message("<span class='notice'>\The [src] talks into \the [used_radios[1]].</span>", null, "<span class='notice'>You hear someone talk into their headset.</span>", 5)
 			if (speech_sound)


### PR DESCRIPTION
The code for "X talks into the Y headset" was very, very outdated and inefficient. This changes it to be much cleaner, as well as adds a message for blind people (before, you would still get the message even if you were blind).

:cl:
bugfix: You can no longer hear "X talks into the Y headset" if you are blind; it is replaced with a generic phrase.
/:cl: