### PR TITLE
Floor tile tweaks

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -120,16 +120,15 @@
 /obj/item/stack/tile/mono/dark
 	name = "dark mono tile"
 	singular_name = "dark mono tile"
-	icon_state = "tile"
+	icon_state = "fr_tile"
 	matter = list(MATERIAL_STEEL = 450)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
 /obj/item/stack/tile/mono/white
 	name = "white mono tile"
 	singular_name = "white mono tile"
-	icon_state = "tile"
-	matter = list(MATERIAL_STEEL = 450)
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	icon_state = "tile_white"
+	matter = list(MATERIAL_PLASTIC = 450)
 
 /obj/item/stack/tile/grid
 	name = "grey grid tile"
@@ -179,7 +178,8 @@
 	name = "dark floor tile"
 	singular_name = "dark floor tile"
 	icon_state = "fr_tile"
-	matter = list(MATERIAL_PLASTEEL = 450)
+	matter = list(MATERIAL_STEEL = 450)
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
 /obj/item/stack/tile/floor_dark/fifty
 	amount = 50

--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -71,6 +71,10 @@
 	title = "white floor tile"
 	result_type = /obj/item/stack/tile/floor_white
 
+/datum/stack_recipe/tile/light/mono
+	title = "white mono floor tile"
+	result_type = /obj/item/stack/tile/mono/white
+
 /datum/stack_recipe/tile/light/freezer
 	title = "freezer floor tile"
 	result_type = /obj/item/stack/tile/floor_freezer


### PR DESCRIPTION
- White monotiles can be crafted from plastic sheets
- Monotile item sprites corresponds with their color
- Dark floor tiles are now made of steel rather than plasteel

🆑 Pawn
tweak: Floor tile tweaks
/🆑