### PR TITLE
Airlocks can no longer be electrified

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -126,17 +126,6 @@
 
 /atom/proc/AICtrlAltClick()
 
-/obj/machinery/door/airlock/AICtrlAltClick() // Electrifies doors.
-	if(usr.incapacitated())
-		return
-	if(!electrified_until)
-		// permanent shock
-		Topic(src, list("command"="electrify_permanently", "activate" = "1"))
-	else
-		// disable/6 is not in Topic; disable/5 disables both temporary and permanent shock
-		Topic(src, list("command"="electrify_permanently", "activate" = "0"))
-	return 1
-
 /atom/proc/AICtrlShiftClick()
 	return
 

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -7,7 +7,7 @@
 
 /datum/wires/airlock
 	holder_type = /obj/machinery/door/airlock
-	wire_count = 12
+	wire_count = 11
 	window_y = 570
 	descriptions = list(
 		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERT),
@@ -18,7 +18,6 @@
 		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "This wire seems to be carrying a heavy current."),
 		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "This wire connects to the door motors."),
 		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
 		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "This wire connects to a safety override."),
 		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "This wire appears to connect to the airlock's proximity detector modules."),
 		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "This wire powers the airlock's built-in lighting.", SKILL_EXPERT)
@@ -32,17 +31,12 @@ var/const/AIRLOCK_WIRE_BACKUP_POWER1 = 16
 var/const/AIRLOCK_WIRE_BACKUP_POWER2 = 32
 var/const/AIRLOCK_WIRE_OPEN_DOOR = 64
 var/const/AIRLOCK_WIRE_AI_CONTROL = 128
-var/const/AIRLOCK_WIRE_ELECTRIFY = 256
-var/const/AIRLOCK_WIRE_SAFETY = 512
-var/const/AIRLOCK_WIRE_SPEED = 1024
-var/const/AIRLOCK_WIRE_LIGHT = 2048
+var/const/AIRLOCK_WIRE_SAFETY = 256
+var/const/AIRLOCK_WIRE_SPEED = 512
+var/const/AIRLOCK_WIRE_LIGHT = 1024
 
 /datum/wires/airlock/CanUse(var/mob/living/L)
 	var/obj/machinery/door/airlock/A = holder
-	if(!istype(L, /mob/living/silicon))
-		if(A.isElectrified())
-			if(A.shock(L, 100))
-				return 0
 	if(A.p_open)
 		return 1
 	return 0
@@ -110,14 +104,6 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 				else if(A.aiControlDisabled == 2)
 					A.aiControlDisabled = -1
 
-		if(AIRLOCK_WIRE_ELECTRIFY)
-			if(!mended)
-				//Cutting this wire electrifies the door, so that the next person to touch the door without insulated gloves gets electrocuted.
-				A.electrify(-1)
-			else
-				A.electrify(0)
-			return // Don't update the dialog.
-
 		if (AIRLOCK_WIRE_SAFETY)
 			A.safe = mended
 
@@ -167,9 +153,6 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 					else if(A.aiControlDisabled == 2)
 						A.aiControlDisabled = -1
 
-		if(AIRLOCK_WIRE_ELECTRIFY)
-			//one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds.
-			A.electrify(30)
 		if(AIRLOCK_WIRE_OPEN_DOOR)
 			//tries to open the door without ID
 			//will succeed only if the ID wire is cut or the door requires no access and it's not emagged

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -3,7 +3,6 @@
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)
 /obj/machinery/door/airlock
 	var/frequency
-	var/shockedby = list()
 	var/datum/radio_frequency/radio_connection
 	var/cur_command = null	//the command the door is currently attempting to complete
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -179,7 +179,6 @@ Any-Mode: (hotkey doesn't need to be on)
 \tCtrl + Click = drag or bolt doors
 \tShift + Click = examine or open doors
 \tAlt + Click = show entities on turf
-\tCtrl + Alt + Click = electrify doors
 </font>"}
 
 	if(isrobot(src.mob))

--- a/nano/templates/door_control.tmpl
+++ b/nano/templates/door_control.tmpl
@@ -41,17 +41,6 @@
 	</div>
 </div>	
 
-<div class="item">
-	<div class="itemLabelWidest">
-		Electrified Status:
-	</div>
-    <div class="itemContentWidest">
-		{{:helper.link('Offline'  , null, {'command' : 'electrify_permanently', 'activate' : "0" }, data.electrified == 0 ? 'selected' : null)}}
-        {{:helper.link(data.electrified <= 0 ? 'Temporary (30s)' : 'Temporary (' + data.electrified +'s)', null, {'command' : 'electrify_temporary',   'activate' : "1"}, data.electrified > 0 ? 'redButton' : null)}}
-        {{:helper.link('Permanent', null, {'command' : 'electrify_permanently', 'activate' : "1"}, data.electrified == -1 ? 'redButton' : null)}}
-	</div>
-</div>	
-
 <br>
 
 <table>

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 497 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 496 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
🆑
rscdel: Airlocks can no longer be intentionally or accidentally electrified (you can still get shocked if not wearing insulated gloves while cutting/mending their wires as before however).
/🆑