### PR TITLE
Add Interface Interaction to the Atmospherics Meter.

### DIFF
--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -78,6 +78,7 @@
 	else
 		icon_state = "meter4"
 
+
 /obj/machinery/meter/examine(mob/user, distance)
 	. = ..()
 
@@ -95,6 +96,12 @@
 			to_chat(user, "The sensor error light is blinking.")
 	else
 		to_chat(user, "The connect error light is blinking.")
+
+
+/obj/machinery/meter/interface_interact(mob/user)
+	var/datum/gas_mixture/environment = target.return_air()
+	to_chat(user, "The pressure gauge reads [round(environment.return_pressure(), 0.01)] kPa; [round(environment.temperature,0.01)]K ([round(environment.temperature-T0C,0.01)]&deg;C)")
+	return TRUE
 
 // turf meter -- prioritizes turfs over pipes for target acquisition
 


### PR DESCRIPTION
:cl:
rscadd: Meters can now be clicked directly to read the value, instead of haveing to examin them. Works only from adjacent tiles for Non-Cyborgs.
rscadd: AIs can now read Meters by clicking on them.
/:cl:

The commit adds an interface_interact function to the Meters that can be wrenched onto atmospheric pipes.
The function prints the same line to the chat as the examin, but leaves out the Name and object description, to create less useless lines in chat should the player look at meters with a certain frequency.

Changes where tested, and no errors occured.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->