### PR TITLE
wizard soulstone fix

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -450,6 +450,8 @@
 	can_hold = list(
 		/obj/item/device/soulstone
 		)
+/obj/item/weapon/storage/belt/soulstone/disrupts_psionics()
+	return FALSE
 
 /obj/item/weapon/storage/belt/soulstone/full/New()
 	..()


### PR DESCRIPTION
:cl: RustingWithYou
tweak: soulstones in a belt no longer nullify psionics/magic
/:cl:

currently the soul stone belt as wizard is next to useless, as wearing it prevents the wizard from casting any spells. this makes it so that when soul stones are in a soul stone belt they no longer prevent the wizard from wizarding.