### PR TITLE
Fixes raider holsters

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -197,16 +197,14 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 		if(!(primary.slot_flags & SLOT_HOLSTER))
 			holster = new new_holster(T)
 			var/datum/extension/holster/H = get_extension(holster, /datum/extension/holster)
-			H.holstered = secondary
-			secondary.forceMove(holster)
+			H.holster(secondary, player)
 		else
 			player.equip_to_slot_or_del(secondary, slot_belt)
 
 	if(primary.slot_flags & SLOT_HOLSTER)
 		holster = new new_holster(T)
 		var/datum/extension/holster/H = get_extension(holster, /datum/extension/holster)
-		H.holstered = primary
-		primary.forceMove(holster)
+		H.holster(primary, player)
 	else if(!player.belt && (primary.slot_flags & SLOT_BELT))
 		player.equip_to_slot_or_del(primary, slot_belt)
 	else if(!player.back && (primary.slot_flags & SLOT_BACK))
@@ -251,7 +249,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	player.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(player), slot_back)
 	player.equip_to_slot_or_del(new /obj/item/device/flashlight(player), slot_r_store)
 	player.equip_to_slot_or_del(new new_glasses(player),slot_glasses)
-	
+
 	var/obj/item/clothing/accessory/storage/holster/holster = new new_holster
 	if(holster)
 		var/obj/item/clothing/under/uniform = player.w_uniform
@@ -259,7 +257,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 			uniform.attackby(holster, player)
 		else
 			player.put_in_any_hand_if_possible(holster)
-	
+
 	player.set_internals(locate(/obj/item/weapon/tank) in player.contents)
 	return 1
 


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Raiders can now properly use their holsters again.
/:cl:

No more bluespace holster weapon teleport shenanigans.

Fixes #25556
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->