### PR TITLE
Fixes windows not blocking movement onto low walls

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -7,7 +7,7 @@
 
 	layer = SIDE_WINDOW_LAYER
 	anchored = 1.0
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE
 	obj_flags = OBJ_FLAG_ROTATABLE
 	alpha = 180
 	var/material/reinf_material


### PR DESCRIPTION
:cl: Slywater
bugfix: Players cannot climb onto low walls with windows.
/:cl:

Fixes grille-less windows being climbable (you can climb onto low walls which have windows installed on them).
