### PR TITLE
Hide source name from gun auth notifications

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
+++ b/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
@@ -61,6 +61,6 @@
 		var/obj/item/weapon/gun/G = locate(href_list["gun"]) in GLOB.secure_weapons
 		var/do_authorize = text2num(href_list["authorize"])
 		var/mode = text2num(href_list["mode"])
-		return isnum(do_authorize) && isnum(mode) && G && G.authorize(mode, do_authorize, usr.name)
+		return isnum(do_authorize) && isnum(mode) && G && G.authorize(mode, do_authorize)
 
 	return FALSE

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(secure_weapons, list())
 	verbs -= /obj/item/weapon/gun/proc/reset_registration
 
 
-/obj/item/weapon/gun/proc/authorize(var/mode, var/authorized, var/by)
+/obj/item/weapon/gun/proc/authorize(mode, authorized)
 	if(mode < 1 || mode > authorized_modes.len || authorized_modes[mode] == authorized)
 		return FALSE
 
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(secure_weapons, list())
 
 	var/mob/user = get_holder_of_type(src, /mob)
 	if(user)
-		to_chat(user, SPAN_NOTICE("Your [src.name] has been [authorized ? "granted" : "denied"] [firemodes[mode]] fire authorization by [by]."))
+		to_chat(user, SPAN_NOTICE("Your [src.name] has been [authorized ? "granted" : "denied"] [firemodes[mode]] fire authorization."))
 
 	return TRUE
 


### PR DESCRIPTION
:cl:
tweak: Smartgun authorization messages sent to the holder no longer show the name of who authorized or denied.
/:cl:

To make it a little harder to identify which person is the antag if they go about removing gun access.