### PR TITLE
Tweaks the locations & names of shuttle navpoints; adjusts d4 EVA to fix desperado and ninja docking

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -988,18 +988,18 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "bC" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external{
-	density = 1;
-	dir = 4;
-	frequency = 1380;
-	id_tag = "merc_shuttle_outer";
-	name = "Ship External Access"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "merc_external"
+	},
+/obj/effect/paint/red,
+/turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "bD" = (
 /obj/machinery/door/airlock,

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -12544,7 +12544,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "EN" = (
-/obj/effect/shuttle_landmark/merc/hanger,
+/obj/effect/shuttle_landmark/merc/hanger{
+	name = "5th Deck, Aft Starboard"
+	},
 /turf/space,
 /area/space)
 "ER" = (
@@ -12681,7 +12683,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "FS" = (
-/obj/effect/shuttle_landmark/skipjack/hanger,
+/obj/effect/shuttle_landmark/skipjack/hanger{
+	name = "5th Deck, Starboard"
+	},
 /turf/space,
 /area/space)
 "FU" = (
@@ -13585,7 +13589,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "IW" = (
-/obj/effect/shuttle_landmark/ert/hanger,
+/obj/effect/shuttle_landmark/ert/hanger{
+	name = "5th Deck, Aft Port"
+	},
 /turf/space,
 /area/space)
 "IY" = (
@@ -17133,7 +17139,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Wb" = (
-/obj/effect/shuttle_landmark/ninja/hanger,
+/obj/effect/shuttle_landmark/ninja/hanger{
+	name = "5th Deck, Fore"
+	},
 /turf/space,
 /area/space)
 "Wg" = (

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -3,15 +3,21 @@
 /turf/space,
 /area/space)
 "ac" = (
-/obj/effect/shuttle_landmark/skipjack/deck4,
+/obj/effect/shuttle_landmark/skipjack/deck5{
+	name = "4th Deck, Aft Starboard"
+	},
 /turf/space,
 /area/space)
 "ad" = (
-/obj/effect/shuttle_landmark/torch/deck1/guppy,
+/obj/effect/shuttle_landmark/torch/deck5/guppy{
+	name = "4th Deck, Starboard"
+	},
 /turf/space,
 /area/space)
 "ae" = (
-/obj/effect/shuttle_landmark/merc/deck4,
+/obj/effect/shuttle_landmark/merc/deck5{
+	name = "4th Deck, Fore Starboard"
+	},
 /turf/space,
 /area/space)
 "af" = (
@@ -342,7 +348,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
 "bn" = (
-/obj/effect/shuttle_landmark/torch/deck1/exploration_shuttle,
+/obj/effect/shuttle_landmark/torch/deck5/aquila{
+	name = "4th Deck, Aft"
+	},
 /turf/space,
 /area/space)
 "bo" = (
@@ -1337,6 +1345,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
+"ew" = (
+/obj/structure/sign/warning/airlock{
+	dir = 4;
+	icon_state = "doors"
+	},
+/turf/simulated/wall/r_wall/hull,
+/area/eva)
 "ex" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -2880,6 +2895,12 @@
 	id_tag = "eva_pump"
 	},
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "eva_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "kc" = (
@@ -3064,9 +3085,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
 "kP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "eva_pump"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
@@ -3173,6 +3204,36 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/auxillary/starboard)
+"lc" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "EVA - Center";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "ld" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3349,6 +3410,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "lU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "eva_pump"
@@ -3356,17 +3423,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
 	icon_state = "techfloor_edges"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
-	id_tag = "eva_airlock";
-	name = "EVA Airlock Console";
-	pixel_y = 24;
-	req_access = list("ACCESS_EVA");
-	tag_airpump = "eva_pump";
-	tag_chamber_sensor = "eva_sensor";
-	tag_exterior_door = "eva_outer";
-	tag_interior_door = "eva_inner"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
@@ -4704,41 +4760,23 @@
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
 "qJ" = (
-/obj/structure/sign/warning/airlock{
-	dir = 4;
-	icon_state = "doors"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "eva_pump"
 	},
-/turf/simulated/wall/r_wall/hull,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "qQ" = (
-/obj/structure/table/rack{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "eva_outer";
+	locked = 1;
+	name = "EVA External Access"
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Center";
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/shuttle_landmark/scavver_gantry/torch/two,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "qR" = (
 /turf/simulated/floor/tiled,
@@ -5068,20 +5106,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
 "sk" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "eva_inner";
-	locked = 1;
-	name = "EVA Internal Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/eva)
-"sl" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1380;
@@ -5091,13 +5115,19 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_EVA")
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
+"sl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
 	icon_state = "map"
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/eva)
 "sm" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -5799,35 +5829,14 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
-"tL" = (
-/obj/effect/shuttle_landmark/torch/deck1/aquila,
-/turf/space,
-/area/space)
 "tO" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = -3
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/eva)
 "tP" = (
 /obj/structure/cable/green{
@@ -6642,6 +6651,31 @@
 "vK" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/deckchief)
+"vO" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = -3
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/eva)
 "vQ" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/office)
@@ -6791,10 +6825,6 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/eva)
-"wB" = (
-/obj/effect/wallframe_spawn/no_grille,
-/turf/simulated/wall/prepainted,
 /area/eva)
 "wC" = (
 /obj/structure/cable/green{
@@ -6984,14 +7014,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/aft)
 "xb" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "eva_outer";
-	locked = 1;
-	name = "EVA External Access"
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
 	},
-/obj/effect/shuttle_landmark/scavver_gantry/torch/two,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "xi" = (
@@ -7894,15 +7920,20 @@
 	dir = 2;
 	id_tag = "eva_pump"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
 	icon_state = "techfloor_edges"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1380;
+	id_tag = "eva_airlock";
+	name = "EVA Airlock Console";
+	pixel_y = 24;
+	req_access = list("ACCESS_EVA");
+	tag_airpump = "eva_pump";
+	tag_chamber_sensor = "eva_sensor";
+	tag_exterior_door = "eva_outer";
+	tag_interior_door = "eva_inner"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
@@ -9505,10 +9536,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod8/station)
-"GA" = (
-/obj/effect/shuttle_landmark/ninja/deck1,
-/turf/space,
-/area/space)
 "GB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -10251,17 +10278,15 @@
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/aft)
 "Jn" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "eva_pump"
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "eva_sensor";
-	pixel_x = 0;
-	pixel_y = -25
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "Jo" = (
@@ -10599,7 +10624,9 @@
 /turf/space,
 /area/space)
 "Kp" = (
-/obj/effect/shuttle_landmark/ert/deck1,
+/obj/effect/shuttle_landmark/ert/deck5{
+	name = "4th Deck, Fore Port"
+	},
 /turf/space,
 /area/space)
 "Kq" = (
@@ -11017,15 +11044,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
 "LD" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "eva_inner";
+	locked = 1;
+	name = "EVA Internal Access"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "eva_pump"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
 	},
-/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "LG" = (
@@ -12763,22 +12792,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "QB" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/shuttle_landmark/ninja/deck5{
+	name = "4th Deck, Fore Dock"
 	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/eva)
+/turf/space,
+/area/space)
 "QC" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -21096,7 +21114,7 @@ aa
 aa
 aa
 aa
-GA
+aa
 aa
 aa
 aa
@@ -23510,7 +23528,7 @@ aa
 aa
 aa
 aa
-aa
+QB
 aa
 aa
 aa
@@ -24719,11 +24737,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+zj
+zj
+qQ
+ew
+zj
 aa
 aa
 aa
@@ -24915,14 +24933,14 @@ aa
 aa
 aa
 aa
-zj
+aa
 zj
 Mc
 zj
 zj
 zj
 zj
-zj
+kP
 xb
 qJ
 zj
@@ -24931,7 +24949,7 @@ zj
 zj
 Mc
 zj
-zj
+aa
 aa
 aa
 aa
@@ -25123,11 +25141,11 @@ zj
 tJ
 gf
 Od
-Dd
+zj
 Am
-kP
+oK
 ka
-Dd
+zj
 pl
 LT
 JD
@@ -25325,11 +25343,11 @@ Yb
 HS
 HS
 os
-Dd
+zj
 lU
 oK
 Jn
-Dd
+zj
 wx
 Iw
 Ci
@@ -25527,11 +25545,11 @@ Kk
 tH
 kc
 gx
-Dd
-QB
-oK
+zj
+zj
 LD
-Dd
+zj
+zj
 Ea
 VI
 ut
@@ -25730,9 +25748,9 @@ Dd
 Dd
 Rp
 Dd
-Dd
+lc
 sk
-Dd
+vO
 Dd
 SZ
 Dd
@@ -25932,7 +25950,7 @@ Pq
 ng
 fX
 SH
-qQ
+qR
 sl
 tO
 Fj
@@ -26744,7 +26762,7 @@ ng
 so
 ng
 ng
-wB
+ng
 Dd
 Dd
 Dd
@@ -44270,7 +44288,7 @@ aa
 aa
 aa
 aa
-ac
+aa
 aa
 aa
 aa
@@ -45689,7 +45707,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 aa
 aa
 aa
@@ -47326,7 +47344,7 @@ aa
 aa
 aa
 aa
-bn
+aa
 aa
 aa
 aa
@@ -48745,7 +48763,7 @@ aa
 aa
 aa
 aa
-aa
+bn
 aa
 aa
 aa
@@ -52191,7 +52209,7 @@ aa
 aa
 aa
 aa
-tL
+aa
 aa
 aa
 aa

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3274,18 +3274,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "gE" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id_tag = "d3fore_shutters";
-	name = "Blast Shields";
-	opacity = 0
+/obj/effect/shuttle_landmark/ninja/deck4{
+	name = "3rd Deck, Aft"
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/observation)
+/turf/space,
+/area/space)
 "gF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -9556,18 +9549,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/habcheck)
 "uO" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "d3aft_shutters";
-	name = "Blast Shields";
-	opacity = 0
+/obj/effect/shuttle_landmark/torch/deck4/exploration_shuttle{
+	name = "3rd Deck, Fore Port"
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/turf/space,
+/area/space)
 "uP" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/sleep/cryo)
