### PR TITLE
Reverts PGUP and PGDOWN to old hotkeys.

### DIFF
--- a/code/modules/mob/observer/freelook/eye.dm
+++ b/code/modules/mob/observer/freelook/eye.dm
@@ -121,6 +121,11 @@
 	for(var/i = 0; i < max(sprint, initial); i += 20)
 		var/turf/step = get_turf(get_step(src, direct))
 		if(step)
+			//We do this specifically as they have special conditions
+			if(direct == UP && !HasAbove(z))
+				return FALSE
+			if(direct == DOWN && !HasBelow(z))
+				return FALSE
 			setLoc(step)
 
 	cooldown = world.time + 5
@@ -128,24 +133,4 @@
 		sprint = min(sprint + 0.5, max_sprint)
 	else
 		sprint = initial
-	return 1
-
-/mob/verb/northeast()
-	set name = ".northeast"
-	if(!eyeobj || !HasAbove(eyeobj.z))
-		return
-	EyeMove(UP)
-
-/mob/observer/northeast()
-	if(HasAbove(z))
-		forceMove(get_step(src, UP))
-
-/mob/verb/southeast()
-	set name = ".southeast"
-	if(!eyeobj || !HasBelow(eyeobj.z))
-		return
-	EyeMove(DOWN)
-
-/mob/observer/southeast()
-	if(HasBelow(z))
-		forceMove(get_step(src, DOWN))
+	return TRUE


### PR DESCRIPTION
I did a 'whoopsie' and didn't realize we already had zlevel transitioning hotkeys. I also didn't realize page up/down were used for anything. 


While testing out this I did manage to find that AIs and (more importantly) Choruses could literally go to ANY level with their eye, and while planet bound Choruses might be fun, they should be restricted to the station as for maximum interaction.

This shouldn't restrict AIs who jump to cameras on planet or off-station.

closes #28710
