### PR TITLE
adds configuration for forbidden message outcomes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -99,6 +99,9 @@ var/list/gamemode_cache = list()
 	var/issuereporturl
 
 	var/forbidden_message_regex
+	var/forbidden_message_warning = "<B>Your message matched a filter and has not been sent.</B>"
+	var/forbidden_message_no_notifications = FALSE
+	var/forbidden_message_hide_details = FALSE
 
 	var/forbid_singulo_possession = 0
 
@@ -772,6 +775,15 @@ var/list/gamemode_cache = list()
 						config.forbidden_message_regex = flags ? regex(matcher, flags) : regex(matcher)
 					catch(var/exception/ex)
 						log_error("Invalid regex '[value]' supplied to '[name]': [ex]")
+
+				if ("forbidden_message_warning")
+					config.forbidden_message_warning = length(value) ? value : FALSE
+
+				if ("forbidden_message_no_notifications")
+					config.forbidden_message_no_notifications = TRUE
+
+				if ("forbidden_message_hide_details")
+					config.forbidden_message_hide_details = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -68,9 +68,13 @@
 		return FALSE
 
 	if (config.forbidden_message_regex && !check_rights(R_INVESTIGATE, 0, communicator) && findtext(message, config.forbidden_message_regex))
-		log_and_message_admins("attempted to send a forbidden message in [name]: [message]", user = C)
-		if (C)
-			to_chat(C, "<B>Your message matched a filter and has not been sent.</B>")
+		if (!config.forbidden_message_no_notifications)
+			if (!config.forbidden_message_hide_details)
+				log_and_message_admins("attempted to send a forbidden message in [name]: [message]", user = C)
+			else
+				log_and_message_admins("attempted to send a forbidden message in [name]", user = C)
+		if (C && config.forbidden_message_warning)
+			to_chat(C, config.forbidden_message_warning)
 		return FALSE
 
 	return TRUE

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -428,6 +428,18 @@ RADIATION_LOWER_LIMIT 0.15
 ## The provided example forbids byond:// and http/https:// unless followed by a permitted domain.
 #FORBIDDEN_MESSAGE_REGEX /((https?)|(byond)):\/\/(?!(.*\.)?baystation12\.net)/i
 
+## The text to send to a user when their message matches FORBIDDEN_MESSAGE_REGEX
+## Defaults to <B>Your message matched a filter and has not been sent.</B>
+## Can be disabled by setting an empty message here
+#FORBIDDEN_MESSAGE_WARNING <B>Your message matched a filter and has not been sent.</B>
+
+## Uncomment this to prevent admins from being notified of of FORBIDDEN_MESSAGE_REGEX matches
+#FORBIDDEN_MESSAGE_NO_NOTIFICATIONS
+
+## Uncomment this to not show the content of forbidden messages in admin notifications
+## Only used when FORBIDDEN_MESSAGE_NO_NOTIFICATIONS is not active
+#FORBIDDEN_MESSAGE_HIDE_DETAILS
+
 ## Direct clients to preload the server resource file from a URL pointing to a .rsc file. NOTE: At this time (byond 512),
 ## the client/resource_rsc var does not function as one would expect. See client_defines.dm, the "preload_rsc" var's
 ## comments on how to use it properly. If you use a resource URL, you must set preload_rsc to 0 at compile time or


### PR DESCRIPTION
ed: adds configuration options for how rejected messages are handled. Whether to send a user message and the content of that message, whether to notify admins, and whether admins are sent the rejected content are new configuration options, defaulting to the current normal actions of sending a short rejection message and notifying admins with the full content of the rejected message.