### PR TITLE
Known sector processing optimization & helm message

### DIFF
--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -22,8 +22,7 @@
 	if(known)
 		layer = ABOVE_LIGHTING_LAYER
 		plane = EFFECTS_ABOVE_LIGHTING_PLANE
-		for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
-			H.get_known_sectors()
+
 	update_icon()
 
 /obj/effect/overmap/Crossed(var/obj/effect/overmap/visitable/other)
@@ -39,3 +38,19 @@
 
 /obj/effect/overmap/on_update_icon()
 	filters = filter(type="drop_shadow", color = color + "F0", size = 2, offset = 1,x = 0, y = 0)
+
+
+/**
+ * Flags the effect as `known` and runs relevant update procs. Intended for admin event usage.
+ */
+/obj/effect/overmap/proc/make_known(notify = FALSE)
+	if (!known)
+		known = TRUE
+		update_known_connections(notify)
+
+
+/**
+ * Runs any relevant code needed for updating anything connected to known overmap effects, such as helms.
+ */
+/obj/effect/overmap/proc/update_known_connections(notify = FALSE)
+	return

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -34,7 +34,7 @@
 
 	if(!GLOB.using_map.overmap_z)
 		build_overmap()
-		
+
 	start_x = start_x || rand(OVERMAP_EDGE, GLOB.using_map.overmap_size - OVERMAP_EDGE)
 	start_y = start_y || rand(OVERMAP_EDGE, GLOB.using_map.overmap_size - OVERMAP_EDGE)
 
@@ -107,6 +107,21 @@
 	icon_state = "sector"
 	anchored = 1
 
+
+/obj/effect/overmap/visitable/sector/Initialize()
+	. = ..()
+
+	if(known)
+		update_known_connections(TRUE)
+
+
+/obj/effect/overmap/visitable/sector/update_known_connections(notify = FALSE)
+	. = ..()
+
+	for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
+		H.add_known_sector(src, notify)
+
+
 // Because of the way these are spawned, they will potentially have their invisibility adjusted by the turfs they are mapped on
 // prior to being moved to the overmap. This blocks that. Use set_invisibility to adjust invisibility as needed instead.
 /obj/effect/overmap/visitable/sector/hide()
@@ -118,7 +133,7 @@
 	testing("Building overmap...")
 	world.maxz++
 	GLOB.using_map.overmap_z = world.maxz
-	
+
 	testing("Putting overmap on [GLOB.using_map.overmap_z]")
 	var/area/overmap/A = new
 	for (var/square in block(locate(1,1,GLOB.using_map.overmap_z), locate(GLOB.using_map.overmap_size,GLOB.using_map.overmap_size,GLOB.using_map.overmap_z)))

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -31,6 +31,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	R.fields["y"] = S.y
 	known_sectors[S.name] = R
 
+	if (notify)
+		audible_message(SPAN_NOTICE("\The [src] pings with a new known sector: [S] at coordinates [S.x] by [S.y]."))
+
 /obj/machinery/computer/ship/helm/Process()
 	..()
 	if (autopilot && dx && dy)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -22,11 +22,14 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	var/area/overmap/map = locate() in world
 	for(var/obj/effect/overmap/visitable/sector/S in map)
 		if (S.known)
-			var/datum/computer_file/data/waypoint/R = new()
-			R.fields["name"] = S.name
-			R.fields["x"] = S.x
-			R.fields["y"] = S.y
-			known_sectors[S.name] = R
+			add_known_sector(S)
+
+/obj/machinery/computer/ship/helm/proc/add_known_sector(obj/effect/overmap/visitable/sector/S, notify = FALSE)
+	var/datum/computer_file/data/waypoint/R = new()
+	R.fields["name"] = S.name
+	R.fields["x"] = S.x
+	R.fields["y"] = S.y
+	known_sectors[S.name] = R
 
 /obj/machinery/computer/ship/helm/Process()
 	..()


### PR DESCRIPTION
Small optimization to initialization of overmap effects that are known - Now only effects of the type helms actually care about (Sector) will process helms, and instead of making the helm loop through every overmap effect each time a sector inits, it just directly adds the initialized sector instead.

Also moves some stuff over to separate procs for future code and adminbus usage.

The helm notification message will probably never happen in the current state of code unless adminbus occurs to create a new planet, or to force a `make_known(TRUE)` call on an existing planet.

:cl:
tweak: Helms will now display a notification if a new sector is detected and added automatically.
/:cl: