### PR TITLE
Removes the transit level from admin levels

### DIFF
--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -5,7 +5,7 @@
 	flags = MAP_HAS_BRANCH | MAP_HAS_RANK
 	config_path = "config/torch_config.txt"
 
-	admin_levels = list(7,8)
+	admin_levels = list(7)
 	empty_levels = list(9)
 	accessible_z_levels = list("1"=1,"2"=3,"3"=1,"4"=1,"5"=1,"6"=1,"9"=30)
 	overmap_size = 35


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes shuttles in transit getting Torch announcements.
/:cl:
As transit is only used for admin shuttle transits in the rarest cases
now.
This effectively prevents shuttles from getting Torch announcements when
they are nowhere near the Torch.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->