### PR TITLE
Fire tweaks, chapter 1, take #I-dunno

### DIFF
--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -320,6 +320,9 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		log_debug("new temperature = [temperature]; new pressure = [return_pressure()]")
 		#endif
 
+		if (temperature<220)
+			firelevel = 0
+
 		return firelevel
 
 datum/gas_mixture/proc/check_recombustability(list/fuel_objs)


### PR DESCRIPTION
:cl: Flying_loulou
tweak: Fires now stop burning under 220K
/:cl:


Partial redo of #27515, which was closed for I was inactive. I'm gonna carry on the intended changes, but step by step this time (inch'allah I can figure out those overpants pressure protection too).

This is to prevent people from freezing while fighting fires (-200°C with a fire still burning and you freezing, y'know...).