### PR TITLE
Assorted wizard fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -420,6 +420,8 @@ var/global/list/damage_icon_parts = list()
 	overlays_standing[HO_UNDERWEAR_LAYER] = list()
 	for(var/entry in worn_underwear)
 		var/obj/item/underwear/UW = entry
+		if (!UW.icon) // Avoid runtimes for nude underwear types
+			continue
 
 		var/image/I = image(icon = UW.icon, icon_state = UW.icon_state)
 		I.appearance_flags = RESET_COLOR

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -420,7 +420,7 @@ var/global/list/damage_icon_parts = list()
 	overlays_standing[HO_UNDERWEAR_LAYER] = list()
 	for(var/entry in worn_underwear)
 		var/obj/item/underwear/UW = entry
-		if (!UW.icon) // Avoid runtimes for nude underwear types
+		if (!UW || !UW.icon) // Avoid runtimes for nude underwear types
 			continue
 
 		var/image/I = image(icon = UW.icon, icon_state = UW.icon_state)

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -40,6 +40,11 @@
 		return
 	return
 
+/spell/area_teleport/check_valid_targets(list/targets)
+	// Teleport should function across z's, so we make sure that happens
+	// without this check, it only works for teleporting to areas you can see
+	return targets && islist(targets) && targets.len > 0
+
 /spell/area_teleport/after_cast()
 	return
 

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -3,7 +3,7 @@
 	desc = "This spell teleports you to a type of area of your selection."
 	feedback = "TP"
 	school = "conjuration"
-	charge_max = 600
+	charge_max = 60 SECONDS
 	spell_flags = NEEDSCLOTHES
 	invocation = "Scyar Nila!"
 	invocation_type = SpI_SHOUT
@@ -26,7 +26,8 @@
 	var/area/thearea
 	if(!randomise_selection)
 		thearea = input("Area to teleport to", "Teleport") as null|anything in wizteleportlocs
-		if(!thearea) return
+		if(!thearea)
+			return
 	else
 		thearea = pick(wizteleportlocs)
 	return list(wizteleportlocs[thearea])

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -33,7 +33,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/message = ""				//whatever it says to the guy affected by it
 	var/selection_type = "view"		//can be "range" or "view"
 	var/atom/movable/holder			//where the spell is. Normally the user, can be an item
-	var/duration = 0 //how long the spell lasts
+	var/duration = 0 				//how long the spell lasts
 
 	var/list/spell_levels = list(Sp_SPEED = 0, Sp_POWER = 0) //the current spell levels - total spell levels can be obtained by just adding the two values
 	var/list/level_max = list(Sp_TOTAL = 4, Sp_SPEED = 4, Sp_POWER = 0) //maximum possible levels in each category. Total does cover both.
@@ -106,10 +106,12 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		holder = user //just in case
 	if(!cast_check(skipcharge, user))
 		return
+	to_chat(user, SPAN_NOTICE("You start casting [name]..."))
 	if(cast_delay && !spell_do_after(user, cast_delay))
 		return
 	var/list/targets = choose_targets(user)
 	if(!check_valid_targets(targets))
+		to_chat(user, SPAN_WARNING("[name] fizzles. There are no valid targets nearby."))
 		return
 	var/time = 0
 	admin_attacker_log(user, "attempted to cast the spell [name]")

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -61,6 +61,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 
 /obj/item/weapon/spellbook/proc/make_sacrifice(obj/item/I as obj, mob/user as mob, var/reagent)
 	if(has_sacrificed)
+		to_chat(user, SPAN_WARNING("\The [src] is already sated! Wait for a return on your investment before you sacrifice more to it."))
 		return
 	if(reagent)
 		var/datum/reagents/R = I.reagents
@@ -78,7 +79,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 
 
 /obj/item/weapon/spellbook/attackby(obj/item/I as obj, mob/user as mob)
-	if(investing_time && !has_sacrificed)
+	if(investing_time)
 		var/list/objects = spellbook.sacrifice_objects
 		if(objects && objects.len)
 			for(var/type in objects)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -139,7 +139,8 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 			dat += " ([spellbook.spells[spellbook.spells[i]]] spell slot[spellbook.spells[spellbook.spells[i]] > 1 ? "s" : "" ])"
 			if(spellbook.book_flags & CAN_MAKE_CONTRACTS)
 				dat += " <A href='byond://?src=\ref[src];path=\ref[spellbook.spells[i]];contract=1;'>Make Contract</a>"
