### PR TITLE
Fixes #28831

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -101,9 +101,6 @@
 			exclude_mobs -= M
 			continue
 		
-		if (M.invisibility < src.invisibility) //M is invisible to the source of the visible message
-			continue
-		
 		var/mob_message = message
 
 		if(isghost(M))
@@ -115,7 +112,7 @@
 			M.show_message(self_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 			continue
 
-		if(!M.is_blind() || narrate)
+		if((!M.is_blind() && M.see_invisible >= src.invisibility) || narrate)
 			M.show_message(mob_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 			continue
 


### PR DESCRIPTION
Checking for invisibility is now corrected, uses `see_invisible` instead of own invisibility level
Check for invisibility is now part of the blindness check (allowing receiving the relevant blindness message, if any)