### PR TITLE
Removes the exploration radio channel; gives relevant personnel science

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -1,7 +1,7 @@
 /obj/item/device/encryptionkey/heads/torchexec
 	name = "executive encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1, "Hailing" = 1)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/headset_torchnt
 	name = "corporate radio encryption key"
@@ -11,7 +11,7 @@
 /obj/item/device/encryptionkey/headset_torchrd
 	name = "chief science officer radio encryption key"
 	icon_state = "nt_cypherkey"
-	channels = list("Science" = 1, "Command" = 1, "Exploration" = 1, "Hailing" = 1)
+	channels = list("Science" = 1, "Command" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/headset_torchcorp
 	name = "corporate radio encryption key"
@@ -26,43 +26,43 @@
 /obj/item/device/encryptionkey/headset_deckofficer
 	name = "deck chief's encryption key"
 	icon_state = "qm_cypherkey"
-	channels = list("Supply" = 1, "Command" = 1, "Exploration" = 1, "Hailing" = 1)
+	channels = list("Supply" = 1, "Command" = 1, "Science" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/bridgeofficer
 	name = "bridge officer's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Supply" = 1, "Service" = 1, "Science" = 1, "Hailing" = 1)
+	channels = list("Command" = 1, "Engineering" = 1, "Supply" = 1, "Service" = 1, "Science" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/heads/ai_integrated
 	name = "ai integrated encryption key"
 	desc = "Integrated encryption key."
 	icon_state = "cap_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1, "AI Private" = 1, "Hailing" = 1)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/exploration
-	name = "exploration radio encryption key"
+	name = "explorer encryption key"
 	icon_state = "srv_cypherkey"
-	channels = list("Exploration" = 1, "Hailing" = 1)
+	channels = list("Science" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/headset_pilot
 	name = "pilot radio encryption key"
 	icon_state = "srv_cypherkey"
-	channels = list("Exploration" = 1, "Supply" = 1, "Science" = 1, "Hailing" = 1)
+	channels = list("Supply" = 1, "Science" = 1, "Hailing" = 1)
 
 /obj/item/device/encryptionkey/headset_mining
 	name = "prospector radio encryption key"
 	icon_state = "srv_cypherkey"
-	channels = list("Exploration" = 1, "Supply" = 1)
+	channels = list("Supply" = 1)
 
 /obj/item/weapon/storage/box/encryptionkey/exploration
-	name = "box of spare exploration radio keys"
-	desc = "A box full of exploration department radio keys."
+	name = "box of spare explorer radio keys"
+	desc = "A box full of explorer-issue radio keys."
 	startswith = list(/obj/item/weapon/screwdriver, /obj/item/device/encryptionkey/exploration = 5)
 
 /obj/item/device/encryptionkey/pathfinder
 	name = "pathfinder's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Exploration" = 1, "Command" = 1, "Science" = 1, "Hailing" = 1)
+	channels = list("Command" = 1, "Science" = 1, "Hailing" = 1)
 
 /obj/item/weapon/storage/box/radiokeys
 	name = "box of radio encryption keys"
@@ -79,4 +79,4 @@
 /obj/item/device/encryptionkey/heads/sea
 	name = "senior enlisted advisor's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1, "Hailing" = 1)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "Hailing" = 1)

--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -17,30 +17,23 @@
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub", "relay", "c_relay", "s_relay", "m_relay", "r_relay", "b_relay", "1_relay", "2_relay", "3_relay", "4_relay", "5_relay", "s_relay", "science", "medical",
-	"supply", "service", "common", "command", "engineering", "security", "exploration", "unused",
+	"supply", "service", "common", "command", "engineering", "security", "unused",
  	"receiverA", "broadcasterA")
 
 /obj/machinery/telecomms/receiver/preset_right
-	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, EXP_FREQ, MED_I_FREQ, SEC_I_FREQ)
+	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, MED_I_FREQ, SEC_I_FREQ)
 
 /obj/machinery/telecomms/bus/preset_two
 	freq_listening = list(SUP_FREQ, SRV_FREQ, EXP_FREQ)
-	autolinkers = list("processor2", "supply", "service", "exploration", "unused")
+	autolinkers = list("processor2", "supply", "service", "unused")
 
 /obj/machinery/telecomms/server/presets/service
-	id = "Service and Exploration Server"
-	freq_listening = list(SRV_FREQ, EXP_FREQ)
+	id = "Service Server"
+	freq_listening = list(SRV_FREQ)
 	channel_tags = list(
 		list(SRV_FREQ, "Service", COMMS_COLOR_SERVICE),
-		list(EXP_FREQ, "Exploration", COMMS_COLOR_EXPLORER)
 	)
-	autolinkers = list("service", "exploration")
-
-/obj/machinery/telecomms/server/presets/exploration
-	id = "Utility Server"
-	freq_listening = list(EXP_FREQ)
-	channel_tags = list(list(EXP_FREQ, "Exploration", COMMS_COLOR_EXPLORER))
-	autolinkers = list("Exploration")
+	autolinkers = list("service")
 
 // Suit cyclers and storage
 /obj/machinery/suit_cycler/exploration


### PR DESCRIPTION
🆑
tweak: Explorers now use the science radio channel instead of the exploration channel, which no longer exists by default.
/🆑
Intended to foster closer collaboration between exploration and science and test the waters for more merging later on. Deck Chief has also gotten the science channel, but prospectors and SEA have _not_. I'm open to changing this, but my reasoning is I'd rather not have the research channel get too many new voices suddenly.