### PR TITLE
APCs on the bearcat spawn with power channels on auto

### DIFF
--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -85,9 +85,6 @@
 
 /obj/machinery/power/apc/derelict
 	cell_type = /obj/item/weapon/cell/crap/empty
-	lighting = 0
-	equipment = 0
-	environ = 0
 	locked = 0
 	coverlocked = 0
 


### PR DESCRIPTION
:cl: Hubblenaut
tweak: The APCs on the bearcat spawn with power channels on 'Auto'
/:cl:

This will save bearcat survivors the annoyance of walking around the ship finding all APCs and setting the power channels to 'Auto'. This has become even slightly more important since APCs will no longer charge their cells at all without the environment channel being powered. I don't believe that spending between five and ten minutes of pressing the same three buttons adds anything of value to the game experience.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->