### PR TITLE
Various bug fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -120,8 +120,8 @@
 					src.attack_self(M)
 				return
 		return
-		
-	
+
+
 /obj/item/weapon/storage/secure/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1)
@@ -198,3 +198,8 @@
 /obj/item/weapon/storage/secure/safe/HoS/New()
 	..()
 	//new /obj/item/weapon/storage/lockbox/clusterbang(src) This item is currently broken... and probably shouldn't exist to begin with (even though it's cool)
+
+/obj/item/weapon/storage/secure/AltClick(/mob/user)
+	if (locked)
+		return
+	..()

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -25,9 +25,10 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	core_skill = SKILL_CHEMISTRY
 	var/sloppy = 1 //Whether reagents will not be fully purified (sloppy = 1) or there will be reagent loss (sloppy = 0) on reagent add.
+	var/reagent_limit = 120
 
 /obj/machinery/chem_master/New()
-	create_reagents(120)
+	create_reagents(reagent_limit)
 	..()
 
 /obj/machinery/chem_master/ex_act(severity)
@@ -74,6 +75,9 @@
 	reagents.clear_reagents()
 	icon_state = "mixer0"
 
+/obj/machinery/chem_master/proc/get_remaining_volume()
+	return Clamp(reagent_limit - reagents.total_volume, 0, reagent_limit)
+
 /obj/machinery/chem_master/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		eject_beaker(user)
@@ -108,7 +112,7 @@
 				var/datum/reagent/their_reagent = locate(href_list["add"]) in R.reagent_list
 				if(their_reagent)
 					var/mult = 1
-					var/amount = Clamp((text2num(href_list["amount"])), 0, 200)
+					var/amount = Clamp((text2num(href_list["amount"])), 0, get_remaining_volume())
 					if(sloppy)
 						var/contaminants = fetch_contaminants(user, R, their_reagent)
 						for(var/datum/reagent/reagent in contaminants)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -9451,21 +9451,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/security/wing)
-"aEI" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "bo_windows"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/bo)
 "aEK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 2;
@@ -10246,10 +10231,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bo)
@@ -23945,6 +23926,9 @@
 /obj/machinery/camera/network/security{
 	c_tag = "Security Wing - Brig Chief";
 	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
@@ -40731,8 +40715,8 @@ nmb
 xRh
 aCy
 aDE
-aEI
-aFQ
+aKE
+cHj
 cHj
 tgs
 cHj


### PR DESCRIPTION
Closes #29355
Closes #29376
Closes #29369

:cl:
bugfix: Locked containers can no longer be bypassed with alt click.
bugfix: Chem masters will no longer delete excess reagents when trying to transfer more than the storage can support.
map: The brig chief newscaster has been moved to a wall next to the desk, which makes the security department buzzer visible and clickable again.
/:cl: