### PR TITLE
Syringes now cause pain when injecting or drawing blood

### DIFF
--- a/code/modules/mob/living/carbon/hallucinations.dm
+++ b/code/modules/mob/living/carbon/hallucinations.dm
@@ -301,4 +301,4 @@
 	min_power = 30
 
 /datum/hallucination/fakeattack/hypo/start()
-	to_chat(holder, "<span class='notice'>You feel a tiny prick!</span>")
+	holder.custom_pain(SPAN_WARNING("You feel a tiny prick!"), 1, TRUE)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -68,7 +68,9 @@
 			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M))
 				return
 		to_chat(user, "<span class='notice'>You inject [M] with the injector.</span>")
-		to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.custom_pain(SPAN_WARNING("You feel a tiny prick!"), 1, TRUE, H.get_organ(user.zone_sel.selecting))
 
 		if(M.reagents)
 			var/t = min(amount_per_transfer_from_this, reagent_volumes[reagent_ids[mode]])

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -57,8 +57,11 @@
 	if(single_use && reagents.total_volume <= 0) // currently only applies to autoinjectors
 		atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER // Prevents autoinjectors to be refilled.
 
-	to_chat(user, "<span class='notice'>You inject [M] with [src].</span>")
-	to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
+	to_chat(user, SPAN_NOTICE("You inject [M] with [src]."))
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.custom_pain(SPAN_WARNING("You feel a tiny prick!"), 1, TRUE, H.get_organ(user.zone_sel.selecting))
+		
 	playsound(src, 'sound/effects/hypospray.ogg',25)
 	user.visible_message("<span class='warning'>[user] injects [M] with [src].</span>")
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -172,6 +172,10 @@
 			for(var/mob/O in viewers(4, user))
 				O.show_message("<span class='notice'>[user] takes a blood sample from [target].</span>", 1)
 
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				H.custom_pain(SPAN_WARNING("The needle stings a bit."), 2, TRUE, H.get_organ(user.zone_sel.selecting))
+
 	else //if not mob
 		if(!target.reagents.total_volume)
 			to_chat(user, "<span class='notice'>[target] is empty.</span>")
@@ -261,6 +265,10 @@
 		user.visible_message("<span class='warning'>\the [user] injects \the [target] with [visible_name]!</span>", "<span class='notice'>You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")
 	else
 		to_chat(user, "<span class='notice'>You inject yourself with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")
+
+	if(ishuman(target))
+		var/mob/living/carbon/human/T = target
+		T.custom_pain(SPAN_WARNING("The needle stings a bit."), 2, TRUE, T.get_organ(user.zone_sel.selecting))
 
 	if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
 		mode = SYRINGE_DRAW


### PR DESCRIPTION
:cl:
tweak: Injecting or drawing blood from someone with a syringe now causes a bit of pain.
tweak: Injecting someone with a hypospray causes a bit of pain, but less than the syringe. By extension, autoinjectors work the same way.
/:cl:

This should help alleviate how stoic people are to being injected 20 times in one minute from EMTs. The pain shouldn't become actually debilitating but should encourage the player to not like it as much.

Since the player should know of each time they get injected, force is turned on for the pain. If it proves to be too spammy, it can be turned back off.