### PR TITLE
Fixes pulling status lights in engineering

### DIFF
--- a/code/game/machinery/status_light.dm
+++ b/code/game/machinery/status_light.dm
@@ -3,6 +3,7 @@
 	desc = "A status indicator for a combustion chamber, based on temperature."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doortimer-p"
+	anchored = 1
 	var/frequency = 1441
 	var/alert_temperature = 10000
 	var/alert = 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Cdbrunow
bugfix: The nacelle status lights in engineering can no longer be moved
/:cl: