### PR TITLE
Modifies "please create an account" message to be slightly more helpful.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -87,7 +87,7 @@ datum/preferences
 		dat += "<a href='?src=\ref[src];reload=1'>Reload slot</a>"
 
 	else
-		dat += "Please create an account to save your preferences."
+		dat += "Please create an account to save your preferences. If you have an account and are seeing this, please adminhelp for assistance."
 
 	dat += "<br>"
 	dat += player_setup.header()


### PR DESCRIPTION
:cl: Sweedle
tweak: The "Please create an account" message now directs you to adminhelp.
/:cl:


Obviously a bandaid fix, but hopefully this will clarify people just being like "guess I'll perish" when they get the bug.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->