### PR TITLE
Add surrender verb

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -155,6 +155,8 @@
 
 #define SPAN_DANGER(X) "<span class='danger'>[X]</span>"
 
+#define SPAN_GOOD(X) "<span class='good'>[X]</span>"
+
 #define SPAN_OCCULT(X) "<span class='cult'>[X]</span>"
 
 #define SPAN_MFAUNA(X) "<span class='mfauna'>[X]</span>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -899,6 +899,30 @@
 	else
 		germ_level += n
 
+mob/living/carbon/human/verb/surrender() 
+	set name = "Surrender"
+	set category = "IC"
+
+	if(src.restrained() || src.buckled || src.stat || (src.weakened && src.stunned))
+		to_chat(src, SPAN_WARNING("You can't do that right now."))
+		return
+
+	var/datum/gender/user_gender = gender_datums[src.get_visible_gender()]
+	var/message = "[src] puts [user_gender.his] hands on [user_gender.his] head and drops to the ground; [user_gender.he] surrenders!"
+
+	if(src.drop_l_hand())
+		message = "[src] drops what [user_gender.he] is holding, puts [user_gender.his] hands on [user_gender.his] head, and drops to the ground; [user_gender.he] surrenders!"
+
+	if(src.drop_r_hand()) //Done separately to bypass short-circuit evaluation
+		message = "[src] drops what [user_gender.he] is holding, puts [user_gender.his] hands on [user_gender.his] head, and drops to the ground; [user_gender.he] surrenders!"
+
+	if(src.lying) //You cannot hold things while lying down so there is no need to check for both conditions at once
+		message = "[src] puts [user_gender.his] hands on [user_gender.his] head while on the ground; [user_gender.he] surrenders!"
+
+	src.Resting(5)
+
+	src.visible_message(SPAN_GOOD(SPAN_BOLD(message)))
+
 /mob/living/carbon/human/revive()
 
 	if(should_have_organ(BP_HEART))


### PR DESCRIPTION
:cl:
rscadd: New verb: Surrender. Found in the IC panel. You will drop anything you are holding and start resting (fall to the ground). A green message will be broadcast in the chat. You can get back up (immediately) using the `rest` verb.
/:cl:

Green text seems the most fitting for this action and also stands out more than blue text, since this is (I believe) one of the only cases where it's used.