### PR TITLE
Spkrtn/tweaks/weight ruin gen

### DIFF
--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -5,7 +5,8 @@
 	How is there a wooden container filled with 18th century coinage in the middle of a lavawracked hellscape? \
 	It is clearly a mystery."
 
-	var/cost = null //negative numbers will always be placed, with lower (negative) numbers being placed first; positive and 0 numbers will be placed randomly
+	var/spawn_weight = 1
+	var/cost = null
 
 	var/prefix = null
 	var/suffixes = null

--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -1,75 +1,73 @@
 GLOBAL_LIST_EMPTY(banned_ruin_ids)
 
-/proc/seedRuins(list/z_levels = null, budget = 0, whitelist = /area/space, list/potentialRuins, var/maxx = world.maxx, var/maxy = world.maxy)
-	if(!z_levels || !z_levels.len)
+/proc/seedRuins(list/zlevels, budget, list/potentialRuins, allowed_area = /area/space, var/maxx = world.maxx, var/maxy = world.maxy)
+	if (!length(z_levels))
 		UNLINT(WARNING("No Z levels provided - Not generating ruins"))
 		return
 
-	for(var/zl in z_levels)
-		var/turf/T = locate(1, 1, zl)
-		if(!T)
-			UNLINT(WARNING("Z level [zl] does not exist - Not generating ruins"))
+	for (var/z in zlevels)
+		var/turf/check = locate(1, 1, z)
+		if (!check)
+			UNLINT(WARNING("Z level [z] does not exist - Not generating ruins"))
 			return
 
-	var/list/ruins = potentialRuins.Copy()
-	for(var/R in potentialRuins)
-		var/datum/map_template/ruin/ruin = R
-		if(ruin.id in GLOB.banned_ruin_ids)
-			ruins -= ruin //remove all prohibited ids from the candidate list; used to forbit global duplicates.
-	var/list/spawned_ruins = list()
-//Each iteration needs to either place a ruin or strictly decrease either the budget or ruins.len (or break).
-	while(budget > 0)
-		// Pick a ruin
-		var/datum/map_template/ruin/ruin = null
-		if(ruins && ruins.len)
-			ruin = pick(ruins)
-			if(ruin.cost > budget)
-				ruins -= ruin
-				continue //Too expensive, get rid of it and try again
-		else
-			log_world("Ruin loader had no ruins to pick from with [budget] left to spend.")
-			break
-		// Try to place it
-		var/sanity = 20
-		// And if we can't fit it anywhere, give up, try again
+	var/list/available = list()
+	var/list/selected = list()
+	var/remaining = budget
 
-		while(sanity > 0)
-			sanity--
+	for(var/datum/map_template/ruin/ruin in potentialRuins)
+		if (ruin.id in GLOB.banned_ruin_ids)
+			continue
+		available[ruin] = ruin.spawn_weight
 
-			var/width_border = TRANSITIONEDGE + RUIN_MAP_EDGE_PAD + round(ruin.width / 2)
-			var/height_border = TRANSITIONEDGE + RUIN_MAP_EDGE_PAD + round(ruin.height / 2)
-			var/z_level = pick(z_levels)
-			if(width_border > maxx - width_border || height_border > maxx - height_border) // Too big and will never fit.
-				ruins -= ruin //So let's not even try anymore with this one.
-				break
+	if (!length(available))
+		UNLINT(WARNING("No ruins available - Not generating ruins"))
 
-			var/turf/T = locate(rand(width_border, maxx - width_border), rand(height_border, maxy - height_border), z_level)
+	while (remaining > 0 && length(available))
+		var/datum/map_template/ruin/ruin = pickweight(available)
+		if (ruin.cost > budget)
+			available -= ruin
+			continue
+
+		var/width = TRANSITIONEDGE + RUIN_MAP_EDGE_PAD + round(ruin.width / 2)
+		var/height = TRANSITIONEDGE + RUIN_MAP_EDGE_PAD + round(ruin.height / 2)
+		if (width > maxx - width || height > maxy - height)
+			available -= ruin
+			continue
+
+		for (var/attempts = 20, attempts > 0, --attempts)
+			var/z = pick(zlevels)
+			var/turf/choice = locate(rand(width, maxx - width), rand(height, maxy - height), z)
+
 			var/valid = TRUE
-
-			for(var/turf/check in ruin.get_affected_turfs(T,1))
-				var/area/new_area = get_area(check)
-				if(!(istype(new_area, whitelist)) || check.turf_flags & TURF_FLAG_NORUINS)
-					if(sanity == 0)
-						ruins -= ruin //It didn't fit, and we are out of sanity. Let's make sure not to keep trying the same one.
+			for (var/turf/check in ruin.get_affected_turfs(choice, 1))
+				var/area/check_area = get_area(check)
+				if (!istype(check_area, allowed_area) || check.turf_flags & TURF_FLAG_NORUINS)
+					if (attempts == 1)
+						available -= ruin
 					valid = FALSE
-					break //Let's try again
-
-			if(!valid)
+					break
+			if (!valid)
 				continue
-			log_world("Ruin \"[ruin.name]\" placed at ([T.x], [T.y], [T.z])")
 
