### PR TITLE
Removes and Remaps AI Areas

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1755,6 +1755,17 @@
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
+"fC" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/eva)
 "fE" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -1825,6 +1836,15 @@
 /obj/random/trash,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
+"fX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "fY" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -1879,6 +1899,11 @@
 /obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/tiled/monotile,
 /area/command/pathfinder)
+"gf" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_cycler/engineering/alt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "gg" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8;
@@ -2010,6 +2035,15 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
+"gx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "gy" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -2993,6 +3027,26 @@
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/port)
+"ka" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "eva_pump"
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
+"kc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Suit Cyclers";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "kg" = (
 /obj/effect/floor_decal/corner/mauve/mono,
 /obj/machinery/button/windowtint{
@@ -3189,6 +3243,13 @@
 "kN" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/fourthdeck/aft)
+"kP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "kQ" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -3242,11 +3303,20 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
 "kZ" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "la" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
@@ -3464,6 +3534,28 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"lU" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "eva_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1380;
+	id_tag = "eva_airlock";
+	name = "EVA Airlock Console";
+	pixel_y = 24;
+	req_access = list("ACCESS_EVA");
+	tag_airpump = "eva_pump";
+	tag_chamber_sensor = "eva_sensor";
+	tag_exterior_door = "eva_outer";
+	tag_interior_door = "eva_inner"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "lX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -3499,31 +3591,43 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/commissary)
 "mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/structure/bed/chair,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"mc" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"md" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
+"mc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
+"md" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Storage";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "me" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -3937,48 +4041,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "ng" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"nh" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 1;
-	target_pressure = 200
-	},
-/obj/random/single/cola,
-/obj/structure/table/gamblingtable,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/eva)
 "ni" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass/command{
+	name = "E.V.A. Storage"
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"nj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/eva)
 "nk" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
@@ -3993,10 +4071,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "nm" = (
@@ -4290,69 +4368,41 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "os" = (
-/obj/structure/sign/solgov{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/space,
-/area/space)
-"ot" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/structure/table/gamblingtable,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"ou" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"ov" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/eva)
+"ot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
-"ow" = (
-/obj/machinery/door/firedoor,
+/area/eva)
+"ou" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/eva)
+"ov" = (
+/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/door/airlock/engineering{
-	autoset_access = 0;
-	name = "Docking Maintenance";
-	req_access = list("ACCESS_MAINT")
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "ox" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
@@ -4431,6 +4481,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
+"oK" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "oM" = (
 /obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
@@ -4531,6 +4585,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor/aux)
+"pl" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "po" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4613,7 +4672,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
@@ -4925,89 +4983,55 @@
 /obj/structure/bedsheetbin,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
-"qP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9;
-	icon_state = "warning"
+"qJ" = (
+/obj/structure/sign/warning/airlock{
+	dir = 4;
+	icon_state = "doors"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "nuke_shuttle_dock_pump"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
+/turf/simulated/wall/r_wall/hull,
+/area/eva)
 "qQ" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/rack{
+	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
 	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Center";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "qR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "nuke_shuttle_dock_sensor";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "nuke_shuttle_dock_pump"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"qS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"qT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "nuke_shuttle_dock_pump"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"qU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9;
-	icon_state = "corner_white"
-	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/eva)
+"qT" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/off,
+/obj/item/device/radio/off,
+/obj/item/device/radio/off,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "qV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5344,48 +5368,75 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
 "sk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "eva_inner";
+	locked = 1;
+	name = "EVA Internal Access"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"sl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"sm" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/item/device/radio/beacon,
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"sn" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"so" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "nuke_shuttle_dock_inner";
-	locked = 1;
-	name = "Docking Port Airlock"
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
+"sl" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "eva_airlock";
+	name = "interior access button";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access = list("ACCESS_EVA")
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	icon_state = "map"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
+"sm" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	target_pressure = 200
+	},
+/turf/simulated/floor/tiled,
+/area/eva)
+"sn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
+"so" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/command{
+	name = "E.V.A.";
+	secured_wires = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/area/eva)
 "sp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5393,18 +5444,24 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
 	icon_state = "corner_white"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "sq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
@@ -5414,6 +5471,12 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "sr" = (
@@ -5581,10 +5644,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
-"sE" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
 "sF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6033,71 +6092,94 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
+"tH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
+"tJ" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/machinery/suit_cycler/science,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "tL" = (
 /obj/effect/shuttle_landmark/torch/deck1/aquila,
 /turf/space,
 /area/space)
-"tM" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "nuke_shuttle_dock_outer";
-	locked = 1;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"tN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 1;
-	id_tag = "nuke_shuttle_dock_pump"
-	},
-/obj/structure/sign/double/solgovflag/left{
-	pixel_y = -32
-	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
 "tO" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/sign/double/solgovflag/right{
-	pixel_y = -32
+/obj/structure/table/rack{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"tP" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 1;
-	id_tag = "nuke_shuttle_dock_pump"
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
 	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"tQ" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"tR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 1;
-	id_tag = "nuke_shuttle_dock_pump"
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = -3
 	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
-"tS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
+"tP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/eva)
+"tQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/eva)
+"tR" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
+"tS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/eva)
 "tT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6369,6 +6451,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
+"ut" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "uu" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -6614,6 +6707,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
+"uZ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "vb" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -6644,39 +6752,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
-"vj" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
 "vk" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
-"vl" = (
-/obj/structure/sign/warning/high_voltage{
-	dir = 4;
-	icon_state = "shock"
-	},
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/fore)
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "vm" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6911,6 +6994,12 @@
 "vQ" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/office)
+"vW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/eva)
 "vZ" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 1;
@@ -6997,94 +7086,53 @@
 "wt" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
-"ww" = (
-/obj/effect/shuttle_landmark/merc/dock,
-/turf/space,
-/area/space)
 "wx" = (
-/obj/structure/sign/solgov{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/space,
-/area/space)
-"wy" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	display_name = "Fore Dock";
-	frequency = 1331;
-	id_tag = "nuke_shuttle_dock_airlock";
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"));
-	tag_airpump = "nuke_shuttle_dock_pump";
-	tag_chamber_sensor = "nuke_shuttle_dock_sensor";
-	tag_exterior_door = "nuke_shuttle_dock_outer";
-	tag_interior_door = "nuke_shuttle_dock_inner"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/fore)
-"wz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/bed/chair/padded/blue{
-	dir = 1;
-	icon_state = "chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/fore)
-"wA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/fore)
-"wB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/area/eva)
+"wz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/door/airlock/glass/command{
-	autoset_access = 0;
-	name = "Primary Docking Port Control";
-	req_access = list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW")
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
+/turf/simulated/floor/tiled,
+/area/eva)
+"wA" = (
+/obj/structure/dispenser/oxygen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
+"wB" = (
+/obj/effect/wallframe_spawn/no_grille,
+/turf/simulated/wall/prepainted,
+/area/eva)
 "wC" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 8;
@@ -7093,15 +7141,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "wD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "wE" = (
@@ -7273,6 +7317,16 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/aft)
+"xb" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "eva_outer";
+	locked = 1;
+	name = "EVA External Access"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "xi" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -7395,36 +7449,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
-"xO" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/random_multi/single_item/boombox,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/fore)
 "xP" = (
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/fore)
-"xQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/airlock/glass/command{
+	name = "E.V.A. Suit Storage"
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Primary Docking Port";
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/eva)
 "xR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7783,20 +7815,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"zj" = (
+/turf/simulated/wall/r_wall/hull,
+/area/eva)
 "zk" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "zl" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -8154,6 +8185,23 @@
 /obj/random/single/lighter,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)
+"Am" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "eva_pump"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "At" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -8193,22 +8241,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
 "AE" = (
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "AF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/security/alt,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/eva)
 "AG" = (
 /turf/simulated/wall/prepainted,
 /area/storage/auxillary/port)
@@ -8571,6 +8614,16 @@
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
+"Ci" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Cr" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -8781,6 +8834,17 @@
 "Dc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/foreport)
+"Dd" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/eva)
+"Dk" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "Dq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -8810,6 +8874,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
+"Dx" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/medical/alt/sol,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "DA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8957,6 +9029,19 @@
 	},
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod9/station)
+"Ea" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Em" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 8;
@@ -9197,6 +9282,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
+"Fe" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/suit_storage_unit/security/alt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "Fi" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -9205,6 +9299,34 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
+"Fj" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/item/clothing/head/welding,
+/obj/item/weapon/storage/belt/utility,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/item/weapon/inflatable_dispenser,
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "Fk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -9949,6 +10071,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
+"HS" = (
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "HU" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -10112,6 +10237,15 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
+"Iq" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Ir" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10186,6 +10320,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
+"Iw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Ix" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -10256,6 +10400,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
+"IQ" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "IT" = (
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -10284,6 +10439,18 @@
 "IZ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/laundry)
+"Jh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "Ji" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -10292,6 +10459,20 @@
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/aft)
+"Jn" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "eva_pump"
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "eva_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "Jo" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
@@ -10374,6 +10555,17 @@
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/foreport)
+"JD" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "JG" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donut,
@@ -10627,6 +10819,11 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
+"Kk" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_cycler/medical/alt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "Kl" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
@@ -11062,25 +11259,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
 "LD" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "nuke_shuttle_dock_outer";
-	locked = 1;
-	name = "Docking Port Airlock"
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1331;
-	master_tag = "nuke_shuttle_dock_airlock";
-	name = "exterior access button";
-	pixel_x = -6;
-	pixel_y = -19;
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"))
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "eva_pump"
 	},
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "LG" = (
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
@@ -11163,6 +11352,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"LT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "LU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11234,6 +11431,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
+"Mc" = (
+/obj/structure/sign/warning/docking_area,
+/turf/simulated/wall/r_wall/hull,
+/area/eva)
 "Me" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
@@ -11254,6 +11455,17 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/forestarboard)
+"Mi" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Mk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -11516,6 +11728,11 @@
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fourthdeck/center)
+"MS" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/engineering/alt/sol,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "MT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11792,6 +12009,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fourthdeck/aft)
+"Nz" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/atmos/alt/sol,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "NA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11962,6 +12184,11 @@
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/monotile,
 /area/maintenance/fourthdeck/forestarboard)
+"Od" = (
+/obj/machinery/suit_cycler/mining,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "Oe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/monotile,
@@ -12093,6 +12320,11 @@
 "OB" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
+"OC" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_storage_unit/medical/alt/sol,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "OG" = (
 /obj/structure/railing/mapped,
 /obj/structure/sign/deck/fourth{
@@ -12411,6 +12643,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
+"Pq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Pu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12464,16 +12711,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
-"PD" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "nuke_shuttle_dock_inner";
-	locked = 1;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
 "PE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12838,9 +13075,22 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "QB" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor,
-/area/hallway/primary/fourthdeck/fore)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "eva_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/eva)
 "QC" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -13095,9 +13345,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor/aux)
 "Rp" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/obj/machinery/door/airlock/glass/command{
+	name = "E.V.A. Cycler Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/eva)
 "Rq" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/manual/anomaly_spectroscopy,
@@ -13142,6 +13400,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
+"Rv" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Suit Storage";
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Rw" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8;
@@ -13402,7 +13674,6 @@
 	dir = 8;
 	icon_state = "bordercolorhalf"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13622,13 +13893,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
-"SA" = (
-/obj/structure/sign/warning/airlock{
-	dir = 4;
-	icon_state = "doors"
-	},
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/fore)
 "SC" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -13698,6 +13962,44 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
+"SH" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/rods{
+	amount = 50
+	},
+/obj/item/stack/material/rods{
+	amount = 50
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "EVA";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "SI" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/fourthdeck)
@@ -13868,6 +14170,22 @@
 	},
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
+"SZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass/command{
+	name = "E.V.A. Miscellaneous Suit Storage"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/eva)
 "Ta" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14720,6 +15038,17 @@
 	},
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
+"Vp" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Vq" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/lounge)
@@ -14848,6 +15177,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"VG" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
+"VI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Miscellaneous Suit Storage";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "VJ" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -15029,6 +15373,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
+"Wu" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eva)
 "Wv" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -15733,6 +16083,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
+"Yb" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_cycler/security/alt,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "Yc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Laundry Maintenance"
@@ -15792,13 +16147,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
-"Yq" = (
-/obj/structure/sign/warning/docking_area{
-	dir = 8;
-	icon_state = "securearea"
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/hallway/primary/fourthdeck/fore)
 "Yr" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/steel,
@@ -16291,6 +16639,24 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
+"Zr" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/eva)
+"Zt" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/eva)
 "Zu" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/conveyor_switch/oneway{
@@ -24338,7 +24704,7 @@ aa
 aa
 aa
 aa
-ww
+aa
 aa
 aa
 aa
@@ -24935,23 +25301,23 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zj
+zj
+Mc
+zj
+zj
+zj
+zj
+zj
+xb
+qJ
+zj
+zj
+zj
+zj
+Mc
+zj
+zj
 aa
 aa
 aa
@@ -25137,23 +25503,23 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zj
+zj
+zj
+tJ
+gf
+Od
+Dd
+Am
+kP
+ka
+Dd
+pl
+LT
+JD
+zj
+zj
+zj
 aa
 aa
 aa
@@ -25338,25 +25704,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+zj
+zj
+zj
+Yb
+HS
+HS
 os
-aa
-aa
-aa
-aa
-aa
+Dd
+lU
+oK
+Jn
+Dd
 wx
-aa
-aa
-aa
-aa
-aa
-aa
+Iw
+Ci
+Zr
+zj
+zj
+zj
 aa
 aa
 aa
@@ -25539,27 +25905,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-WZ
+zj
+zj
+zj
+Dd
+Kk
+tH
+kc
+gx
+Dd
 QB
-tM
+oK
 LD
-WZ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dd
+Ea
+VI
+ut
+IQ
+zj
+zj
+zj
+zj
 aa
 aa
 aa
@@ -25740,29 +26106,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-WZ
-WZ
-Yq
-WZ
+zj
+zj
+zj
+zj
+Dd
+Dd
+Dd
+Dd
 Rp
-Rp
-WZ
-qP
+Dd
+Dd
 sk
-tN
-WZ
-Rp
-Rp
-WZ
-Yq
-WZ
-WZ
-aa
-aa
-aa
+Dd
+Dd
+SZ
+Dd
+Dd
+Dd
+Dd
+Dd
+Dd
+zj
+zj
 aa
 aa
 aa
@@ -25942,29 +26308,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-WZ
-WZ
-WZ
-WZ
-WZ
+zj
+zj
+zj
+zj
+Dd
+VG
+Pq
 ng
-ng
-WZ
+fX
+SH
 qQ
 sl
 tO
-WZ
+Fj
+Jh
 ng
-ng
-WZ
-WZ
-WZ
-WZ
-WZ
-aa
-aa
+Dx
+MS
+MS
+Nz
+Dd
+zj
+zj
 aa
 aa
 aa
@@ -26144,29 +26510,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-WZ
-WZ
-WZ
-WZ
+zj
+zj
+zj
+zj
+Dd
+uZ
 mb
-nh
+ng
 ot
-le
+vW
 qR
 sm
 tP
 tS
-wy
-xO
+ot
+ng
 zk
-WZ
-WZ
-WZ
-WZ
-aa
-aa
+Wu
+Wu
+Vp
+Dd
+zj
+zj
 aa
 aa
 aa
@@ -26346,29 +26712,29 @@ aa
 aa
 aa
 aa
-aa
-WZ
-WZ
-WZ
-WZ
+zj
+zj
+zj
+zj
+Dd
 kZ
 mc
 ni
 ou
-le
-qS
-sl
+vW
+qR
+fC
 tQ
-vj
+tS
 wz
 xP
-xP
+Mi
 AE
-WZ
-WZ
-WZ
-WZ
-aa
+Iq
+Rv
+Dd
+zj
+zj
 aa
 aa
 aa
@@ -26548,29 +26914,29 @@ aa
 aa
 aa
 aa
-WZ
-WZ
-WZ
-WZ
-WZ
-kZ
+zj
+zj
+zj
+zj
+Dd
+Zt
 md
-nj
+ng
 ov
-le
+Dk
 qT
 sn
 tR
 vk
 wA
-xQ
-xP
+ng
+OC
 AF
-WZ
-WZ
-WZ
-WZ
-WZ
+AF
+Fe
+Dd
+zj
+zj
 aa
 aa
 aa
@@ -26749,31 +27115,31 @@ aa
 aa
 aa
 aa
-RQ
-RQ
-RQ
-RQ
-RQ
-dg
-le
-le
-le
-ow
-SA
-sE
+aa
+zj
+zj
+zj
+zj
+Dd
+Dd
+Dd
+Dd
+Dd
+ng
+ng
 so
-PD
-vl
+ng
+ng
 wB
-le
-le
-AG
-BK
-BK
-BK
-BK
-BK
-BK
+Dd
+Dd
+Dd
+Dd
+Dd
+Dd
+zj
+zj
+aa
 aa
 aa
 aa
@@ -26950,8 +27316,8 @@ aa
 aa
 aa
 aa
-RQ
-RQ
+aa
+aa
 RQ
 RQ
 RQ
@@ -26962,7 +27328,7 @@ nk
 Se
 ox
 pJ
-qU
+ox
 sp
 tT
 vm
@@ -26975,8 +27341,8 @@ CN
 BK
 BK
 BK
-BK
-BK
+aa
+aa
 aa
 aa
 aa
@@ -27151,9 +27517,9 @@ aa
 aa
 aa
 aa
-RQ
-RQ
-RQ
+aa
+aa
+aa
 RQ
 RQ
 RQ
@@ -27177,9 +27543,9 @@ BM
 BK
 BK
 BK
-BK
-BK
-BK
+aa
+aa
+aa
 aa
 aa
 aa
@@ -27353,8 +27719,8 @@ aa
 aa
 aa
 aa
-RQ
-RQ
+aa
+aa
 RQ
 RQ
 RQ
@@ -27380,8 +27746,8 @@ DL
 BK
 BK
 BK
-BK
-BK
+aa
+aa
 aa
 aa
 aa
@@ -27554,8 +27920,8 @@ aa
 aa
 aa
 aa
-RQ
-RQ
+aa
+aa
 RQ
 RQ
 RQ
@@ -27583,8 +27949,8 @@ EE
 BK
 BK
 BK
-BK
-BK
+aa
+aa
 aa
 aa
 aa
@@ -27756,7 +28122,7 @@ aa
 aa
 aa
 aa
-RQ
+aa
 RQ
 RQ
 RQ
@@ -27786,7 +28152,7 @@ Fl
 BK
 BK
 BK
-BK
+aa
 aa
 aa
 aa

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -2729,6 +2729,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
+"fJ" = (
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/observation)
 "fK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4372,11 +4375,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "iE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload_foyer)
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "iF" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/drinks/cans/speer,
@@ -5752,9 +5753,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"ll" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/ai_monitored/storage/eva)
 "lm" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6039,67 +6037,72 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
 "lV" = (
-/obj/structure/sign/warning/docking_area,
-/turf/simulated/wall/r_wall/hull,
-/area/ai_monitored/storage/eva)
-"lW" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_cycler/security/alt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"lX" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_cycler/medical/alt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"lY" = (
-/turf/simulated/wall/prepainted,
-/area/ai_monitored/storage/eva)
-"lZ" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"ma" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/machinery/light{
+/obj/structure/flora/pottedplant/orientaltree,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
+"lW" = (
+/obj/machinery/vending/hydronutrients/generic,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
+"lX" = (
+/obj/machinery/seed_storage/garden,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
+"lY" = (
+/obj/structure/table/standard,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/hatchet,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/light/spot{
 	dir = 1
 	},
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/weapon/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"mb" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
+/area/crew_quarters/observation)
+"lZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
+/area/crew_quarters/observation)
+"ma" = (
+/obj/structure/closet/crate/hydroponics/beekeeping,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "mc" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
+/area/crew_quarters/observation)
 "md" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -6362,80 +6365,29 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
 "mL" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/machinery/suit_cycler/science,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "mM" = (
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "mN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "mO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"mP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"mQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "mR" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Storage";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "mS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -6506,6 +6458,11 @@
 	pixel_x = 24
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "mX" = (
@@ -6667,6 +6624,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hardstorage)
+"np" = (
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/flora/pottedplant/stoutbush,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "nq" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -6693,6 +6655,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/storage/tools)
+"nw" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "ny" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder,
@@ -6713,6 +6682,10 @@
 "nA" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/hardstorage)
+"nB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "nC" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/mess)
@@ -6749,34 +6722,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
 "nJ" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_cycler/engineering/alt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"nK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Suit Cyclers";
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "nL" = (
-/obj/effect/wallframe_spawn/no_grille,
-/turf/simulated/floor/plating,
-/area/ai_monitored/storage/eva)
-"nN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass/command{
-	name = "E.V.A. Storage"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "nP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6790,6 +6743,10 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
 	icon_state = "corner_white"
+	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck Hallway - Fore Starboard";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
@@ -6911,30 +6868,23 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/thirddeck/forestarboard)
-"nW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/thirddeck/forestarboard)
 "nY" = (
-/obj/structure/closet/hydrant{
-	pixel_y = 32
+/obj/structure/table/gamblingtable,
+/obj/random/coin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/green,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/forestarboard)
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "nZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7144,11 +7094,6 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -7183,39 +7128,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
-"oD" = (
-/obj/machinery/suit_cycler/mining,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"oE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"oF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"oG" = (
-/obj/machinery/door/airlock/glass/command{
-	name = "E.V.A. Cycler Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ai_monitored/storage/eva)
 "oH" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -7223,21 +7135,14 @@
 	},
 /turf/simulated/open,
 /area/maintenance/thirddeck/starboard)
-"oI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "oJ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/spot{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "oL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7250,10 +7155,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
 	icon_state = "corner_white"
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Fore Starboard";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
@@ -7271,8 +7172,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "oO" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_upload)
+/obj/structure/table/gamblingtable,
+/obj/item/weapon/dice/d20,
+/obj/item/weapon/dice/d12,
+/obj/item/weapon/dice/d4,
+/obj/item/weapon/dice/d8,
+/obj/random/drinkbottle,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "oT" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -7678,58 +7585,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
-"pA" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/rods{
-	amount = 50
-	},
-/obj/item/stack/material/rods{
-	amount = 50
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "EVA";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"pB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "pD" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "pE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7753,37 +7613,33 @@
 "pG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
 "pH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+/obj/structure/flora/pottedplant/flower,
+/obj/item/device/radio/intercom/entertainment{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/machinery/computer/robotics,
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "pI" = (
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d3port)
 "pJ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7796,21 +7652,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/thirddeck/foreport)
 "pL" = (
-/obj/machinery/porta_turret{
-	dir = 8
+/obj/machinery/vending/games,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "pM" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_upload_foyer)
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Recreation"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/crew_quarters/recreation)
 "pO" = (
 /turf/simulated/open,
 /area/hallway/primary/thirddeck/fore)
@@ -8020,14 +7875,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "qu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "qv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8052,88 +7901,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "qx" = (
-/turf/simulated/wall/r_wall/hull,
-/area/ai_monitored/storage/eva)
-"qz" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Center";
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/crew_quarters/observation)
+"qC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/observation)
+"qG" = (
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"qA" = (
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"qC" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"qF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
-"qG" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "qH" = (
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "qI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
-"qJ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "qL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8475,17 +8266,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
-"rI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
-"rJ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
 "rK" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -8519,55 +8299,34 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
-"rN" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	target_pressure = 200
+"rP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"rO" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"rP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/observation)
 "rQ" = (
+/obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/command{
-	name = "E.V.A.";
-	secured_wires = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ai_monitored/storage/eva)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/observation)
 "rR" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -8605,135 +8364,60 @@
 "rS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "rT" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "rU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	pixel_x = 24;
-	pixel_y = 32
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload_foyer)
-"rV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
-"rW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
-"rX" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
-"rY" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/hologram/holopad,
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
-"sa" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "sc" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/green/mono,
-/obj/random/accessory,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
-"sd" = (
-/obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
 	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
 "se" = (
-/obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
@@ -8754,6 +8438,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
@@ -9217,19 +8906,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -9356,13 +9034,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
-"tc" = (
-/obj/structure/sign/warning/airlock{
-	dir = 4;
-	icon_state = "doors"
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/ai_monitored/storage/eva)
 "td" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 2
@@ -9385,65 +9056,15 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
-"tg" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"th" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"ti" = (
+"tj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
-"tj" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/weapon/cell/high,
-/obj/item/weapon/cell/high,
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/observation)
 "tl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9451,25 +9072,14 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
-"tm" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
 "tp" = (
-/obj/structure/bed/chair{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - AI Upload";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/green/half{
-	dir = 8;
-	icon_state = "bordercolorhalf"
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "ts" = (
 /obj/structure/cable/green{
@@ -9652,14 +9262,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"tO" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
 "tP" = (
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
@@ -9858,48 +9460,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"us" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/device/multitool,
-/obj/item/clothing/head/welding,
-/obj/item/weapon/storage/belt/utility,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/item/weapon/inflatable_dispenser,
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"ut" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "uv" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "ux" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 4
@@ -9907,16 +9477,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "uz" = (
-/obj/machinery/camera/network/command{
-	c_tag = "AI Upload - Foyer";
-	dir = 1
-	},
-/obj/machinery/computer/modular/preset/aislot/sysadmin{
-	dir = 1;
-	icon_state = "console"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/obj/structure/flora/pottedplant/large,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "uA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
@@ -9928,82 +9491,53 @@
 /turf/simulated/floor/airless,
 /area/command/disperser)
 "uB" = (
-/obj/machinery/camera/network/command{
-	c_tag = "AI Upload - Center";
-	dir = 1
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
-"uC" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aiModule/freeform,
-/obj/item/weapon/aiModule/protectStation,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	name = "Utility Modules"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
-"uD" = (
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/device/radio/intercom/locked/ai_private{
+/obj/machinery/computer/arcade,
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
-	pixel_y = -28
+	icon_state = "spline_fancy"
 	},
-/obj/machinery/light/small{
+/obj/machinery/light,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
+"uC" = (
+/obj/machinery/computer/arcade,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
+"uG" = (
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
-"uF" = (
-/obj/structure/bed/chair{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/green/half{
-	dir = 8;
-	icon_state = "bordercolorhalf"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "uH" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/bed/chair/comfy/black{
+	icon_state = "comfychair_preview";
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/forestarboard)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "uI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
@@ -10217,6 +9751,9 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/office)
+"vt" = (
+/turf/simulated/wall/r_wall/hull,
+/area/crew_quarters/observation)
 "vu" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -10236,94 +9773,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"vx" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
 "vy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"vz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"vA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass/command{
-	name = "E.V.A. Miscellaneous Suit Storage"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ai_monitored/storage/eva)
-"vB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"vC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
+/obj/item/weapon/beach_ball,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "vD" = (
-/obj/structure/dispenser/oxygen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light/spot{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
-"vE" = (
-/obj/effect/wallframe_spawn/no_grille,
-/turf/simulated/wall/prepainted,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "vF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10602,19 +10067,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "wy" = (
-/obj/machinery/computer/upload/ai{
+/obj/machinery/firealarm{
 	dir = 1;
-	icon_state = "computer"
+	pixel_y = -24
 	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "wz" = (
 /obj/machinery/computer/modular/preset/civilian,
 /turf/simulated/floor/carpet/purple,
@@ -10646,42 +10104,6 @@
 "wD" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/center)
-"wE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"wF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"wG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Miscellaneous Suit Storage";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"wH" = (
-/obj/machinery/door/airlock/glass/command{
-	name = "E.V.A. Suit Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ai_monitored/storage/eva)
 "wI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -10708,6 +10130,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
 "wK" = (
@@ -10726,9 +10151,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
 	icon_state = "map-scrubbers"
@@ -10746,22 +10168,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "wN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10798,9 +10216,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10818,6 +10233,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "wR" = (
@@ -10833,6 +10252,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/fore)
+"wS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Observation"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/crew_quarters/observation)
 "wV" = (
 /obj/structure/sign/deck/third{
 	dir = 1;
@@ -11026,38 +10452,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hardstorage)
-"xB" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"xC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"xD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
 "xE" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 4
@@ -11073,22 +10467,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/gym)
-"xG" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"xH" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/medical/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
 "xI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11144,6 +10522,11 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
@@ -11386,15 +10769,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "yh" = (
-/obj/machinery/computer/upload/robot,
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "yk" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Cryogenic Storage - Aft Starboard";
@@ -11453,6 +10834,19 @@
 /obj/structure/bed/chair/pew/left/mahogany,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"yy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/thirddeck/fore)
 "yz" = (
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 5;
@@ -11482,30 +10876,30 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "yF" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	dir = 1;
+	pixel_y = 3
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "yG" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/glasses/pint,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/carafe,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
+"yH" = (
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/observation)
 "yI" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "yL" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -11791,24 +11185,38 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d3port)
 "zz" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/engineering/alt/sol,
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/reagent_dispensers/water_cooler{
+	dir = 1;
+	icon_state = "water_cooler"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
-"zA" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/area/crew_quarters/observation)
 "zB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/security/alt,
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
+/area/crew_quarters/observation)
+"zC" = (
+/obj/item/device/radio/intercom/entertainment{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "zE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11958,40 +11366,6 @@
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d3starboard)
-"Am" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"An" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Suit Storage";
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
-"Ao" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/suit_storage_unit/security/alt,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
 "Ap" = (
 /obj/effect/floor_decal/spline/plain/red,
 /obj/structure/window/reinforced,
@@ -12473,6 +11847,10 @@
 /obj/structure/table/woodentable_reinforced/mahogany,
 /turf/simulated/floor/wood/maple,
 /area/chapel/main)
+"BQ" = (
+/obj/structure/bed/chair/wood/walnut,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "BR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -12748,6 +12126,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
+"CF" = (
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/recreation)
 "CH" = (
 /turf/simulated/floor/tiled/monotile,
 /area/maintenance/thirddeck/starboard)
@@ -13076,24 +12457,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "DE" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/bed/chair/armchair/brown,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "DF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/wall/prepainted,
 /area/command/disperser)
+"DH" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/recreation)
 "DI" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG,
@@ -13650,6 +13026,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
+"EU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "EV" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -13775,6 +13160,11 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftport)
+"Fn" = (
+/obj/structure/table/woodentable/walnut,
+/obj/structure/flora/pottedplant/deskleaf,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "Fo" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -13963,6 +13353,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftport)
+"FQ" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "FR" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8;
@@ -14056,23 +13450,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/habcheck)
-"Gb" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
 "Ge" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -14904,19 +14281,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/disperser)
-"Iv" = (
-/obj/machinery/turretid/stun{
-	control_area = "\improper AI Upload Chamber";
-	name = "AI Upload turret control";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
 "Iw" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/ship_munition/disperser_charge/explosive,
@@ -15571,15 +14935,19 @@
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "JM" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "JN" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -16162,6 +15530,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
+"KZ" = (
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "La" = (
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d3port)
@@ -16590,6 +15966,9 @@
 /obj/effect/shuttle_landmark/ert/deck3,
 /turf/space,
 /area/space)
+"Md" = (
+/turf/simulated/floor/tiled/monotile,
+/area/hydroponics)
 "Mf" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -16659,16 +16038,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
-"Mo" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
 "Mp" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -16709,20 +16078,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "My" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aiModule/reset,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/media/jukebox/old,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/southright{
-	name = "AI Maintenance"
-	},
-/obj/item/weapon/aiModule/solgov,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "Mz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green{
@@ -16731,6 +16093,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
+"MB" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/thirddeck/fore)
 "MC" = (
 /obj/structure/table/marble,
 /obj/machinery/cooker/candy,
@@ -16805,6 +16178,15 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/storage/tools)
+"MP" = (
+/obj/structure/table/woodentable,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Recreation Room"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "MR" = (
 /obj/machinery/air_sensor{
 	id_tag = "d3po2_sensor"
@@ -16943,11 +16325,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/center)
-"No" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_storage_unit/atmos/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
 "Nq" = (
 /obj/structure/closet/crate/trashcart,
 /obj/random/junk,
@@ -17213,28 +16590,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/office)
-"Oh" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
-	id_tag = "eva_airlock";
-	name = "EVA Airlock Console";
-	pixel_y = 24;
-	req_access = list("ACCESS_EVA");
-	tag_airpump = "eva_pump";
-	tag_chamber_sensor = "eva_sensor";
-	tag_exterior_door = "eva_outer";
-	tag_interior_door = "eva_inner"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
 "Oj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/steel,
@@ -17561,23 +16916,6 @@
 /obj/structure/closet/secure_closet/chaplain,
 /turf/simulated/floor/carpet/purple,
 /area/chapel/office)
-"Ph" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
 "Pj" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -17727,6 +17065,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/gym)
+"PH" = (
+/obj/effect/floor_decal/corner/green/half,
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "PI" = (
 /obj/structure/closet/chefcloset_torch,
 /turf/simulated/floor/tiled/freezer,
@@ -17871,13 +17215,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
-"Qh" = (
-/obj/structure/sign/solgov{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/space,
-/area/space)
 "Qi" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 1
@@ -18098,6 +17435,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
+"QQ" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/crew_quarters/observation)
+"QR" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Recreation"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/crew_quarters/recreation)
 "QS" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -18174,10 +17529,6 @@
 "Rf" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/gym)
-"Rh" = (
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "Ri" = (
 /obj/structure/sign/warning/fire{
 	dir = 2
@@ -18367,6 +17718,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
+"RP" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Observation"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/crew_quarters/observation)
 "RQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18408,15 +17766,6 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
-"RU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
 "RV" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor,
@@ -18450,21 +17799,14 @@
 /turf/simulated/floor/reinforced/airless,
 /area/thruster/d3starboard)
 "Sh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "eva_airlock";
-	name = "exterior access button";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access = list("ACCESS_EVA")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "Si" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/door/airlock/external,
@@ -18658,6 +18000,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/thirddeck/aftport)
+"SE" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/hallway/primary/thirddeck/fore)
 "SH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18852,15 +18199,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "Th" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "eva_outer";
-	locked = 1;
-	name = "EVA External Access"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/observation)
 "Tk" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -18901,17 +18247,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
-"Tr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "Ts" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -19148,27 +18483,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "Uc" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aiModule/asimov,
-/obj/item/weapon/aiModule/paladin,
-/obj/item/weapon/aiModule/robocop,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 2;
-	icon_state = "right";
-	name = "Core Modules"
-	},
-/obj/item/weapon/aiModule/solgov_aggressive,
-/obj/item/weapon/aiModule/nanotrasen,
-/obj/item/weapon/aiModule/freeformcore,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "Ud" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
@@ -19196,19 +18516,15 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "Uh" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "eva_inner";
-	locked = 1;
-	name = "EVA Internal Access"
+/obj/structure/fountain/mundane,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/observation)
 "Ui" = (
 /obj/machinery/meter/turf,
 /turf/simulated/floor/airless,
@@ -19339,6 +18655,19 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
+"Uy" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/thirddeck/forestarboard)
 "UA" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -19401,16 +18730,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "UH" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
+/obj/machinery/computer/modular/preset/civilian{
 	dir = 1;
-	pixel_y = -28
+	icon_state = "console"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "UI" = (
 /obj/structure/table/steel,
 /obj/random/tech_supply,
@@ -19418,9 +18752,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/foreport)
 "UJ" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/thirddeck/forestarboard)
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "UK" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -19460,6 +18796,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
+"UM" = (
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "UN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/dark,
@@ -19603,24 +18946,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
-"Vh" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "eva_airlock";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = 24;
-	req_access = list("ACCESS_EVA")
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/ai_monitored/storage/eva)
 "Vi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19697,6 +19022,19 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/thirddeck/port)
+"Vt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/device/radio/intercom/entertainment{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "Vv" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19993,14 +19331,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
-"Wn" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/medical/alt/sol,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/ai_monitored/storage/eva)
 "Wo" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -20054,6 +19384,9 @@
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3port)
+"Ww" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/crew_quarters/observation)
 "Wx" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -20073,15 +19406,11 @@
 /turf/simulated/floor/reinforced/airless,
 /area/thruster/d3port)
 "Wz" = (
-/obj/machinery/porta_turret{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "WB" = (
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/gym)
@@ -20324,35 +19653,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/chamber)
 "Xg" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aiModule/oxygen,
-/obj/item/weapon/aiModule/oneHuman,
-/obj/item/weapon/aiModule/antimov,
-/obj/item/weapon/aiModule/teleporterOffline,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window{
-	base_state = "left";
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
-	icon_state = "left";
-	name = "High-Risk Modules"
+	icon_state = "spline_fancy"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/item/weapon/aiModule/quarantine,
-/obj/item/weapon/aiModule/purge,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload)
-"Xh" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "eva_pump"
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "Xi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/camera/network/command{
@@ -20406,6 +19715,10 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
+"Xq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "Xr" = (
 /obj/machinery/pointdefense{
 	id_tag = null;
@@ -20695,20 +20008,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"Yh" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "eva_pump"
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "eva_sensor";
-	pixel_x = 0;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
 "Yj" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -20747,6 +20046,9 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/lino,
 /area/crew_quarters/office)
+"Yr" = (
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "Ys" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -20755,23 +20057,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
 "Yt" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload Access"
-	},
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/plating,
+/area/crew_quarters/recreation)
 "Yv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -20785,19 +20079,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
-"Yz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
 "YA" = (
 /obj/structure/lattice,
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d3port)
+"YB" = (
+/obj/structure/bed/chair/wood/walnut{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "YC" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/techfloor,
@@ -20880,9 +20171,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "YO" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "YP" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -21013,18 +20308,6 @@
 /obj/random/torchcloset,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/aftstarboard)
-"Zh" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "eva_pump"
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ai_monitored/storage/eva)
 "Zi" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21061,12 +20344,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics)
 "Zn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/effect/floor_decal/corner/green/half,
+/obj/machinery/vending/fitness{
+	dir = 1;
+	icon_state = "fitness"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "Zo" = (
 /obj/structure/sign/directions/engineering{
 	dir = 1;
@@ -21100,12 +20384,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "Zt" = (
-/obj/machinery/alarm{
+/obj/machinery/computer/modular/preset/civilian{
 	dir = 1;
-	pixel_y = -25
+	icon_state = "console"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_upload_foyer)
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/recreation)
 "Zv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21296,6 +20588,10 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/reinforced/airless,
 /area/thruster/d3starboard)
+"ZU" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "ZV" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
@@ -21305,6 +20601,15 @@
 /obj/item/weapon/spirit_board,
 /turf/simulated/floor/wood/maple,
 /area/chapel/main)
+"ZX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 "ZY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -21316,6 +20621,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/gym)
+"ZZ" = (
+/obj/machinery/beehive,
+/turf/simulated/floor/grass,
+/area/crew_quarters/observation)
 
 (1,1,1) = {"
 aa
@@ -29091,7 +28400,7 @@ aa
 aa
 aa
 aa
-Qh
+aa
 aa
 aa
 aa
@@ -29291,11 +28600,11 @@ qx
 qx
 qx
 qx
+vt
 qx
 qx
-Rh
 qx
-qx
+vt
 qx
 qx
 qx
@@ -29490,17 +28799,17 @@ aa
 aa
 qx
 qx
-qx
-qx
-qx
-qx
-qx
+BQ
+Fn
+YB
+nw
+Xq
 Sh
-qx
-qx
-qx
-qx
-qx
+nB
+Vt
+BQ
+Fn
+YB
 qx
 qx
 aa
@@ -29688,25 +28997,25 @@ ZN
 ZN
 ZN
 ZN
-ZN
-ZN
+aa
+aa
 qx
 lV
-qx
-qx
-qx
-qx
-qx
+Yr
+ZU
+mL
+FQ
+fJ
 Th
-tc
+fJ
+FQ
+Yr
+Yr
+Yr
+np
 qx
-qx
-qx
-qx
-lV
-qx
-qx
-qx
+aa
+aa
 BV
 BV
 BV
@@ -29892,23 +29201,23 @@ ZN
 ZN
 ZN
 ZN
-qx
-qx
+vt
+UM
 mL
 nJ
-oD
-lY
-Gb
-rI
-Xh
-lY
-vx
-wE
-xB
-qx
-qx
-qx
-qx
+nJ
+mN
+Yr
+Th
+Yr
+mL
+Yr
+mN
+Yr
+KZ
+vt
+BV
+BV
 BV
 BV
 BV
@@ -30094,23 +29403,23 @@ hQ
 ZN
 ZN
 ZN
-qx
+Ww
 lW
 mM
-mM
-oE
-lY
-Oh
-rJ
-Yh
-lY
+ZZ
+nJ
+ZU
+Yr
+Th
+Yr
+Yr
 vy
-wF
-xC
+Yr
+Yr
 yF
-qx
-qx
-qx
+yH
+BV
+BV
 BV
 zl
 BX
@@ -30296,23 +29605,23 @@ jo
 Xi
 aM
 aM
-ll
+Ww
 lX
 mN
-nK
-oF
-lY
-Ph
-rJ
-Zh
-lY
-vz
-wG
-xD
+nJ
+nJ
+mN
+fJ
+Th
+fJ
+Yr
+Yr
+Yr
+mN
 yG
-qx
-qx
-qx
+yH
+BV
+BV
 BW
 BX
 ot
@@ -30498,23 +29807,23 @@ hS
 Nt
 jx
 ku
-ll
+Ww
 lY
-lY
-lY
-oG
-lY
-lY
+ZU
+mL
+mO
+mL
+fJ
 Uh
-lY
-lY
-vA
-lY
-lY
-lY
-lY
-lY
-lY
+fJ
+Yr
+ZU
+Yr
+Yr
+PH
+yH
+zS
+zS
 zS
 NL
 zS
@@ -30700,24 +30009,24 @@ hT
 OM
 jy
 kv
-ll
+Ww
 lZ
 mO
-nL
-RU
-pA
-qz
-Vh
-tg
-us
-vB
-nL
-Wn
+nJ
+nJ
+mM
+fJ
+Th
+fJ
+Yr
+Yr
+Yr
+Yr
 zz
-zz
-No
-lY
+yH
 SX
+BX
+BX
 BX
 LA
 LA
@@ -30902,24 +30211,24 @@ hU
 OM
 jz
 kw
-ll
+Ww
 ma
-mP
-nL
-Yz
-pB
-qA
-rN
-th
-ut
-Yz
-nL
-Mo
+Yr
+ZZ
+nJ
+ZU
+Yr
+Th
+Yr
+ZU
+Yr
+mL
+Yr
 yI
-yI
-Am
-lY
+yH
 Yc
+BX
+BX
 LF
 JN
 BX
@@ -31104,24 +30413,24 @@ hV
 fk
 jA
 kx
-ll
-mb
-mQ
-nN
-oI
-pB
-qA
-rO
-ti
-ut
-vC
-wH
-xG
+Ww
+ma
+mN
+nJ
+nJ
+mL
+Yr
+Th
+Yr
+Yr
+Yr
+Yr
+Yr
 Zn
-zA
-An
-lY
+yH
 Kd
+BX
+BX
 Kd
 BX
 Yd
@@ -31306,7 +30615,7 @@ hW
 iJ
 jB
 ky
-ll
+Ww
 mc
 mR
 nL
@@ -31317,13 +30626,13 @@ rP
 tj
 uv
 vD
-nL
-xH
+ZX
+ZX
 zB
-zB
-Ao
-lY
+yH
 JN
+BX
+BX
 BX
 LF
 Yd
@@ -31508,23 +30817,23 @@ hX
 iK
 jC
 kz
-ll
-ll
-lY
-lY
-lY
-nL
-nL
+Ww
+Ww
+yH
+yH
+yH
+QQ
+wS
 rQ
-nL
-nL
-vE
-lY
-lY
-lY
-lY
-lY
-lY
+RP
+QQ
+yH
+yH
+yH
+yH
+yH
+zS
+zS
 zS
 zS
 NL
@@ -31918,10 +31227,10 @@ mT
 nQ
 oM
 pG
-qF
+tl
 rS
-Tr
-pG
+tl
+yy
 vG
 wI
 xJ
@@ -32118,13 +31427,13 @@ lo
 ep
 mU
 nR
-pM
-pM
+CF
+CF
 pM
 Yt
 pM
-pM
-pM
+CF
+CF
 wJ
 pq
 mj
@@ -32320,13 +31629,13 @@ ep
 ep
 mV
 nS
-pM
+CF
 pH
 qG
 rT
 qG
 uz
-pM
+CF
 Cb
 Vb
 yN
@@ -32522,13 +31831,13 @@ lp
 cG
 mj
 nT
-pM
+CF
 DE
 qu
 sL
 iE
 Zt
-pM
+CF
 wL
 xM
 yP
@@ -32724,13 +32033,13 @@ Mu
 ff
 bs
 nU
-pM
+CF
 JM
 YO
 rU
-Iv
+iE
 UH
-pM
+CF
 wM
 xN
 yN
@@ -32924,15 +32233,15 @@ dv
 dv
 dv
 cG
-bs
+Uy
 nU
-oO
-oO
-oO
-rX
-oO
-oO
-oO
+CF
+MP
+qu
+qu
+iE
+Zt
+CF
 wN
 IQ
 yN
@@ -33128,13 +32437,13 @@ dv
 me
 mW
 nV
-oO
+CF
 pL
-qJ
-rW
-tm
-uD
-oO
+qu
+qu
+iE
+Zt
+CF
 wO
 Uo
 yN
@@ -33328,15 +32637,15 @@ jI
 kE
 lq
 mf
-cG
-nW
-oO
+CF
+CF
+CF
 My
-qH
-rV
-qH
+qu
+qu
+qu
 uC
-oO
+CF
 wP
 xP
 yO
@@ -33530,15 +32839,15 @@ jJ
 kF
 lr
 mg
-cG
+CF
 uH
-oO
+uH
 pJ
 qI
-rY
+qI
 qH
 uB
-oO
+CF
 wQ
 xQ
 yN
@@ -33732,15 +33041,15 @@ jI
 kG
 lq
 mh
-cG
+CF
 nY
 oO
 Uc
-qH
-qH
-qH
+qu
+qu
+EU
 Xg
-oO
+CF
 wR
 xR
 ez
@@ -33934,15 +33243,15 @@ jK
 kH
 dv
 cK
-cG
+CF
 UJ
-oO
+zC
 yh
 Wz
-sa
 Wz
+uG
 wy
-oO
+CF
 WD
 XX
 Bm
@@ -34136,15 +33445,15 @@ dv
 dv
 dv
 cK
-mX
-mX
-oO
-oO
-oO
-oO
-oO
-oO
-oO
+DH
+DH
+DH
+DH
+DH
+CF
+QR
+CF
+CF
 wR
 xR
 Bm
@@ -34342,10 +33651,10 @@ Zo
 oa
 oT
 pO
-mj
+SE
 sc
 tp
-uF
+VU
 ob
 qL
 xT
@@ -34544,10 +33853,10 @@ MD
 VU
 hK
 pO
-mj
-sd
+SE
+sc
+tp
 VU
-tO
 QJ
 sN
 ip
@@ -34746,10 +34055,10 @@ mY
 oc
 oU
 pP
-mj
+mX
 se
+tp
 VU
-tO
 VU
 fC
 iI
@@ -34950,7 +34259,7 @@ oV
 mZ
 mZ
 sf
-tl
+MB
 uI
 tl
 gF
@@ -39173,7 +38482,7 @@ LP
 pE
 Um
 vZ
-in
+Md
 wn
 Pn
 bA
@@ -39375,7 +38684,7 @@ CS
 be
 bC
 Oy
-in
+Md
 wn
 Pn
 bA

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -24471,6 +24471,14 @@
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
+"oor" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/computer/upload/ai{
+	dir = 8;
+	icon_state = "computer"
+	},
+/turf/simulated/floor/blackgrid,
+/area/security/nuke_storage)
 "oox" = (
 /obj/effect/floor_decal/corner/research,
 /obj/machinery/firealarm{
@@ -30154,6 +30162,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"vES" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/machinery/computer/upload/robot{
+	dir = 8
+	},
+/turf/simulated/floor/blackgrid,
+/area/security/nuke_storage)
 "vFa" = (
 /obj/structure/table/rack,
 /obj/item/weapon/shield/riot,
@@ -43315,11 +43333,11 @@ mkb
 axR
 axR
 axR
-axR
+vES
 axR
 aDL
 axR
-axR
+oor
 axR
 axR
 axR

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2014,9 +2014,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"dm" = (
-/turf/simulated/wall/r_wall/hull,
-/area/turret_protected/ai_foyer)
 "dn" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
@@ -2125,80 +2122,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
-"dx" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/airless,
-/area/space)
-"dy" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
-"dz" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
-"dA" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
-"dB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
-"dC" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/solar/bridge)
-"dD" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "dE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2229,6 +2152,9 @@
 	dir = 2;
 	health = 1e+007
 	},
+/obj/item/weapon/aiModule/solgov,
+/obj/item/weapon/aiModule/reset,
+/obj/item/weapon/aiModule/purge,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "dG" = (
@@ -2425,15 +2351,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"ea" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "eb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2485,22 +2402,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"eh" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
-/area/space)
-"ei" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_outer_chamber)
-"ej" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/hull,
-/area/turret_protected/ai_outer_chamber)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3131,15 +3032,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"fi" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "fj" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/reinforced/airless,
@@ -3200,30 +3092,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"fq" = (
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
-"fr" = (
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
-"fs" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
-"ft" = (
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
 "fu" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -3804,19 +3672,6 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
-"gt" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_foyer)
-"gu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
 "gv" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -3945,22 +3800,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
-"gW" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "bridge_eva_outer";
-	locked = 1;
-	name = "Bridge EVA External Access"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
 "gX" = (
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/hull,
@@ -4005,34 +3844,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/aquila/cockpit)
-"hd" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_foyer)
-"he" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"hf" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"hg" = (
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"hh" = (
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "hi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack{
@@ -4163,11 +3974,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "hK" = (
@@ -4230,58 +4036,6 @@
 /obj/structure/bed/chair/shuttle/blue,
 /turf/simulated/floor/tiled/dark,
 /area/aquila/mess)
-"hP" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Fore Starboard Access";
-	dir = 4
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"hQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"hR" = (
-/obj/machinery/ai_slipper,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"hS" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Aft Starboard";
-	dir = 8
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "hV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/sol{
@@ -4545,21 +4299,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/xo)
-"iC" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"iD" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai)
-"iE" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai)
 "iI" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -4791,61 +4530,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
-"jm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
-"jn" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "ai_core_airlock";
-	name = "exterior access button";
-	pixel_x = -24;
-	pixel_y = 0;
-	req_access = list("ACCESS_AI_UPLOAD")
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"jo" = (
-/obj/machinery/door/airlock/highsecurity{
-	icon_state = "closed";
-	locked = 1;
-	name = "AI Core Access"
-	},
-/turf/simulated/floor/tiled/dark/airless,
-/area/turret_protected/ai)
-"jp" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/computer/modular/preset/medical,
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"jq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/computer/modular/preset/cardslot/command,
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Starboard"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"jr" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/computer/modular/preset/security,
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"js" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "jw" = (
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
@@ -5055,11 +4739,6 @@
 	locked = 1;
 	name = "Bridge EVA Internal Access"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "kb" = (
@@ -5169,80 +4848,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/passenger)
-"kj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_foyer)
-"kk" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "ai_core_outer";
-	locked = 1;
-	name = "AI Core Internal Access"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"kl" = (
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"km" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"kn" = (
-/obj/machinery/flasher{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"ko" = (
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"kp" = (
-/obj/machinery/flasher{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"kq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"kr" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Outer Ring Access"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
 "kv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5398,11 +5003,6 @@
 /area/hallway/primary/bridge/aft)
 "kS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
@@ -5475,195 +5075,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
-"kY" = (
-/obj/machinery/teleport/hub,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/turret_protected/ai_foyer)
-"kZ" = (
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/power/apc/super/critical{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_foyer)
-"la" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/sign/warning/lethal_turrets{
-	pixel_y = 32
-	},
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/fishbowl,
-/obj/item/weapon/tank/oxygen,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_foyer)
-"lb" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_foyer)
-"lc" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"ld" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
-	id_tag = "ai_core_airlock";
-	name = "AI Core Airlock Console";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access = list("ACCESS_AI_UPLOAD");
-	tag_airpump = "ai_core_pump";
-	tag_chamber_sensor = "ai_core_sensor";
-	tag_exterior_door = "ai_core_outer";
-	tag_interior_door = "ai_core_inner"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
-	dir = 2;
-	id_tag = "ai_core_pump"
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"le" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"lf" = (
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/super/critical{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"lg" = (
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - AI Subgrid";
-	name_tag = "AI Subgrid"
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"lh" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai)
-"li" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"lj" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
-"lk" = (
-/obj/structure/sign/warning/lethal_turrets,
-/turf/simulated/wall/r_wall/hull,
-/area/turret_protected/ai_outer_chamber)
 "lm" = (
 /obj/machinery/hologram/holopad/longrange,
 /obj/effect/landmark{
@@ -5884,11 +5295,6 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -6051,259 +5457,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"md" = (
-/obj/machinery/teleport/station,
-/obj/structure/sign/kiddieplaque{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/turret_protected/ai_foyer)
-"me" = (
-/obj/machinery/bluespace_beacon,
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 6;
-	icon_state = "intact"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_foyer)
-"mf" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 4;
-	target_pressure = 200
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "ai_core_airlock";
-	name = "interior access button";
-	pixel_x = 24;
-	pixel_y = -24;
-	req_access = list("ACCESS_AI_UPLOAD")
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_foyer)
-"mg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "ai_core_inner";
-	locked = 1;
-	name = "AI Internal Access"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"mh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"mi" = (
-/obj/machinery/ai_slipper,
-/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	dir = 4;
-	icon_state = "map"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"mj" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai)
-"mk" = (
-/obj/machinery/ai_slipper,
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Fore";
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"ml" = (
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the AI core maintenance door.";
-	id_tag = "AICore";
-	name = "AI Core Shutter Control";
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/obj/machinery/flasher{
-	pixel_x = 24;
-	pixel_y = 38
-	},
-/obj/machinery/turretid/stun{
-	check_synth = 1;
-	name = "AI Chamber turret control";
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	frequency = 1475;
-	pixel_y = -22
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/item/device/radio/intercom{
-	frequency = 1485;
-	pixel_y = 22
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/greengrid,
-/area/turret_protected/ai)
-"mm" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid/airless,
-/area/turret_protected/ai)
-"mn" = (
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid/airless,
-/area/turret_protected/ai)
-"mo" = (
-/obj/machinery/ai_slipper,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"mp" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/power/smes/buildable{
-	charge = 5e+006;
-	input_attempt = 1;
-	input_level = 125000;
-	output_attempt = 1;
-	output_level = 100000
-	},
-/obj/structure/cable/cyan,
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Aft";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"mq" = (
-/obj/machinery/ai_slipper,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"ms" = (
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Auxiliary Access";
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	pixel_y = 22
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
-"mt" = (
-/obj/machinery/ai_slipper,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
-"mu" = (
-/obj/machinery/power/apc/super/critical{
-	dir = 1;
-	is_critical = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/machinery/turretid/stun{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
-"mv" = (
-/obj/machinery/door/airlock/vault/bolted{
-	name = "AI Core External Access"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
-"mw" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "mx" = (
 /obj/effect/paint/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -6723,177 +5876,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"ns" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
-/area/space)
-"nt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/turret_protected/ai_outer_chamber)
-"nu" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/teleporter{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/turret_protected/ai_foyer)
-"nv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai_foyer)
-"nw" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Entry";
-	dir = 1
-	},
-/obj/machinery/turretid/stun{
-	check_synth = 1;
-	name = "AI Entry Chamber turret control";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/turret_protected/ai_foyer)
-"nx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_foyer)
-"ny" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/porta_turret{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1379;
-	id_tag = "ai_core_sensor";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"nz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
-	dir = 1;
-	id_tag = "ai_core_pump"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"nA" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"nB" = (
-/obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"nC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai)
-"nD" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "nE" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1;
@@ -7154,51 +6136,6 @@
 "on" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/aux_eva)
-"oq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue,
-/turf/simulated/wall/r_wall/prepainted,
-/area/turret_protected/ai_foyer)
-"or" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "ai_core_outer";
-	locked = 1;
-	name = "AI Core Internal Access"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_foyer)
-"os" = (
-/obj/machinery/flasher{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"ot" = (
-/obj/machinery/flasher{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"ou" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "ox" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -7474,41 +6411,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"pm" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
-"pn" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 1;
-	icon_state = "console"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"po" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Port";
-	dir = 1
-	},
-/obj/machinery/computer/modular/preset/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
-"pp" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/computer/modular/preset/aislot/research{
-	dir = 1;
-	icon_state = "console"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turret_protected/ai)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -8067,59 +6969,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"qJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Fore Port Access";
-	dir = 4
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"qK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"qL" = (
-/obj/machinery/ai_slipper,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"qM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera/all/command{
-	c_tag = "AI Core - Aft Port";
-	dir = 8
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "qO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/storage)
@@ -8455,25 +7304,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"rF" = (
-/obj/machinery/light,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"rG" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
-"rH" = (
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_foyer)
 "rI" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8;
@@ -8760,24 +7590,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"sv" = (
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
-"sw" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/item/device/radio/intercom/locked/ai_private{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
 "sx" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -9301,12 +8113,6 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/white/monotile,
 /area/aquila/medical)
-"tP" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/turret_protected/ai_outer_chamber)
 "tR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -13954,23 +12760,6 @@
 /obj/item/weapon/storage/medical_lolli_jar,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"Kg" = (
-/obj/machinery/door/airlock/vault/bolted{
-	name = "AI Core Backup Access"
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "AICore";
-	name = "AI Core Security Shutters"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/turret_protected/ai_outer_chamber)
 "Kh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14018,6 +12807,7 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
+/obj/item/weapon/aiModule/freeform,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
 "Ks" = (
@@ -15613,9 +14403,6 @@
 /obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Rx" = (
-/turf/simulated/wall/r_wall/hull,
-/area/turret_protected/ai_outer_chamber)
 "Rz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -33865,10 +32652,10 @@ cN
 bD
 bD
 gz
-dx
-ea
-ea
-gW
+ad
+ad
+ad
+gV
 hJ
 hJ
 hJ
@@ -34067,7 +32854,7 @@ bD
 bD
 bD
 ad
-dy
+ad
 Oc
 ad
 gX
@@ -34269,7 +33056,7 @@ bD
 bD
 ad
 ad
-dy
+ad
 ad
 DN
 DN
@@ -34471,7 +33258,7 @@ cO
 ad
 ad
 ad
-dy
+ad
 ad
 DN
 DN
@@ -34673,7 +33460,7 @@ cP
 ad
 ad
 ad
-dy
+ad
 ad
 DN
 DN
@@ -34875,7 +33662,7 @@ cP
 ad
 ad
 ad
-dy
+ad
 ad
 ad
 fj
@@ -35077,7 +33864,7 @@ cP
 ad
 ad
 ad
-dy
+ad
 ad
 ad
 gY
@@ -35276,10 +34063,10 @@ ah
 av
 aI
 cP
-dx
-ea
-ea
-fi
+ad
+ad
+ad
+ad
 ad
 ad
 gY
@@ -35478,7 +34265,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 ad
@@ -35680,7 +34467,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 fj
@@ -35882,7 +34669,7 @@ ah
 av
 aI
 cP
-dz
+fj
 eb
 eb
 fk
@@ -36084,7 +34871,7 @@ ah
 av
 aI
 cP
-dA
+gY
 ec
 SA
 SA
@@ -36286,7 +35073,7 @@ ah
 av
 aI
 cP
-dA
+gY
 Ib
 eH
 fm
@@ -36488,7 +35275,7 @@ ah
 av
 aI
 cP
-dA
+gY
 Ib
 eI
 fn
@@ -36690,7 +35477,7 @@ ah
 av
 aI
 cP
-dA
+gY
 Ib
 eJ
 fm
@@ -36892,7 +35679,7 @@ ah
 av
 aI
 cP
-dA
+gY
 ec
 SA
 SA
@@ -37094,7 +35881,7 @@ ah
 av
 aI
 cP
-dB
+fp
 eg
 eg
 nr
@@ -37296,7 +36083,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 fp
@@ -37498,7 +36285,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 ad
@@ -37700,7 +36487,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 ad
@@ -37902,7 +36689,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 ad
@@ -38104,7 +36891,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 ad
@@ -38306,7 +37093,7 @@ ah
 av
 aI
 cP
-dy
+ad
 ad
 ad
 ad
@@ -38508,7 +37295,7 @@ ah
 av
 aI
 cQ
-dC
+aH
 aH
 aH
 aH
@@ -38710,7 +37497,7 @@ ah
 av
 aI
 ad
-dy
+ad
 ad
 ad
 ad
@@ -38912,20 +37699,20 @@ ah
 av
 aI
 ad
-dD
-eh
-eh
-eh
-eh
-eh
-eh
-eh
-eh
-eh
-eh
-eh
-eh
-ns
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -39124,11 +37911,11 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-ej
-nt
-Rx
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -39321,21 +38108,21 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-nt
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -39522,23 +38309,23 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-dm
-kY
-md
-nu
-dm
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -39723,25 +38510,25 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-fr
-fr
-fr
-jm
-kj
-kZ
-me
-nv
-oq
-pm
-fr
-fr
-fr
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -39924,27 +38711,27 @@ aI
 ad
 ad
 ad
-Rx
-Rx
-Rx
-ft
-fr
-ei
-ei
-ei
-gt
-la
-mf
-nw
-gt
-ei
-ei
-ei
-fr
-sv
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -40125,29 +38912,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-Rx
-fr
-fr
-ei
-gt
-gt
-gt
-gt
-lb
-mg
-nx
-gt
-gt
-gt
-gt
-ei
-fr
-fr
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -40327,29 +39114,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fq
-fr
-ei
-gt
-gt
-hd
-jn
-gt
-lc
-mh
-ny
-gt
-jn
-hd
-gt
-gt
-ei
-fr
-fq
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -40529,29 +39316,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-gt
-hP
-iC
-iC
-kk
-ld
-mi
-nz
-or
-ou
-ou
-qJ
-gt
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -40731,29 +39518,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-hd
-hQ
-hh
-iE
-iE
-iE
-mj
-iE
-iE
-iE
-hh
-qK
-hd
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -40933,29 +39720,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-he
-hQ
-hd
-jo
-kl
-le
-mk
-ko
-kl
-jo
-hd
-qK
-rF
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -41135,29 +39922,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fs
-ei
-gt
-hf
-hQ
-iD
-iE
-km
-iE
-iE
-iE
-km
-iE
-iD
-qK
-rG
-gt
-ei
-tP
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -41337,29 +40124,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-hd
-hQ
-iE
-jp
-kn
-iE
-ml
-iE
-os
-pn
-iE
-qK
-hd
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -41539,29 +40326,29 @@ av
 aI
 ad
 ad
-ej
-Rx
-ft
-ei
-gt
-hg
-hR
-iE
-jq
-ko
-iE
-mm
-iE
-ko
-po
-iE
-qL
-rH
-gt
-ei
-sv
-Rx
-ej
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -41741,29 +40528,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-hd
-hQ
-iE
-jr
-km
-iE
-mn
-iE
-km
-pp
-iE
-qK
-hd
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -41943,29 +40730,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-hh
-hQ
-iD
-iE
-kp
-lf
-mo
-nA
-ot
-iE
-iD
-qK
-hh
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -42145,29 +40932,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-he
-hQ
-hd
-iE
-kq
-lg
-mp
-nB
-kq
-iE
-hd
-qK
-rF
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -42347,29 +41134,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-hd
-hQ
-hh
-iE
-iE
-lh
-mj
-nC
-iE
-iE
-hh
-qK
-hd
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -42549,29 +41336,29 @@ av
 aI
 ad
 ad
-Rx
-Rx
-fr
-ei
-gt
-gt
-hS
-iC
-iC
-iC
-li
-mq
-nD
-ou
-ou
-ou
-qM
-gt
-gt
-ei
-fr
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -42751,29 +41538,29 @@ aw
 aI
 ad
 ad
-Rx
-Rx
-fq
-fr
-ei
-gt
-gt
-hd
-js
-hh
-hd
-hQ
-hd
-hh
-js
-hd
-gt
-gt
-ei
-fr
-fq
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ah
@@ -42953,29 +41740,29 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-fr
-fr
-ei
-ei
-ei
-ei
-ei
-ei
-Kg
-ei
-ei
-ei
-ei
-ei
-ei
-fr
-fr
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -43156,27 +41943,27 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-gu
-fr
-ei
-ei
-ei
-ei
-ei
-ms
-ei
-ei
-ei
-ei
-ei
-fr
-sw
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -43359,25 +42146,25 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-fr
-fr
-fr
-fr
-kr
-lj
-mt
-lj
-kr
-fr
-fr
-fr
-fr
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -43562,23 +42349,23 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-mu
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -43765,21 +42552,21 @@ ad
 ad
 ad
 ad
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
-lk
-mv
-ej
-Rx
-Rx
-Rx
-Rx
-Rx
-Rx
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 ad
 ad
@@ -43973,9 +42760,9 @@ ad
 ad
 ad
 ad
-fp
-mw
-nE
+ad
+ad
+ad
 ad
 ad
 ad

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -939,6 +939,14 @@
 	name = "\improper Mess Hall"
 	icon_state = "cafeteria"
 
+/area/crew_quarters/recreation
+	name = "\improper Recreation"
+	icon_state = "crew_quarters"
+
+/area/crew_quarters/observation
+	name = "\improper Observation"
+	icon_state = "fitness"
+
 /area/crew_quarters/galley
 	name = "\improper Galley"
 	icon_state = "kitchen"
@@ -1054,19 +1062,6 @@
 	name = "\improper Fourth Deck Security Checkpoint"
 	icon_state = "checkpoint"
 
-// AI
-/area/turret_protected/ai_foyer
-	name = "\improper AI Chamber Foyer"
-	icon_state = "ai_foyer"
-	sound_env = SMALL_ENCLOSED
-	req_access = list(access_ai_upload)
-
-/area/turret_protected/ai_outer_chamber
-	name = "\improper Outer AI Chamber"
-	icon_state = "ai_chamber"
-	sound_env = SMALL_ENCLOSED
-	req_access = list(access_ai_upload)
-
 // Medbay
 
 /area/medical/equipstorage
@@ -1179,6 +1174,11 @@
 /area/solar/bridge
 	name = "\improper Bridge Solar Array"
 	icon_state = "panelsS"
+
+/area/eva
+	name = "\improper EVA Storage"
+	icon_state = "eva"
+	req_access = list(access_eva)
 
 /area/aux_eva
 	name = "\improper Command EVA Storage"
@@ -1594,35 +1594,6 @@ area/assembly/robotics/office
 /area/tcommsat/computer
 	name = "\improper Telecoms Control Room"
 	icon_state = "tcomsatcomp"
-
-// AI
-
-/area/ai_monitored
-	name = "AI Monitored Area"
-
-/area/ai_monitored/storage/eva
-	name = "\improper EVA Storage"
-	icon_state = "eva"
-	req_access = list(access_eva)
-
-/area/turret_protected/ai
-	name = "\improper AI Chamber"
-	icon_state = "ai_chamber"
-	ambience = list('sound/ambience/ambimalf.ogg')
-	req_access = list(access_ai_upload)
-
-/area/turret_protected/ai_upload
-	name = "\improper AI Upload Chamber"
-	icon_state = "ai_upload"
-	ambience = list('sound/ambience/ambimalf.ogg')
-	req_access = list(access_ai_upload)
-
-/area/turret_protected/ai_upload_foyer
-	name = "\improper  AI Upload Access"
-	icon_state = "ai_foyer"
-	ambience = list('sound/ambience/ambimalf.ogg')
-	sound_env = SMALL_ENCLOSED
-	req_access = list(access_ai_upload)
 
 // Chapel
 

--- a/maps/torch/torch_unit_testing.dm
+++ b/maps/torch/torch_unit_testing.dm
@@ -49,8 +49,6 @@
 		/area/supply = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/thruster = NO_SCRUBBER,
 		/area/turbolift = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/turret_protected/ai = NO_SCRUBBER|NO_VENT,
-		/area/turret_protected/ai_outer_chamber = NO_SCRUBBER|NO_VENT,
 		/area/vacant/bar = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/vacant = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/vacant/brig = NO_SCRUBBER|NO_VENT,
@@ -86,10 +84,6 @@
 		/area/turbolift/fourthdeck,
 		/area/template_noop
 	)
-
-/datum/unit_test/zas_area_test/ai_chamber
-	name = "ZAS: AI Chamber"
-	area_path = /area/turret_protected/ai
 
 /datum/unit_test/zas_area_test/cargo_bay
 	name = "ZAS: Cargo Bay"


### PR DESCRIPTION
:cl: Boznar
maptweak: Removes areas associated with the AI
maptweak: Removes the now defunct AI core
maptweak: Important law boards are now in the CE rack, and upload consoles are in the vault
maptweak: Removes the AI upload, and replaces it with a rec room
maptweak: Moves EVA down to deck four, and replaces it with an observation dome
/:cl:

New rooms added and EVA shifted to make deck 3 feel more habitation like. I will not take it personally if people want to improve/make the spaces into something better.

Prays to travis for successful test as per usual.