### PR TITLE
Make the anonymous ghost toggle a persistent preference

### DIFF
--- a/code/datums/communication/dsay.dm
+++ b/code/datums/communication/dsay.dm
@@ -74,12 +74,14 @@
 
 	var/lname
 	var/mob/observer/ghost/DM
+	var/hide_deadchat_ckey = C.get_preference_value(/datum/client_preference/show_ckey_deadchat) == GLOB.PREF_HIDE
+
 	if(isghost(C.mob))
 		DM = C.mob
 	if(M.client.holder) 							// What admins see
-		lname = "[keyname][(DM && DM.anonsay) ? "*" : (DM ? "" : "^")] ([name])"
+		lname = "[keyname][(DM && hide_deadchat_ckey) ? "*" : (DM ? "" : "^")] ([name])"
 	else
-		if(DM && DM.anonsay)						// If the person is actually observer they have the option to be anonymous
+		if(DM && hide_deadchat_ckey)						// If the person is actually observer they have the option to be anonymous
 			lname = "Ghost of [name]"
 		else if(DM)									// Non-anons
 			lname = "[keyname] ([name])"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -200,6 +200,11 @@ var/list/_client_preferences_by_type
 	key = "SHOW_CKEY_CREDITS"
 	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
 
+/datum/client_preference/show_ckey_deadchat
+	description = "Show Ckey in Deadchat"
+	key = "SHOW_CKEY_DEADCHAT"
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+
 /datum/client_preference/play_instruments
 	description ="Play instruments"
 	key = "SOUND_INSTRUMENTS"

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -441,17 +441,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		remove_client_image(hud_image)
 
-/mob/observer/ghost/verb/toggle_anonsay()
-	set category = "Ghost"
-	set name = "Toggle Anonymous Chat"
-	set desc = "Toggles showing your key in dead chat."
-
-	src.anonsay = !src.anonsay
-	if(anonsay)
-		to_chat(src, "<span class='info'>Your key won't be shown when you speak in dead chat.</span>")
-	else
-		to_chat(src, "<span class='info'>Your key will be publicly visible again.</span>")
-
 /mob/observer/ghost/canface()
 	return 1
 


### PR DESCRIPTION
Removes the 'Toggle Anonymous Ghost' option from the Ghost menu and replaces it with a preference option called 'Show Ckey in Deadchat' in order to make it persistent.

:cl: Mucker
tweak: Replace anonymous ghost toggle in the Ghost tab with a persistent preference option called 'Show Ckey in Deadchat' in the Preferences tab. This is ON by default.

/:cl:

closes #29210