### PR TITLE
Tweaks fuel shutoff valves on mercenary spawn to be above floor

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -218,9 +218,9 @@
 	},
 /obj/machinery/turretid/lethal{
 	ailock = 1;
-	enabled = 0;
 	check_arrest = 0;
 	check_records = 0;
+	enabled = 0;
 	pixel_y = 32;
 	req_access = list("ACCESS_SYNDICATE")
 	},
@@ -1597,8 +1597,9 @@
 	dir = 8;
 	icon_state = "handrail"
 	},
-/obj/effect/floor_decal/industrial/shutoff,
-/obj/machinery/atmospherics/valve/shutoff/fuel,
+/obj/machinery/atmospherics/valve/shutoff/fuel{
+	level = 2
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "cw" = (
@@ -1663,8 +1664,9 @@
 	dir = 4;
 	icon_state = "handrail"
 	},
-/obj/effect/floor_decal/industrial/shutoff,
-/obj/machinery/atmospherics/valve/shutoff/fuel,
+/obj/machinery/atmospherics/valve/shutoff/fuel{
+	level = 2
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "cC" = (


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Fuel shutoff valves on the mercenary shuttle will be above the flooring now.
/:cl:

Since fuel shutoff valves can actually be mapped above flooring now. As far as I know this is the only instance where it's applicable right now.

Basically fixes this weirdness:
![grafik](https://user-images.githubusercontent.com/6383576/90968103-d8427100-e4e8-11ea-82d2-d207bd19a7b0.png)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->