### PR TITLE
Fix gantry paint sprayer reference

### DIFF
--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -245,7 +245,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/obj/item/device/floor_painter,
+/obj/item/device/paint_sprayer,
 /obj/structure/table/rack,
 /obj/item/device/pipe_painter,
 /obj/item/device/cable_painter,


### PR DESCRIPTION
Fixes the `floor_painter` reference in the gantry to `paint_sprayer`; resolves travis fails on /dev