### PR TITLE
Improves light tube code, and makes a few tweaks in relevant areas

### DIFF
--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -79,3 +79,8 @@
 	icon_state = "bulb-construct-item"
 	refund_amt = 1
 	build_machine_type = /obj/machinery/light_construct/small
+
+/obj/item/frame/light/spot
+	name = "large light fixture frame"
+	build_machine_type = /obj/machinery/light_construct/spot
+	refund_amt = 3

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -156,10 +156,16 @@
 		to_chat(U, "<span class='notice'>You replace the [target.get_fitting_name()] with the [src].</span>")
 
 		if(target.lightbulb)
+			var/obj/item/bulb = target.lightbulb
 			target.remove_bulb()
+			if (isrobot(U))
+				qdel(bulb)
 
 		var/obj/item/weapon/light/L = new target.light_type()
-		L.rigged = emagged
+		if (emagged)
+			log_and_message_admins("used an emagged light replacer.", U)
+			L.create_reagents(5)
+			L.reagents.add_reagent(/datum/reagent/toxin/phoron, 5)
 		target.insert_bulb(L)
 
 

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -83,6 +83,7 @@
 	. += new/datum/stack_recipe/grenade(src)
 	. += new/datum/stack_recipe/light(src)
 	. += new/datum/stack_recipe/light_small(src)
+	. += new/datum/stack_recipe/light_large(src)
 	. += new/datum/stack_recipe/light_switch(src)
 	. += new/datum/stack_recipe/light_switch/windowtint(src)
 	. += new/datum/stack_recipe/apc(src)

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -111,6 +111,12 @@
 	result_type = /obj/item/frame/light/small
 	difficulty = 2
 
+/datum/stack_recipe/light_large
+	title = "large light fixture frame"
+	result_type = /obj/item/frame/light/spot
+	req_amount = 3
+	difficulty = 3
+
 /datum/stack_recipe/light_switch
 	title = "light switch"
 	result_type = /obj/item/frame/light_switch


### PR DESCRIPTION
:cl: Ilysen
tweak: Spotlight frames are now constructable with 3 steel sheets. (For those who don't know: spotlights are light fixtures specialized for large tubes, which shed more light. They're generally found in places like the Galley, with large open spaces.)
tweak: Light replacers now destroy broken bulbs when used by cyborgs.
tweak: When held in-hand, you can see if a light tube is rigged to explode by examining it.
tweak: Removing light fixtures from walls now operates at a speed determined by construction skill.
bugfix: You can no longer inject an infinite amount of reagents into light tubes.
bugfix: Light tubes no longer suck all reagents out of a syringe, and instead only remove the necessary phoron to rig them to explode.
bugfix: Unscrewing an empty light tube will no longer delete its wires.
/:cl:

There's a subtype of light fixtures called 'spotlights' that shed more light by accepting a specialized type of light tube called a 'large' light tube, which uses the same sprite as normal light tubes. You could put large tubes into normal frames, but the actual specialized fixture couldn't be constructed, which made it both unintuitive and unavailable to cyborgs. This tries to fix both!

You can now construct a large light fixture frame out of steel for 3 sheets, which light replacers will insert large light tubes into. This is primarily intended to allow silicons to construct spotlights, but also allows other users to construct specialized fixtures specifically for large tubes.

While I was in the area, I also improved light fixtures' feedback during construction by adding spans and sounds to actions that lacked them, and its code by removing instances of `src.` and replacing uses of `usr` with `user` where applicable, as well as removing magic numbers and replacing them with file-specific defines.

Finally, there's a few changes I made in the area to improve consistency and polish:
* Light tubes no longer eat infinite reagents, and instead only consume the 5 phoron necessary to rig them to explode.
* You can't inject phoron into a light if it's already been primed to explode.
* Examining a light tube held in your hand tells you if it's primed to explode or not via a special examine message. I can remove this, if it's preferred - I mainly intend it as a way to allow people to differentiate lights that they've sabotaged from normal lights in their backpack.
* Some things that weren't visible via message to other players now are (i.e. attempting to destroy lights.)
* The speed of removing light fixtures off of a wall now scales with construction skill.
* Starting the deconstruction process of a light fixture no longer deletes its wires.

I wanted to add unique sprites for large light tubes while I was here, but I'm awful at spriting and my attempts to do so failed pretty spectacularly.