### PR TITLE
Assorted improvements for ERT

### DIFF
--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -4,12 +4,10 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	id = MODE_ERT
 	role_text = "Emergency Responder"
 	role_text_plural = "Emergency Responders"
-	antag_text = "You are an <b>anti</b> antagonist! Within the rules, \
-		try to save the installation and its inhabitants from the ongoing crisis. \
-		Try to make sure other players have <i>fun</i>! If you are confused or at a loss, always adminhelp, \
-		and before taking extreme actions, please try to also contact the administration! \
-		Think through your actions and make the roleplay immersive! <b>Please remember all \
-		rules aside from those without explicit exceptions apply to the ERT.</b>"
+	antag_text = "You are an <b>anti</b>-antagonist! Within the rules, try to save the ship and its crew from the ongoing crisis. \
+				 Try to make sure the other players have <i>fun</i>, and if you are confused or at a loss, always adminhelp. \
+				 You should also contact the staff before taking any extreme actions. \
+				 <b>Remember that all rules outside of those with explicit exceptions apply to the ERT!</b>"
 	welcome_text = "You shouldn't see this"
 	leader_welcome_text = "You shouldn't see this"
 	landmark_id = "Response Team"
@@ -26,19 +24,24 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 
 	base_to_load = /datum/map_template/ruin/antag_spawn/ert
 
+	var/reason = ""
+
 /datum/antagonist/ert/create_default(var/mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)
 
 /datum/antagonist/ert/Initialize()
 	..()
-	leader_welcome_text = "As leader of the Emergency Response Team, you answer only to [GLOB.using_map.company_name], and have authority to override the Captain where it is necessary to achieve your mission goals. It is recommended that you attempt to cooperate with the captain where possible, however."
-	welcome_text = "As member of the Emergency Response Team, you answer only to your leader and [GLOB.using_map.company_name] officials."
+	leader_welcome_text = SPAN_BOLD("You are the leader of the Emergency Response Team. ") + "As the leader, you answer only to [GLOB.using_map.company_name] officials. You have authorization to override the Commanding Officer where it is necessary to achieve your goals. However, it is recommended that you work with them to achieve your goals if possible."
+	welcome_text =        SPAN_BOLD("You are a member of the Emergency Response Team.") + "As a member of the Emergency Response Team, you answer only to your leader and [GLOB.using_map.company_name] officials."
 
 /datum/antagonist/ert/greet(var/datum/mind/player)
 	if(!..())
 		return
-	to_chat(player.current, "The Emergency Response Team works for Asset Protection; your job is to protect [GLOB.using_map.company_name]'s ass-ets. There is a code red alert on [station_name()], you are tasked to go and fix the problem.")
-	to_chat(player.current, "You should first gear up and discuss a plan with your team. More members may be joining, don't move out before you're ready.")
+	to_chat(player.current, "You are part of a Fifth Fleet Quick Reaction Force. There is a severe emergency on \the [GLOB.using_map.station_name] and you are tasked to fix the problem.")
+	to_chat(player.current, "You should first gear up and discuss a plan with your team. More members may be joining, so don't move out before you're all ready. You might receive further instruction from a superior in person or through holocomms soon.")
+
+	if(reason)
+		to_chat(player.current, SPAN_BOLD(FONT_LARGE("You have been summoned to \the [GLOB.using_map.station_name] for the following reason: " + SPAN_NOTICE(reason))))
 
 //Equip proc has been moved to the map specific folders.

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -246,13 +246,6 @@
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/headset_service
 
