### PR TITLE
Fixes more id cards having incorrect picture and some cases of items not being added correctly on spawn

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -52,10 +52,12 @@ var/list/outfits_decls_by_type_
 	var/id_pda_assignment
 
 	var/list/backpack_overrides
+	var/list/id_picture_updates
 	var/flags = OUTFIT_RESET_EQUIPMENT
 
 /decl/hierarchy/outfit/New()
 	..()
+	id_picture_updates = id_picture_updates || list()
 	backpack_overrides = backpack_overrides || list()
 
 	if(is_hidden_category())
@@ -120,9 +122,11 @@ var/list/outfits_decls_by_type_
 
 	if(!(OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP & equip_adjustments))
 		post_equip(H)
+
+	// Update all ID pictures last to ensure the photo is as correct as possible.
 	H.update_icons()
-	if(W) // We set ID info last to ensure the ID photo is as correct as possible.
-		H.set_id_info(W)
+	for(var/obj/item/weapon/card/id/I in id_picture_updates)
+		I.set_id_photo(H)
 	return 1
 
 /decl/hierarchy/outfit/proc/equip_base(mob/living/carbon/human/H, var/equip_adjustments)
@@ -208,6 +212,7 @@ var/list/outfits_decls_by_type_
 	if(assignment)
 		W.assignment = assignment
 	H.set_id_info(W)
+	id_picture_updates += W
 	if(H.equip_to_slot_or_store_or_drop(W, id_slot))
 		return W
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -128,7 +128,7 @@
 /obj/item/weapon/storage/proc/can_be_inserted(obj/item/W, mob/user, stop_messages = 0)
 	if(!istype(W)) return //Not an item
 
-	if(!user?.canUnEquip(W))
+	if(user && !user.canUnEquip(W))
 		return 0
 
 	if(src.loc == W)

--- a/maps/torch/job/outfits/medical_outfits.dm
+++ b/maps/torch/job/outfits/medical_outfits.dm
@@ -83,13 +83,15 @@
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor/equip_id(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
 	. = ..()
-	var/obj/item/weapon/card/id/foundation_civilian/regis_card = new
+
+	var/obj/item/weapon/card/id/foundation_civilian/W = new
 	if(rank)
-		regis_card.rank = rank
+		W.rank = rank
 	if(assignment)
-		regis_card.assignment = assignment
-	H.set_id_info(regis_card)
-	H.equip_to_slot_or_store_or_drop(regis_card)
+		W.assignment = assignment
+	H.set_id_info(W)
+	id_picture_updates += W
+	H.equip_to_slot_or_store_or_drop(W)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor/ec
 	name = OUTFIT_JOB_NAME("Counselor - Expeditionary Corps")


### PR DESCRIPTION
Fixes extra id cards added on player spawn having incorrect picture. Currently the Counselor is the only case of this, but things are in place for it to work correctly if other roles add an extra ID to the player in the future

Also fixes items added on spawn sometimes being discarded when attempting to add them to a storage container. Should fix at least the occasions described in #28972 where items seem to disappear entirely (most of the time it seems they have instead ended up on the floor by a different cryopod, possibly even on a different z-level), and guarantee that the item at worst ends up on the same tile as the player if it spawned in their hands