### PR TITLE
Fixes psionic armor not working at all

### DIFF
--- a/code/datums/extensions/armor/armor_psionic.dm
+++ b/code/datums/extensions/armor/armor_psionic.dm
@@ -5,8 +5,10 @@
 
 /datum/extension/armor/psionic/get_value(key)
 	var/datum/psi_complexus/psi = holder
-	psi.get_armour(key)
+	return psi.get_armour(key)
 
 /datum/extension/armor/psionic/on_blocking(damage, damage_type, damage_flags, armor_pen, blocked)
 	var/datum/psi_complexus/psi = holder
-	psi.spend_power(round(damage * blocked))
+	var/blocked_damage = damage * blocked
+	if(blocked_damage)
+		psi.spend_power_armor(blocked_damage)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -59,13 +59,14 @@ meteor_act
 	return ..()
 
 /mob/living/carbon/human/get_armors_by_zone(obj/item/organ/external/def_zone, damage_type, damage_flags)
-	. = ..()
 	if(!def_zone)
 		def_zone = ran_zone()
 	if(!istype(def_zone))
 		def_zone = get_organ(check_zone(def_zone))
 	if(!def_zone)
-		return
+		return ..()
+
+	. = list()
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	for(var/obj/item/clothing/gear in protective_gear)
 		if(gear.accessories.len)
@@ -78,6 +79,9 @@ meteor_act
 			var/armor = get_extension(gear, /datum/extension/armor)
 			if(armor)
 				. += armor
+
+	// Add inherent armor to the end of list so that protective equipment is checked first
+	. += ..()
 
 //this proc returns the Siemens coefficient of electrical resistivity for a particular external organ.
 /mob/living/carbon/human/proc/get_siemens_coefficient_organ(var/obj/item/organ/external/def_zone)

--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -11,13 +11,13 @@
 	var/next_power_use = 0            // world.time minimum before next power use.
 	var/stamina = 50                  // Current psi pool.
 	var/max_stamina = 50              // Max psi pool.
+	var/armor_cost = 0                // Amount of power to substract this tick from psi armor blocking damage
 
 	var/list/latencies                // List of all currently latent faculties.
 	var/list/ranks                    // Assoc list of psi faculties to current rank.
 	var/list/base_ranks               // Assoc list of psi faculties to base rank, in case reset is needed
 	var/list/manifested_items         // List of atoms manifested/maintained by psychic power.
 	var/next_latency_trigger = 0      // world.time minimum before a trigger can be attempted again.
-	var/last_armor_check              // world.time of last armour check.
 	var/last_aura_size
 	var/last_aura_alpha
 	var/last_aura_color

--- a/code/modules/psionics/complexus/complexus_helpers.dm
+++ b/code/modules/psionics/complexus/complexus_helpers.dm
@@ -15,11 +15,9 @@
 	cancel()
 
 /datum/psi_complexus/proc/get_armour(var/armourtype)
-	if(can_use_passive())
-		last_armor_check = world.time
+	if(use_psi_armour && can_use_passive())
 		return round(Clamp(Clamp(4 * rating, 0, 20) * get_rank(SSpsi.armour_faculty_by_type[armourtype]), 0, 100) * (stamina/max_stamina))
 	else
-		last_armor_check = 0
 		return 0
 
 /datum/psi_complexus/proc/get_rank(var/faculty)
@@ -58,6 +56,9 @@
 			stamina = 0
 			. = FALSE
 		ui.update_icon()
+
+/datum/psi_complexus/proc/spend_power_armor(var/value = 0)
+	armor_cost += value
 
 /datum/psi_complexus/proc/hide_auras()
 	if(owner.client)


### PR DESCRIPTION
:cl: Ithalan
bugfix: Psionic armor now actually works
tweak: Resistance from protective gear is now checked and applied to incoming damage before any inherent resistance a mob has
/:cl:

This fixes the following problems:

- Psionic armor straight up never blocked anything because the get_value proc doesn't actually return the armor value that should be used
- Regardless of whether it blocked anything, it just blindly passed the amount blocked to spend_power, which clamps the amount spent to a minimum of 1
- Damage that spread itself evenly across multiple target zones would trigger the psionic armor cost for each zone, even though the damage blocked individually were just tiny fractions, resulting in huge increases in amount of power spent at certain breakpoints due to rounding. Psi armor cost now ramps up more smoothly with overall damage blocked.