### PR TITLE
Potato will display coolant amount in UI

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -343,6 +343,9 @@
 	data["fuel_capacity"] = round(max_sheets * 1000, 0.1)
 	data["fuel_usage"] = active ? round((power_output / time_per_sheet) * 1000) : 0
 	data["fuel_type"] = sheet_name
+	data["uses_coolant"] = !!reagents
+	data["coolant_stored"] = reagents?.total_volume
+	data["coolant_capacity"] = reagents?.maximum_volume
 
 
 

--- a/nano/templates/pacman.tmpl
+++ b/nano/templates/pacman.tmpl
@@ -59,6 +59,26 @@
 		</div>
 	{{/if}}
 </div>
+{{if data.uses_coolant}}
+	<h3>Coolant</h3>
+	<div class='item'>
+		<div class="itemLabel">
+			Coolant Level:
+		</div>
+		<div class="itemContent">
+			{{if data.coolant_stored/data.coolant_capacity >= 0.4}}
+				{{:helper.displayBar(data.coolant_stored, 0, data.coolant_capacity, 'good')}}
+				<br><span class="good">{{:data.coolant_stored}}/{{:data.coolant_capacity}} u</span>
+			{{else data.coolant_stored/data.coolant_capacity >= 0.1}}
+				{{:helper.displayBar(data.coolant_stored, 0, data.coolant_capacity, 'average')}}
+				<br><span class="average">{{:data.coolant_stored}}/{{:data.coolant_capacity}} u</span>
+			{{else}}
+				{{:helper.displayBar(data.coolant_stored, 0, data.coolant_capacity, 'bad')}}
+				<br><span class="bad">{{:data.coolant_stored}}/{{:data.coolant_capacity}} u</span>
+			{{/if}}
+		</div>
+	</div>
+{{/if}}
 <h3>Output</h3>
 <div class='item'>
 	<div class="itemLabel">


### PR DESCRIPTION
🆑 Hubblenaut
tweak: The potato reactor will now display the coolant amount in its UI.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->