### PR TITLE
Fix status bug and map info bug

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -145,7 +145,7 @@ var/world_topic_spam_protect_time = world.timeofday
 		s["players"] = 0
 		s["stationtime"] = stationtime2text()
 		s["roundduration"] = roundduration2text()
-		s["map"] = GLOB.using_map.full_name
+		s["map"] = replacetext(GLOB.using_map.full_name, "\improper", "") //Done to remove the non-UTF-8 text macros 
 
 		var/active = 0
 		var/list/players = list()

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -5,7 +5,7 @@
 
 /datum/map/torch/get_map_info()
 	. = list()
-	. +=  "You're aboard \the <b>[station_name]</b>, an Expeditionary Corps starship. Its primary mission is looking for undiscovered sapient alien species, and general exploration along the way."
+	. +=  "You're aboard the " + replacetext("<b>[station_name]</b>", "\improper", "") + ", an Expeditionary Corps starship. Its primary mission is looking for undiscovered sapient alien species, and general exploration along the way."
 	. +=  "The vessel is staffed with a mix of SCG government personnel and hired contractors."
 	. +=  "This area of space is uncharted, away from SCG territory. You might encounter remote outposts or drifting hulks, but no recognized government holds claim on this sector."
 	return jointext(., "<br>")


### PR DESCRIPTION
:cl:
bugfix: The Discord !status command and the character setup map info blurb will no longer display malformed characters.
/:cl:

Who'd've thought text macros would cause such an issue?