### PR TITLE
adds methyl bromide filter masks to the ascent seedship

### DIFF
--- a/code/modules/ascent/ascent_outfit.dm
+++ b/code/modules/ascent/ascent_outfit.dm
@@ -8,7 +8,7 @@
 	pda_type = null
 	pda_slot = 0
 	flags =    0
-	
+
 /decl/hierarchy/outfit/job/ascent/attendant
 	name = "Ascent - Attendant"
 	back = /obj/item/weapon/rig/mantid
@@ -37,6 +37,15 @@
 	desc = "An alien facemask with chunky gas filters and a breathing valve."
 	filtered_gases = list(GAS_PHORON,GAS_N2O,GAS_CHLORINE,GAS_AMMONIA,GAS_CO,GAS_METHYL_BROMIDE,GAS_METHANE)
 	species_restricted = list(SPECIES_NABBER, SPECIES_MONARCH_QUEEN)
+
+/obj/item/clothing/mask/gas/ascent_captive
+	name = "humanoid filter mask"
+	desc = "A small gas filter designed to enable long-term survival in a methyl bromide atmosphere. It has an input port for food and water."
+	icon_state = "halfgas"
+	item_state = "halfgas"
+	flags_inv = 0
+	body_parts_covered = 0
+	filtered_gases = list(GAS_METHYL_BROMIDE)
 
 /obj/item/clothing/shoes/magboots/ascent
 	name = "mantid mag-claws"
@@ -76,9 +85,9 @@
 	. = ..()
 	for(var/tool in list(
 		/obj/item/weapon/gun/energy/particle/small,
-		/obj/item/device/multitool/mantid, 
-		/obj/item/clustertool, 
-		/obj/item/clustertool, 
+		/obj/item/device/multitool/mantid,
+		/obj/item/clustertool,
+		/obj/item/clustertool,
 		/obj/item/weapon/weldingtool/electric/mantid,
 		/obj/item/stack/medical/resin
 	))

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -5,6 +5,16 @@
 "ab" = (
 /turf/simulated/wall/r_wall/ascent,
 /area/ship/ascent/shuttle_starboard)
+"ac" = (
+/obj/effect/catwalk_plated/ascent,
+/obj/structure/table/rack/dark,
+/obj/item/clothing/mask/gas/ascent_captive,
+/obj/item/clothing/mask/gas/ascent_captive,
+/obj/item/clothing/mask/gas/ascent_captive,
+/obj/item/clothing/mask/gas/ascent_captive,
+/obj/item/clothing/mask/gas/ascent_captive,
+/turf/simulated/floor/ascent,
+/area/ship/ascent/fore_starboard_jut)
 "ad" = (
 /obj/effect/wallframe_spawn/reinforced_phoron/ascent,
 /turf/simulated/floor/ascent,
@@ -11612,7 +11622,7 @@ aa
 aa
 aa
 pr
-qG
+ac
 qG
 Zh
 Zh


### PR DESCRIPTION
🆑 RustingWithYou
rscadd: adds ascent humanoid filter masks
maptweak: places the filter masks on the seedship 
/🆑

Currently, the seedship atmosphere is insanely lethal to most species, making taking captives as Ascent a lot harder. Given that they have an entire room of the ship explicitly for that, I decided to give them masks for their captives and/or visitors to let them filter out the methyl bromide from the air, meaning that you don't have to micromanage internals every second for your prisoners without risking their deaths. The masks only filter methyl bromide, and much like the similar Vox respirators let the wearer eat and drink through them