### PR TITLE
Add stimulant chemical effect, nerf disarming a bit

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -50,6 +50,7 @@
 #define CE_SEDATE        "sedate"       // Applies sedation effects, i.e. paralysis, inability to use items, etc.
 #define CE_ENERGETIC     "energetic"    // Speeds up stamina recovery.
 #define	CE_VOICELOSS     "whispers"     // Lowers the subject's voice to a whisper
+#define CE_STIMULANT     "stimulants"   // Makes it harder to disarm someone
 
 //reagent flags
 #define IGNORE_MOB_SIZE 0x1

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -381,6 +381,7 @@
 	M.add_chemical_effect(CE_MIND, 2)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 20)
+	M.add_chemical_effect(CE_STIMULANT, 10)
 
 /datum/reagent/dylovene/venaxilin
 	name = "Venaxilin"
@@ -501,6 +502,7 @@
 		M.emote(pick("twitch", "blink_r", "shiver"))
 	M.add_chemical_effect(CE_SPEEDBOOST, 1)
 	M.add_chemical_effect(CE_PULSE, 3)
+	M.add_chemical_effect(CE_STIMULANT, 4)
 
 /datum/reagent/ethylredoxrazine
 	name = "Ethylredoxrazine"
@@ -911,6 +913,7 @@
 	else if(M.chem_doses[type] < 1)
 		M.add_chemical_effect(CE_PAINKILLER, min(10*volume, 20))
 	M.add_chemical_effect(CE_PULSE, 2)
+	M.add_chemical_effect(CE_STIMULANT, 2)
 	if(M.chem_doses[type] > 10)
 		M.make_jittery(5)
 	if(volume >= 5 && M.is_asystole())

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -624,6 +624,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 	var/skill_mod = 10 * attacker.get_skill_difference(SKILL_COMBAT, target)
 	var/state_mod = attacker.melee_accuracy_mods() - target.melee_accuracy_mods()
+	var/stim_mod = target.chem_effects[CE_STIMULANT]
 	var/push_mod = min(max(1 + attacker.get_skill_difference(SKILL_COMBAT, target), 1), 3)
 	if(target.a_intent == I_HELP)
 		state_mod -= 30
@@ -633,8 +634,8 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		if(prob(hurt_prob) && I.on_disarm_attempt(target, attacker))
 			return
 
-	var/randn = rand(1, 100) - skill_mod + state_mod
-	if(!(check_no_slip(target)) && randn <= 25)
+	var/randn = rand(1, 100) - skill_mod + state_mod - stim_mod
+	if(!(check_no_slip(target)) && randn <= 20)
 		var/armor_check = 100 * target.get_blocked_ratio(affecting, BRUTE, damage = 20)
 		target.apply_effect(push_mod, WEAKEN, armor_check)
 		playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
@@ -644,7 +645,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			target.visible_message("<span class='warning'>[attacker] attempted to push [target]!</span>")
 		return
 
-	if(randn <= 60)
+	if(randn <= 50)
 		//See about breaking grips or pulls
 		if(target.break_all_grabs(attacker))
 			playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)


### PR DESCRIPTION
Lowers the base check for pushing from 25 to 20. Lowers the base check for disarming from 60 to 50. This will hopefully punish those that rely on disarming too heavily while still making it semi-viable.

In addition, this adds a new chemical effect, CE_STIMULANT. Currently, adrenaline, synaptizine, and hyperzine are the only chemicals that add it (as they are the only chemicals that claim to be true stimulants). CE_STIMULANT is factored into the disarm chance, and every count of it the victim has will decrease the disarm chance by that amount. This is done to simulate having a far tighter grip on whatever you're holding when you're amped up on something like adrenaline. This also gives adrenaline a bit of an extra purpose inside combat (however slight it may be) and adds a further boost to the other combat drugs. Currently, adrenaline gives 2 chem effects, hyperzine 4, and synaptizine 10. Feedback on balancing this (assuming this is something that deserves to be added in the first place) would be appreciated.

I'm making this PR somewhat in response to a lot of criticism over disarm-spammers making fights boring and over quickly in the last few days as well as to add a bit more depth to mid-combat effects (since you will naturally get adrenaline during a fight).

:cl:
tweak: It is now slightly harder to disarm or push someone over.
rscadd: Adrenaline, hyperzine, and synaptizine have a new effect: it is now more difficult to disarm someone amped up on them.
/:cl: