### PR TITLE
Hide AOOC broadcasts from non-AOOC users

### DIFF
--- a/code/datums/communication/aooc.dm
+++ b/code/datums/communication/aooc.dm
@@ -1,3 +1,6 @@
+#define SPAN_AOOC(X) "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", target)] [X]</span></span>"
+
+
 /decl/communication_channel/aooc
 	name = "AOOC"
 	config_setting = "aooc_allowed"
@@ -7,30 +10,34 @@
 	mute_setting = MUTE_AOOC
 	show_preference_setting = /datum/client_preference/show_aooc
 
-/decl/communication_channel/aooc/can_communicate(var/client/C, var/message)
+
+/decl/communication_channel/aooc/can_communicate(client/C, message)
 	. = ..()
 	if(!.)
 		return
 
 	if(!C.holder)
 		if(isghost(C.mob))
-			to_chat(src, "<span class='warning'>You cannot use [name] while ghosting/observing!</span>")
+			to_chat(src, SPAN_WARNING("You cannot use [name] while ghosting/observing!"))
 			return FALSE
-		if(!(C.mob && C.mob.mind && C.mob.mind.special_role))
-			to_chat(C, "<span class='danger'>You must be an antag to use [name].</span>")
+		if(!(C.mob?.mind?.special_role))
+			to_chat(C, SPAN_DANGER("You must be an antag to use [name]."))
 			return FALSE
 
-/decl/communication_channel/aooc/do_communicate(var/client/C, var/message)
+
+/decl/communication_channel/aooc/do_communicate(client/C, message)
 	var/datum/admins/holder = C.holder
 
 	for(var/client/target in GLOB.clients)
-		if(target.holder)
-			receive_communication(C, target, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", target)] <EM>[get_options_bar(C, 0, 1, 1)]:</EM> <span class='message linkify'>[message]</span></span></span>")
-		else if(target.mob && target.mob.mind && target.mob.mind.special_role)
+		if(check_rights(R_INVESTIGATE, FALSE, target))
+			receive_communication(C, target, SPAN_AOOC("<EM>[get_options_bar(C, 0, 1, 1)]:</EM> <span class='message linkify'>[message]</span>"))
+		else if(target.mob?.mind?.special_role)
 			var/display_name = C.key
 			var/player_display = holder ? "[display_name]([usr.client.holder.rank])" : display_name
-			receive_communication(C, target, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", target)] <EM>[player_display]:</EM> <span class='message linkify'>[message]</span></span></span>")
+			receive_communication(C, target, SPAN_AOOC("<EM>[player_display]:</EM> <span class='message linkify'>[message]</span>"))
+
 
 /decl/communication_channel/aooc/do_broadcast(message)
 	for (var/client/target in GLOB.clients)
-		receive_broadcast(target, "<span class='ooc'><span class='aooc'>[create_text_tag("aooc", "Antag-OOC:", target)] <strong>SYSTEM BROADCAST:</strong> <span class='message linkify'>[message]</span></span></span>")
+		if (check_rights(R_INVESTIGATE, FALSE, target) || target.mob?.mind?.special_role)
+			receive_broadcast(target, SPAN_AOOC("<strong>SYSTEM BROADCAST:</strong> <span class='message linkify'>[message]</span>"))


### PR DESCRIPTION
:cl:
bugfix: AOOC enable/disable messages should now be properly hidden from non-antags
/:cl: