### PR TITLE
Add audio notifications for the email program (and for other NTOS devices)

### DIFF
--- a/code/modules/modular_computers/NTNet/emails/email_account.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_account.dm
@@ -13,6 +13,9 @@
 	var/fullname	= "N/A"
 	var/assignment	= "N/A"
 
+	var/notification_mute = FALSE
+	var/notification_sound = "*beep*"
+
 /datum/computer_file/data/email_account/calculate_size()
 	size = 1
 	for(var/datum/computer_file/data/email_message/stored_message in all_emails())

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -39,8 +39,9 @@
 		NME.error = ""
 		NME.check_for_new_messages(1)
 
-/datum/computer_file/program/email_client/proc/new_mail_notify()
-	computer.visible_notification("You got mail!")
+/datum/computer_file/program/email_client/proc/new_mail_notify(var/notification_sound)
+	computer.visible_notification(notification_sound)
+	computer.audible_notification("sound/machines/ping.ogg")
 
 /datum/computer_file/program/email_client/process_tick()
 	..()
@@ -51,8 +52,8 @@
 
 	var/check_count = NME.check_for_new_messages()
 	if(check_count)
-		if(check_count == 2)
-			new_mail_notify()
+		if(check_count == 2 && !NME.current_account.notification_mute)
+			new_mail_notify(NME.current_account.notification_sound)
 		ui_header = "ntnrc_new.gif"
 	else
 		ui_header = "ntnrc_idle.gif"
@@ -203,6 +204,7 @@
 
 	else if(istype(current_account))
 		data["current_account"] = current_account.login
+		data["notification_mute"] = current_account.notification_mute
 		if(addressbook)
 			var/list/all_accounts = list()
 			for(var/datum/computer_file/data/email_account/account in ntnet_global.email_accounts)
@@ -485,6 +487,16 @@
 		current_account.password = newpassword1
 		stored_password = newpassword1
 		error = "Your password has been successfully changed!"
+		return 1
+
+	if(href_list["set_notification"])
+		var/new_notification = sanitize(input(user, "Enter your desired notification sound:", "Set Notification", current_account.notification_sound) as text|null)
+		if(new_notification)
+			current_account.notification_sound = new_notification
+		return 1
+
+	if(href_list["mute"])
+		current_account.notification_mute = !current_account.notification_mute
 		return 1
 
 	// The following entries are Modular Computer framework only, and therefore won't do anything in other cases (like AI View)

--- a/code/modules/modular_computers/ntos/visuals.dm
+++ b/code/modules/modular_computers/ntos/visuals.dm
@@ -36,5 +36,10 @@
 	if(istype(A))
 		A.visible_message("<span class='notice'>\The [A] screen displays a notification: \"[message]\"</span>", range = 1)
 
+/datum/extension/interactive/ntos/proc/audible_notification(notification)
+	var/atom/A = holder
+	if(istype(A))
+		playsound(A, notification, 5, falloff = 1)
+
 /datum/extension/interactive/ntos/proc/show_error(user, message)
 	to_chat(user, "<span class='warning'>[message]</span>")

--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -28,6 +28,12 @@
 	<b>Welcome to your account, {{:data.current_account}}</b><br>
 	{{:helper.link('New Message', 'mail-closed', {'new_message' : 1})}}
 	{{:helper.link('Change Password', 'locked', {'changepassword' : 1})}}
+	{{:helper.link('Set notification', 'alert', {'set_notification' : 1})}}
+	{{if data.notification_mute}}
+		{{:helper.link('Unmute', 'volume-on', {'mute' : 1})}}
+	{{else}}
+		{{:helper.link('Mute', 'volume-off', {'mute' : 1})}}
+	{{/if}}
 	{{:helper.link('Log Out', 'key', {'logout' : 1})}}<br><br>
 	{{if data.addressbook}}
 		{{:helper.link('Back', null, {'close_addressbook' : 1})}}


### PR DESCRIPTION
Whenever someone gets a new email, their device will now play a ping sound. 

The proc is designed to be reusable in cases like these. The sound is quiet and should ideally only be heard by people within touching distance.

:cl: Shadowtail117 & mkalash
rscadd: You will now receive an audible ping when you receive a new email, provided your email client is open. You can change whether you receive this ping or not in the email program.
rscadd: You can now set a custom chat notification when you receive a new email.
/:cl: