### PR TITLE
SEA is now limited to Experienced Combat Skills.

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -333,8 +333,8 @@
 	                    SKILL_COMBAT     = SKILL_BASIC,
 	                    SKILL_WEAPONS    = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_COMBAT       = SKILL_MAX,
-	                    SKILL_WEAPONS      = SKILL_MAX,
+	max_skill = list(   SKILL_COMBAT       = SKILL_EXPERT,
+	                    SKILL_WEAPONS      = SKILL_EXPERT,
 	                    SKILL_PILOT        = SKILL_MAX,
 	                    SKILL_CONSTRUCTION = SKILL_MAX,
 	                    SKILL_ELECTRICAL   = SKILL_MAX,


### PR DESCRIPTION
🆑 
tweak: The Senior Enlisted Advisor is now unable to go above Experienced in their Combat Skills. They're getting too old for this..
/:cl:
The SEA is at *least* 35. But ideally, they should be at least 45.
They've been out of front-line duties for the *majority of their career* by this point.
Keeping your PT score up, or your technical skills is doable. 
But your combat skills will degrade. You can't compete with these younglings anymore!
Sides, you don't get enough range time. 
And in combatives, you can't risk the potential injury, old man.

Also the obvious "SEA master is a meme"
Sorry to anyone who's character is effected by this.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->