### PR TITLE
University ship cleaning

### DIFF
--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -6,8 +6,11 @@
 /turf/simulated/wall/titanium,
 /area/space)
 "ac" = (
-/turf/simulated/wall,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/unishi/engineering)
 "ad" = (
 /obj/machinery/power/port_gen/pacman/super/potato,
 /obj/structure/cable/yellow{
@@ -55,7 +58,13 @@
 /turf/simulated/floor/reinforced/airmix,
 /area/unishi/engineering)
 "ai" = (
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/unishi/engineering)
 "aj" = (
 /obj/machinery/power/port_gen/pacman/super/potato,
@@ -117,10 +126,10 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/floor,
 /area/unishi/engineering)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -137,7 +146,13 @@
 /turf/space,
 /area/unishi/engineering)
 "at" = (
-/turf/simulated/wall/ocp_wall,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/structure/sign/warning/airlock,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
 /area/unishi/engineering)
 "au" = (
 /obj/structure/cable/yellow{
@@ -182,14 +197,17 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/unishi/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall/r_wall,
+/area/unishi/engineroom)
 "aC" = (
 /obj/machinery/atmospherics/portables_connector{
 	icon_state = "map_connector";
@@ -199,13 +217,18 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aD" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/sign/warning/airlock,
-/turf/simulated/wall,
-/area/unishi/engineering)
+/obj/machinery/vending/wallmed1,
+/obj/structure/sign/warning/high_voltage{
+	icon_state = "shock";
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/unishi/engineroom)
 "aE" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "unishi_sensor";
@@ -332,17 +355,14 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "aT" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1438;
+	icon_state = "map_injector";
+	id = "unishi_fuel_in";
+	use_power = 1
 	},
-/obj/machinery/vending/wallmed1,
-/obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 4
-	},
-/turf/simulated/wall,
+/turf/simulated/floor/reinforced/airless,
 /area/unishi/engineroom)
 "aU" = (
 /turf/simulated/floor,
@@ -364,9 +384,8 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aY" = (
-/obj/structure/sign/warning/airlock,
-/turf/simulated/wall/titanium,
-/area/unishi/engineering)
+/turf/simulated/floor/reinforced/airless,
+/area/unishi/engineroom)
 "aZ" = (
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "unishi";
@@ -511,14 +530,11 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bt" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1438;
-	icon_state = "map_injector";
-	id = "unishi_fuel_in";
-	use_power = 1
+/obj/machinery/sparker{
+	id_tag = "unishi";
+	pixel_x = -20
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced/airless,
 /area/unishi/engineroom)
 "bu" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -599,16 +615,13 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bD" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/unishi/engineroom)
 "bE" = (
 /obj/structure/cable/yellow{
@@ -649,13 +662,8 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/wall,
+/obj/structure/closet/hydrant,
+/turf/simulated/wall/r_wall,
 /area/unishi/engineroom)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -678,13 +686,6 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bL" = (
-/obj/machinery/sparker{
-	id_tag = "unishi";
-	pixel_x = -20
-	},
-/turf/simulated/floor,
-/area/unishi/engineroom)
-"bM" = (
 /obj/machinery/atmospherics/unary/vent_pump/engine{
 	dir = 4;
 	external_pressure_bound = 100;
@@ -697,8 +698,12 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced/airless,
 /area/unishi/engineroom)
+"bM" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
+/area/unishi/engineering)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -725,8 +730,9 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bR" = (
-/turf/simulated/wall,
-/area/unishi/engineroom)
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/unishi/engineering)
 "bS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
@@ -763,10 +769,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor,
-/area/unishi/engineroom)
-"bX" = (
-/obj/structure/closet/hydrant,
-/turf/simulated/wall,
 /area/unishi/engineroom)
 "bY" = (
 /obj/structure/table/standard,
@@ -822,10 +824,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/unishi/engineroom)
-"ch" = (
-/obj/structure/sign/warning/vent_port,
-/turf/simulated/wall/titanium,
-/area/space)
 "ci" = (
 /obj/structure/lattice,
 /turf/space,
@@ -840,12 +838,6 @@
 	},
 /turf/simulated/floor,
 /area/unishi/engineroom)
