### PR TITLE
Clerical and Filing module tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -1,11 +1,7 @@
 /obj/item/weapon/robot_module/flying/filing
 	name = "filing drone module"
 	display_name = "Filing"
-	channels = list(
-		"Service" = TRUE,
-		"Supply" = TRUE,
-		"Command" = TRUE
-		)
+	channels = list("Command" = 1, "Supply" = 1, "Service" = 1)
 	languages = list(
 		LANGUAGE_HUMAN_EURO     = TRUE,
 		LANGUAGE_HUMAN_ARABIC   = TRUE,

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -1,7 +1,11 @@
 /obj/item/weapon/robot_module/flying/filing
 	name = "filing drone module"
 	display_name = "Filing"
-	channels = list("Command" = 1, "Supply" = 1, "Service" = 1)
+	channels = list(
+		"Command" = 1,
+		"Supply" = 1,
+		"Service" = 1
+	)
 	languages = list(
 		LANGUAGE_HUMAN_EURO     = TRUE,
 		LANGUAGE_HUMAN_ARABIC   = TRUE,

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -2,8 +2,9 @@
 	name = "filing drone module"
 	display_name = "Filing"
 	channels = list(
-		"Service" = TRUE, 
-		"Supply" = TRUE
+		"Service" = TRUE,
+		"Supply" = TRUE,
+		"Command" = TRUE
 		)
 	languages = list(
 		LANGUAGE_HUMAN_EURO     = TRUE,

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/robot_module/clerical
 	channels = list(
-		"Service" = TRUE
+		"Service" = TRUE,
 	)
 	languages = list(
 		LANGUAGE_HUMAN_EURO       = TRUE,
@@ -88,7 +88,8 @@
 	display_name = "Clerical"
 	channels = list(
 		"Service" = TRUE,
-		"Supply" =  TRUE
+		"Supply" =  TRUE,
+		"Command" = TRUE
 	)
 	sprites = list(
 		"Waitress" = "Service",
@@ -107,6 +108,7 @@
 		/obj/item/weapon/stamp/denied,
 		/obj/item/device/destTagger,
 		/obj/item/weapon/crowbar,
+		/obj/item/device/megaphone,
 		/obj/item/stack/package_wrap/cyborg
 	)
 	emag = /obj/item/weapon/stamp/chameleon

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -86,11 +86,7 @@
 /obj/item/weapon/robot_module/clerical/general
 	name = "clerical robot module"
 	display_name = "Clerical"
-	channels = list(
-		"Service" = TRUE,
-		"Supply" =  TRUE,
-		"Command" = TRUE
-	)
+	channels = list("Command" = 1, "Supply" = 1, "Service" = 1)
 	sprites = list(
 		"Waitress" = "Service",
 		"Kent" =     "toiletbot",

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -86,7 +86,11 @@
 /obj/item/weapon/robot_module/clerical/general
 	name = "clerical robot module"
 	display_name = "Clerical"
-	channels = list("Command" = 1, "Supply" = 1, "Service" = 1)
+	channels = list(
+		"Command" = 1,
+		"Supply" = 1,
+		"Service" = 1
+	)
 	sprites = list(
 		"Waitress" = "Service",
 		"Kent" =     "toiletbot",

--- a/html/changelogs/ben10083 - Clerical Changes.yml
+++ b/html/changelogs/ben10083 - Clerical Changes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Gave both Filing module and Clerical module command channel."
+  - tweak: "Made Filing module and Clerical module have the same equipment."

--- a/html/changelogs/ben10083 - Clerical Changes.yml
+++ b/html/changelogs/ben10083 - Clerical Changes.yml
@@ -23,7 +23,7 @@
 #################################
 
 # Your name.  
-author: Unknown
+author: ben10083
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Gave Clerical module megaphone so it has the same tools as Filing module.

Gave both command radio channel
_Reasons why_
- Command department is who are most likely to utilize the clerical borgs
- "This will cause too much spam in channel" This is realistically unlikely, and in rare cases where this becomes the case, can be resolved easily both icly and oocly.
- Makes the clerical modules more interesting to do.