### PR TITLE
Prevent Airlock Noise Spamming

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1026,6 +1026,8 @@ About the new airlock wires panel:
 		return 1
 
 /obj/machinery/door/airlock/attackby(var/obj/item/C, var/mob/user)
+	user.setClickCooldown(15)
+
 	// Brace is considered installed on the airlock, so interacting with it is protected from electrification.
 	if(brace && (istype(C.GetIdCard(), /obj/item/weapon/card/id/) || istype(C, /obj/item/weapon/crowbar/brace_jack)))
 		return brace.attackby(C, user)


### PR DESCRIPTION
:cl:
tweak: There is now a delay on clicking on an airlock to prevent audio spam.
/:cl:

There's now a 15 decisecond delay on interacting with airlocks via clicking them. This is to prevent obnoxious spam where you click on a bolted door over and over again. It won't effect regular airlock interactions in a noticeable way.