### PR TITLE
Fixes low walls not being interactable with windows on them

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -109,9 +109,10 @@ Quick adjacency (to turf):
 		if(O.atom_flags & ATOM_FLAG_CHECKS_BORDER) // windows have throwpass but are on border, check them first
 			if( O.dir & target_dir || O.dir&(O.dir-1) ) // full tile windows are just diagonals mechanically
 				var/obj/structure/window/W = target_atom
-				if(istype(W))
-					if(!W.is_fulltile())	//exception for breaking full tile windows on top of single pane windows
-						return 0
+				if(istype(W) && W.is_fulltile()) //exception for breaking full tile windows on top of single pane windows
+					return 1
+				if(istype(target_atom, /obj/structure/wall_frame)) // exception for low walls beneath windows
+					return 1
 				else
 					return 0
 


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes low walls not being interactable when they have a window on it.
/:cl:

In particular, this fixes not being able to paint a low wall when it has a window on it.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->