### PR TITLE
Admin tool tweak 2: Electric Boogaloo

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -44,6 +44,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/jumptoturf,			//allows us to jump to a specific turf,
 	/client/proc/admin_call_shuttle,	//allows us to call the emergency shuttle,
 	/client/proc/admin_cancel_shuttle,	//allows us to cancel the emergency shuttle, sending it back to centcomm,
+	/client/proc/cmd_admin_narrate,
 	/client/proc/cmd_admin_direct_narrate,	//send text directly to a player with no padding. Useful for narratives and fluff-text,
 	/client/proc/cmd_admin_visible_narrate,
 	/client/proc/cmd_admin_audible_narrate,
@@ -235,6 +236,7 @@ var/list/admin_verbs_hideable = list(
 	/datum/admins/proc/access_news_network,
 	/client/proc/admin_call_shuttle,
 	/client/proc/admin_cancel_shuttle,
+	/client/proc/cmd_admin_narrate,
 	/client/proc/cmd_admin_direct_narrate,
 	/client/proc/cmd_admin_visible_narrate,
 	/client/proc/cmd_admin_audible_narrate,
@@ -294,6 +296,7 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/show_skills,	// Right-click skill menu,
 	/datum/admins/proc/show_player_panel,// right-click player panel,
 	/client/proc/check_antagonists,
+	/client/proc/cmd_admin_narrate,
 	/client/proc/cmd_admin_direct_narrate,
 	/client/proc/aooc,
 	/datum/admins/proc/sendFax,
@@ -534,10 +537,10 @@ var/list/admin_verbs_mod = list(
 
 	var/turf/epicenter = mob.loc
 	var/list/choices = list("Small Bomb", "Medium Bomb", "Big Bomb", "Custom Bomb")
-	var/choice = input("What size explosion would you like to produce?") in choices
+	var/choice = input("What size explosion would you like to produce?") as null | anything in choices
 	switch(choice)
-		if(null)
-			return 0
+		if (null)
+			return
 		if("Small Bomb")
 			explosion(epicenter, 1, 2, 3, 3)
 		if("Medium Bomb")
@@ -545,10 +548,18 @@ var/list/admin_verbs_mod = list(
 		if("Big Bomb")
 			explosion(epicenter, 3, 5, 7, 5)
 		if("Custom Bomb")
-			var/devastation_range = input("Devastation range (in tiles):") as num
-			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
-			var/light_impact_range = input("Light impact range (in tiles):") as num
-			var/flash_range = input("Flash range (in tiles):") as num
+			var/devastation_range = input("Devastation range (in tiles):") as num|null
+			if (isnull(devastation_range))
+				return
+			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num|null
+			if (isnull(heavy_impact_range))
+				return
+			var/light_impact_range = input("Light impact range (in tiles):") as num|null
+			if (isnull(light_impact_range))
+				return
+			var/flash_range = input("Flash range (in tiles):") as num|null
+			if (isnull(flash_range))
+				return
 			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
 	log_and_message_admins("created an admin explosion at [epicenter.loc].")
 	SSstatistics.add_field_details("admin_verb","DB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -856,6 +867,7 @@ var/list/admin_verbs_mod = list(
 			message_admins("Admin [key_name_admin(usr)] has enabled maint drones.", 1)
 
 /client/proc/man_up(mob/T as mob in SSmobs.mob_list)
+	set popup_menu = FALSE
 	set category = "Fun"
 	set name = "Man Up"
 	set desc = "Tells mob to man up and deal with it."

--- a/code/modules/admin/holoverbs.dm
+++ b/code/modules/admin/holoverbs.dm
@@ -1,5 +1,6 @@
 
 /datum/admins/proc/ai_hologram_set(mob/appear as mob in world)
+	set popup_menu = FALSE
 	set name = "Set AI Hologram"
 	set desc = "Set an AI's hologram to a mob. Use this verb on the mob you want the hologram to look like."
 	set category = "Fun"

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -33,6 +33,7 @@
 	SSstatistics.add_field_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/jumptomob(var/mob/M in SSmobs.mob_list)
+	set popup_menu = FALSE
 	set category = "Admin"
 	set name = "Jump to Mob"
 
@@ -95,6 +96,7 @@
 		alert("Admin jumping disabled")
 
 /client/proc/Getmob(var/mob/M in SSmobs.mob_list)
+	set popup_menu = FALSE
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -150,10 +150,39 @@
 
 	return list(result, style, size, message)
 
+//Condenced version of the mob targeting narrates
+/client/proc/cmd_admin_narrate(atom/A)
+	set category = "Special Verbs"
+	set name = "Narrate"
+	set desc = "Selection of narrates targeting a mob."
+
+	if(!check_rights(R_INVESTIGATE))
+		return
+	
+	var/options = list()
+
+	if(ismob(A))
+		options += list("Direct Narrate")
+
+	if(check_rights(R_ADMIN, FALSE))
+		options += list("Visual Narrate", "Audible Narrate")
+	
+	var/result = input("What type of narrate?") as null | anything in options
+	switch(result)
+		if (null)
+			return
+		if ("Direct Narrate")
+			cmd_admin_direct_narrate(A)
+		if ("Visual Narrate")
+			cmd_admin_visible_narrate(A)
+		if ("Audible Narrate")
+			cmd_admin_audible_narrate(A)
+
 
 // Targetted narrate: will narrate to one specific mob
 /client/proc/cmd_admin_direct_narrate(var/mob/M)
-	set category = "Special Verbs"
+	set popup_menu = FALSE
+	set category = null
 	set name = "Direct Narrate"
 	set desc = "Narrate to a specific mob."
 
@@ -201,7 +230,8 @@
 
 // Visible narrate, it's as if it's a visible message
 /client/proc/cmd_admin_visible_narrate(var/atom/A)
-	set category = "Special Verbs"
+	set popup_menu = FALSE
+	set category = null
 	set name = "Visible Narrate"
 	set desc = "Narrate to those who can see the given atom."
 
@@ -223,7 +253,8 @@
 
 // Visible narrate, it's as if it's a audible message
 /client/proc/cmd_admin_audible_narrate(var/atom/A)
-	set category = "Special Verbs"
+	set popup_menu = FALSE
+	set category = null
 	set name = "Audible Narrate"
 	set desc = "Narrate to those who can hear the given atom."
 


### PR DESCRIPTION
Various tweaks and condensing of admin tools/verbs
🆑 
admin: removed man-up from context menu
admin: drop_bomb is now cancelable.
admin: ai_set_hologram, jump, and get verbs removed from context menu.
admin: Condensed targeted narrates into one verb called 'narrate'. (local and global are still seperate)
/🆑 