### PR TITLE
Fix inability to repair card slot parts

### DIFF
--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -103,7 +103,7 @@
 
 /obj/item/weapon/stock_parts/computer/card_slot/attackby(obj/item/weapon/card/id/I, mob/living/user)
 	if(!istype(I))
-		return
+		return ..()
 	insert_id(I, user)
 	return TRUE
 


### PR DESCRIPTION
:cl:
bugfix: RFID broadcaster and card slot stock parts can now be repaired.
/:cl:

This bug is caused by a missing call to the super function, causing the item to ignore attackby() calls from anything that isn't an ID.

Effect of the fix is that wires and nanopaste now behave as expected on the card slot components, enabling repairs.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->