### PR TITLE
NTOS programs will not start when there's no network connection

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -97,29 +97,32 @@
 // User has to wear their ID or have it inhand for ID Scan to work.
 // Can also be called manually, with optional parameter being access_to_check to scan the user's ID
 /datum/computer_file/program/proc/can_run(var/mob/living/user, var/loud = 0, var/access_to_check)
+	if(requires_ntnet && !get_signal())
+		to_chat(user, SPAN_WARNING("Unable to establish a working network connection. Please try again later. If problem persists, please contact your system administrator."))
+		return FALSE
 	if(!requires_access_to_run)
-		return 1
+		return TRUE
 	// Defaults to required_access
 	if(!access_to_check)
 		access_to_check = required_access
 	if(!access_to_check) // No required_access, allow it.
-		return 1
+		return TRUE
 
 	// Admin override - allows operation of any computer as aghosted admin, as if you had any required access.
 	if(isghost(user) && check_rights(R_ADMIN, 0, user))
-		return 1
+		return TRUE
 
 	if(!istype(user))
-		return 0
+		return FALSE
 
 	var/obj/item/weapon/card/id/I = user.GetIdCard()
 	if(!I)
 		if(loud)
 			to_chat(user, "<span class='notice'>\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning.</span>")
-		return 0
+		return FALSE
 
 	if(access_to_check in I.access)
-		return 1
+		return TRUE
 	else if(loud)
 		to_chat(user, "<span class='notice'>\The [computer] flashes an \"Access Denied\" warning.</span>")
 

--- a/code/modules/modular_computers/ntos/ntos.dm
+++ b/code/modules/modular_computers/ntos/ntos.dm
@@ -103,14 +103,15 @@
 
 	minimize_program(user)
 
+	P.computer = src
 	if(P in running_programs)
 		P.program_state = PROGRAM_STATE_ACTIVE
 		active_program = P
 	else if(P.can_run(user, 1))
 		P.on_startup(user, src)
 		active_program = P
+		running_programs |= P
 
-	running_programs |= P
 	update_host_icon()
 	return 1
 


### PR DESCRIPTION
🆑 Hubblenaut
tweak: NTOS progams will no longer start when there's no network connection.
/:cl:

This will make people unable to sneak peak at the manifest or similar when the information shouldn't be available at all.
Also fixes an instance of computers getting stuck when attempting to launch the same program twice when lacking access/connection.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->