### PR TITLE
Research + Explo supervisor tweaks

### DIFF
--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -42,7 +42,7 @@
 
 /datum/job/nt_pilot
 	title = "Shuttle Pilot"
-	supervisors = "the Pathfinder"
+	supervisors = "the Chief Science Officer and Pathfinder"
 	department = "Exploration"
 	department_flag = EXP
 	total_positions = 1
@@ -82,7 +82,7 @@
 	department_flag = EXP
 	total_positions = 5
 	spawn_positions = 5
-	supervisors = "the Commanding Officer, Executive Officer, and Pathfinder"
+	supervisors = "the Chief Science Officer and Pathfinder"
 	selection_color = "#68099e"
 	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -43,7 +43,7 @@
 	title = "Scientist"
 	total_positions = 6
 	spawn_positions = 6
-	supervisors = "the Chief Science Officer"
+	supervisors = "the Chief Science Officer and Senior Researcher"
 	economic_power = 10
 	minimum_character_age = list(SPECIES_HUMAN = 25)
 	ideal_character_age = 45
@@ -89,7 +89,7 @@
 	department_flag = SCI
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = "the Chief Science Officer and science personnel"
+	supervisors = "the Chief Science Officer and Science personnel"
 	selection_color = "#633d63"
 	economic_power = 3
 	minimum_character_age = list(SPECIES_HUMAN = 18)


### PR DESCRIPTION
:cl: RustingWithYou
tweak: Changes the supervisors for Research and Exploration jobs
/:cl:

Adds the CSO as a supervisor for the Shuttle Pilot and Explorer. Removes the CO and XO from the Explorer's supervisors. Adds the Senior Researcher to the Scientist's supervisors. Capitalises 'science' in the Research Assistant's supervisors because it bugged me.
