### PR TITLE
Adds more unsimulated tiles

### DIFF
--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -19,3 +19,70 @@
 
 /turf/unsimulated/floor/shuttle_ceiling
 	icon_state = "reinforced"
+
+/turf/unsimulated/floor/steel
+	icon_state = "steel"
+
+/turf/unsimulated/floor/reinforced
+	icon_state = "reinforced"
+
+/turf/unsimulated/floor/freezer
+	icon_state = "freezer"
+
+/turf/unsimulated/floor/grass
+	icon_state = "grass0"
+	
+/turf/unsimulated/floor/plating
+	icon_state = "plating"
+
+/turf/unsimulated/floor/steeldirty
+	icon_state = "steel_dirty"
+
+/turf/unsimulated/floor/showroom
+	icon_state = "showroomfloor"
+
+// Snow turfs
+
+/turf/unsimulated/floor/snow
+	icon = 'icons/turf/snow.dmi'
+	icon_state = "snowwhite"
+
+/turf/unsimulated/floor/snow/permafrost
+	icon_state = "permafrost"
+
+/turf/unsimulated/floor/snow/platingdrift
+	icon_state = "platingdrift"
+
+// Lava Turfs
+	
+/turf/unsimulated/floor/lava
+	icon = 'icons/turf/flooring/lava.dmi'
+	icon_state = "lava"
+
+/turf/unsimulated/floor/lava/cold
+	icon_state = "cold"
+	
+/turf/unsimulated/floor/lava/moving
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "lava"
+
+// Techfloors
+
+/turf/unsimulated/floor/techfloor
+	icon = 'icons/turf/flooring/techfloor.dmi'
+	icon_state = "techfloor_gray"
+
+/turf/unsimulated/floor/techfloor_grid
+	icon_state = "techfloor_techfloor_grid"
+
+// Tiled
+
+/turf/unsimulated/floor/tile
+	icon = 'icons/turf/flooring/tiles.dmi'
+	icon_state = "tiled"
+
+/turf/unsimulated/floor/reinforcedlight
+	icon_state = "reinforced_light"
+
+/turf/unsimulated/floor/steeldirty
+	icon_state = "steel_dirty"


### PR DESCRIPTION
I've run into some issues while mapping certain areas/away sites, originally this was just for lava. It started with just a few turfs, but I decided to add a few others that could be used for areas that use unsimulated tiles.

:cl:
rscadd: Adds more unsimulated tiles, mostly useful for building areas for events without worrying about atmos. Includes some tiles that are sitting unused in the files.
/:cl: