### PR TITLE
Shuttle Pilot Ensign

### DIFF
--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -60,9 +60,8 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/nt_pilot,
-		/datum/mil_rank/ec/e7,
-		/datum/mil_rank/fleet/e6,
-		/datum/mil_rank/fleet/e7
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/fleet/o1
 	)
 
 	access = list(


### PR DESCRIPTION
🆑
tweak: EC and Fleet Shuttle Pilots can no longer be enlisted from their respective branch, instead letting them be each branch’s Ensign.  Contractors are unchanged.
/🆑


This fixes the issue where SOP states "Pilots have authority over their respective craft while aboard them, but should keep the Deck Chief informed of ship movement, through flight plans or direct, acknowledged contact.", but both the Deck Chief and Pathfinder can pull rank over the Pilot.