### PR TITLE
Fix gun/holster intents

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -77,7 +77,7 @@
 			if(istype(holstered, /obj/item/weapon/gun))
 				var/obj/item/weapon/gun/G = holstered
 				G.check_accidents(user)
-				if(G.safety() && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //Experienced shooter will disable safety before shooting.
+				if(G.safety() && user.skill_check(SKILL_WEAPONS, SKILL_EXPERT)) //Experienced shooter will disable safety before shooting.
 					G.toggle_safety(user)
 			usr.visible_message(
 				"<span class='danger'>\The [user] draws \the [holstered], ready to go!</span>",

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -200,7 +200,7 @@
 		return
 
 	if(safety())
-		if(user.a_intent == I_HURT && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //reflex un-safeying
+		if(user.a_intent == I_HURT && user.skill_check(SKILL_WEAPONS, SKILL_EXPERT)) //reflex un-safeying
 			toggle_safety(user)
 		else
 			handle_click_safety(user)


### PR DESCRIPTION
:cl:
bugfix: Unholstering a gun on harm intent will now only work if you have Experienced Weapons Expertise or higher.
bugfix: Automatically turning off the safety of a gun when firing on harm intent will now only work if you have Experienced Weapons Expertise or higher.
/:cl:

Both of these checks were poorly coded and resulted in people at the Trained skill level being able to use them while people at Experienced sometimes couldn't.

Closes #28716