### PR TITLE
Handheld radios now use device power cells

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -28,7 +28,7 @@
 	var/const/FREQ_LISTENING = 1
 	var/list/internal_channels
 
-	var/obj/item/weapon/cell/cell = /obj/item/weapon/cell/device
+	var/obj/item/weapon/cell/device/cell = /obj/item/weapon/cell/device/standard
 	var/power_usage = 2800
 
 	var/datum/radio_frequency/radio_connection


### PR DESCRIPTION
:cl:
tweak: Handheld radios now use device power cells instead of regular cells. As a byproduct, they now have considerably less charge—about 60 messages on a full battery. Use it well!
/:cl:

Some small testing showed that each message used up a little under 2% of the battery. Specifically, 6 messages per 10%.