### PR TITLE
Makes config tag of mutiny just 'mutiny'

### DIFF
--- a/maps/torch/datums/game_modes/torch_revolution.dm
+++ b/maps/torch/datums/game_modes/torch_revolution.dm
@@ -6,6 +6,7 @@
 								and the shipbound AI system will complete a series of jumps that will take the ship lightyears further away from home. Outrage from friends and family of crew back \
 								on Mars, Luna and other various worlds has spawned primetime scandals that dominate the 24/7 news cycle. Videolink interviews with Torch crew reveal morale is at an \
 								all time low. Rumors are spreading of an impending mutiny."
+	config_tag = "mutiny"
 
 /datum/antagonist/revolutionary
 	role_text = "Head Mutineer"


### PR DESCRIPTION
:cl: lorwp
bugfix: mutiny is no longer listed as 'revolution' when staff change the gamemode manually. be afraid
/:cl:
To ensure when manually changed in the game panel it's no longer listed as 'revolution' to players