### PR TITLE
Change Terminal Access

### DIFF
--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -113,7 +113,6 @@ Subtypes
 	name = "relays"
 	man_entry = list("Format: relays", "Gives the number of active relays found on the network.")
 	pattern = "^relays$"
-	req_access = list(access_network)
 
 /datum/terminal_command/relays/proper_input_entered(text, mob/user, terminal)
 	return "Number of relays found: [ntnet_global.relays.len]"
@@ -166,7 +165,6 @@ Subtypes
 	name = "ping"
 	man_entry = list("Format: ping nid", "Checks connection to the given nid.")
 	pattern = "^ping"
-	req_access = list(access_network)
 
 /datum/terminal_command/ping/proper_input_entered(text, mob/user, datum/terminal/terminal)
 	. = list("pinging ...")
@@ -222,7 +220,6 @@ Subtypes
 		"It is recommended that the user ensure that the target device is accessible."
 	)
 	pattern = "^proxy"
-	req_access = list(access_network)
 
 /datum/terminal_command/proxy/proper_input_entered(text, mob/user, datum/terminal/terminal)
 	var/datum/extension/interactive/ntos/comp = terminal.computer


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Kroto
Tweak: Ping, Proxy, and Relays commands have NTnet required access removed.
/:cl: