### PR TITLE
remove weapon-specific tests

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -99,13 +99,10 @@
 		return 0
 
 
-/obj/machinery/optable/MouseDrop_T(obj/O as obj, mob/user as mob)
-	if ((!( istype(O, /obj/item/weapon) ) || user.get_active_hand() != O))
-		return
-	if(!user.unequip_item())
-		return
-	if (O.loc != src.loc)
-		step(O, get_dir(O, src))
+/obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
+	if (target.loc != loc)
+		step(target, get_dir(target, loc))
+	..()
 
 /obj/machinery/optable/proc/check_victim()
 	if(!victim || !victim.lying || victim.loc != loc)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -278,7 +278,8 @@
 		repairing = null
 		return
 
-	check_force(I, user)
+	if (check_force(I, user))
+		return
 
 	if(src.operating > 0 || isrobot(user))	return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
 
@@ -304,19 +305,20 @@
 		operating = -1
 		return 1
 
-//psa to whoever coded this, there are plenty of objects that need to call attack() on doors without bludgeoning them.
-/obj/machinery/door/proc/check_force(obj/item/I as obj, mob/user as mob)
-	if(src.density && istype(I, /obj/item/weapon) && user.a_intent == I_HURT && !istype(I, /obj/item/weapon/card))
-		var/obj/item/weapon/W = I
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if(W.damtype == BRUTE || W.damtype == BURN)
-			user.do_attack_animation(src)
-			if(W.force < min_force)
-				user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [W] with no visible effect.</span>")
-			else
-				user.visible_message("<span class='danger'>\The [user] forcefully strikes \the [src] with \the [W]!</span>")
-				playsound(src.loc, hitsound, 100, 1)
-				take_damage(W.force)
+/obj/machinery/door/proc/check_force(obj/item/I, mob/user)
+	if (!density || user.a_intent != I_HURT)
+		return FALSE
+	if (I.damtype != BRUTE && I.damtype != BURN)
+		return FALSE
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.do_attack_animation(src)
+	if (I.force < min_force)
+		visible_message(SPAN_WARNING("\The [user] hits \the [src] with \an [I] to no effect."))
+	else
+		visible_message(SPAN_DANGER("\The [user] hits \the [src] with \an [I], causing damage!"))
+		playsound(src, hitsound, 100, 1)
+		take_damage(I.force)
+	return TRUE
 
 /obj/machinery/door/proc/take_damage(var/damage)
 	var/initialhealth = src.health

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -173,18 +173,7 @@
 			health = between(health, health + used*DOOR_REPAIR_AMOUNT, maxhealth)
 		return
 
-	//psa to whoever coded this, there are plenty of objects that need to call attack() on doors without bludgeoning them.
-	if(src.density && istype(I, /obj/item/weapon) && user.a_intent == I_HURT && !istype(I, /obj/item/weapon/card))
-		var/obj/item/weapon/W = I
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if(W.damtype == BRUTE || W.damtype == BURN)
-			user.do_attack_animation(src)
-			if(W.force < min_force)
-				user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [W] with no visible effect.</span>")
-			else
-				user.visible_message("<span class='danger'>\The [user] forcefully strikes \the [src] with \the [W]!</span>")
-				playsound(src.loc, hitsound, 100, 1)
-				take_damage(W.force)
+	if (check_force(I, user))
 		return
 
 	if(src.operating) return

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -229,16 +229,8 @@
 			operating = 0
 			return
 
-	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
-	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		var/aforce = I.force
-		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		visible_message("<span class='danger'>[src] was hit by [I].</span>")
-		if(I.damtype == BRUTE || I.damtype == BURN)
-			take_damage(aforce)
+	if (check_force(I, user))
 		return
-
 
 	src.add_fingerprint(user, 0, I)
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -723,33 +723,25 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 
 
-/obj/machinery/newscaster/attackby(obj/item/I as obj, mob/user as mob)
-	if (stat & BROKEN)
-		playsound(src.loc, 'sound/effects/hit_on_shattered_glass.ogg', 100, 1)
-		for (var/mob/O in hearers(5, src.loc))
-			O.show_message("<EM>[user.name]</EM> further abuses the shattered [src.name].")
-	else
-		if(istype(I, /obj/item/weapon) )
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			var/obj/item/weapon/W = I
-			if(W.force <15)
-				for (var/mob/O in hearers(5, src.loc))
-					O.show_message("[user.name] hits the [src.name] with the [W.name] with no visible effect." )
-					playsound(src.loc, 'sound/effects/Glasshit.ogg', 100, 1)
-			else
-				src.hitstaken++
-				if(hitstaken==3)
-					for (var/mob/O in hearers(5, src.loc))
-						O.show_message("[user.name] smashes the [src.name]!" )
-					set_broken(TRUE)
-					playsound(src.loc, 'sound/effects/Glassbr3.ogg', 100, 1)
-				else
-					for (var/mob/O in hearers(5, src.loc))
-						O.show_message("[user.name] forcefully slams the [src.name] with the [I.name]!" )
-					playsound(src.loc, 'sound/effects/Glasshit.ogg', 100, 1)
+/obj/machinery/newscaster/attackby(obj/item/I, mob/user)
+	if (user.a_intent == I_HURT)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		if (I.force < 15)
+			visible_message(SPAN_WARNING("\The [user] uselessly bops \the [src] with \an [I]."))
+		else if (stat & BROKEN)
+			visible_message(SPAN_WARNING("\The [user] further abuses the shattered [name]."))
+			playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 100, 1)
+		else if (++hitstaken < 3)
+			visible_message(SPAN_DANGER("\The [user] slams \the [src] with \an [I], cracking it!"))
+			playsound(src, 'sound/effects/Glassbr3.ogg', 100, 1)
 		else
-			to_chat(user, "<span class='notice'>This does nothing.</span>")
-	queue_icon_update()
+			visible_message(SPAN_DANGER("\The [user] smashes \the [src] with \an [I]!"))
+			playsound(src, 'sound/effects/Glasshit.ogg', 100, 1)
+			set_broken(TRUE)
+			update_icon()
+		return TRUE
+	else
+		. = ..()
 
 /datum/news_photo
 	var/is_synth = 0

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -655,7 +655,6 @@ var/global/floorIsLava = 0
 	dat += {"
 		<BR>
 		<A href='?src=\ref[src];create_object=1'>Create Object</A><br>
-		<A href='?src=\ref[src];quick_create_object=1'>Quick Create Object</A><br>
 		<A href='?src=\ref[src];create_turf=1'>Create Turf</A><br>
 		<A href='?src=\ref[src];create_mob=1'>Create Mob</A><br>
 		<br><A href='?src=\ref[src];vsc=airflow'>Edit Airflow Settings</A><br>

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -8,19 +8,3 @@
 		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
 
 	show_browser(user, replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=425x475")
-
-
-/datum/admins/proc/quick_create_object(var/mob/user)
-
-	var/quick_create_object_html = null
-	var/path = input("Select the path of the object you wish to create.", "Path", /obj) as null|anything in list(/obj,/obj/structure,/obj/item,/obj/item/weapon,/obj/item/clothing,/obj/machinery,/obj/prefab)
-	if(!path)
-		return
-
-	if (!quick_create_object_html)
-		var/objectjs = null
-		objectjs = jointext(typesof(path), ";")
-		quick_create_object_html = file2text('html/create_object.html')
-		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
-
-	show_browser(user, replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=425x475")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1604,10 +1604,6 @@
 		if(!check_rights(R_SPAWN))	return
 		return create_object(usr)
 
-	else if(href_list["quick_create_object"])
-		if(!check_rights(R_SPAWN))	return
-		return quick_create_object(usr)
-
 	else if(href_list["create_turf"])
 		if(!check_rights(R_SPAWN))	return
 		return create_turf(usr)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -190,12 +190,7 @@
 	if (src.operating == 1)
 		return
 
-	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
-		var/aforce = I.force
-		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		visible_message("<span class='danger'>\The [src] was hit by \the [I].</span>")
-		if(I.damtype == BRUTE || I.damtype == BURN)
-			take_damage(aforce)
+	if (check_force(I, user))
 		return
 
 	src.add_fingerprint(user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -435,46 +435,21 @@
 	if(!module)
 		module = new /obj/item/weapon/robot_module/drone(src)
 
-	var/dat = "<HEAD><TITLE>Drone modules</TITLE></HEAD><BODY>\n"
-	dat += {"
-	<B>Activated Modules</B>
-	<BR>
-	Module 1: [module_state_1 ? "<A HREF=?src=\ref[src];mod=\ref[module_state_1]>[module_state_1]<A>" : "No Module"]<BR>
-	Module 2: [module_state_2 ? "<A HREF=?src=\ref[src];mod=\ref[module_state_2]>[module_state_2]<A>" : "No Module"]<BR>
-	Module 3: [module_state_3 ? "<A HREF=?src=\ref[src];mod=\ref[module_state_3]>[module_state_3]<A>" : "No Module"]<BR>
-	<BR>
-	<B>Installed Modules</B><BR><BR>"}
-
-
-	var/tools = "<B>Tools and devices</B><BR>"
-	var/resources = "<BR><B>Resources</B><BR>"
-
+	var/window = {"
+	<b>Activated Modules</b><br>
+	Module 1: [module_state_1 ? "<a href=?src=\ref[src];mod=\ref[module_state_1]>[module_state_1]<a>" : "No Module"]<br>
+	Module 2: [module_state_2 ? "<a href=?src=\ref[src];mod=\ref[module_state_2]>[module_state_2]<a>" : "No Module"]<br>
+	Module 3: [module_state_3 ? "<a href=?src=\ref[src];mod=\ref[module_state_3]>[module_state_3]<a>" : "No Module"]<br>
+	<br><b>Available Modules</b><br>"}
 	for (var/O in module.equipment)
-
-		var/module_string = ""
-
 		if (!O)
-			module_string += text("<B>Resource depleted</B><BR>")
-		else if(activated(O))
-			module_string += text("[O]: <B>Activated</B><BR>")
+			window += "<br><b>Depleted Resource</b>"
 		else
-			module_string += text("[O]: <A HREF=?src=\ref[src];act=\ref[O]>Activate</A><BR>")
-
-		if((istype(O,/obj/item/weapon) || istype(O,/obj/item/device)) && !(istype(O,/obj/item/stack/cable_coil)))
-			tools += module_string
-		else
-			resources += module_string
-
-	dat += tools
-
+			window += "<br>[O]: [activated(O) ? "<b>Activated</b>" : "<a href='?src=\ref[src];act=\ref[O]'>Activate</a>"]"
 	if (emagged)
 		if (!module.emag)
-			dat += text("<B>Resource depleted</B><BR>")
-		else if(activated(module.emag))
-			dat += text("[module.emag]: <B>Activated</B><BR>")
+			window += "<br><b>Depleted Resource</b>"
 		else
-			dat += text("[module.emag]: <A HREF=?src=\ref[src];act=\ref[module.emag]>Activate</A><BR>")
-
-	dat += resources
-
-	show_browser(src, dat, "window=robotmod")
+			window += "<br>[module.emag]: [activated(module.emag) ? "<b>Activated</b>" : "<a href='?src=\ref[src];act=\ref[module.emag]'>Activate</a>"]"
+	window = strip_improper("<head><title>Drone modules</title></head><tt>[JOINTEXT(window)]</tt>")
+	show_browser(src, window, "window=robotmod")

--- a/code/modules/random_map/drop/supply.dm
+++ b/code/modules/random_map/drop/supply.dm
@@ -55,25 +55,18 @@
 		choice = alert("Do you wish to add structures or machines?",,"No","Yes")
 		if(choice == "Yes")
 			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj) - typesof(/obj/item)
+				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/structure) + typesof(/obj/machinery)
 				if(!adding_loot_type)
 					break
 				chosen_loot_types |= adding_loot_type
-		choice = alert("Do you wish to add any non-weapon items?",,"No","Yes")
+		choice = alert("Do you wish to add any items?",,"No","Yes")
 		if(choice == "Yes")
 			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item) - typesof(/obj/item/weapon)
+				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item)
 				if(!adding_loot_type)
 					break
 				chosen_loot_types |= adding_loot_type
 
-		choice = alert("Do you wish to add weapons?",,"No","Yes")
-		if(choice == "Yes")
-			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item/weapon)
-				if(!adding_loot_type)
-					break
-				chosen_loot_types |= adding_loot_type
 		choice = alert("Do you wish to add ABSOLUTELY ANYTHING ELSE? (you really shouldn't need to)",,"No","Yes")
 		if(choice == "Yes")
 			while(1)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -64,16 +64,12 @@
 	return 1
 
 
-/obj/structure/table/MouseDrop_T(obj/O as obj, mob/user as mob)
-
-	if ((!( istype(O, /obj/item/weapon) ) || user.get_active_hand() != O))
-		return ..()
-	if(isrobot(user))
+/obj/structure/table/MouseDrop_T(mob/target, mob/user)
+	if (isrobot(user))
 		return
-	user.unequip_item()
-	if (O.loc != src.loc)
-		step(O, get_dir(O, src))
-	return
+	if (target.loc != loc)
+		step(target, get_dir(target, loc))
+	..()
 
 /obj/structure/table/attackby(obj/item/W, mob/user, var/click_params)
 	if (!W) return

--- a/code/modules/xenoarcheaology/triggers/force.dm
+++ b/code/modules/xenoarcheaology/triggers/force.dm
@@ -6,9 +6,9 @@
 	if(istype(O, /obj/item/projectile))
 		var/obj/item/projectile/P = O
 		return (P.damage_type == BRUTE)
-	else if(istype(O, /obj/item/weapon))
-		var/obj/item/weapon/W = O
-		return (W.force >= 10)
+	else if(istype(O, /obj/item))
+		var/obj/item/I = O
+		return I.force >= 10
 
 /datum/artifact_trigger/force/on_explosion(severity)
 	return TRUE


### PR DESCRIPTION
:cl:
admin: Quick Create Object no longer exists.
/:cl:

Rewrote all matches on `/obj/item/weapon[^/]`, which should be all tests that involved that path.
Admin changelog is because `/weapon` is and has been a dead thing, making QCO *even more* valueless.
Tested everything changed and it works on the surface. Encountered a funtime runtime with tabling people but it's pre-existing and belongs to grabs as far as I can tell.

Drop pods are hateful.