### PR TITLE
Various map tweaks

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -220,18 +220,6 @@
 /area/maintenance/fourthdeck/starboard)
 "aJ" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	display_name = "Starboard Dock C";
-	frequency = 1380;
-	id_tag = "admin_shuttle_dock_airlock";
-	pixel_x = -24;
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
-	tag_airpump = "admin_shuttle_dock_pump";
-	tag_chamber_sensor = "admin_shuttle_dock_sensor";
-	tag_exterior_door = "admin_shuttle_dock_outer";
-	tag_interior_door = "admin_shuttle_dock_inner"
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "aK" = (
@@ -331,6 +319,19 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	display_name = "Starboard Dock C";
+	frequency = 1380;
+	id_tag = "admin_shuttle_dock_airlock";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
+	tag_airpump = "admin_shuttle_dock_pump";
+	tag_chamber_sensor = "admin_shuttle_dock_sensor";
+	tag_exterior_door = "admin_shuttle_dock_outer";
+	tag_interior_door = "admin_shuttle_dock_inner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -3491,22 +3492,6 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
-"lQ" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	display_name = "Port Dock C";
-	frequency = 1331;
-	id_tag = "rescue_shuttle_dock_airlock";
-	pixel_x = -24;
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
-	tag_airpump = "rescue_shuttle_dock_pump";
-	tag_chamber_sensor = "rescue_shuttle_dock_sensor";
-	tag_exterior_door = "rescue_shuttle_dock_outer";
-	tag_interior_door = "rescue_shuttle_dock_inner"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
 "lX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -6547,6 +6532,10 @@
 	icon_state = "warningcorner";
 	dir = 1
 	},
+/obj/machinery/camera/network/supply{
+	c_tag = "Supply Office - Lockers";
+	dir = 2
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
 "uK" = (
@@ -8163,10 +8152,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Port";
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
@@ -8625,6 +8610,18 @@
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
+"Cj" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Lounge Window";
+	dir = 4;
+	name = "security camera"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/lounge)
 "Cr" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -8862,6 +8859,10 @@
 	},
 /obj/machinery/oxygen_pump{
 	pixel_x = -32
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Port";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
@@ -10543,6 +10544,19 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	display_name = "Port Dock C";
+	frequency = 1331;
+	id_tag = "rescue_shuttle_dock_airlock";
+	pixel_x = -24;
+	pixel_y = -24;
+	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
+	tag_airpump = "rescue_shuttle_dock_pump";
+	tag_chamber_sensor = "rescue_shuttle_dock_sensor";
+	tag_exterior_door = "rescue_shuttle_dock_outer";
+	tag_interior_door = "rescue_shuttle_dock_inner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -12509,6 +12523,10 @@
 	dir = 4;
 	id_tag = "rescue_shuttle_dock_pump"
 	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Aft Port Docking Port";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "Pz" = (
@@ -13395,6 +13413,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Aft-Starboard Docking Port";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -33938,7 +33960,7 @@ Hv
 PO
 jr
 OO
-Jo
+Cj
 Nw
 pG
 sJ
@@ -40808,7 +40830,7 @@ uj
 uj
 Jx
 JP
-lQ
+aJ
 Px
 Ms
 Yj

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -5667,6 +5667,10 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/corner/yellow/half,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering Storage";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/storage)
 "mD" = (
@@ -6075,6 +6079,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Teleporter";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
@@ -8618,7 +8626,7 @@
 	use_power = 1
 	},
 /obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - North"
+	c_tag = "Atmospherics - Starboard"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -12638,17 +12646,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
-"Fd" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - West";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/atmos)
 "Ff" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
@@ -13930,6 +13927,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/aftport)
+"IY" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Atmospherics - Fore";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
 "Jd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14332,7 +14340,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - South";
+	c_tag = "Atmospherics - Aft";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
@@ -18214,6 +18222,27 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/atmos)
+"Xq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Atmospherics - Port";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
@@ -41034,7 +41063,7 @@ WI
 wc
 yB
 WI
-Fd
+IY
 wM
 GC
 yt
@@ -42046,7 +42075,7 @@ yG
 ES
 DI
 Za
-BE
+Xq
 Qu
 Ec
 Fp

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -6295,10 +6295,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Emergency Armory Entrance";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
@@ -11861,16 +11857,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
-"aRm" = (
-/obj/machinery/deployable/barrier,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Emergency Armory - Port";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aRo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20304,6 +20290,10 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Mech Bay";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
 "hPN" = (
@@ -26409,6 +26399,22 @@
 "pbb" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
+"pbT" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "operation_hallway_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Emergency Armory Entrance";
+	dir = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/aft)
 "pcb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -57980,7 +57986,7 @@ scr
 scr
 scr
 awF
-jqn
+pbT
 ayF
 jqn
 hPN
@@ -59604,7 +59610,7 @@ aHT
 uZO
 xzj
 aQr
-aRm
+aQr
 eRU
 eRU
 acd

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -4724,6 +4724,10 @@
 	icon_state = "techfloor_edges";
 	dir = 8
 	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge Airlock";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "jc" = (
@@ -10768,6 +10772,9 @@
 	icon_state = "techfloor_edges";
 	dir = 8
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "xh" = (
@@ -13113,6 +13120,18 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"GS" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+	dir = 8;
+	id_tag = "bridge_eva_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/bridge/aft)
 "GU" = (
 /obj/structure/displaycase,
 /obj/item/weapon/gun/projectile/revolver/medium/captain{
@@ -17155,6 +17174,10 @@
 "Xz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/guncabinet/PPE,
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge Storage";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "XB" = (
@@ -34186,7 +34209,7 @@ ad
 gX
 hK
 is
-hK
+GS
 DN
 kT
 lO


### PR DESCRIPTION
- Cameras added to fix random blind spots:
	- Mech Bay
	- Bridge airlock
	- Deck 1 aft hallway outside counselor's office
	- Engineering storage (Pump/scrubber connectors)
	- Deck 2 teleporter
	- Atmospherics maintenance hatch
	- Bridge storage
	- Deck 4 aft-port and aft-starboard hallways and docking ports
	- Supply Office locker area
	- Lounge window
- Deck 4 aft docking port controllers are no longer inside windows
- Lights added to bridge airlock
- Redundant camera removed from emergency armory

:cl:
map: Deck 4 aft-port and aft-starboard docking controllers are now accessible from the hallways.
map: Bridge deck airlock now has lights
map: Cameras added to various areas across the map. See PR #28422 for exact locations.
/:cl: