### PR TITLE
Add feedback and sound effects for airlock hacking

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -137,13 +137,20 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 			if(href_list["cut"]) // Toggles the cut/mend status
 				if(isWirecutter(I) || isWirecutter(offhand_item))
 					var/colour = href_list["cut"]
-					CutWireColour(colour)
+					var/message = ""
+					if (CutWireColour(colour))
+						message = SPAN_NOTICE("You mend the [colour] wire.")
+					else
+						message = SPAN_NOTICE("You cut the [colour] wire.")
+
 					if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 20, SKILL_ADEPT)))
 						RandomCut()
-						to_chat(L, "<span class='danger'>You accidentally nick another wire!</span>")
+						message = SPAN_DANGER("You accidentally nick another wire in addition to the [colour] wire!")
 					else if(!L.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
 						RandomCutAll(10)
-						to_chat(L, "<span class='danger'>You think you might have nicked some of the other wires!</span>")
+						message = SPAN_DANGER("You think you might have nicked some of the other wires in addition to the [colour] wire!")
+					to_chat(usr, message)
+					playsound(usr.loc, "sound/items/Wirecutter.ogg", 20)
 				else
 					to_chat(L, "<span class='error'>You need wirecutters!</span>")
 			else if(href_list["pulse"])
@@ -151,11 +158,13 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 					var/colour = href_list["pulse"]
 					if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 30, SKILL_ADEPT)))
 						RandomPulse()
-						to_chat(L, "<span class='danger'>You accidentally pulse another wire!</span>")
+						to_chat(L, "<span class='danger'>You accidentally pulse another wire instead of the [colour] wire!</span>")
 						if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 60, SKILL_BASIC)))
 							RandomPulse() //or two
 					else
 						PulseColour(colour)
+						to_chat(usr, SPAN_NOTICE("You pulse the [colour] wire."))
+					playsound(usr.loc, "sound/effects/pop.ogg", 20)
 					if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 50, SKILL_BASIC)))
 						wires = shuffle(wires) //Leaves them in a different order for anyone else.
 						to_chat(L, "<span class='danger'>You get the wires all tangled up!</span>")
@@ -163,20 +172,25 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 					to_chat(L, "<span class='error'>You need a multitool!</span>")
 			else if(href_list["attach"])
 				var/colour = href_list["attach"]
+				var/failed = 0
 				if(prob(L.skill_fail_chance(SKILL_ELECTRICAL, 80, SKILL_EXPERT)))
 					colour = pick(wires)
 					to_chat(L, "<span class='danger'>Are you sure you got the right wire?</span>")
+					failed = 1
 				// Detach
 				if(IsAttached(colour))
 					var/obj/item/O = Detach(colour)
 					if(O)
 						L.put_in_hands(O)
+						to_chat(usr, SPAN_NOTICE("You detach the signaller from the [colour] wire."))
 
 				// Attach
 				else
 					if(istype(I, /obj/item/device/assembly/signaler))
 						if(L.unEquip(I))
 							Attach(colour, I)
+							if(!failed)
+								to_chat(usr, SPAN_NOTICE("You attach the signaller to the [colour] wire."))
 					else
 						to_chat(L, "<span class='error'>You need a remote signaller!</span>")
 			else if(href_list["examine"])
@@ -322,15 +336,17 @@ var/const/POWER = 8
 
 /datum/wires/proc/CutWireColour(var/colour)
 	var/index = GetIndex(colour)
-	CutWireIndex(index)
+	return CutWireIndex(index)
 
 /datum/wires/proc/CutWireIndex(var/index)
 	if(IsIndexCut(index))
 		wires_status &= ~index
 		UpdateCut(index, 1)
+		return 1
 	else
 		wires_status |= index
 		UpdateCut(index, 0)
+		return 0
 
 /datum/wires/proc/RandomCut()
 	var/r = rand(1, wires.len)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1081,8 +1081,12 @@ About the new airlock wires panel:
 				to_chat(user, "<span class='warning'>The panel is broken, and cannot be closed.</span>")
 			else
 				src.p_open = 0
+				user.visible_message(SPAN_NOTICE("[user.name] closes the maintenance panel on \the [src]."), SPAN_NOTICE("You close the maintenance panel on \the [src]."))
+				playsound(src.loc, "sound/items/Screwdriver.ogg", 20)
 		else
 			src.p_open = 1
+			user.visible_message(SPAN_NOTICE("[user.name] opens the maintenance panel on \the [src]."), SPAN_NOTICE("You open the maintenance panel on \the [src]."))
+			playsound(src.loc, "sound/items/Screwdriver.ogg", 20)
 		src.update_icon()
 	else if(isWirecutter(C))
 		return src.attack_hand(user)


### PR DESCRIPTION
:cl:
rscadd: There are now feedback messages in the chat for when you open or close an airlock's maintenance panel, cut, mend, or pulse a wire, and attach or detach a signaler. There are also sound effects for all of these except signalers.
/:cl: