### PR TITLE
Add service pistols and ammunition to the tactical armory

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15028,16 +15028,18 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "bCX" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/cdeathalarm_kit,
-/obj/item/weapon/melee/telebaton,
-/obj/item/weapon/melee/telebaton,
-/obj/item/weapon/melee/telebaton,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/weapon/gun/projectile/pistol/military,
+/obj/item/weapon/gun/projectile/pistol/military,
+/obj/item/ammo_magazine/pistol/double/rubber,
+/obj/item/ammo_magazine/pistol/double/rubber,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "bDb" = (
@@ -19866,13 +19868,19 @@
 "iAS" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/item/weapon/shield/riot/metal,
 /obj/item/weapon/shield/riot/metal,
 /obj/item/weapon/shield/riot/metal,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/weapon/melee/telebaton,
+/obj/item/weapon/melee/telebaton,
+/obj/item/weapon/melee/telebaton,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "iAZ" = (
@@ -26540,6 +26548,7 @@
 /obj/item/weapon/storage/box/flashbangs,
 /obj/item/weapon/storage/box/smokes,
 /obj/item/weapon/storage/box/handcuffs,
+/obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "qKU" = (
@@ -30008,12 +30017,12 @@
 	dir = 8;
 	icon_state = "techfloor_edges"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 0;
 	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)


### PR DESCRIPTION
:cl:
maptweak: Two service pistols, complete with rubber and lethal ammunition, have been added to the tactical armory.
/:cl:

**While ballistic weaponry is dangerous on a spacefaring vessel given the possibility of decompression, not to mention if you miss, all of the Torch's firearms right now are energy-based.** This means that in case of power loss or EMP, the laser-based guns will be severely less effective or even completely unusable. It stands to reason that if only as a backup in case of emergency, the Torch has ballistics in storage for a rainy day.

In addition, note that the supply program can already order ballistic magazines even on code green. This was probably an oversight from an earlier map but now, having pistols on the Torch by standard makes those order possibilities make a bit more sense.

The tactical armory is already very cramped as-is, so I moved the things that were on the table to their next best locations. The flashes and telescopic batons are now with the riot shield and the death alarm kit box is with the other boxes of grenades and handcuffs.