### PR TITLE
Manually configures the Foyer door access

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2549,7 +2549,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass/medical{
-	name = "Medical Foyer"
+	autoset_access = 0;
+	name = "Medical Foyer";
+	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,


### PR DESCRIPTION
:cl:
bugfix: Forensics Technicians and Chaplains have access to the Medical Foyer, allowing them into the Morgue via the front door.
/:cl:
Access Union/Secure is a bit frustrating and rather than figure out how to fix this specific edge case, I'm just gonna do it manually.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->