### PR TITLE
Tweaks personal lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -1,7 +1,8 @@
 /obj/structure/closet/secure_closet/personal
 	name = "personal closet"
-	desc = "It's a secure locker for personnel. The first card swiped gains control."
+	desc = "It's a secure locker for personnel."
 	req_access = list(access_all_personal_lockers)
+	locked = FALSE
 	var/registered_name = null
 
 /obj/structure/closet/secure_closet/personal/WillContain()
@@ -28,37 +29,20 @@
 	return ..() || (istype(id_card) && id_card.registered_name && (!registered_name || (registered_name == id_card.registered_name)))
 
 /obj/structure/closet/secure_closet/personal/togglelock(var/mob/user, var/obj/item/weapon/card/id/id_card)
-	if (..() && !registered_name)
-		id_card = istype(id_card) ? id_card : user.GetIdCard()
-		if (id_card)
-			set_owner(id_card.registered_name)
+	if (..())
+		if(locked)
+			id_card = istype(id_card) ? id_card : user.GetIdCard()
+			if (id_card)
+				set_owner(id_card.registered_name)
+		else
+			set_owner(null)
 
 /obj/structure/closet/secure_closet/personal/proc/set_owner(var/registered_name)
 	if (registered_name)
 		src.registered_name = registered_name
 		src.SetName(name + " ([registered_name])")
-		src.desc = "Owned by [registered_name]."
+		src.desc = "Currently used by [registered_name]."
 	else
 		src.registered_name = null
 		src.SetName(initial(name))
 		src.desc = initial(desc)
-
-/obj/structure/closet/secure_closet/personal/verb/reset()
-	set src in oview(1) // One square distance
-	set category = "Object"
-	set name = "Reset Lock"
-	if(!CanPhysicallyInteract(usr)) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
-		return
-	if(ishuman(usr))
-		src.add_fingerprint(usr)
-		if (src.locked || !src.registered_name)
-			to_chat(usr, "<span class='warning'>You need to unlock it first.</span>")
-		else if (src.broken)
-			to_chat(usr, "<span class='warning'>It appears to be broken.</span>")
-		else
-			if (src.opened)
-				if(!src.close())
-					return
-			locked = TRUE
-			queue_icon_update()
-			set_owner(null)


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Personal lockers will now spawn unlocked and will only be in use while locked.
/:cl:

Personal lockers will now spawn unlocked. They will now only be in use by a
person as long as the closet is locked.
Consequently, an unlocked closet is now a visual indicator for being
free to be used.
Removes the 'reset lock' verb as it is no longer needed.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->