### PR TITLE
Reduce bridge officer slots to 2

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -359,8 +359,8 @@
 	title = "Bridge Officer"
 	department = "Support"
 	department_flag = SPT
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Commanding Officer and heads of staff"
 	selection_color = "#2f2f7f"
 	minimal_player_age = 0

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -550,14 +550,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/xo)
 "bf" = (
-/obj/structure/closet/secure_closet/bridgeofficer,
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/button/blast_door{
 	id_tag = "bridge sensors";
 	name = "Bridge Sensor Shroud Control";
 	pixel_x = -28;
 	req_access = list("ACCESS_BRIDGE")
 	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/hand_labeler,
+/obj/random/cash,
+/obj/random_multi/single_item/boombox,
+/obj/random/cash,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "bg" = (
@@ -1734,21 +1739,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/rd)
-"cT" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/cash,
-/obj/random/cash,
-/obj/random_multi/single_item/boombox,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/storage)
 "cU" = (
 /obj/machinery/light{
 	dir = 1
@@ -24711,7 +24701,7 @@ Tx
 bI
 qO
 GX
-cT
+dE
 Tl
 jA
 Je


### PR DESCRIPTION
:cl:
tweak: Bridge Officer slots have been reduced from 3 to 2.
/:cl:

Requested by some of the badmins. Bridge officers barely have anything to do as it is - Having three compounds on that issue.