### PR TITLE
Fix name of CoS' office on CamMon

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -6404,7 +6404,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Head of Security - Office";
+	c_tag = "Chief of Security - Office";
 	network = list("Command","Security")
 	},
 /obj/machinery/button/alternate/door{


### PR DESCRIPTION
:cl: lorwp
maptweak: The CoS' office is now named correctly on the camera monitor
/:cl:

`Head of Security - Office` > `Chief of Security - Office`

