### PR TITLE
ship accel/decel fixes

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -35,3 +35,7 @@
 
 // Determines the exchange ratio of reagents being converted to gas and vice versa.
 #define REAGENT_GAS_EXCHANGE_FACTOR 10
+
+//where a unit turf is 1 on a side, its diagonal is sqrt(2)
+#define UNIT_DIAGONAL      1.41421356237
+#define HALF_UNIT_DIAGONAL 0.70710678118

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -36,9 +36,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 			if(linked.is_still())
 				autopilot = 0
 			else
-				linked.decelerate()
+				linked.decelerate(accellimit)
 		else
-			var/brake_path = linked.get_brake_path()
+			var/brake_path = linked.get_brake_path() / HALF_UNIT_DIAGONAL //get_dist is steps, not hypotenuse
 			var/direction = get_dir(linked.loc, T)
 			var/acceleration = min(linked.get_acceleration(), accellimit)
 			var/speed = linked.get_speed()
@@ -46,7 +46,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 			// Destination is current grid or speedlimit is exceeded
 			if ((get_dist(linked.loc, T) <= brake_path) || speed > speedlimit)
-				linked.decelerate()
+				linked.decelerate(accellimit)
 			// Heading does not match direction
 			else if (heading & ~direction)
 				linked.accelerate(turn(heading & ~direction, 180), accellimit)
@@ -199,7 +199,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		linked.relaymove(user, ndir, accellimit)
 
 	if (href_list["brake"])
-		linked.decelerate()
+		linked.decelerate(accellimit)
 
 	if (href_list["apilot"])
 		autopilot = !autopilot


### PR DESCRIPTION
:cl:
bugfix: Ships no longer apply burn acceleration twice for diagonals.
bugfix: Ships no longer burn twice per deceleration step.
/:cl:

ships are no longer capable of straferunning or doubletap deceleration
bhopping may still be a problem