### PR TITLE
Removes gravity from gantry

### DIFF
--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -86,6 +86,7 @@
 
 /area/scavver/
 	icon = 'maps/away/scavver/scavver_gantry_sprites.dmi'
+	has_gravity = FALSE
 
 /area/scavver/gantry/up1
 	name = "\improper Upper Salvage Gantry Arm"


### PR DESCRIPTION
:cl:
tweak: Removed gravity from gantry.
/:cl:

There is absolutely no reason to have gravity on the gantry, it only slows you down and you'll fall quite often if you don't get master EVA. Also it is one of the lightest ships in the game, it definitely should not have a gravity generator.