### PR TITLE
Deletes redundant access define, modifies area name

### DIFF
--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1085,9 +1085,8 @@
 	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
 
 /area/medical/foyer/storeroom
-	name = "\improper Medical Storage Room"
+	name = "\improper Medical Storeroom"
 	icon_state = "medbay"
-	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
 
 /area/medical/locker
 	name = "\improper Medical Locker Room"


### PR DESCRIPTION
:cl: 
tweak: Medical Storeroom area now follows the same naming as the access door to it
/:cl:

This might fix an issue where the chaplain and fors cannot access the foyer door but can access the autopsy door as reported to me?
Honestly no idea if this bug exists in the first place, but I'm told it does
I have no idea why
https://gyazo.com/0ec8b75d3080eb3e69187f648ff9c083
I'm told the chaplain and fors lack access to the blue door but do have the red one.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->