### PR TITLE
Adds Virology icons as props

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1153,6 +1153,7 @@
 #include "code\game\objects\structures\windoor_assembly.dm"
 #include "code\game\objects\structures\window.dm"
 #include "code\game\objects\structures\window_spawner.dm"
+#include "code\game\objects\structures\virologyprops.dm" 
 #include "code\game\objects\structures\crates_lockers\crates.dm"
 #include "code\game\objects\structures\crates_lockers\largecrate.dm"
 #include "code\game\objects\structures\crates_lockers\med_crate.dm"

--- a/code/game/objects/structures/virologyprops.dm
+++ b/code/game/objects/structures/virologyprops.dm
@@ -1,0 +1,139 @@
+/obj/structure/virology
+	name = "Isolator"
+	desc = "A isolator, it appears to be off."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "isolator_off"
+	anchored = TRUE
+
+/obj/structure/virology/iso
+	name = "Isolator"
+	desc = "An isolator, the screen has a series of data streams that you can't quite understand."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "isolator"
+	anchored = TRUE
+
+/obj/structure/virology/iso_on
+	name = "Isolator"
+	desc = "An isolator, there is a sample inserted and the screen has a series of data streams that you can't quite understand."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "isolator_processing"
+	anchored = TRUE
+
+/obj/structure/virology/iso_sample
+	name = "Isolator"
+	desc = "An isolator, there is a sample inserted and the screen has a series of data streams that you can't quite understand."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "isolator_in"
+	anchored = TRUE
+
+/obj/structure/virology/analyser
+	name = "Analyser"
+	desc = "An analyser, there is a sample inserted and the screen has a series of data streams that you can't quite understand."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "analyser_processing"
+	anchored = TRUE
+
+/obj/structure/virology/analyser_off
+	name = "Analyser"
+	desc = "An analyser, it is currently sitting idle."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "analyser"
+	anchored = "1"
+
+/obj/structure/virology/incubator_off
+	name = "Incubator"
+	desc = "An incubator, it is currently idle."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "incubator"
+	anchored = "1"
+
+/obj/structure/virology/incubator_on
+	name = "Incubator"
+	desc = "An incubator, you can see a set of samples inside."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "incubator_on"
+	anchored = "1"
+
+/obj/structure/virology/centrifuge
+	name = "Centrifuge"
+	desc = "A centrifuge, it is currently idle."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "centrifuge"
+	anchored = "1"
+
+/obj/structure/virology/centrifuge_on
+	name = "Centrifuge"
+	desc = "A centrifuge, it is currently processing a sample."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "centrifuge_moving"
+	anchored = "1"
+
+/obj/structure/virology/centrifuge_broken
+	name = "Centrifuge"
+	desc = "A centrifuge, the glass is smashed open."
+	icon = 'icons/obj/virology.dmi'
+	icon_state = "centrifugeb"
+	anchored = "1"
+
+/obj/structure/virology/cryogenics
+	name = "Cryotube"
+	desc = "A cryotube, it is not on."
+	icon = 'icons/obj/cryogenics.dmi'
+	icon_state = "cell-off"
+	anchored = "1"  
+
+/obj/structure/virology/cryogenics_occupied
+	name = "Occupied Cryotube"
+	desc = "A cryotube, a figure floats inside, they do not appear to be conscious."
+	icon = 'icons/obj/cryogenics.dmi'
+	icon_state = "cell-occupied"
+	anchored = "1"
+
+/obj/structure/virology/cryogenics_on
+	name = "Cryotube"
+	desc = "A cryotube, a strange liquid bubbles inside the glass."
+	icon = 'icons/obj/cryogenics.dmi'
+	icon_state = "cell-on"
+	anchored = "1"
+
+/obj/structure/virology/dnaconsole
+	name = "Console"
+	desc = "A console, you're not sure what the information displayed means."
+	icon = 'icons/obj/cryogenic2.dmi'
+	icon_state = "dna_computer"
+	anchored = "1"
+
+/obj/structure/virology/console
+	name = "Console"
+	desc = "A console, the information displayed is far beyond what you can understand."
+	icon = 'icons/obj/cryogenic2.dmi'
+	icon_state = "scannerconsole"
+	anchored = "1"
+
+/obj/structure/virology/console_off
+	name = "Console"
+	desc = "A console, it's not functioning."
+	icon = 'icons/obj/cryogenic2.dmi'
+	icon_state = "c_unpowered"
+	anchored = "1"
+
+/obj/structure/virology/console_broken
+	name = "Console"
+	desc = "A console, the glass is smashed."
+	icon = 'icons/obj/cryogenic2.dmi'
+	icon_state = "broken"
+	anchored = "1"
+
+/obj/structure/virology/scanner
+	name = "Scanner"
+	desc = "Some sort of scanner, you're not sure what it does."
+	icon = 'icons/obj/cryogenic2.dmi'
+	icon_state = "scanner_0"
+	anchored = "1"
+
+/obj/structure/virology/scanner_on
+	name = "Scanner"
+	desc = "Some sort of scanner, it appears there is someone inside as data streams off the console."
+	icon = 'icons/obj/cryogenic2.dmi'
+	icon_state = "scanner_1"
+	anchored = "1"


### PR DESCRIPTION
Originally made for a map I was doing. They're useful props to help decorate areas.

:cl:
rscadd: Adds virology icons as props, includes older icons found in various .dmi
/:cl: 