### PR TITLE
D2 teleporter isn't oddly restricted

### DIFF
--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1490,7 +1490,7 @@
 /area/engineering/storage
 	name = "\improper Engineering Storage"
 	icon_state = "engineering_storage"
-	req_access = list(list(access_engine_equip, access_atmospherics))
+	req_access = list()
 
 /area/engineering/atmos
 	name = "\improper Atmospherics"


### PR DESCRIPTION
🆑
maptweak: The area for the D2 teleporter has been slightly tweaked to allow people with teleporter access to use the main door instead of running into the tunnels.
/🆑

Currently, people with teleporter access but not engineering storage access cannot use the main door into the D2 teleporter. This fixes that minor inconvenience by adjusting the area by one tile.