### PR TITLE
Fixes issue with shortwave radio charge and adds charge to examine text

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -29,7 +29,7 @@
 	var/list/internal_channels
 
 	var/obj/item/weapon/cell/device/cell = /obj/item/weapon/cell/device/standard
-	var/power_usage = 2800
+	var/power_usage = 700
 
 	var/datum/radio_frequency/radio_connection
 	var/list/datum/radio_frequency/secure_radio_connections = new
@@ -45,7 +45,7 @@
 	. = ..()
 	wires = new(src)
 	if(ispath(cell))
-		cell = new(src)
+		cell = new cell(src)
 	internal_channels = GLOB.using_map.default_internal_channels()
 	GLOB.listening_objects += src
 
@@ -554,6 +554,8 @@
 			to_chat(user, "<span class='notice'>\The [src] can be attached and modified!</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [src] can not be modified or attached!</span>")
+		if (power_usage && cell)
+			to_chat(user, "<span class='notice'>\The [src] charge meter reads [round(cell.percent(), 0.1)]%.</span>")
 
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()


### PR DESCRIPTION
Also adds shortwave radio examine text about current charge.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixes #28929

Shortwaves were actually spawning the base device cell instead of the standard cell. The base cell has 4 times the charge of the standard, so to maintain the currently established balance, the power consumption was divided by 4. Also adds cell charge to the examine text for the shortwave.

:cl:
rscadd: Cell powered radios now show their current charge remaining in their examine text.
/:cl: