### PR TITLE
scan consoles and displays connect by shared zlevel

### DIFF
--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -9,7 +9,6 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	var/list/display_tags = list()
 	var/list/connected_displays = list()
 	var/list/data = list()
 	var/scan_data
@@ -46,7 +45,7 @@
 
 /obj/machinery/body_scanconsole/proc/FindDisplays()
 	for(var/obj/machinery/body_scan_display/D in SSmachines.machinery)
-		if(D.tag in display_tags)
+		if (D.z == z)
 			connected_displays += D
 			GLOB.destroyed_event.register(D, src, .proc/remove_display)
 	return !!connected_displays.len

--- a/maps/away/miningstation/miningstation.dmm
+++ b/maps/away/miningstation/miningstation.dmm
@@ -7099,8 +7099,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/body_scanconsole{
-	dir = 1;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7114,8 +7113,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/body_scanconsole{
-	dir = 1;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -779,8 +779,7 @@
 /area/ship/skrellscoutship/crew/medbay)
 "cS" = (
 /obj/machinery/body_scanconsole{
-	dir = 4;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2")
+	dir = 4
 	},
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/medbay)

--- a/maps/away/voxship/voxship-1.dmm
+++ b/maps/away/voxship/voxship-1.dmm
@@ -197,7 +197,6 @@
 "aJ" = (
 /obj/machinery/body_scanconsole{
 	dir = 4;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2");
 	icon_state = "body_scannerconsole"
 	},
 /turf/simulated/floor/plating/vox,

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -2380,7 +2380,6 @@
 "fk" = (
 /obj/machinery/body_scanconsole{
 	dir = 1;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2");
 	icon_state = "body_scannerconsole"
 	},
 /obj/machinery/light/small{

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
@@ -1731,8 +1731,7 @@
 /area/map_template/oldlab/station/xenobio)
 "CX" = (
 /obj/machinery/body_scanconsole{
-	dir = 1;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -16675,7 +16675,6 @@
 "dYb" = (
 /obj/machinery/body_scanconsole{
 	dir = 1;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2");
 	icon_state = "body_scannerconsole"
 	},
 /obj/effect/floor_decal/corner/pink{
@@ -24158,7 +24157,6 @@
 "mzb" = (
 /obj/machinery/body_scanconsole{
 	dir = 4;
-	display_tags = list("med_or_display","rob_or_display1","rob_or_display2");
 	icon_state = "body_scannerconsole"
 	},
 /turf/simulated/floor/tiled/white,


### PR DESCRIPTION
Replaces leftover tags behavior. There are no body scanners that don't share a z with their intended displays anyway.