### PR TITLE
High EER degrades supermatter integrity

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -109,11 +109,12 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 #define SUPERMATTER_ERROR -1		// Unknown status, shouldn't happen but just in case.
 #define SUPERMATTER_INACTIVE 0		// No or minimal energy
 #define SUPERMATTER_NORMAL 1		// Normal operation
-#define SUPERMATTER_NOTIFY 2		// Ambient temp > 80% of CRITICAL_TEMPERATURE
-#define SUPERMATTER_WARNING 3		// Ambient temp > CRITICAL_TEMPERATURE OR integrity damaged
-#define SUPERMATTER_DANGER 4		// Integrity < 50%
-#define SUPERMATTER_EMERGENCY 5		// Integrity < 25%
-#define SUPERMATTER_DELAMINATING 6	// Pretty obvious.
+#define SUPERMATTER_NOTIFY_TEMP 2	// Ambient temp > 80% of CRITICAL_TEMPERATURE
+#define SUPERMATTER_NOTIFY_POWER 3	// EER > 80% of critical_power
+#define SUPERMATTER_WARNING 4		// Ambient temp > CRITICAL_TEMPERATURE OR EER > critical_power OR integrity damaged
+#define SUPERMATTER_DANGER 5		// Integrity < 50%
+#define SUPERMATTER_EMERGENCY 6		// Integrity < 25%
+#define SUPERMATTER_DELAMINATING 7	// Pretty obvious.
 
 #define SUPERMATTER_DATA_EER         "Relative EER"
 #define SUPERMATTER_DATA_TEMPERATURE "Temperature"

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -116,8 +116,10 @@
 		data["SM_integrity"] = min(process_data_output(engine_skill, active.get_integrity()), 100)
 		data["SM_power"] = process_data_output(engine_skill, active.power)
 		data["SM_power_label"] = get_threshhold_color(SUPERMATTER_DATA_EER, active.power)
+		data["SM_power_warn"] = active.power > active.critical_power ? "<span style=\"color: red;\">DANGER</span>" : ""
 		data["SM_ambienttemp"] = process_data_output(engine_skill, air.temperature)
 		data["SM_ambienttemp_label"] = get_threshhold_color(SUPERMATTER_DATA_TEMPERATURE, air.temperature)
+		data["SM_ambienttemp_warn"] = air.temperature > active.critical_temperature ? "<span style=\"color: red;\">DANGER</span>" : ""
 		data["SM_ambientpressure"] = process_data_output(engine_skill, ambient_pressure)
 		data["SM_ambientpressure_label"] = get_threshhold_color(SUPERMATTER_DATA_PRESSURE, ambient_pressure)
 		data["SM_EPR"] = process_data_output(engine_skill, epr)

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -76,6 +76,7 @@
 	phoron_release_modifier = 100000000000
 	oxygen_release_modifier = 100000000000
 	radiation_release_modifier = 1
+	critical_power = 0
 
 /obj/machinery/power/emitter/anchored/on
 	active = 1

--- a/nano/templates/supermatter_monitor.tmpl
+++ b/nano/templates/supermatter_monitor.tmpl
@@ -13,13 +13,13 @@
 				Relative EER:
 			</div>
 			<div class="itemContent">
-				<span class='{{:data.SM_power_label}}'>{{:data.SM_power}} MeV/cm3</span>
+				<span class='{{:data.SM_power_label}}'>{{:data.SM_power}} MeV/cm3</span> {{:data.SM_power_warn}}
 			</div>
 			<div class="itemLabel">
 				Temperature:
 			</div>
 			<div class="itemContent">
-				<span class='{{:data.SM_ambienttemp_label}}'>{{:data.SM_ambienttemp}} K</span>
+				<span class='{{:data.SM_ambienttemp_label}}'>{{:data.SM_ambienttemp}} K</span> {{:data.SM_ambienttemp_warn}}
 			</div>
 			<div class="itemLabel">
 				Pressure:


### PR DESCRIPTION
DNM - Discussion topic: https://forums.baystation12.net/threads/supermatter-delamination-at-high-eer.9194/

Because people keep running absurdly high EER engines to powergame and arguing with staff that because it's not delaminating it's safe.

Now it's not safe.

:cl:
tweak: Supermatter cores now have a maximum EER before they start taking integrity damage. The upper limit is 1,200 MeV, and integrity damage scales up the higher above the limit you go.
tweak: Supermatter monitoring will now display a bright red 'DANGER' next to temperature or EER if they are contributing to integrity damage.
/:cl: