### PR TITLE
Tweaks Chorus Tendril Damage

### DIFF
--- a/code/modules/mob/living/chorus/buildings/growth/tier_four.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_four.dm
@@ -17,8 +17,8 @@
 	name = "thorned tendril"
 	desc = "A large mucus covered tentacle. <span class='notice'>This one has a large spike on the end</span>"
 	icon_state = "growth_tendril_thorned"
-	damage = 30
-	penetration = 30
+	damage = 15
+	penetration = 15
 	health = 300
 
 /datum/chorus_building/set_to_turf/growth/gastric_emitter

--- a/code/modules/mob/living/chorus/buildings/growth/tier_three.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_three.dm
@@ -16,8 +16,8 @@
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 2
 	click_cooldown = 3 SECONDS
-	var/damage = 15
-	var/penetration = 10
+	var/damage = 10
+	var/penetration = 8
 
 /obj/structure/chorus/processor/sentry/tendril/trigger_effect(var/list/targets)
 	var/mob/living/L = pick(targets)


### PR DESCRIPTION
:cl: Boznar
tweak: Makes Chorus Tendrils less lethal
/:cl:

Probably going to need balance tweaks further as it's play tested more. Tendrils were literally lethal damaging people in a couple seconds. We'll try lower numbers with armor penetration.