### PR TITLE
Buffs powersinks to match the power capacity of the Torch

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -14,11 +14,11 @@
 	matter = list(MATERIAL_STEEL = 750,MATERIAL_WASTE = 750)
 
 	origin_tech = list(TECH_POWER = 3, TECH_ESOTERIC = 5)
-	var/drain_rate = 1500000		// amount of power to drain per tick
-	var/apc_drain_rate = 5000 		// Max. amount drained from single APC. In Watts.
+	var/drain_rate = 15000000		// amount of power to drain per tick
+	var/apc_drain_rate = 10000 		// Max. amount drained from single APC. In Watts.
 	var/dissipation_rate = 20000	// Passive dissipation of drained power. In Watts.
 	var/power_drained = 0 			// Amount of power drained.
-	var/max_power = 5e9				// Detonation point.
+	var/max_power = 5e10				// Detonation point.
 	var/mode = 0					// 0 = off, 1=clamped (off), 2=operating
 	var/datum/powernet/PN			// Our powernet
 


### PR DESCRIPTION
Buffs powersinks power draw by a factor of 10 to make them able to disable power systems as intended. Also upped the cap until they exploded to compensate.

:cl: SparklySheep 
rscadd: Buffs powersinks so they can disable power networks as intended
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->