### PR TITLE
Restores AEGs to the research database.

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -66,14 +66,14 @@
 	desc = "An energy gun with an experimental miniaturized reactor."
 	icon = 'icons/obj/guns/adv_egun.dmi'
 	icon_state = "nucgun"
-	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
+	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 5, TECH_POWER = 3)
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE
 	force = 8 //looks heavier than a pistol
 	self_recharge = 1
 	modifystate = null
 	one_hand_penalty = 1 //bulkier than an e-gun, but not quite the size of a carbine
-
+	max_shots = 5
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun),
 		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock),

--- a/code/modules/research/designs/designs_weapon.dm
+++ b/code/modules/research/designs/designs_weapon.dm
@@ -81,6 +81,13 @@
 	build_path = /obj/item/weapon/gun/energy/confuseray
 	sort_string = "TADAD"
 
+/datum/design/item/weapon/nuclear_gun
+	id = "nuclear_gun"
+	req_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 5, TECH_POWER = 3)
+	materials = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 1000, MATERIAL_DIAMOND = 2000, MATERIAL_URANIUM = 500)
+	build_path = /obj/item/weapon/gun/energy/gun/nuclear
+	sort_string = "TAEAA"
+
 /datum/design/item/weapon/lasercannon
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
 	id = "lasercannon"


### PR DESCRIPTION
:cl: Faustico
rscadd: Restored the Advanced Energy Gun blueprint to the research database.
tweak: Increased the AEG's combat tech requirement to 6.
tweak: Added diamonds as a material requirement for AEGs.
tweak: Reduced the AEG's maximum stored shots to 5.
/:cl:

I believe that AEGs were so oppressively popular because the material that should have limited their production (uranium) was freely available to research from their chem lab, rather than the core design itself being inherently overpowered. Adding diamonds as a material requirement should bring their utility in line with the rest of the research weapons, while bumping the research requirement to combat 6 ensures that it requires deliberate effort to unlock. 

My discord username is Faustico#6686, please ping me in the #pr-feedback channel on discord if you have any comments or concerns.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->