### PR TITLE
Remove Master CQC from SEA, gives them Master Medicine to compensate

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -330,16 +330,15 @@
 		/datum/mil_rank/fleet/e9
 	)
 	min_skill = list(   SKILL_EVA        = SKILL_BASIC,
-	                    SKILL_COMBAT     = SKILL_BASIC,
 	                    SKILL_WEAPONS    = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_COMBAT       = SKILL_MAX,
-	                    SKILL_WEAPONS      = SKILL_MAX,
+	max_skill = list(	SKILL_WEAPONS      = SKILL_MAX,
 	                    SKILL_PILOT        = SKILL_MAX,
 	                    SKILL_CONSTRUCTION = SKILL_MAX,
 	                    SKILL_ELECTRICAL   = SKILL_MAX,
 	                    SKILL_ENGINES      = SKILL_MAX,
-	                    SKILL_ATMOS        = SKILL_MAX)
+	                    SKILL_ATMOS        = SKILL_MAX,
+						SKILL_MEDICAL      = SKILL_MAX)
 	skill_points = 24
 
 


### PR DESCRIPTION
🆑 lorwp
tweak: SEAs can no longer have Master CQC, but can now have Master Medicine. Corpsman SEAs rise up
tweak: They also don't have a minimum of basic CQC anymore.
/:cl:

Also cuts out the minimum of basic CQC. Being old doesn't make you big boss

<https://youtu.be/nDtj-2qnTXk>