-"Ic" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/unishi/engineering)
 
 (1,1,1) = {"
 aa
@@ -5257,10 +5249,10 @@ aa
 aa
 ab
 ab
-aG
-aG
-aG
-aG
+bZ
+bZ
+bZ
+bZ
 aG
 aG
 aG
@@ -5358,16 +5350,16 @@ ab
 ab
 ab
 ab
-at
-aG
+ag
+bg
 aO
 ba
 bi
 bo
+aT
+aY
+aY
 bt
-aU
-aU
-bL
 bS
 ca
 ce
@@ -5455,21 +5447,21 @@ aa
 aa
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-at
-aG
+ag
+ag
+ag
+ag
+ag
+ag
+bg
 aP
 bb
 bj
 aG
-aU
-aU
-aU
-bM
+aY
+aY
+aY
+bL
 bT
 cb
 ce
@@ -5557,13 +5549,13 @@ aa
 aa
 ab
 ab
-ab
+ag
 ad
 aj
 aj
-at
-at
-aG
+ag
+ag
+bg
 aP
 bb
 bk
@@ -5659,13 +5651,13 @@ aa
 aa
 ab
 ab
-ab
+ag
 ae
 ak
 ak
-at
-at
-aG
+ag
+ag
+bg
 aQ
 bc
 bd
@@ -5761,7 +5753,7 @@ aa
 aa
 ab
 ab
-ab
+ag
 af
 al
 an
@@ -5863,13 +5855,13 @@ aa
 aa
 ab
 ab
-ab
 ag
 ag
 ag
-at
-at
-at
+ag
+ag
+ag
+ag
 aS
 be
 bm
@@ -5965,14 +5957,14 @@ aa
 aa
 ab
 ab
-ab
+ag
 ah
 ah
 ao
 av
-Ic
-aH
-aT
+aq
+ag
+aD
 bc
 bc
 bc
@@ -6067,11 +6059,11 @@ aa
 aa
 ab
 ab
-ab
+ag
 ah
 ah
 ao
-aw
+aH
 aA
 aw
 aU
@@ -6169,22 +6161,22 @@ aa
 aa
 ab
 ab
-ab
+ag
 ah
 am
 ap
 ax
-aB
+ai
 aI
 aV
 bf
 bn
 bs
 bx
+aB
 bD
+bg
 bI
-bR
-bX
 cc
 ce
 cg
@@ -6271,12 +6263,12 @@ aa
 aa
 ab
 ab
+ag
+ag
+ag
 ac
-ai
-ai
-aq
-ai
-ai
+ag
+ag
 aJ
 aW
 bg
@@ -6480,20 +6472,20 @@ aa
 aa
 as
 ay
-aD
+at
 aL
-aY
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ch
+ay
+ay
+ay
+ay
+ay
+bZ
+bZ
+bZ
+bZ
+bZ
+bZ
+cf
 aa
 aa
 aa
@@ -6685,7 +6677,7 @@ aa
 aa
 ay
 aF
-aw
+bR
 ay
 aa
 aa
@@ -6786,7 +6778,7 @@ aa
 aa
 aa
 ay
-ai
+bM
 aN
 ay
 aa

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -135,8 +135,8 @@
 /turf/simulated/wall/titanium,
 /area/unishi/chem)
 "ay" = (
-/turf/simulated/wall,
-/area/unishi/chem)
+/turf/simulated/wall/r_wall,
+/area/unishi/library)
 "az" = (
 /obj/machinery/door/airlock/glass/research,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -176,12 +176,6 @@
 /turf/simulated/floor/tiled/white,
 /area/unishi/chem)
 "aC" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -191,6 +185,13 @@
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/white,
 /area/unishi/chem)
@@ -441,7 +442,7 @@
 /turf/simulated/wall,
 /area/unishi/common)
 "bm" = (
-/turf/simulated/wall,
+/turf/simulated/wall/titanium,
 /area/unishi/classroom)
 "bn" = (
 /turf/simulated/wall/r_wall,
@@ -604,9 +605,34 @@
 	},
 /turf/simulated/floor,
 /area/unishi/common)
+"bD" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
+/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
+/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
+/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22;
+	req_access = newlist()
+	},
+/obj/item/stack/material/diamond/ten,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/silver/ten,
+/obj/item/stack/material/glass/fifty,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/simulated/floor/tiled,
+/area/unishi/rnd)
 "bE" = (
 /turf/simulated/floor/tiled/dark,
 /area/unishi/classroom)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/wall/titanium,
+/area/unishi/smresearch)
 "bG" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/dark,
@@ -901,9 +927,6 @@
 "cr" = (
 /turf/simulated/wall/titanium,
 /area/unishi/meeting)
-"cs" = (
-/turf/simulated/wall,
-/area/unishi/meeting)
 "ct" = (
 /turf/simulated/wall/r_wall,
 /area/unishi/meeting)
@@ -1065,13 +1088,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/unishi/toxins)
-"cL" = (
-/obj/machinery/door/blast/regular{
-	icon_state = "pdoor1";
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/space)
 "cM" = (
 /obj/structure/bed/chair/office/comfy/black{
 	dir = 4
@@ -1424,9 +1440,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/unishi/toxins)
-"dJ" = (
-/turf/simulated/wall/titanium,
-/area/unishi/hydro)
 "dK" = (
 /obj/structure/bed/chair/office{
 	dir = 1
@@ -1565,23 +1578,6 @@
 /area/unishi/rnd)
 "dZ" = (
 /obj/machinery/r_n_d/protolathe,
-/turf/simulated/floor/tiled,
-/area/unishi/rnd)
-"ea" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
-/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
-/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
-/obj/item/weapon/reagent_containers/glass/bottle/tericadone,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22;
-	req_access = newlist()
-	},
-/obj/item/stack/material/diamond/ten,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/silver/ten,
-/obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/tiled,
 /area/unishi/rnd)
 "eb" = (
@@ -2145,10 +2141,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/unishi/common)
-"fu" = (
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor,
-/area/space)
 "fv" = (
 /obj/structure/flora/pottedplant/aquatic,
 /turf/simulated/floor/tiled/dark,
@@ -2483,9 +2475,6 @@
 	},
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor,
-/area/unishi/smresearch)
-"gn" = (
-/turf/space,
 /area/unishi/smresearch)
 "go" = (
 /obj/effect/decal/cleanable/vomit,
@@ -3049,20 +3038,6 @@
 	dir = 1
 	},
 /turf/simulated/wall/titanium,
-/area/unishi/smresearch)
-"hF" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/space,
-/area/unishi/smresearch)
-"hG" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/space,
 /area/unishi/smresearch)
 "qW" = (
 /obj/structure/table/standard,
@@ -7313,25 +7288,25 @@ ad
 ad
 ad
 ad
-ad
-ad
-fu
-fu
+fh
+fh
+fp
+fp
 fK
 fK
 fK
 fK
 fK
 fK
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -7433,7 +7408,7 @@ gW
 fK
 fK
 fK
-gn
+aa
 aa
 aa
 aa
@@ -7491,10 +7466,10 @@ ax
 ax
 ax
 ax
-ay
-ay
-ay
-ay
+ax
+ax
+ax
+ax
 bm
 bm
 bm
@@ -7502,7 +7477,7 @@ bm
 bm
 bm
 bm
-cs
+ct
 cz
 cM
 cW
@@ -7535,7 +7510,7 @@ fK
 fK
 fK
 fK
-gn
+aa
 aa
 aa
 aa
@@ -7637,7 +7612,7 @@ fL
 ge
 fK
 fK
-gn
+fK
 aa
 aa
 aa
@@ -7691,7 +7666,7 @@ ak
 ak
 ak
 ak
-ay
+bd
 aB
 aM
 aM
@@ -7793,7 +7768,7 @@ al
 aq
 au
 av
-ay
+bd
 aC
 aN
 aU
@@ -7816,7 +7791,7 @@ df
 dr
 dA
 dN
-ea
+bD
 em
 ev
 eD
@@ -7895,7 +7870,7 @@ am
 aq
 ao
 av
-ay
+bd
 aD
 aO
 aV
@@ -7929,10 +7904,10 @@ fl
 fq
 fw
 fF
-fL
+fN
 fO
 fN
-fL
+fN
 fW
 gh
 gp
@@ -7997,7 +7972,7 @@ am
 ar
 ao
 aw
-ak
+ay
 aE
 aP
 aW
@@ -8031,10 +8006,10 @@ aE
 fr
 bl
 fr
-fL
+fN
 fP
 fS
-fL
+fN
 fX
 gi
 gq
@@ -8201,7 +8176,7 @@ ao
 at
 ao
 at
-ak
+ay
 aG
 aG
 aY
@@ -8235,10 +8210,10 @@ dj
 bl
 bl
 bl
-fL
+fN
 fR
 fU
-fL
+fN
 fZ
 gj
 gs
@@ -8303,7 +8278,7 @@ ao
 aq
 ao
 aq
-ak
+ay
 aH
 aR
 aS
@@ -8337,10 +8312,10 @@ dj
 fp
 fy
 fE
-fL
 fN
 fN
-fL
+fN
+fN
 ga
 gk
 gt
@@ -8405,7 +8380,7 @@ ap
 aq
 ao
 aq
-ak
+ay
 aI
 aS
 aS
@@ -8413,9 +8388,9 @@ bh
 aG
 aG
 bA
-bl
-bl
-bl
+aG
+aG
+aG
 bX
 ce
 ck
@@ -8507,22 +8482,22 @@ ak
 ak
 ak
 ak
-ak
+ay
 aJ
 aS
 aZ
 bi
-bl
+aG
 br
 bB
 bK
 aS
-bl
+aG
 bY
 cf
 cl
 cp
-cy
+cx
 cH
 cU
 dd
@@ -8609,17 +8584,17 @@ ad
 ad
 ad
 ad
-ad
+fh
 aK
 aS
 ba
 ba
-bl
+aG
 bs
 bC
 bL
 bP
-bl
+aG
 bZ
 cg
 cm
@@ -8657,7 +8632,7 @@ hd
 hd
 hz
 hD
-hF
+bF
 aa
 aa
 aa
@@ -8711,21 +8686,21 @@ aa
 aa
 aa
 aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
 cy
 cJ
 cV
@@ -8759,7 +8734,7 @@ fN
 fN
 fN
 fK
-hG
+gJ
 aa
 aa
 aa
@@ -8861,7 +8836,7 @@ gW
 fK
 fK
 fK
-hG
+gJ
 aa
 aa
 aa
@@ -8930,13 +8905,13 @@ aa
 aa
 aa
 ad
-ad
-cL
-ad
-ad
-ad
-ad
-dJ
+dp
+cK
+dp
+dp
+dp
+dp
+dp
 dW
 dW
 dW
@@ -8954,7 +8929,7 @@ fK
 fK
 fK
 fK
-ad
+fK
 gw
 gJ
 gU

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -17,7 +17,7 @@
 /turf/simulated/floor,
 /area/unishi/bridge)
 "ae" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor/reinforced/airless,
 /area/unishi/bridge)
 "af" = (
 /obj/effect/wingrille_spawn/reinforced/full,
@@ -141,7 +141,7 @@
 /area/unishi/bridge)
 "aC" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/reinforced/airless,
 /area/unishi/bridge)
 "aD" = (
 /turf/simulated/wall/titanium,
@@ -213,7 +213,7 @@
 /turf/simulated/floor,
 /area/unishi/bridge)
 "aR" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_titanium,
 /area/unishi/bridge)
 "aS" = (
 /obj/machinery/door/airlock/command,
@@ -226,7 +226,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/unishi/living)
+/area/unishi/bridge)
 "aT" = (
 /obj/structure/largecrate,
 /turf/simulated/floor,
@@ -313,8 +313,7 @@
 /turf/simulated/wall,
 /area/unishi/living)
 "bg" = (
-/obj/structure/sign/warning/secure_area/armory,
-/turf/simulated/wall,
+/turf/simulated/wall/r_titanium,
 /area/unishi/living)
 "bh" = (
 /obj/machinery/door/firedoor,
@@ -331,7 +330,7 @@
 /obj/structure/sign/directions/bridge{
 	dir = 1
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/titanium,
 /area/unishi/living)
 "bj" = (
 /obj/structure/closet/crate/med_crate/trauma,
@@ -606,6 +605,7 @@
 	req_access = newlist()
 	},
 /obj/item/weapon/defibrillator/loaded,
+/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
 /area/unishi/med)
 "bT" = (
@@ -919,7 +919,7 @@
 "cA" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor,
-/area/space)
+/area/unishi/lounge)
 "cB" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor,
