### PR TITLE
targetted_emote + check_range

### DIFF
--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -148,11 +148,13 @@
 
 /decl/emote/audible/slap
 	key = "slap"
-	emote_message_1p_target = "<span class='warning'>You slap TARGET across the face!</span>"
+	emote_message_1p_target = "You slap TARGET across the face!"
 	emote_message_1p = "You slap yourself across the face!"
-	emote_message_3p_target = "<span class='warning'>USER slaps TARGET across the face!</span>"
+	emote_message_3p_target = "USER slaps TARGET across the face!"
 	emote_message_3p = "USER slaps USER_SELF across the face!"
 	emote_sound = 'sound/effects/snap.ogg'
+	check_restraints = TRUE
+	check_range = 1
 
 /decl/emote/audible/bug_hiss
 	key ="hiss"

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -83,6 +83,7 @@
 	key = "salute"
 	emote_message_3p_target = "USER salutes TARGET."
 	emote_message_3p = "USER salutes."
+	check_restraints = TRUE
 
 /decl/emote/visible/flap
 	key = "flap"
@@ -128,6 +129,7 @@
 	key = "wave"
 	emote_message_3p_target = "USER waves at TARGET."
 	emote_message_3p = "USER waves."
+	check_restraints = TRUE
 
 /decl/emote/visible/glare
 	key = "glare"
@@ -187,20 +189,13 @@
 	check_restraints = TRUE
 	emote_message_3p_target = "USER hugs TARGET."
 	emote_message_3p = "USER hugs USER_SELF."
+	check_range = 1
 
 /decl/emote/visible/dap
 	key = "dap"
 	check_restraints = TRUE
 	emote_message_3p_target = "USER gives daps to TARGET."
 	emote_message_3p = "USER sadly can't find anybody to give daps to, and daps USER_SELF."
-
-/decl/emote/visible/signal
-	key = "signal"
-	check_restraints = TRUE
-	emote_message_3p = "USER signals."
-
-/decl/emote/visible/signal/check_user(var/atom/user)
-	return ismob(user)
 
 /decl/emote/visible/bounce
 	key = "bounce"
@@ -227,7 +222,7 @@
 	check_restraints = TRUE
 	emote_message_3p_target = "USER shakes hands with TARGET."
 	emote_message_3p = "USER shakes hands with USER_SELF."
-	message_type = VISIBLE_MESSAGE
+	check_range = 1
 
 /decl/emote/visible/handshake/get_emote_message_3p(var/atom/user, var/atom/target, var/extra_params)
 	if(target && !user.Adjacent(target))
@@ -238,7 +233,10 @@
 	key = "signal"
 	emote_message_3p_target = "USER signals at TARGET."
 	emote_message_3p = "USER signals."
-	message_type = VISIBLE_MESSAGE
+	check_restraints = TRUE
+
+/decl/emote/visible/signal/check_user(atom/user)
+	return ismob(user)
 
 /decl/emote/visible/signal/get_emote_message_3p(var/mob/user, var/atom/target, var/extra_params)
 	if(istype(user) && !(user.r_hand && user.l_hand))

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -17,8 +17,9 @@
 	var/message_type = VISIBLE_MESSAGE // Audible/visual flag
 	var/targetted_emote                // Whether or not this emote needs a target.
 	var/check_restraints               // Can this emote be used while restrained?
-	var/conscious = 1				   // Do we need to be awake to emote this?
-	var/emote_range = 0                // If >0, restricts emote visibility to viewers within range.
+	var/check_range                    // falsy, or a range outside which the emote will not work
+	var/conscious = TRUE               // Do we need to be awake to emote this?
+	var/emote_range                    // falsy, or a range outside which the emote is not shown
 
 /decl/emote/proc/get_emote_message_1p(var/atom/user, var/atom/target, var/extra_params)
 	if(target)
@@ -45,6 +46,15 @@
 			if(extra_params == lowertext(thing.name))
 				target = thing
 				break
+
+	if (targetted_emote && !target)
+		to_chat(user, SPAN_WARNING("You can't do that to thin air."))
+		return
+
+	if (target && target != user && check_range)
+		if (get_dist(user, target) > check_range)
+			to_chat(user, SPAN_WARNING("\The [target] is too far away."))
+			return
 
 	var/datum/gender/user_gender = gender_datums[user.get_visible_gender()]
 	var/datum/gender/target_gender


### PR DESCRIPTION
:cl:
tweak: You can no longer slap, hug, or shake hands at a distance.
/:cl:
actually implements a test for `targetted_emote`
adds check_range, applies it to things that reasonably require adjacency
adds some uses of check_restraints where they were missing
removes some redundant restatements of message type
removes duplicate signal emote
