### PR TITLE
Add access restrictions for medical/security HUD eye wear.

### DIFF
--- a/code/modules/clothing/glasses/eyepatch.dm
+++ b/code/modules/clothing/glasses/eyepatch.dm
@@ -65,12 +65,14 @@
 	desc = "A Security-type heads-up display that connects directly to the optical nerve of the user, replacing the need for that useless eyeball."
 	hud = /obj/item/clothing/glasses/hud/security
 	eye_color = COLOR_RED
+	req_access = list(access_security)
 
 /obj/item/clothing/glasses/eyepatch/hud/medical
 	name = "MEDpatch"
 	desc = "A Medical-type heads-up display that connects directly to the ocular nerve of the user, replacing the need for that useless eyeball."
 	hud = /obj/item/clothing/glasses/hud/health
 	eye_color = COLOR_CYAN
+	req_access = list(access_medical)
 
 /obj/item/clothing/glasses/eyepatch/hud/meson
 	name = "MESpatch"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -21,6 +21,7 @@
 	icon_state = "healthhud"
 	hud_type = HUD_MEDICAL
 	body_parts_covered = 0
+	req_access = list(access_medical)
 
 /obj/item/clothing/glasses/hud/health/process_hud(var/mob/M)
 	process_med_hud(M, 1)
@@ -46,6 +47,7 @@
 	hud_type = HUD_SECURITY
 	body_parts_covered = 0
 	var/global/list/jobs[0]
+	req_access = list(access_security)
 
 /obj/item/clothing/glasses/hud/security/prescription
 	name = "prescription security HUD"

--- a/code/modules/clothing/glasses/sunglasses.dm
+++ b/code/modules/clothing/glasses/sunglasses.dm
@@ -24,6 +24,7 @@
 	hud = /obj/item/clothing/glasses/hud/security
 	electric = TRUE
 	flash_protection = FLASH_PROTECTION_MODERATE
+	req_access = list(access_security)
 
 /obj/item/clothing/glasses/sunglasses/sechud/goggles //now just a more "military" set of HUDglasses for the Torch
 	name = "HUD goggles"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -328,7 +328,9 @@
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/clothing/glasses/G = H.glasses
-		return istype(G) && ((G.hud_type & hudtype) || (G.hud && (G.hud.hud_type & hudtype)))
+		var/obj/item/weapon/card/id/ID = M.GetIdCard()
+
+		return (istype(G) && ((G.hud_type & hudtype) || (G.hud && (G.hud.hud_type & hudtype)))) && G.check_access(ID)
 	else if(istype(M, /mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = M
 		for(var/obj/item/borg/sight/sight in list(R.module_state_1, R.module_state_2, R.module_state_3))


### PR DESCRIPTION
This change only stops players from being able to view security/medical records and changing other players' status if they don't have proper access to do so, they will still get the overlay for both HUD types.

Also fixes rig visor HUDs not having the same functionality as hud glasses.

:cl: Mucker
tweak: Changing other players physical status or viewing records with medical/security HUD eyewear is now access restricted.
/:cl:

Fixes #29289 