### PR TITLE
Change Mercenary Ship description

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -19,7 +19,7 @@
 
 /obj/effect/overmap/visitable/ship/landable/merc
 	name = "Desperado"
-	desc = "A military gunship of ICCG design. Scanner detects heavy modification to the framework of the vessel and no designation."
+	desc = "A military gunship of unknown design. Scanner detects heavy modification to the framework of the vessel and no designation."
 	shuttle = "Desperado"
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL


### PR DESCRIPTION
Changes the Mercenary Ship description from "A military gunship of ICCG design" into "A military gunship of unknown design". Should allow some different gimmicks without causing extreme alarm from the crew.


Lightly tested and seemed to work.