@@ -2005,6 +2005,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/unishi/living)
+"fh" = (
+/obj/structure/sign/warning/secure_area/armory,
+/turf/simulated/wall/r_titanium,
+/area/unishi/living)
+"fi" = (
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6392,7 +6399,20 @@ aa
 aa
 aa
 aa
-ae
+fi
+fi
+fi
+fi
+fi
+fi
+be
+be
+be
+aP
+aP
+aP
+aP
+aP
 aO
 aO
 aO
@@ -6406,26 +6426,13 @@ aP
 aP
 aP
 aP
-aO
-aO
-aO
-aO
-aO
-be
-be
-be
-be
-be
-be
-be
-be
-be
-be
-be
-be
-be
-be
-be
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 aP
 aP
 aP
@@ -6495,10 +6502,10 @@ aa
 aC
 ae
 ae
-aP
-aP
-aP
-aP
+aD
+aD
+aD
+aD
 be
 be
 bC
@@ -6604,7 +6611,7 @@ bj
 be
 bw
 bp
-bM
+bN
 bQ
 bZ
 cn
@@ -6696,8 +6703,8 @@ af
 as
 as
 as
-aD
-aD
+as
+as
 aL
 aQ
 aV
@@ -6706,7 +6713,7 @@ bk
 be
 bx
 bD
-bM
+bN
 bR
 ca
 ch
@@ -6801,11 +6808,11 @@ aw
 as
 aE
 aJ
-aD
-aD
+aR
+aR
+bg
 be
 be
-bf
 bf
 bE
 bN
@@ -6903,9 +6910,9 @@ ax
 as
 aF
 aK
-aD
+aR
 aW
-bf
+bg
 bl
 bq
 by
@@ -7007,7 +7014,7 @@ aG
 cg
 aR
 aX
-bg
+fh
 bm
 bp
 bp
@@ -7209,7 +7216,7 @@ aA
 as
 as
 aN
-aR
+aD
 aZ
 bi
 bo
@@ -7313,7 +7320,7 @@ aH
 aJ
 aD
 ba
-bf
+be
 XA
 bs
 bz
@@ -7512,20 +7519,20 @@ af
 as
 as
 as
-aD
-aD
+as
+as
 aJ
 aT
 bb
-aR
-aR
+be
+bf
 bu
 bA
 bK
-be
-bW
-bW
-bW
+bf
+bV
+bV
+bV
 cy
 cz
 cz
@@ -7618,26 +7625,26 @@ aD
 aD
 aD
 aD
-aR
-aR
-aJ
+aD
+be
+bv
 Um
 bB
 bv
 bv
 bX
 ce
-bW
-bW
+bV
+bV
 cG
 cK
 cG
-aP
-aP
-aP
-aP
-aP
-aP
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dI
 dP
@@ -7719,10 +7726,10 @@ aa
 ae
 ae
 ae
-aP
-aP
-aP
-aP
+aD
+aD
+be
+be
 be
 be
 bL
@@ -7730,7 +7737,7 @@ bP
 bY
 cf
 co
-aP
+bW
 cA
 cA
 cA
@@ -7739,19 +7746,19 @@ aP
 aP
 aP
 aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+dA
+dA
+dA
+dA
+be
+be
+be
+be
+be
+be
+be
+be
+be
 aP
 aP
 aP
@@ -7820,19 +7827,19 @@ aa
 aa
 aa
 aa
-aO
-aO
-aO
-aO
-aO
-aO
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+fi
+fi
+fi
+fi
+fi
+fi
+be
+be
+be
+be
+be
+be
+be
 aO
 aO
 aO


### PR DESCRIPTION
:cl:
maptweak: Replaced and moved several odd walls on Verne.
maptweak: Verne airlock now has windows and the interior access button is no longer covered by an airlock sign.
maptweak: Verne's fuel tank now has reinforced floor and spawns without gas.
maptweak: Added science goggles to Verne.
maptweak: Removed chemistry APC access requirement on Verne.
/:cl:

The university ship is a total mess and needs cleaning.
- The ship has a working airlock but people can not get out of the ship normally if they are not aware of the button hidden by the blue airlock sign
- The lowest deck has a scrubber in a wall
- Armory has a bolted door but does not have reinforced walls
- It's a _research vessel_ without any science goggles

This also slightly resizes most areas on the ship, but this change is basically invisible to players.