### PR TITLE
Add OOC warning for entering disposals bins

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -190,6 +190,8 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	if(AM == user)
 		user.visible_message("<span class='danger'>[user] climbs into [src].</span>", \
 							 "<span class='notice'>You climb into [src].</span>")
+		if(is_dangerous)
+			to_chat(user, SPAN_DANGER("Disposals is dangerous and may kill you. Doing this is probably against the rules."))
 		log_and_message_admins("has stuffed themselves into [src].", AM)		 
 	else
 		user.visible_message("<span class='[is_dangerous ? "danger" : "notice"]'>[user] stuffs [AM] into [src][is_dangerous ? "!" : "."]</span>", \


### PR DESCRIPTION
:cl:
rscadd: You will now be given a strong warning in chat if you intentionally enter a disposals chute.
/:cl:

Frankly I'm tired of seeing passenger/civilian disposals divers every other day. I'd like to believe the majority do so because it's common on /tg/ servers where there are no repercussions and less so out of pure malice, so hopefully, this will reduce the number of such cases.