### PR TITLE
re-do of 28897

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -152,49 +152,102 @@ proc/age2agedescription(age)
 	if (progbar)
 		qdel(progbar)
 
-/proc/do_after(mob/user, delay, atom/target = null, needhand = 1, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT, var/same_direction = 0, var/can_move = 0)
-	if(!user)
-		return 0
-	var/atom/target_loc = null
-	var/target_type = null
 
-	var/original_dir = user.dir
+/mob/var/do_unique_user_handle = 0
+/atom/var/do_unique_target_user
 
-	if(target)
-		target_loc = target.loc
-		target_type = target.type
+#define DO_USER_CAN_MOVE     0x1
+#define DO_USER_CAN_TURN     0x2
+#define DO_USER_UNIQUE_ACT   0x4
+#define DO_USER_SAME_HAND    0x8
+#define DO_TARGET_CAN_MOVE   0x10
+#define DO_TARGET_CAN_TURN   0x20
+#define DO_TARGET_UNIQUE_ACT 0x40
+#define DO_SHOW_PROGRESS     0x80
 
-	var/atom/original_loc = user.loc
+#define DO_BOTH_CAN_MOVE     (DO_USER_CAN_MOVE | DO_TARGET_CAN_MOVE)
+#define DO_BOTH_CAN_TURN     (DO_USER_CAN_TURN | DO_TARGET_CAN_TURN)
+#define DO_BOTH_UNIQUE_ACT   (DO_USER_UNIQUE_ACT | DO_TARGET_UNIQUE_ACT)
+#define DO_DEFAULT           (DO_SHOW_PROGRESS | DO_USER_SAME_HAND | DO_BOTH_CAN_TURN)
 
-	var/holding = user.get_active_hand()
+#define DO_MISSING_USER      (-1)
+#define DO_MISSING_TARGET    (-2)
+#define DO_INCAPACITATED     (-3)
 
-	var/datum/progressbar/progbar
-	if (progress)
-		progbar = new(user, delay, target)
+/proc/do_after(mob/user, delay, atom/target, do_flags = DO_DEFAULT, incapacitation_flags = INCAPACITATION_DEFAULT)
+	return !do_after_detailed(user, delay, target, do_flags, incapacitation_flags)
 
-	var/endtime = world.time + delay
-	var/starttime = world.time
-	. = 1
-	while (world.time < endtime)
+/proc/do_after_detailed(mob/user, delay, atom/target, do_flags = DO_DEFAULT, incapacitation_flags = INCAPACITATION_DEFAULT)
+	if (!delay)
+		return FALSE
+
+	if (!user)
+		return DO_MISSING_USER
+
+	var/initial_handle
+	if (do_flags & DO_USER_UNIQUE_ACT)
+		initial_handle = sequential_id("/proc/do_after")
+		user.do_unique_user_handle = initial_handle
+
+	if (target?.do_unique_target_user)
+		return DO_TARGET_UNIQUE_ACT
+
+	if ((do_flags & DO_TARGET_UNIQUE_ACT) && target)
+		target.do_unique_target_user = user
+
+	var/atom/user_loc = do_flags & DO_USER_CAN_MOVE ? null : user.loc
+	var/user_dir = do_flags & DO_USER_CAN_TURN ? null : user.dir
+	var/user_hand = do_flags & DO_USER_SAME_HAND ? user.hand : null
+
+	var/atom/target_loc = do_flags & DO_TARGET_CAN_MOVE ? null : target?.loc
+	var/target_dir = do_flags & DO_TARGET_CAN_TURN ? null : target?.dir
+	var/target_type = target?.type
+
+	var/datum/progressbar/bar = do_flags & DO_SHOW_PROGRESS ? new(user, delay, target) : null
+
+	var/start_time = world.time
+	var/end_time = start_time + delay
+
+	. = FALSE
+
+	for (var/time = world.time, time < end_time, time = world.time)
 		sleep(1)
-		if (progress)
-			progbar.update(world.time - starttime)
-
-		if(QDELETED(user) || user.incapacitated(incapacitation_flags) || (user.loc != original_loc && !can_move) || (same_direction && user.dir != original_dir))
-			. = 0
+		if (bar)
+			bar.update(time - start_time)
+		if (QDELETED(user))
+			. = DO_MISSING_USER
+			break
+		if (target_type && QDELETED(target))
+			. = DO_MISSING_TARGET
+			break
+		if (user.incapacitated(incapacitation_flags))
+			. = DO_INCAPACITATED
+			break
+		if (user_loc && user_loc != user.loc)
+			. = DO_USER_CAN_MOVE
+			break
+		if (target_loc && target_loc != target.loc)
+			. = DO_TARGET_CAN_MOVE
+			break
+		if (user_dir && user_dir != user.dir)
+			. = DO_USER_CAN_TURN
+			break
+		if (target_dir && target_dir != target.dir)
+			. = DO_TARGET_CAN_TURN
+			break
+		if (!isnull(user_hand) && user_hand != user.hand)
+			. = DO_USER_SAME_HAND
+			break
+		if (initial_handle && initial_handle != user.do_unique_user_handle)
+			. = DO_USER_UNIQUE_ACT
 			break
 
-		if(target_loc && (QDELETED(target) || target_loc != target.loc || target_type != target.type))
-			. = 0
-			break
-
-		if(needhand)
-			if(user.get_active_hand() != holding)
-				. = 0
-				break
-
-	if (progbar)
-		qdel(progbar)
+	if (bar)
+		qdel(bar)
+	if ((do_flags & DO_USER_UNIQUE_ACT) && user.do_unique_user_handle == initial_handle)
+		user.do_unique_user_handle = 0
+	if ((do_flags & DO_TARGET_UNIQUE_ACT) && target)
+		target.do_unique_target_user = null
 
 /proc/able_mobs_in_oview(var/origin)
 	var/list/mobs = list()

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -54,7 +54,7 @@
 	to_chat(user, "<span class='notice'>You begin hacking \the [target]...</span>")
 	is_hacking = 1
 	// Hackin takes roughly 15-25 seconds. Fairly small random span to avoid people simply aborting and trying again.
-	var/hack_result = do_after(user, (15 SECONDS + rand(0, 5 SECONDS) + rand(0, 5 SECONDS)), progress = 0)
+	var/hack_result = do_after(user, (15 SECONDS + rand(0, 5 SECONDS) + rand(0, 5 SECONDS)), do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS)
 	is_hacking = 0
 
 	if(hack_result && in_hack_mode)

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -107,7 +107,7 @@
 		if (user.get_skill_value(SKILL_ELECTRICAL) < SKILL_ADEPT)
 			length += rand(40, 60)
 		while(C.charge < C.maxcharge)
-			if(MyC.charge > max(0, MyC.charge*failsafe) && do_after(user, length, target = user))
+			if(MyC.charge > max(0, MyC.charge*failsafe) && do_after(user, length))
 				if(CannotUse(user))
 					return TRUE
 				if(QDELETED(C))

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -440,7 +440,7 @@
 			to_chat(user, "<span class='notice'>There is no tape left inside.</span>")
 			return
 		to_chat(user, "<span class='notice'>You start winding the tape back in...</span>")
-		if(do_after(user, 120, target = src))
+		if(do_after(user, 120, src))
 			to_chat(user, "<span class='notice'>You wound the tape back in.</span>")
 			fix()
 		return

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -39,7 +39,7 @@
 					playsound(src.loc, 'sound/machines/click.ogg', 20, 1)
 					if(creation_time)
 						holocreator_busy = TRUE
-						if(!do_after(user, creation_time, target = target))
+						if(!do_after(user, creation_time, target))
 							holocreator_busy = FALSE
 							return
 						holocreator_busy = FALSE

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -61,7 +61,7 @@
 			else
 				user.visible_message("<span class='warning'>[user] begins to do [H]'s lips with \the [src].</span>", \
 									 "<span class='notice'>You begin to apply \the [src].</span>")
