### PR TITLE
Consistent suits

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -8775,7 +8775,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/suit_storage_unit/atmos/alt/sol,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},


### PR DESCRIPTION
🆑
maptweak: Engineering no longer has two different types of atmospheric suit cycler.
/🆑

The suit cycler in atmospherics was the old atmos suit cycler instead of the torch-specific cycler. It's been changed.
