### PR TITLE
Add control-click to remove pen from PDA

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -5,9 +5,9 @@
 		verbs -= /obj/item/modular_computer/proc/eject_usb
 
 	if(stores_pen && istype(stored_pen))
-		verbs |= /obj/item/modular_computer/proc/remove_pen
+		verbs |= /obj/item/modular_computer/proc/remove_pen_verb
 	else
-		verbs -= /obj/item/modular_computer/proc/remove_pen
+		verbs -= /obj/item/modular_computer/proc/remove_pen_verb
 
 	if(card_slot)
 		verbs |= /obj/item/weapon/stock_parts/computer/card_slot/proc/verb_eject_id
@@ -54,22 +54,26 @@
 	proc_eject_usb(usr)
 	update_verbs()
 
-/obj/item/modular_computer/proc/remove_pen()
+/obj/item/modular_computer/proc/remove_pen_verb()
 	set name = "Remove Pen"
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.incapacitated() || !istype(usr, /mob/living))
-		to_chat(usr, "<span class='warning'>You can't do that.</span>")
+	remove_pen(usr)
+
+/obj/item/modular_computer/proc/remove_pen(mob/user)
+
+	if(user.incapacitated() || !istype(user, /mob/living))
+		to_chat(user, "<span class='warning'>You can't do that.</span>")
 		return
 
-	if(!Adjacent(usr))
-		to_chat(usr, "<span class='warning'>You can't reach it.</span>")
+	if(!Adjacent(user))
+		to_chat(user, "<span class='warning'>You can't reach it.</span>")
 		return
 
 	if(istype(stored_pen))
-		to_chat(usr, "<span class='notice'>You remove [stored_pen] from [src].</span>")
-		usr.put_in_hands(stored_pen) // Silicons will drop it anyway.
+		to_chat(user, "<span class='notice'>You remove [stored_pen] from [src].</span>")
+		user.put_in_hands(stored_pen) // Silicons will drop it anyway.
 		stored_pen = null
 		update_verbs()
 

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -18,6 +18,12 @@
 	. = ..()
 	enable_computer()
 
+obj/item/modular_computer/pda/CtrlClick(mob/user)
+	if(!isturf(loc)) ///If we are dragging the PDA across the ground we don't want to remove the pen
+		remove_pen(user)
+	else
+		. = ..()
+
 /obj/item/modular_computer/pda/AltClick(var/mob/user)
 	if(!CanPhysicallyInteract(user))
 		return


### PR DESCRIPTION
So the pen removal code was pretty sinful. I've refactored it so that it is split up into a verb and a proc and allowed you to control-click it to remove the pen from it, similar to /tg/ code.

:cl:
rscadd: You can now control-click a PDA to remove the pen inside if there is one.
/:cl: