### PR TITLE
Removes the Pathfinder's command comms and bridge access

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -62,7 +62,7 @@
 /obj/item/device/encryptionkey/pathfinder
 	name = "pathfinder's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Exploration" = 1, "Command" = 1, "Science" = 1)
+	channels = list("Exploration" = 1, "Science" = 1)
 
 /obj/item/weapon/storage/box/radiokeys
 	name = "box of radio encryption keys"

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -27,7 +27,7 @@
 	skill_points = 22
 
 	access = list(
-		access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_bridge, access_emergency_storage,
+		access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_emergency_storage,
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
 		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
 		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,


### PR DESCRIPTION
:cl: RustingWithYou
tweak: Removes the Pathfinder's command comms and bridge access
/:cl:

The Pathfinder is not a member of Command staff, and giving them access to Command comms and the bridge only serves to reduce the CSO's role as departmental head. Every Bridge Officer has access to Exploration comms already for coordination of away missions in rounds without a CSO, making the Pathfinder's command access redundant at best.