-/obj/item/device/radio/headset/ert
-	name = "emergency response team radio headset"
-	desc = "The headset of the boss's boss."
-	icon_state = "com_headset"
-	item_state = "headset"
-	ks1type = /obj/item/device/encryptionkey/ert
-
 /obj/item/device/radio/headset/foundation
 	name = "\improper Foundation radio headset"
 	desc = "The headeset of the occult cavalry."

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -18,6 +18,7 @@ var/list/department_radio_keys = list(
 	  ":z" = "Entertainment",".z" = "Entertainment",
 	  ":y" = "Exploration",		".y" = "Exploration",
 	  ":k" = "Recon",		".k" = "Recon",	//Skrell Recon ship
+	  ":o" = "Response Team",".o" = "Response Team", //ERT
 
 	  ":R" = "right ear",	".R" = "right ear",
 	  ":L" = "left ear",	".L" = "left ear",
@@ -36,6 +37,7 @@ var/list/department_radio_keys = list(
 	  ":P" = "AI Private",	".P" = "AI Private",
 	  ":Z" = "Entertainment",".Z" = "Entertainment",
 	  ":Y" = "Exploration",		".Y" = "Exploration",
+	  ":O" = "Response Team", ".O" = "Response Team",
 
 	  //kinda localization -- rastaf0
 	  //same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.

--- a/maps/antag_spawn/ert/ert.dm
+++ b/maps/antag_spawn/ert/ert.dm
@@ -56,3 +56,25 @@
 	name = "\improper Response Team Base"
 	icon_state = "shuttlered"
 	base_turf = /turf/unsimulated/floor/rescue_base
+
+//Objects
+
+/obj/item/device/radio/headset/ert
+	name = "emergency response team radio headset"
+	desc = "The headset of the boss's boss."
+	icon_state = "com_headset"
+	item_state = "headset"
+	ks1type = /obj/item/device/encryptionkey/ert
+
+/obj/item/device/radio/headset/ert/Initialize()
+	. = ..()
+	set_frequency(ERT_FREQ)
+
+/obj/item/weapon/stock_parts/circuitboard/telecomms/allinone/ert
+	build_path = /obj/machinery/telecomms/allinone/ert
+
+/obj/machinery/telecomms/allinone/ert
+	listening_freqs = list(ERT_FREQ)
+	channel_color = COMMS_COLOR_CENTCOMM
+	channel_name = "Response Team"
+	circuitboard = /obj/item/weapon/stock_parts/circuitboard/telecomms/allinone/ert

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -1483,8 +1483,7 @@
 	},
 /area/map_template/rescue_base/base)
 "cO" = (
-/obj/machinery/chemical_dispenser/full,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/machinery/reagentgrinder,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "vault"
@@ -3594,6 +3593,10 @@
 	icon_state = "asteroidfloor"
 	},
 /area/map_template/rescue_base/base)
+"Es" = (
+/obj/machinery/telecomms/allinone/ert,
+/turf/simulated/floor/plating,
+/area/map_template/rescue_base/start)
 
 (1,1,1) = {"
 ab
@@ -5247,7 +5250,7 @@ eU
 gu
 gu
 gK
-gt
+Es
 gY
 hf
 eQ


### PR DESCRIPTION
:cl:
admin: Admins can now specify a reason when dispatching an Emergency Response Team that will be shown to the team when they spawn in.
rscadd: The Emergency Response Team channel has its own key now: "O"/"o".
tweak: The Emergency Response Team welcome text has been modified to be more clear on who the leader is and your role in the game. It also includes the reason specified by the admin that dispatched it.
maptweak: Added an all-in-one telecomms machine to the ERT shuttle that allows them to speak on their own private frequency at the base, in transit, and on the Torch (or anywhere their shuttle is). It is not advised to mess with it even if you have the tools to do so.
tweak: Emergency Response Team headsets now have their default channel set to their private frequency. This can be manually changed back to the common frequency, but doing so is irreversible!
maptweak: Added a reagent grinder to the medical section of the Emergency Response Team base.
/:cl:

Changing the headset's default frequency is the change I'm most concerned about since it blocks off access to the Common channel unless they change it, and even then that change is irreversible due to how headsets work. Some feedback on how best to approach this would be appreciated.

Mockup join text:
![Annotation 2020-07-29 124620](https://user-images.githubusercontent.com/25853190/88845826-93e9dc80-d199-11ea-8f9c-796d4073e670.png)
