### PR TITLE
Revert "nerf lab tech skills"

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -184,11 +184,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/contractor/chemist
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
-	min_skill = list(   SKILL_MEDICAL   = SKILL_BASIC,
+	min_skill = list(   SKILL_MEDICAL   = SKILL_ADEPT,
 	                    SKILL_CHEMISTRY = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_MEDICAL     = SKILL_BASIC,
-						SKILL_ANATOMY	  = SKILL_BASIC,
+	max_skill = list(   SKILL_MEDICAL     = SKILL_ADEPT,
+						SKILL_ANATOMY	  = SKILL_ADEPT,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
 	skill_points = 16
 


### PR DESCRIPTION
Reverts Baystation12/Baystation12#29184

While it's true that lab techs aren't doctors, the fact that this is afaik the only case for a torch job where skills are capped at basic seems strange to me. While a lab tech isn't a medical practicioner, they do work in an infirmary, and it seems dumb that they're incapable of learning medical skills to the same level as a janitor or a bartender. This seems to me like a lazy solution to a problem that's minor at best.