### PR TITLE
Two very small tweaks to Operating Room 2

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15554,8 +15554,8 @@
 	pixel_z = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/ivbag/nanoblood,
@@ -17482,6 +17482,9 @@
 	network = list("Medical, Engineering")
 	},
 /obj/machinery/vitals_monitor,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/surgery2)
 "eOb" = (
@@ -17534,7 +17537,6 @@
 	pixel_x = -2;
 	pixel_y = 24
 	},
-/obj/item/weapon/storage/firstaid/adv,
 /obj/item/weapon/reagent_containers/spray/sterilizine,
 /obj/item/weapon/reagent_containers/spray/cleaner/drone,
 /turf/simulated/floor/tiled/dark,
@@ -18197,6 +18199,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/adv,
 /turf/simulated/floor/tiled/dark,
 /area/medical/surgery2)
 "fDJ" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -17483,7 +17483,7 @@
 	},
 /obj/machinery/vitals_monitor,
 /obj/machinery/light{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/surgery2)


### PR DESCRIPTION
:cl: Ilysen
maptweak: Removes a dark spot in Operating Room 2, and moved the advanced first aid kit onto the empty table instead of sharing a tile with the cleaning sprays.
maptweak: Fixed Operating Room 2 using a cyborg space cleaner bottle instead of a normal one.
/:cl:

OR2 ends up being used for cases requiring organ replacement instead of OR1, but it feels very claustrophobic due to having a dark spot. Dark spots are a thing through all the Torch, but it's really odd to have one in an operating room, as surgeons generally want to see in as much detail as possible when poking someone's insides. This just adds another light tube to try to nip that little detail in the bud.

I also moved the advanced first aid kit down a tile in order to make it consistent with OR1 as well as to make the room feel a little more spread out instead of nearly all of its active-use stuff being clustered in the top four tiles.

Before and After below. Both screenshots are taken with the lights in the Robotics lab on. Catgirl for scale. The pixel shift of the surgery kit seems to be randomized; I didn't adjust it but it looks different across rounds.

### Before:
![image](https://user-images.githubusercontent.com/47678781/79340967-0e4b6500-7ef9-11ea-8fa3-bb3e7cc616c3.png)

### After:
![image](https://user-images.githubusercontent.com/47678781/79341884-73ec2100-7efa-11ea-95ef-e8af13ae554d.png)
