### PR TITLE
Add backup headsets and keys to submaps

### DIFF
--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -878,6 +878,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/device/radio/headset/map_preset/skrellscoutship,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/quarters)
 "dl" = (
@@ -1564,6 +1565,10 @@
 /obj/item/weapon/storage/toolbox/electrical{
 	pixel_y = 6
 	},
+/obj/item/device/encryptionkey/map_preset/skrellscoutship,
+/obj/item/device/encryptionkey/map_preset/skrellscoutship,
+/obj/item/device/encryptionkey/map_preset/skrellscoutship,
+/obj/item/device/encryptionkey/map_preset/skrellscoutship,
 /turf/simulated/floor/carpet/magenta,
 /area/ship/skrellscoutship/wings/starboard)
 "fu" = (
@@ -3579,6 +3584,7 @@
 /obj/machinery/light/skrell{
 	dir = 4
 	},
+/obj/item/device/radio/headset/map_preset/skrellscoutship,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/quarters)
 "mx" = (
@@ -4369,6 +4375,7 @@
 /obj/item/clothing/accessory/storage/black_vest,
 /obj/item/weapon/gun/energy/gun/skrell,
 /obj/item/weapon/rig/skrell/cmd,
+/obj/item/device/radio/headset/map_preset/skrellscoutship,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/quarters)
 "zT" = (
@@ -4434,6 +4441,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/item/device/radio/headset/map_preset/skrellscoutship,
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/quarters)
 "Ap" = (

--- a/maps/away/verne/verne-3.dmm
+++ b/maps/away/verne/verne-3.dmm
@@ -82,6 +82,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/six)
 "ai" = (
@@ -356,6 +357,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/seven)
 "bt" = (
@@ -438,6 +440,11 @@
 	id = "professor_space";
 	pixel_y = 22
 	},
+/obj/item/device/radio/headset/map_preset/verne,
+/obj/item/device/encryptionkey/map_preset/verne,
+/obj/item/device/encryptionkey/map_preset/verne,
+/obj/item/device/encryptionkey/map_preset/verne,
+/obj/item/device/encryptionkey/map_preset/verne,
 /turf/simulated/floor/carpet/blue2,
 /area/verne/common/professor)
 "bE" = (
@@ -568,6 +575,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/three)
 "cu" = (
@@ -1396,6 +1404,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/five)
 "il" = (
@@ -1444,6 +1453,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/three)
 "iu" = (
@@ -2384,6 +2394,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/four)
 "rb" = (
@@ -2861,6 +2872,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room)
 "uP" = (
@@ -4244,6 +4256,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room)
 "GK" = (
@@ -4743,6 +4756,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/eight)
 "KT" = (
@@ -5063,6 +5077,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/eight)
 "NH" = (
@@ -5078,6 +5093,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/seven)
 "NM" = (
@@ -5225,6 +5241,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/five)
 "Pf" = (
@@ -5297,6 +5314,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/two)
 "Qa" = (
@@ -5372,6 +5390,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/four)
 "QO" = (
@@ -5813,6 +5832,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/six)
 "Uy" = (
@@ -6206,6 +6226,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/b_green/full,
+/obj/item/device/radio/headset/map_preset/verne,
 /turf/simulated/floor/tiled,
 /area/verne/common/room/two)
 "XS" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -84,6 +84,10 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/item/device/encryptionkey/map_preset/playablecolony,
+/obj/item/device/encryptionkey/map_preset/playablecolony,
+/obj/item/device/encryptionkey/map_preset/playablecolony,
+/obj/item/device/encryptionkey/map_preset/playablecolony,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/tcomms)
 "ao" = (
@@ -1541,6 +1545,7 @@
 /obj/item/clothing/suit/storage/toggle/hoodie/smw,
 /obj/item/device/radio/map_preset/playablecolony,
 /obj/structure/closet/cabinet,
+/obj/item/device/radio/headset/map_preset/playablecolony,
 /turf/simulated/floor/carpet,
 /area/map_template/colony/dorms)
 "dk" = (
@@ -2579,6 +2584,7 @@
 /obj/structure/closet/shipping_wall{
 	pixel_y = 34
 	},
+/obj/item/device/radio/headset/map_preset/playablecolony,
 /turf/simulated/floor/carpet,
 /area/map_template/colony/dorms)
 "eY" = (
@@ -3064,6 +3070,7 @@
 /obj/item/clothing/suit/storage/toggle/track/gcc,
 /obj/item/device/radio/map_preset/playablecolony,
 /obj/structure/closet/cabinet,
+/obj/item/device/radio/headset/map_preset/playablecolony,
 /turf/simulated/floor/carpet,
 /area/map_template/colony/dorms)
 "fN" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
@@ -327,6 +327,8 @@
 /obj/item/device/radio/map_preset/playablecolony2,
 /obj/item/device/radio/map_preset/playablecolony2,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/device/radio/headset/map_preset/playablecolony2,
+/obj/item/device/radio/headset/map_preset/playablecolony2,
 /turf/simulated/floor/tiled/techmaint,
 /area/map_template/colony2/ship)
 "eY" = (
@@ -339,6 +341,11 @@
 	pixel_x = -21;
 	req_access = newlist()
 	},
+/obj/item/device/encryptionkey/map_preset/playablecolony2,
+/obj/item/device/encryptionkey/map_preset/playablecolony2,
+/obj/item/device/encryptionkey/map_preset/playablecolony2,
+/obj/item/device/encryptionkey/map_preset/playablecolony2,
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/colony2/tcomms)
 "fp" = (
@@ -1370,6 +1377,8 @@
 /obj/item/device/radio/map_preset/playablecolony2,
 /obj/item/device/radio/map_preset/playablecolony2,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/device/radio/headset/map_preset/playablecolony2,
+/obj/item/device/radio/headset/map_preset/playablecolony2,
 /turf/simulated/floor/tiled/techmaint,
 /area/map_template/colony2/ship)
 "BI" = (


### PR DESCRIPTION
:cl:
map: Verne, skrell ship, and colonies now have spare headsets in their crew lockers and spare encryption keys for visitors.
/:cl: