### PR TITLE
Chorus fixes

### DIFF
--- a/code/modules/mob/living/chorus/buildings/blueprint_obj.dm
+++ b/code/modules/mob/living/chorus/buildings/blueprint_obj.dm
@@ -16,6 +16,9 @@
 	overlays += image('icons/obj/items.dmi', src, "blueprints")
 	construct_max = cb.build_time
 	construct_left = cb.build_time
+	if (owner)
+		to_chat(owner, SPAN_NOTICE("You start growing \a [cb.get_name()]."))
+	visible_message(SPAN_NOTICE("\A [cb.get_name()] starts growing from \the [get_turf(src)]!"))
 
 /obj/structure/chorus_blueprint/Destroy()
 	if(owner)
@@ -34,11 +37,23 @@
 
 /obj/structure/chorus_blueprint/proc/construct_target()
 	if(construct_path)
+		var/display_name = "unknown organ"
+		var/constructed_organ
 		if(ispath(construct_path, /obj/structure/chorus))
-			new construct_path(get_turf(src), owner)
+			constructed_organ = new construct_path(get_turf(src), owner)
+			display_name = constructed_organ
+			visible_message(SPAN_NOTICE("\The [display_name] finishes growing from \the [get_turf(src)]!"))
 		else if(ispath(construct_path, /turf))
 			var/turf/T = get_turf(src)
 			T.ChangeTurf(construct_path)
+			display_name = T
+			visible_message(SPAN_NOTICE("\The [display_name] spreads outwards!"))
 		else
-			new construct_path(get_turf(src))
+			constructed_organ = new construct_path(get_turf(src))
+			display_name = constructed_organ
+			visible_message(SPAN_NOTICE("\The [display_name] finishes growing from \the [get_turf(src)]!"))
 	qdel(src)
+
+/obj/structure/chorus_blueprint/proc/stop_building(delete_it = TRUE)
+	if(delete_it)
+		qdel(src)

--- a/code/modules/mob/living/chorus/buildings/building_chorus.dm
+++ b/code/modules/mob/living/chorus/buildings/building_chorus.dm
@@ -15,6 +15,7 @@
 	if(o)
 		owner = o
 		owner.add_building(src)
+		to_chat(owner, SPAN_NOTICE("\A [src] has been built."))
 
 /obj/structure/chorus/Destroy()
 	if (owner)
@@ -53,8 +54,13 @@
 /obj/structure/chorus/take_damage(var/amount)
 	health -= amount
 	if(health < 0)
-		src.visible_message("\The [src] crumbles!")
-		qdel(src)
+		die()
 
 /obj/structure/chorus/bullet_act(var/obj/item/projectile/P)
 	take_damage(P.damage)
+
+/obj/structure/chorus/proc/die()
+	if (owner)
+		to_chat(owner, SPAN_WARNING("\A [src] has been destroyed!"))
+	visible_message("\The [src] withers and dies!")
+	qdel(src)

--- a/code/modules/mob/living/chorus/buildings/building_datum.dm
+++ b/code/modules/mob/living/chorus/buildings/building_datum.dm
@@ -58,7 +58,8 @@
 
 /datum/chorus_building/proc/build(var/atom/target, var/mob/living/chorus/C, var/warnings = FALSE)
 	if(can_build(C, target, warnings) && pay_costs(C))
-		return new /obj/structure/chorus_blueprint(target, src, C)
+		var/obj/structure/chorus_blueprint/cb = new /obj/structure/chorus_blueprint(target, src, C)
+		return cb
 
 /datum/chorus_building/proc/get_print_icon_state()
 	return "<img src=\"[get_rsc_path()]\">"
@@ -118,7 +119,8 @@
 
 /datum/chorus_building/delete/build(var/atom/target, var/mob/living/chorus/C, var/warnings = FALSE)
 	if(can_build(C, target, warnings))
-		to_chat(C, "Removing [target]")
+		to_chat(C, "You deconstruct \the [target]")
+		target.visible_message("\The [target] withers and dies!")
 		qdel(target)
 
 /datum/chorus_building/set_to_turf
@@ -129,6 +131,6 @@
 	. = ..()
 	if(.)
 		for(var/turf/T in range(range, target))
-			if(T.density || istype(T, /turf/space))
+			if(T.density || istype(T, /turf/space) || istype(T, turf_to_change_to))
 				continue
 			T.ChangeTurf(turf_to_change_to)

--- a/code/modules/mob/living/chorus/buildings/growth/tier_one.dm
+++ b/code/modules/mob/living/chorus/buildings/growth/tier_one.dm
@@ -37,7 +37,7 @@
 	flick("growth_articulation_exert", src)
 
 /datum/chorus_building/set_to_turf/growth/nerve_cluster
-	desc = "A mass of twitching nerves used to grow your organs faster"
+	desc = "A mass of twitching nerves used to grow your organs faster and allow you to build more organs at once. The speed and build limit boosts diminish for each additional nerve cluster."
 	building_type_to_build = /obj/structure/chorus/construct_bonus/nerve_cluster
 	build_time = 30
 	resource_cost = list(/datum/chorus_resource/growth_nutrients = 20)

--- a/code/modules/mob/living/chorus/chorus_building.dm
+++ b/code/modules/mob/living/chorus/chorus_building.dm
@@ -4,6 +4,9 @@
 	var/list/currently_building = list()
 	var/list/buildings = list()
 	var/construct_speed = 1 //Split up between all constructs
+	var/construct_limit // Maximum number of active builds
+	var/last_build_warning // world.time of last build warning
+	var/build_warning_interval = 30 SECONDS // Time interval of build warnings
 
 /mob/living/chorus/proc/add_building(var/obj/structure/building)
 	if(!istype(building))
@@ -24,29 +27,57 @@
 /mob/living/chorus/proc/start_building(var/datum/chorus_building/blueprint, var/atom/target)
 	if(blueprint == deletion)
 		return
-	else
-		var/bp = blueprint.build(target, src, TRUE)
-		if(bp)
-			currently_building += bp
+
+	else if (!construct_limit_check())
+		to_chat(usr, SPAN_WARNING("You already have too many in progress constructions. Build more nerve clusters to increase this limit, or cancel an in progress build first."))
+		return
+
+	var/bp = blueprint.build(target, src, TRUE)
+	if(bp)
+		currently_building += bp
 
 /mob/living/chorus/proc/stop_building(var/obj/structure/chorus_blueprint/cb, var/delete_it = TRUE)
 	currently_building -= cb
-	if(delete_it)
-		qdel(cb)
+	cb.stop_building(delete_it)
 
 /mob/living/chorus/proc/get_buildings_by_tier()
 	return form.get_buildings_by_tier()
 
+
+/mob/living/chorus/proc/calculate_real_construct_speed(construct_count = null)
+	if (construct_count == null)
+		construct_count = currently_building.len
+	var/real_construct_speed = 25 * construct_speed / (24 + construct_speed)
+	if (construct_count)
+		real_construct_speed = real_construct_speed / construct_count
+	return real_construct_speed
+
+
+/mob/living/chorus/proc/construct_limit_check(add_one = TRUE)
+	var/construct_count = currently_building.len
+	if (add_one)
+		construct_count++
+	return calculate_real_construct_speed(construct_count) >= 1 ? TRUE : FALSE
+
+
 /mob/living/chorus/Life()
 	. = ..()
 	if(.)
-		var/real_construct_speed = 25 * construct_speed / (24 + construct_speed)
 		if(currently_building.len)
-			var/con_speed = real_construct_speed / currently_building.len
 			for(var/b in currently_building)
 				var/obj/structure/chorus_blueprint/cb = b
+				if (!cb || !istype(cb)) // Null value protection
+					stop_building(cb)
+					if (!currently_building.len) // Divide by 0 protection
+						break
+					continue
+				var/con_speed = calculate_real_construct_speed()
 				if(cb.build_amount(con_speed))
 					currently_building -= cb
+
+			if (world.time > last_build_warning + build_warning_interval && !construct_limit_check(FALSE))
+				to_chat(src, SPAN_WARNING("The number of in progress organ builds exceeds your current limit of ongoing build(s). This will negatively impact build speed and may result in infinite build times. Deleting excess in-progress builds is recommended."))
+				last_build_warning = world.time
 		else if(health < maxHealth) //Not building? Heal ourselves
 			health = min(maxHealth, health + construct_speed)
 

--- a/code/modules/mob/living/chorus/chorus_click.dm
+++ b/code/modules/mob/living/chorus/chorus_click.dm
@@ -13,12 +13,21 @@
 			C.chorus_click(src)
 	else if(A == src)
 		self_click()
+	else if (istype(A, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = A
+		if (!H.mind || (H.mind in followers))
+			return
+		for (var/obj/structure/chorus/converter/converter in get_turf(H))
+			converter.activate()
+			return
 	else if(phase == CHORUS_PHASE_EGG)
 		if(selected_building)
 			start_building(selected_building, A)
 		else if(istype(A, /obj/structure/chorus_blueprint))
 			var/obj/structure/chorus_blueprint/cb = A
 			if(cb.owner == src)
+				to_chat(src, SPAN_NOTICE("You cancel building \the [cb]."))
+				cb.visible_message(SPAN_NOTICE("\The [cb] stops growing and withers away!"))
 				stop_building(cb)
 
 /mob/living/chorus/proc/self_click()


### PR DESCRIPTION
Fixes an issue where the Life() proc would runtime constantly and stop firing due to null entries in the `currently_building` var. I wasn't able to identify the source of null entries actually appearing but suspect it's related to how deleting in-progress structures works. Instead, I updated the Life() proc to auto-correct itself gracefully instead of hard crashing.

Also added a hard limit to how many structures a chorus can build at once because the 'infinite build-time bug' is actually a side effect of build time being reduced with more structures building at once.

:cl:
bugfix: Chorus structures should no longer reach a broken state of not building.
tweak: Chorus can now only build a limited number of structures at a time. This limit is calculated based on the current build speed modifier and effectively caps at 3 at higher numbers of nerve clusters.
tweak: Chorus can now click on mobs that are on the same tile as a parasite adapter to convert them, instead of having to find a way to click the adapter itself through people's sprites.
tweak: Chorus now receives warning messages if it has more active constructions that its current build speed can support.
tweak: Chorus now receives messages when constructions finish and when its structures are destroyed.
tweak: Chorus structures now show visible messages when they're being built, finish building, and die.
bugfix: Flesh tiles no longer constantly re-update and change their sprites.
/:cl: