### PR TITLE
SEV Torch and FTV Bearcat are now improper names

### DIFF
--- a/maps/bearcat/bearcat_define.dm
+++ b/maps/bearcat/bearcat_define.dm
@@ -3,8 +3,8 @@
 	full_name = "Bearcat"
 	path = "overmap_example"
 
-	station_name  = "FTV Bearcat"
-	station_short = "Bearcat"
+	station_name  = "\improper FTV Bearcat"
+	station_short = "\improper Bearcat"
 
 	dock_name     = "FTS Capitalist's Rest"
 	boss_name     = "FTU Merchant Navy"
@@ -36,7 +36,7 @@
 	salary_modifier = 0.2
 
 /datum/map/bearcat/get_map_info()
-	return "You're aboard the <b>[station_name],</b> an independent vessel affiliated with Free Trade Union, on a SPACE FRONTIER. \
+	return "You're aboard \the <b>[station_name],</b> an independent vessel affiliated with Free Trade Union, on a SPACE FRONTIER. \
 	No major corporation or government has laid claim on the planets in this sector, so their exploitation is entirely up to you - mine, poach and deforest all you want."
 
 /datum/map/bearcat/setup_map()

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -1,6 +1,6 @@
 /datum/map/torch
-	name = "Torch"
-	full_name = "SEV Torch"
+	name = "\improper Torch"
+	full_name = "\improper SEV Torch"
 	path = "torch"
 	flags = MAP_HAS_BRANCH | MAP_HAS_RANK
 	config_path = "config/torch_config.txt"
@@ -15,8 +15,8 @@
 	allowed_spawns = list("Cryogenic Storage", "Cyborg Storage")
 	default_spawn = "Cryogenic Storage"
 
-	station_name  = "SEV Torch"
-	station_short = "Torch"
+	station_name  = "\improper SEV Torch"
+	station_short = "\improper Torch"
 	dock_name     = "TBD"
 	boss_name     = "Expeditionary Command"
 	boss_short    = "Command"

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -5,7 +5,7 @@
 
 /datum/map/torch/get_map_info()
 	. = list()
-	. +=  "You're aboard the <b>[station_name]</b>, an Expeditionary Corps starship. Its primary mission is looking for undiscovered sapient alien species, and general exploration along the way."
+	. +=  "You're aboard \the <b>[station_name]</b>, an Expeditionary Corps starship. Its primary mission is looking for undiscovered sapient alien species, and general exploration along the way."
 	. +=  "The vessel is staffed with a mix of SCG government personnel and hired contractors."
 	. +=  "This area of space is uncharted, away from SCG territory. You might encounter remote outposts or drifting hulks, but no recognized government holds claim on this sector."
 	return jointext(., "<br>")


### PR DESCRIPTION
:cl:
spellcheck: The "SEV Torch" is now considered an improper name, meaning "the" will be added before it in some cases. The same goes for the FTV Bearcat.
/:cl:

Unsure if this will have any issues in edge cases where it's *not* meant to have "the" before it. Preliminary testing with some cases like the ATM shows that Byond handles it decently, though.