### PR TITLE
Add flora disks to the protolathe

### DIFF
--- a/code/modules/research/designs/designs_disk.dm
+++ b/code/modules/research/designs/designs_disk.dm
@@ -23,5 +23,6 @@ datum/design/item/disk/flora
 	name = "flora data"
 	desc = "Produce additional disks for storing flora genetic data."
 	id = "flora_disk"
-	req_tech = list(TECH_DATA = 1, TECH_BIO = 3)
+	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/weapon/disk/botany
+	sort_string = "AAAAC"

--- a/code/modules/research/designs/designs_disk.dm
+++ b/code/modules/research/designs/designs_disk.dm
@@ -18,3 +18,10 @@
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/weapon/disk/tech_disk
 	sort_string = "AAAAB"
+
+datum/design/item/disk/flora
+	name = "flora data"
+	desc = "Produce additional disks for storing flora genetic data."
+	id = "flora_disk"
+	req_tech = list(TECH_DATA = 1, TECH_BIO = 3)
+	build_path = /obj/item/weapon/disk/botany

--- a/code/modules/research/designs/designs_disk.dm
+++ b/code/modules/research/designs/designs_disk.dm
@@ -23,5 +23,5 @@ datum/design/item/disk/flora
 	name = "flora data"
 	desc = "Produce additional disks for storing flora genetic data."
 	id = "flora_disk"
-	req_tech = list(TECH_DATA = 1, TECH_BIO = 3)
+	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/weapon/disk/botany

--- a/code/modules/research/designs/designs_disk.dm
+++ b/code/modules/research/designs/designs_disk.dm
@@ -25,3 +25,4 @@ datum/design/item/disk/flora
 	id = "flora_disk"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/weapon/disk/botany
+	sort_string = "AAAAC"


### PR DESCRIPTION
🆑 RustingWithYou
tweak: Adds flora data disks as a protolathe design.
/🆑 

Currently xenobotany is scarcely useful, and made less so by the limited supply of flora disks, which hampers the ability of botanists to distribute gene-modded plants where they can actually have utility. This PR adds a new tech design to print more flora disks.