### PR TITLE
Fixes surgery overlay bug

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -222,8 +222,8 @@ var/global/list/damage_icon_parts = list()
 	var/icon/icon_template = GLOB.species_icon_template_cache[species_key]
 	var/icon/overlay = GLOB.overlay_icon_cache[overlay_key]
 
-	var/x_offset = Ceiling(0.5*(icon_template.Width() - overlay.Width()))
-	var/y_offset = Ceiling(0.5*(icon_template.Height() - overlay.Height()))
+	var/x_offset = Ceiling(0.5*(icon_template.Width() - (overlay.Width() || 32)))
+	var/y_offset = Ceiling(0.5*(icon_template.Height() - (overlay.Height() || 32)))
 
 	return M.Translate(x_offset-y_offset, -(x_offset+y_offset))
 


### PR DESCRIPTION
:cl:
bugfix: fixes surgery overlays floating next to the patient
/:cl:

The incision overlays placed onto mobs during surgery will now appear ontop of them instead of next to them. This bug occurred because .Height() and .Width() were returning 0, which should never happen. The proc for calculating overlay offsets will now use 32 for the height or width if .Height() or .Width() are 0 for whatever reason.