### PR TITLE
Removes the "interior access button" in the window at EVA

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -5904,15 +5904,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "nuke_shuttle_dock_airlock";
-	name = "interior access button";
-	pixel_x = -23;
-	pixel_y = -22;
-	req_access = list(list("ACCESS_EXTERNAL","ACCESS_TORCH_CREW"))
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
 	icon_state = "corner_white"


### PR DESCRIPTION
:cl:
maptweak: Removed the useless access button at EVA.
/:cl:

This seems to be some leftover from the primary docking port which doesn't even exist anymore. The button just does not do anything and looks weird in the window.