### PR TITLE
Adjust LOOC color

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -93,7 +93,7 @@
 			if(C.get_preference_value(/datum/client_preference/show_ooc) == GLOB.PREF_HIDE)
 				line += " <font color='#002eb8'><b><s>(OOC)</s></b></font>"
 			if(C.get_preference_value(/datum/client_preference/show_looc) == GLOB.PREF_HIDE)
-				line += " <font color='#3a9696'><b><s>(LOOC)</s></b></font>"
+				line += " <font color='#3a7496'><b><s>(LOOC)</s></b></font>"
 			if(C.get_preference_value(/datum/client_preference/show_aooc) == GLOB.PREF_HIDE)
 				line += " <font color='#960018'><b><s>(AOOC)</s></b></font>"
 			if(C.get_preference_value(/datum/client_preference/show_dsay) == GLOB.PREF_HIDE)

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -270,7 +270,7 @@ em						{font-style: normal;	font-weight: bold;}
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #5353ff;}
-.ooc .looc				{color: #3a9696;}
+.ooc .looc				{color: #3a7496;}
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -267,7 +267,7 @@ em						{font-style: normal;font-weight: bold;}
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #002eb8;}
-.ooc .looc				{color: #3a9696;}
+.ooc .looc				{color: #3a7496;}
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}

--- a/code/modules/goonchat/browserassets/css/styles_template.css
+++ b/code/modules/goonchat/browserassets/css/styles_template.css
@@ -254,7 +254,7 @@ em						{font-style: normal;	font-weight: bold;}
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #002eb8;}
-.ooc .looc				{color: #3a9696;}
+.ooc .looc				{color: #3a7496;}
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -19,7 +19,7 @@ em						{font-style: normal;font-weight: bold;}
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #002eb8;}
-.ooc .looc				{color: #3a9696;}
+.ooc .looc				{color: #3a7496;}
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}


### PR DESCRIPTION
Makes LOOC easier to distinguish from medical color. For comparison:

Medical: 
![dreamseeker_epMgz4S8km](https://user-images.githubusercontent.com/11140088/94335416-64383480-ff90-11ea-8f15-33f731a58ad6.png)

Old LOOC: 
![dreamseeker_0oTOdTOMcz](https://user-images.githubusercontent.com/11140088/94335418-67332500-ff90-11ea-8aa2-77500b1f27d3.png)

New LOOC: 
![dreamseeker_r9YR4cogCI](https://user-images.githubusercontent.com/11140088/94335419-69957f00-ff90-11ea-8077-eb0c40cf8c9c.png)

:cl:
tweak: LOOC color has been tweaked to be more different from medical color
/:cl: