### PR TITLE
publicly visible do_after + progressbar for atoms

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -359,3 +359,24 @@
 #define CAN_INJECT 1
 #define INJECTION_PORT 2
 #define INJECTION_PORT_DELAY 3 SECONDS // used by injectors to apply delay due to searching for a port on the injectee's suit
+
+
+//used by /proc/do_after
+#define DO_USER_CAN_MOVE     0x1
+#define DO_USER_CAN_TURN     0x2
+#define DO_USER_UNIQUE_ACT   0x4
+#define DO_USER_SAME_HAND    0x8
+#define DO_TARGET_CAN_MOVE   0x10
+#define DO_TARGET_CAN_TURN   0x20
+#define DO_TARGET_UNIQUE_ACT 0x40
+#define DO_SHOW_PROGRESS     0x80
+#define DO_PUBLIC_PROGRESS   0x100
+
+#define DO_BOTH_CAN_MOVE     (DO_USER_CAN_MOVE | DO_TARGET_CAN_MOVE)
+#define DO_BOTH_CAN_TURN     (DO_USER_CAN_TURN | DO_TARGET_CAN_TURN)
+#define DO_BOTH_UNIQUE_ACT   (DO_USER_UNIQUE_ACT | DO_TARGET_UNIQUE_ACT)
+#define DO_DEFAULT           (DO_SHOW_PROGRESS | DO_USER_SAME_HAND | DO_BOTH_CAN_TURN)
+
+#define DO_MISSING_USER      (-1)
+#define DO_MISSING_TARGET    (-2)
+#define DO_INCAPACITATED     (-3)

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -156,24 +156,6 @@ proc/age2agedescription(age)
 /mob/var/do_unique_user_handle = 0
 /atom/var/do_unique_target_user
 
-#define DO_USER_CAN_MOVE     0x1
-#define DO_USER_CAN_TURN     0x2
-#define DO_USER_UNIQUE_ACT   0x4
-#define DO_USER_SAME_HAND    0x8
-#define DO_TARGET_CAN_MOVE   0x10
-#define DO_TARGET_CAN_TURN   0x20
-#define DO_TARGET_UNIQUE_ACT 0x40
-#define DO_SHOW_PROGRESS     0x80
-
-#define DO_BOTH_CAN_MOVE     (DO_USER_CAN_MOVE | DO_TARGET_CAN_MOVE)
-#define DO_BOTH_CAN_TURN     (DO_USER_CAN_TURN | DO_TARGET_CAN_TURN)
-#define DO_BOTH_UNIQUE_ACT   (DO_USER_UNIQUE_ACT | DO_TARGET_UNIQUE_ACT)
-#define DO_DEFAULT           (DO_SHOW_PROGRESS | DO_USER_SAME_HAND | DO_BOTH_CAN_TURN)
-
-#define DO_MISSING_USER      (-1)
-#define DO_MISSING_TARGET    (-2)
-#define DO_INCAPACITATED     (-3)
-
 /proc/do_after(mob/user, delay, atom/target, do_flags = DO_DEFAULT, incapacitation_flags = INCAPACITATION_DEFAULT)
 	return !do_after_detailed(user, delay, target, do_flags, incapacitation_flags)
 
@@ -203,7 +185,12 @@ proc/age2agedescription(age)
 	var/target_dir = do_flags & DO_TARGET_CAN_TURN ? null : target?.dir
 	var/target_type = target?.type
 
-	var/datum/progressbar/bar = do_flags & DO_SHOW_PROGRESS ? new(user, delay, target) : null
+	var/datum/progressbar/bar
+	if (do_flags & DO_SHOW_PROGRESS)
+		if (do_flags & DO_PUBLIC_PROGRESS)
+			bar = new /datum/progressbar/public(user, delay, target)
+		else
+			bar = new /datum/progressbar/private(user, delay, target)
 
 	var/start_time = world.time
 	var/end_time = start_time + delay

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -1,46 +1,84 @@
+
 /datum/progressbar
-	var/goal = 1
+	var/max_progress
+
+/datum/progressbar/proc/update(progress)
+
+
+/datum/progressbar/private
+	var/mob/actor
 	var/image/bar
-	var/shown = 0
-	var/mob/user
 	var/client/client
+	var/visible
+	var/shown
 
-/datum/progressbar/New(mob/user, goal_number, atom/target)
-	. = ..()
-	if(!target) target = user
-	if (!istype(target))
-		EXCEPTION("Invalid target given")
-	if (goal_number)
-		goal = goal_number
-	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0")
-	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	bar.plane = HUD_PLANE
-	bar.layer = HUD_ABOVE_ITEM_LAYER
-	bar.pixel_y = WORLD_ICON_SIZE
-	src.user = user
-	if(user)
-		client = user.client
-
-/datum/progressbar/Destroy()
-	if (client)
+/datum/progressbar/private/Destroy()
+	if (client && bar)
 		client.images -= bar
 	qdel(bar)
 	. = ..()
 
-/datum/progressbar/proc/update(progress)
-//	log_debug("Update [progress] - [goal] - [(progress / goal)] - [((progress / goal) * 100)] - [round(((progress / goal) * 100), 5)]")
-
-	if (!user || !user.client)
-		shown = 0
+/datum/progressbar/private/New(mob/actor, max_progress, atom/actee)
+	actee = actee || actor
+	if (!istype(actee))
+		EXCEPTION("Invalid progressbar/private instance")
+	src.actor = actor
+	src.max_progress = max_progress
+	client = actor.client
+	visible = actor.get_preference_value(/datum/client_preference/show_progress_bar) == GLOB.PREF_SHOW
+	if (!visible)
 		return
-	if (user.client != client)
+	bar = image('icons/effects/progessbar.dmi', actee, "prog_bar_0", HUD_ABOVE_ITEM_LAYER)
+	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	bar.pixel_y = WORLD_ICON_SIZE
+	bar.plane = HUD_PLANE
+
+/datum/progressbar/private/update(progress)
+	if (!visible || !actor || !actor.client)
+		shown = FALSE
+		return
+	if (actor.client != client)
 		if (client)
 			client.images -= bar
-			shown = 0
-		client = user.client
+			shown = FALSE
+		client = actor.client
+	progress = Clamp(progress, 0, max_progress)
+	bar.icon_state = "prog_bar_[round(progress * 100 / max_progress, 5)]"
+	if (!shown)
+		client.images += bar
+		shown = TRUE
 
-	progress = Clamp(progress, 0, goal)
-	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
-	if (!shown && user.get_preference_value(/datum/client_preference/show_progress_bar) == GLOB.PREF_SHOW)
-		user.client.images += bar
-		shown = 1
+
+/datum/progressbar/public
+	var/atom/movable/actor
+	var/atom/movable/actee
+	var/atom/movable/bar
+
+/datum/progressbar/public/Destroy()
+	if (actor && bar)
+		actor.vis_contents -= bar
+	qdel(bar)
+	. = ..()
+
+/datum/progressbar/public/New(atom/movable/actor, max_progress, atom/movable/actee)
+	actee = actee || actor
+	if (!istype(actee))
+		EXCEPTION("Invalid progressbar/public instance")
+	src.actor = actor
+	src.max_progress = max_progress
+	src.actee = actee
+	bar = new()
+	bar.mouse_opacity = 0
+	bar.icon = 'icons/effects/progessbar.dmi'
+	bar.icon_state = "prog_bar_0"
+	bar.pixel_x = (actee.x - actor.x) * WORLD_ICON_SIZE
+	bar.pixel_y = (actee.y - actor.y) * WORLD_ICON_SIZE + WORLD_ICON_SIZE
+	actor.vis_contents += bar
+
+/datum/progressbar/public/update(progress)
+	if (!actor || !actee)
+		return
+	progress = Clamp(progress, 0, max_progress)
+	bar.icon_state = "prog_bar_[round(progress * 100 / max_progress, 5)]"
+	bar.pixel_x = (actee.x - actor.x) * WORLD_ICON_SIZE
+	bar.pixel_y = (actee.y - actor.y) * WORLD_ICON_SIZE + WORLD_ICON_SIZE

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -35,7 +35,7 @@
 				to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 			else
 				user.visible_message("<span class='notice'>\The [user] begins to mop up \the [T].</span>")
-				if(do_after(user, 40, T) && F && !QDELETED(F))
+				if(do_after(user, mopspeed, T, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS) && F && !QDELETED(F))
 					if(F.fluid_amount > FLUID_SHALLOW)
 						to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 					else
@@ -57,7 +57,7 @@
 
 		user.visible_message("<span class='warning'>\The [user] begins to clean \the [T].</span>")
 
-		if(do_after(user, mopspeed, T))
+		if(do_after(user, mopspeed, T, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS))
 			if(T)
 				T.clean(src, user)
 			to_chat(user, "<span class='notice'>You have finished mopping!</span>")


### PR DESCRIPTION
:cl:
tweak: Floor mopping progress bars are now publicly visible.
bugfix: Mopping up water uses the mop's speed instead of a fixed value.
/:cl:

--

/proc/do_after gets a flag DO_PUBLIC_PROGRESS that causes its progressbar instance to be public, if there is one. By default, progressbar instances are not public.

/datum/progressbar is rejigged to take an atom user instead of a mob, and to have flags. It gains a flag PROGRESSBAR_PUBLIC. When a progressbar is flagged as public, it uses an atom/movable and vis_contents instead of an image and client.images. This shows the progressbar to everyone instead of just the user. When a progressbar's user is not a mob, the progressbar is always public. This allows things that aren't mobs to use them.

Using a mop is made public as a demo.