### PR TITLE
More Goonchat fixes

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -28,7 +28,7 @@
 	icon_state = "t-ray[on]"
 
 /obj/item/device/t_scanner/emp_act()
-	audible_message(src, "<span class = 'notice'> \The [src] buzzes oddly.</span>")
+	audible_message("<span class = 'notice'> \The [src] buzzes oddly.</span>")
 	set_active(FALSE)
 
 /obj/item/device/t_scanner/attack_self(mob/user)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -30,8 +30,6 @@
 		handle_privacy_poll()
 		client.playtitlemusic()
 		maybe_send_staffwarns("connected as new player")
-		if(!client.chatOutput.loaded && client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
-			client.chatOutput.start()
 
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 	var/decl/security_level/SL = security_state.current_security_level


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
It should be noted that #28965 is the crash call for invalid message types. This will reopen any time there's a bad message type sent to chat, so expect to see fixes for it often