### PR TITLE
Add ability to hold breath

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -19,8 +19,6 @@
 
 	if(losebreath>0) //Suffocating so do not take a breath
 		losebreath--
-		if (prob(10) && !is_asystole() && active_breathe) //Gasp per 10 ticks? Sounds about right.
-			emote("gasp")
 	else
 		//Okay, we can breathe, now check if we can get air
 		var/volume_needed = get_breath_volume()

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -233,6 +233,9 @@
 	set category = "IC"
 	set src in usr
 
+	if(owner.failed_last_breath)
+		to_chat(owner, SPAN_WARNING("You already can't breathe!"))
+		return
 	holding_breath = !holding_breath
 	if(holding_breath)
 		owner.visible_message(SPAN_NOTICE("[owner.name] takes a large breath and stops breathing."), SPAN_NOTICE("You take a large breath and then stop breathing."))

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -77,6 +77,8 @@
 	if(!owner)
 		return
 
+	update_verbs()
+	
 	if (germ_level > INFECTION_LEVEL_ONE && active_breathing)
 		if(prob(5))
 			owner.emote("cough")		//respitory tract infection, holding breath will not stop you from coughing
@@ -127,6 +129,12 @@
 		var/lung_rupture_prob = BP_IS_ROBOTIC(src) ? prob(30) : prob(60) //Robotic lungs are less likely to rupture.
 		if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
 			rupture()
+
+/obj/item/organ/internal/lungs/proc/update_verbs()
+	if(active_breathing)
+		verbs |= /obj/item/organ/internal/lungs/verb/hold_breath
+	else
+		verbs -= /obj/item/organ/internal/lungs/verb/hold_breath
 
 /obj/item/organ/internal/lungs/proc/handle_breath(datum/gas_mixture/breath, var/forced)
 


### PR DESCRIPTION
Opening this as a draft because I'd like to make sure I'm doing this as efficiently as I can (I'm probably not) and also to get general feedback on the feature as a whole before I start dedicating myself to it. Currently, it works on a basic level but is very unpolished and has some bugs. 

Holding your breath is a verb in the IC panel. It functions exactly as if your lungs were toast - you will not breathe and cannot speak. In addition, you will not make any gasping sounds or any indications that you are holding your breath - unless your lungs are damaged or infected, in which case the urge to cough surpasses the urge to hold your breath. You can resume breathing by using the verb again. If you fall unconscious, you can no longer force yourself to stop breathing and will continue breathing normally, and ideally, your body would force you to breathe before you fall unconscious, but that still needs fleshing out. As with not being able to breathe, this will stop you from inhaling toxic air, along with all the other benefits of not breathing.

To-do list:
- [ ] Holding your breath should not cause brain damage (perhaps change it to only incur brain damage after you fall unconscious and not before)
- [ ] You should involuntarily breathe again just before you pass out. Looks like I have to change it in brain.dm somehow instead of just looking at the user's health
- [ ] It should be clear to other people that they are intentionally not breathing. Already did this by making sure they don't gasp or do other oxyloss emotes but there could be more to do here
- [ ] Ideally, incorporate the ability more into the existing framework instead of making exceptions for all the control flow. Probably something to do with `CE_BREATHLOSS`
- [x] Species that don't actively breathe (like GAS) should not have access to this verb
- [ ] High/low pressures should override this and still mess with your lungs