### PR TITLE
You can now Alt Click to open a storage box / pills bottle / whatever.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -39,6 +39,7 @@
 
 	if ((ishuman(usr) || isrobot(usr) || issmall(usr)) && !usr.incapacitated())
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
+			src.add_fingerprint(usr)
 			src.open(usr)
 			return TRUE
 
@@ -57,6 +58,15 @@
 				if(BP_L_HAND)
 					usr.put_in_l_hand(src)
 
+/obj/item/weapon/storage/AltClick(var/mob/usr)
+
+	if(!canremove)
+		return
+
+	if ((ishuman(usr) || isrobot(usr) || issmall(usr)) && !usr.incapacitated() && Adjacent(usr))
+		src.add_fingerprint(usr)
+		src.open(usr)
+		return TRUE
 
 /obj/item/weapon/storage/proc/return_inv()
 


### PR DESCRIPTION


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
## This PR is dedicated to Rhials Duffy, who keeps dying because of drag clicking.

## About The Pull Request
You can now Alt Click to open a container. Keep in mind I kept the same behaviour as click dragging, meaning you can open a container in another container, but can't take anything out of it (Aka : Box in Backpack etc..)

![HolyAltClick](https://user-images.githubusercontent.com/65850818/87178119-fb201980-c2dc-11ea-8bf5-658f9e84181a.gif)


## Why It's Good For The Game
I believe Alt Clicking to open a container is a really, really good QoL feature. A bunch of people I brought to Bay had troubles with this, so here it is.

## Changelog

:cl: Kathy Ryals
rcsadd: You can now Alt Click a container to open it.
/:cl: