### PR TITLE
Makes ship helm UI show a more precise heading value

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -84,7 +84,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		data["d_y"] = dy
 		data["speedlimit"] = speedlimit ? speedlimit*1000 : "Halted"
 		data["accel"] = min(round(linked.get_acceleration()*1000, 0.01),accellimit*1000)
-		data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
+		data["heading"] = linked.get_heading_angle() ? linked.get_heading_angle() : 0
 		data["autopilot"] = autopilot
 		data["manual_control"] = viewing_overmap(user)
 		data["canburn"] = linked.can_burn()
@@ -236,7 +236,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	data["s_y"] = linked.y
 	data["speed"] = round(linked.get_speed()*1000, 0.01)
 	data["accel"] = round(linked.get_acceleration()*1000, 0.01)
-	data["heading"] = linked.get_heading() ? dir2angle(linked.get_heading()) : 0
+	data["heading"] = linked.get_heading_angle() ? linked.get_heading_angle() : 0
 	data["viewing"] = viewing_overmap(user)
 
 	if(linked.get_speed())

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -56,7 +56,7 @@
 /obj/effect/overmap/visitable/ship/get_scan_data(mob/user)
 	. = ..()
 	if(!is_still())
-		. += "<br>Heading: [dir2angle(get_heading())], speed [get_speed() * 1000]"
+		. += "<br>Heading: [get_heading_angle()], speed [get_speed() * 1000]"
 
 //Projected acceleration based on information from engines
 /obj/effect/overmap/visitable/ship/proc/get_acceleration()
@@ -86,6 +86,12 @@
 			res |= NORTH
 		else
 			res |= SOUTH
+	return res
+
+/obj/effect/overmap/visitable/ship/proc/get_heading_angle()
+	var/res = 0
+	if (MOVING(speed[1]) || MOVING(speed[2]))
+		res = (round(Atan2(speed[1], -speed[2])) + 450)%360
 	return res
 
 /obj/effect/overmap/visitable/ship/proc/adjust_speed(n_x, n_y)


### PR DESCRIPTION
:cl: ToddRafter
tweak: Helm consoles show their ships heading in degrees instead of eighths.
/:cl:

Added a new function to ship code so that their heading can now accurately be shown to the player instead of multiple of 45° derived from snapping to byond dirs.

Kept the original function, which is used in a very specific way to help apply acceleration correctly (no changes)