@@ -12328,6 +12314,19 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
+"Di" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "d3fore_shutters";
+	name = "Blast Shields";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/observation)
 "Dj" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -15818,7 +15817,9 @@
 /turf/simulated/floor/wood/maple,
 /area/chapel/main)
 "LN" = (
-/obj/effect/shuttle_landmark/skipjack/deck3,
+/obj/effect/shuttle_landmark/skipjack/deck4{
+	name = "3rd Deck, Aft Port"
+	},
 /turf/space,
 /area/space)
 "LO" = (
@@ -15936,7 +15937,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
 "Mb" = (
-/obj/effect/shuttle_landmark/ert/deck3,
+/obj/effect/shuttle_landmark/ert/deck4{
+	name = "3rd Deck, Starboard"
+	},
 /turf/space,
 /area/space)
 "Mf" = (
@@ -16230,7 +16233,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "Nb" = (
-/obj/effect/shuttle_landmark/merc/deck3,
+/obj/effect/shuttle_landmark/merc/deck4{
+	name = "3rd Deck, Port"
+	},
 /turf/space,
 /area/space)
 "Nc" = (
@@ -16520,7 +16525,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/thruster/d3port)
 "Ob" = (
-/obj/effect/shuttle_landmark/torch/deck2/aquila,
+/obj/effect/shuttle_landmark/torch/deck4/aquila{
+	name = "3rd Deck, Fore"
+	},
 /turf/space,
 /area/space)
 "Oc" = (
@@ -16870,10 +16877,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/gym)
-"Pb" = (
-/obj/effect/shuttle_landmark/torch/deck2/exploration_shuttle,
-/turf/space,
-/area/space)
 "Pc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -17175,10 +17178,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/thruster/d3starboard)
-"Qb" = (
-/obj/effect/shuttle_landmark/ninja/deck3,
-/turf/space,
-/area/space)
 "Qd" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4;
@@ -17505,10 +17504,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
-"Rb" = (
-/obj/effect/shuttle_landmark/torch/deck2/guppy,
-/turf/space,
-/area/space)
 "Re" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25424,7 +25419,7 @@ aa
 aa
 aa
 aa
-Pb
+aa
 aa
 aa
 aa
@@ -26061,7 +26056,7 @@ aa
 aa
 aa
 aa
-aa
+uO
 aa
 aa
 aa
@@ -28846,8 +28841,8 @@ ZN
 ZN
 aa
 aa
-qx
-gE
+Di
+Di
 BQ
 Fn
 YB
@@ -28859,8 +28854,8 @@ Vt
 BQ
 Fn
 YB
-gE
-qx
+Di
+Di
 aa
 aa
 BV
@@ -29048,7 +29043,7 @@ ZN
 ZN
 aa
 aa
-gE
+Di
 lV
 Yr
 ZU
@@ -29062,7 +29057,7 @@ Yr
 Yr
 Yr
 np
-gE
+Di
 aa
 aa
 BV
@@ -34753,7 +34748,7 @@ aa
 aa
 aa
 aa
-Nb
+aa
 aa
 aa
 aa
@@ -37788,7 +37783,7 @@ aa
 aa
 aa
 aa
-aa
+Nb
 aa
 aa
 aa
@@ -45857,7 +45852,7 @@ aa
 aa
 aa
 aa
-Rb
+aa
 aa
 aa
 aa
@@ -47232,13 +47227,13 @@ aT
 aI
 aI
 aI
-uO
+Su
 Su
 rB
 sX
 uo
 Su
-uO
+Su
 aI
 aI
 aI
@@ -53700,7 +53695,7 @@ aa
 aa
 aa
 aa
-aa
+gE
 aa
 aa
 aa
@@ -55719,7 +55714,7 @@ aa
 aa
 aa
 aa
-Qb
+aa
 aa
 aa
 aa

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -3644,6 +3644,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"gX" = (
+/obj/effect/shuttle_landmark/merc/deck3{
+	name = "2nd Deck, Aft"
+	},
+/turf/space,
+/area/space)
 "gY" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/extinguisher_cabinet{
@@ -7361,6 +7367,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
+"qu" = (
+/obj/effect/shuttle_landmark/torch/deck3/aquila{
+	name = "2nd Deck, Aft Port"
+	},
+/turf/space,
+/area/space)
 "qv" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/drone_fabrication)
@@ -13249,20 +13261,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_bay)
-"FP" = (
-/obj/effect/shuttle_landmark/merc/deck2,
-/turf/space,
-/area/space)
 "FS" = (
-/obj/effect/shuttle_landmark/skipjack/deck2,
+/obj/effect/shuttle_landmark/skipjack/deck3{
+	name = "2nd Deck, Fore Port"
+	},
 /turf/space,
 /area/space)
 "FT" = (
-/obj/effect/shuttle_landmark/torch/deck3/exploration_shuttle,
-/turf/space,
-/area/space)
-"FU" = (
-/obj/effect/shuttle_landmark/torch/deck3/aquila,
+/obj/effect/shuttle_landmark/torch/deck3/exploration_shuttle{
+	name = "2nd Deck, Port"
+	},
 /turf/space,
 /area/space)
 "FV" = (
@@ -13279,7 +13287,9 @@
 /turf/simulated/wall/r_wall/hull,
 /area/space)
 "Gb" = (
-/obj/effect/shuttle_landmark/torch/deck3/guppy,
+/obj/effect/shuttle_landmark/torch/deck3/guppy{
+	name = "2nd Deck, Fore"
+	},
 /turf/space,
 /area/space)
 "Gd" = (
@@ -14577,7 +14587,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/bluespace)
 "Kb" = (
-/obj/effect/shuttle_landmark/ert/deck2,
+/obj/effect/shuttle_landmark/ert/deck3{
+	name = "2nd Deck, Fore Starboard"
+	},
 /turf/space,
 /area/space)
 "Kc" = (
@@ -14812,7 +14824,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
 "Lb" = (
-/obj/effect/shuttle_landmark/ninja/deck2,
+/obj/effect/shuttle_landmark/ninja/deck3{
+	name = "2nd Deck, Aft Starboard"
+	},
 /turf/space,
 /area/space)
 "Lc" = (
@@ -43459,7 +43473,7 @@ aa
 aa
 aa
 aa
-FU
+aa
 aa
 aa
 aa
@@ -48297,7 +48311,7 @@ aa
 aa
 aa
 aa
-aa
+qu
 aa
 aa
 aa
@@ -50710,7 +50724,7 @@ aa
 aa
 aa
 aa
-FP
+aa
 aa
 aa
 aa
@@ -52314,7 +52328,7 @@ aa
 aa
 aa
 aa
-aa
+gX
 aa
 aa
 aa

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -3,15 +3,21 @@
 /turf/space,
 /area/space)
 "aab" = (
-/obj/effect/shuttle_landmark/torch/deck4/aquila,
+/obj/effect/shuttle_landmark/merc/deck2{
+	name = "1st Deck, Aft Starboard"
+	},
 /turf/space,
 /area/space)
 "aac" = (
-/obj/effect/shuttle_landmark/merc/deck1,
+/obj/effect/shuttle_landmark/torch/deck2/exploration_shuttle{
+	name = "1st Deck, Fore Starboard"
+	},
 /turf/space,
 /area/space)
 "aad" = (
-/obj/effect/shuttle_landmark/torch/deck4/exploration_shuttle,
+/obj/effect/shuttle_landmark/torch/deck2/guppy{
+	name = "1st Deck, Aft"
+	},
 /turf/space,
 /area/space)
 "aae" = (
@@ -109,7 +115,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/fuelbay/aux)
 "aar" = (
-/obj/effect/shuttle_landmark/skipjack/deck1,
+/obj/effect/shuttle_landmark/skipjack/deck2{
+	name = "1st Deck, Fore"
+	},
 /turf/space,
 /area/space)
 "aas" = (
@@ -8491,7 +8499,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/armoury/access)
 "azV" = (
-/obj/effect/shuttle_landmark/torch/deck4/guppy,
+/obj/effect/shuttle_landmark/ert/deck2{
+	name = "1st Deck, Fore Port"
+	},
 /turf/space,
 /area/space)
 "aAb" = (
@@ -14547,11 +14557,15 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "aWn" = (
-/obj/effect/shuttle_landmark/ert/deck4,
+/obj/effect/shuttle_landmark/ninja/deck2{
+	name = "1st Deck, Aft Port"
+	},
 /turf/space,
 /area/space)
 "aWo" = (
-/obj/effect/shuttle_landmark/ninja/deck4,
+/obj/effect/shuttle_landmark/torch/deck2/aquila{
+	name = "1st Deck, Port"
+	},
 /turf/space,
 /area/space)
 "aXb" = (
@@ -35040,7 +35054,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aar
 aaa
 aaa
 aaa
@@ -35816,7 +35830,7 @@ aaa
 aaa
 aaa
 aaa
-aar
+aaa
 aaa
 aaa
 aaa
@@ -36691,7 +36705,7 @@ aaa
 aaa
 aaa
 aaa
-aWn
+aaa
 aaa
 aaa
 aaa
@@ -38717,7 +38731,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+azV
 aaa
 aaa
 aaa
@@ -39843,7 +39857,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aac
 aaa
 aaa
 aaa
@@ -44288,7 +44302,7 @@ aaa
 aaa
 aaa
 aaa
-aad
+aaa
 aaa
 aaa
 aaa
@@ -45990,7 +46004,7 @@ aaa
 aaa
 aaa
 aaa
-aWo
+aaa
 aaa
 aaa
 aaa
@@ -47610,7 +47624,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aWo
 aaa
 aaa
 aaa
@@ -50338,7 +50352,7 @@ aaa
 aaa
 aaa
 aaa
-aab
+aaa
 aaa
 aaa
 aaa
@@ -59321,7 +59335,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aWn
 aaa
 aaa
 aaa
@@ -59638,7 +59652,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aab
 aaa
 aaa
 aaa
@@ -61859,7 +61873,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+aaa
 aaa
 aaa
 aaa
@@ -63116,7 +63130,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aad
 aaa
 aaa
 aaa
@@ -64330,7 +64344,7 @@ aaa
 aaa
 aaa
 aaa
-azV
+aaa
 aaa
 aaa
 aaa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3574,6 +3574,12 @@
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"gl" = (
+/obj/effect/shuttle_landmark/torch/deck1/exploration_shuttle{
+	name = "B-Deck, Fore Port"
+	},
+/turf/space,
+/area/space)
 "gm" = (
 /turf/unsimulated/mask,
 /area/hallway/primary/bridge/aft)
@@ -10023,16 +10029,16 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
-"yz" = (
-/obj/effect/shuttle_landmark/torch/deck5/exploration_shuttle,
-/turf/space,
-/area/space)
 "yA" = (
-/obj/effect/shuttle_landmark/skipjack/deck5,
+/obj/effect/shuttle_landmark/skipjack/deck1{
+	name = "B-Deck, Port"
+	},
 /turf/space,
 /area/space)
 "yB" = (
-/obj/effect/shuttle_landmark/ninja/deck5,
+/obj/effect/shuttle_landmark/torch/deck1/guppy{
+	name = "B-Deck, Aft Starboard"
+	},
 /turf/space,
 /area/space)
 "yD" = (
@@ -10095,7 +10101,9 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
 "zb" = (
-/obj/effect/shuttle_landmark/torch/deck5/guppy,
+/obj/effect/shuttle_landmark/merc/deck1{
+	name = "B-Deck, Aft"
+	},
 /turf/space,
 /area/space)
 "zc" = (
@@ -10346,7 +10354,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "Ab" = (
-/obj/effect/shuttle_landmark/merc/deck5,
+/obj/effect/shuttle_landmark/ninja/deck1{
+	name = "B-Deck, Aft Port"
+	},
 /turf/space,
 /area/space)
 "Ac" = (
@@ -10826,7 +10836,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Cb" = (
-/obj/effect/shuttle_landmark/torch/deck5/aquila,
+/obj/effect/shuttle_landmark/torch/deck1/aquila{
+	name = "B-Deck, Fore Starboard"
+	},
 /turf/space,
 /area/space)
 "Cc" = (
@@ -15181,7 +15193,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "UU" = (
-/obj/effect/shuttle_landmark/ert/deck5,
+/obj/effect/shuttle_landmark/ert/deck1{
+	name = "B-Deck, Fore"
+	},
 /turf/space,
 /area/space)
 "UW" = (
@@ -21327,7 +21341,7 @@ aa
 aa
 aa
 aa
-aa
+gl
 aa
 aa
 aa
@@ -22339,7 +22353,7 @@ aa
 aa
 aa
 aa
-yz
+aa
 aa
 aa
 aa
@@ -42347,7 +42361,7 @@ aa
 aa
 aa
 aa
-yB
+aa
 aa
 aa
 aa
@@ -42460,7 +42474,7 @@ aa
 aa
 aa
 aa
-aa
+yB
 aa
 aa
 aa
@@ -43873,7 +43887,6 @@ aa
 aa
 aa
 aa
-zb
 aa
 aa
 aa
@@ -43886,44 +43899,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-aa
-aa
-aa
-aa
-aa
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
 aa
 aa
 aa
@@ -43944,10 +43919,49 @@ aa
 aa
 aa
 aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 aa
 aa
 aa
 aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ab
 aa
 aa
 aa
@@ -47346,7 +47360,7 @@ aa
 aa
 aa
 aa
-aa
+zb
 aa
 aa
 aa
@@ -50174,7 +50188,7 @@ aa
 aa
 aa
 aa
-Ab
+aa
 aa
 aa
 aa


### PR DESCRIPTION
🆑
maptweak: Navpoints around the Torch are renamed to better indicate location, and moved to avoid some of the accidental spacing incidents prone to some ships.
maptweak: Desperado & D4 EVA slightly adjusted to allow the Desperado to "dock".
/🆑

