### PR TITLE
Fixes ruins causing Travis failures with lattices

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -112,11 +112,11 @@
 			plant.pixel_x = 0
 			plant.pixel_y = 0
 
-/turf/simulated/wall/ChangeTurf(var/newtype)
+/turf/simulated/wall/ChangeTurf(turf/N, tell_universe = TRUE, force_lighting_update = FALSE, keep_air = FALSE, ignore_lattice = FALSE)
 	clear_plants()
-	. = ..(newtype)
+	. = ..()
 	var/turf/new_turf = .
-	for (var/turf/simulated/wall/W in RANGE_TURFS(new_turf, 1))
+	for (var/turf/simulated/wall/W in RANGE_TURFS(N, 1))
 		if (W == src)
 			continue
 		W.update_connections()
@@ -189,7 +189,7 @@
 
 	return ..()
 
-/turf/simulated/wall/proc/dismantle_wall(var/devastated, var/explode, var/no_product)
+/turf/simulated/wall/proc/dismantle_wall(devastated, explode, no_product, ignore_lattice)
 
 	playsound(src, 'sound/items/Welder.ogg', 100, 1)
 	if(!no_product)
@@ -211,7 +211,7 @@
 	reinf_material = null
 	update_connections(1)
 
-	ChangeTurf(floor_type)
+	ChangeTurf(floor_type, ignore_lattice = ignore_lattice)
 
 /turf/simulated/wall/ex_act(severity)
 	switch(severity)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -17,7 +17,7 @@
 		above.update_mimic()
 
 //Creates a new turf
-/turf/proc/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
+/turf/proc/ChangeTurf(turf/N, tell_universe = TRUE, force_lighting_update = FALSE, keep_air = FALSE, ignore_lattice = FALSE)
 	if (!N)
 		return
 
@@ -69,7 +69,7 @@
 	if(ispath(N, /turf/simulated))
 		if(old_fire)
 			fire = old_fire
-		if (istype(W,/turf/simulated/floor))
+		if (!ignore_lattice && istype(W,/turf/simulated/floor))
 			W.RemoveLattice()
 	else if(old_fire)
 		qdel(old_fire)

--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -30,7 +30,7 @@
 /obj/effect/landmark/clear/Initialize()
 	var/turf/simulated/wall/W = get_turf(src)
 	if(istype(W))
-		W.dismantle_wall(1,1,1)
+		W.dismantle_wall(TRUE, TRUE, TRUE, TRUE)
 	var/turf/simulated/mineral/M = W
 	if(istype(M))
 		M.GetDrilled()


### PR DESCRIPTION
When exoplanet ruins clear a wall on the same turf that has a lattice mapped on it, changing the turf will have previously erroneously removed the lattice and causing Travis errors due to atoms being deleted before initialization has finished.
As these lattices were not supposed to be removed at all, an exception parameter for lattices got added to `ChangeTurf()` and `dismantle_wall()`.

In the long run, it might be worth considering if `ChangeTurf()` should handle the removal of lattices at all.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->