### PR TITLE
Increases the chances of vermin in random closets

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -430,7 +430,7 @@ obj/random/closet //A couple of random closets to spice up maint
 	desc = "This is a random closet."
 	icon = 'icons/obj/closets/bases/closet.dmi'
 	icon_state = "base"
-	var/vermin_chance = 0.1
+	var/vermin_chance = 5
 	var/list/locker_vermin = list(
 		/mob/living/simple_animal/mouse,
 		/mob/living/simple_animal/opossum,


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Increases the chance of vermin appearing in random maintenance closets.
/:cl:

Increases the chance from one in a thousand to one in twenty.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->