### PR TITLE
Cats, like corgis, can now be ordered through supply

### DIFF
--- a/code/datums/supplypacks/livecargo.dm
+++ b/code/datums/supplypacks/livecargo.dm
@@ -48,6 +48,13 @@
 	cost = 50
 	containertype = /obj/structure/largecrate/animal/corgi
 	containername = "corgi crate"
+	
+/decl/hierarchy/supply_pack/livecargo/cat
+	name = "Live - Cat"
+	contains = list()
+	cost = 50
+	containertype = /obj/structure/largecrate/animal/cat
+	containername = "cat crate"
 
 //farm animals - useless and annoying, but potentially a good source of food. expensive because they're live animals and their produce is available cheaper
 /decl/hierarchy/supply_pack/livecargo/cow


### PR DESCRIPTION
:cl:
rscadd: Cats may now be ordered through the supply computer in the same way a corgi can
/:cl:

For too long cats have gone under-represented in our supply computer.

You'll notice that a supply manifest spawning from the crate will show "0 contents in shipment," this is intended as the corgi crate does the same thing.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->