### PR TITLE
Removes ability to construct tele-circuits

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -552,7 +552,6 @@
 	inputs = list("teleporter", "rift direction")
 	outputs = list()
 	activators = list("open rift" = IC_PINTYPE_PULSE_IN)
-	spawn_flags = IC_SPAWN_RESEARCH
 	action_flags = IC_ACTION_LONG_RANGE
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)


### PR DESCRIPTION
:cl: ozwell
rscdel: Removes the ability to construct tele-circuits
/:cl:
Due to a week-long (possibly longer) abuse of portable teleporters (despite repeated and unreserved in-character punishment), I am removing the ability to create them in the integrated circuits menu. The Captain and ERT hand teleporters will be unaffected by this change, and the component will still exist in the game, just without any way of constructing them.

If there are any questions or concerns about my choice and decision to remove this feature, you are welcome to reach out to me on discord at @Ozwell#3029, where I will happily discuss this.

* Removes the ability to make the component necessary for a teleporter circuit in the integrated circuit menu.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->