### PR TITLE
Remove Limbs from the Bioprinter

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -279,7 +279,8 @@
 	for(var/organ in loaded_species.has_organ)
 		organs += loaded_species.has_organ[organ]
 	for(var/organ in loaded_species.has_limbs)
-		organs += loaded_species.has_limbs[organ]["path"]
+		if ((loaded_species.name == SPECIES_NABBER) || (organ == BP_GROIN))
+			organs += loaded_species.has_limbs[organ]["path"]
 	for(var/organ in organs)
 		var/obj/item/organ/O = organ
 		if(check_printable(organ))

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -277,9 +277,11 @@
 		return
 	var/list/organs = list()
 	for(var/organ in loaded_species.has_organ)
-		organs += loaded_species.has_organ[organ]
+		if (loaded_species.has_organ[organ])
+			organs += loaded_species.has_organ[organ]
 	for(var/organ in loaded_species.has_limbs)
-		organs += loaded_species.has_limbs[organ]["path"]
+		if ((loaded_species.name == SPECIES_NABBER) || (organ == BP_GROIN))
+			organs += loaded_species.has_limbs[organ]["path"]
 	for(var/organ in organs)
 		var/obj/item/organ/O = organ
 		if(check_printable(organ))

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -277,8 +277,7 @@
 		return
 	var/list/organs = list()
 	for(var/organ in loaded_species.has_organ)
-		if (loaded_species.has_organ[organ])
-			organs += loaded_species.has_organ[organ]
+		organs += loaded_species.has_organ[organ]
 	for(var/organ in loaded_species.has_limbs)
 		if ((loaded_species.name == SPECIES_NABBER) || (organ == BP_GROIN))
 			organs += loaded_species.has_limbs[organ]["path"]


### PR DESCRIPTION
:cl: GrazalThruka
rscdel: The Bioprinter can no longer print hands, feet, arms, or legs for all species but GAS
/:cl:

Being able to print flesh limbs makes losing limbs a much smaller deal than it should be (at least in my opinion). This version of the PR allows GAS to still be repaired properly, and allows groins to be printed. The Prosthetic Organ Fabricator hasn't been modified, so medical can still deal with lost limbs without a roboticist.