### PR TITLE
Internals and the SEA's whistle now fit in equipment belts and holster belts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -289,7 +289,10 @@
 		/obj/item/clothing/head/soft,
 		/obj/item/weapon/hand_labeler,
 		/obj/item/clothing/gloves,
-		/obj/item/weapon/crowbar/prybar
+		/obj/item/weapon/crowbar/prybar,
+		/obj/item/weapon/tank/emergency,
+		/obj/item/clothing/mask/breath,
+		/obj/item/toy/bosunwhistle
 		)
 
 /obj/item/weapon/storage/belt/janitor
@@ -345,7 +348,10 @@
 		/obj/item/clothing/head/soft,
 		/obj/item/weapon/hand_labeler,
 		/obj/item/clothing/gloves,
-		/obj/item/weapon/crowbar/prybar
+		/obj/item/weapon/crowbar/prybar,
+		/obj/item/weapon/tank/emergency,
+		/obj/item/clothing/mask/breath,
+		/obj/item/toy/bosunwhistle
 		)
 
 /obj/item/weapon/storage/belt/holster/forensic


### PR DESCRIPTION
:cl: Flying_loulou
tweak: The bosun whistle (SEA's whistle), and your internals now fit in equipment belts and holster belts.
/:cl:


SEA regulars rejoice !!! You can finally stash that _fucking_ whistle in your equipment belt.

That's been infuriating me every SEA round (even if I never use this silly thing) for long enough for me to PR this. And internals because... Well makes sense to me.