### PR TITLE
gives lab assistants guppy helm access

### DIFF
--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -118,6 +118,6 @@
 	                    SKILL_SCIENCE     = SKILL_MAX)
 
 	access = list(access_tox, access_tox_storage, access_research, access_petrov,
-						access_mining_office, access_mining_station, access_xenobiology,
+						access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
 						access_xenoarch, access_nanotrasen, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
 						access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry)


### PR DESCRIPTION
 🆑
 tweak: lab assistants now have access to the guppy helm, aka they can pilot it.
 /🆑
Lab assistants have access to so much of what scientists have, even toxins, so I find it weird they don't have full access to the guppy despite having access to suits- even regular explorers have access to the guppy helm. Looking back, I think the person who originally gave lab assistants access just didn't know guppy_helm was a thing, and that it's intended they're able to use the guppy.