### PR TITLE
Removes illegal reference in dispersive blaster

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -190,7 +190,7 @@
 
 /obj/item/weapon/gun/energy/incendiary_laser
 	name = "dispersive blaster"
-	desc = "The A&M 'Shayatin' was the first of a now-banned class of dispersive laser weapons which, instead of firing a focused beam, scan over a target rapidly with the goal of setting it ablaze."
+	desc = "The A&M 'Shayatin' was the first of a class of dispersive laser weapons which, instead of firing a focused beam, scan over a target rapidly with the goal of setting it ablaze."
 	icon = 'icons/obj/guns/incendiary_laser.dmi'
 	icon_state = "incen"
 	item_state = "incen"


### PR DESCRIPTION
Based on admin rulings.

:cl:
tweak: Dispersive blasters no longer describe themselves as banned/illegal
/:cl: