### PR TITLE
objects don't fall down up ladders

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -57,6 +57,8 @@
 	..()
 
 /obj/structure/ladder/hitby(obj/item/I)
+	if (istype(src, /obj/structure/ladder/up))
+		return
 	var/area/room = get_area(src)
 	if(!room.has_gravity())
 		return


### PR DESCRIPTION
:cl:
bugfix: Objects colliding with upward ladders no longer fall through reality.
/:cl: