### PR TITLE
adds a kv store for instances

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -193,6 +193,7 @@
 #include "code\controllers\subsystems\inactivity.dm"
 #include "code\controllers\subsystems\jobs.dm"
 #include "code\controllers\subsystems\lighting.dm"
+#include "code\controllers\subsystems\kv.dm"
 #include "code\controllers\subsystems\machines.dm"
 #include "code\controllers\subsystems\mapping.dm"
 #include "code\controllers\subsystems\misc_late.dm"

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -44,7 +44,7 @@
 #define SS_PRIORITY_GRAPH         30   // Merging and splitting of graphs
 #define SS_PRIORITY_CHAR_SETUP    25   // Writes player preferences to savefiles.
 #define SS_PRIORITY_GARBAGE       20   // Garbage collection.
-
+#define SS_PRIORITY_KV            10   // \ref based arbitrary storage.
 
 // Subsystem fire priority, from lowest to highest priority
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -87,6 +87,8 @@
 			return global.SSinactivity;
 		if("SSjobs")
 			return global.SSjobs;
+		if("SSkv")
+			return global.SSkv;
 		if("SSlighting")
 			return global.SSlighting;
 		if("SSmachines")
@@ -998,6 +1000,8 @@
 			global.SSinactivity=newval;
 		if("SSjobs")
 			global.SSjobs=newval;
+		if("SSkv")
+			global.SSkv=newval;
 		if("SSlighting")
 			global.SSlighting=newval;
 		if("SSmachines")
@@ -1865,6 +1869,7 @@
 	"SSicon_update",
 	"SSinactivity",
 	"SSjobs",
+	"SSkv",
 	"SSlighting",
 	"SSmachines",
 	"SSmapping",

--- a/code/controllers/subsystems/kv.dm
+++ b/code/controllers/subsystems/kv.dm
@@ -1,0 +1,44 @@
+
+SUBSYSTEM_DEF(kv)
+	name = "KV Store"
+	wait = 30 SECONDS
+	priority = SS_PRIORITY_KV
+	flags = SS_NO_INIT | SS_BACKGROUND
+
+	var/list/store = list()
+	var/checking = 0
+
+/datum/controller/subsystem/kv/Recover()
+	store = SSkv.store
+
+/datum/controller/subsystem/kv/fire(resumed = FALSE)
+	if (!checking)
+		checking = length(store)
+	if (checking)
+		for (var/i = checking, i > 0, --i)
+			var/weakref/W = store[i]
+			var/datum/instance = W.resolve()
+			if (QDELETED(instance))
+				store.Cut(i, i + 1)
+			if (MC_TICK_CHECK)
+				checking = i - 1
+				return
+		checking = 0
+
+/datum/controller/subsystem/kv/proc/Put(key, value, datum/instance = src)
+	var/W = weakref(instance)
+	if (!W)
+		return FALSE
+	var/pool = store[W]
+	if (!pool)
+		pool = store[W] = list()
+	pool[key] = value
+	return TRUE
+
+/datum/controller/subsystem/kv/proc/Get(key, datum/instance = src)
+	var/W = weakref(instance)
+	if (!W)
+		return
+	var/pool = store[W]
+	if (pool)
+		return pool[key]

--- a/code/modules/species/station/human_subspecies.dm
+++ b/code/modules/species/station/human_subspecies.dm
@@ -144,23 +144,24 @@
 	shared Booster genotype is extremely unstable and liable for rapid, apparently random change, \
 	but is certainly both unique and remarkable in its ability to cope with the extremes that the \
 	Universe can throw at it."
-	var/list/mods = list()
 
 #define MOD_BASE     0.85
 #define MOD_VARIANCE 0.35
+
 /datum/species/human/booster/proc/get_mod(var/mob/living/carbon/human/booster, var/mod_type)
 	if(istype(booster) && !booster.isSynthetic())
-		var/mob_ref = booster.ckey || "\ref[booster]"
-		if(!islist(mods[mob_ref]))
-			var/list/new_mods = list()
-			new_mods["brute"] =     MOD_BASE + (MOD_VARIANCE * rand())
-			new_mods["burn"] =      MOD_BASE + (MOD_VARIANCE * rand())
-			new_mods["toxins"] =    MOD_BASE + (MOD_VARIANCE * rand())
-			new_mods["radiation"] = MOD_BASE + (MOD_VARIANCE * rand())
-			new_mods["slowdown"] =  pick(-0.5, 0, 0.5)
-			mods[mob_ref] = new_mods
-		var/list/mob_mods = mods[mob_ref]
-		. = mob_mods[mod_type] || 1
+		var/list/mods = SSkv.Get("mods", booster)
+		if (!length(mods))
+			mods = list(
+				"brute" = MOD_BASE + rand() * MOD_VARIANCE,
+				"burn" = MOD_BASE + rand() * MOD_VARIANCE,
+				"toxins" = MOD_BASE + rand() * MOD_VARIANCE,
+				"radiation" = MOD_BASE + rand() * MOD_VARIANCE,
+				"slowdown" = pick(-0.5, 0, 0.5)
+			)
+			SSkv.Put("mods", mods, booster)
+		return mods[mod_type] || 1
+
 #undef MOD_BASE
 #undef MOD_VARIANCE
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -229,7 +229,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '285799990c1d8da9599db8bfdc5ebe26 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '9b8f20c7117005256a00941eb02cb8ae *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Adds SSkv:
- SSkv allows storage of arbitrary instance stuff by putting it in a list accessed by an instance's \ref.
- SSkv.Put(key, value, instance = src) -> access or create the list for \ref[instance] and put an entry k = v in it, overwriting such an entry if it already exists.
- SSkv.Get(key, instance = src) -> access the list for \ref[source] and return the value for key, or null if there is no list or entry for key
- SSkv pausably iterates over its entries every 30 seconds with low background priority and clears itself of keys that cannot be located or are being qdeleted.

\+ Swaps booster species KV to SSkv.