### PR TITLE
Change experienced weapons to only need 6 points

### DIFF
--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -217,7 +217,9 @@ GLOBAL_LIST_EMPTY(skills)
 			return difficulty
 		if(SKILL_ADEPT)
 			return 2*difficulty
-		if(SKILL_EXPERT, SKILL_PROF)
+		if(SKILL_EXPERT)
+			return 3*difficulty
+		if(SKILL_PROF)
 			return 4*difficulty
 		else
 			return 0


### PR DESCRIPTION
:cl:
tweak: Experienced Weapons Expertise now only requires 6 points instead of 8.
/:cl:

8 seems like too much cost for too little benefit (only slightly increased accuracy and automatic safety off on harm intent - which can easily be done manually), given that firearms are notoriously inaccurate even at the higher skill levels. At the same time guns are still very powerful, which is why I went for 6 instead of 4.

Feel free to discuss this.