-			load_ruin(T, ruin)
-			spawned_ruins += ruin
-			if(ruin.cost >= 0)
-				budget -= ruin.cost
-			if(!(ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
-				for(var/other_ruin_datum in ruins)
-					var/datum/map_template/ruin/other_ruin = other_ruin_datum
-					if(ruin.id == other_ruin.id)
-						ruins -= ruin //Remove all ruins with the same id if we don't allow duplicates
-				GLOB.banned_ruin_ids += ruin.id //and ban them globally too
+			log_world("Ruin \"[ruin.name]\" placed at ([choice.x], [choice.y], [choice.z])")
+
+			load_ruin(choice, ruin)
+			selected += ruin
+			if (ruin.cost > 0)
+				remaining -= ruin.cost
+			if (!(ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
+				GLOB.banned_ruin_ids += ruin.id
+				available -= ruin
 			break
-	return spawned_ruins
+
+	if (remaining)
+		log_world("Ruin loader had no ruins to pick from with [budget] left to spend.")
+
+	if (length(selected))
+		report_progress("Finished selecting planet ruins ([english_list(selected)]) for [budget - remaining] cost of [budget] budget.")
+
+	return selected
 
 /proc/load_ruin(turf/central_turf, datum/map_template/template)
 	if(!template)

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -188,7 +188,7 @@
 				new map_type(null,1,1,zlevel,maxx,maxy,0,1,1,planetary_area)
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_features()
-	spawned_features = seedRuins(map_z, features_budget, /area/exoplanet, possible_features, maxx, maxy)
+	spawned_features = seedRuins(map_z, features_budget, possible_features, /area/exoplanet, maxx, maxy)
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/get_biostuff(var/datum/random_map/noise/exoplanet/random_map)
 	if(!istype(random_map))

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -15,6 +15,7 @@
 		/datum/shuttle/autodock/overmap/ascent, 
 		/datum/shuttle/autodock/overmap/ascent/two
 	)
+	spawn_weight = 0.67
 
 // Overmap objects.
 /obj/effect/overmap/visitable/ship/ascent_seedship

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -1,7 +1,6 @@
 // Hey! Listen! Update \config\away_site_blacklist.txt with your new ruins!
 
 /datum/map_template/ruin/away_site
-	var/spawn_weight = 1
 	var/list/generate_mining_by_z
 	prefix = "maps/away/"
 

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -50,6 +50,7 @@
 		/area/ship/scrap/shuttle/lift = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/ship/scrap/command/hallway = NO_SCRUBBER|NO_VENT
 	)
+	spawn_weight = 0.67
 
 /datum/shuttle/autodock/ferry/lift
 	name = "Cargo Lift"

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -14,11 +14,12 @@
 		/datum/shuttle/autodock/ferry/gantry
 	)
 	ban_ruins = list(
-		list(/datum/map_template/ruin/away_site/bearcat_wreck,
+		/datum/map_template/ruin/away_site/bearcat_wreck,
 		/datum/map_template/ruin/exoplanet/playablecolony,
-		/datum/map_template/ruin/exoplanet/playablecolony2)
+		/datum/map_template/ruin/exoplanet/playablecolony2
 	)
 	area_usage_test_exempted_root_areas = list(/area/scavver)
+	spawn_weight = 0.67
 
 /obj/effect/submap_landmark/joinable_submap/scavver_gantry
 	name = "Salvage Gantry"

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -14,6 +14,7 @@
 		/area/ship/skrellscoutship/externalwing/port = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/ship/skrellscoutship/externalwing/starboard = NO_SCRUBBER|NO_VENT|NO_APC
 	)
+	spawn_weight = 0.67
 
 /obj/effect/overmap/visitable/sector/skrellscoutspace
 	name = "Empty Sector"

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -32,6 +32,7 @@
 	suffixes = list("unishi/unishi-1.dmm", "unishi/unishi-2.dmm", "unishi/unishi-3.dmm")
 	cost = 2
 	area_usage_test_exempted_root_areas = list(/area/unishi)
+	spawn_weight = 0.67
 
 
 /obj/effect/shuttle_landmark/nav_unishi/nav1
@@ -170,4 +171,3 @@ obj/item/weapon/paper/prof2
 
 /datum/chemical_reaction/clonexadone/nophoron
 	required_reagents = list(/datum/reagent/cryoxadone = 1, /datum/reagent/sodium = 1, /datum/reagent/toxin/phoron/safe = 0.1)
-

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -12,6 +12,7 @@
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 	ban_ruins = list(/datum/map_template/ruin/away_site/scavship)
+	spawn_weight = 0.33
 
 /obj/effect/overmap/visitable/sector/vox_base
 	name = "large asteroid"
@@ -96,6 +97,7 @@
 	cost = 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_ship, /datum/shuttle/autodock/overmap/vox_lander)
 	ban_ruins = list(/datum/map_template/ruin/away_site/voxship)
+	spawn_weight = 0.33
 
 /obj/effect/overmap/visitable/sector/vox_scav_ship
 	name = "small asteroid cluster"

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	cost = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
+	spawn_weight = 0.67
 
 /area/map_template/crashed_pod
 	name = "\improper Crashed Survival Pod"

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -10,6 +10,7 @@
 	apc_test_exempt_areas = list(
 		/area/map_template/colony/mineralprocessing = NO_SCRUBBER|NO_VENT
 	)
+	spawn_weight = 0.33
 
 /decl/submap_archetype/playablecolony
 	descriptor = "established colony"

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
@@ -10,6 +10,7 @@
 	apc_test_exempt_areas = list(
 		/area/map_template/colony2/external = NO_SCRUBBER|NO_VENT
 	)
+	spawn_weight = 0.33
 
 /decl/submap_archetype/playablecolony2
 	descriptor = "landed colony ship"


### PR DESCRIPTION
Moved away site weighting up a level of inheritance to ruins. Implements it for ruins.
Fixed ruins testing their height against map width.
Adjusted seedRuins signature to keep arguments with defaults at the end.
Gives all off-ship ruins with jobs a lower picking weight (2/3 normal except vox and colony at 1/3 as there are two of each) to compensate for there being quite a few now.
Fixes the scav gantry having a nested ban_ruins list.
