### PR TITLE
Fixes window blending

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -164,7 +164,7 @@
 					if(istype(O, b_type))
 						success = 1
 						for(var/obj/structure/S in T)
-							if(istype(S, src))
+							if(can_visually_connect_to(S))
 								success = 0
 						for(var/nb_type in noblend_objects)
 							if(istype(O, nb_type))


### PR DESCRIPTION
:cl: Hubblenaut
bugfix: Fixes constructed windows not blending in with spawned ones.
/:cl:

`can_visually_connect_to(S)` is supposed to be used for this typecheck, as it gets overwritten for windows in a way that the exact subtype of window does not matter. Since most if not all subtypes of windows are only used for ease of mapping and spawning windows with different variables set, checking for the exact same type naturally caused issues. This was fixed in an earlier PR of mine from a few years ago (#22209), but apparently I overlooked this single line of code.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->