### PR TITLE
Implements single transferable vote

### DIFF
--- a/code/datums/vote/add_antag.dm
+++ b/code/datums/vote/add_antag.dm
@@ -1,5 +1,9 @@
+#define CHOICE_RANDOM "Random"
+#define CHOICE_NONE "None"
+
 /datum/vote/add_antagonist
 	name = "add antagonist"
+	result_length = 3
 	var/automatic = 0 //Handled slightly differently.
 
 /datum/vote/add_antagonist/can_run(mob/creator, automatic)
@@ -14,21 +18,21 @@
 		var/datum/antagonist/antag = all_antag_types[antag_type]
 		if(!(antag.id in additional_antag_types) && antag.is_votable())
 			choices += antag.role_text
-	choices += "Random"
+	choices += CHOICE_RANDOM
 	if(!automatic)
-		choices += "None"
+		choices += CHOICE_NONE
 	src.automatic = automatic
 	..()
 
 /datum/vote/add_antagonist/report_result()
-	if((. = ..()) || (result[1] == "None")) // Failed vote or no antag desired
+	if((. = ..()) || (result[1] == CHOICE_NONE)) // Failed vote or no antag desired
 		antag_add_finished = 1             // So we will never try this again.
 		return
 
-	if(result[1] == "Random")
+	if(result[1] == CHOICE_RANDOM)
 		var/list/pick_random = choices.Copy()
-		pick_random -= "Random"
-		pick_random -= "None"
+		pick_random -= CHOICE_RANDOM
+		pick_random -= CHOICE_NONE
 		result[1] = pick(pick_random)
 
 	if(GAME_STATE <= RUNLEVEL_LOBBY)
@@ -54,3 +58,6 @@
 		to_world("<b>No antags were added.</b>")
 		if(automatic)
 			SSvote.queued_auto_vote = /datum/vote/transfer
+
+#undef CHOICE_RANDOM
+#undef CHOICE_NONE

--- a/code/datums/vote/custom.dm
+++ b/code/datums/vote/custom.dm
@@ -17,11 +17,12 @@
 		abort = 1
 		return
 	for(var/i=1,i<=10,i++)
-		var/option = capitalize(sanitize(input(creator,"Please enter an option or hit cancel to finish") as text|null))
+		var/option = capitalize(sanitizeSafe(input(creator,"Please enter an option or hit cancel to finish") as text|null))
 		if(!option || !creator.client)
 			break
 		choices += option
 	if(!length(choices))
 		abort = 1
 		return
+	result_length = length(choices)
 	..()

--- a/code/datums/vote/gamemode.dm
+++ b/code/datums/vote/gamemode.dm
@@ -1,8 +1,9 @@
 /datum/vote/gamemode
 	name = "game mode"
-	additional_header = "<td align = 'center'><b>Minimum Players</b></td></tr>"
+	additional_header = "<th>Minimum Players</th>"
 	win_x = 500
 	win_y = 1100
+	result_length = 3
 
 /datum/vote/gamemode/can_run(mob/creator, automatic)
 	if(!automatic && (!config.allow_vote_mode || !is_admin(creator)))

--- a/code/datums/vote/restart.dm
+++ b/code/datums/vote/restart.dm
@@ -1,9 +1,9 @@
+#define CHOICE_RESTART "Restart round"
+#define CHOICE_CONTINUE "Continue playing"
+
 /datum/vote/restart
 	name = "restart"
-	choices = list("Restart Round","Continue Playing")
-	priorities = list("First")
-	weights = list(1)
-	results_length = 1
+	choices = list(CHOICE_RESTART, CHOICE_CONTINUE)
 
 /datum/vote/restart/can_run(mob/creator, automatic)
 	if(!automatic && !config.allow_vote_restart && !is_admin(creator))
@@ -12,10 +12,13 @@
 
 /datum/vote/restart/handle_default_votes()
 	var/non_voters = ..()
-	choices["Continue Playing"] += non_voters
+	choices[CHOICE_CONTINUE] += non_voters
 
 /datum/vote/restart/report_result()
 	if(..())
 		return 1
-	if(result[1] == "Restart Round")
+	if(result[1] == CHOICE_RESTART)
 		SSvote.restart_world()
+
+#undef CHOICE_RESTART
+#undef CHOICE_CONTINUE

--- a/code/datums/vote/transfer.dm
+++ b/code/datums/vote/transfer.dm
@@ -1,3 +1,7 @@
+#define CHOICE_TRANSFER "Initiate crew transfer"
+#define CHOICE_EXTEND "Extend the round ([config.vote_autotransfer_interval / 600] minutes)"
+#define CHOICE_ADD_ANTAG "Add antagonist"
+
 /datum/vote/transfer
 	name = "transfer"
 	question = "End the shift?"
@@ -20,9 +24,9 @@
 		return FALSE
 
 /datum/vote/transfer/setup_vote(mob/creator, automatic)
-	choices = list("Initiate Crew Transfer", "Extend the Round ([config.vote_autotransfer_interval / 600] minutes)")
+	choices = list(CHOICE_TRANSFER, CHOICE_EXTEND)
 	if (config.allow_extra_antags && SSvote.is_addantag_allowed(creator, automatic))
-		choices += "Add Antagonist"
+		choices += CHOICE_ADD_ANTAG
 	..()
 
 /datum/vote/transfer/handle_default_votes()
@@ -40,15 +44,15 @@
 			factor = 1.2
 		else
 			factor = 1.4
-	choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
+	choices[CHOICE_TRANSFER] = round(choices[CHOICE_TRANSFER] * factor)
 	to_world("<font color='purple'>Crew Transfer Factor: [factor]</font>")
 
 /datum/vote/transfer/report_result()
 	if(..())
 		return 1
-	if(result[1] == "Initiate Crew Transfer")
+	if(result[1] == CHOICE_TRANSFER)
 		init_autotransfer()
-	else if(result[1] == "Add Antagonist")
+	else if(result[1] == CHOICE_ADD_ANTAG)
 		SSvote.queued_auto_vote = /datum/vote/add_antagonist
 
 /datum/vote/transfer/mob_not_participating(mob/user)
@@ -63,3 +67,7 @@
 /datum/vote/transfer/toggle(mob/user)
 	if(is_admin(user))
 		config.allow_vote_restart = !config.allow_vote_restart
+
+#undef CHOICE_TRANSFER
+#undef CHOICE_EXTEND
+#undef CHOICE_ADD_ANTAG


### PR DESCRIPTION
:cl: mkalash
tweak: First, second, and third vote weights have been replaced with a blind single transferable vote. Click on vote options in the order you'd like to see them, as few or many as you want. Click on any option again to rescind your vote for it. Options with a 50% majority will win. If the vote wants more than one result (game mode votes need 3), then the winner's voters will have their votes transferred to their next choice. If there is no majority winner, the last place options will be removed and their voters will have their votes transferred to their next choice. Ties and situations where there aren't enough votes to fill all the results are resolved randomly.
/:cl:

![image](https://user-images.githubusercontent.com/313146/81320184-c71b4480-905e-11ea-9ae3-22fb6d4c55ea.png)
![image](https://user-images.githubusercontent.com/313146/81320047-90ddc500-905e-11ea-9094-b0cf55d581e4.png)
![image](https://user-images.githubusercontent.com/313146/81320250-e0bc8c00-905e-11ea-84a1-cddf14af513e.png)
![image](https://user-images.githubusercontent.com/313146/81320290-f16d0200-905e-11ea-9319-1cf8a5a93e80.png)

