### PR TITLE
Fixes Chorus regenerating too fast to actually die

### DIFF
--- a/code/modules/mob/living/chorus/chorus_life.dm
+++ b/code/modules/mob/living/chorus/chorus_life.dm
@@ -1,9 +1,9 @@
 /mob/living/chorus/Life()
-	. = ..()
-	if(. && health <= 0)
+	if(stat != DEAD && health <= 0)
 		death()
+	. = ..()
 
 /mob/living/chorus/death()
 	..()
 	playsound(src, 'sound/hallucinations/wail.ogg', 100, 1)
-	icon_state = "chorus_death"
+	icon_state = "[icon_state]_death"


### PR DESCRIPTION
:cl:
bugfix: Chorus can no longer regenerate health when it should be dead.
/:cl:

So it turns out sometimes the Chorus will just straight up not die. This is because of the order of operations on things: before the check, they regenerate health. 

So here's a fix on that