### PR TITLE
Updated blacklist for personal goals (meats)

### DIFF
--- a/code/modules/goals/definitions/personal_achievement_specific_object.dm
+++ b/code/modules/goals/definitions/personal_achievement_specific_object.dm
@@ -29,6 +29,9 @@
 
 /datum/goal/achievement/specific_object/food/New()
 	possible_objects = subtypesof(/obj/item/weapon/reagent_containers/food/snacks)
+	blacklisted_objects = list(/obj/item/weapon/reagent_containers/food/snacks/meat/corgi,
+	/obj/item/weapon/reagent_containers/food/snacks/meat/human,
+	/obj/item/weapon/reagent_containers/food/snacks/meat/monkey)
 	..()
 
 /datum/goal/achievement/specific_object/food/update_strings()


### PR DESCRIPTION
Because you can get banned for breaking the rules, even if you are encouraged to do so.

:cl: Jovaniph
tweak: Blacklisted Corgi, Human, and Monkey Meat as part of a personal goal to eat.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->