### PR TITLE
Gives BO headsets access to the research, supply and service channels

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -31,7 +31,7 @@
 /obj/item/device/encryptionkey/bridgeofficer
 	name = "bridge officer's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Hailing" = 1)
+	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Supply" = 1, "Service" = 1, "Science" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/heads/ai_integrated
 	name = "ai integrated encryption key"


### PR DESCRIPTION
🆑
tweak: BO headset keys now give access to the research, supply and service channels.
/🆑

BOs have total supply access, excluding the deck chief office, and may be frequently asked to relay requests to the supply and service departments from the rest of command or other departments. This makes it so they don't need to switch a shortwave to these channels, by just giving them the comms straight-up.

Research was added after feedback, with the justification that another person on comms when there isn't a CSO would help to encourage research tagging along on exploration missions.