### PR TITLE
Moves sprite surgery layer to above uniform and underwear

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -117,10 +117,10 @@ Please contact me on #coderbus IRC. ~Carn x
 #define HO_MUTATIONS_LAYER  1
 #define HO_SKIN_LAYER       2
 #define HO_DAMAGE_LAYER     3
-#define HO_SURGERY_LAYER    4 //bs12 specific.
-#define HO_UNDERWEAR_LAYER  5
-#define HO_UNIFORM_LAYER    6
-#define HO_ID_LAYER         7
+#define HO_UNDERWEAR_LAYER  4
+#define HO_UNIFORM_LAYER    5
+#define HO_ID_LAYER         6
+#define HO_SURGERY_LAYER    7 //bs12 specific.
 #define HO_SHOES_LAYER      8
 #define HO_GLOVES_LAYER     9
 #define HO_BELT_LAYER       10


### PR DESCRIPTION
:cl: Slywater
tweak: Moved sprite surgery layer to above uniform and underwear, to emulate operating through clothing
/:cl:

**Why?**
Essentially surgery sprites (that being surgical incisions, exposed ribcages etc.) are invisible 90% of the time since crew members are very rarely stripped of their jumpsuit during surgery.

For the sake of consistency, and to better cooperate with the fact surgeons are operating through clothing, this moves the surgery layer above the undersuit clothing layer, so it actually seems like surgeons have cut open the clothing to operate.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->