### PR TITLE
Revert "Removes ability to construct tele-circuits"

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -552,6 +552,7 @@
 	inputs = list("teleporter", "rift direction")
 	outputs = list()
 	activators = list("open rift" = IC_PINTYPE_PULSE_IN)
+	spawn_flags = IC_SPAWN_RESEARCH
 	action_flags = IC_ACTION_LONG_RANGE
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)


### PR DESCRIPTION
Reverts Baystation12/Baystation12#28523
:cl:
tweak: adds teleporter circuits back to the integrated circuit printer
/:cl:

While I agree that telecircuits were being abused at the time, I noticed that the abuse (which was, to be completely honest, about 90% from one player) stopped quite a while before the PR to remove them was merged. I feel like it's a permanent solution to a temporary problem, and that it's a nerf to a system (integrated circuits) that quite frankly doesn't need any more nerfs than it's already recieved. If you have any further questions about my reasoning for reverting this PR, feel free to reach out to me at RustingWithYou#8798 on Discord.