### PR TITLE
Dynamic tcomms tweaks/fixes

### DIFF
--- a/code/datums/outfits/misc.dm
+++ b/code/datums/outfits/misc.dm
@@ -31,7 +31,7 @@
 /decl/hierarchy/outfit/merchant
 	name = "Merchant"
 	shoes = /obj/item/clothing/shoes/black
-	l_ear = /obj/item/device/radio/headset
+	l_ear = /obj/item/device/radio/headset/merchant
 	uniform = /obj/item/clothing/under/color/grey
 	id_slot = slot_wear_id
 	id_types = list(/obj/item/weapon/card/id/merchant)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -82,6 +82,10 @@
 	icon_state = "com_cypherkey"
 	channels = list("Command" = 1, "Hailing" = 1)
 
+/obj/item/device/encryptionkey/merchant
+	name = "merchant encryption key"
+	channels = list("Hailing" = 1)
+
 /obj/item/device/encryptionkey/heads/captain
 	name = "captain's encryption key"
 	icon_state = "cap_cypherkey"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -179,6 +179,12 @@
 	ks1type = /obj/item/device/encryptionkey/headset_com
 	max_keys = 3
 
+/obj/item/device/radio/headset/merchant
+	name = "merchant headset"
+	desc = "A headset utilizing the universal hailing frequency."
+	frequency = HAIL_FREQ
+	ks1type = /obj/item/device/encryptionkey/merchant
+
 /obj/item/device/radio/headset/heads/captain
 	name = "captain's headset"
 	desc = "The headset of the boss."

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -37,6 +37,10 @@
 
 	var/last_radio_sound = -INFINITY
 
+/obj/item/device/radio/hailing
+	name = "shortwave radio (Hailing)"
+	frequency = HAIL_FREQ
+
 /obj/item/device/radio/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
@@ -813,8 +817,7 @@
 	if (!preset_name)
 		return ..()
 
-	var/name_lower = lowertext(preset_name)
-	name = "[name_lower] intercom"
+	name = "[name] ([preset_name])"
 	frequency = assign_away_freq(preset_name)
 	channels += list(
 		preset_name = 1,
@@ -827,10 +830,10 @@
 
 	internal_channels = list(
 		num2text(frequency) = list(),
-		HAIL_FREQ = list(),
+		num2text(HAIL_FREQ) = list(),
 	)
 	if (use_common)
-		internal_channels += list(PUB_FREQ = list())
+		internal_channels += list(num2text(PUB_FREQ) = list())
 
 /obj/item/device/radio/off
 	listening = 0

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -107,6 +107,10 @@
 	id_tag = "crashedpodEast_pump";
 	power_rating = 25000
 	},
+/obj/item/device/radio/intercom/hailing{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/map_template/crashed_pod)
 "bq" = (
@@ -235,6 +239,10 @@
 	dir = 2;
 	id_tag = "crashedpodWest_pump";
 	power_rating = 25000
+	},
+/obj/item/device/radio/intercom/hailing{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/map_template/crashed_pod)
@@ -875,6 +883,10 @@
 	icon_state = "shuttle_chair_preview"
 	},
 /obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/item/device/radio/intercom/hailing{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "gC" = (
@@ -1063,13 +1075,24 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
+"Hp" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/device/radio/intercom/hailing{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/crashed_pod)
 "RN" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
+/obj/item/device/radio/hailing,
+/obj/item/device/radio/hailing,
+/obj/item/device/radio/hailing,
+/obj/item/device/radio/hailing,
+/obj/item/device/radio/hailing,
 /obj/random/plushie,
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/dark,
@@ -1159,7 +1182,7 @@ fh
 fy
 gd
 ay
-gE
+Hp
 gE
 gV
 RN


### PR DESCRIPTION
- Fixes naming of dynamic radios (No more shortwaves named intercom)
- Fixes hailing frequency not being defined properly in some radios
- Gives crashed pod and merchants access to hailing channel

:cl:
bugfix: Submap radios and shortwaves are now properly named instead of being called intercoms.
bugfix: Submap radios and shortwaves now define the hailing channel properly instead of a broken `0.0` channel.
tweak: Crashed pod now has hailing frequency intercoms but not tcomms server, while merchants now have a headset set to the hailing frequency.
/:cl: