### PR TITLE
Implant codex stuff

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -21,28 +21,6 @@
 	else
 		icon_state = "implanter0"
 
-/obj/item/weapon/implanter/verb/remove_implant()
-	set category = "Object"
-	set name = "Remove implant"
-	set src in usr
-
-	if(issilicon(usr))
-		return
-
-	if(can_use(usr))
-		if(!imp)
-			to_chat(usr, "<span class='notice'>There is no implant to remove.</span>")
-			return
-		imp.forceMove(get_turf(src))
-		usr.put_in_hands(imp)
-		to_chat(usr, "<span class='notice'>You remove \the [imp] from \the [src].</span>")
-		name = "implanter"
-		imp = null
-		update_icon()
-		return
-	else
-		to_chat(usr, "<span class='notice'>You cannot do this in your current condition.</span>")
-
 /obj/item/weapon/implanter/proc/can_use()
 
 	if(!ismob(loc))

--- a/code/modules/codex/entries/implants.dm
+++ b/code/modules/codex/entries/implants.dm
@@ -1,0 +1,21 @@
+/datum/codex_entry/implant
+	associated_paths = list(/obj/item/weapon/implant)
+	mechanics_text = "Implants are devices that can be injected into a person and have varying effects. To inject an implant, you require an implanter. \
+	Once injected, implants can only be removed through surgery."
+
+/datum/codex_entry/implant/imprinting
+	associated_paths = list(/obj/item/weapon/implant/imprinting)
+	antag_text = "Imprinting implants allow you to force your victim to obey the instructions you program it with. For the implant to work correctly, you must first \
+	inject your victim with mindbreaker toxin which should be included in the implanter kit."
+
+/datum/codex_entry/implanter
+	associated_paths = list(/obj/item/weapon/implanter)
+	mechanics_text = "The implanter allows you to inject an implant into another mob or person. <br />\
+	To implant someone, you must first insert the desired implant into the implanter, select a target region to implant into, then click on your target to implant them. \
+	Implanting takes time and can be interrupted. <br />\
+	Implants can only be removed through surgery."
+
+/datum/codex_entry/implanter/imprinting
+	associated_paths = list(/obj/item/weapon/implanter/imprinting)
+	antag_text = "Imprinting implants allow you to force your victim to obey the instructions you program it with. For the implant to work correctly, you must first \
+	inject your victim with mindbreaker toxin which should be included in the implanter kit."


### PR DESCRIPTION
:cl:
add: Codex now includes entries for the imprinting implanter that explains how to use it and the mindbreaker requirements.
rscdel: Removed unused/broken `remove_implant` verb
/:cl: