### PR TITLE
chat markup is config

### DIFF
--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -152,15 +152,15 @@
 	var/key_name = plain_key_name(src)
 	return usr != src ? "[key_name] - usr: [plain_key_name(usr)]" : key_name
 
-/proc/sanitize_and_communicate(channel_type, communicator, message, list/ignore_tags)
+/proc/sanitize_and_communicate(channel_type, communicator, message)
 	message = sanitize(message)
-	message = process_chat_markup(message, ignore_tags)
 	return communicate(arglist(args))
 
 /proc/communicate(var/channel_type, var/communicator, var/message)
 	var/list/channels = decls_repository.get_decls_of_subtype(/decl/communication_channel)
 	var/decl/communication_channel/channel = channels[channel_type]
 
+	message = process_chat_markup(message)
 	var/list/new_args = list(communicator, message)
 	new_args += args.Copy(4)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -375,6 +375,15 @@ RADIATION_LOWER_LIMIT 0.15
 ## Clients will be unable to connect unless their build is equal to or higher than this (a number, e.g. 1000)
 #MINIMUM_BYOND_BUILD
 
+## Uncomment or create lines to add user-accessible chat markup
+## A chat markup line is in the form regex;start;end. The regular expression should have a SINGLE capture group
+## and be in the common /matcher/flags format. Start and end are inserted around the capture group, and the rest of
+## any match is discarded. The provided examples provide /italics/, *bold*, and _underline_ respectively. Using
+## multiple or complex markup options can get strange - do it at your own risk.
+#CHAT_MARKUP /\/([^\/]*)\//g;<i>;</i>
+#CHAT_MARKUP /\*([^\*]*)\*/g;<b>;</b>
+#CHAT_MARKUP /_([^_]*)_/g;<u>;</u>
+
 ## Prevents matching messages from being sent on any communication channel
 ## The provided example forbids byond:// and http/https:// unless followed by a permitted domain.
 #FORBIDDEN_MESSAGE_REGEX /((https?)|(byond)):\/\/(?!(.*\.)?baystation12\.net)/i


### PR DESCRIPTION
Moves chat markup to config. Adds example config entries for italics bold and underline. Moves chat markup processing to communicate. Removes the unused ignored tags argument, unbreaking dsay.

Also pulls the text to regex thing out of forbidden_message_regex as `/proc/text2regex(text)`. Uses it for the chat_markup thing.

I don't actually intend to turn on anything but italics, the others are just there to make it clear that it's a repeatable config option.