### PR TITLE
Update gantry radios

### DIFF
--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -681,7 +681,8 @@
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/random/loot,
 /obj/structure/table/steel_reinforced,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
+	default_hailing = 1;
 	dir = 8;
 	pixel_x = 20
 	},
@@ -812,7 +813,7 @@
 /obj/random/firstaid,
 /obj/random/firstaid,
 /obj/random/firstaid,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	dir = 8;
 	pixel_x = 20
 	},
@@ -2458,8 +2459,8 @@
 /obj/structure/table/rack,
 /obj/item/weapon/storage/belt/utility/full,
 /obj/item/weapon/storage/belt/utility/full,
-/obj/item/device/radio,
-/obj/item/device/radio,
+/obj/item/device/radio/map_preset/scavver,
+/obj/item/device/radio/map_preset/scavver,
 /obj/item/clothing/gloves/insulated,
 /obj/item/clothing/gloves/insulated,
 /obj/item/device/multitool,

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -10,7 +10,7 @@
 /turf/simulated/floor/airless,
 /area/space)
 "ab" = (
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	pixel_y = 23
 	},
 /obj/structure/handrai,
@@ -348,7 +348,7 @@
 	dir = 1
 	},
 /obj/structure/handrai,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
@@ -727,8 +727,10 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/item/device/radio/intercom/map_preset/scavver{
+	default_hailing = 1;
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/scavver/harvestpod)
@@ -1310,7 +1312,8 @@
 /area/scavver/lifepod)
 "ks" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
+	default_hailing = 1;
 	dir = 4;
 	pixel_x = -21
 	},
@@ -1611,7 +1614,7 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/scavver/escapepod)
 "nc" = (
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	dir = 1;
 	pixel_y = -28
 	},
@@ -1788,7 +1791,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up1)
 "ov" = (
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	dir = 1;
 	pixel_y = -28
 	},
@@ -2095,7 +2098,8 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
+	default_hailing = 1;
 	dir = 4;
 	pixel_x = -21
 	},
@@ -2720,7 +2724,7 @@
 "uN" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
 /obj/machinery/atmospherics/portables_connector,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	dir = 4;
 	pixel_x = -21
 	},
@@ -3904,7 +3908,7 @@
 "FA" = (
 /obj/machinery/vending/tool,
 /obj/effect/floor_decal/corner/lightgrey/mono,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -4379,7 +4383,7 @@
 /area/scavver/hab)
 "JO" = (
 /obj/structure/largecrate/animal/goose,
-/obj/item/device/radio/intercom{
+/obj/item/device/radio/intercom/map_preset/scavver{
 	dir = 4;
 	pixel_x = -22
 	},
@@ -4686,7 +4690,7 @@
 	dir = 1
 	},
 /obj/machinery/cell_charger,
-/obj/item/device/radio,
+/obj/item/device/radio/map_preset/scavver,
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 1
 	},
@@ -5560,6 +5564,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/shuttle_control/explore/scavver_gantry/three,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/scavver/harvestpod)
 "WF" = (

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -1,5 +1,6 @@
 #include "scavver_gantry_shuttles.dm"
 #include "scavver_gantry_jobs.dm"
+#include "scavver_gantry_radio.dm"
 
 /datum/map_template/ruin/away_site/scavver_gantry
 	name =  "\improper Salvage Gantry"

--- a/maps/away/scavver/scavver_gantry_jobs.dm
+++ b/maps/away/scavver/scavver_gantry_jobs.dm
@@ -138,10 +138,10 @@
 
 /decl/hierarchy/outfit/job/scavver
 	name = "Salvager"
-	l_ear = null
+	l_ear = /obj/item/device/radio/headset/map_preset/scavver
 	r_ear = null
 	uniform = /obj/item/clothing/under/frontier
-	r_pocket = /obj/item/device/radio
+	r_pocket = /obj/item/device/radio/map_preset/scavver
 	l_pocket = /obj/item/weapon/crowbar/prybar
 	shoes = /obj/item/clothing/shoes/workboots
 	gloves = /obj/item/clothing/gloves/thick
@@ -153,7 +153,7 @@
 /decl/hierarchy/outfit/job/scavver/engineer
 	name = "Salvage Engineer"
 	uniform = /obj/item/clothing/under/hazard
-	r_pocket = /obj/item/device/radio
+	r_pocket = /obj/item/device/radio/map_preset/scavver
 	l_pocket = /obj/item/weapon/crowbar/prybar
 	shoes = /obj/item/clothing/shoes/workboots
 	gloves = /obj/item/clothing/gloves/thick/duty
@@ -164,7 +164,7 @@
 	name = "Salvage Pilot"
 	uniform = /obj/item/clothing/under/rank/dispatch
 	suit = /obj/item/clothing/suit/armor/pcarrier/light
-	r_pocket = /obj/item/device/radio
+	r_pocket = /obj/item/device/radio/map_preset/scavver
 	l_pocket = /obj/item/weapon/crowbar/prybar
 	shoes = /obj/item/clothing/shoes/jackboots
 	belt = null
@@ -172,7 +172,7 @@
 /decl/hierarchy/outfit/job/scavver/doctor
 	name = "Salvage Doctor"
 	uniform = /obj/item/clothing/under/caretaker
-	r_pocket = /obj/item/device/radio
+	r_pocket = /obj/item/device/radio/map_preset/scavver
 	l_pocket = /obj/item/weapon/crowbar/prybar
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/white

--- a/maps/away/scavver/scavver_gantry_radio.dm
+++ b/maps/away/scavver/scavver_gantry_radio.dm
@@ -1,0 +1,13 @@
+/obj/item/device/radio/map_preset/scavver
+	preset_name = "Gantry"
+
+/obj/item/device/radio/intercom/map_preset/scavver
+	preset_name = "Gantry"
+
+/obj/item/device/encryptionkey/map_preset/scavver
+	preset_name = "Gantry"
+	icon_state = "cargo_cypherkey"
+
+/obj/item/device/radio/headset/map_preset/scavver
+	preset_name = "Gantry"
+	encryption_key = /obj/item/device/encryptionkey/map_preset/scavver


### PR DESCRIPTION
:cl:
tweak: Salvage Gantry now has a unique 'encrypted' radio frequency that's not common. Headsets were added but no telecoms server to aid in using shortwaves with the `;` prefix. Intercoms next to salvage gantry helm controls now default to the hailing frequency.
/:cl: