### PR TITLE
Fixes incorrect door repair behavior

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -240,7 +240,7 @@
 		else
 			repairing = stack.split(amount_needed, force=TRUE)
 			if (repairing)
-				repairing.dropInto(loc)
+				repairing.dropInto(src)
 				transfer = repairing.amount
 				repairing.uses_charge = FALSE //for clean robot door repair - stacks hint immortal if true
 


### PR DESCRIPTION
:cl:
bugfix: Placing sheets on an airlock for repair wont dump them under it.
/:cl: