### PR TITLE
Update overlooked power cell references

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -35,7 +35,7 @@
 	name = "Gear - Electrical maintenance"
 	contains = list(/obj/item/weapon/storage/toolbox/electrical = 2,
 					/obj/item/clothing/gloves/insulated = 2,
-					/obj/item/weapon/cell = 2,
+					/obj/item/weapon/cell/standard = 2,
 					/obj/item/weapon/cell/high = 2)
 	cost = 15
 	containername = "electrical maintenance crate"

--- a/code/datums/trading/goods.dm
+++ b/code/datums/trading/goods.dm
@@ -79,7 +79,7 @@
 								/obj/item/stack/cable_coil/cut                           = TRADER_BLACKLIST,
 								/obj/item/weapon/airalarm_electronics                    = TRADER_THIS_TYPE,
 								/obj/item/weapon/airlock_electronics                     = TRADER_ALL,
-								/obj/item/weapon/cell                                    = TRADER_THIS_TYPE,
+								/obj/item/weapon/cell/standard                           = TRADER_THIS_TYPE,
 								/obj/item/weapon/cell/crap                               = TRADER_THIS_TYPE,
 								/obj/item/weapon/cell/high                               = TRADER_THIS_TYPE,
 								/obj/item/weapon/cell/super                              = TRADER_THIS_TYPE,

--- a/code/datums/trading/weaponry.dm
+++ b/code/datums/trading/weaponry.dm
@@ -63,7 +63,7 @@
 								/obj/item/weapon/gun/energy/xray                         = TRADER_THIS_TYPE,
 								/obj/item/weapon/gun/energy/laser                        = TRADER_THIS_TYPE,
 								/obj/item/weapon/gun/energy/gun                          = TRADER_THIS_TYPE,
-								/obj/item/weapon/cell                                    = TRADER_THIS_TYPE,
+								/obj/item/weapon/cell/standard                           = TRADER_THIS_TYPE,
 								/obj/item/weapon/cell/crap                               = TRADER_THIS_TYPE,
 								/obj/item/weapon/cell/high                               = TRADER_THIS_TYPE,
 								/obj/item/weapon/cell/super                              = TRADER_THIS_TYPE,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1179,7 +1179,7 @@
 	vend_delay = 21
 	base_type = /obj/machinery/vending/engivend
 	req_access = list(list(access_atmospherics,access_engine_equip))
-	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/device/multitool = 4,/obj/item/device/geiger = 4,/obj/item/weapon/airlock_electronics = 10,/obj/item/weapon/module/power_control = 10,/obj/item/weapon/airalarm_electronics = 10,/obj/item/weapon/cell = 10,/obj/item/clamp = 10)
+	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/device/multitool = 4,/obj/item/device/geiger = 4,/obj/item/weapon/airlock_electronics = 10,/obj/item/weapon/module/power_control = 10,/obj/item/weapon/airalarm_electronics = 10,/obj/item/weapon/cell/standard = 10,/obj/item/clamp = 10)
 	contraband = list(/obj/item/weapon/cell/high = 3)
 	premium = list(/obj/item/weapon/storage/belt/utility = 3)
 
@@ -1195,7 +1195,7 @@
 	products = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/oiljug = 6,
 					/obj/item/weapon/storage/belt/utility = 4,/obj/item/clothing/glasses/meson = 4,/obj/item/clothing/gloves/insulated = 4, /obj/item/weapon/screwdriver = 12,
 					/obj/item/weapon/crowbar = 12,/obj/item/weapon/wirecutters = 12,/obj/item/device/multitool = 12,/obj/item/weapon/wrench = 12,/obj/item/device/t_scanner = 12,
-					/obj/item/weapon/cell = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
+					/obj/item/weapon/cell/standard = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
 					/obj/item/weapon/light/tube = 10,/obj/item/weapon/stock_parts/scanning_module = 5,/obj/item/weapon/stock_parts/micro_laser = 5,
 					/obj/item/weapon/stock_parts/matter_bin = 5,/obj/item/weapon/stock_parts/manipulator = 5,/obj/item/weapon/stock_parts/console_screen = 5,
 					/obj/item/weapon/stock_parts/capacitor = 5, /obj/item/weapon/stock_parts/keyboard = 5, /obj/item/weapon/stock_parts/power/apc/buildable = 5)
@@ -1214,7 +1214,7 @@
 	req_access = list(access_robotics)
 	base_type = /obj/machinery/vending/robotics
 	products = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/oiljug = 5,
-					/obj/item/stack/cable_coil = 4,/obj/item/device/flash/synthetic = 4,/obj/item/weapon/cell = 4,/obj/item/device/scanner/health = 2,
+					/obj/item/stack/cable_coil = 4,/obj/item/device/flash/synthetic = 4,/obj/item/weapon/cell/standard = 4,/obj/item/device/scanner/health = 2,
 					/obj/item/weapon/scalpel = 1,/obj/item/weapon/circular_saw = 1,/obj/item/weapon/tank/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/weapon/screwdriver = 2,/obj/item/weapon/crowbar = 2)
 	contraband = list(/obj/item/device/flash = 2)

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -9,7 +9,7 @@
 	var/coefficient = 0.9
 	var/opened = FALSE
 	var/failsafe = 0
-	var/obj/item/weapon/cell/cell = /obj/item/weapon/cell
+	var/obj/item/weapon/cell/cell = /obj/item/weapon/cell/standard
 	var/recharging = FALSE
 	origin_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 4)
 	matter = list(MATERIAL_STEEL = 1000, MATERIAL_GLASS = 700)

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -5,7 +5,7 @@
 	icon_state = "battereroff"
 	slot_flags = SLOT_BELT
 	var/open = FALSE
-	var/obj/item/weapon/cell/power_cell = /obj/item/weapon/cell
+	var/obj/item/weapon/cell/power_cell = /obj/item/weapon/cell/standard
 	var/shield_type = /obj/aura/personal_shield/device
 	var/shield_power_cost = 1000
 	var/obj/aura/personal_shield/device/shield
@@ -66,7 +66,7 @@
 	if(open)
 		if(power_cell)
 			to_chat(user, SPAN_NOTICE("You remove \the [power_cell] from \the [src]."))
-			turn_off()	
+			turn_off()
 			user.put_in_hands(power_cell)
 			power_cell = null
 			currently_stored_power = 0
@@ -135,7 +135,7 @@
 
 	currently_stored_power -= shield_power_cost
 	START_PROCESSING(SSobj, src)
-	
+
 	if(currently_stored_power < shield_power_cost)
 		enable_when_powered = TRUE
 		return FALSE

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -78,7 +78,7 @@
 
 /obj/random/powercell/spawn_choices()
 	return list(/obj/item/weapon/cell/crap = 1,
-				/obj/item/weapon/cell = 8,
+				/obj/item/weapon/cell/standard = 8,
 				/obj/item/weapon/cell/high = 5,
 				/obj/item/weapon/cell/super = 2,
 				/obj/item/weapon/cell/hyper = 1,

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -9,5 +9,5 @@
 		/obj/item/clothing/head/helmet/space/void,
 		/obj/item/clothing/suit/space/void,
 		/obj/item/weapon/crowbar,
-		/obj/item/weapon/cell,
+		/obj/item/weapon/cell/standard,
 		/obj/item/device/multitool)

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -8,14 +8,14 @@
 	density = 1
 	anchored = 1
 
-	var/list/loot = list(/obj/item/weapon/cell,/obj/item/stack/material/iron,/obj/item/stack/material/rods)
+	var/list/loot = list(/obj/item/weapon/cell/standard,/obj/item/stack/material/iron,/obj/item/stack/material/rods)
 	var/lootleft = 1
 	var/emptyprob = 95
 	var/health = 40
 	var/is_rummaging = 0
 
 /obj/structure/rubble/New()
-	if(prob(emptyprob)) 
+	if(prob(emptyprob))
 		lootleft = 0
 	..()
 
@@ -63,7 +63,7 @@
 		is_rummaging = 0
 	else
 		to_chat(user, "<span class='warning'>Someone is already rummaging here!</span>")
-		
+
 /obj/structure/rubble/attackby(var/obj/item/I, var/mob/user)
 	if (istype(I, /obj/item/weapon/pickaxe))
 		var/obj/item/weapon/pickaxe/P = I
@@ -74,7 +74,7 @@
 				var/obj/item/booty = pickweight(loot)
 				booty = new booty(loc)
 			qdel(src)
-	else 
+	else
 		..()
 		health -= I.force
 		if(health < 1)

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -149,7 +149,7 @@ var/list/worths = list(
 					/obj/item/weapon/cell/infinite = 50000,
 					/obj/item/weapon/cell/potato = 1,
 					/obj/item/weapon/cell/slime = 160,
-					/obj/item/weapon/cell = 60,
+					/obj/item/weapon/cell/standard = 60,
 //SMES COILS,
 					/obj/item/weapon/stock_parts/smes_coil/weak = 1000,
 					/obj/item/weapon/stock_parts/smes_coil/super_capacity = 5000,

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -67,7 +67,7 @@
 
 /obj/item/weapon/stock_parts/computer/battery_module/Initialize()
 	. = ..()
-	battery = new/obj/item/weapon/cell(src)
+	battery = new/obj/item/weapon/cell/standard(src)
 	battery.maxcharge = battery_rating
 	battery.charge = 0
 

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -64,7 +64,7 @@
 
 /obj/item/weapon/gun/energy/pulse_rifle/destroyer/attack_self(mob/living/user as mob)
 	to_chat(user, "<span class='warning'>[src.name] has three settings, and they are all DESTROY.</span>")
-	
+
 /obj/item/weapon/gun/energy/pulse_rifle/skrell
 	name = "skrellian carbine"
 	icon = 'icons/obj/guns/skrell_carbine.dmi'
@@ -72,7 +72,7 @@
 	item_state = "skrell_carbine"
 	slot_flags = SLOT_BACK|SLOT_BELT
 	desc = "The Vuu'Xqu*ix T-3, known as 'VT-3' by SolGov. Rarely seen out in the wild by anyone outside of a Skrellian SDTF."
-	cell_type = /obj/item/weapon/cell
+	cell_type = /obj/item/weapon/cell/standard
 	self_recharge = 1
 	move_delay = 2
 	projectile_type=/obj/item/projectile/beam/pulse/skrell/single
@@ -82,7 +82,7 @@
 	burst_delay=null
 	wielded_item_state = "skrell_carbine-wielded"
 	accuracy = 1
-	
+
 	firemodes = list(
 		list(mode_name="single", projectile_type=/obj/item/projectile/beam/pulse/skrell/single, charge_cost=120, burst=1, burst_delay=null),
 		list(mode_name="heavy", projectile_type=/obj/item/projectile/beam/pulse/skrell/heavy, charge_cost=55, burst=2, burst_delay=3),

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -46,7 +46,7 @@
 	/obj/item/weapon/caution/cone,
 	/obj/item/weapon/crowbar,
 	/obj/item/weapon/material/clipboard,
-	/obj/item/weapon/cell,
+	/obj/item/weapon/cell/standard,
 	/obj/item/weapon/circular_saw,
 	/obj/item/weapon/material/hatchet,
 	/obj/item/weapon/handcuffs,


### PR DESCRIPTION
Updates all the cell references that weren't updated in the previous power cell PR, resolving a lot of other existing issues.

:cl:
bugfix: A bunch of broken power cell references, including vendable power cells and inducers, are now fixed.
/:cl: