### PR TITLE
adds a PERCENT macro

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -3,6 +3,7 @@
 #define ceil(x) (-round(-(x)))
 #define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
 #define MULT_BY_RANDOM_COEF(VAR,LO,HI) VAR =  round((VAR * rand(LO * 100, HI * 100))/100, 0.1)
+#define PERCENT(val, max, places) round((val) / (max) * 100, !(places) || 10 ** -(places))
 
 // min is inclusive, max is exclusive
 /proc/Wrap(val, min, max)


### PR DESCRIPTION
There wasn't one of these, but there are a lot of in-line percentage calculations.

```
/mob/verb/Test(places as num)
  usr << "[places]: [PERCENT(83.72341, 100, places)]"

=>
0: 84
1: 83.7
2: 83.72
3: 83.723
4: 83.7234

-1: 80
```
tweaked to use negative exponent instead of 1/exp to make -1 nearest 10 instead of 0.1