-			dat += "<br><i>[desc]</i><br>"
+			dat += "<br><i>[desc]</i><br><br>"
+		dat += "<br>"
 		dat += "<center><A href='byond://?src=\ref[src];reset=1'>Re-memorize your spellbook.</a></center>"
 		if(spellbook.book_flags & INVESTABLE)
 			if(investing_time)

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -21,7 +21,7 @@
 	effect_state = "green_sparkles"
 	effect_duration = 5
 
-	message = "You feel a pleasant rush of heat move through your body."
+	message = SPAN_NOTICE("<b>You feel a pleasant rush of heat move through your body.</b>")
 
 /spell/targeted/heal_target/empower_spell()
 	if(!..())
@@ -64,7 +64,7 @@
 	amt_dam_robo = -10
 	amt_blood  = 28
 
-	message = "Your body feels like a furnace."
+	message = SPAN_NOTICE("<b>Your body feels like a warm, cozy fire.</b>")
 
 /spell/targeted/heal_target/major/empower_spell()
 	if(!..())

--- a/code/modules/spells/targeted/cleric_spells.dm
+++ b/code/modules/spells/targeted/cleric_spells.dm
@@ -21,7 +21,8 @@
 	effect_state = "green_sparkles"
 	effect_duration = 5
 
-	message = SPAN_NOTICE("<b>You feel a pleasant rush of heat move through your body.</b>")
+	// Vars expect a constant at compile time, so we can't use macros for spans here
+	message = "<span class='notice'><b>You feel a pleasant rush of heat move through your body.</b></span>"
 
 /spell/targeted/heal_target/empower_spell()
 	if(!..())
@@ -64,7 +65,7 @@
 	amt_dam_robo = -10
 	amt_blood  = 28
 
-	message = SPAN_NOTICE("<b>Your body feels like a warm, cozy fire.</b>")
+	message = "<span class='notice'><b>Your body feels like a warm, cozy fire.</b></span>"
 
 /spell/targeted/heal_target/major/empower_spell()
 	if(!..())
@@ -152,7 +153,7 @@
 
 
 /spell/targeted/heal_target/trance
-	name = "trance"
+	name = "Trance"
 	desc = "A mighty spell of restoration that briefly forces its target into a deep, dreamless sleep, rapidly repairing their body and soul as their senses are dulled. The users of this mighty art are known for being short lived, slowly devolving into raving madness as the power they once relied on fails them with excessive use."
 	feedback = "TC"
 	spell_flags = SELECTABLE
@@ -176,7 +177,7 @@
 		L.forceMove(effect)
 		var/time = (L.getBruteLoss() + L.getFireLoss()) * 20
 		L.status_flags &= GODMODE
-		to_chat(L,"<span class='notice'>You will be in stasis for [time/10] second\s</span>")
+		to_chat(L,"<span class='notice'>You will be in stasis for [time/10] second\s.</span>")
 		addtimer(CALLBACK(src,.proc/cancel_rift),time)
 
 /spell/targeted/heal_target/trance/Destroy()

--- a/code/modules/spells/targeted/equip/holy_relic.dm
+++ b/code/modules/spells/targeted/equip/holy_relic.dm
@@ -1,18 +1,18 @@
 /spell/targeted/equip_item/holy_relic
 	name = "Summon Holy Relic"
-	desc = "This spell summons a relic of purity into your hand for a short while."
+	desc = "This spell summons a relic of purity into your hand for a short while. The relic will disrupt occult and magical energies - be wary, as this includes your own."
 	feedback = "SR"
 	school = "conjuration"
 	charge_type = Sp_RECHARGE
-	charge_max = 600
 	spell_flags = NEEDSCLOTHES | INCLUDEUSER
 	invocation = "Yee'Ro Su!"
 	invocation_type = SpI_SHOUT
-	range = -1
+	range = 0
 	max_targets = 1
 	level_max = list(Sp_TOTAL = 2, Sp_SPEED = 1, Sp_POWER = 1)
-	duration = 250
-	cooldown_min = 350
+	charge_max = 60 SECONDS
+	duration = 25 SECONDS
+	cooldown_min = 35 SECONDS
 	delete_old = 0
 	compatible_mobs = list(/mob/living/carbon/human)
 
@@ -23,7 +23,7 @@
 /spell/targeted/equip_item/holy_relic/cast(list/targets, mob/user = usr)
 	..()
 	for(var/mob/M in targets)
-		M.visible_message("A rod of metal appears in \the [M]'s hand!")
+		M.visible_message(SPAN_DANGER("A rod of metal appears in \the [M]'s hand!"))
 
 /spell/targeted/equip_item/holy_relic/empower_spell()
 	if(!..())

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -7,7 +7,7 @@
 	spell_flags = Z2NOCAST | NEEDSCLOTHES | INCLUDEUSER
 	invocation = "none"
 	invocation_type = SpI_NONE
-	range = -1
+	range = 0
 	max_targets = 1
 	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 4, Sp_POWER = 3)
 	cooldown_min = 100 //50 deciseconds reduction per rank

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -3,15 +3,15 @@
 	desc = "This spell creates your ethereal form, temporarily making you invisible and able to pass through walls."
 	feedback = "EJ"
 	school = "transmutation"
-	charge_max = 300
+	charge_max = 30 SECONDS
 	spell_flags = Z2NOCAST | NEEDSCLOTHES | INCLUDEUSER
 	invocation = "none"
 	invocation_type = SpI_NONE
 	range = 0
 	max_targets = 1
 	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 4, Sp_POWER = 3)
-	cooldown_min = 100 //50 deciseconds reduction per rank
-	duration = 50 //in deciseconds
+	cooldown_min = 10 SECONDS //50 deciseconds reduction per rank
+	duration = 5 SECONDS
 
 	hud_state = "wiz_jaunt"
 
@@ -58,7 +58,7 @@
 /spell/targeted/ethereal_jaunt/empower_spell()
 	if(!..())
 		return 0
-	duration += 20
+	duration += 2 SECONDS
 
 	return "[src] now lasts longer."
 

--- a/code/modules/spells/targeted/projectile/dumbfire.dm
+++ b/code/modules/spells/targeted/projectile/dumbfire.dm
@@ -1,5 +1,6 @@
 /spell/targeted/projectile/dumbfire
 	name = "dumbfire spell"
+	selection_type = "range"
 
 /spell/targeted/projectile/dumbfire/choose_targets(mob/user = usr)
 	var/list/targets = list()

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -5,7 +5,7 @@
 	proj_type = /obj/item/projectile/spell_projectile/fireball
 
 	school = "conjuration"
-	charge_max = 100
+	charge_max = 10 SECONDS
 	spell_flags = 0
 	invocation = "Oni-Soma!"
 	invocation_type = SpI_SHOUT


### PR DESCRIPTION
:cl: Ilysen
bugfix: The Teleport, Ethereal Jaunt, and Summon Holy Relic wizard spells now work properly!
tweak: If a spell fails to cast, it now displays a message.
tweak: Improved the spellbook's formatting.
/:cl:

I recently played wizard for the first time and had a blast. I had some bugs with several spells, though, and according to the admins who helped me out in AOOC, they've been bugged for a while. So I fixed them!

In no particular order:
* Teleport attempts to check if the area being teleported to is within 7 tiles of the user. For obvious reasons, this is very silly, as it's intended to let them teleport regardless of location. This is now fixed, with Teleport letting you use it normally.
* Ethereal Jaunt had a range of -1, which prevented it from locating the caster. It now has a range of 0, which appears to make it *only* locate the caster (similar to Mutate and other self-casting spells.)
* Summon Holy Relic had the same problem as Ethereal Jaunt.
* Fireball can now shoot at turfs/walls/hapless victims off-screen.
* Failing to cast a spell now displays an error message, instead of failing silently.
* Starting to cast a spell now displays a message. Casting on Bay requires the user to stand still for a very short period, which can be interrupted if they cast while moving.
* Added a line break between spell entries, preventing them from all being clustered together.
* Added an error message when you try to sacrifice something to your spell book when it already has a sacrifice for that cycle.
* Adjusted some spells to use `X SECONDS` definitions instead of deciseconds.
* Added spans to targeted healing spell messages.

It also fixes a runtime caused by regenerating icons with nude underwear types, which closes the following duplicate issues:
* Fixes #20518
* Fixes #22492
* Fixes #23619
* Fixes #24240
* Fixes #26096
* Fixes #28176

Future todo: Probably more fixes.