### PR TITLE
sensor report no-vermap

### DIFF
--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -143,5 +143,17 @@ SUBSYSTEM_DEF(shuttle)
 		var/obj/effect/overmap/visitable/ship/ship_effect = ship
 		overmap_halted ? ship_effect.halt() : ship_effect.unhalt()
 
+/datum/controller/subsystem/shuttle/proc/ship_by_name(name)
+	for (var/obj/effect/overmap/visitable/ship/ship in ships)
+		if (ship.name == name)
+			return ship
+	return null
+
+/datum/controller/subsystem/shuttle/proc/ship_by_type(type)
+	for (var/obj/effect/overmap/visitable/ship/ship in ships)
+		if (ship.type == type)
+			return ship
+	return null
+
 /datum/controller/subsystem/shuttle/stat_entry()
 	..("Shuttles:[shuttles.len], Ships:[ships.len], L:[registered_shuttle_landmarks.len][overmap_halted ? ", HALT" : ""]")

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -11,46 +11,47 @@
 	return jointext(., "<br>")
 
 /datum/map/torch/send_welcome()
+	var/obj/effect/overmap/visitable/ship/torch = SSshuttle.ship_by_type(/obj/effect/overmap/visitable/ship/torch)
+
 	var/welcome_text = "<center><img src = sollogo.png /><br /><font size = 3><b>SEV Torch</b> Sensor Readings:</font><br>"
 	welcome_text += "Report generated on [stationdate2text()] at [stationtime2text()]</center><br /><br />"
-	welcome_text += "<hr>Current system:<br /><b>[system_name()]</b><br /><br>"
+	welcome_text += "<hr>Current system:<br /><b>[torch ? system_name() : "Unknown"]</b><br /><br>"
 
-	var/list/space_things = list()
-	var/obj/effect/overmap/visitable/torch = map_sectors["1"]
+	if (torch) //If the overmap is disabled, it's possible for there to be no torch.
+		var/list/space_things = list()
+		welcome_text += "Current Coordinates:<br /><b>[torch.x]:[torch.y]</b><br /><br>"
+		welcome_text += "Next system targeted for jump:<br /><b>[generate_system_name()]</b><br /><br>"
+		welcome_text += "Travel time to Sol:<br /><b>[rand(15,45)] days</b><br /><br>"
+		welcome_text += "Time since last port visit:<br /><b>[rand(60,180)] days</b><br /><hr>"
+		welcome_text += "Scan results show the following points of interest:<br />"
 
-	welcome_text += "Current Coordinates:<br /><b>[torch.x]:[torch.y]</b><br /><br>"
-	welcome_text += "Next system targeted for jump:<br /><b>[generate_system_name()]</b><br /><br>"
-	welcome_text += "Travel time to Sol:<br /><b>[rand(15,45)] days</b><br /><br>"
-	welcome_text += "Time since last port visit:<br /><b>[rand(60,180)] days</b><br /><hr>"
-	welcome_text += "Scan results show the following points of interest:<br />"
-	
-	for(var/zlevel in map_sectors)
-		var/obj/effect/overmap/visitable/O = map_sectors[zlevel]
-		if(O.name == torch.name)
-			continue
-		if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles
-			continue
-		if (O.hide_from_reports)
-			continue
-		space_things |= O
+		for(var/zlevel in map_sectors)
+			var/obj/effect/overmap/visitable/O = map_sectors[zlevel]
+			if(O.name == torch.name)
+				continue
+			if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles
+				continue
+			if (O.hide_from_reports)
+				continue
+			space_things |= O
 
-	var/list/distress_calls
-	for(var/obj/effect/overmap/visitable/O in space_things)
-		var/location_desc = " at present co-ordinates."
-		if(O.loc != torch.loc)
-			var/bearing = round(90 - Atan2(O.x - torch.x, O.y - torch.y),5) //fucking triangles how do they work
-			if(bearing < 0)
-				bearing += 360
-			location_desc = ", bearing [bearing]."
-		if(O.has_distress_beacon)
-			LAZYADD(distress_calls, "[O.has_distress_beacon][location_desc]")
-		welcome_text += "<li>\A <b>[O.name]</b>[location_desc]</li>"
+		var/list/distress_calls
+		for(var/obj/effect/overmap/visitable/O in space_things)
+			var/location_desc = " at present co-ordinates."
+			if(O.loc != torch.loc)
+				var/bearing = round(90 - Atan2(O.x - torch.x, O.y - torch.y),5) //fucking triangles how do they work
+				if(bearing < 0)
+					bearing += 360
+				location_desc = ", bearing [bearing]."
+			if(O.has_distress_beacon)
+				LAZYADD(distress_calls, "[O.has_distress_beacon][location_desc]")
+			welcome_text += "<li>\A <b>[O.name]</b>[location_desc]</li>"
 
-	if(LAZYLEN(distress_calls))
-		welcome_text += "<br><b>Distress calls logged:</b><br>[jointext(distress_calls, "<br>")]<br>"
-	else
-		welcome_text += "<br>No distress calls logged.<br />"
-	welcome_text += "<hr>"
+		if(LAZYLEN(distress_calls))
+			welcome_text += "<br><b>Distress calls logged:</b><br>[jointext(distress_calls, "<br>")]<br>"
+		else
+			welcome_text += "<br>No distress calls logged.<br />"
+		welcome_text += "<hr>"
 
 	post_comm_message("SEV Torch Sensor Readings", welcome_text)
 	minor_announcement.Announce(message = "New [GLOB.using_map.company_name] Update available at all communication consoles.")


### PR DESCRIPTION
guards against a roundstart runtime in sensor reports where the torch is expected to exist but the overmap is disabled

also adds fetching ships by name and type from SSshuttle
