### PR TITLE
Fix tank console injector status on round start

### DIFF
--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -37,6 +37,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()
 	. = ..()
 	set_frequency(frequency)
+	broadcast_status()
 
 /obj/machinery/atmospherics/unary/outlet_injector/Destroy()
 	unregister_radio(src, frequency)


### PR DESCRIPTION
:cl: 
bugfix: Atmospheric Injector status is now displayed correctly on all tank consoles at round start
/:cl: