### PR TITLE
Roboticist alt title + skill tweaks

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -172,7 +172,8 @@
 	selection_color = "#5b4d20"
 	economic_power = 6
 	alt_titles = list(
-		"Mechsuit Technician")
+		"Mechsuit Technician"
+		"Biomechanical Engineer")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticistec,
@@ -188,6 +189,7 @@
 	                    SKILL_DEVICES		= SKILL_ADEPT,
 	                    SKILL_EVA           = SKILL_ADEPT,
 	                    SKILL_ANATOMY       = SKILL_ADEPT,
+	                    SKILL_MEDICAL       = SKILL_BASIC,
 	                    SKILL_MECH          = HAS_PERK)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,


### PR DESCRIPTION
🆑 RustingWithYou
tweak: gives roboticists basic medicine by default
tweak: adds biomechanical engineer as an alt-title for roboticist
/🆑 


Adds Biomechanical Engineer as an alt-title for the roboticist. Also gives them basic medicine by default to alleviate the problem of roboticists needing to dump every spare point they get into medical to be able to reliably perform any kind of flesh surgery.
