### PR TITLE
Adds job titles to ID appearance selection

### DIFF
--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -238,7 +238,11 @@
 			CS.color = initial(ID.color)
 			CS.detail_color = initial(ID.detail_color)
 			CS.extra_details = initial(ID.extra_details)
-			CS.name = initial(ID.name) + " - " + initial(ID.icon_state)
+			CS.name = initial(ID.name)
+			if (initial(ID.job_access_type))
+				var/datum/job/J = initial(ID.job_access_type)
+				CS.name += " ([initial(J.title)]) "
+			CS.name += " - [initial(ID.icon_state)]"
 			var/color_pair = ""
 			if(CS.color)
 				color_pair += CS.color


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: The ID appearance selection shows the job titles again.
/:cl:

Since I assume that this was introduced as an oversight from when job titles were removed from ID names, I'm treating this as a bug.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->