### PR TITLE
Tweaks personal shields

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -225,8 +225,8 @@
 /obj/item/weapon/cell/infinite/check_charge()
 	return 1
 
-/obj/item/weapon/cell/infinite/use()
-	return 1
+/obj/item/weapon/cell/infinite/use(amount)
+	return amount
 
 
 /obj/item/weapon/cell/potato


### PR DESCRIPTION
:cl:
add: Personal shields now have an internal charge, refilled by the installed power cell
add: Personal shields shut down when the internal charge level is insufficient to protect the user
add: Personal shields automatically turn back on once the charge level is sufficient, if they shut down for the above reason
add: Personal shields can be examined to see both cell and charge levels
bugfix: Personal shields turn off when the power cell is removed
/:cl:

Proposed alternative to #28867 