### PR TITLE
Replica swords no longer have a parry chance

### DIFF
--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -24,6 +24,7 @@
 	force_divisor = 0.2
 	thrown_force_divisor = 0.2
 	worth_multiplier = 15
+	base_parry_chance = 0
 
 /obj/item/weapon/material/sword/katana
 	name = "katana"


### PR DESCRIPTION
:cl:
bugfix: Because they're only replicas and not meant for actual battle, you can no longer parry with officer's/NCO's swords unless you have a very high melee stat.
/:cl: