### PR TITLE
Make Mutiny require at least 4 antagonists and 10 players

### DIFF
--- a/maps/torch/datums/game_modes/torch_revolution.dm
+++ b/maps/torch/datums/game_modes/torch_revolution.dm
@@ -7,6 +7,8 @@
 								on Mars, Luna and other various worlds has spawned primetime scandals that dominate the 24/7 news cycle. Videolink interviews with Torch crew reveal morale is at an \
 								all time low. Rumors are spreading of an impending mutiny."
 	config_tag = "mutiny"
+	required_enemies = 4
+	required_players = 10
 
 /datum/antagonist/revolutionary
 	role_text = "Head Mutineer"


### PR DESCRIPTION
:cl: lorwp
tweak: Mutiny now requires at least 4 antagonists and 10 players readied up
/:cl:

Player count can be tweaked on request, this is mainly to ensure both loyalists and mutineers exist, to prevent situations like solo loyalist or mutineer.

edit: now 10 because people like to latejoin