### PR TITLE
All Exoplanets and Planets are now known

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -2,6 +2,7 @@
 	name = "exoplanet"
 	icon_state = "globe"
 	in_space = 0
+	known = 1
 	var/area/planetary_area
 	var/list/seeds = list()
 	var/list/animals = list()

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -4,6 +4,7 @@
 	name = "arctic planetoid"
 	desc = "Sensor array detects an arctic planet with a small vessle on the planet's surface. Scans further indicate strange energy levels below the planet's surface."
 	in_space = 0
+	known = 1
 	icon_state = "globe"
 	initial_generic_waypoints = list(
 		"nav_blueriv_1",

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -4,7 +4,7 @@
 	name = "forest planetoid"
 	desc = "Sensors detect anomalous radiation area with the presence of artificial structures."
 	icon_state = "globe"
-	known = 0
+	known = 1
 	in_space = 0
 	initial_generic_waypoints = list(
 		"nav_icarus_1",


### PR DESCRIPTION
🆑 
tweak: All Exoplanets and Planets are now known by helm control consoles by default.
/:cl:
Assist in the congregation of Mainmap and Submaps to enable earlier interaction and provide a better return on investment for submap slots.

Blundering about the overmap should take about ~15-20 minutes before you halt, at least for Torch.
Anything more and it's (more) boring.

Lore justification of `planets are big and we're able to observe and estimate their position with relative ease`

Away sites (Bluespace river and Icarus) also made known, given they're pretending to be planets.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->