### PR TITLE
Move the fuel valve on the GUP into the foreground

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -1016,6 +1016,7 @@
 "cg" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/valve/open{
+	layer = 2.07;
 	open = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{


### PR DESCRIPTION
🆑 Mucker
tweak: Move the fuel valve on the GUP into the foreground.
/🆑

Before:
![image](https://user-images.githubusercontent.com/1161516/90294706-eedb2f00-de3b-11ea-95fc-83b7005c82f6.png)

After: 
![image](https://user-images.githubusercontent.com/1161516/90294726-fac6f100-de3b-11ea-9e35-a03b23c0e181.png)

