### PR TITLE
Removes a footgun from firemodes code

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -8,6 +8,7 @@
 /datum/firemode
 	var/name = "default"
 	var/list/settings = list()
+	var/list/original_settings
 
 /datum/firemode/New(obj/item/weapon/gun/gun, list/properties = null)
 	..()
@@ -24,8 +25,18 @@
 			settings[propname] = propvalue
 
 /datum/firemode/proc/apply_to(obj/item/weapon/gun/gun)
+	LAZYINITLIST(original_settings)
+
 	for(var/propname in settings)
+		original_settings[propname] = gun.vars[propname]
 		gun.vars[propname] = settings[propname]
+
+/datum/firemode/proc/restore_original_settings(obj/item/weapon/gun/gun)
+	if (LAZYLEN(original_settings))
+		for (var/propname in original_settings)
+			gun.vars[propname] = original_settings[propname]
+	
+		LAZYCLEARLIST(original_settings)
 
 //Parent gun type. Guns are weapons that can be aimed at mobs and act over a distance
 /obj/item/weapon/gun
@@ -512,6 +523,9 @@
 	var/next_mode = get_next_firemode()
 	if(!next_mode || next_mode == sel_mode)
 		return null
+
+	var/datum/firemode/old_mode = firemodes[sel_mode]
+	old_mode.restore_original_settings(src)
 
 	sel_mode = next_mode
 	var/datum/firemode/new_mode = firemodes[sel_mode]


### PR DESCRIPTION
Firemodes work by overriding a dynamic set of variables. However, they do not restore them when done. It is the responsibility of OTHER firemodes to mark those variables as `null` for special init-time-magic in order to avoid agglutinative changes. But this is a footgun waiting to go off: forget one null marker and you have changes from the last firemode persisting. And L6 has this bug.

Fix: Make firemodes store the initial settings of the values they override, and reapply them before applying the settings from the new firemode. Stored in a lazylist because memory is important or something.