### PR TITLE
toggle-tint helmets tint less

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -78,7 +78,7 @@
 		icon_state = "[initial(icon_state)]_dark"
 		flash_protection = FLASH_PROTECTION_MAJOR
 		flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
-		tint = TINT_HEAVY
+		tint = TINT_MODERATE
 	else
 		icon_state = initial(icon_state)
 		flash_protection = FLASH_PROTECTION_NONE


### PR DESCRIPTION
:cl:
tweak: Toggle-tint helmets have a moderate instead of heavy overlay while tinted.
/:cl:

Practical: You can see to the edge of the screen, but the outer two tiles are partly shaded. Previous heavy tint completely blacked out those tiles and shaded another layer inside.

alt for #28303