### PR TITLE
Buffs Chorus defenses

### DIFF
--- a/code/modules/mob/living/chorus/buildings/growth/tier_four.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_four.dm
@@ -17,57 +17,9 @@
 	name = "thorned tendril"
 	desc = "A large mucus covered tentacle. <span class='notice'>This one has a large spike on the end</span>"
 	icon_state = "growth_tendril_thorned"
-	damage = 14
+	damage = 30
+	penetration = 30
 	health = 300
-
-/datum/chorus_building/set_to_turf/growth/bone_shooter
-	desc = "Automatically shoots bone fragments at enemies"
-	building_type_to_build = /obj/structure/chorus/processor/sentry/bone_shooter
-	build_time = 60
-	build_level = 4
-	range = 0
-	resource_cost = list(
-		/datum/chorus_resource/growth_meat = 15,
-		/datum/chorus_resource/growth_bones = 30
-	)
-
-/obj/structure/chorus/processor/sentry/bone_shooter
-	name = "bone spitter"
-	desc = "A group of meat fashioned together into a form not unsimilar to a turret"
-	icon_state = "growth_bone_shooter"
-	health = 20
-	range = 3
-	gives_sight = FALSE
-	activation_cost_resource = /datum/chorus_resource/growth_bones
-	activation_cost_amount = 2
-	click_cooldown = 8 SECONDS
-
-/obj/structure/chorus/processor/sentry/bone_shooter/trigger_effect(var/list/targets)
-	var/mob/living/T = get_atom_closest_to_atom(src, targets)
-	var/obj/item/projectile/bone_shard/bs = new(get_turf(src), owner)
-	set_dir(get_dir(src, T))
-	visible_message("<b>\The [src]</b> fires a small dart at \the [T]")
-	bs.firer = src
-	bs.launch(T, BP_CHEST)
-
-/obj/item/projectile/bone_shard
-	name = "bone shard"
-	damage = 10
-	icon_state = "sliver"
-	damage_type = BRUTE
-	damage_flags = 0
-	var/mob/living/chorus/ignore
-
-/obj/item/projectile/bone_shard/Initialize(var/maploading, var/ignoring)
-	..()
-	ignore = ignoring
-
-/obj/item/projectile/bone_shard/Bump(atom/A as mob|obj|turf|area, forced=0)
-	if(istype(A, /obj/structure/chorus))
-		var/obj/structure/chorus/c = A
-		if(c.owner == ignore)
-			return FALSE
-	. = ..()
 
 /datum/chorus_building/set_to_turf/growth/gastric_emitter
 	desc = "Activate to spill acid on nearby tiles: watch out for your allies!"

--- a/code/modules/mob/living/chorus/buildings/growth/tier_three.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_three.dm
@@ -16,7 +16,8 @@
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 2
 	click_cooldown = 3 SECONDS
-	var/damage = 7
+	var/damage = 15
+	var/penetration = 10
 
 /obj/structure/chorus/processor/sentry/tendril/trigger_effect(var/list/targets)
 	var/mob/living/L = pick(targets)
@@ -24,56 +25,9 @@
 	visible_message("<span class='danger'>\The [src] whips out at \the [L]!</span>")
 	if(istype(L, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = L
-		H.apply_damage(damage, BRUTE, BP_CHEST)
+		H.apply_damage(damage, BRUTE, BP_CHEST, armor_pen = penetration)
 	else
 		L.adjustBruteLoss(damage)
-
-/datum/chorus_building/set_to_turf/growth/bitter
-	desc = "A small teeth-filled hole, used to injure prey"
-	building_type_to_build = /obj/structure/chorus/biter
-	build_time = 20
-	build_level = 3
-	range = 0
-	resource_cost = list(
-		/datum/chorus_resource/growth_meat = 30,
-		/datum/chorus_resource/growth_bones = 15
-	)
-	building_requirements = list(/obj/structure/chorus/ossifier = 2)
-
-/obj/structure/chorus/biter
-	name = "biter"
-	desc = "a pit filled with teeth, capable of biting at those who step on it."
-	icon_state = "growth_biter"
-	activation_cost_resource = /datum/chorus_resource/growth_nutrients
-	activation_cost_amount = 5
-	gives_sight = FALSE
-	health = 1
-	density = 0
-	var/damage = 5
-
-/obj/structure/chorus/biter/chorus_click(var/mob/living/chorus/c)
-	to_chat(c, "<span class='warning'>\The [src] automatically bites those who walk on it</span>")
-
-/obj/structure/chorus/biter/Initialize(var/maploading, var/o)
-	. = ..()
-	GLOB.entered_event.register(get_turf(src), src, .proc/bite_victim)
-
-/obj/structure/chorus/biter/Destroy()
-	GLOB.entered_event.unregister(get_turf(src), src)
-	. = ..()
-
-/obj/structure/chorus/biter/proc/bite_victim(var/atom/a, var/mob/living/L)
-	if(istype(L))
-		if((owner && owner.get_implant(L)) || !can_activate(owner))
-			return
-		flick("growth_biter_attack", src)
-		visible_message("<span class='danger'>\The [src] bites at \the [L]'s feet!</span>")
-		if(istype(L, /mob/living/carbon/human))
-			var/target_foot = pick(list(BP_L_FOOT, BP_R_FOOT))
-			var/mob/living/carbon/human/H = L
-			H.apply_damage(damage, BRUTE, target_foot)
-		else
-			L.adjustBruteLoss(damage)
 
 /datum/chorus_building/set_to_turf/growth/converter
 	desc = "An immunity building organ: turns pesky foreign agents into loyal thralls"

--- a/code/modules/mob/living/chorus/buildings/growth/tier_two.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_two.dm
@@ -124,3 +124,54 @@
 	gives_sight = TRUE
 	density = TRUE
 	turf_type_to_add = /turf/simulated/floor/scales
+
+/datum/chorus_building/set_to_turf/growth/bone_shooter
+	desc = "Automatically shoots bone fragments at enemies"
+	building_type_to_build = /obj/structure/chorus/processor/sentry/bone_shooter
+	build_time = 60
+	build_level = 2
+	range = 0
+	resource_cost = list(
+		/datum/chorus_resource/growth_meat = 5,
+		/datum/chorus_resource/growth_bones = 3
+	)
+
+/obj/structure/chorus/processor/sentry/bone_shooter
+	name = "bone spitter"
+	desc = "A group of meat fashioned together into a form not unsimilar to a turret"
+	icon_state = "growth_bone_shooter"
+	health = 20
+	range = 7
+	gives_sight = FALSE
+	activation_cost_resource = /datum/chorus_resource/growth_bones
+	activation_cost_amount = 1
+	click_cooldown = 8 SECONDS
+
+/obj/structure/chorus/processor/sentry/bone_shooter/trigger_effect(var/list/targets)
+	var/mob/living/T = get_atom_closest_to_atom(src, targets)
+	var/obj/item/projectile/bone_shard/bs = new(get_turf(src), owner)
+	set_dir(get_dir(src, T))
+	visible_message("<b>\The [src]</b> fires a small dart at \the [T]")
+	bs.firer = src
+	bs.launch(T, BP_CHEST)
+
+/obj/item/projectile/bone_shard
+	name = "bone shard"
+	damage = 10
+	embed = TRUE
+	weaken = 3
+	icon_state = "sliver"
+	damage_type = BRUTE
+	damage_flags = 0
+	var/mob/living/chorus/ignore
+
+/obj/item/projectile/bone_shard/Initialize(var/maploading, var/ignoring)
+	..()
+	ignore = ignoring
+
+/obj/item/projectile/bone_shard/Bump(atom/A as mob|obj|turf|area, forced=0)
+	if(istype(A, /obj/structure/chorus))
+		var/obj/structure/chorus/c = A
+		if(c.owner == ignore)
+			return FALSE
+	. = ..()


### PR DESCRIPTION
🆑
tweak: Tendrils now penetrate armor and deal more damage.
tweak: Biters are now a tier 1 item.
tweak: Shooters have more range and their projectiles weaken and embed. They are now a tier 2 item.
tweak: Doubled the number of resources nutrient siphons give.
/🆑
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->