### PR TITLE
Fix protein bar reagents reacting

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3440,6 +3440,8 @@
 	icon_state = "proteinbar"
 	trash = /obj/item/trash/proteinbar
 	bitesize = 6
+	atom_flags = ATOM_FLAG_NO_REACT
+
 /obj/item/weapon/reagent_containers/food/snacks/proteinbar/Initialize()
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment, 9)


### PR DESCRIPTION
:cl:
bugfix: The reagents in protein bars will no longer react with each other to produce new reagents (looking at you, citrus blast).
/:cl: