### PR TITLE
Give forensic technician webbing

### DIFF
--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -151,6 +151,7 @@
 		/obj/item/weapon/melee/baton/loaded,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/taperoll/police,
+		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/device/tape/random = 3,
 		/obj/item/clothing/glasses/sunglasses/sechud/toggle,
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,


### PR DESCRIPTION
:cl:
rscadd: The forensic technician's locker now has black webbing in it at roundstart.
/:cl:

Makes sense given they have a lot of equipment they need to store on their person (especially if they use the forensic belt) and the rest of security spawns with them.