### PR TITLE
Research Assistants and Scientists now default to contractor

### DIFF
--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -66,9 +66,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/scientist
 	allowed_branches = list(
-		/datum/mil_branch/expeditionary_corps,
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/solgov
+		/datum/mil_branch/solgov,
+		/datum/mil_branch/expeditionary_corps
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/ec/o1,
@@ -103,9 +103,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research
 	allowed_branches = list(
-		/datum/mil_branch/expeditionary_corps,
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/solgov
+		/datum/mil_branch/solgov,
+		/datum/mil_branch/expeditionary_corps
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/ec/e3,


### PR DESCRIPTION
:cl:
tweak: Research Assistants and Scientists now have their default branch to contractor
/:cl:

The kind of people (new players who are unfamiliar with our lore and setting) coming into the Science department undermines the perception of how an Expeditionary Corps Ensign (or even Explorer) would behave as according to a supposed standard for uniformed persons (especially officers). As such, I think it's appropriate that the order be changed so one (who is knowledgeable of how branch changing works) would have to go out of their way to be Expeditionary Corps.

tl;dr, no more bald greytider ensigns wandering around

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->