### PR TITLE
Fix Paint Sprayer "Reset decal" being affected by floor decal limit

### DIFF
--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -200,7 +200,7 @@
 		to_chat(user, SPAN_WARNING("\The [src] flashes an error light. You might need to reconfigure it."))
 		return FALSE
 
-	if(F.decals && F.decals.len > 5)
+	if((F.decals && F.decals.len > 5) && !ispath(painting_decal, /obj/effect/floor_decal/reset))
 		to_chat(user, SPAN_WARNING("\The [F] has been painted too much; you need to clear it off."))
 		return FALSE
 


### PR DESCRIPTION
:cl:
bugfix: The paint-sprayer can now correctly clear decals off of floor tiles that have hit the decals limit (currently 5).
/:cl: