### PR TITLE
Changes AirAlarm breach behavour

### DIFF
--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -197,6 +197,9 @@ Used In File(s): \code\game\machinery\alarm.dm
 			</div>
 		{{/for}}
     {{else data.screen == 5}}
+		<H3>Breach Threshold</H3>
+		Under this pressure, vents will be turned off.<br>
+		{{:helper.link(data.breach_data.selected >= 0 ? helper.fixed(data.breach_data.selected, 2) : "Off", null, { 'command' : 'set_breach'})}} Kpa
 		<H3>Alarm Threshold</H3>
 		Partial pressure for gases.
 		<table class='fixed'>


### PR DESCRIPTION
TLDR: Vent outages due to breaches are less likely to propegate far away from breaches, allowing other areas to recover.

Each alarm has a breach pressure, default at about 50kpa, below which the vents will be shut off to avoid wasting air. This breach pressure can be edited by those with alarm acsess to their likeing, or dissabled completly by setting it negative. 

To allow for engineers to refill rooms, changing the alarm mode will start a 10 minute cooldown where the breach detection system is dissabled.

:cl:
tweak: Breach detection pressures on air alarms can now be adjusted.
tweak: Breach detection is now more forgiving, allowing rooms to recover.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->