### PR TITLE
adds forcing tanks open

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -1,5 +1,12 @@
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))
 
+// Flag Utils
+#define GET_FLAGS(field, mask)      ((field) & (mask))
+#define HAS_FLAGS(field, mask)      (((field) & (mask)) == (mask))
+#define SET_FLAGS(field, mask)      ((field) |= (mask))
+#define CLEAR_FLAGS(field, mask)    ((field) &= ~(mask))
+#define FLIP_FLAGS(field, mask)     ((field) ^= (mask))
+
 #define CLOSET_HAS_LOCK  1
 #define CLOSET_CAN_BE_WELDED 2
 
@@ -49,3 +56,9 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASS_FLAG_TABLE  0x1
 #define PASS_FLAG_GLASS  0x2
 #define PASS_FLAG_GRILLE 0x4
+
+// Flags for gas tanks
+#define TANK_FLAG_WELDED      0x000001
+#define TANK_FLAG_FORCED      0x000002
+#define TANK_FLAG_LEAKING     0x000004
+#define TANK_FLAG_WIRED       0x000008

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -143,8 +143,6 @@
 // Spawns multiple objects of the same type
 #define cast_new(type, num, args...) if((num) == 1) { new type(args) } else { for(var/i=0;i<(num),i++) { new type(args) } }
 
-#define FLAGS_EQUALS(flag, flags) ((flag & (flags)) == (flags))
-
 #define JOINTEXT(X) jointext(X, null)
 
 #define SPAN_ITALIC(X) "<span class='italic'>[X]</span>"

--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -50,7 +50,7 @@
 /decl/backpack_outfit/New()
 	tweaks = tweaks || list()
 
-	if(FLAGS_EQUALS(flags, BACKPACK_HAS_TYPE_SELECTION|BACKPACK_HAS_SUBTYPE_SELECTION))
+	if(HAS_FLAGS(flags, BACKPACK_HAS_TYPE_SELECTION|BACKPACK_HAS_SUBTYPE_SELECTION))
 		CRASH("May not have both type and subtype selection tweaks")
 
 	if(flags & BACKPACK_HAS_TYPE_SELECTION)

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -175,14 +175,14 @@
 	PT.master = V
 	OT.master = V
 
-	PT.valve_welded = 1
+	SET_FLAGS(PT.tank_flags, TANK_FLAG_WELDED)
 	PT.air_contents.gas[GAS_PHORON] = phoron_amt
 	PT.air_contents.gas[GAS_CO2] = carbon_amt
 	PT.air_contents.total_moles = phoron_amt + carbon_amt
 	PT.air_contents.temperature = PHORON_MINIMUM_BURN_TEMPERATURE+1
 	PT.air_contents.update_values()
 
-	OT.valve_welded = 1
+	SET_FLAGS(OT.tank_flags, TANK_FLAG_WELDED)
 	OT.air_contents.gas[GAS_OXYGEN] = oxygen_amt
 	OT.air_contents.total_moles = oxygen_amt
 	OT.air_contents.temperature = PHORON_MINIMUM_BURN_TEMPERATURE+1

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -25,15 +25,16 @@ var/list/global/tank_gauge_cache = list()
 	var/distribute_pressure = ONE_ATMOSPHERE
 	var/integrity = 20
 	var/maxintegrity = 20
-	var/valve_welded = 0
 	var/obj/item/device/tankassemblyproxy/proxyassembly
 
 	var/volume = 70
 	var/manipulated_by = null		//Used by _onclick/hud/screen_objects.dm internals to determine if someone has messed with our tank or not.
 						//If they have and we haven't scanned it with the PDA or gas analyzer then we might just breath whatever they put in it.
 	var/failure_temp = 173 //173 deg C Borate seal (yes it should be 153 F, but that's annoying)
-	var/leaking = 0
-	var/wired = 0
+
+
+	var/tank_flags = 0x000000
+
 	var/list/starting_pressure //list in format 'xgm gas id' = 'desired pressure at start'
 
 /obj/item/weapon/tank/Initialize()
@@ -63,35 +64,50 @@ var/list/global/tank_gauge_cache = list()
 
 	. = ..()
 
-/obj/item/weapon/tank/examine(mob/user)
+/obj/item/weapon/tank/examine(mob/user, distance)
 	. = ..()
-	var/descriptive
-	if(!air_contents)
-		descriptive = "empty"
+
+	if (distance < 5)
+		var/list/mods = list()
+		if (GET_FLAGS(tank_flags, TANK_FLAG_WIRED))
+			mods += "some wires"
+		if (proxyassembly.assembly)
+			mods += user.skill_check(SKILL_DEVICES, SKILL_ADEPT) ? "an ignition assembly" : "a device"
+		if (length(mods))
+			to_chat(user, "[english_list(mods)] are attached.")
 	else
-		var/celsius_temperature = air_contents.temperature - T0C
-		switch(celsius_temperature)
-			if(300 to INFINITY)
-				descriptive = "furiously hot"
-			if(100 to 300)
-				descriptive = "hot"
-			if(80 to 100)
-				descriptive = "warm"
-			if(40 to 80)
-				descriptive = "lukewarm"
-			if(20 to 40)
-				descriptive = "room temperature"
-			if(-20 to 20)
-				descriptive = "cold"
-			else
-				descriptive = "bitterly cold"
-	to_chat(user, "<span class='notice'>\The [src] feels [descriptive].</span>")
+		return
 
-	if(proxyassembly.assembly || wired)
-		to_chat(user, "<span class='warning'>It seems to have [wired? "some wires ": ""][wired && proxyassembly.assembly? "and ":""][proxyassembly.assembly ? "some sort of assembly ":""]attached to it.</span>")
-	if(valve_welded)
-		to_chat(user, "<span class='warning'>\The [src] emergency relief valve has been welded shut!</span>")
+	if (distance < 3)
+		if (GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
+			to_chat(user, SPAN_WARNING("The emergency relief valve has been welded shut!"))
+		else if (GET_FLAGS(tank_flags, TANK_FLAG_FORCED))
+			to_chat(user, SPAN_WARNING("The emergency relief valve has been forced open!"))
+	else
+		return
 
+	if (distance < 1)
+		var/descriptive
+		if(!air_contents)
+			descriptive = "empty"
+		else
+			var/celsius_temperature = air_contents.temperature - T0C
+			switch(celsius_temperature)
+				if(300 to INFINITY)
+					descriptive = "furiously hot"
+				if(100 to 300)
+					descriptive = "hot"
+				if(80 to 100)
+					descriptive = "warm"
+				if(40 to 80)
+					descriptive = "lukewarm"
+				if(20 to 40)
+					descriptive = "room temperature"
+				if(-20 to 20)
+					descriptive = "cold"
+				else
+					descriptive = "bitterly cold"
+		to_chat(user, SPAN_ITALIC("\The [src] feels [descriptive]."))
 
 /obj/item/weapon/tank/attackby(var/obj/item/weapon/W, var/mob/user)
 	..()
@@ -101,24 +117,51 @@ var/list/global/tank_gauge_cache = list()
 	if (istype(W, /obj/item/device/scanner/gas))
 		return
 
+	if (W.isscrewdriver())
+		add_fingerprint(user)
+		user.visible_message(
+			SPAN_ITALIC("\The [user] starts to use \the [W] on \the [src]."),
+			SPAN_ITALIC("You start to force \the [src]'s emergency relief valve with \the [W]."),
+			SPAN_ITALIC("You can hear metal scratching on metal."),
+			range = 5
+		)
+		if (GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
+			to_chat(user, SPAN_WARNING("The valve is stuck. You can't move it at all!"))
+			return
+		var/reduction = round(user.get_skill_value(SKILL_ATMOS) * 0.5) //0,1,1,2,2
+		if (do_after(user, (5 - reduction) SECONDS, src))
+			if (GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
+				to_chat(user, SPAN_WARNING("The valve is stuck. You can't move it at all!"))
+				return
+			FLIP_FLAGS(tank_flags, TANK_FLAG_FORCED)
+			to_chat(user, SPAN_NOTICE("You finish forcing the valve [GET_FLAGS(tank_flags, TANK_FLAG_FORCED) ? "open" : "closed"]."))
+		return
+
 	if (istype(W,/obj/item/latexballon))
+		add_fingerprint(user)
 		var/obj/item/latexballon/LB = W
 		LB.blow(src)
-		add_fingerprint(user)
 
 	if(isCoil(W))
-		var/obj/item/stack/cable_coil/C = W
-		if(C.use(1))
-			wired = 1
-			to_chat(user, "<span class='notice'>You attach the wires to the tank.</span>")
-			update_icon(TRUE)
+		if (GET_FLAGS(tank_flags, TANK_FLAG_WIRED))
+			to_chat(user, SPAN_WARNING("\The [src] is already wired."))
+		else
+			add_fingerprint(user)
+			var/obj/item/stack/cable_coil/C = W
+			var/single = C.get_amount() == 1
+			if(C.use(1))
+				SET_FLAGS(tank_flags, TANK_FLAG_WIRED)
+				to_chat(user, SPAN_NOTICE("You attach [single ? "" : "some of "]\the [C] to \the [src]."))
+				update_icon(TRUE)
+		return
 
 	if(isWirecutter(W))
-		if(wired && proxyassembly.assembly)
+		add_fingerprint(user)
+		if(GET_FLAGS(tank_flags, TANK_FLAG_WIRED) && proxyassembly.assembly)
 
 			to_chat(user, "<span class='notice'>You carefully begin clipping the wires that attach to the tank.</span>")
 			if(do_after(user, 100,src))
-				wired = 0
+				CLEAR_FLAGS(tank_flags, TANK_FLAG_WIRED)
 				to_chat(user, "<span class='notice'>You cut the wire and remove the device.</span>")
 
 				var/obj/item/device/assembly_holder/assy = proxyassembly.assembly
@@ -140,17 +183,18 @@ var/list/global/tank_gauge_cache = list()
 				if(prob(85))
 					proxyassembly.receive_signal()
 
-		else if(wired)
+		else if(GET_FLAGS(tank_flags, TANK_FLAG_WIRED))
 			if(do_after(user, 10, src))
 				to_chat(user, "<span class='notice'>You quickly clip the wire from the tank.</span>")
-				wired = 0
+				CLEAR_FLAGS(tank_flags, TANK_FLAG_WIRED)
 				update_icon(TRUE)
 
 		else
 			to_chat(user, "<span class='notice'>There are no wires to cut!</span>")
 
 	if(istype(W, /obj/item/device/assembly_holder))
-		if(wired)
+		if(GET_FLAGS(tank_flags, TANK_FLAG_WIRED))
+			add_fingerprint(user)
 			to_chat(user, "<span class='notice'>You begin attaching the assembly to \the [src].</span>")
 			if(do_after(user, 50, src))
 				to_chat(user, "<span class='notice'>You finish attaching the assembly to \the [src].</span>")
@@ -164,13 +208,17 @@ var/list/global/tank_gauge_cache = list()
 
 	if(isWelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
+		if (GET_FLAGS(tank_flags, TANK_FLAG_FORCED))
+			to_chat(user, SPAN_WARNING("\The [src]'s emergency relief valve must be closed before you can weld it shut!"))
+			return
 		if(WT.remove_fuel(1,user))
-			if(!valve_welded)
+			add_fingerprint(user)
+			if(!GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
 				to_chat(user, "<span class='notice'>You begin welding the \the [src] emergency pressure relief valve.</span>")
 				if(do_after(user, 40,src))
 					to_chat(user, "<span class='notice'>You carefully weld \the [src] emergency pressure relief valve shut.</span><span class='warning'> \The [src] may now rupture under pressure!</span>")
-					valve_welded = 1
-					leaking = 0
+					SET_FLAGS(tank_flags, TANK_FLAG_WELDED)
+					CLEAR_FLAGS(tank_flags, TANK_FLAG_LEAKING)
 				else
 					GLOB.bombers += "[key_name(user)] attempted to weld a [src]. [air_contents.temperature-T0C]"
 					log_and_message_admins("attempted to weld a [src]. [air_contents.temperature-T0C]", user)
@@ -181,7 +229,6 @@ var/list/global/tank_gauge_cache = list()
 						air_contents.add_thermal_energy(rand(2000,50000))
 			else
 				to_chat(user, "<span class='notice'>The emergency pressure relief valve has already been welded.</span>")
-		add_fingerprint(user)
 
 	if(istype(W, /obj/item/weapon/flamethrower))
 		var/obj/item/weapon/flamethrower/F = W
@@ -354,7 +401,7 @@ var/list/global/tank_gauge_cache = list()
 /obj/item/weapon/tank/on_update_icon(var/override)
 
 	var/list/overlays_to_add
-	if(override && (proxyassembly.assembly || wired))
+	if(override && (proxyassembly.assembly || GET_FLAGS(tank_flags, TANK_FLAG_WIRED)))
 		LAZYADD(overlays_to_add, image(icon,"bomb_assembly"))
 		if(proxyassembly.assembly)
 			var/image/bombthing = image(proxyassembly.assembly.icon, proxyassembly.assembly.icon_state)
@@ -457,8 +504,8 @@ var/list/global/tank_gauge_cache = list()
 			qdel(src)
 		else
 			integrity-= 5
-	else if(pressure && (pressure > TANK_LEAK_PRESSURE || air_contents.temperature - T0C > failure_temp))
-		if((integrity <= 19 || leaking) && !valve_welded)
+	else if(pressure && (GET_FLAGS(tank_flags, TANK_FLAG_FORCED) || pressure > TANK_LEAK_PRESSURE || air_contents.temperature - T0C > failure_temp))
+		if((integrity <= 19 || GET_FLAGS(tank_flags, TANK_FLAG_LEAKING | TANK_FLAG_FORCED)) && !GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
 			var/turf/simulated/T = get_turf(src)
 			if(!T)
 				return
@@ -470,10 +517,10 @@ var/list/global/tank_gauge_cache = list()
 			//dynamic air release based on ambient pressure
 
 			T.assume_air(leaked_gas)
-			if(!leaking)
+			if(!GET_FLAGS(tank_flags, TANK_FLAG_LEAKING))
 				visible_message("\icon[src] <span class='warning'>\The [src] relief valve flips open with a hiss!</span>", "You hear hissing.")
 				playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
-				leaking = 1
+				SET_FLAGS(tank_flags, TANK_FLAG_LEAKING)
 				#ifdef FIREDBG
 				log_debug("<span class='warning'>[x],[y] tank is leaking: [pressure] kPa, integrity [integrity]</span>")
 				#endif
@@ -482,19 +529,19 @@ var/list/global/tank_gauge_cache = list()
 	else
 		if(integrity < maxintegrity)
 			integrity++
-			if(leaking)
+			if(GET_FLAGS(tank_flags, TANK_FLAG_LEAKING))
 				integrity++
 			if(integrity == maxintegrity)
-				leaking = 0
+				CLEAR_FLAGS(tank_flags, TANK_FLAG_LEAKING)
 
 /////////////////////////////////
 ///Prewelded tanks
 /////////////////////////////////
 
 /obj/item/weapon/tank/phoron/welded
-	valve_welded = 1
+	tank_flags = TANK_FLAG_WELDED
 /obj/item/weapon/tank/oxygen/welded
-	valve_welded = 1
+	tank_flags = TANK_FLAG_WELDED
 
 /////////////////////////////////
 ///Onetankbombs (added as actual items)
@@ -507,10 +554,8 @@ var/list/global/tank_gauge_cache = list()
 	air_contents.gas[GAS_PHORON] = phoron_amt
 	air_contents.gas[GAS_OXYGEN] = oxygen_amt
 	air_contents.update_values()
-	valve_welded = 1
+	SET_FLAGS(tank_flags, TANK_FLAG_WELDED | TANK_FLAG_WIRED)
 	air_contents.temperature = PHORON_MINIMUM_BURN_TEMPERATURE-1
-
-	wired = 1
 
 	var/obj/item/device/assembly_holder/H = new(src)
 	proxyassembly.assembly = H

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -353,7 +353,7 @@ var/list/gear_datums = list()
 	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.
 
 /datum/gear/New()
-	if(FLAGS_EQUALS(flags, GEAR_HAS_TYPE_SELECTION|GEAR_HAS_SUBTYPE_SELECTION))
+	if(HAS_FLAGS(flags, GEAR_HAS_TYPE_SELECTION|GEAR_HAS_SUBTYPE_SELECTION))
 		CRASH("May not have both type and subtype selection tweaks")
 	if(!description)
 		var/obj/O = path

--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -201,7 +201,7 @@
 	They can be attached to various portable atmospheric devices to be filled or emptied. <br>\
 	<br>\
 	Each tank is fitted with an emergency relief valve. This relief valve will open if the tank is pressurised to over ~3000kPa or heated to over 173?C. \
-	The valve itself will close after expending most or all of the contents into the air.<br>\
+	Normally the valve itself will close after expending most or all of the contents into the air, but can be forced open or closed with a screwdriver.<br>\
 	<br>\
 	Filling a tank such that experiences ~4000kPa of pressure will cause the tank to rupture, spilling out its contents and destroying the tank. \
 	Tanks filled over ~5000kPa will rupture rather violently, exploding with significant force."


### PR DESCRIPTION
:cl:
rscadd: You can force gas tanks' release valves open and closed with a screwdriver, taking 5/4/4/3/3 seconds by atmospherics skill level.
tweak: You can see gas tank attachments at 5 steps, whether they are welded or forced open at 3, and check their temperature on the same tile.
/:cl:

also replaces `FLAGS_EQUALS` with HAS_FLAGS, and adds GET_FLAGS, SET_FLAGS, CLEAR_FLAGS, and FLIP_FLAGS. Uses them for tank states.