### PR TITLE
Computers can no longer turn on when they should not

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -112,9 +112,6 @@
 			to_chat(user, "You send an activation signal to \the [src] but it does not respond")
 		else
 			to_chat(user, "You press the power button but \the [src] does not respond")
-	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
-	if(os)
-		os.system_boot()
 
 /obj/item/modular_computer/proc/shutdown_computer(var/loud = 1)
 	QDEL_NULL_LIST(terminals)


### PR DESCRIPTION
:cl:
bugfix: Computers can no longer turn on when they should not.
/:cl:

Computers that should not be able to turn on would do it anyway and then be turned off in their next power step. Some computers (PDAs) buggily have no power cost, and so can always be turned on. This fixes the turning on part.