### PR TITLE
bee smokers use a sprite that exists.

### DIFF
--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -221,7 +221,7 @@
 	name = "bee smoker"
 	desc = "A device used to calm down bees before harvesting honey."
 	icon = 'icons/obj/device.dmi'
-	icon_state = "battererburnt"
+	icon_state = "batterer"
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/honey_frame


### PR DESCRIPTION
:cl:
bugfix: The bee smoker uses a sprite that exists, so it no longer breaks in bags.
/:cl: