### PR TITLE
Fixes spacecash causing Travis errors

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -48,7 +48,7 @@
 
 /obj/item/weapon/spacecash/bundle
 	name = "pile of thalers"
-	icon_state = ""
+	icon_state = "spacecash1"
 	desc = "They are worth 0 Thalers."
 	worth = 0
 


### PR DESCRIPTION
I don't know what instance has been causing those errors specifically, but for the purpose of mapping spacecash bundles need a valid icon_state anyway.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->