### PR TITLE
soulstones disrupt spells if they are full, not empty

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -23,7 +23,7 @@
 	. = ..(mapload)
 
 /obj/item/device/soulstone/disrupts_psionics()
-	return (full == SOULSTONE_EMPTY) ? src : FALSE
+	return (full == SOULSTONE_ESSENCE) ? src : FALSE
 
 /obj/item/device/soulstone/proc/shatter()
 	playsound(loc, "shatter", 70, 1)


### PR DESCRIPTION
:cl:
tweak: Soulstones disrupt spells and psionics when full instead of empty.
/:cl:

closes #29125