### PR TITLE
grinder boards & general changes

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
@@ -34,3 +34,32 @@
 /obj/item/weapon/stock_parts/circuitboard/sublimator/sauna
 	name = T_BOARD("sauna sublimator")
 	build_path = /obj/machinery/portable_atmospherics/reagent_sublimator/sauna
+
+
+/obj/item/weapon/stock_parts/circuitboard/reagentgrinder
+	name = T_BOARD("reagent grinder")
+	build_path = /obj/machinery/reagentgrinder
+	board_type = "machine"
+	origin_tech = list(TECH_BIO = 1, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
+	req_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 2,
+		/obj/item/weapon/stock_parts/manipulator = 2,
+		/obj/item/weapon/stock_parts/capacitor = 2
+	)
+	additional_spawn_components = list(
+		/obj/item/weapon/stock_parts/power/apc/buildable = 1
+	)
+
+/obj/item/weapon/stock_parts/circuitboard/juicer
+	name = T_BOARD("blender")
+	build_path = /obj/machinery/reagentgrinder/juicer
+	board_type = "machine"
+	origin_tech = list(TECH_BIO = 1, TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
+	req_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 1,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/weapon/stock_parts/capacitor = 1
+	)
+	additional_spawn_components = list(
+		/obj/item/weapon/stock_parts/power/apc/buildable = 1
+	)

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -9,239 +9,221 @@
 	idle_power_usage = 5
 	active_power_usage = 100
 	obj_flags = OBJ_FLAG_ANCHORABLE
+	construct_state = /decl/machine_construction/default/panel_closed
 
-	var/inuse = 0
-	var/obj/item/weapon/reagent_containers/beaker = null
-	var/limit = 10
-	var/list/holdingitems = list()
-
-	var/list/bag_whitelist = list(
-		/obj/item/weapon/storage/pill_bottle,
-		/obj/item/weapon/storage/plants)
-	var/blacklisted_types = list()
-	var/item_size_limit = ITEM_SIZE_HUGE
-	var/skill_to_check = SKILL_CHEMISTRY
+	var/skill = SKILL_CHEMISTRY
 	var/grind_sound = 'sound/machines/grinder.ogg'
+	var/list/items = list()
+	var/max_items = 10
+	var/max_item_size = ITEM_SIZE_HUGE
+	var/list/banned_items = list()
+	var/list/storage_types = list(
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/weapon/storage/sheetsnatcher,
+		/obj/item/weapon/storage/plants
+	)
+	var/list/allowed_containers = list(
+		/obj/item/weapon/reagent_containers/glass/beaker
+	)
+	var/list/banned_containers = list(
+		/obj/item/weapon/reagent_containers/glass/beaker/bowl,
+		/obj/item/weapon/reagent_containers/glass/beaker/vial
+	)
+	var/grind_time = 6 SECONDS
+	var/obj/item/weapon/reagent_containers/container
+	var/grinding
 
-/obj/machinery/reagentgrinder/New()
-	..()
-	beaker = new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
+
+/obj/machinery/reagentgrinder/proc/detach(mob/user)
+	if (!container)
+		return
+	if (user)
+		user.put_in_hands(container)
+	else
+		container.dropInto(get_turf(src))
+	container = null
 	update_icon()
 
-/obj/machinery/reagentgrinder/on_update_icon()
-	if(inuse)
-		icon_state = "[initial(icon_state)]_grinding"
+
+/obj/machinery/reagentgrinder/proc/eject()
+	for (var/obj/item/I in items)
+		I.dropInto(get_turf(src))
+	items.Cut()
+
+
+/obj/machinery/reagentgrinder/proc/reset_machine(mob/user)
+	grinding = FALSE
+	update_icon()
+	if (user)
+		interact(user)
+
+
+/obj/machinery/reagentgrinder/proc/grind(mob/user)
+	if (grinding)
 		return
-	if(beaker)
+	power_change()
+	if (stat & (NOPOWER|BROKEN))
+		return
+	if (!container?.reagents || container.reagents.total_volume >= container.reagents.maximum_volume)
+		return
+	playsound(src, grind_sound, 75, 1)
+	grinding = TRUE
+	update_icon()
+
+	addtimer(CALLBACK(src, .proc/reset_machine, user), grind_time)
+	var/skill_multiplier = CLAMP01(0.5 + (user.get_skill_value(skill) - 1) * 0.167)
+	for (var/obj/item/I in items)
+		if (container.reagents.total_volume >= container.reagents.maximum_volume)
+			break
+		if (I.reagents?.total_volume)
+			I.reagents.trans_to(container, I.reagents.total_volume, skill_multiplier)
+			I.reagents.clear_reagents()
+		var/material/M = I.get_material()
+		if (M?.chem_products?.len)
+			if (isstack(I))
+				var/sheet_volume = 0
+				for (var/chem in M.chem_products)
+					sheet_volume += M.chem_products[chem] * skill_multiplier
+				var/obj/item/stack/material/S = I
+				var/used_sheets = ceil((container.reagents.maximum_volume - container.reagents.total_volume) / sheet_volume)
+				var/used_all = used_sheets == S.get_amount()
+				S.use(used_sheets)
+				for (var/chem in M.chem_products)
+					container.reagents.add_reagent(chem, used_sheets * M.chem_products[chem] * skill_multiplier)
+				if (!used_all)
+					break
+			else
+				for (var/chem in M.chem_products)
+					container.reagents.add_reagent(chem, M.chem_products[chem] * skill_multiplier)
+		items -= I
+		qdel(I)
+
+
+/obj/machinery/reagentgrinder/proc/grindable(obj/item/I)
+	if (I.reagents?.total_volume)
+		return TRUE
+	var/material/M = I.get_material()
+	if (M?.chem_products?.len)
+		return TRUE
+	return FALSE
+
+
+/obj/machinery/reagentgrinder/on_update_icon()
+	if (grinding)
+		icon_state = "[initial(icon_state)]_grinding"
+	else if (container)
 		icon_state = "[initial(icon_state)]_beaker"
 	else
 		icon_state = "[initial(icon_state)]"
 
-/obj/machinery/reagentgrinder/attackby(var/obj/item/O as obj, var/mob/user as mob)
 
-	if (istype(O,/obj/item/weapon/reagent_containers/glass) || \
-		istype(O,/obj/item/weapon/reagent_containers/food/drinks/glass2) || \
-		istype(O,/obj/item/weapon/reagent_containers/food/drinks/shaker))
+/obj/machinery/reagentgrinder/attackby(obj/item/I, mob/user)
+	if((. = component_attackby(I, user)))
+		detach()
+		eject()
 
-		if (beaker)
-			return 1
-		else
-			if(!user.unEquip(O, src))
-				return
-			src.beaker =  O
+	else if (is_type_in_list(I, allowed_containers) && !is_type_in_list(I, banned_containers))
+		if (container)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [container]."))
+		else if (user.unEquip(I, src))
+			container = I
 			update_icon()
-			src.updateUsrDialog()
-			return 0
+			updateUsrDialog()
 
-	if(is_type_in_list(O, blacklisted_types))
-		to_chat(user, SPAN_NOTICE("\The [src] cannot grind \the [O]."))
-		return
-
-	if(is_type_in_list(O, bag_whitelist))
-		var/obj/item/weapon/storage/bag = O
-		var/failed = 1
-		for(var/obj/item/G in O)
-			if(!G.reagents || !G.reagents.total_volume)
-				continue
-			failed = 0
-			bag.remove_from_storage(G, src, 1)
-			holdingitems += G
-			if(holdingitems && holdingitems.len >= limit)
-				break
-
-		if(failed)
-			to_chat(user, SPAN_NOTICE("Nothing in \the [O] is usable."))
-			return 1
-		bag.finish_bulk_removal()
-
-		if(!O.contents.len)
-			to_chat(user, "You empty \the [O] into \the [src].")
+	else if (is_type_in_list(I, storage_types))
+		var/obj/item/weapon/storage/S = I
+		if (!S.contents.len)
+			to_chat(user, SPAN_WARNING("\The [S] is empty."))
+		else if (items.len >= max_items)
+			to_chat(user, SPAN_WARNING("\The item hopper on \the [src] is full."))
 		else
-			to_chat(user, "You fill \the [src] from \the [O].")
+			var/list/removed = list()
+			for (var/obj/item/G in S)
+				if (G.w_class > max_item_size || is_type_in_list(G, banned_items))
+					continue
+				if (!grindable(G))
+					continue
+				S.remove_from_storage(G, src, 1)
+				removed += G
+				items += G
+				if (items.len >= max_items)
+					break
+			if (removed.len)
+				S.finish_bulk_removal()
+				var/full = items.len >= max_items
+				user.visible_message(
+					"\The [user] empties things from \the [S] into \the [src].",
+					"You empty [english_list(removed)] from \the [S] into \the [src][full ? ", filling it to capacity" : ""]."
+				)
+				updateUsrDialog()
+			else
+				to_chat(user, SPAN_WARNING("Nothing more in \the [S] will go into \the [src]."))
 
-		src.updateUsrDialog()
-		return 0
+	else if (I.w_class > max_item_size)
+		to_chat(user, SPAN_WARNING("\The [I] is too large for \the [src]."))
 
-	if(O.w_class > item_size_limit)
-		to_chat(user, SPAN_NOTICE("\The [src] cannot fit \the [O]."))
-		return
+	else if (items.len >= max_items)
+		to_chat(user, SPAN_WARNING("\The [src] is full."))
 
-	if(holdingitems && holdingitems.len >= limit)
-		to_chat(user, SPAN_NOTICE("\The [src] cannot hold any additional items."))
-		return 1
+	else if (is_type_in_list(I, banned_items) || !grindable(I))
+		to_chat(user, SPAN_WARNING("\The [src] cannot grind \the [I]."))
 
-	if(!istype(O))
-		return
+	else if (user.unEquip(I, src))
+		items += I
+		updateUsrDialog()
 
-	if(istype(O,/obj/item/stack/material))
-		var/obj/item/stack/material/stack = O
-		var/material/material = stack.material
-		if(!length(material.chem_products))
-			to_chat(user, SPAN_NOTICE("\The [material.name] is unable to produce any usable reagents."))
-			return 1
+	return TRUE
 
-	else if(!O.reagents || !O.reagents.total_volume)
-		to_chat(user, SPAN_NOTICE("\The [O] is not suitable for grinding."))
-		return 1
-
-	if(!user.unEquip(O, src))
-		return
-	holdingitems += O
-	src.updateUsrDialog()
-	return 0
 
 /obj/machinery/reagentgrinder/interface_interact(mob/user)
 	interact(user)
 	return TRUE
 
-/obj/machinery/reagentgrinder/interact(mob/user as mob) // The microwave Menu
-	if(inoperable())
+
+/obj/machinery/reagentgrinder/interact(mob/user)
+	if (inoperable())
 		return
 	user.set_machine(src)
-	var/is_chamber_empty = 0
-	var/is_beaker_ready = 0
-	var/processing_chamber = ""
-	var/beaker_contents = ""
-	var/dat = list()
-
-	if(!inuse)
-		for (var/obj/item/O in holdingitems)
-			processing_chamber += "\A [O.name]<BR>"
-
-		if (!processing_chamber)
-			is_chamber_empty = 1
-			processing_chamber = "Nothing."
-		if (!beaker)
-			beaker_contents = "<B>No beaker attached.</B><br>"
-		else
-			is_beaker_ready = 1
-			beaker_contents = "<B>The beaker contains:</B><br>"
-			var/anything = 0
-			for(var/datum/reagent/R in beaker.reagents.reagent_list)
-				anything = 1
-				beaker_contents += "[R.volume] - [R.name]<br>"
-			if(!anything)
-				beaker_contents += "Nothing<br>"
-
-
-		dat += {"
-	<b>Processing chamber contains:</b><br>
-	[processing_chamber]<br>
-	[beaker_contents]<hr>
-	"}
-		if (is_beaker_ready && !is_chamber_empty && !(stat & (NOPOWER|BROKEN)))
-			dat += "<A href='?src=\ref[src];action=grind'>Process the reagents</a><BR>"
-		if(holdingitems && holdingitems.len > 0)
-			dat += "<A href='?src=\ref[src];action=eject'>Eject the reagents</a><BR>"
-		if (beaker)
-			dat += "<A href='?src=\ref[src];action=detach'>Detach the beaker</a><BR>"
+	var/window = list()
+	if (grinding)
+		window += "Working, please wait..."
 	else
-		dat += "Please wait..."
-	dat = "<HEAD><TITLE>[name]</TITLE></HEAD><TT>[JOINTEXT(dat)]</TT>"
-	show_browser(user, strip_improper(dat), "window=reagentgrinder")
+		window += "<b>Processing Hopper</b>"
+		if (!items.len)
+			window += " (empty)"
+		else
+			window += "<br><a href='?src=\ref[src];action=grind'>(grind)</a> <a href='?src=\ref[src];action=eject'>(eject)</a><br>"
+			for (var/obj/item/I in items)
+				window += "<br>\An [I]"
+				if (isstack(I))
+					var/obj/item/stack/material/S = I
+					window += " ([S.get_amount()])"
+		window += "<br><br><b>Chemical Container</b>"
+		if (!container)
+			window += " (not attached)"
+		else
+			window += " (\an [container], [PERCENT(container.reagents.total_volume, container.reagents.maximum_volume, 1)]% full)"
+			window += "<br><a href='?src=\ref[src];action=detach'>(detach)</a><br>"
+			for (var/datum/reagent/R in container.reagents.reagent_list)
+				window += "<br>[R.volume] - [R.name]"
+
+	window = strip_improper("<head><title>[name]</title></head><tt>[JOINTEXT(window)]</tt>")
+	show_browser(user, window, "window=reagentgrinder")
 	onclose(user, "reagentgrinder")
 
+
 /obj/machinery/reagentgrinder/OnTopic(user, href_list)
-	if(href_list["action"])
-		switch(href_list["action"])
+	if (user && href_list && href_list["action"])
+		switch (href_list["action"])
 			if ("grind")
 				grind(user)
-			if("eject")
+			if ("eject")
 				eject()
 			if ("detach")
 				detach(user)
 		interact(user)
 		return TOPIC_REFRESH
 
-/obj/machinery/reagentgrinder/proc/detach(mob/user)
-	if(!beaker)
-		return
-	var/obj/item/weapon/reagent_containers/B = beaker
-	user.put_in_hands(B)
-	beaker = null
-	update_icon()
-
-/obj/machinery/reagentgrinder/proc/eject()
-	if (!holdingitems || holdingitems.len == 0)
-		return
-	for(var/obj/item/O in holdingitems)
-		O.dropInto(loc)
-		holdingitems -= O
-	holdingitems.Cut()
-
-/obj/machinery/reagentgrinder/proc/grind(mob/user)
-
-	power_change()
-	if(stat & (NOPOWER|BROKEN))
-		return
-
-	// Sanity check.
-	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
-		return
-
-	attempt_skill_effect(user)
-	playsound(src.loc, grind_sound, 75, 1)
-	inuse = 1
-	update_icon()
-
-	// Reset the machine.
-	addtimer(CALLBACK(src, .proc/reset_machine, user), 60)
-
-	var/skill_factor = CLAMP01(1 + 0.3*(user.get_skill_value(skill_to_check) - SKILL_EXPERT)/(SKILL_EXPERT - SKILL_MIN))
-	// Process.
-	for (var/obj/item/O in holdingitems)
-
-		var/remaining_volume = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-		if(remaining_volume <= 0)
-			break
-
-		var/obj/item/stack/material/stack = O
-		if(istype(stack))
-			var/material/material = stack.material
-			if(!material.chem_products.len)
-				break
-
-			var/list/chem_products = material.chem_products
-			var/sheet_volume = 0
-			for(var/chem in chem_products)
-				sheet_volume += chem_products[chem]
-
-			var/amount_to_take = max(0,min(stack.amount,round(remaining_volume/sheet_volume)))
-			if(amount_to_take)
-				stack.use(amount_to_take)
-				if(QDELETED(stack))
-					holdingitems -= stack
-				for(var/chem in chem_products)
-					beaker.reagents.add_reagent(chem, (amount_to_take*chem_products[chem]*skill_factor))
-				continue
-
-		if(O.reagents)
-			O.reagents.trans_to(beaker, O.reagents.total_volume, skill_factor)
-			if(O.reagents.total_volume == 0)
-				holdingitems -= O
-				qdel(O)
-			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
-				break
 
 /obj/machinery/reagentgrinder/AltClick(mob/user)
 	if(CanDefaultInteract(user))
@@ -249,11 +231,13 @@
 	else
 		..()
 
+
 /obj/machinery/reagentgrinder/CtrlClick(mob/user)
-	if(CanDefaultInteract(user))
+	if(anchored && CanDefaultInteract(user))
 		grind(user)
 	else
 		..()
+
 
 /obj/machinery/reagentgrinder/CtrlAltClick(mob/user)
 	if(CanDefaultInteract(user))
@@ -261,40 +245,10 @@
 	else
 		..()
 
-/obj/machinery/reagentgrinder/proc/reset_machine(mob/user)
-	inuse = 0
-	interact(user)
 
+/obj/machinery/reagentgrinder/RefreshParts()
+	..()
 
-/obj/machinery/reagentgrinder/proc/attempt_skill_effect(mob/living/carbon/human/user)
-	if(!istype(user) || !prob(user.skill_fail_chance(skill_to_check, 50, SKILL_BASIC)))
-		return
-	var/hand = pick(BP_L_HAND, BP_R_HAND)
-	var/obj/item/organ/external/hand_organ = user.get_organ(hand)
-	if(!hand_organ)
-		return
-
-	var/dam = rand(10, 15)
-	user.visible_message("<span class='danger'>\The [user]'s hand gets caught in \the [src]!</span>", "<span class='danger'>Your hand gets caught in \the [src]!</span>")
-	user.apply_damage(dam, BRUTE, hand, damage_flags = DAM_SHARP, used_weapon = "grinder")
-	if(BP_IS_ROBOTIC(hand_organ))
-		beaker.reagents.add_reagent(/datum/reagent/iron, dam)
-	else
-		user.take_blood(beaker, dam)
-	user.Stun(2)
-	addtimer(CALLBACK(src, .proc/shake, user, 40), 0)
-
-/obj/machinery/reagentgrinder/proc/shake(mob/user, duration)
-	for(var/i = 1, i<=duration, i++)
-		sleep(1)
-		if(!user || !Adjacent(user))
-			break
-		if(user.is_jittery)
-			continue
-		user.do_jitter(4)
-
-	if(user && !user.is_jittery)
-		user.do_jitter(0) //resets the icon.
 
 /obj/machinery/reagentgrinder/juicer
 	name = "blender"
@@ -302,16 +256,17 @@
 	icon_state = "juicer"
 	density = FALSE
 	anchored = FALSE
-	obj_flags = null
 	grind_sound = 'sound/machines/juicer.ogg'
-	blacklisted_types = list(/obj/item/stack/material)
-	bag_whitelist = list(/obj/item/weapon/storage/plants)
-	item_size_limit = ITEM_SIZE_SMALL
-	skill_to_check = SKILL_COOKING
-
-/obj/machinery/reagentgrinder/juicer/attempt_skill_effect(mob/living/carbon/human/user)
-	if(!istype(user) || !prob(user.skill_fail_chance(skill_to_check, 50, SKILL_BASIC)))
-		return
-	visible_message(SPAN_NOTICE("\The [src] whirrs violently and spills its contents all over \the [user]!"))
-	if(beaker && beaker.reagents)
-		beaker.reagents.splash(user, beaker.reagents.total_volume)
+	max_item_size = ITEM_SIZE_SMALL
+	skill = SKILL_COOKING
+	banned_items = list(
+		/obj/item/stack/material
+	)
+	storage_types = list(
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/weapon/storage/plants
+	)
+	allowed_containers = list(
+		/obj/item/weapon/reagent_containers/glass/beaker,
+		/obj/item/weapon/reagent_containers/food/drinks/shaker
+	)

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -767,6 +767,20 @@
 	build_path = /obj/item/weapon/stock_parts/circuitboard/vending
 	sort_string = "WAABA"
 
+/datum/design/circuit/reagentgrinder
+	name = "reagent grinder"
+	id = "reagent_grinder"
+	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
+	build_path = /obj/item/weapon/stock_parts/circuitboard/reagentgrinder
+	sort_string = "WAABB"
+
+/datum/design/circuit/juicer
+	name = "blender"
+	id = "blender"
+	req_tech = list(TECH_BIO = 1, TECH_MATERIAL = 2, TECH_ENGINEERING = 1)
+	build_path = /obj/item/weapon/stock_parts/circuitboard/juicer
+	sort_string = "WAABC"
+
 /datum/design/circuit/aicore
 	name = "AI core"
 	id = "aicore"

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -1484,6 +1484,7 @@
 /area/map_template/rescue_base/base)
 "cO" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "vault"

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -5313,6 +5313,7 @@
 	color = "PURPLE";
 	name = "reactant obliterator"
 	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/fore_starboard_prow)
 "Uf" = (

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -1982,6 +1982,7 @@
 "dE" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/sign/monkey_painting{
 	pixel_y = 32

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -2971,6 +2971,7 @@
 "hX" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/casino/casino_kitchen)
 "hY" = (

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -3923,6 +3923,7 @@
 "ju" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/dorms)
 "jv" = (
@@ -4767,6 +4768,7 @@
 	dir = 1
 	},
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/science_wing)
 "lR" = (

--- a/maps/away/icarus/icarus-1.dmm
+++ b/maps/away/icarus/icarus-1.dmm
@@ -468,6 +468,7 @@
 	dir = 4
 	},
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "bO" = (

--- a/maps/away/icarus/icarus-2.dmm
+++ b/maps/away/icarus/icarus-2.dmm
@@ -945,6 +945,7 @@
 "cZ" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "da" = (

--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -3328,6 +3328,7 @@
 /area/meatstation/engineering)
 "hl" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white,
 /area/meatstation/lab)
 "hm" = (

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -1003,6 +1003,7 @@
 /area/ship/skrellscoutship/crew/quarters)
 "dD" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/stack/material/phoron/fifty,
 /obj/item/stack/material/phoron/fifty,
 /turf/simulated/floor/tiled/skrell/white,
@@ -2462,6 +2463,7 @@
 "hU" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/kitchen)
 "hX" = (

--- a/maps/away/verne/verne-2.dmm
+++ b/maps/away/verne/verne-2.dmm
@@ -4071,6 +4071,7 @@
 	dir = 4
 	},
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/verne/xenosci/workshop)
 "Bh" = (

--- a/maps/away/verne/verne-3.dmm
+++ b/maps/away/verne/verne-3.dmm
@@ -615,6 +615,7 @@
 /area/verne/common/hydroponics)
 "cJ" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Pill Cabinet";
 	pixel_x = 0;

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -219,6 +219,7 @@
 /obj/structure/table/marble,
 /obj/item/trash/snack_bowl,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/paper{
 	info = "Tonight I woke up to a sound I hoped to have never heard, a small explosion. I rushed to the bridge to diagnose the damage and saw the worst possible news. My solar tracker is gone, and so is the fucking computer. No way to override the settings now, because the assholes EMPd  the computer. No way to charge my SMES reliably, and no way to heat the fuel. I am stuck in the water! Unheated, this gas will not be enough to get absolutely anywhere near a port. This is bad. Real bad. The current charge on SMES is 20 percent, so I'll just try and orient the ship to hit the current star at maximum efficiency so we will charge at 100, and maybe make it to the next solar system. The next port is in the orbit of a Gas giant named Duma. Maybe I can dock there and repair my array. I freaking knew I needed to get a generator. I spent all of the money the Terrans gave me, and this piece of shit is all I could get.  "

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -5444,6 +5444,7 @@
 "Bc" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/sign/monkey_painting{
 	pixel_y = 32

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -289,6 +289,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "Q" = (

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
@@ -174,6 +174,7 @@
 	name = "plastic table frame"
 	},
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/carpet/blue2,
 /area/template_noop)
 "aL" = (

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1519,6 +1519,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/structure/table/glass/pglass,
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/processing)

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
@@ -171,6 +171,7 @@
 /area/map_template/oldlab/station/northairlockatmos)
 "cY" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/chem)
 "dc" = (

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -4241,6 +4241,7 @@
 /area/map_template/oldlab2/recandlockers)
 "wl" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -2496,6 +2496,7 @@
 /area/map_template/colony/engineering)
 "eS" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/stack/material/phoron/ten,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -8792,6 +8792,7 @@
 /area/vacant/infirmary)
 "sR" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plating,
 /area/vacant/infirmary)
 "sS" = (
@@ -10304,6 +10305,7 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "wY" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
@@ -11682,6 +11684,7 @@
 	dir = 1
 	},
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/stack/material/phoron,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/analysis)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -2603,9 +2603,7 @@
 "fw" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder/juicer,
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
@@ -3825,6 +3823,7 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder/juicer,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/dark,
 /area/vacant/mess)
 "hE" = (
@@ -20102,6 +20101,7 @@
 /obj/machinery/reagentgrinder/juicer{
 	pixel_y = 8
 	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "YA" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -577,6 +577,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abo" = (
@@ -14018,6 +14019,7 @@
 /area/rnd/xenobiology)
 "aUI" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -21363,6 +21365,7 @@
 /area/hallway/primary/firstdeck/center)
 "kpb" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "kqb" = (
@@ -26388,6 +26391,7 @@
 "qGb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -7714,6 +7714,7 @@
 /area/acting/backstage)
 "aLb" = (
 /obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/unsimulated/floor{
 	icon_state = "plating";
 	name = "plating"


### PR DESCRIPTION
:cl: afirpo & spookerton
rscadd: Reagent grinders and juicers can be constructed with printed circuit boards.
tweak: Reagent grinder UI is updated to be more informative.
tweak: Reagent grinder and juicer skill multiplier is now 50%, 67%, 83%, 100%, 100%.
tweak: Reagent grinders and juicers no longer steal fingers.
tweak: Reagent grinders can use any beaker except vials and bowls as product containers. Juicers can use the same, plus shakers.
tweak: Reagent grinders can accept material stacks from sheet snatchers. Juicers can accept pills from pill bottles.
tweak: Reagent grinders and juicers can grind material objects like coins. Not all material objects have chemical products set up, so this is spotty.
/:cl:

![https://i.imgur.com/gIkKg86.png](https://i.imgur.com/gIkKg86.png)

Reimplemented the guts of reagent grinders while I was fixing the construction requirements. I think that's everything.
closes #29192