### PR TITLE
Adds vomiting into toilets and disposal units

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -696,9 +696,27 @@
 			if(species.gluttonous & GLUT_PROJECTILE_VOMIT)
 				M.throw_at(get_edge_target_turf(src,dir),7,7,src)
 
+	// vomit into a toilet
+	for(var/obj/structure/hygiene/toilet/T in range(1, src))
+		if(T.open)
+			visible_message(SPAN_DANGER("\The [src] throws up into the toilet!"),SPAN_DANGER("You throw up into the toilet!"))
+			playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+			stomach.ingested.remove_any(15)
+			return
+
+	// check if you can vomit into a disposal unit
+	// see above comment for how vomit reagents are handled
+	for(var/obj/machinery/disposal/D in orange(1, src))
+		visible_message(SPAN_DANGER("\The [src] throws up into the disposal unit!"),SPAN_DANGER("You throw up into the disposal unit!"))
+		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+		if(stomach.ingested.total_volume)
+			stomach.ingested.trans_to_holder(D.reagents, 15)
+		return
+			
+	var/turf/location = loc
+	
 	visible_message(SPAN_DANGER("\The [src] throws up!"),SPAN_DANGER("You throw up!"))
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-	var/turf/location = loc
 	if(istype(location, /turf/simulated))
 		var/obj/effect/decal/cleanable/vomit/splat = new /obj/effect/decal/cleanable/vomit(location)
 		if(stomach.ingested.total_volume)

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -17,9 +17,9 @@
 
 	var/partialTag = "" //set by a partial tagger the first time round, then put in destinationTag if it goes through again.
 
-
 	// initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(var/obj/machinery/disposal/D, var/datum/gas_mixture/flush_gas)
+
 	gas = flush_gas// transfer gas resv. into holder object -- let's be explicit about the data this proc consumes, please.
 	var/stuff = D.contents - D.component_parts
 	//Check for any living mobs trigger hasmob.
@@ -112,6 +112,9 @@
 // merge two holder objects
 // used when a a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(var/obj/structure/disposalholder/other)
+	if(other.reagents?.total_volume)
+		src.create_reagents()
+		other.reagents.trans_to_holder(src.reagents, other.reagents.total_volume)
 	for(var/atom/movable/AM in other)
 		AM.forceMove(src)		// move everything in other holder to this one
 		if(ismob(AM))

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -127,6 +127,16 @@ obj/structure/disposalpipe/Destroy()
 					if(AM)
 						AM.throw_at(target, 100, 1)
 			H.vent_gas(T)
+
+			// throw out vomit
+			if(H.reagents.total_volume)
+				visible_message(SPAN_DANGER("Vomit spews out of the disposal pipe!"))
+				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+				if(istype(src.loc, /turf/simulated))
+					var/obj/effect/decal/cleanable/vomit/splat = new /obj/effect/decal/cleanable/vomit(src.loc)
+					H.reagents.trans_to_obj(splat, min(15, H.reagents.total_volume))
+					splat.update_icon()
+
 			qdel(H)
 
 	else	// no specified direction, so throw in random direction


### PR DESCRIPTION
🆑 
rscadd: Humans will now vomit into adjacent toilets.
rscadd: Humans will now vomit into adjacent disposal units. Vomit will be thrown out of the corresponding disposal outlet.
/🆑
Vomit going into toilets will simply disappear from existence because their plumbing isn't modeled. Vomit going into disposal units will cause a flush to occur. It will gently seep out of attached disposal outlets or broken bits of pipe.
This is my first substantial PR so please don't hesitate to point out where I screwed up or acceptable code that could have been done better.