### PR TITLE
Add ":" to excluded characters for auto-punctuation

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -151,7 +151,7 @@ proc/get_radio_key_from_channel(var/channel)
 	message = html_decode(message)
 
 	var/end_char = copytext(message, length(message), length(message) + 1)
-	if(!(end_char in list(".", "?", "!", "-", "~")))
+	if(!(end_char in list(".", "?", "!", "-", "~", ":")))
 		message += "."
 
 	return html_encode(message)


### PR DESCRIPTION
Some people like to end their messages with ":" for when they're about to enumerate something. Or for whatever reason you use colons in a message. Plus, when stating your laws the first message ends with a colon and it's unnatural for there to be double punctuation.

:cl:
bugfix: Ending a say message with a colon will no longer append an unwanted period.
/:cl: