### PR TITLE
Colony map tweaks - Pipes and air alarms

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -586,6 +586,10 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/machinery/alarm{
+	locked = 0;
+	pixel_y = 20
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "bt" = (
@@ -2172,6 +2176,10 @@
 	dir = 8;
 	icon_state = "techfloor_edges"
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/atmospherics)
 "es" = (
@@ -2664,9 +2672,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/atmospherics)
 "fi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/exoplanet/concrete,
-/area/template_noop)
+/area/map_template/colony/atmospherics)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3539,6 +3547,10 @@
 	dir = 9;
 	icon_state = "techfloor_edges"
 	},
+/obj/machinery/alarm{
+	locked = 0;
+	pixel_y = 20
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "gr" = (
@@ -4066,16 +4078,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "hq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
+	dir = 4
+	},
 /turf/simulated/floor/exoplanet/concrete,
-/area/template_noop)
+/area/map_template/colony/atmospherics)
 "hr" = (
 /turf/simulated/wall,
 /area/map_template/colony)
@@ -4605,17 +4616,16 @@
 	dir = 1;
 	icon_state = "techfloor_hole_right"
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 28
+/obj/structure/bed/chair{
+	dir = 8
 	},
 /obj/machinery/recharger/wallcharger{
+	pixel_x = -8;
 	pixel_y = 20
 	},
 /obj/machinery/recharger/wallcharger{
-	pixel_y = 36
-	},
-/obj/structure/bed/chair{
-	dir = 8
+	pixel_x = 8;
+	pixel_y = 20
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/jail)
@@ -5990,6 +6000,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	locked = 0;
+	pixel_y = 20
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
 "ku" = (
@@ -8805,6 +8819,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
+"JY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/colony)
 "Kn" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
@@ -10004,7 +10035,7 @@ ek
 dH
 fv
 fR
-ek
+JY
 fW
 dI
 dI


### PR DESCRIPTION
:cl:
map: The open atmosphere pipes on the playable colony for processing the planet's air have been replaced with proper in/out vents
map: Air alarms have been added to parts of the playable colony that were missing them
map: Playable colony no longer has three wall chargers stacked on top of each other with no pixel adjustment.
/:cl: