### PR TITLE
Fixes/Tweaks around the personal shield

### DIFF
--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -5,7 +5,7 @@
 	icon_state = "battereroff"
 	slot_flags = SLOT_BELT
 	var/open = FALSE
-	var/obj/item/weapon/cell/power_cell = /obj/item/weapon/cell
+	var/obj/item/weapon/cell/power_cell = /obj/item/weapon/cell/high
 	var/shield_type = /obj/aura/personal_shield/device
 	var/shield_power_cost = 1000
 	var/obj/aura/personal_shield/device/shield
@@ -39,11 +39,12 @@
 
 /obj/item/device/personal_shield/examine(mob/user, distance)
 	. = ..()
-	if(power_cell)
-		power_cell.examine(user, distance)
-	else
-		to_chat(user, "There is no cell in \the [src].")
-	to_chat(user, "The internal capacitor currently has [round(currently_stored_power/max_stored_power)]% charge.")
+	if(open)
+		if(power_cell)
+			to_chat(user, "There is \a [power_cell] in \the [src].")
+		else
+			to_chat(user, "There is no cell in \the [src].")
+	to_chat(user, "The internal capacitor currently has [round(currently_stored_power/max_stored_power * 100)]% charge.")
 
 /obj/item/device/personal_shield/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W, /obj/item/weapon/cell))
@@ -52,30 +53,41 @@
 		else if(power_cell)
 			to_chat(user, SPAN_WARNING("\The [src] already has a battery."))
 		else if(user.unEquip(W, src))
-			user.visible_message("\The [user] installs \the [W] into \the [src].")
+			user.visible_message("\The [user] installs \the [W] into \the [src].", SPAN_NOTICE("You install \the [W] into \the [src]."))
 			power_cell = W
 			START_PROCESSING(SSobj, src)
 			update_icon()
 	if(isScrewdriver(W))
 		playsound(src, 'sound/items/Screwdriver.ogg', 15, 1)
-		user.visible_message("\The [user] [open ? "screws" : "unscrews"] the top to \the [src].")
+		user.visible_message("\The [user] [open ? "screws" : "unscrews"] the top of \the [src].", SPAN_NOTICE("You [open ? "screw" : "unscrew"] the top of \the [src]."))
 		open = !open
 		update_icon()
 
 /obj/item/device/personal_shield/attack_self(var/mob/living/user)
-	if(open)
-		if(power_cell)
-			to_chat(user, SPAN_NOTICE("You remove \the [power_cell] from \the [src]."))
-			turn_off()	
-			user.put_in_hands(power_cell)
-			power_cell = null
-			currently_stored_power = 0
-			enable_when_powered = FALSE
-			update_icon()
-		else
-			to_chat(user, SPAN_WARNING("There's no battery in \the [src]."))
+	if (open && power_cell)
+		user.visible_message("\The [user] shakes \the [power_cell] out of \the [src].", SPAN_NOTICE("You shake \the [power_cell] out of \the [src]."))
+		turn_off()
+		power_cell.dropInto(user.loc)
+		on_remove_cell()
 	else
 		toggle(user)
+
+/obj/item/device/personal_shield/attack_hand(var/mob/living/user)
+	if(open && (loc == user))
+		if(power_cell)
+			user.visible_message("\The [user] removes \the [power_cell] from \the [src].", SPAN_NOTICE("You remove \the [power_cell] from \the [src]."))
+			turn_off()	
+			user.put_in_active_hand(power_cell)
+			on_remove_cell()
+		else
+			to_chat(user, SPAN_WARNING("There's no battery in \the [src]."))
+	else . = ..()
+
+/obj/item/device/personal_shield/proc/on_remove_cell()
+	power_cell = null
+	currently_stored_power = 0
+	enable_when_powered = FALSE
+	update_icon()
 
 /obj/item/device/personal_shield/dropped(var/mob/user)
 	turn_off()
@@ -91,8 +103,6 @@
 		power_cell.emp_act(severity)
 		if(shield)
 			visible_message(SPAN_DANGER("\The [src] explodes!"))
-			power_cell.dropInto(loc)
-			power_cell = null
 			explosion(src, -1, -1, 1, 2)
 			qdel(src)
 	else
@@ -106,13 +116,18 @@
 	if(!power_cell)
 		to_chat(user, SPAN_WARNING("\The [src] doesn't have a power supply."))
 		return
+	if(currently_stored_power < shield_power_cost)
+		to_chat(user, SPAN_WARNING("\The [src]'s internal capacitor does not have enough charge."))
+		return
 	shield = new shield_type(user, src)
+	update_name()
 	update_icon()
 
 /obj/item/device/personal_shield/proc/turn_off(var/mob/user)
 	if(!shield)
 		return
 	QDEL_NULL(shield)
+	update_name()
 	update_icon()
 
 /obj/item/device/personal_shield/proc/toggle(var/mob/user)
@@ -120,6 +135,12 @@
 		turn_off(user)
 	else
 		turn_on(user)
+
+/obj/item/device/personal_shield/AltClick(mob/user)
+	if (loc == user)
+		toggle(user)
+	else
+		. = ..()
 
 /obj/item/device/personal_shield/proc/take_charge()
 	if(!actual_take_charge())
@@ -150,3 +171,9 @@
 			icon_state = "battereropen[power_cell ? "full" : "empty"]"
 		else
 			icon_state = "battereroff"
+
+/obj/item/device/personal_shield/proc/update_name()
+	if(shield)
+		SetName("activated [initial(name)]")
+	else
+		SetName(initial(name))


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes several issues around personal shields.
tweak: The personal shield can now be toggled using Alt+Click.
tweak: You can now remove the power cell from the personal shield using a free hand.
rscdel: The personal shield will no longer leave an intact power cell behind after exploding.
/:cl:

- Fixes charge not being displayed correctly.
- Fixes convoluted examine text.
- Fixes device turning on when not having enough charge.
- The shield will now show as 'activated' in the name when it's on.
- Adds Alt+Click as a shortcut for toggling the device.
- The shield will no longer leave a power cell behind after exploding.
- The power cell can now also be removed using `attack_hand()`.

Resolves #29263
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->