### PR TITLE
Add firedoor locking

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -112,6 +112,7 @@
 		if(!all_doors)
 			return
 		for(var/obj/machinery/door/firedoor/E in all_doors)
+			E.locked = FALSE
 			if(!E.blocked)
 				if(E.operating)
 					E.nextstate = FIREDOOR_OPEN
@@ -144,6 +145,7 @@
 		if(!all_doors)
 			return
 		for(var/obj/machinery/door/firedoor/D in all_doors)
+			D.locked = FALSE
 			if(!D.blocked)
 				if(D.operating)
 					D.nextstate = FIREDOOR_OPEN

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -24,6 +24,7 @@
 	closed_layer = ABOVE_WINDOW_LAYER
 	movable_flags = MOVABLE_FLAG_Z_INTERACT
 	pry_mod = 0.75
+	var/locked = FALSE //If the door is forced open, it will not close again until the next atmosphere alert in the area
 
 	//These are frequenly used with windows, so make sure zones can pass.
 	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
@@ -88,7 +89,11 @@
 
 /obj/machinery/door/firedoor/examine(mob/user, distance)
 	. = ..()
-	if(distance > 1 || !density)
+	if(distance > 1)
+		return
+	if(locked)
+		to_chat(user, SPAN_WARNING("A light on the control mechanism is flashing red, indicating it is locked open."))
+	if(!density)
 		return
 
 	if(pdiff >= FIREDOOR_MAX_PRESSURE_DIFF)
@@ -130,6 +135,12 @@
 		return ..()
 	return 0
 
+/obj/machinery/door/firedoor/proc/get_alarm()
+	for(var/area/A in areas_added) //Checks if there are fire alarms in any areas associated with that firedoor
+		if(A.fire || A.air_doors_activated)
+			return TRUE
+	return FALSE
+
 /obj/machinery/door/firedoor/attack_hand(mob/user as mob)
 	add_fingerprint(user)
 	if(operating)
@@ -140,9 +151,7 @@
 		return
 
 	var/alarmed = lockdown
-	for(var/area/A in areas_added)		//Checks if there are fire alarms in any areas associated with that firedoor
-		if(A.fire || A.air_doors_activated)
-			alarmed = 1
+	alarmed = get_alarm()
 
 	var/answer = alert(user, "Would you like to [density ? "open" : "close"] this [src.name]?[ alarmed && density ? "\nNote that by doing so, you acknowledge any damages from opening this\n[src.name] as being your own fault, and you will be held accountable under the law." : ""]",\
 	"\The [src]", "Yes, [density ? "open" : "close"]", "No")
@@ -172,22 +181,23 @@
 			open()
 	else
 		spawn()
+			locked = FALSE
 			close()
 
 	if(needs_to_close)
-		spawn(50)
-			alarmed = 0
-			for(var/area/A in areas_added)		//Just in case a fire alarm is turned off while the firedoor is going through an autoclose cycle
-				if(A.fire || A.air_doors_activated)
-					alarmed = 1
-			if(alarmed)
-				nextstate = FIREDOOR_CLOSED
-				close()
+		sleep(100)
+		alarmed = 0
+		alarmed = get_alarm()	//Just in case a fire alarm is turned off while the firedoor is going through an autoclose cycle
+
+		if(alarmed)
+			nextstate = FIREDOOR_CLOSED
+			close()
 
 /obj/machinery/door/firedoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	add_fingerprint(user, 0, C)
 	if(operating)
-		return//Already doing something.
+		return //Already doing something.
+			
 	if(isWelder(C) && !repairing)
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0, user))
@@ -264,8 +274,11 @@
 			if(density)
 				spawn(0)
 					open(1)
+					if(lockdown || get_alarm())
+						locked = TRUE
 			else
 				spawn(0)
+					locked = FALSE
 					close()
 			return
 		else
@@ -344,8 +357,9 @@
 	return
 
 /obj/machinery/door/firedoor/close()
-	if(closing)
+	if(closing || locked)
 		return
+
 	closing = 1
 	latetoggle()
 	var/list/people = list()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -39,7 +39,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto use" 'goto '
-exactly 492 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 491 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 


### PR DESCRIPTION
:cl:
bugfix: Prying open a firedoor with a crowbar-like tool once again causes it to remain open until it is closed manually or by a new alarm.
tweak: Doubled automatic closing time for firedoors opened by hand during an alarm.
/:cl: