### PR TITLE
Makes railings paintable

### DIFF
--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -116,7 +116,7 @@
 		new_color = pick_color_from_floor(A, user)
 	else if (istype(A, /obj/machinery/door/airlock))
 		new_color = pick_color_from_airlock(A, user)
-	else
+	else if (A.atom_flags & ATOM_FLAG_CAN_BE_PAINTED)
 		new_color = A.get_color()
 	if (!change_color(new_color, user))
 		to_chat(user, SPAN_WARNING("\The [A] does not have a color that you could pick from."))
@@ -346,6 +346,8 @@
 /datum/click_handler/default/paint_sprayer/OnClick(atom/A, params)
 	var/list/modifiers = params2list(params)
 	if (A != paint_sprayer)
+		if(!istype(user.buckled) || user.buckled.buckle_movable)
+			user.face_atom(A)
 		if(modifiers["ctrl"] && paint_sprayer.pick_color(A, user))
 			return
 		if(modifiers["shift"] && paint_sprayer.remove_paint(A, user))

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -8,7 +8,7 @@
 	layer = OBJ_LAYER
 	climb_speed_mult = 0.25
 	anchored = FALSE
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CLIMBABLE
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_ROTATABLE
 
 	var/broken =    FALSE
@@ -294,3 +294,6 @@
 	if(.)
 		if(!anchored || material.is_brittle())
 			take_damage(maxhealth) // Fatboy
+
+/obj/structure/railing/set_color(color)
+	src.color = color ? color : material.icon_colour


### PR DESCRIPTION
🆑 Hubblenaut
rscadd: Railings can now be painted using the paint sprayer.
/:cl:

- Railings can now be painted using the paint sprayer.
- Removing and picking paint will have the user face it.
- You can now only color pick from paintable atoms.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->