### PR TITLE
Gives deck chief EVA and teleporter access

### DIFF
--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -31,7 +31,7 @@
 
 	access = list(access_maint_tunnels, access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
 						access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
-						access_mining, access_mining_office, access_mining_station, access_commissary)
+						access_mining, access_mining_office, access_mining_station, access_commissary, access_teleporter, access_eva)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/supply,


### PR DESCRIPTION
🆑 
tweak: Gave Deck Chief access to EVA and teleporters.
/🆑
The Deck Chief is in charge of supply and logistics on the SEV Torch but cannot send things to shuttles that have departed. Instead they have to bother engineering or the AI, which is a massive pain and doesn't make any sense lore-wise. As a Senior NCO they have many years of service under their belt and should be trusted with access to the teleporters.
EVA access is also included because away teams request additional voidsuits quite often. Despite this, and the fact that EVA is not a high security area, Deck Chiefs are not allowed in.
I'd also like to mention that these changes were personally requested by one of Bay's most prolific Deck Chiefs.

