### PR TITLE
Quick fix to unathi langs

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_unathi.dm
+++ b/code/modules/culture_descriptor/culture/cultures_unathi.dm
@@ -5,9 +5,8 @@
 	over their lowland vassals, protecting them and Moghes in the name of the Grand Strategem - even though the clear \
 	division between feudal masters and their subject clans has been gradually wearing away."
 	economic_power = 0.8
-	name_language = LANGUAGE_UNATHI_SINTA
+	language = LANGUAGE_UNATHI_SINTA
 	secondary_langs = list(
-		LANGUAGE_UNATHI_YEOSA,
 		LANGUAGE_SIGN,
 		LANGUAGE_HUMAN_EURO,
 		LANGUAGE_GUTTER,
@@ -19,23 +18,51 @@
 	description = "These unathi hail from the dense jungles of Moghes' poles. Generally, they're the most welcoming of outsiders and the most \
 	common to find off-world. Most of these unathi are followers of the Precursors or the Fruitful Lights, with technology and progress being \
 	an important concept in the polar city-states."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_desert
 	name = CULTURE_UNATHI_DESERT
 	description = "These are the survivalists of the unathi. They hunker down in long-forgotten bunkers of the precursors and survive on \
 	whatever creatures that still live in the deserts. They're incredibly self-sufficient despite their living conditions. They have a heavy focus on \
 	the Precursors and the Grand Stratagem in their clan faiths, and are often considered the most spiritual."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_savannah
 	name = CULTURE_UNATHI_SAVANNAH
 	description = "These unathi belong to the numerous rural and nomadic clans spread across the great plains of either hemisphere of Moghes. \
 	Excellent farmers, riders and herdsmen, most savannah unathi follow the Hand of the Vines."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)
 	
 /decl/cultural_info/culture/unathi_salt_swamp
 	name = CULTURE_UNATHI_SALT_SWAMP
 	description = "Combining assorted elements of various cultures with an adventurous spirit and resolve, salt swamp unathi are noted for their friendliness and openness to outsiders, \
 	along with their knack for rituals that often get mistaken as \"parties\" by humans. The Fruitful Lights and Hand of the Vines both have numerous \
 	followers with these unathi."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_space
 	name = CULTURE_UNATHI_SPACE
@@ -43,6 +70,14 @@
 	much of their origins to the nomadic savannah clans, though it still varies greatly. Many of them still retain their traditions from their \
 	original homes. Now considering themselves as pioneers, they are varied in their ways. Many function as merchants and trade haulers, offering services \
 	to the Moghes Hegemony and Sol businesses alike."
+	secondary_langs = list(
+		LANGUAGE_UNATHI_SINTA,
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_tersten
 	name = CULTURE_UNATHI_TERSTEN
@@ -51,6 +86,13 @@
 	hegemony, with their primary focus being unity of the clans as well as maintaining relations with the native Tersten people. Still traditional to their \
 	beliefs, sinta on Tersten have integrated well with the planet's inhabitants. Tersten clans are seen by some Moghes clans as traitors - clans that have \
 	abandoned their homeland. Regardless, the clans on Tersten enjoy a peace that could not be achieved on the rough surface of Moghes."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_yeosa
 	name = CULTURE_UNATHI_YEOSA_LITTORAL
@@ -64,7 +106,7 @@
 	clan leagues, city-states, and the Krukzuz. Technology works the same way - just as the well-preserved units of precursor crafts found their way to \
 	the poles and the peaks, off-world and polar-produced flechette pistols and wetsuits became more commonplace in littoral areas as well."
 	economic_power = 0.8
-	name_language = LANGUAGE_UNATHI_YEOSA
+	language = LANGUAGE_UNATHI_YEOSA
 	secondary_langs = list(
 		LANGUAGE_UNATHI_SINTA,
 		LANGUAGE_SIGN,
@@ -80,4 +122,11 @@
 	known as the Abyssals - an ethnic group connected to yeosa proper, yet very different from any race found on land. To their few guests, the Abyssals may appear uncannily secretive, if not strange. Abyssal yeosa keep track of time intently, only travelling through the \
 	waters during certain hours, and sunbathing during others. They follow Aga-Eakhe to the letter, and tend to believe in many a superstition, performing \
 	augury and seeking signs before every major enterprise."
-	
+	language = LANGUAGE_UNATHI_YEOSA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_SINTA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SPACER
+	)


### PR DESCRIPTION
A error means that you do not have your default language set when you select a unathi culture. This fixes that.

:cl:
bugfix: Quick fix to Unathi cultures so proper languages are now assigned based on your culture.
/:cl: