### PR TITLE
Thermal implants aren't Implants

### DIFF
--- a/code/modules/clothing/glasses/thermals.dm
+++ b/code/modules/clothing/glasses/thermals.dm
@@ -40,8 +40,8 @@
 	body_parts_covered = 0
 
 /obj/item/clothing/glasses/thermal/plain/jensen
-	name = "optical thermal implants"
+	name = "adhesive thermal lenses"
 	gender = PLURAL
-	desc = "A set of implantable lenses designed to augment your vision."
+	desc = "A set of deployable thermal lenses that adhere to the eyebrows. Cool looking, probably."
 	icon_state = "thermalimplants"
 	item_state = "syringe_kit"


### PR DESCRIPTION
🆑
tweak: The Jensen shades no longer describe themselves at implants when they're worn like glasses.
/🆑

Open to changing the new name/description. Was the first thing that came to my mind - partially just calls attention to this if people want to make them into an augment.