### PR TITLE
Updates github issues to use the new template format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,62 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+	Anything inside tags like these is a comment and will not be displayed in the final issue.
+	Be careful not to write inside them!
+
+	Every field other than 'specific information for locating' is required.
+	If you do not fill out the 'specific information' field, please delete the header.
+	/!\ Omitting or not answering a required field will result in your issue being closed. /!\
+	Repeated violation of this rule, or joke or spam issues, will result in punishment.
+	
+	PUT YOUR ANSWERS ON THE BLANK LINES BELOW THE HEADERS 
+	(The lines with four #'s) 
+	Don't edit them or delete them - it's part of the formatting
+-->
+
+#### Description of issue
+
+
+
+#### Difference between expected and actual behavior
+
+
+
+#### Steps to reproduce
+
+
+
+#### Specific information for locating
+<!-- e.g. an object name, paste specific message outputs... -->
+
+
+
+#### Length of time in which bug has been known to occur
+<!--
+	Be specific if you approximately know the time it's been occurring
+	for—this can speed up finding the source. If you're not sure
+	about it, tell us too!
+-->
+
+
+
+#### Client version, Server revision & Game ID
+<!-- Found with the "Show server revision" verb in the OOC tab in game. -->
+
+
+
+#### Issue bingo
+<!-- Check these by writing an x inside the [ ] (like this: [x])-->
+<!-- Don't forget to remove the space between the brackets, or it won't work! -->
+- [ ] Issue could be reproduced at least once
+- [ ] Issue could be reproduced by different players
+- [ ] Issue could be reproduced in multiple rounds
+- [ ] Issue happened in a recent (less than 7 days ago) round
+- [ ] [Couldn't find an existing issue about this](https://github.com/Baystation12/Baystation12/issues)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
We've been using the old system for a while. While it's probably not going to be deprecated any time soon, github recommends using the new issue system, which for the most part works the exact same as our current system, just with one additional button push. The added benefit as well is attempting to report security vulnerabilities automatically redirects would be reporters to SECURITY.md

For the time being, the version of the bug report template it uses is identical to the one we currently have in ISSUE_TEMPLATE.md, and attempting to create a blank issue will default to the one found in ISSUE_TEMPLATE.md