### PR TITLE
Give forensics drones anatomy for autopsies

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -34,7 +34,8 @@
 		SKILL_COMPUTER            = SKILL_EXPERT,
 		SKILL_FORENSICS           = SKILL_PROF,
 		SKILL_WEAPONS             = SKILL_EXPERT,
-		SKILL_CONSTRUCTION        = SKILL_ADEPT
+		SKILL_CONSTRUCTION        = SKILL_ADEPT,
+		SKILL_ANATOMY             = SKILL_ADEPT
 	)
 
 /obj/item/weapon/robot_module/flying/forensics/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)


### PR DESCRIPTION
:cl:
tweak: Forensics drones now have anatomy skill to allow them to perform autopsies.
/:cl: