### PR TITLE
you can't mop overlays

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -14,7 +14,6 @@
 	var/mopspeed = 40
 	var/list/moppable_types = list(
 		/obj/effect/decal/cleanable,
-		/obj/effect/overlay,
 		/obj/effect/rune,
 		/obj/structure/catwalk
 		)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -286,7 +286,7 @@ var/const/enterloopsanity = 100
 
 /turf/proc/remove_cleanables()
 	for(var/obj/effect/O in src)
-		if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+		if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable))
 			qdel(O)
 
 /turf/proc/update_blood_overlays()


### PR DESCRIPTION
:cl:
bugfix: You can no longer delete holograms, laser beams, and singularity effects through the vigorous application of a mop.
/:cl:

fixes #28365