### PR TITLE
resting tweaks

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -138,7 +138,7 @@
 	if (C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src
-	C.resting = 1
+	C.Weaken(5)
 	C.dropInto(loc)
 	src.add_fingerprint(user)
 	if(ishuman(C))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -251,7 +251,6 @@
 /obj/machinery/cryopod/Destroy()
 	if(occupant)
 		occupant.forceMove(loc)
-		occupant.resting = 1
 	. = ..()
 
 /obj/machinery/cryopod/Initialize()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -221,8 +221,6 @@
 			else if(lying || src.sleeping || player_triggered_sleeping)
 				src.player_triggered_sleeping = 0
 				src.sleeping = max(0,src.sleeping - 5)
-				if(src.sleeping == 0)
-					src.resting = 0
 				M.visible_message("<span class='notice'>[M] shakes [src] trying to wake [t_him] up!</span>", \
 									"<span class='notice'>You shake [src] trying to wake [t_him] up!</span>")
 			else

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -719,7 +719,7 @@ var/list/ai_verbs_default = list(
 	set name = "Rest"
 	set category = "IC"
 
-	resting = 0
+	resting = FALSE
 	var/obj/item/weapon/rig/rig = src.get_rig()
 	if(rig)
 		rig.force_rest(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 
 	// Move us into the card and move the card to the ground.
 	stop_pulling()
-	resting = 0
+	resting = FALSE
 
 	// If we are being held, handle removing our holder from their inv.
 	var/obj/item/weapon/holder/H = loc
@@ -246,7 +246,7 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 /mob/living/silicon/pai/lay_down()
 	// Pass lying down or getting up to our pet human, if we're in a rig.
 	if(istype(loc,/obj/item/device/paicard))
-		resting = 0
+		resting = FALSE
 		var/obj/item/weapon/rig/rig = get_rig()
 		if(istype(rig))
 			rig.force_rest(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -851,19 +851,6 @@
 	sleeping = max(sleeping + amount,0)
 	return
 
-/mob/proc/Resting(amount)
-	facing_dir = null
-	resting = max(max(resting,amount),0)
-	return
-
-/mob/proc/SetResting(amount)
-	resting = max(amount,0)
-	return
-
-/mob/proc/AdjustResting(amount)
-	resting = max(resting + amount,0)
-	return
-
 /mob/proc/get_species()
 	return ""
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -88,7 +88,7 @@
 	var/druggy = 0			//Carbon
 	var/confused = 0		//Carbon
 	var/sleeping = 0		//Carbon
-	var/resting = 0			//Carbon
+	var/resting = FALSE			//Carbon
 	var/lying = 0
 	var/lying_prev = 0
 

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -177,7 +177,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to return to this body! You can't change your mind so choose wisely!)", "Are you sure you want to ghost?", "Ghost", "Stay in body")
 		if(response != "Ghost")
 			return
-		resting = 1
 		log_and_message_admins("has ghosted.")
 		var/mob/observer/ghost/ghost = ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		if (ghost)


### PR DESCRIPTION
:cl:
tweak: You can't force someone intentionally lying down to stand up.
tweak: Operating tables apply a short forced weakened state instead of setting manual resting.
/:cl:

you can't force someone intentionally resting to stand up
optables weaken instead of setting resting
ghosts and deleted cryopods don't set resting
removed unused mob resting procs, since they wanted to treat it like a ticking state and it isn't
changed literal sets of resting to use truth macros
