### PR TITLE
Fixes nabber slowdown bug

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -91,6 +91,7 @@
 #define INFECTION_LEVEL_THREE 1000 // infections grow from two to three in ~10 minutes
 
 //Blood levels. These are percentages based on the species blood_volume far.
+#define BLOOD_VOLUME_FULL    100
 #define BLOOD_VOLUME_SAFE    85
 #define BLOOD_VOLUME_OKAY    70
 #define BLOOD_VOLUME_BAD     60

--- a/code/modules/organs/internal/species/nabber.dm
+++ b/code/modules/organs/internal/species/nabber.dm
@@ -173,6 +173,8 @@
 
 	//Effects of bloodloss
 	switch(blood_volume)
+		if (BLOOD_VOLUME_FULL)
+			lowblood_tally = 0
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 			lowblood_tally = 2
 			if(prob(1))


### PR DESCRIPTION
🆑 
bugfix: Nabbers will no longer retain their slowness after their blood has been restored.
/🆑

The lowblood tally would get stuck at any value which was greater than 85%, due to missing a default case.

Fixes #26943