### PR TITLE
Enforce standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 jobs:
     include:
     - name: "DreamChecker"
-      env: SPACEMAN_DMM_VERSION=suite-1.4
+      env: SPACEMAN_DMM_VERSION=suite-1.5
       cache:
         directories: $HOME/spaceman_dmm/$SPACEMAN_DMM_VERSION
       install:

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1091,7 +1091,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 	virtual_mob = null
 
-/mob/dview/Destroy()
+/mob/dview/Destroy(forced)
+	if(forced)
+		GLOB.dview_mob = new/mob/dview()
+		return ..()
 	crash_with("Prevented attempt to delete dview mob: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE // Prevents destruction
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -360,6 +360,7 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 	screen_loc = "CENTER-7,CENTER-7"
 
 /obj/screen/click_catcher/Destroy()
+	SHOULD_CALL_PARENT(FALSE)
 	return QDEL_HINT_LETMELIVE
 
 /proc/create_click_catcher()

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -31,6 +31,7 @@
 /datum/action/Destroy()
 	if(owner)
 		Remove(owner)
+	return ..()
 
 /datum/action/proc/SetTarget(var/atom/Target)
 	target = Target

--- a/code/controllers/evacuation/evacuation_predicate.dm
+++ b/code/controllers/evacuation/evacuation_predicate.dm
@@ -1,8 +1,10 @@
 /datum/evacuation_predicate/New()
 	return
 
-/datum/evacuation_predicate/Destroy()
-	return 0
+/datum/evacuation_predicate/Destroy(forced)
+	if(forced)
+		return ..()
+	return QDEL_HINT_LETMELIVE
 
 /datum/evacuation_predicate/proc/is_valid()
 	return FALSE

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -16,6 +16,8 @@
 // This should be overridden to remove all references pointing to the object being destroyed.
 // Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.
 /datum/proc/Destroy(force=FALSE)
+	SHOULD_CALL_PARENT(TRUE)
+	SHOULD_NOT_SLEEP(TRUE)
 	tag = null
 	weakref = null // Clear this reference to ensure it's kept for as brief duration as possible.
 

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -11,6 +11,7 @@
 		if(child.parent_type == type)
 			dd_insertObjectList(children, child)
 			child.parent = src
+	return ..()
 
 /decl/hierarchy/proc/is_category()
 	return hierarchy_type == type || children.len

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -44,8 +44,10 @@
 		fetched_decl_subtypes[decl_prototype] = .
 
 /decl/proc/Initialize()
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	SHOULD_NOT_SLEEP(TRUE)
 
 /decl/Destroy()
+	SHOULD_CALL_PARENT(FALSE)
 	crash_with("Prevented attempt to delete a decl instance: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE // Prevents Decl destruction

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -28,6 +28,7 @@
 /weakref/Destroy()
 	// A weakref datum should not be manually destroyed as it is a shared resource,
 	//  rather it should be automatically collected by the BYOND GC when all references are gone.
+	SHOULD_CALL_PARENT(FALSE)
 	return QDEL_HINT_IWILLGC
 
 /weakref/proc/resolve()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -44,6 +44,9 @@
 //Must return an Initialize hint. Defined in __DEFINES/subsystems.dm
 
 /atom/proc/Initialize(mapload, ...)
+	SHOULD_CALL_PARENT(TRUE)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	if(atom_flags & ATOM_FLAG_INITIALIZED)
 		crash_with("Warning: [src]([type]) initialized multiple times!")
 	atom_flags |= ATOM_FLAG_INITIALIZED
@@ -377,6 +380,7 @@ its easier to just keep the beam vertical.
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /atom/proc/visible_message(message, blind_message, range = world.view, checkghosts = null, list/exclude_objs = null, list/exclude_mobs = null)
+	set waitfor = FALSE
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -404,6 +404,7 @@
 
 
 /obj/machinery/door/proc/open(var/forced = 0)
+	set waitfor = FALSE
 	if(!can_open(forced))
 		return
 	operating = 1
@@ -429,6 +430,7 @@
 	return world.time + (normalspeed ? 150 : 5)
 
 /obj/machinery/door/proc/close(var/forced = 0)
+	set waitfor = FALSE
 	if(!can_close(forced))
 		return
 	operating = 1

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -65,6 +65,7 @@
 
 // Fades out the smoke smoothly using it's alpha variable.
 /obj/effect/effect/smoke/chem/proc/fadeOut(var/frames = 16)
+	set waitfor = FALSE
 	if(!alpha) return //already transparent
 
 	frames = max(frames, 1) //We will just assume that by 0 frames, the coder meant "during one frame".

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -117,6 +117,8 @@ obj/effect/paint/ocean
 	var/pressure = 20* ONE_ATMOSPHERE
 
 /obj/effect/gas_setup/Initialize()
+	SHOULD_CALL_PARENT(FALSE)
+	atom_flags |= ATOM_FLAG_INITIALIZED
 	var/obj/machinery/atmospherics/pipe/P = locate() in loc
 	if(P && !P.air_temporary)
 		P.air_temporary = new(P.volume, tempurature)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -344,8 +344,6 @@
 		import_key_data(ekey)
 	for (var/ch_name in channels)
 		if(!radio_controller)
-			sleep(30) // Waiting for the radio_controller to be created.
-		if(!radio_controller)
 			src.SetName("broken radio headset")
 			return
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -804,8 +804,9 @@
 	cell = null
 
 /obj/item/device/radio/announcer/Destroy()
+	SHOULD_CALL_PARENT(FALSE)
 	crash_with("attempt to delete a [src.type] detected, and prevented.")
-	return 1
+	return QDEL_HINT_LETMELIVE
 
 /obj/item/device/radio/announcer/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -429,6 +429,7 @@ var/list/global/tank_gauge_cache = list()
 
 //Handle exploding, leaking, and rupturing of the tank
 /obj/item/weapon/tank/proc/check_status()
+	set waitfor = FALSE
 	if(!air_contents)
 		return 0
 

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -395,6 +395,7 @@
 
 /obj/item/weapon/welder_tank/experimental/Destroy()
 	STOP_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/item/weapon/welder_tank/experimental/Process()
 	var/cur_fuel = reagents.get_reagent_amount(/datum/reagent/fuel)

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -19,6 +19,7 @@ var/list/floor_decals = list()
 	..(newloc)
 
 /obj/effect/floor_decal/Initialize()
+	SHOULD_CALL_PARENT(FALSE)
 	if(supplied_dir) set_dir(supplied_dir)
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
@@ -45,6 +46,7 @@ var/list/floor_decals = list()
 	name = "reset marker"
 
 /obj/effect/floor_decal/reset/Initialize()
+	SHOULD_CALL_PARENT(FALSE)
 	var/turf/T = get_turf(src)
 	T.remove_decals()
 	T.update_icon()

--- a/code/modules/augment/simple.dm
+++ b/code/modules/augment/simple.dm
@@ -13,8 +13,9 @@
 	if(holding)
 		GLOB.item_unequipped_event.unregister(holding, src)
 		if(holding.loc == src)
-			QDEL_NULL(holding)
-
+			qdel(holding)
+		holding = null
+	return ..()
 
 /obj/item/organ/internal/augment/active/simple/proc/holding_dropped()
 

--- a/code/modules/awaymissions/loot.dm
+++ b/code/modules/awaymissions/loot.dm
@@ -6,6 +6,7 @@
 	var/loot = ""			//a list of possible items to spawn- a string of paths
 
 /obj/effect/spawner/lootdrop/Initialize()
+	SHOULD_CALL_PARENT(FALSE)
 	var/list/things = params2list(loot)
 
 	if(things && things.len)
@@ -21,4 +22,5 @@
 				continue
 
 			new loot_path(get_turf(src))
+	atom_flags |= ATOM_FLAG_INITIALIZED
 	return INITIALIZE_HINT_QDEL

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -281,6 +281,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/tmp/iconCache.sav")) //Cache o
 		send_output(C, url_encode(url_encode(message)), "browseroutput:output")
 
 /proc/to_chat(target, message, handle_whitespace = TRUE, trailing_newline = TRUE)
+	set waitfor = FALSE
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized)
 		to_chat_immediate(target, message, handle_whitespace, trailing_newline)
 		return

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -22,6 +22,7 @@
 
 /atom/movable/lighting_overlay/Initialize()
 	// doesn't need special init
+	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_FLAG_INITIALIZED
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/modules/mechs/mech_construction.dm
+++ b/code/modules/mechs/mech_construction.dm
@@ -60,7 +60,7 @@
 			pilot.client.screen -= module_to_forget
 
 /mob/living/exosuit/proc/install_system(var/obj/item/system, var/system_hardpoint, var/mob/user)
-
+	set waitfor = FALSE
 	if(hardpoints_locked || hardpoints[system_hardpoint])
 		return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -83,6 +83,7 @@
 // self_message (optional) is what the src mob sees  e.g. "You do something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 /mob/visible_message(message, self_message, blind_message, range = world.view, checkghosts = null, narrate = FALSE, list/exclude_objs = null, list/exclude_mobs = null)
+	set waitfor = FALSE
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -28,13 +28,13 @@ GLOBAL_LIST_EMPTY(skills)
 /decl/hierarchy/skill/proc/update_special_effects(mob/mob, level)
 
 /decl/hierarchy/skill/Initialize()
-	..()
+	. = ..()
 	if(is_hidden_category())
 		if(!GLOB.skills.len)
 			for(var/decl/hierarchy/skill/C in children)
 				GLOB.skills += C.get_descendents()
 		else
-			log_error("<span class='warning'>Warning: multiple instances of /decl/hierarchy/skill have been created!</span>")
+			CRASH("Warning: multiple instances of /decl/hierarchy/skill have been created!")
 
 /decl/hierarchy/skill/dd_SortValue()
 	return ID

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -19,6 +19,7 @@ var/list/cached_space = list()
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 	map_sectors["[map_z]"] = null
 	testing("Temporary sector at [x],[y] was deleted.")
+	return ..()
 
 /obj/effect/overmap/visitable/sector/temporary/proc/can_die(var/mob/observer)
 	testing("Checking if sector at [map_z[1]] can die.")

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -41,24 +41,6 @@
 			job.blacklisted_species = archetype.blacklisted_species
 		jobs[job.title] = job
 
-	// Either find or build our map.
-	if(!associated_z)
-		// Load a map + overmap object from archetype map file.
-		if(archetype.map && SSmapping.map_templates[archetype.map])
-			var/datum/map_template/template = SSmapping.map_templates[archetype.map]
-			if (template.loaded && !(template.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
-				testing( "Submap ([template.name]) tried to place duplicate of existing non-duplicate template.")
-				qdel(src)
-				return
-			var/turf/new_z_centre = template.load_new_z()
-			if(!istype(new_z_centre))
-				testing( "Failed to place submap ([template.name])")
-				qdel(src)
-				return
-			testing( "Submap '[template.name]' placed on zlevel [new_z_centre.z].")
-			log_and_message_admins("Submap ([template.name]) has been placed on a new zlevel.", location=new_z_centre)
-			associated_z = new_z_centre.z
-
 	if(!associated_z)
 		testing( "Submap error - [name]/[archetype ? archetype.descriptor : "NO ARCHETYPE"] could not find an associated z-level for spawnpoint placement.")
 		qdel(src)

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -130,6 +130,7 @@
 	update_use_power(POWER_USE_ACTIVE)
 
 /obj/machinery/suspension_gen/proc/deactivate()
+	set waitfor = FALSE
 	//drop anything we picked up
 	var/turf/T = get_turf(suspension_field)
 

--- a/~code/global_init.dm
+++ b/~code/global_init.dm
@@ -16,6 +16,3 @@ var/global/datum/global_init/init = new ()
 	load_configuration()
 	callHook("global_init")
 	qdel(src) //we're done
-
-/datum/global_init/Destroy()
-	return 1


### PR DESCRIPTION
* Bump linter version
* /Initialize() & /Destroy() must now call ..()
* /Initialize() & /Destroy() may no longer sleep
* Fix issues in /Processing(), found by the updated linter
* Removes vestigial (according to original author) code 