### PR TITLE
Changes Corp helmet cover to be a more generic white helmet cover

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -384,8 +384,8 @@
 	icon_state = "helmcover_tan"
 
 /obj/item/clothing/accessory/armor/helmcover/nt
-	name = "corporate helmet cover"
-	desc = "A fabric cover for armored helmets. This one has corporate colors."
+	name = "white helmet cover"
+	desc = "A fabric cover for armored helmets. This one is white."
 	icon_state = "helmcover_nt"
 
 /obj/item/clothing/accessory/armor/helmcover/pcrc


### PR DESCRIPTION
Changes corp helmet cover title and desc to a simple white cover.

:cl: Deadmon
tweak: Changes the Corporate helmet cover to white helmet cover.
:cl:
