### PR TITLE
Adjusts thruster lighting and fixes an image repo proc

### DIFF
--- a/code/datums/repositories/images.dm
+++ b/code/datums/repositories/images.dm
@@ -44,10 +44,16 @@
 	var/cache_key = "[icon]-[icon_state]-[alpha]-[appearance_flags]-[color]-[dir]-[plane]-[layer]"
 	. = image_cache_for_overlays[cache_key]
 	if(!.)
-		var/image/I = image(icon = icon, icon_state = icon_state, dir = dir)
-		I.alpha = alpha
-		I.appearance_flags = appearance_flags
-		I.plane = plane
-		I.layer = layer
+		var/image/I = image(icon = icon, icon_state = icon_state)
+		if(!isnull(dir))
+			I.dir = dir
+		if(!isnull(alpha))
+			I.alpha = alpha
+		if(!isnull(appearance_flags))
+			I.appearance_flags = appearance_flags
+		if(!isnull(plane))
+			I.plane = plane
+		if(!isnull(layer))
+			I.layer = layer
 		image_cache_for_overlays[cache_key] = I
 		return I

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -102,7 +102,7 @@
 /obj/machinery/atmospherics/unary/engine/on_update_icon()
 	overlays.Cut()
 	if(is_on())
-		overlays += "nozzle_idle"
+		overlays += image_repository.overlay_image(icon, "nozzle_idle", plane = EFFECTS_ABOVE_LIGHTING_PLANE, layer = ABOVE_LIGHTING_LAYER)
 
 /obj/machinery/atmospherics/unary/engine/proc/get_status()
 	. = list()
@@ -176,7 +176,7 @@
 	var/turf/T = get_step(src,exhaust_dir)
 	if(T)
 		T.assume_air(removed)
-		new/obj/effect/engine_exhaust(T, dir, air_contents.check_combustability() && air_contents.temperature >= PHORON_MINIMUM_BURN_TEMPERATURE)
+		new/obj/effect/engine_exhaust(T, dir)
 
 /obj/machinery/atmospherics/unary/engine/proc/calculate_thrust(datum/gas_mixture/propellant, used_part = 1)
 	return round(sqrt(propellant.get_mass() * used_part * sqrt(air_contents.return_pressure()/200)),0.1)
@@ -200,12 +200,10 @@
 	light_color = "#00a2ff"
 	anchored = 1
 
-/obj/effect/engine_exhaust/New(var/turf/nloc, var/ndir, var/flame)
+/obj/effect/engine_exhaust/New(turf/nloc, ndir)
 	..(nloc)
-	if(flame)
-		icon_state = "exhaust"
-		nloc.hotspot_expose(1000,125)
-		set_light(0.5, 1, 4)
+	nloc.hotspot_expose(1000,125)
+	set_light(0.5, 1, 4)
 	set_dir(ndir)
 	spawn(20)
 		qdel(src)


### PR DESCRIPTION
- The thruster flames will now always light up its area.
- Thruster exhaust will now always be a hotspot and act as a flame, as the new overlay suggests.
- Fixes an issue with the image repository in where not providing all arguments to `overlay_image()` would override image defaults.
- Thruster overlays now use the image repository cache.

![grafik](https://user-images.githubusercontent.com/6383576/92329305-ece54400-f066-11ea-8091-5e5d041d03fc.png)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->