### PR TITLE
Adjusts access on Corporate Liaison and Solgov Rep

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -301,7 +301,7 @@
 	minimum_character_age = list(SPECIES_HUMAN = 27)
 
 	access = list(access_representative, access_security, access_medical,
-			            access_bridge, access_cargo, access_solgov_crew, access_hangar)
+			            access_bridge, access_cargo, access_solgov_crew, access_hangar, access_keycard_auth)
 
 	software_on_spawn = list(/datum/computer_file/program/reports)
 

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -22,7 +22,7 @@
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
 	access = list(access_liaison, access_bridge, access_solgov_crew,
-						access_nanotrasen, access_commissary)
+						access_nanotrasen, access_commissary, access_research, access_xenobiology , access_petrov, access_petrov_phoron, access_petrov_chemistry, access_keycard_auth, access_petrov_analysis, access_petrov_rd)
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
 /datum/job/liaison/get_description_blurb()


### PR DESCRIPTION
🆑Connorjg1

tweak: Adds Research and Petrov Access  back to the CL

tweak: Allows both the CL and SCGR to use the Keycard Auth device

/🆑

I figured I may as well get this done. This is (obviously) very easy to adjust or change. 

(Draft for a moment because it's been a while since I used git and want to make sure I'm making the pull to the right place)