### PR TITLE
Deletes the XO's Quarters camera

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2178,9 +2178,6 @@
 	dir = 4;
 	pixel_x = 21
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Executive Officer - Quarters"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
 "dJ" = (


### PR DESCRIPTION
:cl:
tweak: Executive Officer no longer has a camera overlooking their Bedroom.
/:cl:
The XO's quarters has no expectation of Non-access Habitation (ie a visitor for a meeting), one of the requirements for having a camera.
The CO's at least does, given it has the space and the desk.
The Cl's for sure does.

Also the XO's camera is pervy as fuck.

Duffy don't you ever correct me again.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->