### PR TITLE
adds forbidden message regex configuration

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -97,6 +97,8 @@ var/list/gamemode_cache = list()
 	var/githuburl
 	var/issuereporturl
 
+	var/forbidden_message_regex
+
 	var/forbid_singulo_possession = 0
 
 	//game_options.txt configs
@@ -755,6 +757,17 @@ var/list/gamemode_cache = list()
 					config.max_acts_per_interval = text2num(value)
 				if ("act_interval")
 					config.act_interval = text2num(value) SECONDS
+
+				if ("forbidden_message_regex")
+					var/end = findlasttext(value, "/")
+					if (length(value) < 3 || value[1] != "/" || end < 3)
+						log_error("Invalid regex '[value]' supplied to '[name]'")
+					var/matcher = copytext(value, 2, end)
+					var/flags = end == length(value) ? FALSE : copytext(value, end + 1)
+					try
+						config.forbidden_message_regex = flags ? regex(matcher, flags) : regex(matcher)
+					catch(var/exception/ex)
+						log_error("Invalid regex '[value]' supplied to '[name]': [ex]")
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -67,6 +67,12 @@
 		to_chat(communicator, "<span class='danger'>Guests may not use the [name] channel.</span>")
 		return FALSE
 
+	if (config.forbidden_message_regex && !check_rights(R_INVESTIGATE, 0, communicator) && findtext(message, config.forbidden_message_regex))
+		log_and_message_admins("attempted to send a forbidden message in [name]: [message]", user = C)
+		if (C)
+			to_chat(C, "<B>Your message matched a filter and has not been sent.</B>")
+		return FALSE
+
 	return TRUE
 
 /decl/communication_channel/proc/do_communicate(var/communicator, var/message)

--- a/code/datums/communication/ooc.dm
+++ b/code/datums/communication/ooc.dm
@@ -16,10 +16,6 @@
 		if(!config.dooc_allowed && (C.mob.stat == DEAD))
 			to_chat(C, "<span class='danger'>[name] for dead mobs has been turned off.</span>")
 			return FALSE
-		if(findtext(message, "byond://"))
-			to_chat(C, "<B>Advertising other servers is not allowed.</B>")
-			log_and_message_admins("has attempted to advertise in [name]: [message]")
-			return FALSE
 
 /decl/communication_channel/ooc/do_communicate(var/client/C, var/message)
 	var/datum/admins/holder = C.holder

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -421,6 +421,10 @@ RADIATION_LOWER_LIMIT 0.15
 ## Clients will be unable to connect unless their build is equal to or higher than this (a number, e.g. 1000)
 #MINIMUM_BYOND_BUILD
 
+## Prevents matching messages from being sent on any communication channel
+## The provided example forbids byond:// and http/https:// unless followed by a permitted domain.
+#FORBIDDEN_MESSAGE_REGEX /((https?)|(byond)):\/\/(?!(.*\.)?baystation12\.net)/i
+
 ## Direct clients to preload the server resource file from a URL pointing to a .rsc file. NOTE: At this time (byond 512),
 ## the client/resource_rsc var does not function as one would expect. See client_defines.dm, the "preload_rsc" var's
 ## comments on how to use it properly. If you use a resource URL, you must set preload_rsc to 0 at compile time or


### PR DESCRIPTION
:cl:
admin: Configuration now permits setting a regular expression to test against all communications, preventing them on match, and circumvented by R_INVESTIGATE.
/:cl:

alt for #28568
