### PR TITLE
Changed shield breach rate while intregrity is below 100%

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -6,6 +6,10 @@
 #define ENERGY_UPKEEP_PER_TILE (3 KILOWATTS)	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
 #define ENERGY_UPKEEP_IDLE 40                  // Base upkeep when idle; modified by other factors.
 
+#define MINOR_BREACH_THRESHOLD 99
+#define MAJOR_BREACH_THRESHOLD 50
+#define CRITICAL_BREACH_THRESHOLD 25
+
 // This shield model is slightly inspired by Sins of a Solar Empire series. In short, shields are designed to analyze what hits them, and adapt themselves against that type of damage.
 // This means shields will become increasingly effective against things like emitters - as they will adapt to heat damage, however they will be vulnerable to brute and EM damage.
 // In a theoretical assault scenario, it is best to combine all damage types, so mitigation can't build up. The value is capped to prevent full scale invulnerability.

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -384,11 +384,12 @@
 		energy_failure()
 		return SHIELD_BREACHED_FAILURE
 
-	if(prob(10 - field_integrity()))
+	var/breachChance = rand(field_integrity(), field_integrity() + 100)
+	if(breachChance <= CRITICAL_BREACH_THRESHOLD)
 		return SHIELD_BREACHED_CRITICAL
-	if(prob(20 - field_integrity()))
+	else if(breachChance <= MAJOR_BREACH_THRESHOLD)
 		return SHIELD_BREACHED_MAJOR
-	if(prob(35 - field_integrity()))
+	else if(breachChance <= MINOR_BREACH_THRESHOLD)
 		return SHIELD_BREACHED_MINOR
 	return SHIELD_ABSORBED
 


### PR DESCRIPTION
:cl:
tweak: Shieldgenerator shields now have a chance breach while the shield integrity is below 100% - up from 35%.
/:cl:

Kinda tweak kinda bugfix since imho it is to expect that while integrity is not 100% the shield can be breached. 
Before it was only breachable while integrity was less than 35% which seems odd. 
Shouldn't have any major gameplay influence.