### PR TITLE
Smokable butts go into your hands when extinguished

### DIFF
--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -211,6 +211,8 @@
 			var/mob/living/M = loc
 			if (!no_message)
 				to_chat(M, "<span class='notice'>Your [name] goes out.</span>")
+			// if the mob has free hands, put the cig in them
+			M.put_in_any_hand_if_possible(butt)
 		qdel(src)
 
 /obj/item/clothing/mask/smokable/cigarette/menthol
@@ -342,7 +344,7 @@
 
 /obj/item/clothing/mask/smokable/cigarette/attack_self(var/mob/user)
 	if(lit == 1)
-		user.visible_message("<span class='notice'>[user] calmly drops and treads on the lit [src], putting it out instantly.</span>")
+		user.visible_message("<span class='notice'>[user] puts out the lit [src].</span>")
 		extinguish(no_message = 1)
 	return ..()
 


### PR DESCRIPTION
🆑 
tweak: Smokable butts will be held instead of being dumped on the ground, if a hand is available.
tweak: Changed the extinguishing chat message to reflect smokables no longer being dropped.
/🆑 
People will now be considerate of others when smoking.