### PR TITLE
Mantid cryotanks are now functional and have oversight

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -144,6 +144,7 @@
 	var/base_icon_state = "body_scanner_0"
 	var/occupied_icon_state = "body_scanner_1"
 	var/on_store_message = "has entered long-term storage."
+	var/on_store_visible_message = "hums and hisses as it moves $occupant$ into storage." // $occupant$ is automatically converted to the occupant's name
 	var/on_store_name = "Cryogenic Oversight"
 	var/on_enter_occupant_message = "You feel cool air surround you. You go numb as your senses turn inward."
 	var/allow_occupant_types = list(/mob/living/carbon/human)
@@ -153,6 +154,7 @@
 	var/time_till_despawn = 9000  // Down to 15 minutes //30 minutes-ish is too long
 	var/time_entered = 0          // Used to keep track of the safe period.
 	var/obj/item/device/radio/intercom/announce //
+	var/announce_despawn = TRUE
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
@@ -410,8 +412,11 @@
 		control_computer._admin_logs += "[key_name(occupant)] ([role_alt_title]) at [stationtime2text()]"
 	log_and_message_admins("[key_name(occupant)] ([role_alt_title]) entered cryostorage.")
 
-	announce.autosay("[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
-	visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [occupant.real_name] into storage.</span>", range = 3)
+	if(announce_despawn)
+		announce.autosay("[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
+
+	var/despawnmessage = replacetext(on_store_visible_message, "$occupant$", occupant.real_name) 
+	visible_message(SPAN_NOTICE("\The [initial(name)] " + despawnmessage), range = 3)
 
 	//This should guarantee that ghosts don't spawn.
 	occupant.ckey = null

--- a/code/modules/ascent/ascent_atoms.dm
+++ b/code/modules/ascent/ascent_atoms.dm
@@ -20,11 +20,3 @@ MANTIDIFY(/obj/item/weapon/tank/jetpack/carbondioxide, "maneuvering pack",      
 	color = COLOR_CYAN
 	b_colour = COLOR_CYAN
 	desc = "Some kind of strange alien lightbulb technology."
-
-/obj/structure/ascent_spawn
-	name = "mantid cryotank"
-	desc = "A liquid-filled, cloudy tank with strange forms twitching inside."
-	icon = 'icons/obj/cryogenics.dmi'
-	icon_state = "cellold2"
-	anchored = TRUE
-	density =  TRUE

--- a/code/modules/ascent/ascent_machines.dm
+++ b/code/modules/ascent/ascent_machines.dm
@@ -243,3 +243,49 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	icon = 'icons/obj/machines/power/mantid_smes.dmi'	
 	overlay_icon = 'icons/obj/machines/power/mantid_smes.dmi'
 	construct_state = /decl/machine_construction/default/no_deconstruct
+
+/obj/machinery/cryopod/ascent_spawn
+	name = "mantid cryotank"
+	desc = "A liquid-filled, cloudy tank with strange forms twitching inside."
+	icon = 'icons/obj/cryogenics.dmi'
+	icon_state = "cellold2"
+
+	base_icon_state = "cellold2"
+	occupied_icon_state = "cellold2" //The cell looks the same whether something is in it or not
+	on_store_visible_message = "lets out a quiet hiss as $occupant$ disappears into the cloudy liquid."
+	on_enter_occupant_message = "You feel a cool touch on your skin as the cryogenic liquid permeates throughout your body. You go numb as your senses turn inward."
+	announce_despawn = FALSE
+
+/obj/machinery/cryopod/ascent_spawn/despawn_occupant()
+	var/oname = occupant.name
+	. = ..()
+	var/obj/machinery/computer/cryopod/ascent_spawn/announce_computer
+	if(istype(control_computer, /obj/machinery/computer/cryopod/ascent_spawn))
+		announce_computer = control_computer
+	else
+		CRASH("Mantid cryotank has a non-mantid oversight console!")
+	announce_computer.announcer.say(",\[ [oname] has returned to the cryotank.")
+
+/obj/machinery/computer/cryopod/ascent_spawn
+	name = "cryotank oversight console"
+	desc = "An interface between the gyne's brood and the cryotank oversight system."
+	color = COLOR_VIOLET
+	construct_state = null
+	
+	storage_type = "lifeforms"
+	storage_name = "Cryotank Oversight Control"
+
+	var/mob/living/carbon/announcer
+
+
+/obj/machinery/computer/cryopod/ascent_spawn/Initialize()
+	. = ..()
+	announcer = new /mob/living/carbon(src)
+	announcer.status_flags |= GODMODE
+	announcer.name = "Cryotank Oversight"
+	announcer.add_language(LANGUAGE_MANTID_BROADCAST)
+
+/obj/machinery/computer/cryopod/ascent_spawn/Destroy()
+	qdel(announcer)
+	. = ..()
+	

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -345,7 +345,7 @@
 /area/ship/ascent/bridge)
 "bl" = (
 /obj/effect/submap_landmark/spawnpoint/ascent_seedship/alate,
-/obj/structure/ascent_spawn,
+/obj/machinery/cryopod/ascent_spawn,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
 "bm" = (
@@ -556,6 +556,9 @@
 	level = 2
 	},
 /obj/structure/bed/chair/padded/purple/ascent,
+/obj/machinery/computer/cryopod/ascent_spawn{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
 "bL" = (
@@ -767,7 +770,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
 "ch" = (
-/obj/structure/ascent_spawn,
+/obj/machinery/cryopod/ascent_spawn,
 /obj/effect/submap_landmark/spawnpoint/ascent_seedship,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
@@ -812,7 +815,7 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/wing_port)
 "cm" = (
-/obj/structure/ascent_spawn,
+/obj/machinery/cryopod/ascent_spawn,
 /obj/effect/submap_landmark/spawnpoint/ascent_seedship/adjunct,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)
@@ -1339,7 +1342,7 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/wing_port)
 "dB" = (
-/obj/structure/ascent_spawn,
+/obj/machinery/cryopod/ascent_spawn,
 /obj/effect/submap_landmark/spawnpoint/ascent_seedship/queen,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/habitation)


### PR DESCRIPTION
:cl:
rscadd: Mantid cryotanks now function as cryogenic storage. Similarly, there is now an oversight console for them.
/:cl:

Kharmaani still don't spawn inside them nor is there any join message. I'd love to add those two but this already proved to be more difficult than I previously thought.

A lot of this is hacky to deal with the way worldnet works and short of refactoring everything I doubt this is the best way to do it. Feedback would be well-appreciated.