### PR TITLE
Fixes typos in disposal conveyor switches and a few codex entries

### DIFF
--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -169,14 +169,14 @@
 /datum/codex_entry/atmos_power_pump
 	associated_paths = list(/obj/machinery/portable_atmospherics/powered/pump)
 	mechanics_text = "Invaluable for filling air in a room rapidly after a breach repair.  The internal gas container can be filled by \
-	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The powercell inside can be \
+	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The power cell inside can be \
 	replaced by using a screwdriver, and then adding a new cell.  A tank of gas can also be attached to the air pump."
 
 //Portable scrubbers
 /datum/codex_entry/atmos_power_scrubber
 	associated_paths = list(/obj/machinery/portable_atmospherics/powered/scrubber)
 	mechanics_text = "Filters the air, placing harmful gases into the internal gas container.  The container can be emptied by \
-	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The powercell inside can be \
+	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The power cell inside can be \
 	replaced by using a screwdriver, and then adding a new cell.  A tank of gas can also be attached to the scrubber. "
 
 //Meters

--- a/code/modules/codex/entries/engineering.dm
+++ b/code/modules/codex/entries/engineering.dm
@@ -10,7 +10,7 @@
 	<br>\
 	Touching the supermatter will result in *instant death*, with no corpse left behind!  You can drag the supermatter, but anything else will kill you. \
 	It is advised to obtain a genetic backup before trying to drag it."
-	antag_text = "Exposing the supermatter to oxygen or vaccum will cause it to start rapidly heating up.  Sabotaging the supermatter and making it explode will \
+	antag_text = "Exposing the supermatter to oxygen or vacuum will cause it to start rapidly heating up.  Sabotaging the supermatter and making it explode will \
 	cause a period of lag as the explosion is processed by the server, as well as irradiating the entire station and causing hallucinations to happen.  \
 	Wearing radiation equipment will protect you from most of the delamination effects sans explosion."
 

--- a/code/modules/codex/entries/machinery.dm
+++ b/code/modules/codex/entries/machinery.dm
@@ -15,7 +15,7 @@
 
 /datum/codex_entry/conveyor_construct
 	associated_paths = list(/obj/machinery/conveyor, /obj/item/conveyor_construct)
-	mechanics_text = "This device must be connected to a switch assembly before placement by clicking the switch on the conveyor belt assembly. When active it will move objects on top of it to the adjacent space based on its direction and if it is runnnig in forward or reverse mode. Can be removed with a crowbar."
+	mechanics_text = "This device must be connected to a switch assembly before placement by clicking the switch on the conveyor belt assembly. When active it will move objects on top of it to the adjacent space based on its direction and if it is running in forward or reverse mode. Can be removed with a crowbar."
 
 /datum/codex_entry/conveyor_construct
 	associated_paths = list(/obj/machinery/conveyor_switch,/obj/machinery/conveyor_switch/oneway,/obj/item/conveyor_switch_construct,/obj/item/conveyor_switch_construct/oneway)

--- a/code/modules/codex/entries/misc.dm
+++ b/code/modules/codex/entries/misc.dm
@@ -1,7 +1,7 @@
 /datum/codex_entry/suitcooler
 	associated_paths = list(/obj/item/device/suit_cooling_unit)
 	mechanics_text = "You may wear this instead of your backpack to cool yourself down. It is commonly used by full-body prosthetic users, \
-	as it allows them to go into low pressure environments for more than few seconds without overhating. It runs off energy provided by internal power cell. \
+	as it allows them to go into low pressure environments for more than few seconds without overheating. It runs off energy provided by internal power cell. \
 	Remember to turn it on by clicking it when it's your in your hand before you put it on."
 
 /datum/codex_entry/barsign

--- a/code/modules/codex/entries/mobs.dm
+++ b/code/modules/codex/entries/mobs.dm
@@ -7,7 +7,7 @@
 	such as fire, radiation, vacuum, and more. Ghosts can join the round as a maintenance drone by using the appropriate verb in the 'ghost' tab. \
 	An inactive drone can be rebooted by swiping an ID card on it with engineering or robotics access, and an active drone can be shut down in the same manner. \
 	Maintenance drone presence can be requested to specific areas from any maintenance drone control console."
-	antag_text = "A crypotgraphic sequencer, available via a traitor uplink, can be used to subvert the drone to your cause."
+	antag_text = "A cryptographic sequencer, available via a traitor uplink, can be used to subvert the drone to your cause."
 
 /datum/codex_entry/uncertified_module
 	associated_paths = list(/obj/item/borg/upgrade/uncertified)

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -255,7 +255,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
 	id = "garbage";
-	name = "disposal coveyor"
+	name = "disposal conveyor"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/mapped{
@@ -13475,7 +13475,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
 	id = "garbage2";
-	name = "disposal coveyor"
+	name = "disposal conveyor"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/mapped{


### PR DESCRIPTION
:cl:
spellcheck: Fixes some small mistakes in codex entries.
spellcheck: Disposal conveyor switches now have proper names.
/:cl: