### PR TITLE
FTechs can no longer be black belts, SEA isn't an ace pilot.

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -91,7 +91,7 @@
 							 /datum/computer_file/program/reports)
 
 /datum/job/hop/get_description_blurb()
-	return "You are the Executive Officer. You are an experienced senior officer, second in command of the ship, and are responsible for the smooth operation of the ship under your Commanding Officer. In his absence, you are expected to take his place. Your primary duty is directly managing department heads and all those outside a department heading. You are also responsible for the contractors and passengers aboard the ship. Consider the Senior Enlisted Advisor and Bridge Officers tools at your disposal."
+	return "You are the Executive Officer. You are an experienced senior officer, second in command of the ship, and are responsible for the smooth operation of the ship under your Commanding Officer. In their absence, you are expected to take their place. Your primary duty is directly managing department heads and all those outside a department heading. You are also responsible for the contractors and passengers aboard the ship. Consider the Senior Enlisted Advisor and Bridge Officers tools at your disposal."
 
 /datum/job/rd
 	title = "Chief Science Officer"
@@ -333,9 +333,9 @@
 	                    SKILL_COMBAT     = SKILL_BASIC,
 	                    SKILL_WEAPONS    = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_COMBAT       = SKILL_EXPERT,
+	max_skill = list(	SKILL_PILOT        = SKILL_ADEPT, 
+	                    SKILL_COMBAT       = SKILL_EXPERT,
 	                    SKILL_WEAPONS      = SKILL_EXPERT,
-	                    SKILL_PILOT        = SKILL_MAX,
 	                    SKILL_CONSTRUCTION = SKILL_MAX,
 	                    SKILL_ELECTRICAL   = SKILL_MAX,
 	                    SKILL_ENGINES      = SKILL_MAX,

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -73,8 +73,8 @@
 	                    SKILL_WEAPONS     = SKILL_BASIC,
 	                    SKILL_FORENSICS   = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
-	                    SKILL_WEAPONS     = SKILL_MAX,
+	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT,
 	                    SKILL_FORENSICS   = SKILL_MAX)
 	skill_points = 20
 
@@ -115,7 +115,7 @@
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
 	                    SKILL_WEAPONS     = SKILL_MAX,
-	                    SKILL_FORENSICS   = SKILL_MAX)
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
 
 	access = list(access_security, access_brig, access_maint_tunnels,
 						access_external_airlocks, access_emergency_storage,


### PR DESCRIPTION
🆑
tweak: MAs are capped at expert forensics. FTechs are capped at expert weapons and CQC. SEA is capped at trained piloting.
tweak: Minor adjustment to XO job description; COs aren't all male.
/🆑

F-Techs are capped because they're not combat specialist but going as low as trained felt wrong. Similar theory applies to MAs- They aren't forensic specialists, but it's still their department.

Since SEA lost helm access, it makes little sense for them to have a master piloting cap.