### PR TITLE
Prevents buckling grabbed people

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -66,6 +66,9 @@
 		return 0
 	if(M == buckled_mob)
 		return 0
+	if (M.grabbed_by.len)
+		to_chat(user, SPAN_WARNING("\The [M] is being grabbed and cannot be buckled."))
+		return FALSE
 	if(istype(M, /mob/living/carbon/slime))
 		to_chat(user, "<span class='warning'>\The [M] is too squishy to buckle in.</span>")
 		return 0
@@ -105,4 +108,3 @@
 				"<span class='notice'>You hear metal clanking.</span>")
 		add_fingerprint(user)
 	return M
-


### PR DESCRIPTION
Intended to prevent instances of people being buckled while also being grabbed, which allows them to be moved while still buckled and makes for some really broken states that are difficult to fix if the buckled person isn't able to resist out of the buckle due to cuffs, injury, etc.

Considered finding a way to force-drop all grabs on a mob when they're buckled, but realized that could get power gamed to escape a grab.

:cl:
tweak: You can no longer buckle mobs if they're currently being grabbed.
/:cl:

![dreamseeker_NS5wmSetGe](https://user-images.githubusercontent.com/11140088/91006600-aab00300-e58e-11ea-8639-90346f4358d4.png)
