### PR TITLE
Add Pickpockets' gloves

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -175,3 +175,9 @@
 	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
 			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
 			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."
+
+/datum/uplink_item/item/tools/pickpocket_gloves
+	name = "Pickpocket's Gloves"
+	item_cost = 15
+	path = /obj/item/clothing/gloves/thick/duty/pickpocket
+	desc = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others."

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -180,4 +180,4 @@
 	name = "Pickpocket's Gloves"
 	item_cost = 15
 	path = /obj/item/clothing/gloves/thick/duty/pickpocket
-	desc = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others."
+	desc = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others or adjust their suit sensors."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -279,6 +279,7 @@ BLIND     // can't see anything
 	var/clipped = 0
 	var/obj/item/clothing/ring/ring = null		//Covered ring
 	var/mob/living/carbon/human/wearer = null	//Used for covered rings when dropping
+	var/pickpocket = FALSE  //Indicates these gloves are pickpocketing gloves.
 	body_parts_covered = HANDS
 	slot_flags = SLOT_GLOVES
 	attack_verb = list("challenged")

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -186,3 +186,7 @@
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 
+/obj/item/clothing/gloves/thick/duty/pickpocket
+	desc = "These brown duty gloves are made from a durable synthetic. The inside is lined with wiring."
+	pickpocket = TRUE
+

--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -81,4 +81,4 @@
 
 /datum/codex_entry/pickpocket_gloves
 	associated_paths = list(/obj/item/clothing/gloves/thick/duty/pickpocket)
-	antag_text = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others."
+	antag_text = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others or adjust their suit sensors."

--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -78,3 +78,7 @@
 /obj/item/clothing/suit/armor/pcarrier/get_mechanics_info()
 	. = ..()
 	. += "<br>Its protection is provided by the plate inside, examine it for details on armor.<br>"
+
+/datum/codex_entry/pickpocket_gloves
+	associated_paths = list(/obj/item/clothing/gloves/thick/duty/pickpocket)
+	antag_text = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others."


### PR DESCRIPTION
:cl: SammasC123
rscadd: Adds pickpockets' gloves to the uplink for 15 tc. Pickpockets' gloves allow you to silently take and plant items in hands, ID slot, suit storage, accessories, and the ears. Emptying and planting on pockets is also silent- and moves the items to your hands, rather than the floor. It also slightly reduces the amount of time it takes to take and plant items, all while looking like normal work gloves!
/:cl: