### PR TITLE
Fix rescue bags

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -84,9 +84,18 @@
 	return 0
 
 /obj/structure/closet/body_bag/proc/fold(var/user)
-	if(!(ishuman(user) || isrobot(user)))	return 0
-	if(opened)	return 0
-	if(contents.len)	return 0
+	if(!(ishuman(user) || isrobot(user)))
+		to_chat(user, SPAN_NOTICE("You lack the dexterity to close \the [name]."))
+		return FALSE
+
+	if(opened)
+		to_chat(user, SPAN_NOTICE("You must close \the [name] before it can be folded."))
+		return FALSE
+
+	if(contents.len)
+		to_chat(user, SPAN_NOTICE("You can't fold \the [name] while it has something inside it."))
+		return FALSE
+
 	visible_message("[user] folds up the [name]")
 	. = new item_path(get_turf(src))
 	qdel(src)

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -53,7 +53,7 @@
 		to_chat(user,"The distribution valve on \the [airtank] is set to '[airtank.distribute_pressure] kPa'.")
 	else
 		to_chat(user, "<span class='warning'>The air tank is missing.</span>")
-		
+
 /obj/structure/closet/body_bag/rescue
 	name = "rescue bag"
 	desc = "A reusable plastic bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
@@ -105,12 +105,15 @@
 
 /obj/structure/closet/body_bag/rescue/fold(var/user)
 	var/obj/item/weapon/tank/my_tank = airtank
-	airtank = null
+	airtank = null // Apparently this is required to avoid breaking my_tank checks further down after the parent proc runs qdel(src)
 	var/obj/item/bodybag/rescue/folded = ..()
-	if(istype(folded) && my_tank)
-		my_tank.air_contents.merge(atmo)
-		folded.airtank = my_tank
-		my_tank.forceMove(folded)
+	if (folded && istype(folded))
+		if (my_tank)
+			my_tank.air_contents.merge(atmo)
+			folded.airtank = my_tank
+			my_tank.forceMove(folded)
+	else
+		airtank = my_tank
 
 /obj/structure/closet/body_bag/rescue/Process()
 	if(!airtank)


### PR DESCRIPTION
:cl:
bugfix: Rescue bags will no longer randomly delete their air tanks when trying to fold them while open, holding someone, or other failure states.
tweak: Body bags, stasis bags, rescue bags, etc now provide a failure hint in chat when you fail to fold them.
/:cl:

Closes #29114 