### PR TITLE
adds ftech & research fax, makes fax rights assignable

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -71,7 +71,7 @@
 					access_expedition_shuttle_helm, access_aquila, access_aquila_helm, access_solgov_crew, access_nanotrasen,
 					access_emergency_armory, access_sec_guard, access_gun, access_expedition_shuttle, access_guppy, access_seneng, access_senmed, access_senadv,
 					access_explorer, access_pathfinder, access_pilot, access_commissary, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
-					access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd)
+					access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax)
 	minimal_access = list(access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
 						access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
 						access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
@@ -83,7 +83,7 @@
 						access_expedition_shuttle_helm, access_aquila, access_aquila_helm, access_solgov_crew, access_nanotrasen,
 						access_emergency_armory, access_sec_guard, access_gun, access_expedition_shuttle, access_guppy, access_seneng, access_senmed, access_senadv,
 						access_explorer, access_pathfinder, access_pilot, access_commissary, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
-						access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd)
+						access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/card_mod,
@@ -128,7 +128,7 @@
 		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_rd,
 		access_petrov_security, access_petrov_maint, access_pathfinder, access_explorer, access_eva, access_solgov_crew,
-		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels
+		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels, access_torch_fax
 	)
 	minimal_access = list()
 
@@ -172,7 +172,7 @@
 			            access_teleporter, access_eva, access_bridge, access_heads,
 			            access_chapel_office, access_crematorium, access_chemistry, access_virology,
 			            access_cmo, access_surgery, access_RC_announce, access_keycard_auth, access_psychiatrist,
-			            access_medical_equip, access_solgov_crew, access_senmed, access_hangar)
+			            access_medical_equip, access_solgov_crew, access_senmed, access_hangar, access_torch_fax)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -218,12 +218,12 @@
 			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 			            access_tech_storage, access_robotics, access_atmospherics, access_janitor, access_construction,
 			            access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
-			            access_solgov_crew, access_seneng, access_hangar)
+			            access_solgov_crew, access_seneng, access_hangar, access_torch_fax)
 	minimal_access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 			            access_tech_storage, access_atmospherics, access_janitor, access_construction,
 			            access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
-			            access_solgov_crew, access_seneng, access_hangar, access_robotics)
+			            access_solgov_crew, access_seneng, access_hangar, access_robotics, access_torch_fax)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/ntnetmonitor,
@@ -271,7 +271,7 @@
 			            access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_bridge, access_heads,
 			            access_hos, access_RC_announce, access_keycard_auth, access_sec_doors,
-			            access_solgov_crew, access_gun, access_emergency_armory, access_hangar)
+			            access_solgov_crew, access_gun, access_emergency_armory, access_hangar, access_torch_fax)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -301,7 +301,7 @@
 	minimum_character_age = list(SPECIES_HUMAN = 27)
 
 	access = list(access_representative, access_security, access_medical,
-			            access_bridge, access_cargo, access_solgov_crew, access_hangar)
+			            access_bridge, access_cargo, access_solgov_crew, access_hangar, access_torch_fax)
 
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
@@ -346,7 +346,8 @@
 	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_janitor,
 			            access_kitchen, access_cargo, access_RC_announce, access_keycard_auth, access_guppy_helm,
-			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_emergency_armory)
+			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_emergency_armory,
+			            access_torch_fax)
 
 	software_on_spawn = list(/datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/reports)
@@ -385,7 +386,8 @@
 	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
 			            access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
 			            access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
-			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter)
+			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
+			            access_torch_fax)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -22,7 +22,7 @@
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20
 	access = list(access_liaison, access_bridge, access_solgov_crew,
-						access_nanotrasen, access_commissary)
+						access_nanotrasen, access_commissary, access_torch_fax)
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
 /datum/job/liaison/get_description_blurb()
@@ -66,7 +66,7 @@
 	skill_points = 20
 	access = list(access_liaison, access_bridge, access_solgov_crew,
 						access_nanotrasen, access_commissary,
-						access_sec_guard)
+						access_sec_guard, access_torch_fax)
 	defer_roundstart_spawn = TRUE
 
 /datum/job/bodyguard/is_position_available()

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -31,7 +31,7 @@
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
 		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
 		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
-		access_xenobiology, access_xenoarch
+		access_xenobiology, access_xenoarch, access_torch_fax
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management,

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -25,7 +25,7 @@
 						access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen, access_solgov_crew,
 						access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_security,
-						access_petrov_maint)
+						access_petrov_maint, access_torch_fax)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_FINANCE     = SKILL_BASIC,
@@ -79,7 +79,7 @@
 	access = list(access_tox, access_tox_storage, access_research, access_petrov, access_petrov_helm,
 						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
 						access_xenoarch, access_nanotrasen, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
-						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry)
+						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_torch_fax)
 	minimal_access = list()
 	skill_points = 20
 

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -31,7 +31,7 @@
 
 	access = list(access_security, access_brig, access_armory, access_forensics_lockers,
 			            access_maint_tunnels, access_external_airlocks, access_emergency_storage,
-			            access_eva, access_sec_doors, access_solgov_crew, access_gun)
+			            access_eva, access_sec_doors, access_solgov_crew, access_gun, access_torch_fax)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
@@ -80,7 +80,8 @@
 
 	access = list(access_security, access_brig, access_forensics_lockers,
 			            access_maint_tunnels, access_emergency_storage,
-			            access_sec_doors, access_solgov_crew, access_morgue)
+			            access_sec_doors, access_solgov_crew, access_morgue,
+			            access_torch_fax)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -31,7 +31,7 @@
 
 	access = list(access_maint_tunnels, access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
 						access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
-						access_mining, access_mining_office, access_mining_station, access_commissary, access_teleporter, access_eva)
+						access_mining, access_mining_office, access_mining_station, access_commissary, access_teleporter, access_eva, access_torch_fax)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/supply,

--- a/maps/torch/job/torch_access.dm
+++ b/maps/torch/job/torch_access.dm
@@ -141,9 +141,11 @@
 /datum/access/qm
 	desc = "Deck Chief"
 
-/************
-* SEV Torch *
-************/
+/var/const/access_torch_fax = "ACCESS_TORCH_FAX"
+/datum/access/torch_fax
+	id = access_torch_fax
+	desc = "Fax Machines"
+	region = ACCESS_REGION_COMMAND
 
 /datum/access/robotics
 	region = ACCESS_REGION_ENGINEERING

--- a/maps/torch/machinery/faxmachine.dm
+++ b/maps/torch/machinery/faxmachine.dm
@@ -1,0 +1,10 @@
+
+/**
+* Torch fax machine overrides. Cleaner than map stuff.
+**/
+
+/obj/machinery/photocopier/faxmachine
+  send_access = list()
+
+/obj/machinery/photocopier/faxmachine/torch
+	send_access = list(access_torch_fax)

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -109,6 +109,7 @@
 	#include "language/human/misc/spacer.dm"
 
 	#include "machinery/apc_shuttle.dm"
+	#include "machinery/faxmachine.dm"
 	#include "machinery/keycard authentication.dm"
 	#include "machinery/suit_storage.dm"
 

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -12651,8 +12651,8 @@
 /area/shuttle/petrov/cell3)
 "Gc" = (
 /obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Science Officer's Office"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Petrov - Chief Science Officer"
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -3005,8 +3005,8 @@
 	pixel_y = -6
 	},
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "Pathfinder"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Pathfinder"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/command/pathfinder)
@@ -13438,8 +13438,8 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "Quartermaster's Office"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Deck Chief"
 	},
 /obj/machinery/camera/network/supply{
 	c_tag = "Supply Office - Deck Officer";

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15284,13 +15284,13 @@
 /area/security/brig)
 "bSD" = (
 /obj/structure/table/standard,
-/obj/item/weapon/hand_labeler,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/device/destTagger,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/research/mono,
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Research Paperwork Office"
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
 "bTb" = (
@@ -15853,6 +15853,9 @@
 /obj/item/weapon/pen/crayon/yellow{
 	desc = "A colourful crayon. Please refrain from eating it or putting it in your nose. This one is labeled 'Canary Yellow.'"
 	},
+	/obj/item/weapon/hand_labeler,
+	/obj/item/stack/package_wrap/twenty_five,
+	/obj/item/device/destTagger,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
 "cBU" = (
@@ -22851,6 +22854,9 @@
 	pixel_y = 0
 	},
 /obj/item/device/camera,
+/obj/item/device/taperecorder{
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "mvl" = (
@@ -23713,8 +23719,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/device/taperecorder{
-	pixel_y = 0
+/obj/machinery/photocopier/faxmachine{
+	department = "Torch - Investigations Office"
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
@@ -23869,8 +23875,8 @@
 /area/teleporter/firstdeck)
 "nFh" = (
 /obj/structure/table/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "Brig Chief's Office"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Brig Chief"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security Wing - Brig Chief";

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1944,8 +1944,8 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Bridge"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Bridge"
 	},
 /obj/machinery/button/alternate/door{
 	id_tag = "meetingstarboard";
@@ -6418,8 +6418,8 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "COS"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Chief of Security"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
@@ -10500,9 +10500,8 @@
 /area/crew_quarters/heads/office/cos)
 "wD" = (
 /obj/structure/table/woodentable/walnut,
-/obj/machinery/photocopier/faxmachine{
-	anchored = 1;
-	department = "SolGov Representative"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - SolGov Representative"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -12841,8 +12840,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "FG" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "XO"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Executive Officer"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 30
@@ -13656,8 +13655,8 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "SEA"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Senior Enlisted Advisor"
 	},
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/requests_console{
@@ -14115,8 +14114,8 @@
 "KP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer's Office - Torch"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Chief Medical Officer"
 	},
 /obj/item/weapon/stamp/cmo,
 /obj/item/device/radio{
@@ -14599,8 +14598,8 @@
 	pixel_x = -6;
 	pixel_y = 24
 	},
-/obj/machinery/photocopier/faxmachine{
-	department = "CO"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Commanding Officer"
 	},
 /obj/machinery/button/windowtint{
 	id = "co_windows";
@@ -16255,9 +16254,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/maintenance)
 "Uc" = (
-/obj/machinery/photocopier/faxmachine{
-	anchored = 1;
-	department = "Corporate Liasion"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Corporate Liasion"
 	},
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/structure/noticeboard{
@@ -16825,8 +16823,8 @@
 /area/security/bridgecheck)
 "Wi" = (
 /obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Science Officer's Office - Torch"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Chief Science Officer"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -17522,8 +17520,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
-/obj/machinery/photocopier/faxmachine{
-	department = "CE"
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Torch - Chief Engineer"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)


### PR DESCRIPTION
:cl:
maptweak: Added a fax machine to the forensics office and research paperwork office.
tweak: Access to torch fax machines is now assignable as "Fax Machines" under Command in the ID editor program.
tweak: Renamed all torch fax machines for ease of sorting and comprehension.
/:cl:

besides adding the fax machines, this now:

- Adds ACCESS_TORCH_FAX
- Overrides the base fax machine to have free access when torch is the main map
- Adds faxmachine/torch with access ACCESS_TORCH_FAX
- Replaces all torch fax machines with faxmachine/torch
- Adds ACCESS_TORCH_FAX to:
  - all of command, including SCGR and CL
  - deck chief
  - brig chief
  - forensics tech
  - senior researcher
  - scientist
  - pathfinder
  - executive assistant
