### PR TITLE
Fixes modular computers emitting light when offline

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -41,6 +41,15 @@
 		os.ui_interact(user)
 	return TRUE
 
+/obj/machinery/computer/modular/on_update_icon()
+	. = ..()
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os)
+		if(os.on)
+			set_light(light_max_bright_on, light_inner_range_on, light_outer_range_on, 2, light_color)
+		else
+			set_light(0)
+
 /obj/machinery/computer/modular/get_screen_overlay()
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)

--- a/code/modules/modular_computers/ntos/subtypes/device.dm
+++ b/code/modules/modular_computers/ntos/subtypes/device.dm
@@ -22,14 +22,14 @@
 	return C.computer_emagged
 
 /datum/extension/interactive/ntos/device/system_shutdown()
-	..()
 	var/obj/item/modular_computer/C = holder
 	C.enabled = FALSE
+	..()
 
 /datum/extension/interactive/ntos/device/system_boot()
-	..()
 	var/obj/item/modular_computer/C = holder
 	C.enabled = TRUE
+	..()
 
 /datum/extension/interactive/ntos/device/extension_act(href, href_list, user)
 	. = ..()


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes modular computers, PDAs, tablets, ect. still emitting light when offline.
/:cl:

Item types updated light before logic was fully handled, machine types just inherited light behavior from simple computers that have no concept of being shut down.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->