### PR TITLE
Stasis clamp deletion logic fixes

### DIFF
--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -20,6 +20,7 @@
 	else
 		target = locate(/obj/machinery/atmospherics/pipe/simple) in loc
 	if(target)
+		target.clamp = src
 		update_networks()
 		dir = target.dir
 	return 1
@@ -50,6 +51,8 @@
 /obj/machinery/clamp/Destroy()
 	if(!open)
 		spawn(-1) open()
+	if (target && target.clamp == src)
+		target.clamp = null
 	. = ..()
 
 /obj/machinery/clamp/proc/open()
@@ -132,6 +135,12 @@
 	else
 		to_chat(usr, "<span class='warning'>You can't remove \the [src] while it's active!</span>")
 
+/obj/machinery/clamp/proc/detach()
+	if (target && target.clamp == src)
+		target.clamp = null
+	new/obj/item/clamp(loc)
+	qdel(src)
+
 /obj/item/clamp
 	name = "stasis clamp"
 	desc = "A magnetic clamp which can halt the flow of gas in a pipe, via a localised stasis field."
@@ -144,8 +153,18 @@
 		return
 
 	if (istype(A, /obj/machinery/atmospherics/pipe/simple))
+		var/obj/machinery/atmospherics/pipe/simple/P = A
+		if (P.clamp)
+			to_chat(user, SPAN_WARNING("There is already \a [P.clamp] attached to \the [P]."))
+			return
+
 		to_chat(user, "<span class='notice'>You begin to attach \the [src] to \the [A]...</span>")
 		if (do_after(user, 30, src))
+			if (QDELETED(P))
+				return
+			if (P.clamp)
+				to_chat(user, SPAN_WARNING("There is already \a [P.clamp] attached to \the [P]."))
+				return
 			if(!user.unEquip(src))
 				return
 			to_chat(user, "<span class='notice'>You have attached \the [src] to \the [A].</span>")

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -14,6 +14,7 @@
 	var/alert_pressure = 170 * ONE_ATMOSPHERE
 	var/in_stasis = 0
 		//minimum pressure before check_pressure(...) should be called
+	var/obj/machinery/clamp/clamp // Linked stasis clamp
 
 	can_buckle = 1
 	buckle_require_restraints = 1
@@ -97,6 +98,8 @@
 /obj/machinery/atmospherics/pipe/Destroy()
 	QDEL_NULL(parent)
 	QDEL_NULL(sound_token)
+	if (clamp)
+		clamp.detach()
 	if(air_temporary)
 		loc.assume_air(air_temporary)
 
@@ -117,6 +120,10 @@
 			to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 			return 1
 
+		if (clamp)
+			to_chat(user, SPAN_WARNING("You must remove \the [clamp] first."))
+			return TRUE
+
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()
 
@@ -129,6 +136,10 @@
 		to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 
 		if (do_after(user, 40, src))
+			if (clamp)
+				to_chat(user, SPAN_WARNING("You must remove \the [clamp] first."))
+				return TRUE
+
 			user.visible_message("<span class='notice'>\The [user] unfastens \the [src].</span>", "<span class='notice'>You have unfastened \the [src].</span>", "You hear a ratchet.")
 
 			new /obj/item/pipe(loc, src)


### PR DESCRIPTION
Fixes some logic with stasis clamps when pipes are deleted/modified. This should resolve stasis clamps entering a broken, unfixable state due to their attached pipes being deleted, and fix a couple of runtimes related to stasis clamp garbage collection.

Closes #29377
Closes #19947
Closes #19615

:cl:
bugfix: It is no longer possible to remove pipes that have stasis clamps attached to them.
bugfix: It is no longer possible to attach multiple stasis clamps to the same pipe.
bugfix: Deletes pipes will now probably de-activate and detach any attached stasis clamps.
/:cl: