### PR TITLE
Fixes inconsistency of using shortwaves with ;

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -177,6 +177,10 @@
 				var/obj/item/device/radio/R = r_ear
 				R.talk_into(src,message,null,verb,speaking)
 				used_radios += r_ear
+			else
+				for(var/obj/item/device/radio/R in src)
+					if(!R.subspace_transmission)
+						return R.talk_into(src, message, null, verb, speaking)
 		if("right ear")
 			var/obj/item/device/radio/R
 			var/has_radio = 0


### PR DESCRIPTION
There is an inconsistency in which shortwaves will only be talked in
with the shortcut `;` if the user has a headset on their ear that does not
have a working radio connection.
Now even when not having a headset on their ear, shortwaves on a person
will be used with `;`.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->