### PR TITLE
Enhance feedback messages and logs for place map

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -14,16 +14,21 @@
 	var/turf/T = get_turf(usr)
 	if(!T)
 		return
+	var/log_name = "([template.name]) in [get_area(T)]"
 
 	var/list/preview = list()
 	for(var/S in template.get_affected_turfs(T,centered = TRUE))
 		preview += image('icons/turf/overlays.dmi',S,"greenOverlay")
 	usr.client.images += preview
 	if(alert(usr,"Confirm location.","Template Confirm","Yes","No") == "Yes")
+		log_and_message_admins("is attempting to place a map template [log_name].")
+		to_chat(usr, "Attempting to place map template [log_name].")
 		if(template.load(T, centered = TRUE))
-			log_and_message_admins("has placed a map template ([template.name]).")
+			log_and_message_admins("has placed a map template [log_name].")
+			to_chat(usr, "Successfully place map template [log_name].")
 		else
-			to_chat(usr, "Failed to place map")
+			log_and_message_admins("has failed to place a map template [log_name].")
+			to_chat(usr, "Failed to place map template [log_name].")
 	usr.client.images -= preview
 
 /datum/admins/proc/map_template_load_new_z()
@@ -42,6 +47,7 @@
 		return
 
 	var/datum/map_template/template = SSmapping.map_templates[map]
+	var/log_name = "([template.name]) on a new zlevel"
 
 	if (template.loaded && !(template.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 		var/jesus_take_the_wheel = alert(usr, "That template has already been loaded and doesn't want to be loaded again. \
@@ -49,11 +55,15 @@
 		if (!jesus_take_the_wheel)
 			return
 
+	log_and_message_admins("is attempting to place a map template [log_name].")
+	to_chat(usr, "Attempting to place map template [log_name].")
 	var/new_z_centre = template.load_new_z(FALSE) // Don't skip changeturf
 	if (new_z_centre)
-		log_and_message_admins("has placed a map template ([template.name]) on a new zlevel.", location=new_z_centre)
+		log_and_message_admins("has placed a map template [log_name].")
+		to_chat(usr, "Successfully place map template [log_name].")
 	else
-		to_chat(usr, "Failed to place map")
+		log_and_message_admins("has failed to place a map template [log_name].")
+		to_chat(usr, "Failed to place map template [log_name].")
 
 /datum/admins/proc/map_template_upload()
 	set category = "Fun"
@@ -70,9 +80,13 @@
 		return
 
 	var/datum/map_template/M = new(list(map), "[map]")
+
+	log_and_message_admins("is attempting to upload a map template '[map]''.")
+	to_chat(usr, "Attempting to upload map template '[map]''.")
 	if(M.preload_size())
-		to_chat(usr, "Map template '[map]' ready to place ([M.width]x[M.height])")
+		to_chat(usr, "Map template '[map]' ready to place ([M.width]x[M.height]).")
 		SSmapping.map_templates[M.name] = M
-		message_admins("<span class='adminnotice'>[key_name_admin(usr)] has uploaded a map template ([map])</span>")
+		log_and_message_admins("has uploaded map template '[map]''.")
 	else
+		log_and_message_admins("failed to upload map template '[map]''.")
 		to_chat(usr, "Map template '[map]' failed to load properly")


### PR DESCRIPTION
:cl:
admin: Place-map now displays user feedback and admin log messages when starting to place a map. No more wondering if the map is actually spawning or not. Also makes the existing feedback and log messages a bit more informative.
/:cl: