### PR TITLE
More information in electrical storm APC crash

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -44,7 +44,7 @@
 		if(shield_gen.take_damage(30 * severity, SHIELD_DAMTYPE_EM) <= SHIELD_BREACHED_MINOR)
 			return
 	if(!length(valid_apcs))
-		CRASH("No valid APCs found for electrical storm event! This is likely a bug.")
+		CRASH("No valid APCs found for electrical storm event! This is likely a bug. Location: [location_name()] - Z Level: [affecting_z]")
 	var/list/picked_apcs = list()
 	for(var/i=0, i< severity*2, i++) // up to 2/4/6 APCs per tick depending on severity
 		picked_apcs |= pick(valid_apcs)


### PR DESCRIPTION
Because the runtime logs in #27119 aren't giving me enough information to reproduce the crash. Will close the issue report on merge so that when this happens again we'll get a runtime log with location details.

Closes #27119