### PR TITLE
Adds human language chat colours to goonchat

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -348,16 +348,16 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .nabber_lang			{color: #525252;}
 .solcom					{color: #22228b;}
 .vox					{color: #aa00aa;}
+.yeosa 					{color:	#059223}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif; color: #7c6256}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-.terran					{color: #9c250b;}
+.russian				{color: #9c250b;}
 .moon					{color: #422863;}
 .spacer					{color: #ff6600;}
 .selenian				{color: #5a83c5;}
 .arabic					{color: #95d16c;}
 .chinese				{color: #7d60cc;}
 .indian					{color: #5dbba4;}
-.russian				{color: #c45c72;}
 .iberian				{color: #be4ac9;}
 
 .interface				{color: #750e75;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -345,11 +345,17 @@ h1.alert, h2.alert		{color: #000080;}
 .nabber_lang			{color: #525252;}
 .solcom					{color: #22228b;}
 .vox					{color: #aa00aa;}
+.yeosa 					{color:	#059223}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-.terran					{color: #9c250b;}
+.russian				{color: #9c250b;}
 .moon					{color: #422863;}
 .spacer					{color: #ff6600;}
+.selenian				{color: #5a83c5;}
+.arabic					{color: #95d16c;}
+.chinese				{color: #7d60cc;}
+.indian					{color: #5dbba4;}
+.iberian				{color: #be4ac9;}
 
 .interface				{color: #750e75;}
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Most human languages don't have chat colours to differentiate them from ZAC when using goonchat. This adds the colours back, but please feel free to shout at me if I'm going about this wrong. This PR also gives Yeosa'unathi the green chat colour for goonchat.

:cl: SealCure
rscadd: Adds chat colours for all human languages to goonchat
bugfix: Returns the green chat colour to Yeosa'unathi
/:cl: