### PR TITLE
Add trainee roles to protected antag jobs

### DIFF
--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -1,21 +1,27 @@
 //Makes sure we don't get any merchant antags as a balance concern. Can also be used for future Torch specific antag restrictions.
 /datum/antagonist/changeling
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/submap)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/godcultist
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/submap)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/cultist
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/submap)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/loyalists
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/submap)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/revolutionary
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/submap)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/traitor
 	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/ert
 	var/sic //Second-In-Command


### PR DESCRIPTION
The trainee roles exist to allow people to learn how to play medical, engineering, etc. Being made an antag is counterproductive to that purpose as:
A: You're taking up a trainee slot that someone else may have used to learn while you're focusing on antagging.
B: If you did intend to join to learn you now also have to worry about the responsibilities of being an antag.

:cl:
tweak: Trainee roles are no longer eligible for round start on-ship antags. Trainees can still be converted by loyalists, cultists, etc and are otherwise note exempt from antagonist actions.
/:cl: