### PR TITLE
Remove security access from bridge officers

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -383,7 +383,7 @@
 	skill_points = 20
 
 
-	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+	access = list(access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
 			            access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
 			            access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
 			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,


### PR DESCRIPTION
:cl:
tweak: Bridge officers no longer have access to the security channel on handheld radios, nor the security equipment room.
/:cl:

Service and supply channels were not touched since bridge officers reasonably need those access (it may be better to, then, give them those channels by default?). However, it makes little to no sense for a junior officer to be able to use a critical frequency on an insecure device that they could drop or have taken from them, not to mention the fact that radios broadcast their channel in a wide radius, allowing communication security to be compromised further.