### PR TITLE
reagent heaters/coolers are not dense

### DIFF
--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -10,8 +10,7 @@
 	icon = 'icons/obj/machines/heat_sources.dmi'
 	icon_state = "hotplate"
 	atom_flags = ATOM_FLAG_CLIMBABLE
-	density =    TRUE
-	anchored =   TRUE
+	anchored = TRUE
 	idle_power_usage = 0
 	active_power_usage = 1.2 KILOWATTS
 	construct_state = /decl/machine_construction/default/panel_closed


### PR DESCRIPTION
:cl:
tweak: Reagent heaters/coolers no longer block mobs.
/:cl:

Small tabletop machines don't get to block all movement.