### PR TITLE
Emag redux & codex entry fix

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -93,15 +93,24 @@
  */
 
 /obj/item/weapon/card/emag_broken
-	desc = "It's a card with a magnetic strip attached to some circuitry. It looks too busted to be used for anything but salvage."
-	name = "broken cryptographic sequencer"
+	desc = "It's a blank ID card with a magnetic strip and some odd circuitry attached."
+	name = "identification card"
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 
+/obj/item/weapon/card/emag_broken/examine(mob/user, distance)
+	. = ..()
+	if(distance <= 0 && (user.skill_check(SKILL_DEVICES, SKILL_ADEPT) || player_is_antag(user.mind)))
+		to_chat(user, SPAN_WARNING("You can tell the components are completely fried; whatever use it may have had before is gone."))
+
+/obj/item/weapon/card/emag_broken/get_antag_info()
+	. = ..()
+	. += "You can use this cryptographic sequencer in order to subvert electronics or forcefully open doors you don't have access to. These actions are irreversible and the card only has a limited number of charges!"
+
 /obj/item/weapon/card/emag
-	desc = "It's a card with a magnetic strip attached to some circuitry."
-	name = "cryptographic sequencer"
+	desc = "It's a blank ID card with a magnetic strip and some odd circuitry attached."
+	name = "identification card"
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ESOTERIC = 2)
@@ -117,6 +126,7 @@
 						) //Should be enough of a selection for most purposes
 
 var/const/NO_EMAG_ACT = -50
+
 /obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)
 	var/used_uses = A.emag_act(uses, user, src)
 	if(used_uses == NO_EMAG_ACT)
@@ -150,11 +160,10 @@ var/const/NO_EMAG_ACT = -50
 			return
 
 		disguise(card_choices[picked], usr)
-
-/obj/item/weapon/card/emag/examine(mob/user)
+	
+/obj/item/weapon/card/emag/get_antag_info()
 	. = ..()
-	if(user.skill_check(SKILL_DEVICES,SKILL_ADEPT))
-		to_chat(user, SPAN_WARNING("This ID card has some form of non-standard modifications."))
+	. += "You can use this cryptographic sequencer in order to subvert electronics or forcefully open doors you don't have access to. These actions are irreversible and the card only has a limited number of charges!"
 
 /obj/item/weapon/card/id
 	name = "identification card"

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -25,5 +25,7 @@
 
 /atom/examine(mob/user, distance, infix = "", suffix = "")
 	. = ..()
-	if(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value()))
+	var/datum/codex_entry/entry = SScodex.get_codex_entry(get_codex_value())
+	//This odd check v is done in case an item only has antag text but someone isn't an antag, in which case they shouldn't get the notice
+	if(entry && (entry.lore_text || entry.mechanics_text || (entry.antag_text && player_is_antag(user.mind))) && user.can_use_codex())
 		to_chat(user, "<span class='notice'>The codex has <b><a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>relevant information</a></b> available.</span>")


### PR DESCRIPTION
Emags are now no longer named "cryptographic sequencers" as that breaks the meta. Antagonists now get a codex entry upon examining telling them what it does, and when holding it, an antagonist can tell how many charges are left in the emag.

Broken emags function similarly, having their name and description changed. However, a broken and functioning emag are identical to the untrained eye; only someone with trained+ complex devices (or who is an antagonist) can tell if it's busted or not.

In addition to this, a logic change was added to codexes to prevent the edge case where an item only had an antagonist description for the codex but the user examining was not an antagonist, allowing for an empty codex page to be seen.

:cl:
tweak: Cryptographic sequencers (and their broken variants) have had their names and descriptions altered to be less incriminating.
tweak: If you are an antagonist, you can now see how many charges are left on a cryptographic sequencer by examining it in your hand.
spellcheck: Cryptographic sequencers now have a codex entry for antagonists.
tweak: You can now only distinguish between a functioning/broken cryptographic sequencer if you are either an antagonist or have Trained+ Complex Devices.
/:cl: