### PR TITLE
Makes mobs resistant to negligible amounts of radiation

### DIFF
--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -63,7 +63,7 @@
 	return 1
 
 /mob/living/rad_act(var/severity)
-	if(severity)
+	if(severity > RAD_LEVEL_LOW)
 		src.apply_damage(severity, IRRADIATE, damage_flags = DAM_DISPERSED)
 		for(var/atom/I in src)
 			I.rad_act(severity)


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Mobs will no longer accumulate radiation in areas with green geiger readings.
/:cl:

Mobs will only accumulate radiation when it is higher than `RAD_LEVEL_LOW`, which is the lowest define that is above 0.
This will prevent from mobs getting negligible radiation burns in areas that are deemed safe.
Green geiger readings used to imply no radiation damage, not sure if this was an oversight in one of the radiation overhauls.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->