### PR TITLE
RCD oversight fixes

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -69,6 +69,8 @@
 
 #define isspace(A) istype(A, /area/space)
 
+#define isspaceturf(A) istype(A, /turf/space)
+
 #define ispAI(A) istype(A, /mob/living/silicon/pai)
 
 #define isrobot(A) istype(A, /mob/living/silicon/robot)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -268,7 +268,7 @@
 	work_type = /turf/simulated/floor/airless
 
 /decl/hierarchy/rcd_mode/floor_and_walls/base_turf/can_handle_work(var/rcd, var/turf/target)
-	return istype(target) && (isspace(target) || istype(target, get_base_turf_by_area(target)))
+	return istype(target) && (isspaceturf(target) || isopenspace(target) || istype(target, get_base_turf_by_area(target)))
 
 /decl/hierarchy/rcd_mode/floor_and_walls/floor_turf
 	cost = 3
@@ -306,3 +306,28 @@
 
 /decl/hierarchy/rcd_mode/deconstruction/wall/can_handle_work(var/obj/item/weapon/rcd/rcd, var/turf/simulated/wall/target)
 	return ..() && (rcd.canRwall || !target.reinf_material)
+
+/decl/hierarchy/rcd_mode/deconstruction/wall_frame
+	cost = 4
+	delay = 2 SECONDS
+	handles_type = /obj/structure/wall_frame
+
+/decl/hierarchy/rcd_mode/deconstruction/wall_frame/can_handle_work(obj/item/weapon/rcd/rcd, obj/structure/wall_frame/target)
+	. = ..()
+	if (.)
+		var/turf/T = get_turf(target)
+		if ((locate(/obj/structure/window) in T) || (locate(/obj/structure/grille) in T))
+			return FALSE
+
+/decl/hierarchy/rcd_mode/deconstruction/window
+	cost = 4
+	delay = 2 SECONDS
+	handles_type = /obj/structure/window
+
+/decl/hierarchy/rcd_mode/deconstruction/window/can_handle_work(obj/item/weapon/rcd/rcd, obj/structure/window/target)
+	return ..() && (rcd.canRwall || !target.reinf_material)
+
+/decl/hierarchy/rcd_mode/deconstruction/grille
+	cost = 2
+	delay = 1 SECOND
+	handles_type = /obj/structure/grille

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -289,7 +289,7 @@
 			playsound(src, 'sound/items/Welder.ogg', 80, 1)
 			construction_state = 0
 			set_anchored(0)
-	else
+	else if (!istype(W, /obj/item/weapon/rcd))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(W.damtype == BRUTE || W.damtype == BURN)
 			user.do_attack_animation(src)


### PR DESCRIPTION
Allows RCD to dismantle windows, grilles, and low walls, and to build on open space tiles
Closes #29038
Closes #29035

:cl:
tweak: RCDs can now dismantle windows, grilles, and low walls. Low walls can only be dismantled if the accompanying grille and window is already dismantled.
bugfix: RCDs can now build on open space tiles and on space tiles that aren't in `/area/space`
/:cl: