### PR TITLE
adds helm access to torch, torch shuttles, and damaged bearcat

### DIFF
--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -45,7 +45,9 @@
 /turf/simulated/floor/bluegrid/airless,
 /area/ship/scrap/command/bridge)
 "ah" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	req_access = list(list("ACCESS_BEARCAT"))
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/bluegrid/airless,
 /area/ship/scrap/command/bridge)

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -71,7 +71,7 @@
 					access_expedition_shuttle_helm, access_aquila, access_aquila_helm, access_solgov_crew, access_nanotrasen,
 					access_emergency_armory, access_sec_guard, access_gun, access_expedition_shuttle, access_guppy, access_seneng, access_senmed, access_senadv,
 					access_explorer, access_pathfinder, access_pilot, access_commissary, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
-					access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax)
+					access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax, access_torch_helm)
 	minimal_access = list(access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
 						access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
 						access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
@@ -83,7 +83,7 @@
 						access_expedition_shuttle_helm, access_aquila, access_aquila_helm, access_solgov_crew, access_nanotrasen,
 						access_emergency_armory, access_sec_guard, access_gun, access_expedition_shuttle, access_guppy, access_seneng, access_senmed, access_senadv,
 						access_explorer, access_pathfinder, access_pilot, access_commissary, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
-						access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax)
+						access_petrov_toxins, access_petrov_chemistry, access_petrov_security, access_petrov_maint, access_rd, access_petrov_rd, access_torch_fax, access_torch_helm)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/card_mod,
@@ -218,12 +218,12 @@
 			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 			            access_tech_storage, access_robotics, access_atmospherics, access_janitor, access_construction,
 			            access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
-			            access_solgov_crew, access_seneng, access_hangar, access_torch_fax)
+			            access_solgov_crew, access_seneng, access_hangar, access_torch_fax, access_torch_helm)
 	minimal_access = list(access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 			            access_tech_storage, access_atmospherics, access_janitor, access_construction,
 			            access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
-			            access_solgov_crew, access_seneng, access_hangar, access_robotics, access_torch_fax)
+			            access_solgov_crew, access_seneng, access_hangar, access_robotics, access_torch_fax, access_torch_helm)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/ntnetmonitor,
@@ -387,7 +387,7 @@
 			            access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
 			            access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
 			            access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
-			            access_torch_fax)
+			            access_torch_fax, access_torch_helm)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,

--- a/maps/torch/job/torch_access.dm
+++ b/maps/torch/job/torch_access.dm
@@ -209,3 +209,9 @@
 	id = access_petrov_maint
 	desc = "Petrov Maintenance"
 	region = ACCESS_REGION_NT
+
+/var/const/access_torch_helm = "ACCESS_TORCH_HELM"
+/datum/access/torch_helm
+	id = access_torch_helm
+	desc = "Torch Helm"
+	region = ACCESS_REGION_COMMAND

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -732,7 +732,9 @@
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
 "bw" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	req_access = list(list("ACCESS_EXPLO_HELM"))
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
 "bx" = (
@@ -2022,7 +2024,8 @@
 /area/exploration_shuttle/airlock)
 "dM" = (
 /obj/machinery/computer/ship/helm{
-	dir = 1
+	dir = 1;
+	req_access = list(list("ACCESS_TORCH_GUP_HELM"))
 	},
 /obj/machinery/light{
 	dir = 8

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2698,7 +2698,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "eH" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	req_access = list(list("ACCESS_TORCH_AQUILA_HELM"))
+	},
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
 "eI" = (
@@ -14338,7 +14340,8 @@
 "Rq" = (
 /obj/machinery/computer/ship/helm{
 	dir = 4;
-	icon_state = "computer"
+	icon_state = "computer";
+	req_access = list(list("ACCESS_TORCH_HELM"))
 	},
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/cable/green{


### PR DESCRIPTION
:cl:
tweak: The overmap helms of the Charon, Guppy, Aquila, and away mission Bearcat now require the same access as their docking/landing consoles.
tweak: The Torch helm now requires its own access, assignable by ID modification and given to the CO, XO, BOs, and CE by default.
/:cl:

The torch helm is the only novel access entry and is given to the CO, XO, BOs, and CE.
Other helms are duplicates of the docking console for each shuttle.
