### PR TITLE
Rework defibrillation and resuscitation

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -51,7 +51,7 @@
 #define PULSE_NORM    2   //  60-90  bpm
 #define PULSE_FAST    3   //  90-120 bpm
 #define PULSE_2FAST   4   // >120    bpm
-#define PULSE_THREADY 5   // Occurs during hypovolemic shock
+#define PULSE_THREADY 5   // Ventricular fibrillation. Occurs when the heart is barely working and requires defibrillation
 #define GETPULSE_HAND 0   // Less accurate. (hand)
 #define GETPULSE_TOOL 1   // More accurate. (med scanner, sleeper, etc.)
 #define PULSE_MAX_BPM 250 // Highest, readable BPM by machines and humans.

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -173,7 +173,9 @@
 	else
 		dat += "<td>[scan["pulse"]]bpm</td></tr>"
 	if(skill_level >= SKILL_ADEPT)
-		if((scan["pulse"] >= 140) || (scan["pulse"] == -3))
+		if(scan["pulse"] >= PULSE_MAX_BPM || scan["pulse"] == -3)
+			dat+= "<tr><td colspan='2'><span class='bad'>Patient's heart is fibrillating.</span></td></tr>"
+		else if((scan["pulse"] >= 140))
 			dat+= "<tr><td colspan='2'><span class='bad'>Patient is tachycardic.</span></td></tr>"
 		else if(scan["pulse"] >= 120)
 			dat += "<tr><td colspan='2'><span class='average'>Patient is tachycardic.</span></td></tr>"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -273,6 +273,10 @@
 /obj/item/weapon/shockpaddles/proc/can_revive(mob/living/carbon/human/H) //This is checked right before attempting to revive
 	if(H.stat == DEAD)
 		return "buzzes, \"Resuscitation failed - Severe neurological decay makes recovery of patient impossible. Further attempts futile.\""
+	
+	var/obj/item/organ/internal/heart/O = H.internal_organs_by_name[BP_HEART]
+	if(O.pulse == PULSE_NONE) //Requires heart to be in VFib (PULSE_THREADY)
+		return "buzzes, \"Resuscitation failed - Patient's heart is not in a shockable rhythm. Administer CPR to bring heart into a shockable rhythm.\""
 
 /obj/item/weapon/shockpaddles/proc/check_contact(mob/living/carbon/human/H)
 	if(!combat)
@@ -374,7 +378,7 @@
 	//set oxyloss so that the patient is just barely in crit, if possible
 	make_announcement("pings, \"Resuscitation successful.\"", "notice")
 	playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
-	H.resuscitate()
+	H.resuscitate(1)
 	var/obj/item/organ/internal/cell/potato = H.internal_organs_by_name[BP_CELL]
 	if(istype(potato) && potato.cell)
 		var/obj/item/weapon/cell/C = potato.cell

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1658,7 +1658,7 @@
 		if((MUTATION_SKELETON in mutations) && (!w_uniform) && (!wear_suit))
 			play_xylophone()
 
-/mob/living/carbon/human/proc/resuscitate()
+/mob/living/carbon/human/proc/resuscitate(var/method) //0 for CPR, 1 for defibrillator
 	if(!is_asystole() || !should_have_organ(BP_HEART))
 		return
 	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
@@ -1669,14 +1669,22 @@
 			var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species_organ]
 			if(L)
 				active_breaths = L.active_breathing
-		if(!nervous_system_failure() && active_breaths)
-			visible_message("\The [src] jerks and gasps for breath!")
-		else
-			visible_message("\The [src] twitches a bit as \his heart restarts!")
+		if(method && heart.pulse == PULSE_THREADY)
+			if(!nervous_system_failure() && active_breaths)
+				visible_message("\The [src] jerks and gasps for breath!")
+			else
+				visible_message("\The [src] twitches a bit!")
+		else 
+			visible_message("\The [src] twitches very slightly.")
 		shock_stage = min(shock_stage, 100) // 120 is the point at which the heart stops.
 		if(getOxyLoss() >= 75)
 			setOxyLoss(75)
-		heart.pulse = PULSE_NORM
+		if(method && heart.pulse == PULSE_THREADY)
+			heart.pulse = PULSE_NORM
+		else if (method)
+			return FALSE
+		else
+			heart.pulse = PULSE_THREADY
 		heart.handle_pulse()
 		return TRUE
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -101,7 +101,7 @@
 						heart.external_pump = list(world.time, 0.4 + 0.1*pumping_skill + rand(-0.1,0.1))
 
 					if(stat != DEAD && prob(10 + 5 * pumping_skill))
-						resuscitate()
+						resuscitate(0)
 
 				if(!H.check_has_mouth())
 					to_chat(H, "<span class='warning'>You don't have a mouth, you cannot do mouth-to-mouth resuscitation!</span>")

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -89,8 +89,8 @@
 	if(pulse && fibrillation)	//I SAID MOAR OXYGEN
 		pulse = PULSE_THREADY
 
-	// Stablising chemicals pull the heartbeat towards the center
-	if(pulse != PULSE_NORM && is_stable)
+	// Stablising chemicals pull the heartbeat towards the center. If we are in ventricular fibrillation this will not work
+	if(pulse != PULSE_NORM && pulse != PULSE_THREADY && is_stable)
 		if(pulse > PULSE_NORM)
 			pulse--
 		else
@@ -120,7 +120,8 @@
 	if(!owner || owner.InStasis() || owner.stat == DEAD || owner.bodytemperature < 170)
 		return
 
-	if(pulse != PULSE_NONE || BP_IS_ROBOTIC(src))
+	//Fibrillating or stopped hearts do not pump the blood.
+	if((pulse != PULSE_NONE && pulse != PULSE_THREADY ) || BP_IS_ROBOTIC(src))
 		//Bleeding out
 		var/blood_max = 0
 		var/list/do_spray = list()
@@ -193,7 +194,7 @@
 	if(!is_usable())
 		return FALSE
 
-	return pulse > PULSE_NONE || BP_IS_ROBOTIC(src) || (owner.status_flags & FAKEDEATH)
+	return (pulse > PULSE_NONE && pulse < PULSE_THREADY) || BP_IS_ROBOTIC(src) || (owner.status_flags & FAKEDEATH)
 
 /obj/item/organ/internal/heart/listen()
 	if(BP_IS_ROBOTIC(src) && is_working())

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -168,7 +168,7 @@
 
 			// Fix our heart if we're paramount.
 			if(heal_general && H.is_asystole() && H.should_have_organ(BP_HEART) && spend_power(heal_rate))
-				H.resuscitate()
+				H.resuscitate(1)
 
 			// Heal organ damage.
 			if(heal_internal)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -915,7 +915,7 @@
 		M.make_jittery(5)
 	if(volume >= 5 && M.is_asystole())
 		remove_self(5)
-		if(M.resuscitate())
+		if(M.resuscitate(0))
 			var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
 			heart.take_internal_damage(heart.max_damage * 0.15)
 


### PR DESCRIPTION
This makes a stopped heart much more serious and dangerous than simply being able to use a defibrillator or CPR. They now have to be used in tandem and should be a priority 1 focus for medical.

:cl:
rscadd: Stopped hearts can no longer be defibrillated instantly. CPR must be administered to put the heart into a shockable rhythm (ventricular fibrillation), at which time a defibrillator must be used to resuscitate the person. Neither method will work on its own.
:tweak: A heart in ventricular fibrillation (>250bpm on a scanner) will not slow down on its own even with inaprovaline and requires a defibrillator to return to a normal rhythm.
/:cl: