### PR TITLE
Add autopsy report

### DIFF
--- a/maps/torch/datums/reports/medical.dm
+++ b/maps/torch/datums/reports/medical.dm
@@ -9,6 +9,7 @@
 	available_on_ntnet = 1
 
 /datum/computer_file/report/recipient/medical/checkup/generate_fields()
+	..()
 	add_field(/datum/report_field/text_label/instruction, "You would need following equipment for this: stethoscope, health analyzer, penlight.")
 	add_field(/datum/report_field/people/from_manifest, "Patient")
 	add_field(/datum/report_field/date, "Date")
@@ -25,3 +26,34 @@
 	add_field(/datum/report_field/pencode_text, "Other Notes")
 	add_field(/datum/report_field/signature, "Doctor's Signature")
 	set_access(access_edit = access_medical_equip)
+
+/datum/computer_file/report/recipient/medical/autopsy
+	form_name = "SCG-MED-015"
+	title = "Autopsy Report"
+	available_on_ntnet = 1
+
+/datum/computer_file/report/recipient/medical/autopsy/generate_fields()
+	..()
+	add_field(/datum/report_field/simple_text, "Vessel", GLOB.using_map.station_name)
+	add_field(/datum/report_field/simple_text, "Patient Name")
+	add_field(/datum/report_field/text_label/header, "Death Information")
+	add_field(/datum/report_field/date, "Date of Death")
+	add_field(/datum/report_field/time, "Time of Death")
+	add_field(/datum/report_field/text_label/instruction, "Check yes if the time of death is estimated, no if it is exact.")
+	add_field(/datum/report_field/options/yes_no, "Estimated")
+	add_field(/datum/report_field/simple_text, "Cause(s) of Death")
+	add_field(/datum/report_field/text_label/instruction, "Describe how the patient died.")
+	add_field(/datum/report_field/pencode_text, "Death Narrative")
+	add_field(/datum/report_field/text_label/instruction, "Describe postmortem handling of the body.")
+	add_field(/datum/report_field/pencode_text, "Postmortem Narrative")
+	add_field(/datum/report_field/text_label/header, "Doctor Information")
+	add_field(/datum/report_field/text_label/instruction, "By signing below, I affirm that all of the above is factually correct to the best of my knowledge.")
+	add_field(/datum/report_field/people/from_manifest, "Doctor")
+	add_field(/datum/report_field/signature, "Doctor's Signature")
+	set_access(access_morgue, access_surgery)
+
+	add_field(/datum/report_field/text_label/instruction, "By signing below, I affirm that I have reviewed all of the above and affirm it is factually correct to the best of my knowledge. If there is no Chief Medical Officer available, this signature may be skipped.")
+	var/datum/report_field/cmofield = add_field(/datum/report_field/people/from_manifest, "Chief Medical Officer")
+	cmofield.set_access(access_morgue, access_cmo)	
+	cmofield = add_field(/datum/report_field/signature, "Chief Medical Officer's Signature")
+	cmofield.set_access(access_morgue, access_cmo)


### PR DESCRIPTION
:cl:
rscadd: SCG-MED-15, an autopsy report, is now available to medical staff.
/:cl:
You shouldn't have to go onto the paperwork simulator just for an autopsy report. This is available to all medical staff, but the CMO's name and signature are restricted to the CMO only. I'd greatly appreciate feedback on the layout of the form as well. Compared to the one on the paperwork simulator, a few redundant/extraneous ones were removed to keep it concise.

Example report (as a physician without a CMO's signature):
![image](https://user-images.githubusercontent.com/25853190/83004885-089b7180-9fc5-11ea-8774-3c616d562762.png)
