### PR TITLE
Fixes space tile under window tiles on Old Lab spawn

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
@@ -1408,7 +1408,7 @@
 	opacity = 0
 	},
 /obj/effect/paint/black,
-/turf/space,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab/station/xenobio)
 "xg" = (
 /obj/structure/table/steel,
@@ -1520,7 +1520,7 @@
 	opacity = 0
 	},
 /obj/effect/paint/black,
-/turf/space,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab/station/chem)
 "zb" = (
 /obj/structure/cable/yellow{
@@ -2287,7 +2287,7 @@
 	opacity = 0
 	},
 /obj/effect/paint/black,
-/turf/space,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab/station/xenobio)
 "LW" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -2743,7 +2743,7 @@
 	opacity = 0
 	},
 /obj/effect/paint/black,
-/turf/space,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab/station/hall)
 "TS" = (
 /turf/simulated/wall/r_wall/prepainted,


### PR DESCRIPTION
:cl: Deadmon
tweak: Fixes Space tiles under Window tiles in the old lab exoplanet spawn
/:cl: