### PR TITLE
Tweaks engi and surveyor borg tools and materials

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
@@ -31,7 +31,10 @@
 		/obj/item/device/pipe_painter,
 		/obj/item/device/floor_painter,
 		/obj/item/weapon/inflatable_dispenser/robot,
+		/obj/item/weapon/reagent_containers/spray/cleaner/drone,
 		/obj/item/inducer/borg,
+		/obj/item/device/plunger/robot,
+		/obj/item/weapon/matter_decompiler,
 		/obj/item/stack/material/cyborg/steel,
 		/obj/item/stack/material/cyborg/aluminium,
 		/obj/item/stack/material/rods/cyborg,
@@ -39,14 +42,13 @@
 		/obj/item/stack/material/cyborg/glass,
 		/obj/item/stack/material/cyborg/glass/reinforced,
 		/obj/item/stack/cable_coil/cyborg,
-		/obj/item/stack/material/cyborg/plasteel,
-		/obj/item/device/plunger/robot
+		/obj/item/stack/material/cyborg/plasteel
 	)
 	synths = list(
 		/datum/matter_synth/metal = 	30000,
 		/datum/matter_synth/glass = 	20000,
 		/datum/matter_synth/plasteel = 	10000,
-		/datum/matter_synth/wire
+		/datum/matter_synth/wire = 		40
 	)
 	emag = /obj/item/weapon/melee/baton/robot/electrified_arm
 	skills = list(
@@ -62,6 +64,10 @@
 	var/datum/matter_synth/glass/glass =       locate() in synths
 	var/datum/matter_synth/plasteel/plasteel = locate() in synths
 	var/datum/matter_synth/wire/wire =         locate() in synths
+
+	var/obj/item/weapon/matter_decompiler/MD = locate() in equipment
+	MD.metal = metal
+	MD.glass = glass
 
 	for(var/thing in list(
 		 /obj/item/stack/material/cyborg/steel,

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -8,7 +8,7 @@
 		NETWORK_ENGINEERING
 	)
 	subsystems = list(
-		/datum/nano_module/power_monitor, 
+		/datum/nano_module/power_monitor,
 		/datum/nano_module/supermatter_monitor
 	)
 	supported_upgrades = list(
@@ -25,7 +25,7 @@
 		/obj/item/device/flash,
 		/obj/item/borg/sight/meson,
 		/obj/item/weapon/extinguisher,
-		/obj/item/weapon/weldingtool/largetank,
+		/obj/item/weapon/weldingtool/hugetank,
 		/obj/item/weapon/screwdriver,
 		/obj/item/weapon/wrench,
 		/obj/item/weapon/crowbar,
@@ -37,11 +37,13 @@
 		/obj/item/taperoll/engineering,
 		/obj/item/taperoll/atmos,
 		/obj/item/weapon/gripper,
+		/obj/item/weapon/gripper,
 		/obj/item/weapon/gripper/no_use/loader,
 		/obj/item/device/lightreplacer,
 		/obj/item/device/pipe_painter,
 		/obj/item/device/floor_painter,
 		/obj/item/weapon/inflatable_dispenser/robot,
+		/obj/item/weapon/reagent_containers/spray/cleaner/drone,
 		/obj/item/inducer/borg,
 		/obj/item/device/plunger/robot,
 		/obj/item/weapon/matter_decompiler,
@@ -49,6 +51,8 @@
 		/obj/item/stack/material/cyborg/aluminium,
 		/obj/item/stack/material/rods/cyborg,
 		/obj/item/stack/tile/floor/cyborg,
+		/obj/item/stack/material/cyborg/wood,
+		/obj/item/stack/tile/wood/cyborg,
 		/obj/item/stack/material/cyborg/glass,
 		/obj/item/stack/material/cyborg/glass/reinforced,
 		/obj/item/stack/cable_coil/cyborg,
@@ -57,8 +61,9 @@
 	synths = list(
 		/datum/matter_synth/metal =    60000,
 		/datum/matter_synth/glass =    40000,
+		/datum/matter_synth/wood =     30000,
 		/datum/matter_synth/plasteel = 20000,
-		/datum/matter_synth/wire
+		/datum/matter_synth/wire =     50
 	)
 	emag = /obj/item/weapon/melee/baton/robot/electrified_arm
 	skills = list(
@@ -73,12 +78,14 @@
 
 	var/datum/matter_synth/metal/metal =       locate() in synths
 	var/datum/matter_synth/glass/glass =       locate() in synths
+	var/datum/matter_synth/wood/wood =         locate() in synths
 	var/datum/matter_synth/plasteel/plasteel = locate() in synths
 	var/datum/matter_synth/wire/wire =         locate() in synths
 
 	var/obj/item/weapon/matter_decompiler/MD = locate() in equipment
 	MD.metal = metal
 	MD.glass = glass
+	MD.wood = wood
 
 	for(var/thing in list(
 		 /obj/item/stack/material/cyborg/steel,
@@ -96,6 +103,13 @@
 		))
 		var/obj/item/stack/stack = locate(thing) in equipment
 		LAZYDISTINCTADD(stack.synths, glass)
+
+	for(var/thing in list(
+		 /obj/item/stack/tile/wood/cyborg,
+		 /obj/item/stack/material/cyborg/wood
+		))
+		var/obj/item/stack/stack = locate(thing) in equipment
+		LAZYDISTINCTADD(stack.synths, wood)
 
 	var/obj/item/stack/cable_coil/cyborg/C = locate() in equipment
 	C.synths = list(wire)

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -33,6 +33,7 @@
 		/obj/item/device/scanner/mining,
 		/obj/item/weapon/extinguisher,
 		/obj/item/weapon/gun/launcher/net/borg,
+		/obj/item/device/gps,
 		/obj/item/weapon/weldingtool/largetank,
 		/obj/item/weapon/screwdriver,
 		/obj/item/weapon/wrench,


### PR DESCRIPTION
:cl: Slywater
tweak: Added space cleaner to engineering borg modules.
tweak: Decreased borg repair module wire synth capacity from 50 to 40.
tweak: Added a matter decompiler to the borg repair module.
tweak: Added wood synthesizers to borg engineering module.
tweak: Increased the engineering borg's welder capacity.
tweak: Added a second gripper to the engineering borg.
tweak: Added a GPS to the surveyor borg.
/:cl:

I noticed when playing both as a flying repair and grounded engi borg that some tools were missing for a "complete repair job", and at times even the maint drones were more able in terms of materials.
I also noticed that the repair and engi borgs were rather similar in terms of tools, so these tweaks aim to set them apart a bit:

Changes to repair module:
- Added space cleaner (to clean scorch marks and grime from explosions)
- Decreased wire synth from 50 to 40
- Added a matter decompiler (not being able to clean up broken glass is infuriating, especially with a smaller glass supply compared to the grounded module)

Changes to engineering module:
- Added space cleaner (to clean scorch marks and grime from explosions)
- Added wood (and floor tile) synthesizers
- Increased the size of the welding tank to huge
- Added a second gripper (ferrying components one at a time to new machinery can be tedious)

Changes to surveyor module:
- Added a GPS/relay
