### PR TITLE
Various fixes for valves

### DIFF
--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -31,23 +31,26 @@
 /obj/machinery/atmospherics/valve/shutoff/Initialize()
 	. = ..()
 	open()
-	hide(1)
 
-/obj/machinery/atmospherics/valve/shutoff/interface_interact(var/mob/user)
+/obj/machinery/atmospherics/valve/atmos_init()
+	. = ..()
+	var/turf/T = loc
+	hide(hides_under_flooring() && !T.is_plating())
+
+/obj/machinery/atmospherics/valve/shutoff/interface_interact(mob/user)
 	if(CanInteract(user, DefaultTopicState()))
 		close_on_leaks = !close_on_leaks
 		update_icon()
 		to_chat(user, "You [close_on_leaks ? "enable" : "disable"] the automatic shutoff circuit.")
 		return TRUE
 
+/obj/machinery/atmospherics/valve/shutoff/physical_attack_hand(mob/user)
+	return FALSE
+
 /obj/machinery/atmospherics/valve/shutoff/hide(var/do_hide)
-	if(do_hide)
-		if(level == 1)
-			layer = PIPE_LAYER
-		else if(level == 2)
-			..()
-	else
-		reset_plane_and_layer()
+	if(istype(loc, /turf/simulated))
+		set_invisibility(do_hide ? 101 : 0)
+	update_underlays()
 
 /obj/machinery/atmospherics/valve/shutoff/Process()
 	..()

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -18,6 +18,7 @@
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	connect_dir_type = SOUTH | NORTH
+	pipe_class = PIPE_CLASS_BINARY
 	rotate_class = PIPE_ROTATE_TWODIR
 	build_icon_state = "mvalve"
 


### PR DESCRIPTION
:cl: Hubblenaut
bugfix: Fixes valves not connecting to adjacent pipes when being constructed.
bugfix: Fixes shutoff valves not being interactable.
bugfix: Fixes shutoff valves layering.
/:cl:

- Fixes constructed valves not connecting to pipes.
- Fixes shutoff valves not being interactable.
- Fixes shutoff valves not layering correctly above and beneath
flooring.
Shutoff valves will now be properly invisible beneath flooring like other pipes and are now possible to actually be installed above flooring.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->