### PR TITLE
Change say/me inputs to text|null

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -48,7 +48,7 @@ I IS TYPIN'!'
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","say (text)") as text
+	var/message = input("","say (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		say_verb(message)
@@ -58,7 +58,7 @@ I IS TYPIN'!'
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","me (text)") as text
+	var/message = input("","me (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		me_verb(message)


### PR DESCRIPTION
🆑 
tweak: There is a now cancel button when you use the say/me verbs to close out of the window quickly.
/:cl:

On a related note, version 513 will allow inputs with `anything|null` to be cancelable with escape so when/if we update the server version I'll probably make a PR in accordance.