### PR TITLE
"Start Now" changes

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -839,16 +839,17 @@ var/global/floorIsLava = 0
 	set desc="Start the round RIGHT NOW"
 	set name="Start Now"
 	if(GAME_STATE < RUNLEVEL_LOBBY)
-		to_chat(usr, "<span class='bigdanger'>Unable to start the game as it is not yet set up.</span>")
+		to_chat(usr, FONT_LARGE(SPAN_DANGER("Unable to start the game as it is not yet set up.")))
 		SSticker.start_ASAP = !SSticker.start_ASAP
 		if(SSticker.start_ASAP)
-			to_chat(usr, "<span class='bigwarning'>The game will begin as soon as possible.</span>")
+			to_chat(usr, FONT_LARGE(SPAN_WARNING("The game will begin as soon as possible.")))
+			log_and_message_admins("will begin the game as soon as possible.")
 		else
-			to_chat(usr, "<span class='bigwarning'>The game will begin as normal.</span>")
+			to_chat(usr, FONT_LARGE(SPAN_WARNING("The game will begin as normal.")))
+			log_and_message_admins("will begin the game as normal.")
 		return 0
 	if(SSticker.start_now())
-		log_admin("[usr.key] has started the game.")
-		message_admins("<font color='blue'>[usr.key] has started the game.</font>")
+		log_and_message_admins("has started the game.")
 		SSstatistics.add_field_details("admin_verb","SN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		return 1
 	else


### PR DESCRIPTION
Start Now has had its spans fixed, as "bigdanger" and "bigwarning" did not work with goonchat. In addition, there are now logs/message for when you use the verb even when the game isn't ready yet, as doing so will still change `SSticker.start_ASAP`).

:cl:
admin: "Start Now" now has more logging and looks nice again.
/:cl: