### PR TITLE
Adds a Relay Positioning Device to MedTech closets

### DIFF
--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -107,6 +107,7 @@
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/weapon/storage/box/autoinjectors,
+		/obj/item/device/gps,
 		/obj/item/device/scanner/health,
 		/obj/item/clothing/glasses/hud/health,
 		/obj/item/weapon/storage/firstaid/adv,


### PR DESCRIPTION
🆑 Piccione
maptweak: Adds a Relay Positioning Device to MedTech closets
/🆑
It's useful for Corpsmen to compare their position to the person they're going to retrieve, as well as for Explo Mission so they won't have to ask Explo for a Spare RPD.