### PR TITLE
Move UpdateDamageIcon() to Life()

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -81,6 +81,9 @@
 
 		handle_medical_side_effects()
 
+		if(life_tick % 2 == 0)
+			UpdateDamageIcon() //To solve the problem of not updating after all wounds heal
+
 		if(!client && !mind)
 			species.handle_npc(src)
 


### PR DESCRIPTION
:cl:
bugfix: Visible damage will now correctly disappear after you are fully healed.
/:cl:

See #28495 for further context.

Fixes #28495 