### PR TITLE
Limit atmosphere control to connected z levels

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -56,6 +56,9 @@
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : SSmachines.machinery))
+		var/Z = get_host_z()
+		if ((!monitored_alarms.len) && (!Z || !AreConnectedZLevels(Z, alarm.z)))
+			continue
 		var/danger_level = max(alarm.danger_level, alarm.alarm_area.atmosalm)
 		if(danger_level == 2)
 			alarmsAlert[++alarmsAlert.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
@@ -63,10 +66,10 @@
 			alarmsDanger[++alarmsDanger.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
 		else
 			alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
-	
-	data["alarms"] = alarms
-	data["alarmsAlert"] = alarmsAlert
-	data["alarmsDanger"] = alarmsDanger
+
+	data["alarms"] = sortByKey(alarms, "name")
+	data["alarmsAlert"] = sortByKey(alarmsAlert, "name")
+	data["alarmsDanger"] = sortByKey(alarmsDanger, "name")
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)


### PR DESCRIPTION
:cl:
tweak: Atmosphere Control software now only displays alarms from connected z-levels.
tweak: Atmosphere Control software now displays alarms in alphabetical order.
/:cl: