### PR TITLE
Allows forensicing bags, tables, racks, etc on non-help intents

### DIFF
--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -152,6 +152,12 @@
 	var/obj/item/weapon/sample/S = new evidence_path(get_turf(user), supplied)
 	to_chat(user, "<span class='notice'>You transfer [S.evidence.len] [S.evidence.len > 1 ? "[evidence_type]s" : "[evidence_type]"] to \the [S].</span>")
 
+/obj/item/weapon/forensics/sample_kit/resolve_attackby(atom/A, mob/user, click_params)
+	if (user.a_intent != I_HELP) // Prevents putting sample kits in bags, on racks/tables, etc when trying to take samples
+		return FALSE
+
+	. = ..()
+
 /obj/item/weapon/forensics/sample_kit/afterattack(var/atom/A, var/mob/user, var/proximity)
 	if(!proximity)
 		return


### PR DESCRIPTION
Fixes #29272

:cl:
tweak: Forensics sample kits can now be used on containers, tables, racks, etc on non-help intents without dropping/placing/storing them.
/:cl: