### PR TITLE
Add control-alt-clicking to point at things

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -300,8 +300,9 @@
 	Control+Alt click
 */
 /mob/proc/CtrlAltClickOn(var/atom/A)
-	A.CtrlAltClick(src)
-	return
+	if(A.CtrlAltClick(src))
+		return
+	pointed(A)
 
 /atom/proc/CtrlAltClick(var/mob/user)
 	return

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -516,6 +516,7 @@
 
 /obj/structure/closet/CtrlAltClick(var/mob/user)
 	verb_toggleopen()
+	return 1
 
 /obj/structure/closet/emp_act(severity)
 	for(var/obj/O in src)

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -227,10 +227,11 @@
 
 /obj/item/modular_computer/CtrlAltClick(mob/user)
 	if(!CanPhysicallyInteract(user))
-		return
+		return 0
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		os.open_terminal(user)
+		return 1
 
 /obj/item/modular_computer/CouldUseTopic(var/mob/user)
 	..()

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -109,10 +109,11 @@
 
 /obj/machinery/computer/modular/CtrlAltClick(mob/user)
 	if(!CanPhysicallyInteract(user))
-		return
+		return 0
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		os.open_terminal(user)
+		return 1
 
 /obj/machinery/computer/modular/verb/emergency_shutdown()
 	set name = "Forced Shutdown"

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -43,6 +43,8 @@
 			darts -= D
 			D.dropInto(user.loc)
 			D.mix_up()
+		return 1
+	return 0
 
 /obj/item/weapon/gun/launcher/foam/burst
 	name = "foam machine pistol"


### PR DESCRIPTION
:cl:
rscadd: You can now control-alt-click something to quickly point at it instead of using the context menu.
/:cl:

I chose to use the base-level proc since all mobs are able to point at things.

As a side effect of this, all calls of `CtrlAltClick` should return 0 if they did not do anything (or if they *should* point) and 1 if they did do something (or if they should *not* point).