### PR TITLE
Fixes sprites not updating after getting touched by space cleaner

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -299,6 +299,7 @@
 		else
 			H.clean_blood(1)
 			return
+	M.update_icons()
 	M.clean_blood()
 
 /datum/reagent/lube


### PR DESCRIPTION
:cl: Hubblenaut
bugfix: Fixes sprites not updating when getting cleaned by space cleaner.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->