### PR TITLE
Allow trained engines to fully use SM monitor

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -68,8 +68,6 @@
 			return (0.6 + 0.8 * rand()) * value
 		if(SKILL_BASIC)
 			return (0.8 + 0.4 * rand()) * value
-		if(SKILL_ADEPT)
-			return (0.95 + 0.1 * rand()) * value
 		else
 			return value
 


### PR DESCRIPTION
Because why does being trained in engines not let you use and read the standard engine.

:cl:
tweak: Trained engines skill now lets you properly read the supermatter monitor instead of getting randomized numbers.
/:cl: