### PR TITLE
Fixes window construction

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -61,7 +61,10 @@
 
 	health = maxhealth
 
-	set_anchored(!constructed)
+	if (constructed)
+		set_anchored(FALSE)
+		construction_state = 0
+
 	update_connections(1)
 	update_icon()
 	update_nearby_tiles(need_rebuild=1)


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes constructed windows being in an invalid construction state.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->