### PR TITLE
Tweak placement of Toxin Lab area borders

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -12898,14 +12898,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"GU" = (
-/obj/structure/sign/warning/hot_exhaust{
-	dir = 4;
-	icon_state = "fire"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/isolation)
 "GX" = (
 /obj/structure/bed/chair/padded/red,
 /obj/structure/cable/cyan{
@@ -15839,7 +15831,7 @@
 "Rt" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/isolation)
+/area/shuttle/petrov/toxins)
 "Rv" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/techfloor,
@@ -49299,7 +49291,7 @@ yo
 wU
 wU
 wU
-GU
+yo
 VP
 VP
 fF


### PR DESCRIPTION
Expands the Toxin Lab area definition just a bit so the shutters in the chamber don't drop when the isolation lab has an alarm. Prevents things like this: 
![dreamseeker_dXjLE835kk](https://user-images.githubusercontent.com/11140088/89553883-f3ac3d00-d7c2-11ea-8b3a-9060546b6814.png)

:cl:
maptweak: Toxins lab window shutters should no longer randomly drop when the isolation lab has an alarm
/:cl: