### PR TITLE
Small Grammar fixes

### DIFF
--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -20,7 +20,7 @@
 	var/naming
 	switch(severity)
 		if(EVENT_LEVEL_MUNDANE)
-			naming = "malfuncion"
+			naming = "malfunction"
 		if(EVENT_LEVEL_MODERATE)
 			naming = "uprising"
 		if(EVENT_LEVEL_MAJOR)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -2,7 +2,7 @@
 /// Droppers.
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/weapon/reagent_containers/dropper
-	name = "Dropper"
+	name = "dropper"
 	desc = "A dropper. Transfers 5 units."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "dropper0"


### PR DESCRIPTION
:cl:
spellcheck: Changed "Dropper" to "dropper" for the item's name.
spellcheck: Changed "malfuncion" to "malfunction" for the maintenance drone malfunction event.
/:cl:
