### PR TITLE
Fixes horrible lie in hub listing

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -594,9 +594,6 @@ var/world_topic_spam_protect_time = world.timeofday
 	if (config && config.allow_vote_mode)
 		features += "vote"
 
-	if (config && config.allow_ai)
-		features += "AI allowed"
-
 	var/n = 0
 	for (var/mob/M in GLOB.player_list)
 		if (M.client)


### PR DESCRIPTION
AI isn't a joinable job anymore, so shouldn't be on the hub listing.

:cl:
tweak: Hub listing on longer shows 'AI allowed'.
/:cl: