### PR TITLE
Give CE access to Robot cameras

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -1,4 +1,5 @@
 // Returns which access is relevant to passed network. Used by the program.
+// A return value of 0 indicates no access reqirement
 /proc/get_camera_access(var/network)
 	if(!network)
 		return 0
@@ -9,6 +10,8 @@
 	switch(network)
 		if(NETWORK_ENGINEERING, NETWORK_ALARM_ATMOS, NETWORK_ALARM_CAMERA, NETWORK_ALARM_FIRE, NETWORK_ALARM_POWER)
 			return access_engine
+		if(NETWORK_ROBOTS)
+			return access_ai_upload
 		if(NETWORK_CRESCENT, NETWORK_ERT)
 			return access_cent_specops
 		if(NETWORK_MEDICAL)


### PR DESCRIPTION
:cl:
tweak: Chief Engineers now have access to view the Robot camera network
/:cl:

### Why?
The CE is the only person with access to AI upload who does not also have access to the robot camera network. The person in charge of maintaining the robot laws should have some level of oversight over the robots.

### Please yell at me
I welcome feedback, especially as to whether people think that roboticists should also have access to robot cameras. Come `@zkxs#1039` me in `#pr-feedback`.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->