### PR TITLE
Adds ETA timer to shuttle consoles

### DIFF
--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -49,6 +49,7 @@
 		"can_launch" = shuttle.can_launch(),
 		"can_cancel" = shuttle.can_cancel(),
 		"can_force" = shuttle.can_force(),
+		"timeleft" = max(round((shuttle.arrive_time - world.time) / 10, 1), 0),
 		"docking_codes" = shuttle.docking_codes
 	)
 

--- a/nano/templates/shuttle_control_console.tmpl
+++ b/nano/templates/shuttle_control_console.tmpl
@@ -22,6 +22,24 @@
 		</div>
 	</div>
 </div>
+<div class="item" style="padding-top: 10px">
+	<div class="itemLabel">
+		ETA:
+	</div>
+	<div class="itemContent">
+		{{if data.shuttle_state == "warmup"}}
+			<span style="font-weight: bold;color: #336699">CALIBRATING</span>
+		{{else data.shuttle_state == "in_transit"}}
+			{{if data.timeleft > 0}}
+				<span class="average">{{:data.timeleft}} s</span>
+			{{else}}
+				<span class="bad">IMMINENT</span>
+			{{/if}}
+		{{else}}
+			<span class="idle">NONE</span>
+		{{/if}}
+	</div>
+</div>
 {{if data.has_docking}}
 	<div class="item" style="padding-top: 10px">
 		<div class="item">

--- a/nano/templates/shuttle_control_console_antag.tmpl
+++ b/nano/templates/shuttle_control_console_antag.tmpl
@@ -25,6 +25,24 @@
 		</div>
 	</div>
 </div>
+<div class="item" style="padding-top: 10px">
+	<div class="itemLabel">
+		ETA:
+	</div>
+	<div class="itemContent">
+		{{if data.shuttle_state == "warmup"}}
+			<span style="font-weight: bold;color: #336699">CALIBRATING</span>
+		{{else data.shuttle_state == "in_transit"}}
+			{{if data.timeleft > 0}}
+				<span class="average">{{:data.timeleft}} s</span>
+			{{else}}
+				<span class="bad">IMMINENT</span>
+			{{/if}}
+		{{else}}
+			<span class="idle">NONE</span>
+		{{/if}}
+	</div>
+</div>
 {{if data.has_docking}}
 	<div class="item" style="padding-top: 10px">
 		<div class="item">

--- a/nano/templates/shuttle_control_console_exploration.tmpl
+++ b/nano/templates/shuttle_control_console_exploration.tmpl
@@ -22,6 +22,24 @@
 		</div>
 	</div>
 </div>
+<div class="item" style="padding-top: 10px">
+	<div class="itemLabel">
+		ETA:
+	</div>
+	<div class="itemContent">
+		{{if data.shuttle_state == "warmup"}}
+			<span style="font-weight: bold;color: #336699">CALIBRATING</span>
+		{{else data.shuttle_state == "in_transit"}}
+			{{if data.timeleft > 0}}
+				<span class="average">{{:data.timeleft}} s</span>
+			{{else}}
+				<span class="bad">IMMINENT</span>
+			{{/if}}
+		{{else}}
+			<span class="idle">NONE</span>
+		{{/if}}
+	</div>
+</div>
 {{if data.has_docking}}
 	<div class="item" style="padding-top: 10px">
 		<div class="item">

--- a/nano/templates/shuttle_control_console_multi.tmpl
+++ b/nano/templates/shuttle_control_console_multi.tmpl
@@ -22,6 +22,24 @@
 		</div>
 	</div>
 </div>
+<div class="item" style="padding-top: 10px">
+	<div class="itemLabel">
+		ETA:
+	</div>
+	<div class="itemContent">
+		{{if data.shuttle_state == "warmup"}}
+			<span style="font-weight: bold;color: #336699">CALIBRATING</span>
+		{{else data.shuttle_state == "in_transit"}}
+			{{if data.timeleft > 0}}
+				<span class="average">{{:data.timeleft}} s</span>
+			{{else}}
+				<span class="bad">IMMINENT</span>
+			{{/if}}
+		{{else}}
+			<span class="idle">NONE</span>
+		{{/if}}
+	</div>
+</div>
 {{if data.has_docking}}
 	<div class="item" style="padding-top: 10px">
 		<div class="item">


### PR DESCRIPTION
🆑 Hubblenaut
rscadd: Adds ETA timer to shuttle consoles.
/:cl:

![grafik](https://user-images.githubusercontent.com/6383576/91775994-d4030b80-ebec-11ea-9ce0-ee0cde696c7e.png)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->