### PR TITLE
public progress bars appear above things

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -73,6 +73,7 @@
 	bar.icon_state = "prog_bar_0"
 	bar.pixel_x = (actee.x - actor.x) * WORLD_ICON_SIZE
 	bar.pixel_y = (actee.y - actor.y) * WORLD_ICON_SIZE + WORLD_ICON_SIZE
+	bar.layer = ABOVE_HUMAN_LAYER
 	actor.vis_contents += bar
 
 /datum/progressbar/public/update(progress)


### PR DESCRIPTION
:cl:
bugfix: Publicly visible progress bars appear above other stuff.
/:cl:

same layer as stuff like antag icons.