### PR TITLE
Fix paging and alert changes

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -881,8 +881,9 @@ FIRE ALARM
 
 /obj/machinery/firealarm/examine(mob/user)
 	. = ..()
-	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-	to_chat(user, "The current alert level is [security_state.current_security_level.name].")
+	if(loc.z in GLOB.using_map.contact_levels)
+		var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
+		to_chat(user, "The current alert level is [security_state.current_security_level.name].")
 
 /obj/machinery/firealarm/Initialize()
 	. = ..()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -141,7 +141,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 
 	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
 		var/obj/item/modular_computer/pda/pda = locate() in H
-		if(!pda)
+		if(!pda || !(get_z(pda) in GLOB.using_map.station_levels))
 			continue
 
 		var/datum/job/J = SSjobs.get_by_title(H.get_authentification_rank())


### PR DESCRIPTION
:cl:
bugfix: PDA paging messages will no longer reach you if you are not on the Torch.
bugfix: Fire alarms will no longer tell you the current alert level if you examine them if you are not on the Torch.
/:cl:

Fire alarm overlays themselves weren't touched since they looked like a mess and have their own set of inconsistencies.