### PR TITLE
Legalese has a shorthand

### DIFF
--- a/code/modules/mob/language/human/misc/legalese.dm
+++ b/code/modules/mob/language/human/misc/legalese.dm
@@ -4,6 +4,7 @@
 	speech_verb = "states"
 	exclaim_verb = "objects"
 	ask_verb = "inquiries"
+	shorthand = "Law"
 	space_chance = 100
 	key = "u"
 	partial_understanding = list(


### PR DESCRIPTION
:cl:
tweak: Legalese now has a proper shorthand name, "Law", instead of "???".
/:cl: