### PR TITLE
Adjusts the Coilgun's research values to be more reasonable.

### DIFF
--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -4,9 +4,9 @@
 	icon = 'icons/obj/guns/coilgun.dmi'
 	icon_state = "coilgun"
 	item_state = "coilgun"
+	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_MAGNET = 4)
 	one_hand_penalty = 5
 	fire_delay = 20
-	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_ESOTERIC = 2, TECH_MAGNET = 4)
 	w_class = ITEM_SIZE_LARGE
 	bulk = GUN_BULK_RIFLE
 	combustion = 1


### PR DESCRIPTION
🆑 
tweak: Adjusts the deconstructive analyzer values for the improvised coilgun to match existing weapons more closely.
/🆑
The improv'd coilgun currently has _better_ research value than even x-ray carbines, which seems rather silly given how easy they are to make as engineering and, to an extent, research. This brings the values down to earth.