### PR TITLE
Deep Space can no longer move to nullspace with people inside of it

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -1,4 +1,4 @@
-//list used to cache empty zlevels to avoid nedless map bloat
+//list used to cache empty zlevels to avoid needless map bloat
 var/list/cached_space = list()
 
 //Space stragglers go here
@@ -9,17 +9,27 @@ var/list/cached_space = list()
 	known = 0
 
 /obj/effect/overmap/visitable/sector/temporary/New(var/nx, var/ny, var/nz)
-	loc = locate(nx, ny, GLOB.using_map.overmap_z)
-	x = nx
-	y = ny
 	map_z += nz
-	map_sectors["[nz]"] = src
-	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [nz].")
+	testing("Temporary sector at zlevel [nz] was created.")
+	register(nx, ny)
 
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
-	map_sectors["[map_z]"] = null
-	testing("Temporary sector at [x],[y] was deleted.")
+	unregister()
+	testing("Temporary sector at [x],[y] was deleted. zlevel [map_z[1]] is no longer accessible.")
 	return ..()
+
+/obj/effect/overmap/visitable/sector/temporary/proc/register(var/nx, var/ny)
+	forceMove(locate(nx, ny, GLOB.using_map.overmap_z))
+	map_sectors["[map_z[1]]"] = src
+	testing("Temporary sector at zlevel [map_z[1]] moved to coordinates [x],[y]")
+
+/obj/effect/overmap/visitable/sector/temporary/proc/unregister()
+	// Note that any structures left in the zlevel will remain there, and may later turn up at completely different
+	// coordinates if this temporary sector is recycled. Perhaps everything remaining in the zlevel should be destroyed?
+	testing("Caching temporary sector for future use, corresponding zlevel is [map_z[1]], previous coordinates were [x],[y]")
+	map_sectors.Remove(src)
+	src.forceMove(null)
+	cached_space += src
 
 /obj/effect/overmap/visitable/sector/temporary/proc/can_die(var/mob/observer)
 	testing("Checking if sector at [map_z[1]] can die.")
@@ -30,17 +40,20 @@ var/list/cached_space = list()
 	return 1
 
 proc/get_deepspace(x,y)
-	var/obj/effect/overmap/visitable/sector/temporary/res = locate(x,y,GLOB.using_map.overmap_z)
+	var/turf/map = locate(x,y,GLOB.using_map.overmap_z)
+	var/obj/effect/overmap/visitable/sector/temporary/res
+	for(var/obj/effect/overmap/visitable/sector/temporary/O in map)
+		res = O
+		break
 	if(istype(res))
 		return res
 	else if(cached_space.len)
 		res = cached_space[cached_space.len]
 		cached_space -= res
-		res.x = x
-		res.y = y
+		res.register(x, y)
 		return res
 	else
-		return new /obj/effect/overmap/visitable/sector/temporary(x, y, GLOB.using_map.get_empty_zlevel())
+		return new /obj/effect/overmap/visitable/sector/temporary(x, y, ++world.maxz)
 
 /atom/movable/proc/lost_in_space()
 	for(var/atom/movable/AM in contents)
@@ -109,7 +122,5 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 
 	if(istype(M, /obj/effect/overmap/visitable/sector/temporary))
 		var/obj/effect/overmap/visitable/sector/temporary/source = M
-		if (source.can_die())
-			testing("Caching [M] for future use")
-			source.forceMove(null)
-			cached_space += source
+		if (source != TM && source.can_die())
+			source.unregister()


### PR DESCRIPTION
:cl:
bugfix: Deep Space can no longer move to nullspace with people inside of it
/:cl:

"Deep Space" here refers to the lost-in-space mechanic where an empty temporary sector is created. When a player moves to the edge of a temporary sector, a list of all overmap sectors in the same coordinates is created. There is a random chance of moving into any of these colocated sectors, or simply being moved to the other side of the temporary sector.

Previously, all temporary sectors were using a single zlevel. This is noteworthy, because:
- There can be more than one temporary sector instance (imagine two players simultaneously getting lost, but they originate from two different ships (e.g. Torch and Bearcat)
- The overmap code assumes that a zlevel only exists in a single place in the overmap. If this assumption is false, then the zlevel -> sector lookup table `map_sectors` fails to work as expected.
- The temporary sector zlevel was being pulled to the overmap coordinates where a player last entered deep space. This could enable some strange teleportation behavior, where someone enters deep space at overmap coordinates (1,1), then someone else enters deep space at overmap coordinates (25,25). Both players are now in the same zlevel, and are at overmap coordinates (25,25).
- The design of the code heavily implies that each temporary sector instance was supposed to have its own zlevel. It's unclear if the current behavior was always to use a single zlevel across all deep space instances, or if this was a regression introduced at some point.

In this PR, each new temporary sector is allocated a new zlevel. Once a temporary sector has been vacated by all players, it is returned to a pool for later reuse to prevent unbounded creation of new zlevels.

With that explanation behind us, the bug was caused by two things:
- Improper handling of the temporary sector cache, causing their `loc`s to be nulled and never reset.
- The previously explained shared zlevel issue

The effect of the bug was that the temporary sector would effectively be moved to overmap coordinates (0,0) even if players were in it under certain edge cases, effectively stranding everyone in the sector, as it is unlikely there is a ship located at (0,0).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->