### PR TITLE
Moves R-UST air alarm into the main chamber

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -287,6 +287,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/prototype/engine)
 "az" = (


### PR DESCRIPTION
:cl: Zenithstar
maptweak: Added R-UST air alarm in the main chamber.
/:cl:

The current placement of the R-UST's air alarm in the airlock between the control room and the main chamber results in an inability to monitor the atmosphere of the main chamber unless said airlock is open on the inside. It is entirely possible for atmospheric issues in the R-UST to go unnoticed due to a door not being open. This moves that air alarm into the main chamber and resolves that problem.