### PR TITLE
Restricts prying tiles and catwalks with a crowbar to help intent

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -87,6 +87,8 @@
 		deconstruct(user)
 		return
 	if(isCrowbar(C) && plated_tile)
+		if(user.a_intent != I_HELP)
+			return
 		hatch_open = !hatch_open
 		if(hatch_open)
 			playsound(src, 'sound/items/Crowbar.ogg', 100, 2)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -11,6 +11,8 @@
 
 	if(flooring)
 		if(isCrowbar(C))
+			if(user.a_intent != I_HELP)
+				return
 			if(broken || burnt)
 				to_chat(user, "<span class='notice'>You remove the broken [flooring.descriptor].</span>")
 				make_plating()


### PR DESCRIPTION
So you don't accidentally pull up the floor if you ever find yourself using a crowbar as a melee weapon.

:cl: Slywater
tweak: You can now only pry up tiles or catwalks with a crowbar on help intent.
/:cl: