### PR TITLE
Reduce skill requirements for scanning planet atmosphere's to trained

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -368,7 +368,7 @@
 	. = ..()
 	var/list/extra_data = list("<hr>")
 	if(atmosphere)
-		if(user.skill_check(SKILL_SCIENCE, SKILL_EXPERT))
+		if(user.skill_check(SKILL_SCIENCE, SKILL_ADEPT))
 			var/list/gases = list()
 			for(var/g in atmosphere.gas)
 				if(atmosphere.gas[g] > atmosphere.total_moles * 0.05)
@@ -411,14 +411,14 @@
 
 	for(var/datum/exoplanet_theme/theme in themes)
 		skybox_image.overlays += theme.get_planet_image_extra()
-	
+
 	if(water_color) //TODO: move water levels out of randommap into exoplanet
 		var/image/water = image('icons/skybox/planet.dmi', "water")
 		water.color = water_color
 		water.appearance_flags = PIXEL_SCALE
 		water.transform = water.transform.Turn(rand(0,360))
 		skybox_image.overlays += water
-	
+
 	if(atmosphere && atmosphere.return_pressure() > SOUND_MINIMUM_PRESSURE)
 
 		var/atmo_color = get_atmosphere_color()
@@ -435,7 +435,7 @@
 
 		var/image/atmo = image('icons/skybox/planet.dmi', "atmoring")
 		skybox_image.underlays += atmo
-		
+
 	var/image/shadow = image('icons/skybox/planet.dmi', "shadow")
 	shadow.blend_mode = BLEND_MULTIPLY
 	skybox_image.overlays += shadow


### PR DESCRIPTION
Atmosphere scanning was the only aspect of the sensor scanner that required anything higher than trained in science, which was therefore unattainable for anyone who'd be on the bridge that wasn't the CSO, XO, or CO (And unlikely for the XO and CO due to the skill costs). As bridge officers are primarily the ones manning sensors (And pilots can just get the same details using the Charon's atmos scanner once landed), it makes sense to bump that requirement down.

:cl:
tweak: Scanning a planet's atmosphere from the sensor suite now only requires TRAINED science skill. Down from EXPERIENCED.
/:cl: