### PR TITLE
 Rename Officer's Mess Entrance and Vacant Office Cameras

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -9816,7 +9816,7 @@
 /area/thruster/d3port)
 "tL" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Officer's Mess Hall Entrance";
+	c_tag = "Third Deck Hallway - Center";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green{
@@ -11908,7 +11908,7 @@
 /area/command/disperser)
 "zn" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Vacant Offices";
+	c_tag = "Computer Lab";
 	dir = 4
 	},
 /obj/machinery/power/apc{


### PR DESCRIPTION
Renames two cameras that were misleading. O-mess entrance camera is not actually on the entrance, it's in the hallway. Vacant office is not called that, it's the computer lab.

🆑 
tweak: The "Third Deck Hallway - Officer's Mess Hall Entrance" camera is now known as the "Third Deck Hallway - Center" camera.
tweak: The "Vacant Offices" camera is now known as the "Computer Lab" camera.
/:cl: