### PR TITLE
Give AI Master IT

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -212,7 +212,7 @@
 	if(LAZYACCESS(minimum_character_age, S.get_bodytype()) && (prefs.age < minimum_character_age[S.get_bodytype()]))
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_bodytype()]].</span>")
 		return TRUE
-	
+
 	if(!S.check_background(src, prefs))
 		to_chat(feedback, "<span class='boldannounce'>Incompatible background for [title].</span>")
 		return TRUE
@@ -464,3 +464,9 @@
 
 /datum/job/proc/handle_variant_join(var/mob/living/carbon/human/H, var/alt_title)
 	return
+
+/datum/job/proc/get_min_skill(decl/hierarchy/skill/S)
+	if(min_skill)
+		. = min_skill[S.type]
+	if(!.)
+		. = SKILL_MIN

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -15,6 +15,29 @@
 	hud_icon = "hudblank"
 	skill_points = 0
 	no_skill_buffs = TRUE
+	min_skill = list(
+		SKILL_BUREAUCRACY   = SKILL_EXPERT,
+		SKILL_FINANCE       = SKILL_EXPERT,
+		SKILL_EVA           = SKILL_EXPERT,
+		SKILL_MECH          = SKILL_EXPERT,
+		SKILL_PILOT         = SKILL_EXPERT,
+		SKILL_HAULING       = SKILL_NONE,
+		SKILL_COMPUTER      = SKILL_PROF,
+		SKILL_BOTANY        = SKILL_EXPERT,
+		SKILL_COOKING       = SKILL_EXPERT,
+		SKILL_COMBAT        = SKILL_EXPERT,
+		SKILL_WEAPONS       = SKILL_EXPERT,
+		SKILL_FORENSICS     = SKILL_EXPERT,
+		SKILL_CONSTRUCTION  = SKILL_EXPERT,
+		SKILL_ELECTRICAL    = SKILL_EXPERT,
+		SKILL_ATMOS         = SKILL_EXPERT,
+		SKILL_ENGINES       = SKILL_EXPERT,
+		SKILL_DEVICES       = SKILL_EXPERT,
+		SKILL_SCIENCE       = SKILL_EXPERT,
+		SKILL_MEDICAL       = SKILL_EXPERT,
+		SKILL_ANATOMY       = SKILL_EXPERT,
+		SKILL_CHEMISTRY     = SKILL_EXPERT
+	)
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -75,6 +75,16 @@
 		skill_list[S.type] = min + (allocation[S] || 0)
 	on_levels_change()
 
+/datum/skillset/proc/obtain_from_job(datum/job/job)
+	if(!job)
+		return
+
+	skill_list = list()
+
+	for(var/decl/hierarchy/skill/S in GLOB.skills)
+		skill_list[S.type] = job.get_min_skill(S)
+	on_levels_change()
+
 //Skill-related mob helper procs
 
 /mob/proc/get_skill_value(skill_path)
@@ -102,8 +112,8 @@
 /mob/proc/get_skill_difference(skill_path, mob/opponent)
 	return get_skill_value(skill_path) - opponent.get_skill_value(skill_path)
 
-// A generic way of modifying times via skill values	
-/mob/proc/skill_delay_mult(skill_path, factor = 0.3) 
+// A generic way of modifying times via skill values
+/mob/proc/skill_delay_mult(skill_path, factor = 0.3)
 	var/points = get_skill_value(skill_path)
 	switch(points)
 		if(SKILL_BASIC)
@@ -117,7 +127,7 @@
 	return do_after(src, base_delay * skill_delay_mult(skill_path, factor), target)
 
 // A generic way of modifying success probabilities via skill values. Higher factor means skills have more effect. fail_chance is the chance at SKILL_NONE.
-/mob/proc/skill_fail_chance(skill_path, fail_chance, no_more_fail = SKILL_MAX, factor = 1) 
+/mob/proc/skill_fail_chance(skill_path, fail_chance, no_more_fail = SKILL_MAX, factor = 1)
 	var/points = get_skill_value(skill_path)
 	if(points >= no_more_fail)
 		return 0

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -72,6 +72,8 @@
 	if(mind)
 		mind.transfer_to(O)
 		O.mind.original = O
+		var/datum/job/job = SSjobs.get_by_title(O.mind.assigned_role)
+		O.skillset.obtain_from_job(job)
 	else
 		O.key = key
 


### PR DESCRIPTION
:cl:
tweak: AI now has master information technology skill, and no athletics skill
/:cl:

This PR does two things.
1. Add a system to override the AI's default (expert) skill levels.
2. Give the AI master Information Technology.

Every time I have to inform Engineering that the AI cannot run `locate`
they are surprised and skeptical. The only option is to wait for a CE to
join, and hope the CE happens to have master IT, which oftentimes they
don't.

If there is a reason that the AI should not have `locate` please let me
know, and I will revise this PR to only add the skill adjustment
feature, but do nothing with it.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->