### PR TITLE
Fix replacement lights box in medical

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -14725,7 +14725,7 @@
 	dir = 8
 	},
 /obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/lights,
+/obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/hand_labeler,
 /obj/item/stack/package_wrap/twenty_five,
 /obj/item/weapon/reagent_containers/spray/cleaner{


### PR DESCRIPTION
:cl:
bugfix: The medical storage room lights box now contains lights.
/:cl:

"Fixes" #28855.