### PR TITLE
Minor Ascent and Seedship stuff

### DIFF
--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -188,3 +188,6 @@
 
 /obj/structure/wall_frame/hull/vox
 	paint_color = COLOR_GREEN_GRAY
+
+/obj/structure/wall_frame/hull/ascent
+	paint_color = COLOR_PURPLE

--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -116,6 +116,10 @@
 	name = "reinforced vox hull wall frame window spawner"
 	frame_path = /obj/structure/wall_frame/hull/vox
 
+/obj/effect/wallframe_spawn/reinforced/hull/ascent
+	name = "reinforced ascent hull wall frame window spawner"
+	frame_path = /obj/structure/wall_frame/hull/ascent
+
 /obj/effect/wallframe_spawn/reinforced/bare //standard type is used most often so its in the master type, this one is for away sites etc with unpainted walls
 	name = "bare metal reinforced wall frame window spawner"
 	icon_state = "r-wingrille"
@@ -132,6 +136,10 @@
 	name = "reinforced phoron wall frame window spawner"
 	icon_state = "pr-wingrille"
 	win_path = /obj/structure/window/phoronreinforced/full
+
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent
+	name = "reinforced ascent reinforced phoron wall frame window spawner"
+	frame_path = /obj/structure/wall_frame/hull/ascent
 
 /obj/effect/wallframe_spawn/reinforced_phoron/titanium
 	frame_path = /obj/structure/wall_frame/titanium

--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -318,6 +318,7 @@
 
 /obj/item/clothing/gloves/rig/mantid
 	desc = "They look like a cross between a can opener and a Swiss army knife the size of a shoebox."
+	siemens_coefficient = 0
 	species_restricted = list(SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_NABBER)
 	sprite_sheets = list(
 		SPECIES_MANTID_GYNE =  'icons/mob/species/mantid/onmob_gloves_gyne.dmi',
@@ -398,7 +399,7 @@
 		/obj/item/rig_module/mounted/plasmacutter,
 		/obj/item/rig_module/maneuvering_jets
 	)
-		
+
 /obj/item/weapon/rig/mantid/nabber/seed
 	online_slowdown = 1
 	armor = list(

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -6,7 +6,7 @@
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/shuttle_starboard)
 "ad" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
 "ae" = (
@@ -104,7 +104,9 @@
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/bridge)
 "aA" = (
-/turf/simulated/floor/tiled/ascent,
+/obj/effect/catwalk_plated/ascent,
+/obj/machinery/portable_atmospherics/canister/methyl_bromide,
+/turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_spike)
 "aC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -211,6 +213,8 @@
 /obj/machinery/light/ascent{
 	dir = 1
 	},
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_spike)
 "aR" = (
@@ -310,17 +314,22 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on/ascent,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_spike)
 "bi" = (
-/obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "bk" = (
@@ -822,6 +831,7 @@
 "cn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on/ascent,
 /obj/machinery/access_button/airlock_interior{
+	frequency = 1331;
 	master_tag = "ascent_seedship_fore_dock_controller";
 	pixel_x = -4;
 	pixel_y = 24
@@ -897,8 +907,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/catwalk_plated/ascent,
-/obj/item/weapon/storage/bag/trash/purple/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_spike)
 "cv" = (
@@ -913,8 +925,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/catwalk_plated/ascent,
-/obj/item/weapon/storage/bag/trash/purple/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_spike)
 "cx" = (
@@ -955,9 +969,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_spike)
@@ -1022,7 +1034,7 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/wing_starboard)
 "cH" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1062,7 +1074,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_starboard)
 "cL" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "cN" = (
@@ -1099,11 +1111,11 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
 "cU" = (
-/obj/effect/wallframe_spawn/phoron,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
 "cV" = (
-/obj/effect/wallframe_spawn/phoron,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "cW" = (
@@ -1435,6 +1447,8 @@
 	dir = 5
 	},
 /obj/structure/table/rack/dark,
+/obj/item/weapon/storage/bag/trash/purple/ascent,
+/obj/item/weapon/storage/bag/trash/purple/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "dM" = (
@@ -1453,6 +1467,9 @@
 /obj/structure/table/rack/dark,
 /obj/item/weapon/reagent_containers/glass/beaker,
 /obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "dN" = (
@@ -1481,13 +1498,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/access_button/airlock_interior,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/habitation)
-"dQ" = (
-/obj/effect/wallframe_spawn/phoron,
-/turf/simulated/floor/ascent,
-/area/ship/ascent/wing_port)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -1502,15 +1514,15 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/hydroponics_starboard)
 "dT" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_port_prow)
 "dU" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_port)
 "dV" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "dW" = (
@@ -1594,7 +1606,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "ee" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1657,14 +1669,8 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_port_prow)
 "ej" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_port)
+/area/ship/ascent/shuttle_starboard)
 "ek" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -1987,12 +1993,12 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_port)
 "eH" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "eN" = (
@@ -2042,10 +2048,6 @@
 /obj/structure/window/phoronreinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/ascent,
-/area/ship/ascent/shuttle_port)
-"eU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on/ascent,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "eV" = (
@@ -2145,10 +2147,8 @@
 /obj/machinery/light/ascent{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
@@ -2161,49 +2161,42 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "fl" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
+"fn" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
+"fo" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
-"fm" = (
-/obj/machinery/atmospherics/unary/vent_pump/on/ascent,
-/obj/structure/bed/chair/padded/purple/ascent{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ascent,
-/area/ship/ascent/shuttle_port)
-"fn" = (
+"fp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1331;
-	id_tag = "ascent_port_shuttle_dock";
-	pixel_x = 24;
-	tag_airpump = "ascent_port_pump";
-	tag_chamber_sensor = "ascent_port_sensor";
-	tag_exterior_door = "ascent_port_outer";
-	tag_interior_door = "ascent_port_inner"
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "ascent_port_sensor";
-	pixel_x = 24;
-	pixel_y = -12
-	},
-/obj/effect/catwalk_plated/ascent,
-/turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_port)
-"fo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/padded/purple/ascent{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/ascent,
-/turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_port)
-"fp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
@@ -2280,22 +2273,32 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "fy" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
 	id_tag = "ascent_port_pump"
 	},
-/turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_port)
-"fz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1331;
+	id_tag = "ascent_port_shuttle_dock";
+	pixel_x = -24;
+	tag_airpump = "ascent_port_pump";
+	tag_chamber_sensor = "ascent_port_sensor";
+	tag_exterior_door = "ascent_port_outer";
+	tag_interior_door = "ascent_port_inner"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "ascent_port_sensor";
+	pixel_x = -24;
+	pixel_y = -12
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
+"fz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2502,11 +2505,9 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_port_prow)
 "fU" = (
-/obj/machinery/computer/ship/sensors/ascent{
-	dir = 1
-	},
+/obj/machinery/shipsensors,
 /turf/simulated/floor/ascent,
-/area/ship/ascent/bridge)
+/area/ship/ascent/shuttle_starboard)
 "fV" = (
 /obj/structure/table/rack/dark,
 /obj/item/weapon/tank/mantid/methyl_bromide,
@@ -2690,32 +2691,36 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "gt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/bed/chair/padded/purple/ascent{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "gu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "gv" = (
-/obj/machinery/light/ascent{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
 	id_tag = "ascent_port_pump"
+	},
+/obj/machinery/light/ascent{
+	dir = 4
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
@@ -2726,6 +2731,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
@@ -2802,6 +2812,11 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
@@ -2971,7 +2986,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/hydroponics_starboard)
 "gQ" = (
-/obj/effect/wallframe_spawn/phoron,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_starboard)
 "gR" = (
@@ -3032,7 +3047,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "gY" = (
-/obj/effect/wallframe_spawn/phoron,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -3093,7 +3108,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/hydroponics_port)
 "hg" = (
-/obj/effect/wallframe_spawn/phoron,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -3133,7 +3148,7 @@
 	},
 /area/ship/ascent/engineering)
 "hm" = (
-/obj/effect/wallframe_spawn/phoron,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/habitation)
 "hn" = (
@@ -3203,6 +3218,9 @@
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/glass/phoronrglass/ten,
 /obj/item/stack/material/glass/phoronrglass/ten,
+/obj/item/stack/material/glass/reinforced/fifty,
+/obj/item/stack/material/plasteel/fifty,
+/obj/item/stack/material/plasteel/fifty,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "hA" = (
@@ -3329,10 +3347,11 @@
 /area/ship/ascent/wing_starboard)
 "hP" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/stack/material/glass/reinforced/fifty,
 /obj/machinery/light/ascent{
 	dir = 1
 	},
+/obj/item/weapon/card/id/ascent,
+/obj/item/weapon/card/id/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "hQ" = (
@@ -3485,6 +3504,11 @@
 	dir = 5
 	},
 /obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "ik" = (
@@ -3543,6 +3567,13 @@
 /obj/machinery/light/ascent{
 	dir = 4
 	},
+/obj/machinery/power/smes/buildable/power_shuttle/ascent{
+	charge = 5e+006
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "is" = (
@@ -3582,6 +3613,11 @@
 	pixel_y = 24
 	},
 /obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "iw" = (
@@ -3592,6 +3628,11 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "ix" = (
@@ -3607,6 +3648,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
@@ -3638,6 +3684,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
@@ -3664,10 +3715,8 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_starboard)
 "iH" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "iJ" = (
@@ -3705,7 +3754,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "iO" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -3819,6 +3868,11 @@
 /obj/machinery/light/ascent{
 	dir = 8
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "jd" = (
@@ -3878,6 +3932,11 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
@@ -3966,11 +4025,21 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "ju" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "jv" = (
@@ -4130,22 +4199,13 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "jN" = (
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/smes/buildable/power_shuttle/ascent{
-	charge = 5e+006
-	},
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/methyl_bromide,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "jO" = (
-/obj/structure/cable/cyan{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "jQ" = (
@@ -4237,11 +4297,9 @@
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/aft_starboard_jut)
 "md" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/obj/structure/window/phoronreinforced,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/aft_starboard_jut)
 "me" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4272,13 +4330,10 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "mM" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/reagent_temperature{
-	color = "PURPLE";
-	name = "reactant boiler"
-	},
-/turf/simulated/floor/tiled/ascent,
-/area/ship/ascent/fore_starboard_prow)
+/obj/machinery/light/ascent,
+/obj/effect/catwalk_plated/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/aft_starboard_jut)
 "mN" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/ascent,
@@ -4322,6 +4377,16 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_jut)
+"nU" = (
+/obj/effect/catwalk_plated/ascent,
+/obj/structure/bed/chair/padded/purple/ascent{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "nV" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1331;
@@ -4370,7 +4435,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/habitation)
 "pr" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_jut)
 "py" = (
@@ -4391,6 +4456,16 @@
 	frequency = 1331;
 	id_tag = "ascent_port_inner"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
+"pQ" = (
+/obj/effect/catwalk_plated/ascent,
+/obj/structure/bed/chair/padded/purple/ascent{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "qc" = (
@@ -4413,7 +4488,6 @@
 /area/ship/ascent/fore_starboard_prow)
 "qR" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "rb" = (
@@ -4423,6 +4497,23 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on/ascent,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_jut)
+"rq" = (
+/obj/structure/bed/chair/padded/purple/ascent{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
+"sc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on/ascent{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/shuttle_port)
 "sF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -4436,6 +4527,15 @@
 "tr" = (
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/aft_starboard_jut)
+"ts" = (
+/obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "tw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/ascent{
 	dir = 1;
@@ -4458,6 +4558,19 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_prow)
+"us" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "uV" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/phoronreinforced{
@@ -4478,7 +4591,7 @@
 	color = "PURPLE";
 	name = "reactant cooler"
 	},
-/turf/simulated/floor/tiled/ascent,
+/turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "vz" = (
 /obj/machinery/chemical_dispenser/full{
@@ -4558,6 +4671,15 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"xl" = (
+/obj/machinery/hologram/holopad/longrange/ascent,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/shuttle_port)
+"xm" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/methyl_bromide,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/engineering)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4617,6 +4739,22 @@
 	},
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/aft_starboard_jut)
+"Ag" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/engineering)
+"Ah" = (
+/obj/effect/catwalk_plated/ascent,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "Aj" = (
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/hydroponics_port)
@@ -4654,6 +4792,26 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
+"Bz" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/shuttle_port)
+"BE" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "BX" = (
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/engineering)
@@ -4663,6 +4821,10 @@
 /area/ship/ascent/shuttle_starboard)
 "CA" = (
 /obj/structure/table/steel_reinforced,
+/obj/machinery/reagent_temperature{
+	color = "PURPLE";
+	name = "reactant boiler"
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "CV" = (
@@ -4674,6 +4836,21 @@
 /obj/machinery/portable_atmospherics/canister/methyl_bromide,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
+"Df" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "Ek" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/methyl_bromide,
@@ -4742,12 +4919,14 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/aft_starboard_jut)
 "Gd" = (
-/obj/structure/window/phoronreinforced,
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/area/ship/ascent/fore_starboard_spike)
+"Ge" = (
+/obj/machinery/computer/ship/sensors/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/bridge)
 "Gl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4766,6 +4945,10 @@
 /obj/machinery/portable_atmospherics/canister/methyl_bromide,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/hydroponics_starboard)
+"GM" = (
+/obj/structure/mopbucket/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_port_spike)
 "GZ" = (
 /obj/structure/window/phoronreinforced,
 /obj/structure/table/rack/dark,
@@ -4773,27 +4956,29 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/aft_starboard_jut)
 "HZ" = (
-/obj/structure/window/phoronreinforced{
-	dir = 8
-	},
-/obj/structure/window/phoronreinforced,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/methyl_bromide,
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/area/ship/ascent/fore_starboard_spike)
 "If" = (
-/obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
 "IQ" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
 	icon_state = "intact"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
+"IY" = (
+/obj/machinery/computer/ship/navigation/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/bridge)
 "IZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on/ascent{
 	dir = 4
@@ -4811,9 +4996,9 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/hydroponics_port)
 "Jx" = (
-/obj/machinery/hologram/holopad/longrange/ascent,
-/turf/simulated/floor/tiled/ascent,
-/area/ship/ascent/shuttle_port)
+/obj/machinery/portable_atmospherics/canister/methyl_bromide,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_starboard_spike)
 "JC" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/ascent,
@@ -4835,12 +5020,6 @@
 /obj/item/weapon/rig/mantid/seed,
 /obj/item/weapon/rig/mantid/seed,
 /obj/machinery/light/ascent,
-/obj/structure/window/phoronreinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	color = "PURPLE"
-	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
 "Kh" = (
@@ -4855,6 +5034,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
+"KL" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/shuttle_port)
 "KO" = (
 /obj/machinery/ion_engine{
 	dir = 8
@@ -4864,18 +5048,30 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
+"Ld" = (
+/obj/machinery/door/airlock/ascent{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/ascent,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/ascent,
+/area/ship/ascent/shuttle_port)
 "Lp" = (
 /obj/structure/table/rack/dark,
 /obj/item/weapon/rig/mantid/seed,
 /obj/item/weapon/rig/mantid/seed,
 /obj/machinery/light/ascent{
 	dir = 1
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/southright{
-	color = "PURPLE"
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/bridge)
@@ -4908,6 +5104,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/weapon/pickaxe/diamonddrill/ascent,
+/obj/item/weapon/storage/ore{
+	color = "PURPLE";
+	name = "mineral carrier"
+	},
+/obj/item/stack/material/rods/fifty,
+/obj/item/stack/material/rods/fifty,
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_starboard)
 "NJ" = (
@@ -5076,14 +5279,9 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_jut)
 "TN" = (
-/obj/structure/window/phoronreinforced{
-	dir = 1
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 8
-	},
-/turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/fore_starboard_spike)
 "TO" = (
 /obj/structure/hygiene/shower/ascent{
 	dir = 8;
@@ -5098,6 +5296,12 @@
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
+"Uf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on/ascent{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ascent,
+/area/ship/ascent/shuttle_port)
 "Uy" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -5127,14 +5331,11 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
 "Vf" = (
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/area/ship/ascent/fore_starboard_spike)
 "Vr" = (
 /obj/structure/table/rack/dark,
 /obj/item/weapon/tank/mantid/reactor,
@@ -5160,11 +5361,15 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "VC" = (
-/obj/structure/window/phoronreinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_starboard_spike)
+"VH" = (
+/obj/machinery/computer/ship/sensors/ascent{
+	dir = 1
 	},
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/area/ship/ascent/bridge)
 "VR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/effect/catwalk_plated/ascent,
@@ -5203,7 +5408,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_port)
 "XG" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/hull,
+/obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/aft_starboard_jut)
 "XM" = (
@@ -5212,15 +5417,11 @@
 	},
 /area/ship/ascent/shuttle_port)
 "Yh" = (
-/obj/machinery/shipsensors,
-/obj/structure/window/phoronreinforced{
+/obj/machinery/atmospherics/binary/pump/on{
 	dir = 4
 	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
-	},
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/area/ship/ascent/fore_starboard_spike)
 "Zh" = (
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/fore_starboard_jut)
@@ -5232,14 +5433,12 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/wing_starboard)
 "Zx" = (
-/obj/structure/window/phoronreinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
-	},
+/obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
-/area/ship/ascent/shuttle_starboard)
+/area/ship/ascent/fore_starboard_spike)
 "ZF" = (
 /obj/machinery/computer/ship/helm/ascent{
 	dir = 1
@@ -8859,8 +9058,8 @@ aa
 aa
 aa
 al
-aL
-aL
+Gd
+Vf
 al
 aa
 aa
@@ -8982,7 +9181,7 @@ aa
 aa
 al
 aP
-aA
+VC
 al
 aa
 aa
@@ -9103,8 +9302,8 @@ aa
 aa
 aa
 al
-aL
-aA
+HZ
+VC
 al
 aa
 aa
@@ -9117,7 +9316,7 @@ aa
 aa
 fQ
 fR
-hs
+GM
 fQ
 aa
 aa
@@ -9225,8 +9424,8 @@ aa
 aa
 aa
 al
-aL
-aA
+HZ
+VC
 al
 aa
 aa
@@ -9347,8 +9546,8 @@ aa
 aa
 aa
 al
-aL
-aA
+Jx
+Yh
 al
 aa
 aa
@@ -9470,7 +9669,7 @@ aa
 aa
 al
 aA
-aA
+Zx
 al
 aa
 aa
@@ -9591,7 +9790,7 @@ aa
 aa
 aa
 al
-aA
+TN
 cu
 al
 aa
@@ -10323,7 +10522,7 @@ aa
 cL
 TV
 as
-vx
+mN
 as
 dC
 Uy
@@ -10445,7 +10644,7 @@ aa
 cL
 qR
 as
-mM
+mN
 as
 as
 hH
@@ -10687,7 +10886,7 @@ aa
 aa
 mg
 cL
-CA
+vx
 as
 as
 as
@@ -12137,8 +12336,8 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 ab
 Ek
 MZ
@@ -12174,7 +12373,7 @@ cN
 cN
 cN
 ft
-cN
+dV
 cN
 cN
 cN
@@ -12258,10 +12457,10 @@ aa
 aa
 aa
 aa
+aa
 ab
-Zx
-VC
-HZ
+ab
+ab
 ab
 aw
 zA
@@ -12379,11 +12578,11 @@ aa
 aa
 aa
 aa
+aa
 ab
-TN
-aa
-aa
-aa
+ej
+ej
+ej
 ab
 ab
 ab
@@ -12537,7 +12736,7 @@ ce
 cy
 cy
 cN
-ej
+cN
 iO
 cN
 iv
@@ -12664,7 +12863,7 @@ fl
 gs
 iw
 cQ
-cQ
+xl
 ix
 iC
 dV
@@ -12784,7 +12983,7 @@ jM
 gv
 fn
 pE
-iw
+Df
 cQ
 cQ
 cQ
@@ -12888,15 +13087,15 @@ fv
 js
 aj
 az
-ck
-fL
+IY
+be
 be
 iU
 az
 bR
 be
-fL
-ck
+be
+jD
 az
 bW
 dX
@@ -12904,11 +13103,11 @@ bW
 bW
 cN
 cN
-cN
+BE
 cN
 iA
 cQ
-Jx
+cQ
 cQ
 cQ
 dV
@@ -13025,13 +13224,13 @@ gE
 iB
 bW
 cN
-fm
+jO
 fo
 gt
 iD
 cQ
-cQ
-cQ
+Uf
+sc
 zf
 cN
 XM
@@ -13111,11 +13310,11 @@ aa
 aa
 aa
 aa
+aa
 ab
-Yh
-aa
-aa
-aa
+fU
+ej
+ej
 ab
 ab
 ab
@@ -13147,13 +13346,13 @@ jd
 dA
 bW
 cN
-eU
+jN
 fp
 gu
-gT
-gT
-gT
-gT
+Ah
+pQ
+rq
+nU
 gT
 cN
 cN
@@ -13234,10 +13433,10 @@ aa
 aa
 aa
 aa
+aa
 ab
-Vf
-md
-Gd
+ab
+ab
 ab
 wu
 nh
@@ -13271,8 +13470,8 @@ bW
 cN
 cN
 cN
-ft
-cN
+Ld
+dV
 cN
 cN
 cN
@@ -13357,8 +13556,8 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 ab
 Ek
 NJ
@@ -13393,8 +13592,8 @@ dU
 aa
 ik
 iP
-gu
-gT
+us
+ts
 jc
 jl
 cN
@@ -13745,9 +13944,9 @@ az
 bm
 cY
 be
-bm
+Ge
 ht
-fU
+fI
 be
 fK
 fI
@@ -13856,23 +14055,23 @@ lW
 tr
 tr
 zV
-tr
-na
-na
+md
+JC
+CW
 aj
 ai
 bI
 aK
 az
-ck
-fH
+Ge
 be
 be
 be
 be
 be
-fH
-ck
+be
+be
+VH
 az
 hS
 gI
@@ -13881,8 +14080,8 @@ bW
 aa
 cN
 jb
-cQ
-cQ
+Bz
+KL
 ir
 cN
 cN
@@ -13980,7 +14179,7 @@ tr
 tr
 Fd
 If
-NR
+mM
 aj
 aj
 aC
@@ -14729,7 +14928,7 @@ bW
 bW
 bW
 dd
-dQ
+dU
 bW
 bW
 aa
@@ -14963,7 +15162,7 @@ oL
 aE
 ef
 BX
-gL
+xm
 df
 ds
 fE
@@ -15085,7 +15284,7 @@ oL
 aH
 fX
 cV
-gL
+Ag
 dn
 bw
 gy


### PR DESCRIPTION
:cl:
bugfix: Ascent Exosuit gauntlets are now insulated. 
maptweak: Modified some of the Ascent seedship's rooms.
/:cl:
Fixed their windows being Torch Hull/Unpainted
Made their gauntlets insulated
Gave them gas in their distro loop.
Fixed a leak.
Dropped some gear they need/always make. (like large beakers and whatnot)
Change the interior of the Trichoptera to fix their airlock breaking due to lack of gas.
Drops some gear onto the Lepidoptera, mining, rods (until they have beacons).
Critical: Gave them the unused ascent mop bucket.
Modified the Control Chamber to fix inaccessible tables.
Deleted some windoors that didn't need to exist.
Gave them more atmos cans.
Gave them plasteel to repair hull damage.
Idk maybe something else.
Pretty minor stuff.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->