### PR TITLE
Remove maintenance from chef access

### DIFF
--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -80,7 +80,7 @@
 	min_skill = list(   SKILL_COOKING   = SKILL_ADEPT,
 	                    SKILL_BOTANY    = SKILL_BASIC,
 	                    SKILL_CHEMISTRY = SKILL_BASIC)
-	access = list(access_maint_tunnels, access_hydroponics, access_kitchen, access_solgov_crew, access_bar, access_commissary)
+	access = list(access_hydroponics, access_kitchen, access_solgov_crew, access_bar, access_commissary)
 	minimal_access = list()
 
 /datum/job/bartender


### PR DESCRIPTION
:cl:
tweak: Chefs no longer have full access to maintenance.
/:cl:

There's no good reason for them to have it. Scrounging for food in maintenance is hardly a productive use of time, not to mention unsanitary.