### PR TITLE
Ninja blade fixes

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -13,7 +13,7 @@
 
 /obj/item/weapon/melee/energy/can_embed()
 	return FALSE
-	
+
 /obj/item/weapon/melee/energy/Initialize()
 	. = ..()
 	if(active)
@@ -22,7 +22,7 @@
 	else
 		active = TRUE
 		deactivate()
-		
+
 /obj/item/weapon/melee/energy/on_update_icon()
 	. = ..()
 	if(active)
@@ -45,7 +45,7 @@
 		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>\The [src] is now energised.</span>")
 	set_light(0.8, 1, 2, 4, lighting_color)
-	
+
 /obj/item/weapon/melee/energy/proc/deactivate(mob/living/user)
 	if(!active)
 		return
@@ -140,11 +140,11 @@
 /obj/item/weapon/melee/energy/sword/Initialize()
 	if(!blade_color)
 		blade_color = pick("red","blue","green","purple")
-	
+
 	active_icon = "sword[blade_color]"
 	var/color_hex = list("red" = COLOR_SABER_RED,  "blue" = COLOR_SABER_BLUE, "green" = COLOR_SABER_GREEN, "purple" = COLOR_SABER_PURPLE)
 	lighting_color = color_hex[blade_color]
-	
+
 	. = ..()
 
 /obj/item/weapon/melee/energy/sword/green
@@ -191,13 +191,13 @@
 	icon_state = "blade"
 	active_icon = "blade"	//It's all energy, so it should always be visible.
 	lighting_color = COLOR_SABER_GREEN
-	force = 40 //Normal attacks deal very high damage - about the same as wielded fire axe
+	active_force = 40 //Normal attacks deal very high damage - about the same as wielded fire axe
 	active = 1
 	armor_penetration = 100
 	sharp = 1
 	edge = 1
 	anchored = 1    // Never spawned outside of inventory, should be fine.
-	throwforce = 1  //Throwing or dropping the item deletes it.
+	active_throwforce = 1  //Throwing or dropping the item deletes it.
 	throw_speed = 1
 	throw_range = 1
 	w_class = ITEM_SIZE_TINY //technically it's just energy or something, I dunno
@@ -245,7 +245,7 @@
 			host.embedded -= src
 			host.drop_from_inventory(src)
 		QDEL_IN(src, 0)
-		
+
 /obj/item/weapon/melee/energy/machete
 	name = "energy machete"
 	desc = "A machete handle that extends out into a long, purple machete blade. It appears to be Skrellian in origin."

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -17,7 +17,7 @@
 	name = "mounted flash"
 	desc = "You are the law."
 	icon_state = "flash"
-	
+
 	selectable = 0
 	toggleable = 1
 	activates_on_touch = 1
@@ -314,7 +314,7 @@
 	selectable = 1
 	toggleable = 1
 	use_power_cost = 10 KILOWATTS
-	active_power_cost = 500
+	active_power_cost = 0.5 KILOWATTS
 	passive_power_cost = 0
 
 	gun = /obj/item/weapon/gun/energy/crossbow/ninja/mounted
@@ -329,10 +329,6 @@
 	return ..()
 
 /obj/item/rig_module/mounted/energy_blade/activate()
-
-	if(!..() || !gun)
-		return 0
-
 	var/mob/living/M = holder.wearer
 
 	if(M.l_hand && M.r_hand)
@@ -343,6 +339,9 @@
 	var/obj/item/weapon/melee/energy/blade/blade = new(M)
 	blade.creator = M
 	M.put_in_hands(blade)
+
+	if(!..() || !gun)
+		return 0
 
 /obj/item/rig_module/mounted/energy_blade/deactivate()
 


### PR DESCRIPTION
:cl: AshtonFox
bugfix: Fixed ominous suit's Project Blade option.
bugfix: Fixed Ninja's energy blade not dealing any damage.
/:cl:

Not entirely sure if these two are still things, since I couldn't find an appropriate Issue report. 
If so, I should say that moving the `if(!..() || !gun)` check may look questionable, but it can at least serve as a temporary solution to the bug, or give other contributors the idea of a different implementation.
