### PR TITLE
GUP airlock overhaul

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -15,6 +15,7 @@
 	var/tag_air_alarm
 	var/list/dummy_terminals = list()
 	var/cycle_to_external_air = 0
+	var/scrubber_assist = 0
 
 /obj/machinery/embedded_controller/radio/airlock/Destroy()
 	for(var/thing in dummy_terminals)

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -25,8 +25,10 @@
 	var/target_state = TARGET_NONE
 
 	var/cycle_to_external_air = 0
+	var/scrubber_assist = 0
 	var/tag_pump_out_external
 	var/tag_pump_out_internal
+	var/tag_pump_out_scrubber
 
 	var/tag_air_alarm
 
@@ -46,9 +48,12 @@
 	if (istype(M, /obj/machinery/embedded_controller/radio/airlock))	//if our controller is an airlock controller than we can auto-init our tags
 		var/obj/machinery/embedded_controller/radio/airlock/controller = M
 		cycle_to_external_air = controller.cycle_to_external_air
+		scrubber_assist = controller.scrubber_assist
 		if(cycle_to_external_air)
 			tag_pump_out_external = "[id_tag]_pump_out_external"
 			tag_pump_out_internal = "[id_tag]_pump_out_internal"
+		if(scrubber_assist)
+			tag_pump_out_scrubber = "[id_tag]_pump_out_scrubber"
 		tag_exterior_door = controller.tag_exterior_door? controller.tag_exterior_door : "[id_tag]_outer"
 		tag_interior_door = controller.tag_interior_door? controller.tag_interior_door : "[id_tag]_inner"
 		tag_airpump = controller.tag_airpump? controller.tag_airpump : "[id_tag]_pump"

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -731,11 +731,10 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/guppy{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
 	dir = 4;
-	id_tag = "guppy_shuttle_pump_out_internal";
-	power_rating = 15000;
-	scrubbing = "siphon"
+	id_tag = "guppy_shuttle_pump_out_external";
+	
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
@@ -753,9 +752,8 @@
 	req_access = list()
 	},
 /obj/machinery/shield_diffuser,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -800,7 +798,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
 	dir = 8;
 	id_tag = "guppy_shuttle_pump_out_internal";
-	use_power = 1
+	
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -1008,10 +1006,6 @@
 /turf/simulated/wall/prepainted,
 /area/quartermaster/expedition/storage)
 "cf" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
-	},
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1431;
@@ -1020,6 +1014,7 @@
 	req_access = list()
 	},
 /obj/machinery/shield_diffuser,
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "cg" = (
@@ -1055,11 +1050,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/unary/vent_scrubber/guppy{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
 	dir = 8;
-	id_tag = "guppy_shuttle_pump_out_external";
-	power_rating = 15000;
-	scrubbing = "siphon"
+	id_tag = "guppy_shuttle_pump_out_internal";
+	
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
@@ -1303,7 +1297,7 @@
 "cH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/guppy{
 	dir = 8;
-	id_tag = "guppy_shuttle_pump_out_external";
+	id_tag = "guppy_shuttle_pump_out_scrubber";
 	power_rating = 15000;
 	scrubbing = "siphon"
 	},
@@ -4758,7 +4752,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/guppy{
 	dir = 8;
-	id_tag = "guppy_shuttle_pump_out_external";
+	id_tag = "guppy_shuttle_pump_out_scrubber";
 	power_rating = 15000;
 	scrubbing = "siphon"
 	},
@@ -11654,9 +11648,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/toxins)
 "Cm" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
+	dir = 4;
+	id_tag = "guppy_shuttle_pump_out_external";
+	
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
@@ -12376,9 +12371,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "Ex" = (
@@ -15980,16 +15973,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"RW" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
 "RX" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
@@ -37230,7 +37213,7 @@ cy
 Ho
 Ho
 iq
-RW
+Ho
 Ho
 Ho
 Ho

--- a/nano/templates/tin_can.tmpl
+++ b/nano/templates/tin_can.tmpl
@@ -14,9 +14,9 @@
 <div class="item" style="padding-top: 10px">
 	<div class="item">
 		<div class="itemContent" style="width: 100%">
-			{{:helper.link('Evacuate Air', null, {'command' : 'evacuate_atmos'}, data.state == 2 ? 'selected' : null)}}
+			{{:helper.link('Purge Air', null, {'command' : 'evacuate_atmos'}, data.state == 2 ? 'selected' : null)}}
 			{{:helper.link('Equalize With Exterior', null, {'command' : 'fill_atmos'}, data.state == 1 ? 'selected' : null)}}
-			{{:helper.link('Seal', null, {'command' : 'seal'}, data.state == 3 ? 'selected' : null)}}
+			{{:helper.link('Hold', null, {'command' : 'seal'}, data.state == 3 ? 'selected' : null)}}
 		</div>
 		<div class="itemContent" style="padding-top: 2px; width: 100%">
 		{{if data.door_safety}}


### PR DESCRIPTION
🆑 
tweak: The GUP airlock has been overhauled, again. The buttons now function as follows: Purge Air, removes the air and puts it outside the GUP. Equalize With Exterior, which uses exterior air to fill the GUP to the pressure found outside the GUP. Hold, which turns off all vents/scrubbers to save power.
tweak: The GUP airlock now functions with a combination of scrubbers and vents, this may improve performance under some situations.
/🆑

I experimented with some different options for improving the GUP and this is the best I could come up with. I welcome anyone else to try because honestly, the airlock code is painful to deal with. The GUP maintains it's somewhat janky setup, but it's fairly simple to use in a basic form and someone who is more advanced with controlling it can probably get it to go a lot faster now. 