### PR TITLE
adds config main menu delays for respawning

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -50,7 +50,8 @@ var/list/gamemode_cache = list()
 	var/secret_hide_possibilities = FALSE // Whether or not secret modes show list of possible round types
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
 	var/hostedby = null
-	var/respawn_delay = 30
+	var/respawn_delay = 30 //An observer must wait this many minutes before being able to return to the main menu
+	var/respawn_menu_delay = 0 //An observer that has returned to the main menu must wait this many minutes before rejoining
 	var/guest_jobban = 1
 	var/usewhitelist = 0
 	var/kick_inactive = 0				//force disconnect for inactive players after this many minutes, if non-0
@@ -371,6 +372,10 @@ var/list/gamemode_cache = list()
 				if ("respawn_delay")
 					config.respawn_delay = text2num(value)
 					config.respawn_delay = config.respawn_delay > 0 ? config.respawn_delay : 0
+
+				if ("respawn_menu_delay")
+					config.respawn_menu_delay = text2num(value)
+					config.respawn_menu_delay = config.respawn_menu_delay > 0 ? config.respawn_menu_delay : 0
 
 				if ("servername")
 					config.server_name = value

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -2,6 +2,7 @@
 
 /mob/new_player
 	var/ready = 0
+	var/respawned_time = 0
 	var/spawning = 0//Referenced when you want to delete the new_player later on in the code.
 	var/totalPlayers = 0		 //Player counts for the Lobby tab
 	var/totalPlayersReady = 0
@@ -158,10 +159,14 @@
 			return 1
 
 	if(href_list["late_join"])
-
 		if(GAME_STATE != RUNLEVEL_GAME)
-			to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
+			to_chat(usr, SPAN_WARNING("The round has either not started yet or already ended."))
 			return
+		if (!client.holder)
+			var/dsdiff = config.respawn_menu_delay MINUTES - (world.time - respawned_time)
+			if (dsdiff > 0)
+				to_chat(usr, SPAN_WARNING("You must wait [time2text(dsdiff, "mm:ss")] before rejoining."))
+				return
 		LateChoices() //show the latejoin job selection menu
 
 	if(href_list["manifest"])

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -568,5 +568,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	announce_ghost_joinleave(client, 0)
 
 	var/mob/new_player/M = new /mob/new_player()
+	if (can_reenter_corpse != CORPSE_CAN_REENTER_AND_RESPAWN)
+		M.respawned_time = world.time
 	M.key = key
 	log_and_message_admins("has respawned.", M)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -285,8 +285,11 @@ EVENT_CUSTOM_START_MAJOR 80;100
 ## Uncomment to disable respawning by default.
 #DISABLE_RESPAWN
 
-## Respawn delay in minutes before one may respawn as a crew member.
+## The delay in minutes before an observer may return to the main menu.
 #RESPAWN_DELAY 30
+
+## The delay in minutes before an observer that has returned to the main menu may rejoin the game.
+#RESPAWN_MENU_DELAY 0
 
 ## Strength of ambient star light. Set to 0 or less to turn off. A value of 1 is unlikely to have a noticeable effect in most lighting systems.
 STARLIGHT 0


### PR DESCRIPTION
Implements a configurable main menu delay for latejoining after being observed, but not for re-observing. Clients that have been allowed to respawn by an admin or which have a holder (ie, are staff in some way) ignore it. Defaults to off.

The aim of this is to allow disincentivizing players waiting for action in observe and then accurately dogpiling it.