### PR TITLE
Makes changes to the Scan Target ghost verb. Moves body scan verbs from the debug menu into the ghost menu.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -200,8 +200,6 @@ var/list/admin_verbs_debug = list(
 	/turf/proc/update_chunk,
 	/datum/admins/proc/capture_map,
 	/datum/admins/proc/view_runtimes,
-	/client/proc/cmd_analyse_health_context,
-	/client/proc/cmd_analyse_health_panel,
 	/client/proc/visualpower,
 	/client/proc/visualpower_remove,
 	/client/proc/ping_webhook,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -416,38 +416,6 @@
 
 	GLOB.error_cache.show_to(usr.client)
 
-/client/proc/cmd_analyse_health_panel()
-	set category = "Debug"
-	set name = "Analyse Health"
-	set desc = "Get an advanced health reading on a human mob."
-
-	var/mob/living/carbon/human/H = input("Select mob.", "Analyse Health") as null|anything in GLOB.human_mob_list
-	if(!H)	return
-
-	cmd_analyse_health(H)
-
-/client/proc/cmd_analyse_health(var/mob/living/carbon/human/H)
-
-	if(!check_rights(R_DEBUG))
-		return
-
-	if(!H)	return
-
-	var/dat = display_medical_data(H.get_raw_medical_data(), SKILL_MAX)
-
-	dat += text("<BR><A href='?src=\ref[];mach_close=scanconsole'>Close</A>", usr)
-	show_browser(usr, dat, "window=scanconsole;size=430x600")
-
-/client/proc/cmd_analyse_health_context(mob/living/carbon/human/H as mob in GLOB.human_mob_list)
-	set category = null
-	set name = "Analyse Human Health"
-
-	if(!check_rights(R_DEBUG))
-		return
-	if(!ishuman(H))	return
-	cmd_analyse_health(H)
-	SSstatistics.add_field_details("admin_verb","ANLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 /obj/effect/debugmarker
 	icon = 'icons/effects/lighting_overlay.dmi'
 	icon_state = "transparent"

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -224,6 +224,34 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		medHUD = 1
 		to_chat(src, "<span class='notice'>Medical HUD Enabled</span>")
+		
+/mob/observer/ghost/verb/cmd_analyse_health_panel()
+	set category = "Ghost"
+	set name = "Analyse Health"
+	set desc = "Get an advanced health reading on a human mob."
+
+	var/mob/living/carbon/human/H = input("Select mob.", "Analyse Health") as null|anything in GLOB.human_mob_list
+	if(!H)	return
+
+	cmd_analyse_health(H)
+
+/mob/observer/ghost/verb/cmd_analyse_health(var/mob/living/carbon/human/H)
+	set category = null
+	set name = "Analyse Human Health"
+
+	if(!client)
+		return
+	if(!ishuman(H))	return
+	cmd_analyse_health(H)
+	if(!client)
+		return
+
+	if(!H)	return
+
+	var/dat = display_medical_data(H.get_raw_medical_data(), SKILL_MAX)
+
+	dat += text("<BR><A href='?src=\ref[];mach_close=scanconsole'>Close</A>", usr)
+	show_browser(usr, dat, "window=scanconsole;size=430x600")
 
 /mob/observer/ghost/verb/toggle_antagHUD()
 	set category = "Ghost"
@@ -301,7 +329,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/stop_following()
 	if(following)
 		to_chat(src, "<span class='notice'>No longer following \the [following]</span>")
-		verbs -= /mob/observer/ghost/proc/scan_target
 	..()
 
 /mob/observer/ghost/keep_following(var/atom/movable/am, var/old_loc, var/new_loc)
@@ -338,7 +365,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/rads = SSradiation.get_rads_at_turf(t)
 		to_chat(src, "<span class='notice'>Radiation level: [rads ? rads : "0"] Roentgen.</span>")
 
-/mob/observer/ghost/proc/scan_target()
+/mob/observer/ghost/verb/scan_target()
 	set name = "Scan Target"
 	set category = "Ghost"
 	set desc = "Analyse whatever you are following."


### PR DESCRIPTION
:cl:
rscadd: Adds some new verbs to the Ghost verbs tab previously in the admin-protected Debug verbs tab. You can now right click on someone and have a verb (Analyse Human Health) which shows you their body scan- you also have a global verb (Analyse Health) that allows you to body scan any person globally.
rscdel: Removes the aforementioned bodyscan verbs from the Debug tab; they now live in the Ghost tab.
tweak: The Scan Target verb once again functions for ghosts. The verb will always be visible, but you can only use it as it is right now by following a ghost.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->