### PR TITLE
Removes AI status displays from Torch

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -3177,7 +3177,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/auxillary/starboard)
 "lc" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/fore)
 "ld" = (
@@ -4717,7 +4716,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/janitor)
 "qB" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "qC" = (
@@ -7987,7 +7985,6 @@
 /turf/simulated/wall/prepainted,
 /area/storage/auxillary/port)
 "AH" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
 /area/storage/auxillary/port)
 "AI" = (
@@ -15996,7 +15993,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "YJ" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "YK" = (

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -7770,7 +7770,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/holocontrol)
 "qd" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
 /area/holocontrol)
 "qe" = (
@@ -9558,7 +9557,6 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/sleep/cryo)
 "uP" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/sleep/cryo)
 "uQ" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -3646,7 +3646,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "gX" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/bluespace)
 "gY" = (
@@ -18895,7 +18894,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "Yy" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/seconddeck)
 "Yz" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -4808,7 +4808,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/counselor/therapy)
 "ait" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/counselor/therapy)
 "aiu" = (
@@ -8550,7 +8549,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
 "aAm" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/head/aux)
 "aAn" = (
@@ -8629,7 +8627,6 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
 "aAT" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
 "aAU" = (
@@ -9314,7 +9311,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
 "aDL" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/nuke_storage)
 "aDN" = (
@@ -10787,7 +10783,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aKH" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
 /area/security/brig)
 "aKJ" = (
@@ -19438,7 +19433,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
 "hVG" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/firstdeck/center)
 "hWb" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3926,7 +3926,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/ce)
 "hC" = (
-/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "hE" = (


### PR DESCRIPTION
:cl:
maptweak: Removed AI displays.
/:cl:

They won't cover our beautiful walls with their ugly blank faces anymore.