### PR TITLE
Increase TEG rated output

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -8,7 +8,7 @@
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 100 //Watts, I hope.  Just enough to do the computer and display things.
 
-	var/max_power = 500000
+	var/max_power = 1500000
 	var/thermal_efficiency = 0.65
 
 	var/obj/machinery/atmospherics/binary/circulator/circ1


### PR DESCRIPTION
:cl:
tweak: Increased TEG rated output before overload to 1500KW
/:cl:

**Description:** 
- This PR increases the TEG nominal output to 1500KW from 500KW
- A normal (wiki based) SM setup runs about 3MW (1500KW) of power, the default SMES also has about 3KW throughput. It seems in conflict to use 500KW rated TEGS for an expected output of 3MW.

**Side effects:**
- Slightly more efficient power generation at <1500KW, but we are talking a few percents at best. After 1500KW, the normal debuff kicks just like always, the overload debuff is applied to the _whole_ power, so when going to 1501, its applied to the whole load, which negates any gain people may have <1500KW.

**RP-Consequences:**
- Currently red values and overloads on the TEG's tend to be ignored, because everyone know they are often just wrong anyhow. With this change a red overload warning actually means something, it means that you are running a (slightly) above nominal power output like it should. 
- In practice this could (for example) lead to a CE asking an engine-tech if he has properly setup the second main SMES to cope with the extra output of running at overload, while directly pointing at the TEG output.

**Required feedback:**
- While I think the nominal output is something most people can agree on it might be worth looking into optimising it to make sure normal run would run in the green. But this would be minimal effort.
