### PR TITLE
Add chat markup (courtesy of Aurora)

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -247,6 +247,21 @@
 		characters += character
 	return JOINTEXT(characters)
 
+GLOBAL_LIST_INIT(markup_tags, list("/" = list("<i>", "</i>")))
+GLOBAL_LIST_INIT(markup_regex, list("/" = new /regex("((\\W|^)\\/)(\[^\\/\]*)(\\/(\\W|$))", "g")))
+
+//Take the regex expressions and tags in the above two lists and apply them to message. Any tags in ignore will not be regexed (they will remain in the string).
+/proc/process_chat_markup(message, list/ignore)
+	if(!config.allow_chat_markup || !message)
+		return message
+
+	for(var/tag in GLOB.markup_tags)
+		if (ignore?.Find(tag))
+			continue
+		var/regex/markup = GLOB.markup_regex[tag]
+		message = markup.Replace(message, "$2[GLOB.markup_tags[tag][1]]$3[GLOB.markup_tags[tag][2]]$5")
+		
+	return message
 
 //Returns a string with reserved characters and spaces before the first letter removed
 /proc/trim_left(text)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -21,6 +21,7 @@ var/list/gamemode_cache = list()
 	var/log_world_output = 0			// log world.log to game log
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
+	var/allow_chat_markup = 0			// allow markup tags to be applied in chat
 	var/ert_admin_call_only = 0
 	var/allow_vote_mode = 0				// allow votes to change mode
 	var/allow_admin_jump = 1			// allows admin jumping
@@ -332,6 +333,9 @@ var/list/gamemode_cache = list()
 
 				if ("allow_vote_mode")
 					config.allow_vote_mode = 1
+
+				if ("allow_chat_markup")
+					config.allow_chat_markup = 1
 
 				if ("allow_admin_jump")
 					config.allow_admin_jump = 1

--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -152,8 +152,9 @@
 	var/key_name = plain_key_name(src)
 	return usr != src ? "[key_name] - usr: [plain_key_name(usr)]" : key_name
 
-/proc/sanitize_and_communicate(var/channel_type, var/communicator, var/message)
+/proc/sanitize_and_communicate(channel_type, communicator, message, list/ignore_tags)
 	message = sanitize(message)
+	message = process_chat_markup(message, ignore_tags)
 	return communicate(arglist(args))
 
 /proc/communicate(var/channel_type, var/communicator, var/message)

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -131,7 +131,7 @@
 		message = format_emote(src, message)
 	else
 		return
-
+	message = process_chat_markup(message)
 	if (message)
 		log_emote("[name]/[key] : [message]")
 	//do not show NPC animal emotes to ghosts, it turns into hellscape

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -210,7 +210,8 @@ proc/get_radio_key_from_channel(var/channel)
 	message = trim_left(message)
 	message = handle_autohiss(message, speaking)
 	message = format_say_message(message)
-
+	message = process_chat_markup(message)
+	
 	if(speaking && !speaking.can_be_spoken_properly_by(src))
 		message = speaking.muddle(message)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -111,6 +111,9 @@ ALLOW_ADMIN_OOCCOLOR
 ## allow players to initiate a restart vote
 ALLOW_VOTE_RESTART
 
+## Allow chat markup ingame.
+ALLOW_CHAT_MARKUP
+
 ## allow players to initate a mode-change start
 ALLOW_VOTE_MODE
 


### PR DESCRIPTION
This pull request adds the ability for the chat to have markup applied to it. Meaning, just like on GitHub/Discord, adding certain characters to a message will replace them with rich text. This affects IC communications (`say` and `me`) and OOC communications (`OOC` and `LOOC`).

Currently, surrounding something in /forward slashes/ will italicize it. Other keys and values can be added as needed.

This is a partial port of Aurora's chat markup system—credit to them for the majority of the regexes used as well as the structure of the proc itself.

This feature is a config setting and requires ALLOW_CHAT_MARKUP to be present in config.txt. (Config files are excluded in the .gitignore so you'll need to add it yourself.)

#### Known Issues

Currently, ending a `say` message with a markup character (e.g., `say "/Help!/"`) will add an extra period at the end because of the auto-punctuation system. Fixing this is a very difficult issue and not something that I intend on doing at the moment. I think it would be far more efficient to ask players to bear in mind this issue and not end their messages with markup characters (e.g., by rephrasing the previous to `say "/Help/!"`.

-----

:cl:
rscadd: Added chat markup. Surrounding something in /forward slashes/ when sending an (L)OOC message or a "say" or "me" message will italicize it. Credit to Aurora for some of the code used.
admin: Added a config setting, ALLOW_CHAT_MARKUP. This must be present in config.txt to enable chat markup.
/:cl: