### PR TITLE
Adjust helmet and sunglasses tints

### DIFF
--- a/code/modules/clothing/glasses/sunglasses.dm
+++ b/code/modules/clothing/glasses/sunglasses.dm
@@ -5,6 +5,7 @@
 	item_state = "sunglasses"
 	darkness_view = -1
 	flash_protection = FLASH_PROTECTION_MINOR
+	tint = TINT_MODERATE
 
 /obj/item/clothing/glasses/sunglasses/prescription
 	name = "prescription sunglasses"
@@ -55,12 +56,14 @@
 /obj/item/clothing/glasses/sunglasses/sechud/toggle/attack_self(mob/user)
 	if(toggleable && !user.incapacitated())
 		on = !on
-		if(on)
+		if(!on)
 			flash_protection = FLASH_PROTECTION_NONE
+			tint = TINT_NONE
 			src.hud = hud_holder
 			to_chat(user, "You switch \the [src] to HUD mode.")
 		else
 			flash_protection = initial(flash_protection)
+			tint = initial(tint)
 			src.hud = null
 			to_chat(user, "You toggle \the [src]'s darkened mode on.")
 		update_icon()

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -28,6 +28,7 @@
 	randpixel = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA)
 	flash_protection = FLASH_PROTECTION_MAJOR
+	tint = TINT_MODERATE
 
 	var/obj/machinery/camera/camera
 
@@ -78,7 +79,7 @@
 		icon_state = "[initial(icon_state)]_dark"
 		flash_protection = FLASH_PROTECTION_MAJOR
 		flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
-		tint = TINT_HEAVY
+		tint = TINT_MODERATE
 	else
 		icon_state = initial(icon_state)
 		flash_protection = FLASH_PROTECTION_NONE


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Exploration voidsuit helmets now use a less obnoxious tinting overlay when tinting is on
tweak: Mild tinting overlay added to all void suit helmets and sunglasses
bugfix: Fixed an issue with toggleable sechud aviators where they spawned with a weird hybrid of on and off.
/:cl: