### PR TITLE
You can now draw from a bottle with an EMPTY hypospray.

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -61,7 +61,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.custom_pain(SPAN_WARNING("You feel a tiny prick!"), 1, TRUE, H.get_organ(user.zone_sel.selecting))
-		
+
 	playsound(src, 'sound/effects/hypospray.ogg',25)
 	user.visible_message("<span class='warning'>[user] injects [M] with [src].</span>")
 
@@ -138,6 +138,22 @@
 
 /obj/item/weapon/reagent_containers/hypospray/vial/afterattack(obj/target, mob/user, proximity) // hyposprays can be dumped into, why not out? uses standard_pour_into helper checks.
 	if(!proximity)
+		return
+	if (!reagents.total_volume && istype(target, /obj/item/weapon/reagent_containers/glass))
+		var/good_target = is_type_in_list(target, list(
+			/obj/item/weapon/reagent_containers/glass/beaker,
+			/obj/item/weapon/reagent_containers/glass/bottle
+		))
+		if (!good_target)
+			return
+		if (!target.is_open_container())
+			to_chat(user, SPAN_ITALIC("\The [target] is closed."))
+			return
+		if (!target.reagents?.total_volume)
+			to_chat(user, SPAN_ITALIC("\The [target] is empty."))
+			return
+		var/trans = target.reagents.trans_to_obj(src, amount_per_transfer_from_this)
+		to_chat(user, SPAN_NOTICE("You fill \the [src] with [trans] units of the solution."))
 		return
 	standard_pour_into(user, target)
 


### PR DESCRIPTION
## About The Pull Request
Click on a reagent container with an empty hypospray, it will draw X units of reagents from said container.

## Why It's Good For The Game
Quality of life change for the hypospray to make it a bit less clunky to use.

## Changelog

:cl: Kathy Ryals & Spookerton
rcsadd: You can now draw reagents from a container with an empty hypospray.
/:cl: