### PR TITLE
Allow outfits to have multiple id cards

### DIFF
--- a/code/datums/outfits/_defines.dm
+++ b/code/datums/outfits/_defines.dm
@@ -3,6 +3,8 @@
 #define OUTFIT_HAS_BACKPACK                  0x0002
 #define OUTFIT_EXTENDED_SURVIVAL             0x0004
 #define OUTFIT_RESET_EQUIPMENT               0x0008
+#define OUTFIT_USES_ACCOUNT                  0x0010
+#define OUTFIT_USES_EMAIL                    0x0020
 
 #define OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP    0x0001
 #define OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR 0x0002

--- a/code/datums/outfits/horror_killers.dm
+++ b/code/datums/outfits/horror_killers.dm
@@ -12,7 +12,7 @@
 	r_hand = /obj/item/weapon/material/twohanded/fireaxe
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/centcom/station
+	id_types = list(/obj/item/weapon/card/id/centcom/station)
 	id_pda_assignment = "Tunnel Clown!"
 
 /decl/hierarchy/outfit/masked_killer
@@ -45,7 +45,7 @@
 	l_pocket = /obj/item/weapon/melee/energy/sword
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/syndicate/station_access
+	id_types = list(/obj/item/weapon/card/id/syndicate/station_access)
 	pda_slot = slot_belt
 	pda_type = /obj/item/modular_computer/pda/heads
 

--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -8,19 +8,19 @@
 	shoes = /obj/item/clothing/shoes/brown
 	glasses = /obj/item/clothing/glasses/sunglasses
 	l_hand = /obj/item/weapon/material/clipboard
-	id_type = /obj/item/weapon/card/id/cargo/head
+	id_types = list(/obj/item/weapon/card/id/cargo/head)
 	pda_type = /obj/item/modular_computer/pda/cargo
 
 /decl/hierarchy/outfit/job/cargo/cargo_tech
 	name = OUTFIT_JOB_NAME("Cargo technician")
 	uniform = /obj/item/clothing/under/rank/cargotech
-	id_type = /obj/item/weapon/card/id/cargo
+	id_types = list(/obj/item/weapon/card/id/cargo)
 	pda_type = /obj/item/modular_computer/pda/cargo
 
 /decl/hierarchy/outfit/job/cargo/mining
 	name = OUTFIT_JOB_NAME("Shaft miner")
 	uniform = /obj/item/clothing/under/rank/miner
-	id_type = /obj/item/weapon/card/id/cargo/mining
+	id_types = list(/obj/item/weapon/card/id/cargo/mining)
 	pda_type = /obj/item/modular_computer/pda/science
 	backpack_contents = list(/obj/item/weapon/crowbar = 1, /obj/item/weapon/storage/ore = 1)
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -8,7 +8,7 @@
 /decl/hierarchy/outfit/job/service/bartender
 	name = OUTFIT_JOB_NAME("Bartender")
 	uniform = /obj/item/clothing/under/rank/bartender
-	id_type = /obj/item/weapon/card/id/civilian/bartender
+	id_types = list(/obj/item/weapon/card/id/civilian/bartender)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/service/chef
@@ -16,7 +16,7 @@
 	uniform = /obj/item/clothing/under/rank/chef
 	suit = /obj/item/clothing/suit/chef
 	head = /obj/item/clothing/head/chefhat
-	id_type = /obj/item/weapon/card/id/civilian/chef
+	id_types = list(/obj/item/weapon/card/id/civilian/chef)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/service/gardener
@@ -25,7 +25,7 @@
 	suit = /obj/item/clothing/suit/apron
 	gloves = /obj/item/clothing/gloves/thick/botany
 	r_pocket = /obj/item/device/scanner/plant
-	id_type = /obj/item/weapon/card/id/civilian/botanist
+	id_types = list(/obj/item/weapon/card/id/civilian/botanist)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/service/gardener/New()
@@ -37,13 +37,13 @@
 /decl/hierarchy/outfit/job/service/janitor
 	name = OUTFIT_JOB_NAME("Janitor")
 	uniform = /obj/item/clothing/under/rank/janitor
-	id_type = /obj/item/weapon/card/id/civilian/janitor
+	id_types = list(/obj/item/weapon/card/id/civilian/janitor)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/librarian
 	name = OUTFIT_JOB_NAME("Librarian")
 	uniform = /obj/item/clothing/under/suit_jacket/red
-	id_type = /obj/item/weapon/card/id/civilian/librarian
+	id_types = list(/obj/item/weapon/card/id/civilian/librarian)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/internal_affairs_agent
@@ -54,12 +54,12 @@
 	shoes = /obj/item/clothing/shoes/brown
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	l_hand = /obj/item/weapon/storage/briefcase
-	id_type = /obj/item/weapon/card/id/civilian/internal_affairs_agent
+	id_types = list(/obj/item/weapon/card/id/civilian/internal_affairs_agent)
 	pda_type = /obj/item/modular_computer/pda/heads/paperpusher
 
 /decl/hierarchy/outfit/job/chaplain
 	name = OUTFIT_JOB_NAME("Chaplain")
 	uniform = /obj/item/clothing/under/rank/chaplain
 	l_hand = /obj/item/weapon/storage/bible
-	id_type = /obj/item/weapon/card/id/civilian/chaplain
+	id_types = list(/obj/item/weapon/card/id/civilian/chaplain)
 	pda_type = /obj/item/modular_computer/pda/medical

--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -5,7 +5,7 @@
 	uniform = /obj/item/clothing/under/rank/captain
 	l_ear = /obj/item/device/radio/headset/heads/captain
 	shoes = /obj/item/clothing/shoes/brown
-	id_type = /obj/item/weapon/card/id/gold
+	id_types = list(/obj/item/weapon/card/id/gold)
 	pda_type = /obj/item/modular_computer/pda/captain
 	backpack_contents = list(/obj/item/weapon/storage/box/ids = 1)
 
@@ -33,6 +33,6 @@
 	uniform = /obj/item/clothing/under/rank/head_of_personnel
 	l_ear = /obj/item/device/radio/headset/heads/hop
 	shoes = /obj/item/clothing/shoes/brown
-	id_type = /obj/item/weapon/card/id/silver
+	id_types = list(/obj/item/weapon/card/id/silver)
 	pda_type = /obj/item/modular_computer/pda/heads/hop
 	backpack_contents = list(/obj/item/weapon/storage/box/ids = 1)

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -16,7 +16,7 @@
 	uniform = /obj/item/clothing/under/rank/chief_engineer
 	l_ear = /obj/item/device/radio/headset/heads/ce
 	gloves = /obj/item/clothing/gloves/thick
-	id_type = /obj/item/weapon/card/id/engineering/head
+	id_types = list(/obj/item/weapon/card/id/engineering/head)
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 
 /decl/hierarchy/outfit/job/engineering/engineer
@@ -24,7 +24,7 @@
 	head = /obj/item/clothing/head/hardhat
 	uniform = /obj/item/clothing/under/rank/engineer
 	r_pocket = /obj/item/device/t_scanner
-	id_type = /obj/item/weapon/card/id/engineering
+	id_types = list(/obj/item/weapon/card/id/engineering)
 	pda_type = /obj/item/modular_computer/pda/engineering
 
 /decl/hierarchy/outfit/job/engineering/engineer/void

--- a/code/datums/outfits/jobs/job.dm
+++ b/code/datums/outfits/jobs/job.dm
@@ -7,19 +7,8 @@
 	shoes = /obj/item/clothing/shoes/black
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/civilian
+	id_types = list(/obj/item/weapon/card/id/civilian)
 	pda_slot = slot_belt
 	pda_type = /obj/item/modular_computer/pda
 
-	flags = OUTFIT_HAS_BACKPACK
-
-/decl/hierarchy/outfit/job/equip_id(mob/living/carbon/human/H)
-	var/obj/item/weapon/card/id/C = ..()
-	if(!C)
-		return
-	if(H.mind)
-		if(H.mind.initial_account)
-			C.associated_account_number = H.mind.initial_account.account_number
-		if(H.mind.initial_email_login)
-			C.associated_email_login = H.mind.initial_email_login.Copy()
-	return C
+	flags = OUTFIT_HAS_BACKPACK|OUTFIT_USES_ACCOUNT|OUTFIT_USES_EMAIL

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -17,7 +17,7 @@
 	shoes = /obj/item/clothing/shoes/brown
 	l_hand = /obj/item/weapon/storage/firstaid/adv
 	r_pocket = /obj/item/device/flashlight/pen
-	id_type = /obj/item/weapon/card/id/medical/head
+	id_types = list(/obj/item/weapon/card/id/medical/head)
 	pda_type = /obj/item/modular_computer/pda/heads/cmo
 
 /decl/hierarchy/outfit/job/medical/doctor
@@ -26,7 +26,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	l_hand = /obj/item/weapon/storage/firstaid/adv
 	r_pocket = /obj/item/device/flashlight/pen
-	id_type = /obj/item/weapon/card/id/medical
+	id_types = list(/obj/item/weapon/card/id/medical)
 
 /decl/hierarchy/outfit/job/medical/doctor/emergency_physician
 	name = OUTFIT_JOB_NAME("Emergency physician")
@@ -66,7 +66,7 @@
 	name = OUTFIT_JOB_NAME("Chemist")
 	uniform = /obj/item/clothing/under/rank/chemist
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/chemist
-	id_type = /obj/item/weapon/card/id/medical/chemist
+	id_types = list(/obj/item/weapon/card/id/medical/chemist)
 	pda_type = /obj/item/modular_computer/pda/chemistry
 
 /decl/hierarchy/outfit/job/medical/chemist/New()
@@ -78,7 +78,7 @@
 	uniform = /obj/item/clothing/under/rank/geneticist
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/genetics
 	r_pocket = /obj/item/device/flashlight/pen
-	id_type = /obj/item/weapon/card/id/medical/geneticist
+	id_types = list(/obj/item/weapon/card/id/medical/geneticist)
 	pda_type = /obj/item/modular_computer/pda/medical
 
 /decl/hierarchy/outfit/job/medical/geneticist/New()
@@ -91,7 +91,7 @@
 	uniform = /obj/item/clothing/under/rank/psych
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/laceup
-	id_type = /obj/item/weapon/card/id/medical/psychiatrist
+	id_types = list(/obj/item/weapon/card/id/medical/psychiatrist)
 
 /decl/hierarchy/outfit/job/medical/paramedic
 	name = OUTFIT_JOB_NAME("Paramedic")
@@ -100,7 +100,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_hand = /obj/item/weapon/storage/firstaid/adv
 	belt = /obj/item/weapon/storage/belt/medical/emt
-	id_type = /obj/item/weapon/card/id/medical/paramedic
+	id_types = list(/obj/item/weapon/card/id/medical/paramedic)
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 
 /decl/hierarchy/outfit/job/medical/paramedic/emt

--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -15,19 +15,19 @@
 	uniform = /obj/item/clothing/under/rank/research_director
 	shoes = /obj/item/clothing/shoes/brown
 	l_hand = /obj/item/weapon/material/clipboard
-	id_type = /obj/item/weapon/card/id/science/head
+	id_types = list(/obj/item/weapon/card/id/science/head)
 	pda_type = /obj/item/modular_computer/pda/heads/rd
 
 /decl/hierarchy/outfit/job/science/scientist
 	name = OUTFIT_JOB_NAME("Scientist")
 	uniform = /obj/item/clothing/under/rank/scientist
-	id_type = /obj/item/weapon/card/id/science
+	id_types = list(/obj/item/weapon/card/id/science)
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/science
 
 /decl/hierarchy/outfit/job/science/xenobiologist
 	name = OUTFIT_JOB_NAME("Xenobiologist")
 	uniform = /obj/item/clothing/under/rank/scientist
-	id_type = /obj/item/weapon/card/id/science/xenobiologist
+	id_types = list(/obj/item/weapon/card/id/science/xenobiologist)
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/science
 
 /decl/hierarchy/outfit/job/science/roboticist
@@ -35,7 +35,7 @@
 	uniform = /obj/item/clothing/under/rank/scientist
 	shoes = /obj/item/clothing/shoes/black
 	belt = /obj/item/weapon/storage/belt/utility/full
-	id_type = /obj/item/weapon/card/id/science/roboticist
+	id_types = list(/obj/item/weapon/card/id/science/roboticist)
 	pda_slot = slot_r_store
 	pda_type = /obj/item/modular_computer/pda/roboticist
 

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -14,7 +14,7 @@
 	name = OUTFIT_JOB_NAME("Head of security")
 	l_ear = /obj/item/device/radio/headset/heads/hos
 	uniform = /obj/item/clothing/under/rank/head_of_security
-	id_type = /obj/item/weapon/card/id/security/head
+	id_types = list(/obj/item/weapon/card/id/security/head)
 	pda_type = /obj/item/modular_computer/pda/heads/hos
 	backpack_contents = list(/obj/item/weapon/handcuffs = 1)
 
@@ -22,7 +22,7 @@
 	name = OUTFIT_JOB_NAME("Warden")
 	uniform = /obj/item/clothing/under/rank/warden
 	l_pocket = /obj/item/device/flash
-	id_type = /obj/item/weapon/card/id/security/warden
+	id_types = list(/obj/item/weapon/card/id/security/warden)
 	pda_type = /obj/item/modular_computer/pda/security
 
 /decl/hierarchy/outfit/job/security/detective
@@ -33,7 +33,7 @@
 	l_pocket = /obj/item/weapon/flame/lighter/zippo
 	shoes = /obj/item/clothing/shoes/laceup
 	r_hand = /obj/item/weapon/storage/briefcase/crimekit
-	id_type = /obj/item/weapon/card/id/security/detective
+	id_types = list(/obj/item/weapon/card/id/security/detective)
 	pda_type = /obj/item/modular_computer/pda/forensics
 	backpack_contents = list(/obj/item/weapon/storage/box/evidence = 1)
 
@@ -51,5 +51,5 @@
 	uniform = /obj/item/clothing/under/rank/security
 	l_pocket = /obj/item/device/flash
 	r_pocket = /obj/item/weapon/handcuffs
-	id_type = /obj/item/weapon/card/id/security
+	id_types = list(/obj/item/weapon/card/id/security)
 	pda_type = /obj/item/modular_computer/pda/security

--- a/code/datums/outfits/misc.dm
+++ b/code/datums/outfits/misc.dm
@@ -25,7 +25,7 @@
 	suit = /obj/item/clothing/suit/hgpirate
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/centcom/station
+	id_types = list(/obj/item/weapon/card/id/centcom/station)
 	id_pda_assignment = "Admiral"
 
 /decl/hierarchy/outfit/merchant
@@ -34,7 +34,7 @@
 	l_ear = /obj/item/device/radio/headset
 	uniform = /obj/item/clothing/under/color/grey
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/merchant
+	id_types = list(/obj/item/weapon/card/id/merchant)
 	pda_slot = slot_r_store
 	pda_type = /obj/item/modular_computer/pda //cause I like the look
 	id_pda_assignment = "Merchant"

--- a/code/datums/outfits/nanotrasen.dm
+++ b/code/datums/outfits/nanotrasen.dm
@@ -7,7 +7,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/centcom/station
+	id_types = list(/obj/item/weapon/card/id/centcom/station)
 	pda_slot = slot_r_store
 	pda_type = /obj/item/modular_computer/pda/heads
 

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -42,7 +42,7 @@ var/list/outfits_decls_by_type_
 	var/holster = null
 	var/list/backpack_contents = list() // In the list(path=count,otherpath=count) format
 
-	var/id_type
+	var/id_types
 	var/id_desc
 	var/id_slot
 
@@ -102,13 +102,14 @@ var/list/outfits_decls_by_type_
 
 // end of check_and_try_equip_xeno
 
-/decl/hierarchy/outfit/proc/equip(mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
+/decl/hierarchy/outfit/proc/equip(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
 	equip_base(H, equip_adjustments)
 
 	rank = id_pda_assignment || rank
 	assignment = id_pda_assignment || assignment || rank
-	var/obj/item/weapon/card/id/W = equip_id(H, rank, assignment, equip_adjustments)
-	if(W)
+	var/list/id_cards = equip_ids(H, rank, assignment, equip_adjustments)
+	if(length(id_cards))
+		var/obj/item/weapon/card/id/W = id_cards[1]
 		rank = W.rank
 		assignment = W.assignment
 	equip_pda(H, rank, assignment, equip_adjustments)
@@ -121,9 +122,11 @@ var/list/outfits_decls_by_type_
 	if(!(OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP & equip_adjustments))
 		post_equip(H)
 	H.update_icons()
-	if(W) // We set ID info last to ensure the ID photo is as correct as possible.
-		H.set_id_info(W)
-	return 1
+
+	// We set ID info last to ensure the ID photo is as correct as possible.
+	for(var/id_card in id_cards)
+		H.set_id_info(id_card)
+	return TRUE
 
 /decl/hierarchy/outfit/proc/equip_base(mob/living/carbon/human/H, var/equip_adjustments)
 	pre_equip(H)
@@ -195,21 +198,30 @@ var/list/outfits_decls_by_type_
 		H.species.equip_survival_gear(H, flags&OUTFIT_EXTENDED_SURVIVAL)
 	check_and_try_equip_xeno(H)
 
-/decl/hierarchy/outfit/proc/equip_id(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
-	if(!id_slot || !id_type)
+/decl/hierarchy/outfit/proc/equip_ids(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
+	if(!id_slot || !length(id_types))
 		return
 	if(OUTFIT_ADJUSTMENT_SKIP_ID_PDA & equip_adjustments)
 		return
-	var/obj/item/weapon/card/id/W = new id_type(H)
-	if(id_desc)
-		W.desc = id_desc
-	if(rank)
-		W.rank = rank
-	if(assignment)
-		W.assignment = assignment
-	H.set_id_info(W)
-	if(H.equip_to_slot_or_store_or_drop(W, id_slot))
-		return W
+	var/created_cards = list()
+	for(var/id_type in id_types)
+		var/obj/item/weapon/card/id/W = new id_type(H)
+		if(id_desc)
+			W.desc = id_desc
+		if(rank)
+			W.rank = rank
+		if(assignment)
+			W.assignment = assignment
+
+		if((flags & OUTFIT_USES_ACCOUNT) && H.mind?.initial_account)
+			W.associated_account_number = H.mind.initial_account.account_number
+		if(flags & OUTFIT_USES_EMAIL && H.mind?.initial_account.account_number)
+			W.associated_email_login = H.mind.initial_email_login.Copy()				
+
+		var/item_slot = id_types[id_type] || id_slot
+		H.equip_to_slot_or_store_or_drop(W, item_slot)
+		created_cards += W
+	return created_cards
 
 /decl/hierarchy/outfit/proc/equip_pda(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
 	if(!pda_slot || !pda_type)

--- a/code/datums/outfits/spec_op.dm
+++ b/code/datums/outfits/spec_op.dm
@@ -12,7 +12,7 @@
 	gloves = /obj/item/clothing/gloves/thick/combat
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/centcom/ERT
+	id_types = list(/obj/item/weapon/card/id/centcom/ERT)
 	id_desc = "Special operations ID."
 	id_pda_assignment = "Special Operations Officer"
 
@@ -35,7 +35,7 @@
 	back = /obj/item/weapon/storage/backpack/satchel
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/centcom/ERT
+	id_types = list(/obj/item/weapon/card/id/centcom/ERT)
 
 /decl/hierarchy/outfit/death_command
 	name = "Spec Ops - Death commando"
@@ -62,7 +62,7 @@
 	l_pocket = /obj/item/weapon/reagent_containers/pill/cyanide
 
 	id_slot = slot_wear_id
-	id_type = /obj/item/weapon/card/id/syndicate
+	id_types = list(/obj/item/weapon/card/id/syndicate)
 	id_pda_assignment = "Mercenary"
 
 	backpack_contents = list(/obj/item/clothing/suit/space/void/merc/prepared = 1, /obj/item/clothing/mask/gas/syndicate = 1)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -128,7 +128,7 @@
 /obj/item/weapon/storage/proc/can_be_inserted(obj/item/W, mob/user, stop_messages = 0)
 	if(!istype(W)) return //Not an item
 
-	if(!user?.canUnEquip(W))
+	if(user && !user.canUnEquip(W))
 		return 0
 
 	if(src.loc == W)

--- a/code/modules/ascent/ascent_outfit.dm
+++ b/code/modules/ascent/ascent_outfit.dm
@@ -2,7 +2,7 @@
 	name = "Ascent - Gyne"
 	mask =     /obj/item/clothing/mask/gas/ascent
 	uniform =  /obj/item/clothing/under/ascent
-	id_type =  /obj/item/weapon/card/id/ascent
+	id_types = list( /obj/item/weapon/card/id/ascent)
 	shoes =    /obj/item/clothing/shoes/magboots/ascent
 	l_ear =    null
 	pda_type = null

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -110,7 +110,7 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/equip_to_storage_or_drop(obj/item/newitem)
 	var/stored = equip_to_storage(newitem)
 	if(!stored && newitem)
-		newitem.forceMove(loc)
+		newitem.dropInto(loc)
 	return stored
 
 //These procs handle putting s tuff in your hand. It's probably best to use these rather than setting l_hand = ...etc

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -45,7 +45,7 @@
 	var/docking_tag = docking_controller
 	docking_controller = SSshuttle.docking_registry[docking_tag]
 	if(!istype(docking_controller))
-		log_error("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
+		CRASH("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 	if(GLOB.using_map.use_overmap)
 		var/obj/effect/overmap/visitable/location = map_sectors["[z]"]
 		if(location && location.docking_codes)

--- a/maps/away/bearcat/bearcat_jobs.dm
+++ b/maps/away/bearcat/bearcat_jobs.dm
@@ -28,14 +28,14 @@
 
 /decl/hierarchy/outfit/job/bearcat/crew
 	name = BEARCAT_OUTFIT_JOB_NAME("Crew")
-	id_type = /obj/item/weapon/card/id/bearcat
+	id_types = list(/obj/item/weapon/card/id/bearcat)
 
 /decl/hierarchy/outfit/job/bearcat/captain
 	name = BEARCAT_OUTFIT_JOB_NAME("Captain")
 	uniform = /obj/item/clothing/under/casual_pants/classicjeans
 	shoes = /obj/item/clothing/shoes/black
 	pda_type = /obj/item/modular_computer/pda/captain
-	id_type = /obj/item/weapon/card/id/bearcat_captain
+	id_types = list(/obj/item/weapon/card/id/bearcat_captain)
 
 /decl/hierarchy/outfit/job/bearcat/captain/post_equip(var/mob/living/carbon/human/H)
 	..()

--- a/maps/away/scavver/scavver_gantry_jobs.dm
+++ b/maps/away/scavver/scavver_gantry_jobs.dm
@@ -147,7 +147,7 @@
 	gloves = /obj/item/clothing/gloves/thick
 	belt = /obj/item/weapon/gun/energy/gun/small
 	hierarchy_type = /decl/hierarchy/outfit/job/scavver
-	id_type = null
+	id_types = null
 	pda_type = null
 
 /decl/hierarchy/outfit/job/scavver/engineer

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -139,7 +139,7 @@
 	pda_type = /obj/item/modular_computer/pda
 	pda_slot = slot_l_store
 	l_ear = /obj/item/device/radio/headset/skrellian
-	id_type = /obj/item/weapon/card/id/skrellscoutship
+	id_types = list(/obj/item/weapon/card/id/skrellscoutship)
 	l_pocket = /obj/item/clothing/accessory/badge/tags/skrell
 
 /obj/item/weapon/stock_parts/circuitboard/telecomms/allinone/skrellscoutship

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -169,7 +169,7 @@
 	r_ear = null
 
 /decl/hierarchy/outfit/job/voxship/crew
-	id_type = /obj/item/weapon/card/id/voxship
+	id_types = list(/obj/item/weapon/card/id/voxship)
 	name = ("Vox - Job - Shoal Scavenger")
 	uniform = /obj/item/clothing/under/vox/vox_robes
 	r_pocket = /obj/item/device/radio

--- a/maps/bearcat/bearcat_jobs.dm
+++ b/maps/bearcat/bearcat_jobs.dm
@@ -159,7 +159,7 @@
 	shoes = /obj/item/clothing/shoes/black
 	pda_type = /obj/item/modular_computer/pda/captain
 	r_pocket = /obj/item/device/radio
-	id_type = /obj/item/weapon/card/id/gold
+	id_types = list(/obj/item/weapon/card/id/gold)
 
 
 /decl/hierarchy/outfit/job/bearcat/captain/post_equip(var/mob/living/carbon/human/H)
@@ -182,7 +182,7 @@
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 	l_hand = /obj/item/weapon/wrench
 	belt = /obj/item/weapon/storage/belt/utility/full
-	id_type = /obj/item/weapon/card/id/engineering/head
+	id_types = list(/obj/item/weapon/card/id/engineering/head)
 	r_pocket = /obj/item/device/radio
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 
 /decl/hierarchy/outfit/job/survivor
 	name = OUTFIT_JOB_NAME("Survivor")
-	id_type = null
+	id_types = null
 	pda_type = null
 
 /datum/job/submap/pod/New(var/datum/submap/_owner, var/abstract_job = FALSE)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -24,7 +24,7 @@
 
 /decl/hierarchy/outfit/job/colonist
 	name = OUTFIT_JOB_NAME("Colonist")
-	id_type = null
+	id_types = null
 	pda_type = null
 
 /obj/effect/submap_landmark/spawnpoint/colonist_spawn

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -10,7 +10,7 @@
 	l_ear = /obj/item/device/radio/headset/heads/torchexec
 	shoes = /obj/item/clothing/shoes/dutyboots
 	head = /obj/item/clothing/head/soft/solgov/expedition/co
-	id_type = /obj/item/weapon/card/id/torch/gold
+	id_types = list(/obj/item/weapon/card/id/torch/gold)
 	pda_type = /obj/item/modular_computer/pda/captain
 
 /decl/hierarchy/outfit/job/torch/crew/command/CO/New()
@@ -24,7 +24,7 @@
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
 	l_ear = /obj/item/device/radio/headset/heads/torchexec
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/silver
+	id_types = list(/obj/item/weapon/card/id/torch/silver)
 	pda_type = /obj/item/modular_computer/pda/heads/hop
 
 /decl/hierarchy/outfit/job/torch/crew/command/XO/fleet
@@ -37,7 +37,7 @@
 	l_ear  =/obj/item/device/radio/headset/heads/cmo
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/silver/medical
+	id_types = list(/obj/item/weapon/card/id/torch/silver/medical)
 	pda_type = /obj/item/modular_computer/pda/heads/cmo
 	pda_slot = slot_l_store
 
@@ -55,7 +55,7 @@
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/engineering
 	shoes = /obj/item/clothing/shoes/dutyboots
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	id_type = /obj/item/weapon/card/id/torch/silver/engineering
+	id_types = list(/obj/item/weapon/card/id/torch/silver/engineering)
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 	pda_slot = slot_l_store
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
@@ -74,7 +74,7 @@
 	l_ear = /obj/item/device/radio/headset/heads/cos
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/security
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/silver/security
+	id_types = list(/obj/item/weapon/card/id/torch/silver/security)
 	pda_type = /obj/item/modular_computer/pda/heads/hos
 
 /decl/hierarchy/outfit/job/torch/crew/command/cos/New()
@@ -91,7 +91,7 @@
 	l_ear = /obj/item/device/radio/headset/heads/torchntcommand
 	uniform = /obj/item/clothing/under/suit_jacket/corp
 	shoes = /obj/item/clothing/shoes/laceup
-	id_type = /obj/item/weapon/card/id/torch/passenger/corporate/liaison
+	id_types = list(/obj/item/weapon/card/id/torch/passenger/corporate/liaison)
 	pda_type = /obj/item/modular_computer/pda/heads/paperpusher
 	backpack_contents = list(/obj/item/clothing/accessory/badge/nanotrasen = 1)
 
@@ -100,7 +100,7 @@
 	l_ear =    /obj/item/device/radio/headset/heads/torchcorp
 	uniform =  /obj/item/clothing/under/suit_jacket/corp
 	shoes =    /obj/item/clothing/shoes/laceup
-	id_type =  /obj/item/weapon/card/id/torch/passenger/corporate
+	id_types = list( /obj/item/weapon/card/id/torch/passenger/corporate)
 	pda_type = /obj/item/modular_computer/pda/heads/paperpusher
 
 /decl/hierarchy/outfit/job/torch/crew/representative
@@ -109,7 +109,7 @@
 	uniform = /obj/item/clothing/under/rank/internalaffairs/plain/solgov
 	suit = /obj/item/clothing/suit/storage/toggle/suit/black
 	shoes = /obj/item/clothing/shoes/laceup
-	id_type = /obj/item/weapon/card/id/torch/crew/representative
+	id_types = list(/obj/item/weapon/card/id/torch/crew/representative)
 	pda_type = /obj/item/modular_computer/pda/heads/paperpusher
 
 /decl/hierarchy/outfit/job/torch/crew/command/sea/fleet
@@ -117,14 +117,14 @@
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/command
 	shoes = /obj/item/clothing/shoes/dutyboots
 	l_ear = /obj/item/device/radio/headset/sea
-	id_type = /obj/item/weapon/card/id/torch/crew/sea
+	id_types = list(/obj/item/weapon/card/id/torch/crew/sea)
 	pda_type = /obj/item/modular_computer/pda/heads
 
 /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
 	name = OUTFIT_JOB_NAME("Bridge Officer")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/bridgeofficer
+	id_types = list(/obj/item/weapon/card/id/torch/crew/bridgeofficer)
 	pda_type = /obj/item/modular_computer/pda/heads
 	l_ear = /obj/item/device/radio/headset/bridgeofficer
 

--- a/maps/torch/job/outfits/corporate_outfits.dm
+++ b/maps/torch/job/outfits/corporate_outfits.dm
@@ -7,14 +7,14 @@
 	uniform = /obj/item/clothing/under/rank/ntpilot
 	shoes = /obj/item/clothing/shoes/workboots
 	l_ear = /obj/item/device/radio/headset/headset_pilot
-	id_type = /obj/item/weapon/card/id/torch/passenger/research/nt_pilot
+	id_types = list(/obj/item/weapon/card/id/torch/passenger/research/nt_pilot)
 
 /decl/hierarchy/outfit/job/torch/passenger/research/scientist
 	name = OUTFIT_JOB_NAME("Scientist - Torch")
 	uniform = /obj/item/clothing/under/rank/scientist
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/modular_computer/pda/science
-	id_type = /obj/item/weapon/card/id/torch/passenger/research/scientist
+	id_types = list(/obj/item/weapon/card/id/torch/passenger/research/scientist)
 
 /decl/hierarchy/outfit/job/torch/passenger/research/scientist/New()
 	..()
@@ -25,7 +25,7 @@
 	uniform = /obj/item/clothing/under/rank/scientist
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/modular_computer/pda/science
-	id_type = /obj/item/weapon/card/id/torch/passenger/research
+	id_types = list(/obj/item/weapon/card/id/torch/passenger/research)
 
 /decl/hierarchy/outfit/job/torch/passenger/research/assist/testsubject
 	name = OUTFIT_JOB_NAME("Testing Assistant")

--- a/maps/torch/job/outfits/engineering_outfits.dm
+++ b/maps/torch/job/outfits/engineering_outfits.dm
@@ -12,7 +12,7 @@
 	name = OUTFIT_JOB_NAME("Senior Engineer")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/engineering
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/engineering/senior
+	id_types = list(/obj/item/weapon/card/id/torch/crew/engineering/senior)
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/senior_engineer/fleet
@@ -24,7 +24,7 @@
 	name = OUTFIT_JOB_NAME("Engineer - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/engineering
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/engineering
+	id_types = list(/obj/item/weapon/card/id/torch/crew/engineering)
 	pda_type = /obj/item/modular_computer/pda/engineering
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/engineer/fleet
@@ -36,26 +36,26 @@
 	name = OUTFIT_JOB_NAME("Engineering Assistant")
 	uniform = /obj/item/clothing/under/rank/engineer
 	shoes = /obj/item/clothing/shoes/workboots
-	id_type = /obj/item/weapon/card/id/torch/contractor/engineering
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/engineering)
 	pda_type = /obj/item/modular_computer/pda/engineering
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	name = OUTFIT_JOB_NAME("Roboticist - Contractor")
 	uniform = /obj/item/clothing/under/rank/roboticist
 	shoes = /obj/item/clothing/shoes/black
-	id_type = /obj/item/weapon/card/id/torch/contractor/engineering/roboticist
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/engineering/roboticist)
 	pda_type = /obj/item/modular_computer/pda/roboticist
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/roboticistec
 	name = OUTFIT_JOB_NAME("Roboticist - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/engineering
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/contractor/engineering/roboticist
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/engineering/roboticist)
 	pda_type = /obj/item/modular_computer/pda/roboticist
 
 /decl/hierarchy/outfit/job/torch/crew/engineering/roboticistfleet
 	name = OUTFIT_JOB_NAME("Roboticist - Fleet")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/engineering
-	id_type = /obj/item/weapon/card/id/torch/contractor/engineering/roboticist
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/engineering/roboticist)
 	shoes = /obj/item/clothing/shoes/dutyboots
 	pda_type = /obj/item/modular_computer/pda/roboticist

--- a/maps/torch/job/outfits/exploration_outfits.dm
+++ b/maps/torch/job/outfits/exploration_outfits.dm
@@ -8,7 +8,7 @@
 	name = OUTFIT_JOB_NAME("Pathfinder")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/exploration
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/pathfinder
+	id_types = list(/obj/item/weapon/card/id/torch/crew/pathfinder)
 	pda_type = /obj/item/modular_computer/pda/explorer
 	l_ear = /obj/item/device/radio/headset/pathfinder
 
@@ -16,7 +16,7 @@
 	name = OUTFIT_JOB_NAME("Explorer")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/exploration
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/explorer
+	id_types = list(/obj/item/weapon/card/id/torch/crew/explorer)
 	pda_type = /obj/item/modular_computer/pda/explorer
 	l_ear = /obj/item/device/radio/headset/exploration
 
@@ -25,14 +25,14 @@
 	uniform = /obj/item/clothing/under/color/black
 	shoes = /obj/item/clothing/shoes/dutyboots
 	l_ear = /obj/item/device/radio/headset/headset_pilot
-	id_type = /obj/item/weapon/card/id/torch/passenger/research/nt_pilot
+	id_types = list(/obj/item/weapon/card/id/torch/passenger/research/nt_pilot)
 	head = /obj/item/clothing/head/helmet/solgov/pilot
 
 /decl/hierarchy/outfit/job/torch/crew/exploration/pilot
 	name = OUTFIT_JOB_NAME("Shuttle Pilot - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/exploration
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/pilot
+	id_types = list(/obj/item/weapon/card/id/torch/crew/pilot)
 	pda_type = /obj/item/modular_computer/pda/explorer
 	l_ear = /obj/item/device/radio/headset/headset_pilot
 

--- a/maps/torch/job/outfits/medical_outfits.dm
+++ b/maps/torch/job/outfits/medical_outfits.dm
@@ -12,7 +12,7 @@
 	name = OUTFIT_JOB_NAME("Physician")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/medical/senior
+	id_types = list(/obj/item/weapon/card/id/torch/crew/medical/senior)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/senior/fleet
 	name = OUTFIT_JOB_NAME("Physician - Fleet")
@@ -21,13 +21,13 @@
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/senior
 	name = OUTFIT_JOB_NAME("Physician - Contractor")
-	id_type = /obj/item/weapon/card/id/torch/contractor/medical/senior
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/medical/senior)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/junior
 	name = OUTFIT_JOB_NAME("Medical Resident")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/medical/senior
+	id_types = list(/obj/item/weapon/card/id/torch/crew/medical/senior)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/junior/fleet
 	name = OUTFIT_JOB_NAME("Medical Resident - Fleet")
@@ -36,13 +36,13 @@
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/junior
 	name = OUTFIT_JOB_NAME("Medical Resident - Contractor")
-	id_type = /obj/item/weapon/card/id/torch/contractor/medical/senior
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/medical/senior)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/doctor
 	name = OUTFIT_JOB_NAME("Medical Technician")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/medical
+	id_types = list(/obj/item/weapon/card/id/torch/crew/medical)
 	l_ear = /obj/item/device/radio/headset/headset_corpsman
 
 /decl/hierarchy/outfit/job/torch/crew/medical/doctor/fleet
@@ -55,7 +55,7 @@
 	name = OUTFIT_JOB_NAME("Medical Technician - Contractor")
 	uniform = /obj/item/clothing/under/rank/medical
 	shoes = /obj/item/clothing/shoes/white
-	id_type = /obj/item/weapon/card/id/torch/contractor/medical
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/medical)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/contractor/mortus
 	name = OUTFIT_JOB_NAME("Mortician")
@@ -73,23 +73,15 @@
 	uniform = /obj/item/clothing/under/rank/medical
 	shoes = /obj/item/clothing/shoes/white
 	pda_type = /obj/item/modular_computer/pda/medical
-	id_type = /obj/item/weapon/card/id/torch/contractor/chemist
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/chemist)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor
 	name = OUTFIT_JOB_NAME("Counselor")
 	uniform = /obj/item/clothing/under/rank/psych/turtleneck
 	shoes = /obj/item/clothing/shoes/white
-	id_type = /obj/item/weapon/card/id/torch/contractor/medical/counselor
-
-/decl/hierarchy/outfit/job/torch/crew/medical/counselor/equip_id(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
-	. = ..()
-	var/obj/item/weapon/card/id/foundation_civilian/regis_card = new
-	if(rank)
-		regis_card.rank = rank
-	if(assignment)
-		regis_card.assignment = assignment
-	H.set_id_info(regis_card)
-	H.equip_to_slot_or_store_or_drop(regis_card)
+	id_types = list(
+		/obj/item/weapon/card/id/torch/contractor/medical/counselor,
+		/obj/item/weapon/card/id/foundation_civilian)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor/ec
 	name = OUTFIT_JOB_NAME("Counselor - Expeditionary Corps")

--- a/maps/torch/job/outfits/misc_outfits.dm
+++ b/maps/torch/job/outfits/misc_outfits.dm
@@ -4,7 +4,7 @@
 	l_ear = /obj/item/device/radio/headset
 	shoes = /obj/item/clothing/shoes/black
 	pda_type = /obj/item/modular_computer/pda
-	id_type = /obj/item/weapon/card/id/torch/passenger
+	id_types = list(/obj/item/weapon/card/id/torch/passenger)
 
 /decl/hierarchy/outfit/job/torch/passenger/passenger/psychologist
 	name = OUTFIT_JOB_NAME("Passenger - Psychologist")
@@ -30,14 +30,14 @@
 	l_ear = null
 	shoes = /obj/item/clothing/shoes/black
 	pda_type = /obj/item/modular_computer/pda
-	id_type = /obj/item/weapon/card/id/torch/merchant
+	id_types = list(/obj/item/weapon/card/id/torch/merchant)
 
 /decl/hierarchy/outfit/job/torch/ert
 	name = OUTFIT_JOB_NAME("ERT - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/combat
 	head = /obj/item/clothing/head/beret/solgov/fleet
 	gloves = /obj/item/clothing/gloves/thick
-	id_type = /obj/item/weapon/card/id/centcom/ERT
+	id_types = list(/obj/item/weapon/card/id/centcom/ERT)
 	pda_type = /obj/item/modular_computer/pda/ert
 	l_ear = /obj/item/device/radio/headset/ert
 	shoes = /obj/item/clothing/shoes/dutyboots

--- a/maps/torch/job/outfits/research_outfits.dm
+++ b/maps/torch/job/outfits/research_outfits.dm
@@ -2,7 +2,7 @@
 	name = OUTFIT_JOB_NAME("Research Assistant - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/research
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/research
+	id_types = list(/obj/item/weapon/card/id/torch/crew/research)
 	pda_type = /obj/item/modular_computer/pda/science
 	l_ear = /obj/item/device/radio/headset/torchnanotrasen
 
@@ -10,18 +10,18 @@
 	name = OUTFIT_JOB_NAME("Chief Science Officer - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/research
 	l_ear = /obj/item/device/radio/headset/heads/torchntdirector
-	id_type = /obj/item/weapon/card/id/torch/silver/research
+	id_types = list(/obj/item/weapon/card/id/torch/silver/research)
 	pda_type = /obj/item/modular_computer/pda/heads/rd
 
 /decl/hierarchy/outfit/job/torch/crew/research/senior_scientist
 	name = OUTFIT_JOB_NAME("Senior Scientist - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/research
-	id_type = /obj/item/weapon/card/id/torch/crew/research/senior_scientist
+	id_types = list(/obj/item/weapon/card/id/torch/crew/research/senior_scientist)
 
 /decl/hierarchy/outfit/job/torch/crew/research/scientist
 	name = OUTFIT_JOB_NAME("Scientist - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/research
-	id_type = /obj/item/weapon/card/id/torch/crew/research/scientist
+	id_types = list(/obj/item/weapon/card/id/torch/crew/research/scientist)
 
 /decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov
 	name = OUTFIT_JOB_NAME("Research Assistant - SCG")

--- a/maps/torch/job/outfits/security_outfits.dm
+++ b/maps/torch/job/outfits/security_outfits.dm
@@ -11,7 +11,7 @@
 	name = OUTFIT_JOB_NAME("Brig Chief")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/security/brigchief
+	id_types = list(/obj/item/weapon/card/id/torch/crew/security/brigchief)
 	pda_type = /obj/item/modular_computer/pda/security
 
 /decl/hierarchy/outfit/job/torch/crew/security/brig_chief/fleet
@@ -23,7 +23,7 @@
 	name = OUTFIT_JOB_NAME("Forensic Technician - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/security/forensic
+	id_types = list(/obj/item/weapon/card/id/torch/crew/security/forensic)
 	pda_type = /obj/item/modular_computer/pda/forensics
 
 /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech/contractor
@@ -47,7 +47,7 @@
 	name = OUTFIT_JOB_NAME("Master at Arms")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/security
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/security
+	id_types = list(/obj/item/weapon/card/id/torch/crew/security)
 	pda_type = /obj/item/modular_computer/pda/security
 
 /decl/hierarchy/outfit/job/torch/crew/security/maa/fleet

--- a/maps/torch/job/outfits/service_outfits.dm
+++ b/maps/torch/job/outfits/service_outfits.dm
@@ -6,14 +6,14 @@
 	name = OUTFIT_JOB_NAME("Sanitation Technician - Torch")
 	uniform = /obj/item/clothing/under/rank/janitor
 	shoes = /obj/item/clothing/shoes/black
-	id_type = /obj/item/weapon/card/id/torch/crew/service/janitor
+	id_types = list(/obj/item/weapon/card/id/torch/crew/service/janitor)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/torch/crew/service/janitor/ec
 	name = OUTFIT_JOB_NAME("Sanitation Technician - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/service
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/service/janitor
+	id_types = list(/obj/item/weapon/card/id/torch/crew/service/janitor)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/torch/crew/service/janitor/fleet
@@ -25,14 +25,14 @@
 	name = OUTFIT_JOB_NAME("Cook - Torch")
 	uniform = /obj/item/clothing/under/rank/chef
 	shoes = /obj/item/clothing/shoes/black
-	id_type = /obj/item/weapon/card/id/torch/crew/service/chef
+	id_types = list(/obj/item/weapon/card/id/torch/crew/service/chef)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/torch/crew/service/cook/ec
 	name = OUTFIT_JOB_NAME("Cook - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/service
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/service/chef
+	id_types = list(/obj/item/weapon/card/id/torch/crew/service/chef)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/torch/crew/service/cook/fleet
@@ -44,14 +44,14 @@
 	name = OUTFIT_JOB_NAME("Bartender - Torch")
 	uniform = /obj/item/clothing/under/rank/bartender
 	shoes = /obj/item/clothing/shoes/laceup
-	id_type = /obj/item/weapon/card/id/torch/contractor/service/bartender
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/service/bartender)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/torch/crew/service/crewman
 	name = OUTFIT_JOB_NAME("Crewman")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew
+	id_types = list(/obj/item/weapon/card/id/torch/crew)
 	pda_type = /obj/item/modular_computer/pda
 
 /decl/hierarchy/outfit/job/torch/crew/service/crewman/fleet
@@ -66,7 +66,7 @@
 /decl/hierarchy/outfit/job/torch/crew/service/chaplain
 	name = OUTFIT_JOB_NAME("Chaplain - Torch")
 	uniform = /obj/item/clothing/under/rank/chaplain
-	id_type = /obj/item/weapon/card/id/torch/crew/service/chaplain
+	id_types = list(/obj/item/weapon/card/id/torch/crew/service/chaplain)
 
 /decl/hierarchy/outfit/job/torch/crew/service/chaplain/ec
 	name = OUTFIT_JOB_NAME("Chaplain - Expeditionary Corps")

--- a/maps/torch/job/outfits/supply_outfits.dm
+++ b/maps/torch/job/outfits/supply_outfits.dm
@@ -11,7 +11,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_deckofficer
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/supply
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/supply/deckofficer
+	id_types = list(/obj/item/weapon/card/id/torch/crew/supply/deckofficer)
 	pda_type = /obj/item/modular_computer/pda/cargo
 
 /decl/hierarchy/outfit/job/torch/crew/supply/deckofficer/fleet
@@ -23,7 +23,7 @@
 	name = OUTFIT_JOB_NAME("Deck Technician")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/supply
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_type = /obj/item/weapon/card/id/torch/crew/supply
+	id_types = list(/obj/item/weapon/card/id/torch/crew/supply)
 	pda_type = /obj/item/modular_computer/pda/cargo
 
 /decl/hierarchy/outfit/job/torch/crew/supply/tech/fleet
@@ -35,14 +35,14 @@
 	name = OUTFIT_JOB_NAME("Supply Assistant")
 	uniform = /obj/item/clothing/under/rank/cargotech
 	shoes = /obj/item/clothing/shoes/brown
-	id_type = /obj/item/weapon/card/id/torch/contractor/supply
+	id_types = list(/obj/item/weapon/card/id/torch/contractor/supply)
 	pda_type = /obj/item/modular_computer/pda/cargo
 
 /decl/hierarchy/outfit/job/torch/passenger/research/prospector
 	name = OUTFIT_JOB_NAME("Prospector")
 	uniform = /obj/item/clothing/under/rank/ntwork
 	shoes = /obj/item/clothing/shoes/workboots
-	id_type = /obj/item/weapon/card/id/torch/passenger/research/mining
+	id_types = list(/obj/item/weapon/card/id/torch/passenger/research/mining)
 	pda_type = /obj/item/modular_computer/pda/mining
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 	l_ear = /obj/item/device/radio/headset/headset_mining


### PR DESCRIPTION
:cl:
bugfix: When outfits, typically the clothes and items that come with a job, are equipped any items which are put in already occupied slots should now properly be put in bags or similar storage instead of being dropped (usually in nullspace)
/:cl:

Reduces copy-paste and snowflake code, partially supersedes #29284