### PR TITLE
fax destination tweaks

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -23,7 +23,19 @@
 	company_name  = "Sol Central Government"
 	company_short = "SolGov"
 
-	map_admin_faxes = list("Corporate Central Office")
+	map_admin_faxes = list(
+		"Expeditionary Corps Command",
+		"Expeditionary Corps Logistics",
+		"EXO Head Office",
+		"EXO Internal Affairs",
+		"SFP Territory Support",
+		"SFP Special Investigations",
+		"SFP Fugitive Recovery",
+		"Sol Fleet Mars Commmand",
+		"Bureau of Diplomatic Affairs",
+		"Emergency Management Bureau",
+		"Secure Routing Service"
+	)
 
 	//These should probably be moved into the evac controller...
 	shuttle_docked_message = "Attention all hands: Jump preparation complete. The bluespace drive is now spooling up, secure all stations for departure. Time to jump: approximately %ETD%."

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -58,7 +58,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/company_short = "BM"
 	var/system_name = "Uncharted System"
 
-	var/map_admin_faxes = list()
+	var/list/map_admin_faxes = list()
 
 	var/shuttle_docked_message
 	var/shuttle_leaving_dock


### PR DESCRIPTION
:cl:
tweak: Some new fax machine destinations are available.
/:cl:

Now only generates destinations if there is no map or the map has none.
New admin destinations for the torch are
```
Expeditionary Corps Command
Expeditionary Corps Logistics
EXO Head Office
EXO Internal Affairs
SFP Territory Support
SFP Special Investigations
SFP Fugitive Recovery
Sol Fleet Mars Commmand
Bureau of Diplomatic Affairs
Emergency Management Bureau
Secure Routing Service
```
because everyone likes fluff.