### PR TITLE
Changes to the CSO's locker and equipment

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/_closet_appearance_definitions.dm
+++ b/code/game/objects/structures/crates_lockers/closets/_closet_appearance_definitions.dm
@@ -451,11 +451,15 @@
 	)
 
 /decl/closet_appearance/secure_closet/rd
+	color = COLOR_BOTTLE_GREEN
+	decals = list(
+		"lower_holes"
+	)
 	extra_decals = list(
-		"stripe_vertical_mid_full" = COLOR_CLOSET_GOLD,
+		"stripe_vertical_mid_full" = COLOR_GOLD,
 		"stripe_vertical_left_full" = COLOR_PURPLE,
 		"stripe_vertical_right_full" = COLOR_PURPLE,
-		"research" = COLOR_CLOSET_GOLD
+		"research" = COLOR_GOLD
 	)
 
 /decl/closet_appearance/secure_closet/corporate

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -44,9 +44,14 @@
 /obj/item/device/radio/headset/heads/torchntdirector
 	name = "chief science officer headset"
 	desc = "Headset of the masters of the universe."
-	icon_state = "sci_headset"
+	icon_state = "com_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/headset_torchrd
+
+/obj/item/device/radio/headset/heads/torchntdirector/alt
+	name = "chief science officer's bowman headset"
+	icon_state = "com_headset_alt"
+	item_state = "com_headset_alt"
 
 /obj/item/device/radio/headset/heads/torchntcommand/alt
 	name = "corporate command bowman headset"

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -9,11 +9,15 @@
 	)
 
 /decl/closet_appearance/secure_closet/torch/science/cso
+	color = COLOR_BOTTLE_GREEN
+	decals = list(
+		"lower_holes"
+	)
 	extra_decals = list(
-		"stripe_vertical_left_full" =  COLOR_PURPLE_GRAY,
-		"stripe_vertical_mid_full" =   COLOR_CLOSET_GOLD,
-		"stripe_vertical_right_full" = COLOR_PURPLE_GRAY,
-		"research" = COLOR_CLOSET_GOLD
+		"stripe_vertical_mid_full" = COLOR_GOLD,
+		"stripe_vertical_left_full" = COLOR_PURPLE,
+		"stripe_vertical_right_full" = COLOR_PURPLE,
+		"research" = COLOR_GOLD
 	)
 
 /obj/structure/closet/secure_closet/RD_torch
@@ -29,6 +33,7 @@
 		/obj/item/clothing/gloves/latex,
 		/obj/item/clothing/glasses/science,
 		/obj/item/device/radio/headset/heads/torchntdirector,
+		/obj/item/device/radio/headset/heads/torchntdirector/alt,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/clothing/mask/gas,
 		/obj/item/device/flash,
@@ -37,9 +42,11 @@
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape/random = 3,
 		/obj/item/device/camera,
+		/obj/item/weapon/material/clipboard/steel,
 		/obj/item/taperoll/research,
 		/obj/item/clothing/glasses/welding/superior,
-		/obj/item/clothing/suit/armor/pcarrier/light,
+		/obj/item/clothing/suit/armor/pcarrier/medium/command,
+		/obj/item/clothing/head/helmet/solgov/command,
 		/obj/item/weapon/storage/box/secret_project_disks/science,
 		/obj/item/weapon/storage/belt/general,
 		/obj/item/device/holowarrant,

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -4855,8 +4855,8 @@
 /area/turret_protected/ai)
 "js" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_foyer)
@@ -5246,8 +5246,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
@@ -16180,8 +16180,8 @@
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "EVA - Command";
@@ -16190,9 +16190,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "Ti" = (
-/obj/structure/closet/secure_closet/RD,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/corner/research/mono,
+/obj/structure/closet/secure_closet/RD_torch,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Tl" = (


### PR DESCRIPTION
:cl: lorwp
tweak: the CSO's locker is now a pimped out Gold, Purple and EXO Green. Bling
tweak: the CSO now as the same equipment as other Line officers in their locker, namely, warrant projector, disorienter, plate carrier and helmet, and combi-knife, also their clipboard is now steel, because bling bling
bugfix: the CSO's spare headset is now the torch variant, not the old exodus variant
rscadd: the CSO now has a spare bowman variant of their headset. bling bling bling
/:cl:

- The CSO's locker is now EXO green with the locker's gold decals changed to bright gold
- Makes the CSO's locker actually use the torch variant, which has been implemented for years(?) but never actually mapped into their office
- Makes the torch variant  have a steel clipboard and SolGov Plate Carrier and helmet
- Headsets in their locker are now the torch versions, since they were still the Exodus versions. Made a bowman variant as well and put it in their locker, they're also using `com_headset` as their icons to be consistent with the rest of the line officer sets


New Locker Sprite:
![dreamseeker_YAcyDl46fV](https://user-images.githubusercontent.com/8052896/81492059-2cc63580-92d8-11ea-9749-72403857bd29.png)
