### PR TITLE
Adds Portable Freezers to the Protolathe designs

### DIFF
--- a/code/modules/research/designs/designs_singletons.dm
+++ b/code/modules/research/designs/designs_singletons.dm
@@ -31,6 +31,14 @@
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_POWER = 3)
 	materials = list(MATERIAL_ALUMINIUM = 2500, MATERIAL_STEEL = 500, MATERIAL_PLASTIC = 200)
 	build_path = /obj/item/weapon/mop/advanced
+	
+/datum/design/item/weapon/storage/box/freezer
+	name = "Portable Freezer"
+	desc = "This nifty shock-resistant device will keep your 'groceries' nice and non-spoiled."
+	id= "freezer"
+	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2)
+	materials = list(MATERIAL_PLASTIC = 350)
+	build_path = /obj/item/weapon/storage/box/freezer
 
 /datum/design/blutrash
 	name = "Trashbag of Holding"

--- a/code/modules/research/designs/designs_singletons.dm
+++ b/code/modules/research/designs/designs_singletons.dm
@@ -35,7 +35,7 @@
 /datum/design/item/weapon/storage/box/freezer
 	name = "Portable Freezer"
 	desc = "This nifty shock-resistant device will keep your 'groceries' nice and non-spoiled."
-	id= "freezer"
+	id = "freezer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2)
 	materials = list(MATERIAL_PLASTIC = 350)
 	build_path = /obj/item/weapon/storage/box/freezer

--- a/code/modules/research/designs/designs_singletons.dm
+++ b/code/modules/research/designs/designs_singletons.dm
@@ -31,6 +31,14 @@
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_POWER = 3)
 	materials = list(MATERIAL_ALUMINIUM = 2500, MATERIAL_STEEL = 500, MATERIAL_PLASTIC = 200)
 	build_path = /obj/item/weapon/mop/advanced
+	
+/datum/design/item/weapon/storage/box/freezer
+	name = "Portable Freezer"
+	desc = "This nifty shock-resistant device will keep your 'groceries' nice and non-spoiled."
+	id = "freezer"
+	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2)
+	materials = list(MATERIAL_PLASTIC = 350)
+	build_path = /obj/item/weapon/storage/box/freezer
 
 /datum/design/blutrash
 	name = "Trashbag of Holding"


### PR DESCRIPTION
🆑 
rscadd: Portable freezers now in the Protolathe menu
/:cl:

This adds the portable freezer item to the Protolathe designs.

Requires materials 3, tech 2, and 350 plastic to build.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->