### PR TITLE
Add missing subtle style to goonchat

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -331,6 +331,7 @@ h1.alert, h2.alert		{color: #a4bad6;}
 
 .danger					{color: #c51e1e;}
 .warning				{color: #c51e1e;	font-style: italic;}
+.subtle					{color: #4343ca; font-size: 75%; font-style: italic;}
 .boldannounce			{color: #c51e1e;	font-weight: bold;}
 .rose					{color: #ff5050;}
 .info					{color: #6685f5;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -328,6 +328,7 @@ h1.alert, h2.alert		{color: #000080;}
 
 .danger					{color: #ff0000;}
 .warning				{color: #ff0000;	font-style: italic;}
+.subtle					{color: #000099; font-size: 75%; font-style: italic;}
 .boldannounce			{color: #ff0000;	font-weight: bold;}
 .rose					{color: #ff5050;}
 .info					{color: #0000CC;}


### PR DESCRIPTION
:cl: Mucker
tweak: Add the missing 'subtle' style class to goonchat, tweaks colour for darkmode.
/:cl:

Adds the missing subtle style class to goonchat and tweaks the colour for darkmode.

Closes #29601 