### PR TITLE
applies atmos_canpass to inflatable structures

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -5,8 +5,6 @@
 	var/deploy_path = null
 	var/inflatable_health
 
-	atmos_canpass = CANPASS_DENSITY
-
 /obj/item/inflatable/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!deploy_path)
 		return
@@ -65,6 +63,7 @@
 	opacity = 0
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"
+	atmos_canpass = CANPASS_DENSITY
 
 	var/undeploy_path = null
 	var/health = 10
@@ -76,6 +75,7 @@
 /obj/structure/inflatable/wall
 	name = "inflatable wall"
 	undeploy_path = /obj/item/inflatable/wall
+	atmos_canpass = CANPASS_NEVER
 
 /obj/structure/inflatable/New(location)
 	..()


### PR DESCRIPTION
it was erroneously set on the item instead
