### PR TITLE
Fixes underwear getting quick-equipped into pockets

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -13,14 +13,14 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(!I)
 			to_chat(H, "<span class='notice'>You are not holding anything to equip.</span>")
 			return
-		if(H.equip_to_appropriate_slot(I))
+		if(istype (I, /obj/item/underwear))
+			var/obj/item/underwear/U = I
+			U.EquipUnderwear(H, H)
+		else if(H.equip_to_appropriate_slot(I))
 			if(hand)
 				update_inv_l_hand(0)
 			else
 				update_inv_r_hand(0)
-		else if (istype (I, /obj/item/underwear))
-			var/obj/item/underwear/U = I
-			U.EquipUnderwear(H, H)
 		else
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
 


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Underwear will no longer be quick-equipped into pockets.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->