### PR TITLE
Makes teleporters use more power

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -201,7 +201,7 @@
 	icon_state = "tele0"
 	dir = 4
 	idle_power_usage = 10
-	active_power_usage = 2000
+	active_power_usage = 100000
 	var/obj/machinery/computer/teleporter/com
 
 /obj/machinery/teleport/hub/New()
@@ -213,7 +213,7 @@
 	spawn()
 		if (src.icon_state == "tele1")
 			teleport(M)
-			use_power_oneoff(5000)
+			use_power_oneoff(100000)
 
 /obj/machinery/teleport/hub/proc/teleport(atom/movable/M as mob|obj)
 	do_teleport(M, com.locked)
@@ -233,7 +233,7 @@
 	dir = 4
 	var/engaged = 0
 	idle_power_usage = 10
-	active_power_usage = 2000
+	active_power_usage = 100000
 	var/obj/machinery/computer/teleporter/com
 	var/obj/machinery/teleport/hub/hub
 
@@ -270,7 +270,7 @@
 
 	if (hub)
 		hub.icon_state = "tele1"
-		use_power_oneoff(5000)
+		use_power_oneoff(200000)
 		update_use_power(POWER_USE_ACTIVE)
 		hub.update_use_power(POWER_USE_ACTIVE)
 		audible_message("<span class='notice'>Teleporter engaged!</span>")

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -236,6 +236,21 @@
 	active_power_usage = 100000
 	var/obj/machinery/computer/teleporter/com
 	var/obj/machinery/teleport/hub/hub
+	var/autodisengage = 20
+	
+/obj/machinery/teleport/station/verb/setdelay()
+	set name = "Set automatic shutdown timer"
+	set category = "Object"
+	set src in view(1)
+
+	if(usr.incapacitated())
+		return
+	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
+		var/new_autodisengage = input("Set automatic shutdown timer") as null|anything in list(5, 10, 15, 20, 25, 30)
+		if(new_autodisengage)
+			autodisengage = new_autodisengage
+			to_chat(usr, "You set the automatic teleporter shutdown timer to [new_autodisengage] seconds.")
+	return
 
 /obj/machinery/teleport/station/New()
 	..()
@@ -275,6 +290,13 @@
 		hub.update_use_power(POWER_USE_ACTIVE)
 		audible_message("<span class='notice'>Teleporter engaged!</span>")
 	src.engaged = 1
+	autodisengage()
+	return
+	
+/obj/machinery/teleport/station/proc/autodisengage() //could have definitely done auto-shutdown better but this works
+	sleep(src.autodisengage SECONDS)
+	if(engaged)
+		disengage()
 	return
 
 /obj/machinery/teleport/station/proc/disengage()


### PR DESCRIPTION
:cl:
tweak: Increased teleporter power usage.
tweak: Teleporters disengage automatically after a while.
/:cl:
Teleporters currently use 4000-9000W while active. That's absolutely ridiculous for a machine that creates a safe and stable mini-wormhole.