### PR TITLE
allows away sites to force/allow/ban other sites

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -87,6 +87,9 @@
 #define TEMPLATE_FLAG_NO_RUINS         8 // if it should forbid ruins from spawning on top of it
 #define TEMPLATE_FLAG_NO_RADS          16// Removes all radiation from the template after spawning.
 
+//Ruin map template flags
+#define TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED 32 // Ruin is not available during spawning unless another ruin permits it.
+
 // Convoluted setup so defines can be supplied by Bay12 main server compile script.
 // Should still work fine for people jamming the icons into their repo.
 #ifndef CUSTOM_ITEM_CONFIG

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -11,6 +11,11 @@
 	var/suffixes = null
 	template_flags = 0 // No duplicates by default
 
+	// !! Currently only implemented for away sites
+	var/list/force_ruins // Listed ruins are always spawned unless disallowed by flags.
+	var/list/allow_ruins // Listed ruins are added to the set of available spawns.
+	var/list/ban_ruins   // Listed ruins are removed from the set of available spawns. Beats allowed.
+
 /datum/map_template/ruin/New()
 	if (suffixes)
 		mappaths = list()


### PR DESCRIPTION
Away site datums gain lists that allow them to force spawn, make available, or ban other sites, and a flag that allows them to not be initially available during picking. This allows for away site chains, random branching (to an extent), mutually exclusive spawns, etc.

Only in mapgen; does not apply to user-spawned sites.

forgive my code, I can feel my eyes today