### PR TITLE
Fixes instances of airlock controllers not updating sprites

### DIFF
--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -72,7 +72,7 @@ obj/machinery/embedded_controller/radio/Destroy()
 	else
 		overlays += image(icon, "indicator_active")
 	var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
-	var/datum/computer/file/embedded_program/airlock/docking/airlock_program = program
+	var/datum/computer/file/embedded_program/airlock/airlock_program = program
 	if(istype(docking_program))
 		if(docking_program.override_enabled)
 			overlays += image(icon, "indicator_forced")


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes airlock controller sprite updates.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->