### PR TITLE
Desperado turrets start disabled

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -218,6 +218,7 @@
 	},
 /obj/machinery/turretid/lethal{
 	ailock = 1;
+	enabled = 0;
 	check_arrest = 0;
 	check_records = 0;
 	pixel_y = 32;


### PR DESCRIPTION
:cl:
maptweak: Desperado turrets start disabled (you can now safely be naked in the mercenary base).
/:cl: