### PR TITLE
Removes the Nuke from the Merc Ship

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1909,9 +1909,6 @@
 	icon_state = "intact-supply";
 	dir = 5
 	},
-/obj/effect/landmark{
-	name = "Nuclear-Bomb"
-	},
 /obj/structure/railing/mapped{
 	icon_state = "railing0-1";
 	dir = 8
@@ -2518,9 +2515,6 @@
 /area/map_template/merc_spawn)
 "uV" = (
 /obj/structure/table/standard,
-/obj/effect/landmark{
-	name = "Nuclear-Code"
-	},
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
 "va" = (


### PR DESCRIPTION
:CL:
rscdel: Removes the Nuke from the merc ship.
/:CL:

The Nuke is not something people really enjoy dealing with. If antagonists want to destroy the Torch they can still use the ship's self destruct.