### PR TITLE
Cryostorage is rad shielded

### DIFF
--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -980,6 +980,7 @@
 /area/crew_quarters/sleep/cryo/aux
 	name = "\improper First Deck Cryogenic Storage"
 	icon_state = "Sleep"
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/crew_quarters/adherent
 	name = "\improper Adherent Maintenence"
@@ -1575,6 +1576,7 @@ area/assembly/robotics/office
 /area/crew_quarters/sleep/cryo
 	name = "\improper Third Deck Cryogenic Storage"
 	icon_state = "Sleep"
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/hydroponics
 	name = "\improper Hydroponics"


### PR DESCRIPTION
🆑
maptweak: The Cryostorage areas are now radiation and ion shielded so poorly timed spawns don't suffer.
/🆑

Should also prevent people who don't ghost in the tubes from slowly and violently melting because of a rad storm.