### PR TITLE
Fixes an instance of dual wielded items not getting updated

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -349,9 +349,13 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if((W == src.l_hand) && (slot != slot_l_hand))
 		src.l_hand = null
 		update_inv_l_hand() //So items actually disappear from hands.
+		if(r_hand)
+			r_hand.update_twohanding()
 	else if((W == src.r_hand) && (slot != slot_r_hand))
 		src.r_hand = null
 		update_inv_r_hand()
+		if(l_hand)
+			l_hand.update_twohanding()
 
 	W.hud_layerise()
 	for(var/s in species.hud.gear)


### PR DESCRIPTION
:cl: Hubblenaut
bugfix: Fixes dual-wielded items not getting updated when an item in the other hand is being equipped to an inventory slot.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->