### PR TITLE
Make athletics more expensive

### DIFF
--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -146,6 +146,19 @@ GLOBAL_LIST_EMPTY(skills)
 						"Experienced"		= "You have experience with heavy work in trying physical conditions, and are in excellent shape. You visit the gym frequently.",
 						"Master"		= "In addition to your excellent strength and endurance, you have a lot of experience with the specific physical demands of your job. You may have competitive experience with some form of athletics.")
 
+/decl/hierarchy/skill/general/hauling/get_cost(var/level)
+	switch(level)
+		if(SKILL_BASIC)
+			return difficulty
+		if(SKILL_ADEPT)
+			return 2*difficulty
+		if(SKILL_EXPERT)
+			return 3*difficulty
+		if(SKILL_PROF)
+			return 4*difficulty
+		else
+			return 0
+
 /decl/hierarchy/skill/general/computer
 	ID = "computer"
 	name = "Information Technology"


### PR DESCRIPTION
Let's face it, it's practically the meta that if you don't take at least trained athletics you're "wasting" your skill points. But it's a horrible meta; experienced/master athletics puts you on par with literal bodybuilders and triathletes, and there's no way that everyone on the ship can run a marathon in only 2 hours. This helps to dissuade people from automatically picking it for all their characters while still making it available for those who really, really need their endurance for whatever reason.

Basic: 1 -> 1
Trained: 1 -> 2
Experienced: 2 -> 3
Master: 2 - > 4

:cl:
tweak: The Athletics skill now takes more skill points at the higher levels; Trained is 2 points instead of 1, Experienced is 3 points instead of 2, and Master is 4 points instead of 2.
/:cl: