### PR TITLE
Fixes runtimes when loading marooned.dmm caused by decals in passthrough turfs

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
@@ -2,10 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/template_noop,
-/area/template_noop)
 "ac" = (
 /obj/item/stack/material/rods,
 /turf/template_noop,
@@ -795,7 +791,7 @@ ai
 ai
 ai
 ai
-ab
+aa
 aa
 aa
 aa
@@ -981,7 +977,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 aa
@@ -1134,7 +1130,7 @@ aa
 "}
 (24,1,1) = {"
 aa
-ab
+aa
 aa
 aa
 aa


### PR DESCRIPTION
As it turns out putting decals on a passthrough turf for a ruin causes things to runtime in travis if travis decides to put a wall there on an exoplanet.