### PR TITLE
Sets the medical cooler to 80 kelvin

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -16535,6 +16535,7 @@
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 1;
 	icon_state = "freezer";
+	set_temperature = 80;
 	use_power = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,


### PR DESCRIPTION
:cl:
tweak: Medical's Cryogenic Cooler now starts at 80 kelvin by default. It already starts on.
/:cl:
@Alex6511 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->