### PR TITLE
Minor Chorus tweaks

### DIFF
--- a/code/modules/mob/living/chorus/buildings/blueprint_obj.dm
+++ b/code/modules/mob/living/chorus/buildings/blueprint_obj.dm
@@ -5,6 +5,7 @@
 	var/construct_path
 	var/mob/living/chorus/owner
 	alpha = 25
+	density = FALSE
 
 /obj/structure/chorus_blueprint/Initialize(var/maploading, var/datum/chorus_building/cb, var/constructor)
 	. = ..()

--- a/code/modules/mob/living/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/chorus/buildings/generic.dm
@@ -1,6 +1,7 @@
 /obj/structure/chorus/processor
 	name = "Processor"
 	desc = "Activates through process, not clicking"
+	var/warning = TRUE
 
 /obj/structure/chorus/processor/Initialize()
 	. = ..()
@@ -11,7 +12,9 @@
 	. = ..()
 
 /obj/structure/chorus/processor/chorus_click(var/mob/living/chorus/C)
-	to_chat(C, "<span class='warning'>\The [src] is automatic; it does not need to be activated</span>")
+	if(warning)
+		to_chat(C, SPAN_WARNING("\The [src] is automatic; it does not need to be activated"))
+		warning = FALSE
 
 /obj/structure/chorus/processor/clicker
 	name = "Clicker"

--- a/code/modules/mob/living/chorus/buildings/growth/tier_one.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_one.dm
@@ -27,6 +27,7 @@
 	desc = "A organic facsimile to a mouth without teeth."
 	icon_state = "growth_articulation"
 	speaking_verb = "wails"
+	density = FALSE
 	click_cooldown = 5 SECONDS
 	gives_sight = FALSE
 
@@ -46,6 +47,7 @@
 	desc = "A cluster of nerve endings sprouting from the floor"
 	icon_state = "growth_nerves"
 	gives_sight = FALSE
+	density = FALSE
 
 /datum/chorus_building/set_to_turf/growth/sight_organ
 	desc = "An eye to see the world, inside and out."
@@ -57,6 +59,7 @@
 	name = "sight organ"
 	desc = "An eye on a stalk... it seems to look about the room."
 	icon_state = "growth_eye"
+	density = FALSE
 
 /datum/chorus_building/set_to_turf/growth/bitter
 	desc = "A small teeth-filled hole, used to injure prey"

--- a/code/modules/mob/living/chorus/chorus_building.dm
+++ b/code/modules/mob/living/chorus/chorus_building.dm
@@ -40,8 +40,9 @@
 /mob/living/chorus/Life()
 	. = ..()
 	if(.)
+		var/real_construct_speed = 25 * construct_speed / (24 + construct_speed)
 		if(currently_building.len)
-			var/con_speed = construct_speed / currently_building.len
+			var/con_speed = real_construct_speed / currently_building.len
 			for(var/b in currently_building)
 				var/obj/structure/chorus_blueprint/cb = b
 				if(cb.build_amount(con_speed))


### PR DESCRIPTION
:cl:
tweak: Chorus construction speed is now hardcapped using the algorithm (25 * speed)/(24+speed). This means each point is worth slightly less than the previous one.
tweak: Removed the density of a few chorus objects that shouldn't have them
tweak: Processor structures for chorus now only warn you once per structure that you don't have to click it.
/:cl: