### PR TITLE
Increase the number of RPDs inside a RPD crate

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -34,7 +34,7 @@
 
 /decl/hierarchy/supply_pack/atmospherics/rpd
 	name = "Equipment - Rapid Piping Device"
-	contains = list(/obj/item/weapon/rpd)
+	contains = list(/obj/item/weapon/rpd = 2)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure
 	access = access_atmospherics


### PR DESCRIPTION
The RPD crate from supply is a little overpriced compared to what a normal pipe dispenser costs (35 credits)
🆑 
tweak: Increases the amount of RPD in the RPD crate from 1 to 2.
/🆑 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->