### PR TITLE
Give overmap effects a default color

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3145,6 +3145,7 @@
 #include "code\unit_tests\music_test.dm"
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\organ_tests.dm"
+#include "code\unit_tests\overmap_tests.dm"
 #include "code\unit_tests\power_tests.dm"
 #include "code\unit_tests\reagent_color_test.dm"
 #include "code\unit_tests\seed_tests.dm"

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -2,6 +2,7 @@
 	name = "map object"
 	icon = 'icons/obj/overmap.dmi'
 	icon_state = "object"
+	color = "#fffffe"
 
 	var/known = 1		//shows up on nav computers automatically
 	var/scannable       //if set to TRUE will show up on ship sensors for detailed scans
@@ -17,7 +18,7 @@
 	. = ..()
 	if(!GLOB.using_map.use_overmap)
 		return INITIALIZE_HINT_QDEL
-	
+
 	if(known)
 		layer = ABOVE_LIGHTING_LAYER
 		plane = EFFECTS_ABOVE_LIGHTING_PLANE

--- a/code/unit_tests/overmap_tests.dm
+++ b/code/unit_tests/overmap_tests.dm
@@ -1,0 +1,24 @@
+/datum/unit_test/overmap_test
+	template = /datum/unit_test/overmap_test
+
+/datum/unit_test/overmap_test/New()
+	name = "OVERMAP: " + name
+
+// 513 no longer allows no color or white as a filter color, hence this test
+/datum/unit_test/overmap_test/shall_have_non_white_color
+	name = "Shall have non-white color"
+
+/datum/unit_test/overmap_test/shall_have_non_white_color/start_test()
+	var/list/invalid_overmap_types = list()
+	for(var/omt in subtypesof(/obj/effect/overmap))
+		var/obj/overmap = omt
+		var/color = initial(overmap.color)
+		if(!color || color == COLOR_WHITE)
+			invalid_overmap_types += omt
+
+	if(invalid_overmap_types.len)
+		fail("Following /obj/effect/overmap types types have invalid colors: [english_list(invalid_overmap_types)]")
+	else
+		pass("All /obj/effect/overmap types have a valid color")
+
+	return TRUE


### PR DESCRIPTION
Fixes startup runtimes in 513 due to invalid colors in `on_update_Icon()`
Adds a test to prevent setting invalid colors in the future