### PR TITLE
Harm-Intend exception for crowbar interaction on APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -433,7 +433,7 @@
 	if(istype(W, /obj/item/inducer))
 		return FALSE // inducer.dm afterattack handles this
 
-	if(isCrowbar(W))
+	if(isCrowbar(W) && user.a_intent != I_HURT)//bypass when on harm intend to actually make use of the cover hammer off check further down.
 		if(opened) // Closes or removes board.
 			if (has_electronics == 1)
 				if (terminal())
@@ -626,7 +626,7 @@
 			&& !opened \
 			&& W.force >= 5 \
 			&& W.w_class >= 3.0 \
-			&& prob(20) )
+			&& prob(W.force) )
 		opened = 2
 		user.visible_message("<span class='danger'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
 			"<span class='danger'>You knock down the APC cover with your [W.name]!</span>", \


### PR DESCRIPTION
:cl:
tweak: Weapon force affects APC cover knockdown chance. Crowbars can hit APCs on harm.
/:cl:

The crowbar is the only tool(Atleast the code suggests so) that has  the sufficent weapon class(w_class) to be considered for knocking off the broken cover, but before all crowbar interactions were cought here. This commit fixes that.

Dependent on feed back I will drop the second commit or squash it, the Idea is to increase the chances of knocking off the broken cover with heavier weapons.
_A fire axe is probably better used to hammer off some heat warped/explsion smithed display cover than a crowbar or a spear._

Dependent on feedback I will also remove the Changelog, as the addition is relatively minor(the crowbar thing is actually major because almost no engineer knows how to fix that stuck cover...)