### PR TITLE
Practice carbines deal no damage

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -21,7 +21,7 @@
 
 /obj/item/projectile/beam/practice
 	fire_sound = 'sound/weapons/Taser.ogg'
-	damage = 2
+	damage = 0
 	eyeblur = 2
 
 /obj/item/projectile/beam/smalllaser


### PR DESCRIPTION
:cl:
tweak: The lenses in practice laser carbines have been tweaked to refract the beams at an even lower concentration. As a result, they will no longer damage anything they hit, though living targets will still feel the effects.
/:cl:

In OOC terms, damage is now 0 but the eye blur effect is still in place. Emagging them still has the same effect since it uses a different beam entirely.