### PR TITLE
Removes advanced weapons board for mechs

### DIFF
--- a/code/modules/mechs/_mech_setup.dm
+++ b/code/modules/mechs/_mech_setup.dm
@@ -19,7 +19,6 @@ GLOBAL_LIST_INIT(mech_weapon_overlays, icon_states('icons/mecha/mech_weapon_over
 #define MECH_SOFTWARE_UTILITY "utility equipment"                // Plasma torch, clamp, drill.
 #define MECH_SOFTWARE_MEDICAL "medical support systems"          // Sleeper.
 #define MECH_SOFTWARE_WEAPONS "standard weapon systems"          // Ballistics and energy weapons.
-#define MECH_SOFTWARE_ADVWEAPONS "advanced weapon systems"       // Railguns, missile launcher.
 #define MECH_SOFTWARE_ENGINEERING "advanced engineering systems" // RCD.
 
 // EMP damage points before various effects occur.

--- a/code/modules/mechs/components/software.dm
+++ b/code/modules/mechs/components/software.dm
@@ -30,10 +30,4 @@
 	icon_state = "mainboard"
 	origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 3)
 
-/obj/item/weapon/circuitboard/exosystem/advweapons
-	name = T_BOARD_MECH("advanced weapon systems")
-	contains_software = list(MECH_SOFTWARE_ADVWEAPONS)
-	icon_state = "mainboard"
-	origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 5)
-
 #undef T_BOARD_MECH

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -50,6 +50,13 @@
 	if(LAZYISIN(pilots, user) && !hatch_closed)
 		return TRUE
 	. = ..()
+
+//UI distance checks
+/mob/living/exosuit/contents_nano_distance(src_object, mob/living/user)
+	. = ..()
+	if(!hatch_closed)
+		return max(shared_living_nano_distance(src_object), .) //Either visible to mech(outside) or visible to user (inside)
+	
 	
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)
 

--- a/code/modules/mechs/premade/combat.dm
+++ b/code/modules/mechs/premade/combat.dm
@@ -51,7 +51,7 @@
 /obj/item/mech_component/sensors/combat/prebuild()
 	..()
 	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_WEAPONS, MECH_SOFTWARE_ADVWEAPONS)
+	software.installed_software = list(MECH_SOFTWARE_WEAPONS)
 
 /obj/item/mech_component/chassis/combat
 	name = "sealed exosuit chassis"

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -55,7 +55,7 @@
 /obj/item/mech_component/sensors/heavy/prebuild()
 	..()
 	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_WEAPONS, MECH_SOFTWARE_ADVWEAPONS)
+	software.installed_software = list(MECH_SOFTWARE_WEAPONS)
 
 /obj/item/mech_component/chassis/heavy
 	name = "reinforced exosuit chassis"

--- a/code/modules/research/designs/designs_exosuits.dm
+++ b/code/modules/research/designs/designs_exosuits.dm
@@ -30,10 +30,3 @@
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/weapon/circuitboard/exosystem/weapons
 	sort_string = "NAACA"
-
-/datum/design/circuit/exosuit/advweapons
-	name = "advanced weapon control"
-	id = "mech_software_advweapons"
-	req_tech = list(TECH_DATA = 4)
-	build_path = /obj/item/weapon/circuitboard/exosystem/advweapons
-	sort_string = "NAACB"


### PR DESCRIPTION
🆑CrimsonShrike
rscdel: Removed unsued advanced weapons boards for exosuits.
bugfix: Fixes a case with some UI interactions from cockpit of exosuit not working correctly.
/🆑

They  are not used at current time so it doesnt make a lot of sense to keep them around.

Also fixes a small case where interaction wouldnt pass through correctly.