### PR TITLE
Verne spawn weight added, made rarer.

### DIFF
--- a/maps/away/verne/verne.dm
+++ b/maps/away/verne/verne.dm
@@ -38,6 +38,7 @@
 	description = "Active CTI research ship"
 	suffixes = list("verne/verne-1.dmm", "verne/verne-2.dmm", "verne/verne-3.dmm")
 	cost = 2
+	spawn_weight = 0.33
 	area_usage_test_exempted_root_areas = list(/area/verne)
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/verne,


### PR DESCRIPTION
🆑 
tweak: SRV Verne spawn weight has been modified. It will now appear 1/3rd as often.
/:cl:
1 --> 0.33
Player and design concerns prompted me to add a much reduced spawn weight. 
It should've been 0.67 during initial commit, but it was missed.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
