### PR TITLE
Admin tool decluttering

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1295,6 +1295,7 @@
 #include "code\modules\admin\secrets\fun_secrets\triple_ai_mode.dm"
 #include "code\modules\admin\secrets\fun_secrets\waddle.dm"
 #include "code\modules\admin\secrets\investigation\attack_logs.dm"
+#include "code\modules\admin\secrets\investigation\view_persistant.dm"
 #include "code\modules\admin\verbs\adminhelp.dm"
 #include "code\modules\admin\verbs\adminjump.dm"
 #include "code\modules\admin\verbs\adminpm.dm"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -31,7 +31,7 @@ var/global/floorIsLava = 0
 ///////////////////////////////////////////////////////////////////////////////////////////////Panels
 
 /datum/admins/proc/show_player_panel(var/mob/M in SSmobs.mob_list)
-	set category = "Admin"
+	set category = null
 	set name = "Show Player Panel"
 	set desc="Edit player (respawn, ban, heal, etc)"
 
@@ -74,6 +74,7 @@ var/global/floorIsLava = 0
 		[admin_jump_link(M, src)]\] <br>
 		<b>Mob type:</b> [M.type]<br>
 		<b>Inactivity time:</b> [M.client ? "[M.client.inactivity/600] minutes" : "Logged out"]<br/><br/>
+		<A href='?src=\ref[src];paralyze=\ref[M]'>PARALYZE</A> |
 		<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> |
 		<A href='?_src_=holder;warn=[last_ckey]'>Warn</A> |
 		<A href='?src=\ref[src];newban=\ref[M];last_key=[last_ckey]'>Ban</A> |
@@ -1238,7 +1239,7 @@ var/global/floorIsLava = 0
 		to_chat(usr, "<b>No AIs located</b>")//Just so you know the thing is actually working and not just ignoring you.
 
 /datum/admins/proc/show_skills(mob/M)
-	set category = "Admin"
+	set category = null
 	set name = "Skill Panel"
 
 	if (!istype(src,/datum/admins))
@@ -1383,7 +1384,7 @@ var/global/floorIsLava = 0
 	SSticker.mode.process_autoantag()
 
 /datum/admins/proc/paralyze_mob(mob/H as mob in GLOB.player_list)
-	set category = "Admin"
+	set category = null
 	set name = "Toggle Paralyze"
 	set desc = "Toggles paralyze state, which stuns, blinds and mutes the victim."
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,6 +1,6 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
-	/datum/admins/proc/show_player_panel,	//shows an interface for individual players, with various links (links require additional flags,
+	/datum/admins/proc/show_player_panel, //shows an interface for individual players, with various links (links require additional flags), right-click player panel,
 	/client/proc/player_panel,
 	/client/proc/secrets,
 	/client/proc/deadmin_self,			//destroys our own admin datum so we can play as a regular player,
@@ -75,7 +75,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_rejuvenate,
 	/client/proc/toggleghostwriters,
 	/client/proc/toggledrones,
-	/datum/admins/proc/show_skills,
+	/datum/admins/proc/show_skills, //Right click skill menu,
 	/client/proc/man_up,
 	/client/proc/global_man_up,
 	/client/proc/response_team, // Response Teams admin verb,
@@ -291,15 +291,14 @@ var/list/admin_verbs_mod = list(
 	/client/proc/cmd_mod_say,
 	/datum/admins/proc/show_player_info,
 	/client/proc/dsay,
-	/datum/admins/proc/show_skills,
-	/datum/admins/proc/show_player_panel,
+	/datum/admins/proc/show_skills,	// Right-click skill menu,
+	/datum/admins/proc/show_player_panel,// right-click player panel,
 	/client/proc/check_antagonists,
 	/client/proc/cmd_admin_direct_narrate,
 	/client/proc/aooc,
 	/datum/admins/proc/sendFax,
 	/client/proc/check_fax_history,
-	/datum/admins/proc/paralyze_mob,
-	/datum/admins/proc/view_persistent_data
+	/datum/admins/proc/paralyze_mob // right-click paralyze ,
 )
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/secrets/investigation/view_persistant.dm
+++ b/code/modules/admin/secrets/investigation/view_persistant.dm
@@ -1,0 +1,7 @@
+/datum/admin_secret_item/investigation/view_persistant
+	name = "View Persistant Data"
+
+/datum/admin_secret_item/investigation/view_persistant/execute(var/mob/user)
+	. = ..()
+	if(.)
+		SSpersistence.show_info(user)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1948,6 +1948,11 @@
 
 			show_player_panel(M)
 
+	else if(href_list["paralyze"])
+		var/mob/M = locate(href_list["paralyze"])
+		paralyze_mob(M)
+
+
 	// player info stuff
 
 	if(href_list["add_player_info"])


### PR DESCRIPTION
Various tweaks to help declutter the admin-tab and the admin context menu.

:cl:
admin: Added Paralyze option to player panel.
admin: Removed Paralyze from admin tab (still in right-click and player panel).
admin: Moved 'View Persistant Data' to Secrets->Investigations.
admin: Removed 'Show Player Panel' from admin tab (right-click still works, 'player panel' unchanged).
admin: Removed skills from admin tab (still in player panel / right-click menu).
/:cl: