### PR TITLE
fixes a pickweight snafu

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -126,8 +126,10 @@ Checks if a list has the same entries and values as an element of big.
 /proc/pickweight(list/L)
 	var/len = length(L)
 	if (len && islist(L))
-		if (isnum(L[1]))
-			return pick(L)
+		for (var/key in L)
+			if (isnull(L[key]))
+				return pick(L)
+			break
 		var/sum = 0
 		for (var/key in L)
 			sum += L[key]


### PR DESCRIPTION
fixes a thing I fixed and then unfixed by accident. Pickweight properly uses pick for lists that don't appear associative. There are no uses of pickweight that involve a null value, nor can I think of a useful one, so this works out.