### PR TITLE
Removes the Fire Axe from Bridge Storage

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -13097,9 +13097,6 @@
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "LP" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;


### PR DESCRIPTION
🆑
maptweak: Removes the fireaxe from bridge storage.
/🆑

The Torch's bridge has two axes closer together than almost any other place on the ship, with less overall travel time between the two. The placement of the one in bridge storage, right next to two weapons lockers, could make some players believe it is to be used as a defensive weapon. Removing this axe fixes that little problem. And in an emergency where a fireaxe is *actually* necessary, the saferooms should be unbolted and the other fire axe will be available.