### PR TITLE
Update codex for clothing armor entries

### DIFF
--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -33,10 +33,8 @@
 					armor_strings += "It is very strong against [armour_to_descriptive_term[armor_type]]."
 				if(71 to 80)
 					armor_strings += "This gives a very robust defense against [armour_to_descriptive_term[armor_type]]."
-				if(81 to 99)
+				if(81 to 100)
 					armor_strings += "Wearing this would make you nigh-invulerable against [armour_to_descriptive_term[armor_type]]."
-				if(100)
-					armor_strings += "You would be immune to [armour_to_descriptive_term[armor_type]] if you wore this."
 
 	if(item_flags & ITEM_FLAG_AIRTIGHT)
 		armor_strings += "It is airtight."
@@ -76,7 +74,7 @@
 		armor_strings += "It can be worn on your [english_list(slots)]."
 
 	return jointext(armor_strings, "<br>")
-	
+
 /obj/item/clothing/suit/armor/pcarrier/get_mechanics_info()
 	. = ..()
 	. += "<br>Its protection is provided by the plate inside, examine it for details on armor.<br>"


### PR DESCRIPTION
Closes #27377 in the form of updating codex to be more in line with current behavior.

Armor updates apparently made 100 no longer fully immune. Codex no longer uses 'immune' wording for clothing with an armor rating of 100 in any category.

:cl:
tweak: Codex will no longer call things 'immune' to any damage sources since recent armor updates mean immunity is technically impossible now.
/:cl: