### PR TITLE
Unathi are no longer affected by capsaicin

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -391,7 +391,7 @@
 	M.adjustToxLoss(0.5 * removed)
 
 /datum/reagent/capsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
+	if(alien == IS_DIONA || alien == IS_UNATHI)
 		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M


### PR DESCRIPTION
:cl:
tweak: Unathi are no longer affected by capsaicin and can casually drink hot sauce without batting an eye.
/:cl:

Taken from the newliz instructions on the unathi channel. I was considering making special messages for them (e.g., "You're starting to feel a bit of spice" when drinking ludicrous amounts) but decided against it.

Do note: This only affected normal capsaicin. Condensed capsaicin will still affect unathi, both ingested and sprayed.