### PR TITLE
Fixes Atmospherics Injector Interactions

### DIFF
--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -32,7 +32,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()
 	. = ..()
 	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500	
+	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500
 
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()
 	. = ..()
@@ -43,7 +43,7 @@
 	unregister_radio(src, frequency)
 	. = ..()
 
-/obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()	
+/obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()
 	if (!node)
 		update_use_power(POWER_USE_OFF)
 
@@ -83,7 +83,7 @@
 	if((. = ..()))
 		return
 	if(href_list["toggle_power"])
-		use_power = update_use_power(!use_power)
+		update_use_power(!use_power)
 		queue_icon_update()
 		to_chat(user, "<span class='notice'>The multitool emits a short beep confirming the change.</span>")
 		return TOPIC_REFRESH
@@ -180,9 +180,11 @@
 
 	if(signal.data["power"])
 		update_use_power(sanitize_integer(text2num(signal.data["power"]), POWER_USE_OFF, POWER_USE_ACTIVE, use_power))
+		queue_icon_update()
 
 	if(signal.data["power_toggle"] || signal.data["command"] == "valve_toggle") // some atmos buttons use "valve_toggle" as a command
 		update_use_power(!use_power)
+		queue_icon_update()
 
 	if(signal.data["inject"])
 		inject()
@@ -194,11 +196,9 @@
 
 	if(signal.data["status"])
 		addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
-		return //do not update_icon
+		return
 
 	addtimer(CALLBACK(src, .proc/broadcast_status), 2, TIMER_UNIQUE)
-
-	queue_icon_update()
 
 /obj/machinery/atmospherics/unary/outlet_injector/hide(var/i)
 	update_underlays()
@@ -209,7 +209,7 @@
 		popup.set_content(jointext(get_console_data(),"<br>"))
 		popup.open()
 		return
-		
+
 	if(isWrench(O))
 		new /obj/item/pipe(loc, src)
 		qdel(src)


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Multitool can now toggle the power of injectors.
bugfix: Sprites of injectors will now update accordingly again.
/:cl:

- Fixes sprite not updating when toggled by atmos control computer.
- Fixes multitool not being able to toggle power back online.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->