### PR TITLE
Makes some augments available at round start

### DIFF
--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -482,14 +482,12 @@
 	name = "Engineering toolset"
 	build_path = /obj/item/organ/internal/augment/active/polytool/engineer
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 1000)
-	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4, TECH_BIO = 2)
 	id = "augment_toolset_engineering"
 
 /datum/design/item/mechfab/augment/surgery
 	name = "Surgical toolset"
 	build_path = /obj/item/organ/internal/augment/active/polytool/surgical
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000)
-	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 4)
 	id = "augment_toolset_surgery"
 
 /datum/design/item/mechfab/augment/reflex
@@ -510,14 +508,12 @@
 	name = "Mechanical muscles"
 	build_path = /obj/item/organ/internal/augment/boost/muscle
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000)
-	req_tech = list(TECH_MATERIAL = 3, TECH_BIO = 4)
 	id = "augment_booster_muscles"
 
 /datum/design/item/mechfab/augment/armor
 	name = "Subdermal armor"
 	build_path = /obj/item/organ/internal/augment/armor
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 750)
-	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4, TECH_BIO = 4)
 	id = "augment_armor"
 
 /datum/design/item/mechfab/augment/nanounit


### PR DESCRIPTION
:cl: Faustico
tweak: The following augments no longer have a research requirement and can be printed from roundstart: surgical toolset, engineering toolset, mechanical muscles, subdermal armor.
/:cl:

Removing the research requirement from some of the augments should give both robotics and medical something interesting to do in the early game while they wait for research to research and exploration to get injured.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->