### PR TITLE
Diona Changes

### DIFF
--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -314,9 +314,9 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	heat_level_1 = 2000
-	heat_level_2 = 2550
-	heat_level_3 = 3100
+	heat_level_1 = 3000
+	heat_level_2 = 4000
+	heat_level_3 = 5000
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -305,16 +305,18 @@
 		/mob/living/carbon/human/proc/diona_heal_toggle
 		)
 
-	warning_low_pressure = 50
+	warning_low_pressure = -1
 	hazard_low_pressure = -1
-
-	cold_level_1 = 50
+	warning_high_pressure = 95000
+	hazard_high_pressure = 120000
+	
+	cold_level_1 = -1
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	heat_level_1 = 2000
-	heat_level_2 = 3000
-	heat_level_3 = 4000
+	heat_level_1 = 32000
+	heat_level_2 = 40000
+	heat_level_3 = 45000
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -307,16 +307,16 @@
 
 	warning_low_pressure = -1
 	hazard_low_pressure = -1
-	warning_high_pressure = 95000
-	hazard_high_pressure = 120000
+	warning_high_pressure = 1500
+	hazard_high_pressure = 2000
 	
 	cold_level_1 = -1
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	heat_level_1 = 32000
-	heat_level_2 = 40000
-	heat_level_3 = 45000
+	heat_level_1 = 2000
+	heat_level_2 = 2550
+	heat_level_3 = 3100
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 


### PR DESCRIPTION
(Same as before but fixed to no longer look like patch bukkake)

A small breakdown

-- the following changes are to make tree people more space comfortable, since they are all made of hull grade plants
cold_level_1 = -1
warning_low_pressure = -1
hazard_low_pressure = -1

-- The following changes are to reflect the fact that diona live in the actual heart of stars in their spare time which are very dense and hot
heat_level_1 = 32000
heat_level_2 = 40000
heat_level_3 = 45000
warning_high_pressure = 95000
hazard_high_pressure = 120000

🆑
Tweak: Made Diona more space faring and heat resistant
/🆑 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->