### PR TITLE
Gives Gantry a Cryopod, other small Gantry changes.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -7,7 +7,7 @@
  *		Bombsuit Closet
  *		Hydrant
  *		First Aid
- *		Excavation Closet
+ *		Excavation Closet Away Site
  *		Shipping Supplies Closet
  */
 
@@ -184,6 +184,31 @@
 	return list(
 		/obj/random/firstaid,
 		/obj/random/medical/lite = 12)
+
+/obj/structure/closet/toolcloset/excavation/awaysite //no teleport beacons
+	name = "excavation equipment closet"
+	desc = "It's a storage unit for excavation equipment."
+	closet_appearance = /decl/closet_appearance/secure_closet/engineering/tools
+
+/obj/structure/closet/toolcloset/excavation/awaysite/WillContain()
+	return list(
+		/obj/item/weapon/storage/belt/archaeology,
+		/obj/item/weapon/storage/excavation,
+		/obj/item/device/flashlight/lantern,
+		/obj/item/device/ano_scanner,
+		/obj/item/device/depth_scanner,
+		/obj/item/device/core_sampler,
+		/obj/item/device/gps,
+		/obj/item/weapon/pinpointer/radio,
+		/obj/item/clothing/glasses/meson,
+		/obj/item/clothing/glasses/science,
+		/obj/item/weapon/pickaxe,
+		/obj/item/device/measuring_tape,
+		/obj/item/weapon/pickaxe/xeno/hand,
+		/obj/item/weapon/storage/bag/fossils,
+		/obj/item/weapon/hand_labeler,
+		/obj/item/device/spaceflare
+	)
 
 /obj/structure/closet/shipping_wall
 	name = "shipping supplies closet"

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -1,10 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/vehicle/train/cargo/engine,
+/turf/simulated/floor/airless,
+/area/scavver/gantry/down2)
+"ak" = (
+/obj/machinery/suspension_gen,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "aL" = (
-/obj/machinery/vitals_monitor,
+/obj/machinery/optable,
+/obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/scavver/calypso)
 "aO" = (
@@ -33,7 +41,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down2)
 "bw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/ladder/up,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "bC" = (
@@ -51,10 +59,21 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "bL" = (
-/obj/machinery/suspension_gen,
+/obj/machinery/mineral/stacking_machine{
+	input_turf = 2
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
 "bN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "bQ" = (
@@ -72,6 +91,17 @@
 /obj/machinery/meter,
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
+"cj" = (
+/obj/machinery/vitals_monitor,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/alarm{
+	dir = 8;
+	locked = 0;
+	pixel_x = 25;
+	req_access = list()
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/scavver/calypso)
 "cu" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 8
@@ -102,15 +132,13 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down2)
 "cP" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/railing/mapped,
-/turf/space,
-/area/space)
+/turf/simulated/floor/tiled/white/airless,
+/area/scavver/calypso)
 "db" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -136,7 +164,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/spot{
 	dir = 8
 	},
@@ -155,14 +182,11 @@
 /area/scavver/yachtdown)
 "dQ" = (
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
-	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/tiled/white/airless,
 /area/scavver/calypso)
 "ec" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -172,9 +196,12 @@
 /area/scavver/yachtdown)
 "el" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
 	dir = 8
@@ -185,6 +212,13 @@
 /obj/effect/shuttle_landmark/scavver_gantry/generic/four,
 /turf/space,
 /area/space)
+"es" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtdown)
 "ev" = (
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
@@ -204,7 +238,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/white/airless,
 /area/scavver/calypso)
 "eJ" = (
 /obj/structure/railing/mapped{
@@ -244,19 +278,35 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "fA" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
 "fE" = (
-/obj/structure/anomaly_container,
-/turf/simulated/floor/airless,
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "west bump";
+	pixel_x = 24;
+	req_access = list()
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
 /area/scavver/calypso)
 "fF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -271,6 +321,19 @@
 /obj/structure/lattice,
 /turf/space,
 /area/scavver/yachtdown)
+"fI" = (
+/obj/structure/closet/crate/plastic,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plasteel/fifty,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "fL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -302,6 +365,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 10;
 	icon_state = "intact"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
@@ -354,6 +425,7 @@
 /area/scavver/yachtdown)
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
 "hB" = (
@@ -362,11 +434,12 @@
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
 "hC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
@@ -384,11 +457,15 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
 "hM" = (
-/obj/machinery/sleeper{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "it" = (
 /obj/structure/railing/mapped,
@@ -443,6 +520,13 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
+"jg" = (
+/obj/machinery/atmospherics/pipe/cap/visible/fuel{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "ji" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -454,6 +538,13 @@
 /obj/effect/shuttle_landmark/lift/gantry/bottom,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
+"jr" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtdown)
 "jt" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/docking_area{
@@ -476,15 +567,25 @@
 /obj/structure/railing/mapped,
 /turf/space,
 /area/space)
+"jz" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/scavver/calypso)
+"jH" = (
+/obj/structure/lattice,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/turf/space,
+/area/space)
 "jJ" = (
 /obj/structure/iv_drip,
-/obj/machinery/alarm{
-	dir = 4;
-	locked = 0;
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access = list()
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -494,10 +595,9 @@
 /turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "jR" = (
-/obj/item/weapon/material/hatchet/machete,
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 5;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/manifold/hidden/blue,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
@@ -510,8 +610,30 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
+/obj/machinery/power/apc/super{
+	dir = 1;
+	locked = 0;
+	name = "north bump";
+	operating = 0;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
+"kl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "kt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
@@ -524,7 +646,7 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "kx" = (
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/tiled/white/airless,
 /area/scavver/calypso)
 "ky" = (
 /obj/structure/cable{
@@ -538,6 +660,10 @@
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/random/loot,
 /obj/structure/table/steel_reinforced,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/calypso)
 "kU" = (
@@ -610,6 +736,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
 "mb" = (
@@ -650,7 +777,15 @@
 /obj/random/firstaid,
 /obj/random/firstaid,
 /obj/random/firstaid,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
 /turf/simulated/floor/tiled/white/monotile,
+/area/scavver/calypso)
+"na" = (
+/obj/structure/anomaly_container,
+/turf/simulated/floor/airless,
 /area/scavver/calypso)
 "nb" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -702,10 +837,10 @@
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down2)
-"op" = (
-/obj/item/device/radio/beacon,
+"ox" = (
+/obj/machinery/floodlight,
 /turf/simulated/floor/airless,
-/area/scavver/gantry/down2)
+/area/scavver/calypso)
 "oC" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/airless,
@@ -727,18 +862,15 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
 "oH" = (
-/obj/machinery/pointdefense_control{
-	initial_id_tag = "Salvage_Gantry";
-	name = "Point Defense Controller"
-	},
 /obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_x = 32
-	},
+/obj/machinery/cryopod,
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/calypso)
 "oJ" = (
@@ -770,6 +902,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
+"oX" = (
+/obj/machinery/computer/mining,
+/turf/simulated/wall,
+/area/scavver/calypso)
 "po" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -808,10 +944,18 @@
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/calypso)
+"pQ" = (
+/obj/structure/girder,
+/turf/simulated/floor/airless,
+/area/scavver/yachtdown)
 "qe" = (
 /obj/machinery/microwave,
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/white/airless,
+/area/scavver/calypso)
+"qk" = (
+/obj/structure/closet/toolcloset/excavation/awaysite,
+/turf/simulated/floor/airless,
 /area/scavver/calypso)
 "qC" = (
 /turf/simulated/floor/wood/yew,
@@ -846,7 +990,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/tiled/white/monotile,
 /area/scavver/calypso)
 "rb" = (
 /obj/machinery/hologram/holopad/longrange,
@@ -857,6 +1001,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
 "rr" = (
@@ -913,19 +1058,44 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/portable_atmospherics/hydroponics{
+	closed_system = 1
+	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "sj" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
-/turf/simulated/floor/airless,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"sC" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
+	dir = 4
+	},
+/turf/space,
 /area/scavver/calypso)
 "sG" = (
-/obj/structure/cable,
-/obj/machinery/power/smes/buildable/preset/scavver/smes{
-	charge = 100000
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/tiled/white/airless,
 /area/scavver/calypso)
 "sN" = (
 /obj/machinery/computer/ship/engines,
@@ -942,29 +1112,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/scavver/calypso)
+"te" = (
+/obj/machinery/mineral/unloading_machine{
+	output_turf = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "to" = (
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/obj/structure/closet/crate/solar,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down2)
 "tE" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24;
-	req_access = list()
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "tL" = (
@@ -972,6 +1141,13 @@
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket,
 /turf/space,
 /area/scavver/calypso)
+"tO" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtdown)
 "tX" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -979,6 +1155,12 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down2)
+"ua" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/space,
+/area/space)
 "uo" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/airless,
@@ -1003,6 +1185,22 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
+"uO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "uR" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/lattice,
@@ -1044,6 +1242,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
+/obj/machinery/meter,
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "vM" = (
@@ -1054,9 +1253,11 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light/spot{
 	dir = 4
+	},
+/obj/machinery/portable_atmospherics/hydroponics{
+	closed_system = 1
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
@@ -1069,9 +1270,14 @@
 /turf/space,
 /area/space)
 "vX" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
-/area/scavver/yachtdown)
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/scavver/calypso)
 "wh" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -1089,6 +1295,16 @@
 /obj/item/clothing/gloves/insulated,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down2)
+"wS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/space,
+/area/scavver/calypso)
 "xa" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/three,
 /turf/space,
@@ -1122,9 +1338,13 @@
 /turf/simulated/floor/plating,
 /area/scavver/calypso)
 "xr" = (
-/obj/vehicle/train/cargo/engine,
+/obj/machinery/mineral/processing_unit{
+	input_turf = 4;
+	output_turf = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/airless,
-/area/scavver/gantry/down2)
+/area/scavver/calypso)
 "xw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1174,9 +1394,15 @@
 /turf/space,
 /area/scavver/calypso)
 "yc" = (
-/obj/structure/ladder/up,
+/obj/machinery/power/smes/buildable/preset/scavver/smes{
+	charge = 100000
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/airless,
-/area/scavver/yachtdown)
+/area/scavver/calypso)
 "yo" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -1214,11 +1440,19 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "AE" = (
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/clothing/head/surgery,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/reagent_containers/spray/sterilizine,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = -5
+	},
+/obj/item/device/robotanalyzer,
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/item/device/scanner/health,
 /obj/machinery/vending/wallmed1{
 	pixel_y = 32
 	},
-/obj/machinery/optable,
-/obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/scavver/calypso)
 "AK" = (
@@ -1269,6 +1503,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
+"Ba" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
+/obj/structure/ore_box,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "Bd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1297,9 +1539,15 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
+"BA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/machinery/door/airlock/external/bolted,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/scavver/calypso)
 "BM" = (
@@ -1333,6 +1581,21 @@
 	},
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
+"Ck" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
+"Cl" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/meter,
+/turf/space,
+/area/scavver/calypso)
 "Cq" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -1344,18 +1607,27 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
+"Cr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/meter,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "Cx" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 2
 	},
 /obj/machinery/light/spot,
+/obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "Cz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
@@ -1389,21 +1661,28 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
+"CN" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/door_assembly/door_assembly_ext{
+	anchored = 1
+	},
+/turf/simulated/floor/wood/yew,
+/area/scavver/yachtdown)
 "CZ" = (
 /obj/effect/paint/black,
 /turf/simulated/wall,
 /area/scavver/gantry/down1)
 "DB" = (
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/clothing/head/surgery,
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/reagent_containers/spray/sterilizine,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -5
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
-/obj/item/device/robotanalyzer,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/bed/chair/shuttle/white,
+/turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "DF" = (
 /obj/structure/railing/mapped{
@@ -1464,6 +1743,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/scavver/yachtdown)
+"EP" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "EU" = (
 /obj/machinery/atmospherics/omni/mixer{
 	tag_north = 2;
@@ -1640,7 +1926,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "Ht" = (
-/obj/machinery/atmospherics/pipe/cap/visible/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
@@ -1661,11 +1947,12 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtdown)
 "HJ" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/scavver/calypso)
 "HU" = (
@@ -1675,20 +1962,14 @@
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "HY" = (
-/obj/machinery/power/apc/super{
-	dir = 1;
-	locked = 0;
-	name = "north bump";
-	operating = 0;
-	pixel_y = 24;
-	req_access = list()
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/airless,
-/area/scavver/yachtdown)
+/turf/simulated/floor/tiled,
+/area/scavver/calypso)
 "ID" = (
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/dark,
@@ -1723,7 +2004,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtdown)
 "IV" = (
 /obj/structure/lattice,
@@ -1740,7 +2021,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
 "Ja" = (
-/obj/machinery/floodlight,
+/obj/structure/ore_box,
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
 "JF" = (
@@ -1792,6 +2073,8 @@
 "KL" = (
 /obj/structure/lattice,
 /obj/random/loot,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped,
 /turf/space,
 /area/space)
 "KP" = (
@@ -1821,6 +2104,14 @@
 /obj/structure/inflatable/door,
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
+"LD" = (
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "LR" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -1844,9 +2135,12 @@
 /turf/simulated/wall/ocp_wall,
 /area/scavver/yachtdown)
 "Mf" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
+/obj/structure/lattice,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/space,
 /area/scavver/calypso)
 "Mz" = (
 /turf/space,
@@ -1861,11 +2155,29 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/scavver/yachtdown)
+"NK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "NP" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control/autostart{
 	dir = 1
 	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtdown)
+"Om" = (
+/obj/effect/floor_decal/corner/blue/mono,
+/obj/machinery/pointdefense_control{
+	initial_id_tag = "Salvage_Gantry";
+	name = "Point Defense Controller"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/scavver/calypso)
+"Oq" = (
+/obj/machinery/atmospherics/pipe/cap/visible/fuel,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "Or" = (
@@ -1878,6 +2190,14 @@
 /obj/random/tool,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
+"Pd" = (
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "Pn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1887,11 +2207,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
-"Py" = (
-/obj/structure/lattice,
-/obj/structure/railing/mapped,
-/turf/space,
-/area/scavver/calypso)
 "PA" = (
 /obj/structure/bed/chair/shuttle/white{
 	dir = 1
@@ -1899,8 +2214,16 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
+"PD" = (
+/obj/machinery/atmospherics/binary/passive_gate,
+/obj/machinery/door/airlock/external/bolted_open,
+/turf/simulated/floor/wood/yew,
+/area/scavver/yachtdown)
 "PE" = (
 /turf/simulated/wall/ocp_wall,
 /area/scavver/yachtdown)
@@ -1917,7 +2240,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtdown)
 "PT" = (
 /obj/structure/lattice,
@@ -1937,7 +2260,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtdown)
 "QD" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1946,10 +2269,6 @@
 /obj/item/device/flashlight/lantern,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
-"QJ" = (
-/obj/structure/closet/toolcloset/excavation,
-/turf/simulated/floor/airless,
-/area/scavver/calypso)
 "QL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -2041,6 +2360,13 @@
 /obj/structure/inflatable/wall,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
+"Ss" = (
+/obj/structure/railing/mapped,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "St" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -2060,6 +2386,16 @@
 	},
 /turf/space,
 /area/space)
+"Sz" = (
+/obj/machinery/atmospherics/valve/shutoff/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/airless,
+/area/scavver/calypso)
 "SF" = (
 /turf/simulated/wall/titanium,
 /area/scavver/yachtdown)
@@ -2067,7 +2403,9 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/portable_atmospherics/hydroponics{
+	closed_system = 1
+	},
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "SW" = (
@@ -2100,10 +2438,10 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
 "TK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/cap/visible/fuel{
-	dir = 4
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8
 	},
+/obj/structure/lattice,
 /turf/space,
 /area/space)
 "TU" = (
@@ -2131,7 +2469,9 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/portable_atmospherics/hydroponics{
+	closed_system = 1
+	},
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "TZ" = (
@@ -2164,7 +2504,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "UU" = (
@@ -2178,7 +2518,7 @@
 "UV" = (
 /obj/machinery/recharge_station,
 /obj/structure/fireaxecabinet{
-	pixel_y = 32
+	pixel_x = 32
 	},
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
@@ -2193,6 +2533,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/yew,
+/area/scavver/yachtdown)
+"Vr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/girder/displaced,
+/turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "Vs" = (
 /obj/structure/railing/mapped{
@@ -2225,24 +2574,20 @@
 	dir = 6;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtdown)
-"VZ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
-/area/scavver/calypso)
 "Wo" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/calypso)
 "Wp" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8
+/obj/structure/inflatable/door,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
@@ -2259,7 +2604,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtdown)
 "Xb" = (
 /obj/machinery/light/small{
@@ -2287,6 +2632,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "XA" = (
@@ -2331,18 +2677,13 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/down1)
 "XN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/scavver/yachtdown)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/scavver/calypso)
 "XQ" = (
 /obj/machinery/shipsensors/weak{
 	use_power = 0
@@ -2383,12 +2724,11 @@
 /turf/simulated/wall,
 /area/scavver/gantry/down2)
 "Zg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
-/area/scavver/yachtdown)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply,
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
+/turf/space,
+/area/space)
 "Zr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
@@ -2405,6 +2745,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/yew,
+/area/scavver/yachtdown)
+"ZG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/inflatable/door,
+/turf/simulated/floor/airless,
 /area/scavver/yachtdown)
 "ZS" = (
 /obj/structure/railing/mapped{
@@ -12715,8 +13060,8 @@ vM
 vM
 vM
 SF
-HY
-XN
+WM
+DK
 SF
 vM
 UM
@@ -12874,7 +13219,7 @@ SF
 UM
 UM
 UM
-UM
+jg
 UM
 UM
 UM
@@ -13174,7 +13519,7 @@ oE
 oE
 oE
 HU
-yc
+WM
 SF
 SF
 SF
@@ -13327,7 +13672,7 @@ WM
 nb
 Eg
 oE
-oE
+ZG
 dv
 bw
 iI
@@ -13479,9 +13824,9 @@ oE
 EU
 Gz
 WM
+SF
+Bt
 WM
-Zg
-vX
 iI
 gZ
 UM
@@ -13624,17 +13969,17 @@ uo
 Sq
 po
 gf
-UU
+Vr
 SF
-rO
-SF
-SF
+CN
 SF
 SF
-WM
+SF
+SF
+SF
 Bt
 WM
-iI
+tO
 gZ
 UM
 UM
@@ -13776,13 +14121,13 @@ mU
 Xn
 Eg
 Eq
-WM
+pQ
 TV
 pA
 TV
 TV
 TV
-WM
+SF
 WM
 Bt
 WM
@@ -13928,7 +14273,7 @@ Aj
 mb
 SW
 vD
-SW
+PD
 nU
 cg
 Sj
@@ -14058,7 +14403,7 @@ Ga
 cu
 Ga
 Ga
-op
+Ga
 Ga
 Ga
 TZ
@@ -14207,10 +14552,10 @@ Ga
 Ga
 Ga
 Ga
-xr
-lp
-lp
 Ga
+lp
+lp
+aa
 Ga
 Ga
 Bi
@@ -14242,7 +14587,7 @@ SF
 Lv
 Bt
 WM
-iI
+es
 gZ
 UM
 UM
@@ -14394,7 +14739,7 @@ lz
 WM
 po
 WM
-iI
+es
 gZ
 UM
 UM
@@ -14536,17 +14881,17 @@ Mz
 mU
 Mz
 mU
+uo
 WM
 WM
-WM
-WM
-WM
+Oq
+oE
 Ht
 pq
 Aa
 Hs
 fc
-Eg
+jr
 gZ
 UM
 UM
@@ -14677,7 +15022,7 @@ UM
 UM
 jy
 UM
-UM
+vM
 UM
 SF
 SF
@@ -14827,13 +15172,13 @@ IV
 BM
 nS
 BM
-cP
-vM
-vM
-vM
-vM
-UM
-vM
+BM
+jH
+jH
+jH
+jH
+nS
+nS
 SF
 Mz
 Mz
@@ -14982,13 +15327,13 @@ UM
 vM
 UM
 UM
+vM
 UM
-UM
-UM
+nS
 KL
 mU
-Mz
-Mz
+mU
+mU
 mU
 mU
 SF
@@ -15123,8 +15468,8 @@ UM
 UM
 UM
 UM
-vM
-vM
+UM
+UM
 UM
 UM
 ky
@@ -15132,12 +15477,12 @@ UM
 nS
 UM
 vM
-vM
+Zg
+ua
+sj
 UM
-UM
-UM
-UM
-vM
+nS
+jy
 UM
 UM
 UM
@@ -15284,12 +15629,12 @@ UM
 uR
 UM
 UM
-vM
-UM
+NK
+fI
+sC
+oX
 ry
-ry
-ry
-vM
+Ba
 UM
 UM
 UM
@@ -15430,7 +15775,7 @@ ry
 ry
 uY
 ry
-ky
+yc
 ry
 ry
 xm
@@ -15438,10 +15783,10 @@ CE
 ry
 ry
 bL
-PY
-yb
-yb
-vM
+uO
+xr
+EP
+te
 UM
 UM
 UM
@@ -15589,11 +15934,11 @@ uq
 fF
 ry
 ry
+oX
+wS
 ry
-uY
-ry
-yb
-PY
+Ja
+Ss
 UM
 UM
 UM
@@ -15732,7 +16077,7 @@ gs
 ry
 ry
 qe
-Wo
+cP
 kx
 yb
 ry
@@ -15740,9 +16085,9 @@ sO
 Br
 fF
 ry
-fE
-uY
-PY
+na
+yb
+Sz
 ry
 ry
 ry
@@ -15880,23 +16225,23 @@ UM
 UM
 gs
 sN
-yo
+vX
 Gq
 ry
 ry
 qQ
-ry
+CE
 ry
 ry
 CE
 QL
 CE
 ry
-Ja
-PY
-yb
-sj
-Mf
+ox
+ak
+kl
+BA
+LD
 UM
 UM
 UM
@@ -16044,11 +16389,11 @@ RC
 St
 AK
 ry
-QJ
+qk
 PY
-PY
-uY
-Py
+Ck
+Cl
+Mf
 UM
 UM
 UM
@@ -16194,14 +16539,14 @@ HJ
 lV
 Cz
 hC
-Cz
+XN
 BJ
 hu
 hu
 jR
-PY
-VZ
-vM
+Cr
+Pd
+UM
 UM
 UM
 UM
@@ -16344,9 +16689,9 @@ bN
 np
 CE
 vf
-vf
+HY
 Yc
-vf
+jz
 ry
 UV
 Gu
@@ -16492,12 +16837,12 @@ UM
 ry
 ry
 aL
-bN
+Wo
 mV
 ry
 pM
 xL
-xL
+Om
 oH
 ry
 ry
@@ -16643,7 +16988,7 @@ UM
 UM
 UM
 ry
-ry
+cj
 hM
 ry
 ry
@@ -16794,9 +17139,9 @@ UM
 UM
 UM
 UM
-UM
 ry
 ry
+fE
 ry
 vM
 vM
@@ -17100,8 +17445,8 @@ UM
 UM
 UM
 UM
-UM
-UM
+ry
+ry
 UM
 UM
 UM

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -22,6 +22,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/fabricator/hacked,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "ae" = (
@@ -37,7 +38,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "as" = (
-/obj/structure/curtain/open/bed,
+/obj/structure/curtain/black,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/scavver/hab)
 "aw" = (
@@ -48,11 +49,18 @@
 /turf/simulated/wall/r_wall,
 /area/scavver/lifepod)
 "aA" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless,
-/area/scavver/yachtup)
+/area/scavver/lifepod)
 "aB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1;
@@ -113,6 +121,13 @@
 /obj/item/weapon/mop,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
+"bs" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "bA" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/blast/regular{
@@ -123,10 +138,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "bE" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "bI" = (
@@ -145,12 +160,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
-"bS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 10
-	},
-/turf/simulated/floor/airless,
-/area/scavver/yachtup)
 "bV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -171,12 +180,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "cc" = (
@@ -201,13 +210,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 21
-	},
 /turf/simulated/floor/tiled/dark,
 /area/scavver/hab)
 "co" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/scavver/hab)
@@ -242,7 +251,14 @@
 	pressure_checks_default = 2;
 	pump_direction = 0
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
+/area/scavver/yachtup)
+"cQ" = (
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 4;
+	icon_state = "cap"
+	},
+/turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "cS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -495,6 +511,13 @@
 "eN" = (
 /turf/space,
 /area/space)
+"fj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/scavver/lifepod)
 "fq" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -553,7 +576,7 @@
 	id = "scavver_teg_in_fuel";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "fH" = (
 /obj/machinery/meter,
@@ -594,10 +617,14 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up2)
 "fV" = (
-/obj/structure/ladder,
-/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
+/obj/machinery/power/solar,
+/obj/structure/cable,
 /turf/simulated/floor/airless,
-/area/scavver/yachtup)
+/area/scavver/lifepod)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -669,6 +696,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
+"gx" = (
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "gD" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "dropodeast_pump";
@@ -780,7 +811,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "ij" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -837,14 +868,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/scavver/escapepod)
-"iV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless,
-/area/scavver/lifepod)
 "iW" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -939,7 +962,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "jA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -970,8 +993,7 @@
 /area/scavver/gantry/up1)
 "jL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
@@ -989,11 +1011,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
+"jS" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "jW" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/storage/box/glasses/pint,
-/obj/item/weapon/storage/box/donkpockets,
 /obj/effect/floor_decal/corner/lightgrey/mono,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "kb" = (
@@ -1007,10 +1035,6 @@
 	master_tag = "dropodeast";
 	pixel_y = 20;
 	pixel_z = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/airless,
 /area/scavver/lifepod)
@@ -1078,14 +1102,22 @@
 	name = "Burn Chamber Window Blast Doors";
 	pixel_y = -21
 	},
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 4;
-	icon_state = "cap"
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "kP" = (
@@ -1103,6 +1135,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
+"la" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
@@ -1162,6 +1202,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
+"me" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "mi" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -1176,14 +1229,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "mj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "ml" = (
@@ -1273,6 +1324,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/scavver/hab)
 "nw" = (
@@ -1306,7 +1360,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "nI" = (
 /obj/effect/floor_decal/techfloor{
@@ -1354,7 +1408,7 @@
 	dir = 10;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "om" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -1374,20 +1428,18 @@
 /area/scavver/gantry/up1)
 "os" = (
 /obj/structure/railing/mapped,
-/obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner_steel_grid,
+/obj/structure/closet/crate/solar,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "ov" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/effect/catwalk_plated,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/scavver/yachtup)
+/turf/simulated/floor/plating,
+/area/scavver/hab)
 "ow" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1491,15 +1543,12 @@
 /turf/simulated/wall/ocp_wall,
 /area/scavver/yachtup)
 "pw" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/airless,
 /area/scavver/lifepod)
 "pK" = (
@@ -1518,11 +1567,14 @@
 /turf/space,
 /area/scavver/yachtup)
 "qf" = (
-/obj/machinery/light_switch{
-	pixel_y = -24
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
-/area/scavver/hab)
+/turf/simulated/floor/airless,
+/area/scavver/gantry/up1)
 "qh" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
@@ -1596,11 +1648,8 @@
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "qU" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4;
-	icon_state = "map_connector"
-	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/structure/ladder,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "qV" = (
@@ -1635,6 +1684,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 4;
+	icon_state = "map"
+	},
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	id_tag = "dropodwest_interior_door";
@@ -1658,18 +1711,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
-"rG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/mining{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/scavver/lifepod)
 "rJ" = (
 /obj/item/weapon/storage/bag/trash,
 /obj/item/weapon/airlock_brace,
@@ -1767,6 +1808,16 @@
 /obj/item/stack/material/wood/fifty,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
+"sE" = (
+/obj/machinery/atmospherics/omni/mixer{
+	tag_east = 2;
+	tag_south = 1;
+	tag_south_con = 0.85;
+	tag_west = 1;
+	tag_west_con = 0.15
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "sF" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
@@ -1813,6 +1864,12 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
+"sY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/scavver/hab)
 "sZ" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -1820,6 +1877,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/solar,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/airless,
 /area/scavver/lifepod)
 "ta" = (
@@ -1858,6 +1919,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
+"tp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "tx" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/scavver/gantry/lift)
@@ -1867,6 +1946,9 @@
 	dir = 4
 	},
 /obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "tX" = (
@@ -1979,6 +2061,12 @@
 /obj/item/weapon/gun/launcher/crossbow/rapidcrossbowdevice,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/scavver/hab)
+"vp" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "vt" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/two,
 /turf/space,
@@ -2083,7 +2171,9 @@
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "wb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8
+	},
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	id_tag = "dropodwest_interior_door";
@@ -2133,18 +2223,15 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
+"wG" = (
+/obj/structure/cable,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "wI" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/wood/yew,
-/area/scavver/hab)
-"wJ" = (
-/obj/machinery/alarm{
-	dir = 4;
-	locked = 0;
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access = list()
-	},
+/obj/structure/closet/secure_closet/freezer/fridge/scavver,
+/obj/random/maintenance,
+/obj/item/weapon/material/kitchen/utensil/spork/plastic,
+/obj/item/weapon/material/kitchen/utensil/spork/plastic,
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
 "wN" = (
@@ -2235,6 +2322,10 @@
 /obj/effect/floor_decal/corner/lightgrey/mono,
 /obj/item/weapon/storage/backpack/satchel/leather/reddish,
 /obj/item/weapon/storage/belt/holster/general,
+/obj/random/accessory,
+/obj/machinery/light_switch{
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "yf" = (
@@ -2248,15 +2339,14 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/scavver/lifepod)
 "yq" = (
-/obj/machinery/atmospherics/omni/mixer{
-	tag_east = 2;
-	tag_south = 1;
-	tag_south_con = 0.85;
-	tag_west = 1;
-	tag_west_con = 0.15
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/scavver/yachtup)
+/area/scavver/hab)
 "yr" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -2273,12 +2363,10 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "yx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/scavver/hab)
@@ -2339,6 +2427,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
+"yR" = (
+/obj/structure/wall_frame,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "yT" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -2419,6 +2511,23 @@
 	},
 /turf/space,
 /area/space)
+"zX" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
+"Ad" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/girder/displaced,
+/turf/space,
+/area/scavver/yachtup)
 "Af" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -2467,17 +2576,26 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
 "AM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/mining{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/loading,
 /obj/structure/closet/crate/plastic,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plasteel/fifty,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
+/obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "AN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2517,11 +2635,7 @@
 /area/scavver/hab)
 "Bf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/processing_unit{
-	input_turf = 4;
-	output_turf = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "Br" = (
@@ -2541,6 +2655,9 @@
 	dir = 4
 	},
 /obj/effect/paint/sun,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/scavver/hab)
 "BA" = (
@@ -2656,11 +2773,25 @@
 /area/scavver/hab)
 "CF" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "CI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
@@ -2681,14 +2812,27 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "scav_pod_sensor_chamber";
 	pixel_x = 22
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/reinforced,
 /area/scavver/escapepod)
+"Db" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "Dc" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -2741,6 +2885,20 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
+"Dl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "Ds" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/docking_area{
@@ -2761,6 +2919,11 @@
 	icon_state = "intact"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/floor_decal/industrial/hatch/orange,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "DI" = (
@@ -2801,6 +2964,15 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/scavver/lifepod)
+"Eu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "EA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2864,6 +3036,15 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/scavver/hab)
+"Fb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "Fe" = (
 /obj/structure/fuel_port,
 /turf/simulated/wall/r_wall,
@@ -2891,6 +3072,9 @@
 "FA" = (
 /obj/machinery/vending/tool,
 /obj/effect/floor_decal/corner/lightgrey/mono,
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "FB" = (
@@ -2898,6 +3082,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "dropodwest_pump";
+	power_rating = 25000
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/scavver/lifepod)
@@ -2921,7 +3109,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "FO" = (
 /obj/effect/paint/black,
@@ -3091,15 +3279,16 @@
 	dir = 9
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "HN" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/material/kitchen/utensil/spork/plastic,
-/obj/item/weapon/material/kitchen/utensil/spork/plastic,
+/obj/item/weapon/storage/box/glasses/pint,
+/obj/item/weapon/storage/box/donkpockets,
 /obj/effect/floor_decal/corner/lightgrey/mono,
-/obj/random/maintenance,
-/obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "HR" = (
@@ -3118,7 +3307,6 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/obj/machinery/fabricator/hacked,
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
@@ -3197,6 +3385,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
+"IP" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "IS" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -3272,6 +3467,10 @@
 /area/scavver/hab)
 "JO" = (
 /obj/structure/largecrate/animal/goose,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/scavver/hab)
 "JS" = (
@@ -3347,10 +3546,17 @@
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "Lk" = (
+/obj/structure/closet/crate/plastic,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plasteel/fifty,
 /obj/structure/railing/mapped,
-/obj/structure/table/rack,
 /obj/random/powercell,
 /obj/random/powercell,
+/obj/item/stack/material/plasteel/fifty,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "Lp" = (
@@ -3367,6 +3573,9 @@
 "Lr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -3428,9 +3637,6 @@
 /obj/item/weapon/storage/backpack/dufflebag/eng,
 /obj/item/weapon/storage/backpack/dufflebag/med,
 /obj/structure/closet/crate/plastic,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/item/device/gps,
 /obj/item/weapon/card/id/guest,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -3469,7 +3675,7 @@
 	pixel_x = -18
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "MI" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/five,
@@ -3477,11 +3683,11 @@
 /area/space)
 "MK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "ML" = (
@@ -3586,6 +3792,10 @@
 /obj/effect/floor_decal/corner/lightgrey/mono,
 /obj/item/weapon/storage/belt/utility/full,
 /obj/item/weapon/storage/backpack/industrial,
+/obj/random/accessory,
+/obj/machinery/light_switch{
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "Nz" = (
@@ -3630,6 +3840,10 @@
 /obj/effect/floor_decal/corner/lightgrey/mono,
 /obj/item/weapon/storage/belt/medical/emt,
 /obj/item/weapon/storage/backpack/satchel/med,
+/obj/random/accessory,
+/obj/machinery/light_switch{
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "NM" = (
@@ -3689,10 +3903,8 @@
 /area/scavver/yachtup)
 "Om" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
 /obj/structure/ore_box,
+/obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "Ow" = (
@@ -3771,7 +3983,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
-/area/space)
+/area/scavver/gantry/up1)
 "PD" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -3868,6 +4080,13 @@
 /obj/structure/flora/pottedplant/sticky,
 /turf/simulated/floor/tiled,
 /area/scavver/hab)
+"Qy" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "QB" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -3898,10 +4117,11 @@
 /area/scavver/hab)
 "Rb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/unloading_machine{
-	output_turf = 2
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "Rj" = (
@@ -3937,7 +4157,7 @@
 /area/scavver/hab)
 "RE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
@@ -3989,14 +4209,10 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "Sn" = (
-/obj/machinery/vending/cigarette{
-	name = "hacked cigarette machine";
-	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo/random = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
 "Sx" = (
@@ -4008,21 +4224,24 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "SA" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "SF" = (
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/obj/machinery/mineral/stacking_machine{
-	input_turf = 1;
-	output_turf = 2
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "SQ" = (
@@ -4042,15 +4261,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/airless,
 /area/scavver/lifepod)
 "SX" = (
@@ -4089,6 +4305,13 @@
 /area/scavver/hab)
 "TY" = (
 /obj/machinery/media/jukebox/old,
+/obj/machinery/alarm{
+	dir = 4;
+	locked = 0;
+	pixel_x = -25;
+	pixel_y = 0;
+	req_access = list()
+	},
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
 "Ub" = (
@@ -4209,6 +4432,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/airless,
 /area/scavver/lifepod)
+"VP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "VS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4259,7 +4491,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "Wl" = (
-/obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -4269,21 +4500,22 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "Ww" = (
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "WA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
@@ -4311,8 +4543,24 @@
 /obj/vehicle/train/cargo/trolley,
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up2)
+"WX" = (
+/obj/structure/door_assembly/door_assembly_ext{
+	anchored = 1
+	},
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "Xb" = (
 /obj/machinery/seed_storage/garden,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
+"Xj" = (
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "Xr" = (
@@ -4418,6 +4666,13 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
+"Yc" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/airless,
+/area/scavver/yachtup)
 "Yd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/catwalk_plated,
@@ -4472,17 +4727,19 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
+"YL" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/turf/space,
+/area/scavver/yachtup)
 "YY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/scavver/lifepod)
 "Zd" = (
@@ -4505,7 +4762,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/scavver/yachtup)
 "ZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11484,7 +11741,7 @@ eN
 eN
 eN
 eN
-eN
+IP
 eN
 eN
 eN
@@ -11631,13 +11888,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -11783,13 +12040,13 @@ eN
 eN
 eN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+oN
+oN
+hX
+oN
+YA
+oN
 eN
 eN
 eN
@@ -11935,13 +12192,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12087,13 +12344,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12239,13 +12496,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12391,13 +12648,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12543,13 +12800,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12695,13 +12952,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12847,13 +13104,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -12999,13 +13256,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -13151,13 +13408,13 @@ eN
 eN
 eN
 eN
+oN
+oN
+oN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -13303,13 +13560,13 @@ eN
 eN
 eN
 eN
+oN
+la
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -13455,13 +13712,13 @@ eN
 eN
 eN
 eN
+oN
+me
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -13607,13 +13864,13 @@ eN
 eN
 eN
 eN
+oN
+me
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -13759,13 +14016,13 @@ eN
 eN
 eN
 eN
+oN
+me
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+oN
+YA
+oN
 eN
 eN
 eN
@@ -13911,13 +14168,13 @@ eN
 eN
 eN
 eN
+bs
+tp
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+bs
+tp
+wG
 eN
 eN
 eN
@@ -14063,13 +14320,13 @@ eN
 eN
 eN
 eN
+bs
+tp
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+bs
+tp
+wG
 eN
 eN
 eN
@@ -14215,13 +14472,13 @@ eN
 eN
 eN
 eN
+bs
+tp
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+bs
+tp
+wG
 eN
 eN
 eN
@@ -14367,13 +14624,13 @@ eN
 eN
 eN
 eN
+bs
+tp
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+bs
+tp
+wG
 eN
 eN
 eN
@@ -14519,13 +14776,13 @@ eN
 eN
 eN
 eN
+bs
+tp
+wG
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+bs
+tp
+wG
 eN
 eN
 eN
@@ -14672,12 +14929,12 @@ eN
 eN
 eN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
+vp
+sX
+sX
+ma
+rt
+oN
 eN
 eN
 eN
@@ -14826,9 +15083,9 @@ sF
 sF
 jL
 oN
-oN
-VX
-eN
+zX
+Db
+hX
 eN
 eN
 eN
@@ -14977,9 +15234,9 @@ hv
 VX
 hv
 kP
-Ca
-VX
-VX
+yR
+yR
+Eu
 VX
 eN
 eN
@@ -15270,11 +15527,11 @@ bX
 sW
 hX
 VX
-te
-te
-te
+NY
+NY
+NY
 VX
-oN
+Qy
 Ce
 ju
 Ob
@@ -15284,7 +15541,7 @@ mu
 rB
 LF
 dX
-fV
+oN
 mV
 VX
 VX
@@ -15423,13 +15680,13 @@ VX
 VX
 Ca
 Ca
-NY
-NY
+te
+te
 VX
 Ww
 GZ
 XG
-DB
+Pc
 hv
 YA
 mu
@@ -15438,7 +15695,7 @@ Ib
 sU
 oN
 oN
-SA
+oN
 qU
 Ng
 VX
@@ -15590,8 +15847,8 @@ qR
 rt
 oN
 oN
-yq
-WA
+oN
+Qy
 Ng
 VX
 eN
@@ -15742,9 +15999,9 @@ oN
 oN
 oN
 oN
-mu
-FF
-Ng
+om
+sE
+jS
 VX
 eN
 eN
@@ -15891,7 +16148,7 @@ om
 Zx
 YA
 VW
-oN
+cQ
 qk
 CN
 Pc
@@ -16035,7 +16292,7 @@ oN
 bV
 lU
 dS
-aA
+Ob
 XF
 YA
 hv
@@ -16187,9 +16444,9 @@ EL
 nJ
 We
 jO
-We
+Dl
 HF
-rt
+Fb
 hv
 Nn
 Nn
@@ -16318,9 +16575,9 @@ In
 In
 In
 In
+WU
+WU
 jc
-WU
-WU
 In
 In
 Qr
@@ -16330,7 +16587,7 @@ EA
 Py
 Py
 Py
-Py
+SA
 sX
 ow
 BA
@@ -16497,8 +16754,8 @@ NY
 hv
 aB
 WA
-oN
-bS
+gx
+WA
 fH
 gf
 cA
@@ -16629,14 +16886,14 @@ eN
 eN
 eN
 eN
-cc
+qf
 eN
 eN
 eN
 An
 eN
 VX
-VX
+WX
 VX
 BA
 oN
@@ -16781,7 +17038,7 @@ eN
 eN
 eN
 eN
-cc
+qf
 eN
 eN
 eN
@@ -16933,14 +17190,14 @@ XR
 XR
 XR
 XR
-cc
+qf
 XR
 XR
 XR
 hD
 hX
 NY
-oN
+Yc
 VX
 eN
 eN
@@ -17085,29 +17342,29 @@ hX
 eN
 eN
 eN
-cc
+yq
 eN
 eN
 eN
 hX
 eN
 VX
-ov
+VP
 VX
 eN
 hX
 NY
-te
-te
-te
-te
+NY
+NY
+NY
+NY
 VX
 VX
 VX
 NY
 te
 te
-te
+NY
 VX
 eN
 eN
@@ -17237,15 +17494,15 @@ eN
 eN
 eN
 eN
-cc
+yq
 eN
 eN
 eN
 hX
-eN
+YL
+Ad
+Xj
 NY
-Ek
-pV
 eN
 hX
 eN
@@ -17365,12 +17622,12 @@ vE
 SQ
 pw
 pw
-iV
+pw
 ke
 sZ
-Af
-Af
-Af
+aA
+aA
+fV
 Af
 Af
 Af
@@ -17538,7 +17795,7 @@ zR
 xg
 Ko
 zR
-wJ
+mS
 Qn
 dV
 QB
@@ -17981,7 +18238,7 @@ wT
 KK
 KK
 KK
-FC
+fj
 ab
 vE
 Hg
@@ -17993,7 +18250,7 @@ dj
 er
 EU
 so
-EU
+ov
 Qn
 Qn
 pc
@@ -18449,7 +18706,7 @@ Qe
 er
 so
 Rv
-qf
+so
 Qn
 FA
 Qu
@@ -18459,7 +18716,7 @@ Qn
 VC
 CB
 ck
-CB
+sY
 zm
 JK
 Qn
@@ -18737,7 +18994,7 @@ Je
 Pd
 CI
 Rb
-rG
+Rb
 KK
 NQ
 Eo

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -2,9 +2,9 @@
 #include "scavver_gantry_jobs.dm"
 
 /datum/map_template/ruin/away_site/scavver_gantry
-	name = "Salvage Gantry"
+	name =  "\improper Salvage Gantry"
 	id = "awaysite_gantry"
-	description = "Salvage Gantry turned Ship."
+	description = "Salvage Gantry turned Ship"
 	suffixes = list("scavver/scavver_gantry-1.dmm","scavver/scavver_gantry-2.dmm")
 	cost = 1
 	accessibility_weight = 10
@@ -13,16 +13,21 @@
 		/datum/shuttle/autodock/overmap/scavver_gantry/two,
 		/datum/shuttle/autodock/ferry/gantry
 	)
-	ban_ruins = list(
-		/datum/map_template/ruin/away_site/bearcat_wreck,
-		/datum/map_template/ruin/exoplanet/playablecolony,
-		/datum/map_template/ruin/exoplanet/playablecolony2
-	)
 	area_usage_test_exempted_root_areas = list(/area/scavver)
+	apc_test_exempt_areas = list(
+		/area/scavver/yachtdown = NO_SCRUBBER|NO_VENT,
+		/area/scavver/yachtup = NO_SCRUBBER|NO_VENT,
+		/area/scavver/gantry/down1 = NO_SCRUBBER|NO_VENT,
+		/area/scavver/gantry/down2= NO_SCRUBBER|NO_VENT,
+		/area/scavver/gantry/up1 = NO_SCRUBBER|NO_VENT,
+		/area/scavver/gantry/up2 = NO_SCRUBBER|NO_VENT,
+		/area/scavver/escapepod = NO_SCRUBBER|NO_VENT,
+		/area/scavver/gantry/lift = NO_SCRUBBER|NO_VENT|NO_APC,
+	)
 	spawn_weight = 0.67
 
 /obj/effect/submap_landmark/joinable_submap/scavver_gantry
-	name = "Salvage Gantry"
+	name =  "Salvage Gantry"
 	archetype = /decl/submap_archetype/derelict/scavver_gantry
 
 /decl/submap_archetype/derelict/scavver_gantry
@@ -163,3 +168,13 @@
 	suit= /obj/item/clothing/suit/space/void/engineering/salvage
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering/salvage/pilot
 	mask = /obj/item/clothing/mask/breath
+
+/obj/structure/closet/secure_closet/freezer/fridge/scavver
+	req_access = list()
+
+/obj/structure/closet/secure_closet/freezer/fridge/scavver/WillContain()
+	return list(
+		/obj/item/weapon/reagent_containers/food/drinks/milk = 6,
+		/obj/item/weapon/reagent_containers/food/drinks/soymilk = 4,
+		/obj/item/weapon/storage/fancy/egg_box = 4
+	)

--- a/maps/away_sites_testing/away_sites_testing.dm
+++ b/maps/away_sites_testing/away_sites_testing.dm
@@ -22,7 +22,7 @@
 	#include "../away/ascent/ascent.dm"
 	#include "../away/meatstation/meatstation.dm"
 	#include "../away/miningstation/miningstation.dm"
-
+	#include "../away/scavver/scavver_gantry.dm"
 	#include "../away/voxship/voxship.dm"
 
 	#define using_map_DATUM /datum/map/away_sites_testing


### PR DESCRIPTION
🆑 
bugfix: Gives the Gantry a Cryostasis pod.
bugfix: Small changes to Gantry to reflect play.
bugfix: Gets rid of teleport beacons on Gantry and Bluespace river.
/🆑 
Extends an air supply line so hopefully the crew realizes they need to actually hook up their air system, also.
Switches Burn chambers to vacuum floor.
Shifts, or adds items, objects, turfs, or pipes where needed. All minor stuff to incentivize players to rebuild or modify in intended ways.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->