### PR TITLE
Makes Torch exterior area not a child of maint

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -5010,7 +5010,7 @@
 "ky" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced/airless,
-/area/maintenance/exterior)
+/area/torchexterior)
 "kz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5350,7 +5350,7 @@
 /area/engineering/engine_room)
 "lk" = (
 /turf/simulated/floor/reinforced/airless,
-/area/maintenance/exterior)
+/area/torchexterior)
 "ll" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1,7 +1,7 @@
 /datum/map/torch
 
 	base_floor_type = /turf/simulated/floor/reinforced/airless
-	base_floor_area = /area/maintenance/exterior
+	base_floor_area = /area/torchexterior
 
 	post_round_safe_areas = list (
 		/area/centcom,
@@ -1262,7 +1262,7 @@
 	sound_env = SMALL_ENCLOSED
 	req_access = list(access_engine_equip)
 
-/area/maintenance/exterior
+/area/torchexterior
 	name = "\improper Exterior Reinforcements"
 	icon_state = "maint_exterior"
 	area_flags = AREA_FLAG_EXTERNAL

--- a/maps/torch/torch_unit_testing.dm
+++ b/maps/torch/torch_unit_testing.dm
@@ -18,7 +18,7 @@
 		/area/maintenance/auxsolarbridge = NO_SCRUBBER|NO_VENT,
 		/area/maintenance/auxsolarport = NO_SCRUBBER|NO_VENT,
 		/area/maintenance/auxsolarstarboard = NO_SCRUBBER|NO_VENT,
-		/area/maintenance/exterior = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/torchexterior = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/maintenance/firstdeck/foreport = NO_SCRUBBER|NO_VENT,
 		/area/maintenance/firstdeck/forestarboard = NO_SCRUBBER|NO_VENT,
 		/area/maintenance/incinerator = NO_SCRUBBER,
@@ -63,7 +63,7 @@
 	area_coherency_test_exempt_areas = list(
 		/area/aquila/airlock,
 		/area/centcom/control,
-		/area/maintenance/exterior,
+		/area/torchexterior,
 		/area/space
 	)
 


### PR DESCRIPTION
Did you know the blob can spawn out in space because it's a child of the maintenance area?
What do we say to that? Not today!
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->