### PR TITLE
Change mix messages and colors for unathi drinks

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -2718,7 +2718,7 @@
 	name = "Hrukhza Leaf Extract"
 	description = "A bitter liquid used in most recipes on Moghes."
 	taste_description = "bland, disgusting bitterness"
-	color = "#e78108"
+	color = "#345c52"
 	glass_name = "hrukhza leaf extract"
 	glass_desc = "A bitter extract from the hrukhza."
 
@@ -2734,7 +2734,7 @@
 	name = "Mumbak Sting"
 	description = "A drink made from the venom of the Yuum."
 	taste_description = "harsh and stinging sweetness"
-	color = "#7e4c2e"
+	color = "#550000"
 	glass_name = "Mumbak sting"
 	glass_desc = "A drink made from the venom of the Yuum."
 
@@ -2742,7 +2742,7 @@
 	name = "Wasgaelhi"
 	description = "Wine made from various fruits from the swamps of Moghes."
 	taste_description = "swampy fruit"
-	color = "#678e46"
+	color = "#6b596b"
 	strength = 10
 	glass_name = "wasgaelhi"
 	glass_desc = "Wine made from various fruits from the swamps of Moghes."

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2714,28 +2714,28 @@
 	result_amount = 3
 	minimum_temperature = 50 CELSIUS
 	maximum_temperature = (70 CELSIUS) + 100
-	mix_message = "The tea turns a bitter black"
+	mix_message = "The tea turns a bitter black."
 
 /datum/chemical_reaction/mumbaksting
 	name = "Mumbak Sting"
 	result = /datum/reagent/drink/alien/mumbaksting
 	required_reagents = list(/datum/reagent/drink/alien/unathijuice = 2, /datum/reagent/toxin = 1)
 	result_amount = 3
-	mix_message = "The toxins mix with the juice to create a dark red substance"
+	mix_message = "The toxins mix with the juice to create a dark red substance."
 
 /datum/chemical_reaction/wasgaelhi
 	name = "Wasgaelhi"
 	result = /datum/reagent/ethanol/alien/wasgaelhi
 	required_reagents = list(/datum/reagent/drink/alien/unathijuice = 2, /datum/reagent/ethanol/wine = 1)
 	result_amount = 3
-	mix_message = "The mixture turns a dark green"
+	mix_message = "The mixture turns a dull purple."
 
 /datum/chemical_reaction/kzkzaa
 	name = "Kzkzaa"
 	result = /datum/reagent/drink/alien/kzkzaa
 	required_reagents = list(/datum/reagent/drink/alien/unathijuice = 2, /datum/reagent/nutriment/protein = 1)
 	result_amount = 3
-	mix_message = "The mixture turns a dark green"
+	mix_message = "The mixture turns a deep orange."
 
 //Fruit Expansion
 


### PR DESCRIPTION
:cl:
tweak: The colors for hrukhza leaf extract, kzkzaa, wasgaelhi, and mumbak sting have been changed. The mixing messages have also been updated accordingly.
/:cl:

Hrukhza went from orange to a dull-sea green. Mumbak sting went from brown to dark red. Wasgaelhi went from sea green to dull purple. 

This change was made after talk with the species maintainer.