### PR TITLE
Remove CL's suicide book

### DIFF
--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -92,22 +92,6 @@ Unique items
 	colour = colors[selectedColor]
 	to_chat(user, "<span class='notice'>Changed color to '[colour].'</span>")
 
-/obj/item/weapon/storage/fakebook
-	name = "Workplace Crisis Management"
-	desc = "Also known as 'I fucked up, what do?'. A very popular book amongst corporate management."
-	icon = 'icons/obj/library.dmi'
-	icon_state = "booknanoregs"
-	attack_verb = list("bashed", "whacked", "educated")
-	throw_speed = 1
-	throw_range = 5
-	w_class = ITEM_SIZE_NORMAL
-	max_w_class = ITEM_SIZE_SMALL
-	max_storage_space = 4
-	startswith = list(
-			/obj/item/weapon/reagent_containers/pill/tox,
-			/obj/item/weapon/paper/liason_note
-	)
-
 /******
 Weapons
 ******/

--- a/maps/torch/items/manuals.dm
+++ b/maps/torch/items/manuals.dm
@@ -67,13 +67,6 @@
 
 /obj/item/weapon/folder/nt/rd
 
-/obj/item/weapon/paper/liason_note
-	name = "note"
-	info = {"
-	<i>Here's your back-out plan.<br>
-	H.B.</i>
-	"}
-
 /obj/item/weapon/folder/envelope/captain
 	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - TORCH UMBRA'."
 
@@ -119,7 +112,7 @@
 	new/obj/item/weapon/paper/umbra(src)
 
 /obj/item/weapon/folder/envelope/rep
-	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - UMBRA'."
+	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - TORCH UMBRA'."
 
 /obj/item/weapon/folder/envelope/rep/Initialize()
 	. = ..()

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -43,7 +43,6 @@
 		/obj/item/weapon/storage/belt/general,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel)),
 		new /datum/atom_creator/simple(/obj/item/weapon/storage/backpack/messenger, 50),
-		/obj/item/weapon/storage/fakebook,
 		/obj/item/device/radio/headset/heads/torchntcommand,
 		/obj/item/device/radio/headset/heads/torchntcommand/alt
 	)


### PR DESCRIPTION
There is no reason for the corporate liaison to have a dedicated way to kill themselves; the pill is almost never used in a practical scenario (nor does it actually work in killing you most of the time) and suicide must be checked with staff first anyway. I don't find a good rationale for a **liaison** (not an executive or board member) to have so many dark secrets that they need to sneak a backdoor to commit suicide on a government ship where nothing has happened for several months.

Change to the UMBRA guide was to fix Travis bug, and also to make the SCGR's copy identical to the CO's.

Alternative to #29593.
(Closes #29593)

:cl:
rscdel: The Corporate Liaison's book containing a suicide pill has been removed.
/:cl: