### PR TITLE
Chemistry reagents grinder and juicer printable circuit boards

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
@@ -34,3 +34,15 @@
 /obj/item/weapon/stock_parts/circuitboard/sublimator/sauna
 	name = T_BOARD("sauna sublimator")
 	build_path = /obj/machinery/portable_atmospherics/reagent_sublimator/sauna
+
+/obj/item/weapon/stock_parts/circuitboard/reagentgrinder
+	name = T_BOARD("reagent grinder")
+	build_path = /obj/machinery/reagentgrinder
+	board_type = "machine"
+	origin_tech = list(TECH_BIO = 2, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
+	req_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 3,
+		/obj/item/weapon/stock_parts/manipulator = 2,
+		/obj/item/weapon/stock_parts/micro_laser = 2,
+		/obj/item/weapon/stock_parts/capacitor = 1
+	)

--- a/code/game/objects/items/weapons/circuitboards/machinery/household.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/household.dm
@@ -93,3 +93,14 @@
 		var/obj/machinery/vending/vendor = path
 		var/base_type = initial(vendor.base_type) || path
 		. |= base_type
+
+/obj/item/weapon/stock_parts/circuitboard/juicer
+	name = T_BOARD("blender")
+	build_path = /obj/machinery/reagentgrinder/juicer
+	board_type = "machine"
+	origin_tech = list(TECH_BIO = 1, TECH_MATERIAL = 2, TECH_ENGINEERING = 1)
+	req_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 1,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/weapon/stock_parts/micro_laser = 1,
+		/obj/item/weapon/stock_parts/capacitor = 1)

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -9,6 +9,8 @@
 	idle_power_usage = 5
 	active_power_usage = 100
 	obj_flags = OBJ_FLAG_ANCHORABLE
+	construct_state = /decl/machine_construction/default/panel_closed
+	uncreated_component_parts = null
 
 	var/inuse = 0
 	var/obj/item/weapon/reagent_containers/beaker = null
@@ -38,6 +40,13 @@
 		icon_state = "[initial(icon_state)]"
 
 /obj/machinery/reagentgrinder/attackby(var/obj/item/O as obj, var/mob/user as mob)
+	// Maybe someone is constructing this machine.
+	// Or someone is going to move it around.
+	// In any circumstance, it's better to call the parent's
+	// implementation without inhibit any "custom" behaviour
+	// related to the grinder.
+	if((. = ..()))
+		return TRUE
 
 	if (istype(O,/obj/item/weapon/reagent_containers/glass) || \
 		istype(O,/obj/item/weapon/reagent_containers/food/drinks/glass2) || \
@@ -250,7 +259,7 @@
 		..()
 
 /obj/machinery/reagentgrinder/CtrlClick(mob/user)
-	if(CanDefaultInteract(user))
+	if(anchored && CanDefaultInteract(user))
 		grind(user)
 	else
 		..()
@@ -302,7 +311,6 @@
 	icon_state = "juicer"
 	density = FALSE
 	anchored = FALSE
-	obj_flags = null
 	grind_sound = 'sound/machines/juicer.ogg'
 	blacklisted_types = list(/obj/item/stack/material)
 	bag_whitelist = list(/obj/item/weapon/storage/plants)

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -760,6 +760,20 @@
 	build_path = /obj/item/weapon/stock_parts/circuitboard/vending
 	sort_string = "WAABA"
 
+/datum/design/circuit/reagentgrinder
+	name = "reagent grinder"
+	id = "reagent_grinder"
+	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/stock_parts/circuitboard/reagentgrinder
+	sort_string = "WAABB"
+
+/datum/design/circuit/juicer
+	name = "blender"
+	id = "blender"
+	req_tech = list(TECH_BIO = 1, TECH_MATERIAL = 2, TECH_ENGINEERING = 1)
+	build_path = /obj/item/weapon/stock_parts/circuitboard/juicer
+	sort_string = "WAABC"
+
 /datum/design/circuit/aicore
 	name = "AI core"
 	id = "aicore"


### PR DESCRIPTION
:cl:
rscadd: chemistry reagents grinder AND juicer (blender) circuit boards can be printed.
bugfix: juicer and reagents grinder can be un-anchored using a wrench.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->