### PR TITLE
CL now has tramadol+booze instead of suicide pill

### DIFF
--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -43,7 +43,8 @@
 		/obj/item/weapon/storage/belt/general,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel)),
 		new /datum/atom_creator/simple(/obj/item/weapon/storage/backpack/messenger, 50),
-		/obj/item/weapon/storage/fakebook,
+		/obj/item/weapon/storage/pill_bottle/tramadol,
+		/obj/random/drinkbottle,
 		/obj/item/device/radio/headset/heads/torchntcommand,
 		/obj/item/device/radio/headset/heads/torchntcommand/alt
 	)


### PR DESCRIPTION
🆑 
tweak: Corporate Liaisons Suicide pill is now a bottle of booze and tramadol. 
/:cl:
The suicide pill is a terribly memey holder.
If you want to kill yourself, ahelp and disposal dive like the rest of us.
You can still kill yourself with these. 
You'll just suffer the entire time.

Also, the booze and tramadol will see more use than the suicide pill.

Alternative to #29594.
(Closes #29594)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->