### PR TITLE
nerf lab tech skills

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -184,11 +184,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(   SKILL_MEDICAL   = SKILL_ADEPT,
+	min_skill = list(   SKILL_MEDICAL   = SKILL_BASIC,
 	                    SKILL_CHEMISTRY = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_MEDICAL     = SKILL_ADEPT,
-						SKILL_ANATOMY	  = SKILL_ADEPT,
+	max_skill = list(   SKILL_MEDICAL     = SKILL_BASIC,
+						SKILL_ANATOMY	  = SKILL_BASIC,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
 	skill_points = 16
 


### PR DESCRIPTION
:cl: 
tweak: Lab Techs can now only take basic medicine and anatomy, instead of trained.
/:cl:

They aren't medical techs and aren't trained. They also aren't medical doctors.