-				if(do_after(user, 20, H) && do_after(H, 20, needhand = 0, progress = 0, incapacitation_flags = INCAPACITATION_NONE))	//user needs to keep their active hand, H does not.
+				if(do_after(user, 4 SECONDS, H, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 					user.visible_message("<span class='notice'>[user] does [H]'s lips with \the [src].</span>", \
 										 "<span class='notice'>You apply \the [src].</span>")
 					H.lip_style = colour

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -39,7 +39,7 @@
 /obj/item/clothing/mask/gas/attack_self(var/mob/user)
 	if(clogged)
 		user.visible_message("<span class='notice'>\The [user] begins unclogging the intakes of \the [src].</span>")
-		if(do_after(user, 100, progress = 1) && clogged)
+		if(do_after(user, 100) && clogged)
 			user.visible_message("<span class='notice'>\The [user] has unclogged \the [src].</span>")
 			clogged = FALSE
 		return

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -293,7 +293,7 @@
 
 				if(!failed_to_seal && wearer.back == src && piece == compare_piece)
 
-					if(seal_delay && !instant && !do_after(wearer,seal_delay,src,needhand=0))
+					if(seal_delay && !instant && do_after(wearer, seal_delay, src, do_flags = DO_DEFAULT & ~DO_USER_SAME_HAND))
 						failed_to_seal = 1
 
 					piece.icon_state = "[initial(icon_state)][!seal_target ? "_sealed" : ""]"

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -51,7 +51,7 @@
 		return
 	if(user != H)
 		visible_message("<span class='danger'>\The [user] is trying to remove \the [H]'s [name]!</span>")
-		if(!do_after(user, HUMAN_STRIP_DELAY, H, progress = 0))
+		if(!do_after(user, HUMAN_STRIP_DELAY, H, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 			return FALSE
 	. = RemoveUnderwear(user, H)
 	if(. && user != H)
@@ -63,7 +63,7 @@
 		return
 	if(user != H)
 		user.visible_message("<span class='warning'>\The [user] has begun putting on \a [src] on \the [H].</span>", "<span class='notice'>You begin putting on \the [src] on \the [H].</span>")
-		if(!do_after(user, HUMAN_STRIP_DELAY, H, progress = FALSE))
+		if(!do_after(user, HUMAN_STRIP_DELAY, H, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 			return FALSE
 	. = EquipUnderwear(user, H)
 	if(. && user != H)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -84,7 +84,7 @@
 		var/target_text = trans_dest? "\the [trans_dest]" : "\the [user.loc]"
 		user.visible_message("<span class='danger'>\The [user] begins to wring out [src] over [target_text].</span>", "<span class='notice'>You begin to wring out [src] over [target_text].</span>")
 
-		if(do_after(user, reagents.total_volume*5, progress = 0)) //50 for a fully soaked rag
+		if(do_after(user, reagents.total_volume*5, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS)) //50 for a fully soaked rag
 			if(trans_dest)
 				reagents.trans_to(trans_dest, reagents.total_volume)
 			else
@@ -99,7 +99,7 @@
 		user.visible_message("\The [user] starts to wipe down [A] with [src]!")
 		reagents.splash(A, 1) //get a small amount of liquid on the thing we're wiping.
 		update_name()
-		if(do_after(user,30, progress = 1))
+		if(do_after(user,30))
 			user.visible_message("\The [user] finishes wiping off the [A]!")
 			if(isturf(A))
 				var/turf/T = A

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -232,7 +232,7 @@
 		var/chop_time = (health/W.force) * 0.5 SECONDS
 		if(user.skill_check(SKILL_BOTANY, SKILL_ADEPT))
 			chop_time *= 0.5
-		if(do_after(user, chop_time, src, TRUE))
+		if(do_after(user, chop_time, src))
 			visible_message(SPAN_NOTICE("[user] chops down \the [src]."))
 			playsound(get_turf(src), W.hitsound, 100, 1)
 			die_off()

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -110,7 +110,7 @@
 					return
 			to_chat(user, "<span class='notice'>You begin recycling [EA]'s components...</span>")
 			playsound(src, 'sound/items/electronic_assembly_emptying.ogg', 50, TRUE)
-			if(!do_after(user, 30, target = src) || recycling) //short channel so you don't accidentally start emptying out a complex assembly
+			if(!do_after(user, 30, src) || recycling) //short channel so you don't accidentally start emptying out a complex assembly
 				return
 			recycling = TRUE
 			for(var/V in EA.assembly_components)

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -96,7 +96,7 @@
 				return
 
 			owner.visible_message(SPAN_NOTICE("\The [owner] begins loading \the [O]."))
-			if(do_after(owner, 20, O, 0, 1))
+			if(do_after(owner, 20, O, do_flags = DO_DEFAULT & ~DO_USER_SAME_HAND))
 				if(O in carrying || O.buckled_mob || O.anchored || (locate(/mob/living) in O)) //Repeat checks
 					return
 				if(length(carrying) >= carrying_capacity)

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -249,7 +249,7 @@
 	user.visible_message("<span class='danger'>\The [user] begins to slit [affecting]'s throat with \the [W]!</span>")
 
 	user.next_move = world.time + 20 //also should prevent user from triggering this repeatedly
-	if(!do_after(user, 20*user.skill_delay_mult(SKILL_COMBAT) , progress = 0))
+	if(!do_after(user, 20 * user.skill_delay_mult(SKILL_COMBAT), do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 		return 0
 	if(!(G && G.affecting == affecting)) //check that we still have a grab
 		return 0
@@ -300,7 +300,7 @@
 	user.visible_message(SPAN_DANGER("\The [user] begins to cut \the [affecting]'s [O.tendon_name] with \the [W]!"))
 	user.next_move = world.time + 20
 
-	if(!do_after(user, 20, progress=0))
+	if(!do_after(user, 20, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 		return 0
 	if(!(G && G.affecting == affecting)) //check that we still have a grab
 		return 0

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -54,7 +54,7 @@
 
 /datum/grab/normal/struggle/proc/resolve_struggle(var/obj/item/grab/G)
 	set waitfor = FALSE
-	if(do_after(G.assailant, upgrade_cooldown, G, can_move = 1))
+	if(do_after(G.assailant, upgrade_cooldown, G, do_flags = DO_DEFAULT | DO_USER_CAN_MOVE))
 		G.done_struggle = TRUE
 		G.upgrade(TRUE)
 	else

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -69,7 +69,7 @@
 	visible_message("\The [src] begins to clean up \the [D]")
 	update_icons()
 	var/cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
-	if(do_after(src, cleantime, progress = 0))
+	if(do_after(src, cleantime, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 		if(istype(loc, /turf/simulated))
 			var/turf/simulated/f = loc
 			f.dirt = 0

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -17,17 +17,17 @@
 		if("pockets")
 			if(stripping)
 				visible_message("<span class='danger'>\The [user] is trying to empty [src]'s pockets!</span>")
-				if(do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+				if(do_after(user, HUMAN_STRIP_DELAY, src, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 					empty_pockets(user)
 			else
 				//should it be possible to discreetly slip something into someone's pockets?
 				visible_message("<span class='danger'>\The [user] is trying to stuff \a [held] into [src]'s pocket!</span>")
-				if(do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+				if(do_after(user, HUMAN_STRIP_DELAY, src, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 					place_in_pockets(held, user)
 			return
 		if("sensors")
 			visible_message("<span class='danger'>\The [user] is trying to set \the [src]'s sensors!</span>")
-			if(do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+			if(do_after(user, HUMAN_STRIP_DELAY, src, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 				toggle_sensors(user)
 			return
 		if ("lock_sensors")
@@ -35,7 +35,7 @@
 				return
 			var/obj/item/clothing/under/subject_uniform = w_uniform
 			visible_message(SPAN_DANGER("\The [user] is trying to [subject_uniform.has_sensor == SUIT_LOCKED_SENSORS ? "un" : ""]lock \the [src]'s sensors!"))
-			if (do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+			if (do_after(user, HUMAN_STRIP_DELAY, src, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 				if (subject_uniform != w_uniform)
 					to_chat(user, SPAN_WARNING("\The [src] is not wearing \the [subject_uniform] anymore."))
 					return
@@ -51,7 +51,7 @@
 			return
 		if("internals")
 			visible_message("<span class='danger'>\The [usr] is trying to set \the [src]'s internals!</span>")
-			if(do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+			if(do_after(user, HUMAN_STRIP_DELAY, src, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 				toggle_internals(user)
 			return
 		if("tie")
@@ -64,7 +64,7 @@
 				return
 			visible_message("<span class='danger'>\The [user] is trying to remove \the [src]'s [A.name]!</span>")
 
-			if(!do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+			if(!do_after(user, HUMAN_STRIP_DELAY, src, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 				return
 
 			if(!A || holder.loc != src || !(A in holder.accessories))

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -153,7 +153,7 @@
 	if(unbuckle_time && buckled)
 		var/stages = 2
 		for(var/i = 1 to stages)
-			if(!unbuckle_time || do_after(usr, unbuckle_time*0.5, incapacitation_flags = INCAPACITATION_DEFAULT & ~(INCAPACITATION_RESTRAINED | INCAPACITATION_BUCKLED_FULLY)))
+			if(!unbuckle_time || do_after(usr, unbuckle_time*0.5, incapacitation_flags = INCAPACITATION_DISABLED))
 				if(!buckled)
 					return
 				visible_message(

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -130,7 +130,7 @@
 		else if(prob(5)) //earthquake spell
 			visible_message("<span class='cultannounce'>\The [src]' eyes begin to glow ominously as dust and debris in the area is kicked up in a light breeze.</span>")
 			stop_automation = TRUE
-			if(do_after(src, 6 SECONDS, src))
+			if(do_after(src, 6 SECONDS))
 				var/health_holder = health
 				visible_message(SPAN_MFAUNA("\The [src] raises its fore-hooves and stomps them into the ground with incredible force!"))
 				explosion(get_step(src,pick(GLOB.cardinal)), -1, 2, 2, 3, 6)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -299,7 +299,7 @@
 				return
 			var/time_to_butcher = (mob_size)
 			to_chat(user, SPAN_NOTICE("You begin harvesting \the [src]."))
-			if(do_after(user, time_to_butcher, src, same_direction = TRUE))
+			if(do_after(user, time_to_butcher, src, do_flags = DO_DEFAULT & ~DO_BOTH_CAN_TURN))
 				if(prob(user.skill_fail_chance(SKILL_COOKING, 60, SKILL_ADEPT)))
 					to_chat(user, SPAN_NOTICE("You botch harvesting \the [src], and ruin some of the meat in the process."))
 					subtract_meat(user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -133,7 +133,7 @@
 			else
 				user.visible_message("<span class='warning'>[user] begins to wipe [H]'s lipstick off with \the [src].</span>", \
 								 	 "<span class='notice'>You begin to wipe off [H]'s lipstick.</span>")
-				if(do_after(user, 10, H) && do_after(H, 10, needhand = 0))	//user needs to keep their active hand, H does not.
+				if(do_after(user, 2 SECONDS, H, do_flags = DO_DEFAULT & ~DO_BOTH_CAN_TURN))
 					user.visible_message("<span class='notice'>[user] wipes [H]'s lipstick off with \the [src].</span>", \
 										 "<span class='notice'>You wipe off [H]'s lipstick.</span>")
 					H.lip_style = null

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -444,7 +444,7 @@
 
 	mouthshoot = 1
 	M.visible_message("<span class='danger'>[user] sticks their gun in their mouth, ready to pull the trigger...</span>")
-	if(!do_after(user, 40, progress=0))
+	if(!do_after(user, 40, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 		M.visible_message("<span class='notice'>[user] decided life was worth living</span>")
 		mouthshoot = 0
 		return

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -148,7 +148,7 @@
 	var/mob/living/carbon/human/M = user
 	M.visible_message("<span class='danger'>[user] sticks [src] in their mouth, ready to pull the trigger...</span>")
 
-	if(!do_after(user, 40, progress = 0))
+	if(!do_after(user, 40, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
 		M.visible_message("<span class='notice'>[user] decided life was worth living.</span>")
 		return
 

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -160,7 +160,7 @@
 		user.visible_message("<span class='danger'><i>\The [user] seizes the head of \the [target] in both hands...</i></span>")
 		to_chat(user, "<span class='warning'>You plunge your mentality into that of \the [target]...</span>")
 		to_chat(target, "<span class='danger'>Your mind is invaded by the presence of \the [user]! They are trying to make you a slave!</span>")
-		if(!do_after(user, target.stat == CONSCIOUS ? 80 : 40, target, 0, 1))
+		if(!do_after(user, target.stat == CONSCIOUS ? 80 : 40, target))
 			user.psi.backblast(rand(10,25))
 			return TRUE
 		to_chat(user, "<span class='danger'>You sear through \the [target]'s neurons, reshaping as you see fit and leaving them subservient to your will!</span>")
@@ -184,7 +184,7 @@
 		user.visible_message(SPAN_WARNING("\The [user] holds the head of \the [target] in both hands..."))
 		to_chat(user, SPAN_NOTICE("You insinuate your mentality into that of \the [target]..."))
 		to_chat(target, SPAN_WARNING("Your persona is being probed by the psychic lens of \the [user]."))
-		if(!do_after(user, (target.stat == CONSCIOUS ? 50 : 25), target, 0, 1))
+		if(!do_after(user, (target.stat == CONSCIOUS ? 50 : 25), target))
 			user.psi.backblast(rand(5,10))
 			return TRUE
 		to_chat(user, SPAN_NOTICE("You retreat from \the [target], holding your new knowledge close."))
@@ -208,7 +208,7 @@
 		user.visible_message(SPAN_WARNING("\The [user] holds the head of \the [target] in both hands..."))
 		to_chat(user, SPAN_NOTICE("You probe \the [target]'s mind for various ailments.."))
 		to_chat(target, SPAN_WARNING("Your mind is being cleansed of ailments by \the [user]."))
-		if(!do_after(user, (target.stat == CONSCIOUS ? 50 : 25), target, 0, 1))
+		if(!do_after(user, (target.stat == CONSCIOUS ? 50 : 25), target))
 			user.psi.backblast(rand(5,10))
 			return TRUE
 		to_chat(user, SPAN_WARNING("You clear \the [target]'s mind of ailments."))

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -171,7 +171,7 @@
 			return TRUE
 
 		user.visible_message(SPAN_NOTICE("<i>\The [user] splays out their hands over \the [target]'s body...</i>"))
-		if(!do_after(user, 100, target, 0, 1))
+		if(!do_after(user, 100, target))
 			user.psi.backblast(rand(10,25))
 			return TRUE
 

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -130,7 +130,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			after_cast(targets) //generates the sparks, smoke, target messages etc.
 		else
 			break
-	while(time != number_of_channels && do_after(user, time_between_channels, incapacitation_flags = INCAPACITATION_KNOCKOUT|INCAPACITATION_FORCELYING|INCAPACITATION_STUNNED, same_direction=1))
+	while(time != number_of_channels && do_after(user, time_between_channels, do_flags = DO_DEFAULT & ~DO_USER_CAN_TURN, incapacitation_flags = INCAPACITATION_KNOCKOUT | INCAPACITATION_FORCELYING | INCAPACITATION_STUNNED))
 	after_spell(targets, user, time) //When we are done with the spell completely.
 
 
@@ -394,4 +394,4 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	if(!(spell_flags & (GHOSTCAST)))
 		incap_flags |= INCAPACITATION_KNOCKOUT
 
-	return do_after(user,delay, incapacitation_flags = incap_flags)
+	return do_after(user, delay, incapacitation_flags = incap_flags)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -142,7 +142,7 @@ var/list/ventcrawl_machinery = list(
 						to_chat(src, "<span class='warning'>You feel a strong current pushing you away from the vent.</span>")
 					if(HAZARD_HIGH_PRESSURE to INFINITY)
 						to_chat(src, "<span class='danger'>You feel a roaring wind pushing you away from the vent!</span>")
-			if(!do_after(src, 45, vent_found, 1, 1))
+			if(!do_after(src, 45, vent_found))
 				return
 			if(!can_ventcrawl())
 				return


### PR DESCRIPTION
#28897

Actually does the thing now. The failure was on targetless do_afters trying to check target types anyway. 1 character fix `target.type => target?.type` but I've removed that test instead. Checking if an immutable property has changed seems redundant. I'm not sure why it was in the original do_after.
