### PR TITLE
Allows overriding of physical distance

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -28,7 +28,7 @@
 	icon_state = "t-ray[on]"
 
 /obj/item/device/t_scanner/emp_act()
-	audible_message(src, "<span class = 'notice'> \The [src] buzzes oddly.</span>")
+	audible_message("<span class = 'notice'> \The [src] buzzes oddly.</span>")
 	set_active(FALSE)
 
 /obj/item/device/t_scanner/attack_self(mob/user)

--- a/code/modules/nano/interaction/physical.dm
+++ b/code/modules/nano/interaction/physical.dm
@@ -12,7 +12,7 @@ GLOBAL_DATUM_INIT(physical_state, /datum/topic_state/physical, new)
 	return default_can_use_topic(src_object)
 
 /mob/living/check_physical_distance(var/src_object)
-	return shared_living_nano_distance(src_object)
+	return loc ? loc.contents_nano_distance(src_object, src) : shared_living_nano_distance(src_object)
 
 /mob/living/silicon/ai/check_physical_distance(var/src_object)
 	return max(STATUS_UPDATE, shared_living_nano_distance(src_object))


### PR DESCRIPTION
I dont see why physical interaction ignores the loc shared distance. But it's handy to be able to override it for vehicles.