### PR TITLE
Remove supply, engineering, security, and research access from CL and LPA

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -16,12 +16,12 @@
 /obj/item/device/encryptionkey/headset_torchcorp
 	name = "corporate radio encryption key"
 	icon_state = "nt_cypherkey"
-	channels = list("Science" = 1, "Service" = 1)
+	channels = list("Service" = 1)
 
 /obj/item/device/encryptionkey/headset_torchcl
 	name = "corporate liaison radio encryption key"
 	icon_state = "nt_cypherkey"
-	channels = list("Science" = 1, "Service" = 1, "Command" = 1)
+	channels = list("Service" = 1, "Command" = 1)
 
 /obj/item/device/encryptionkey/headset_deckofficer
 	name = "deck chief's encryption key"

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -21,10 +21,8 @@
 	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
-	access = list(access_liaison, access_security, access_medical,
-						access_engine, access_research, access_bridge,
-						access_cargo, access_solgov_crew, access_hangar,
-						access_nanotrasen, access_commissary, access_petrov)
+	access = list(access_liaison, access_bridge, access_solgov_crew,
+						access_nanotrasen, access_commissary)
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
 /datum/job/liaison/get_description_blurb()
@@ -66,10 +64,8 @@
 		"Asset Protection Agent"
 	)
 	skill_points = 20
-	access = list(access_liaison, access_security, access_medical,
-						access_engine, access_research, access_bridge,
-						access_cargo, access_solgov_crew, access_hangar,
-						access_nanotrasen, access_commissary, access_petrov,
+	access = list(access_liaison, access_bridge, access_solgov_crew,
+						access_nanotrasen, access_commissary,
 						access_sec_guard)
 	defer_roundstart_spawn = TRUE
 


### PR DESCRIPTION
As someone that's been playing CL lately, there's no reason for the liaison to have access to any of this. The only CL's that use it use it to meme or borderline grief.

:cl:
tweak: Corporate Liaison and Liaison Protection Agent no longer have access to research, medbay, security, or supply
tweak: Liaison Protection Agent can no longer set intercoms and handheld radios to the security channel
/:cl: