### PR TITLE
Change Config Tag of Chorus

### DIFF
--- a/code/game/gamemodes/chorus/chorus.dm
+++ b/code/game/gamemodes/chorus/chorus.dm
@@ -2,7 +2,7 @@
 	name = "Chorus"
 	round_description = "An ever-growing beast has selected your station to be born on"
 	extended_round_description = "The station has become the birthplace of a large, ever growing monster. Watch as it takes over your fellow crewmembers and strengthens itself by snacking on your ship. Have fun!"
-	config_tag = "god"
+	config_tag = "chorus"
 	required_players = 10
 	required_enemies = 3
 	end_on_antag_death = 0


### PR DESCRIPTION
:cl:
bugfix: Chorus is now appropriately titled in some contexts.
/:cl:

Closes #28722 