### PR TITLE
Tweaks to Unathi Cultures

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_unathi.dm
+++ b/code/modules/culture_descriptor/culture/cultures_unathi.dm
@@ -5,12 +5,11 @@
 	over their lowland vassals, protecting them and Moghes in the name of the Grand Strategem - even though the clear \
 	division between feudal masters and their subject clans has been gradually wearing away."
 	economic_power = 0.8
-	name_language = LANGUAGE_UNATHI_SINTA
+	language = LANGUAGE_UNATHI_SINTA
 	secondary_langs = list(
 		LANGUAGE_UNATHI_YEOSA,
 		LANGUAGE_SIGN,
 		LANGUAGE_HUMAN_EURO,
-		LANGUAGE_GUTTER,
 		LANGUAGE_SPACER
 	)
 
@@ -19,23 +18,51 @@
 	description = "These unathi hail from the dense jungles of Moghes' poles. Generally, they're the most welcoming of outsiders and the most \
 	common to find off-world. Most of these unathi are followers of the Precursors or the Fruitful Lights, with technology and progress being \
 	an important concept in the polar city-states."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SIGN,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_desert
 	name = CULTURE_UNATHI_DESERT
 	description = "These are the survivalists of the unathi. They hunker down in long-forgotten bunkers of the precursors and survive on \
 	whatever creatures that still live in the deserts. They're incredibly self-sufficient despite their living conditions. They have a heavy focus on \
 	the Precursors and the Grand Stratagem in their clan faiths, and are often considered the most spiritual."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_savannah
 	name = CULTURE_UNATHI_SAVANNAH
 	description = "These unathi belong to the numerous rural and nomadic clans spread across the great plains of either hemisphere of Moghes. \
 	Excellent farmers, riders and herdsmen, most savannah unathi follow the Hand of the Vines."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 	
 /decl/cultural_info/culture/unathi_salt_swamp
 	name = CULTURE_UNATHI_SALT_SWAMP
 	description = "Combining assorted elements of various cultures with an adventurous spirit and resolve, salt swamp unathi are noted for their friendliness and openness to outsiders, \
 	along with their knack for rituals that often get mistaken as \"parties\" by humans. The Fruitful Lights and Hand of the Vines both have numerous \
 	followers with these unathi."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_space
 	name = CULTURE_UNATHI_SPACE
@@ -43,6 +70,13 @@
 	much of their origins to the nomadic savannah clans, though it still varies greatly. Many of them still retain their traditions from their \
 	original homes. Now considering themselves as pioneers, they are varied in their ways. Many function as merchants and trade haulers, offering services \
 	to the Moghes Hegemony and Sol businesses alike."
+	secondary_langs = list(
+		LANGUAGE_UNATHI_SINTA,
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_tersten
 	name = CULTURE_UNATHI_TERSTEN
@@ -51,6 +85,13 @@
 	hegemony, with their primary focus being unity of the clans as well as maintaining relations with the native Tersten people. Still traditional to their \
 	beliefs, sinta on Tersten have integrated well with the planet's inhabitants. Tersten clans are seen by some Moghes clans as traitors - clans that have \
 	abandoned their homeland. Regardless, the clans on Tersten enjoy a peace that could not be achieved on the rough surface of Moghes."
+	language = LANGUAGE_UNATHI_SINTA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/culture/unathi_yeosa
 	name = CULTURE_UNATHI_YEOSA_LITTORAL
@@ -64,12 +105,11 @@
 	clan leagues, city-states, and the Krukzuz. Technology works the same way - just as the well-preserved units of precursor crafts found their way to \
 	the poles and the peaks, off-world and polar-produced flechette pistols and wetsuits became more commonplace in littoral areas as well."
 	economic_power = 0.8
-	name_language = LANGUAGE_UNATHI_YEOSA
+	language = LANGUAGE_UNATHI_YEOSA
 	secondary_langs = list(
 		LANGUAGE_UNATHI_SINTA,
 		LANGUAGE_SIGN,
 		LANGUAGE_HUMAN_EURO,
-		LANGUAGE_GUTTER,
 		LANGUAGE_SPACER
 	)
 
@@ -80,4 +120,10 @@
 	known as the Abyssals - an ethnic group connected to yeosa proper, yet very different from any race found on land. To their few guests, the Abyssals may appear uncannily secretive, if not strange. Abyssal yeosa keep track of time intently, only travelling through the \
 	waters during certain hours, and sunbathing during others. They follow Aga-Eakhe to the letter, and tend to believe in many a superstition, performing \
 	augury and seeking signs before every major enterprise."
-	
+	language = LANGUAGE_UNATHI_YEOSA
+	secondary_langs = list(
+		LANGUAGE_UNATHI_SINTA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)

--- a/code/modules/culture_descriptor/location/locations_unathi.dm
+++ b/code/modules/culture_descriptor/location/locations_unathi.dm
@@ -6,6 +6,13 @@
 	back to life, or to become strong enough that they don't have to."
 	ruling_body = "Clan Hegemony"
 	distance = "20 light-years"
+		secondary_langs = list(
+		LANGUAGE_UNATHI_SINTA,
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/location/ouere
 	name = HOME_SYSTEM_OUERE
@@ -15,7 +22,14 @@ no clear consensus on how to treat this new world - either as a logical extensio
 or simply as a resource base for improving the home planet. Many colonists, artifact hunters, and ostracised groups have \
 flocked to the planet, with Markesheli communities growing quite rapidly in numbers compared to other parts of Moghes. "
 	ruling_body = "Clan Hegemony"
-	distance = "20 light-years"
+	distance = "20 light-years"	
+	secondary_langs = list(
+		LANGUAGE_UNATHI_SINTA,
+		LANGUAGE_UNATHI_YEOSA,
+		LANGUAGE_SIGN,
+		LANGUAGE_HUMAN_EURO,
+		LANGUAGE_SPACER
+	)
 
 /decl/cultural_info/location/offworld
 	name = HOME_SYSTEM_OFFWORLD


### PR DESCRIPTION
The update for some reason added a older file that included Gutter for Unathi, this fixes that and allows Yeosa to be a secondary language for Sinta cultures. Adds the same options to Moghes and Ouere for some redundancy.

:cl:
tweak: Changes some languages around, removes gutter again, and also adds Yeosa languages to Sinta cultures.
/:cl: