### PR TITLE
Soporific shows up on medical scanners

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -412,6 +412,7 @@
 	metabolism = REM * 0.5
 	overdose = REAGENTS_OVERDOSE
 	value = 2.5
+	scannable = TRUE
 
 /datum/reagent/soporific/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)


### PR DESCRIPTION
:cl:
tweak: Soporific will now show up as a reagent on handheld medical scanners.
/:cl:

Given soporific is a known sedative and it is readily available in medical, it only makes sense that it's detectable by the scanners instead of being an "unknown" reagent.