### PR TITLE
Drops job count of Life pod from 4 to 2

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -898,11 +898,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "gE" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
+/obj/machinery/sleeper{
+	dir = 8
 	},
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "gF" = (
@@ -1046,21 +1045,23 @@
 /area/map_template/crashed_pod)
 "pO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "vG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/sleeper{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "ED" = (
 /obj/effect/submap_landmark/joinable_submap/crashed_pod,
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
+"Gp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "RN" = (
 /obj/structure/table/steel_reinforced,
@@ -1074,16 +1075,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "ZI" = (
-/obj/structure/closet/emcloset,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/crowbar,
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 
@@ -1271,7 +1264,7 @@ ay
 gz
 gK
 gZ
-vG
+Gp
 ab
 "}
 (12,1,1) = {"


### PR DESCRIPTION
For such a small, meaningless map, the Life Pod has a larger than required number of off-Torch Jobslots.

Lowers it so we can have *more* low-slot maps, instead of *fewer* highslot maps.
🆑 
tweak: Drops job count of Life pod from 4 to 2. Too small of a map, too many slots.
/🆑 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->