### PR TITLE
The duplicate message badge no longer appears on a new line

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -371,7 +371,7 @@ function output(message, flag) {
 			} else {
 				badge = $('<span/>', {'class': 'r', 'text': 2});
 			}
-			lastmessages.html(message);
+			lastmessages.html(message.replace(/<br\s*\/?>\s*$/g,'&ensp;'));
 			lastmessages.find('[replaceRegex]').each(replaceRegex);
 			lastmessages.append(badge);
 			badge.animate({


### PR DESCRIPTION
Now appears like this:

![spaaaaaaace](https://user-images.githubusercontent.com/47489928/89734533-90393e00-da54-11ea-8f3b-b94721247584.PNG)

🆑 
tweak: The duplicate message indicator in goonchat will now appear on the same line as the message.
/🆑 