### PR TITLE
Added a bunch of alt clicks / ctrl click behaviours.

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -126,6 +126,8 @@
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
 
+#define CanDefaultInteract(user) (CanUseTopic(user, DefaultTopicState()) == STATUS_INTERACTIVE)
+
 #define CanInteractWith(user, target, state) (target.CanUseTopic(user, state) == STATUS_INTERACTIVE)
 
 #define CanPhysicallyInteract(user) (CanUseTopicPhysical(user) == STATUS_INTERACTIVE)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -256,6 +256,12 @@
 		O.dropInto(loc)
 	toggle_filter()
 
+/obj/machinery/sleeper/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		go_out()
+	else
+		..()
+
 /obj/machinery/sleeper/proc/set_occupant(var/mob/living/carbon/occupant)
 	src.occupant = occupant
 	update_icon()

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -29,8 +29,14 @@
 
 	if (usr.incapacitated())
 		return
-	src.go_out()
+	go_out()
 	add_fingerprint(usr)
+
+/obj/machinery/bodyscanner/AltClick(mob/user)
+	if(CanPhysicallyInteract(user))
+		eject()
+	else
+		..()
 
 /obj/machinery/bodyscanner/verb/move_inside()
 	set src in oview(1)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -272,14 +272,25 @@
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
 	occupant.forceMove(get_step(loc, SOUTH))
-	if (occupant.bodytemperature < 261 && occupant.bodytemperature >= 70) 
-		occupant.bodytemperature = 261									  
+	if (occupant.bodytemperature < 261 && occupant.bodytemperature >= 70)
+		occupant.bodytemperature = 261
 	occupant = null
 	current_heat_capacity = initial(current_heat_capacity)
 	update_use_power(POWER_USE_IDLE)
 	update_icon()
 	SetName(initial(name))
 	return
+
+/obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		go_out()
+	else
+		..()
+
+/obj/machinery/atmospherics/unary/cryo_cell/CtrlClick(mob/user)
+	if(CanDefaultInteract(user))
+		on = !on
+		update_icon()
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M as mob)
 	if (stat & (NOPOWER|BROKEN))
@@ -383,3 +394,4 @@
 
 /datum/data/function/proc/display()
 	return
+

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -241,9 +241,12 @@
 	else
 		to_chat(src, "<span class='notice'>You need to disable a module first!</span>")
 
-/mob/living/silicon/robot/put_in_hands(var/obj/item/W) // No hands.
-	W.forceMove(get_turf(src))
-	return 1
+/mob/living/silicon/put_in_hands(var/obj/item/W) // No hands.
+	if(W.loc)
+		W.dropInto(W.loc)
+	else if(loc)
+		W.dropInto(loc)
+	return FALSE
 
 //Robots don't use inventory slots, so we need to override this.
 /mob/living/silicon/robot/canUnEquip(obj/item/I)

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -81,7 +81,7 @@
 
 		src.updateUsrDialog()
 		return 0
-	
+
 	if(O.w_class > item_size_limit)
 		to_chat(user, SPAN_NOTICE("\The [src] cannot fit \the [O]."))
 		return
@@ -113,9 +113,6 @@
 /obj/machinery/reagentgrinder/interface_interact(mob/user)
 	interact(user)
 	return TRUE
-
-/obj/machinery/reagentgrinder/DefaultTopicState()
-	return GLOB.physical_state
 
 /obj/machinery/reagentgrinder/interact(mob/user as mob) // The microwave Menu
 	if(inoperable())
@@ -172,21 +169,21 @@
 			if("eject")
 				eject()
 			if ("detach")
-				detach()
+				detach(user)
 		interact(user)
 		return TOPIC_REFRESH
 
-/obj/machinery/reagentgrinder/proc/detach()
-	if (!beaker)
+/obj/machinery/reagentgrinder/proc/detach(mob/user)
+	if(!beaker)
 		return
-	beaker.dropInto(loc)
+	var/obj/item/weapon/reagent_containers/B = beaker
+	user.put_in_hands(B)
 	beaker = null
 	update_icon()
 
 /obj/machinery/reagentgrinder/proc/eject()
 	if (!holdingitems || holdingitems.len == 0)
 		return
-
 	for(var/obj/item/O in holdingitems)
 		O.dropInto(loc)
 		holdingitems -= O
@@ -245,6 +242,24 @@
 				qdel(O)
 			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 				break
+
+/obj/machinery/reagentgrinder/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		detach(user)
+	else
+		..()
+
+/obj/machinery/reagentgrinder/CtrlClick(mob/user)
+	if(CanDefaultInteract(user))
+		grind(user)
+	else
+		..()
+
+/obj/machinery/reagentgrinder/CtrlAltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject(user)
+	else
+		..()
 
 /obj/machinery/reagentgrinder/proc/reset_machine(mob/user)
 	inuse = 0

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -65,6 +65,21 @@
 		to_chat(user, "You add the pill bottle into the dispenser slot!")
 		src.updateUsrDialog()
 
+/obj/machinery/chem_master/proc/eject_beaker(mob/user)
+	if(!beaker)
+		return
+	var/obj/item/weapon/reagent_containers/B = beaker
+	user.put_in_hands(B)
+	beaker = null
+	reagents.clear_reagents()
+	icon_state = "mixer0"
+
+/obj/machinery/chem_master/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject_beaker(user)
+	else
+		..()
+
 /obj/machinery/chem_master/Topic(href, href_list, state)
 	if(..())
 		return 1
@@ -144,10 +159,7 @@
 			interact(user)
 			return
 		else if (href_list["eject"])
-			beaker.forceMove(loc)
-			beaker = null
-			reagents.clear_reagents()
-			icon_state = "mixer0"
+			eject_beaker(user)
 		else if (href_list["createpill"] || href_list["createpill_multiple"])
 			var/count = 1
 
@@ -236,9 +248,6 @@
 	P.icon_state = bottlesprite
 	reagents.trans_to_obj(P,60)
 	P.update_icon()
-
-/obj/machinery/chem_master/DefaultTopicState()
-	return GLOB.physical_state
 
 /obj/machinery/chem_master/interface_interact(mob/user)
 	interact(user)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -108,6 +108,14 @@
 		..()
 	return
 
+/obj/machinery/chemical_dispenser/proc/eject_beaker(mob/user)
+	if(!container)
+		return
+	var/obj/item/weapon/reagent_containers/B = container
+	user.put_in_hands(B)
+	container = null
+	update_icon()
+
 /obj/machinery/chemical_dispenser/ui_interact(mob/user, ui_key = "main",var/datum/nanoui/ui = null, var/force_open = 1)
 	// this is the data which will be sent to the ui
 	var/data[0]
@@ -166,13 +174,16 @@
 		return TOPIC_HANDLED
 
 	else if(href_list["ejectBeaker"])
-		if(container)
-			var/obj/item/weapon/reagent_containers/B = container
-			B.dropInto(loc)
-			container = null
-			update_icon()
-			return TOPIC_REFRESH
-		return TOPIC_HANDLED
+		eject_beaker(user)
+		return TOPIC_REFRESH
+
+
+
+/obj/machinery/chemical_dispenser/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject_beaker(user)
+	else
+		..()
 
 /obj/machinery/chemical_dispenser/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -65,6 +65,20 @@
 		update_use_power(POWER_USE_IDLE)
 		queue_icon_update()
 
+/obj/machinery/reagent_temperature/proc/eject_beaker(mob/user)
+	if(!container)
+		return
+	var/obj/item/weapon/reagent_containers/B = container
+	user.put_in_hands(B)
+	container = null
+	update_icon()
+
+/obj/machinery/reagent_temperature/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject_beaker(user)
+	else
+		..()
+
 /obj/machinery/reagent_temperature/interface_interact(var/mob/user)
 	interact(user)
 	return TRUE
@@ -191,11 +205,7 @@
 			to_chat(user, SPAN_WARNING("The button clicks, but nothing happens."))
 
 	if(href_list["remove_container"])
-		if(container)
-			container.dropInto(loc)
-			user.put_in_hands(container)
-			container = null
-			update_icon()
+		eject_beaker(user)
 		. = TOPIC_REFRESH
 
 	if(. == TOPIC_REFRESH)


### PR DESCRIPTION
## This PR is made in honor of SierraKomodo, who just learned he needed to actually press the submit button to submit a review.

## About The Pull Request
You can now Alt Click to eject people from Scanners / Cryotubes / sleepers. You can now CtrlClick to toggle on and off a cryotube.
Edit : Alt click to eject beakers from Chem dispenser and Chem master.
Edit Edit : Alt click to eject beakers from freezer / heater / grinder. Ctrl Click to grind. CtrlAlt Click to eject pills from the grinder.
## Why It's Good For The Game
QoL changes for people who don't like using the UI / right clicking the scanner, then drop down, the click eject scanner. 

## Changelog

:cl: Kathy Ryals
tweak: You can now Alt Click to eject people from scanners, cryotubes, or sleepers.
tweak: You can now Alt Click to eject a beaker from a chem master, dispenser, grinder, heater, or cooler.
tweak: You can now Ctrl Click a cryotube to turn it on and off.
tweak: You can now Ctrl Click a grinder to grind.
tweak: You can now CtrlAlt Click a grinder to eject the contents.
/:cl: