### PR TITLE
Gives EC/Fleet basic athletics

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -133,7 +133,8 @@
 
 	assistant_job = /datum/job/crew
 
-	min_skill = list(	SKILL_SCIENCE = SKILL_BASIC,
+	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
+						SKILL_SCIENCE = SKILL_BASIC,
 						SKILL_EVA     = SKILL_BASIC)
 
 /datum/mil_branch/fleet
@@ -186,7 +187,8 @@
 	)
 
 	assistant_job = /datum/job/crew
-	min_skill = list(	SKILL_WEAPONS = SKILL_BASIC,
+	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
+						SKILL_WEAPONS = SKILL_BASIC,
 						SKILL_EVA     = SKILL_BASIC)
 
 /datum/mil_branch/army


### PR DESCRIPTION
Play a branch with some prerequisites, get simple skill.
🆑 
rscadd: Exploratory Corps and Fleet now get Basic Athletics for free.
/:cl:
With how awful skills are balanced atm, I'd expect this to get denied based on skill balance concerns.
If it matters, I believe having real-life skills based on background conditions given by _default_ should make Skill balance concerns easier to handle in the future.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->