### PR TITLE
config chat markup is more configurable

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -595,5 +595,5 @@ proc/TextPreview(var/string,var/len=40)
 	if (message && length(config.chat_markup))
 		for (var/list/entry in config.chat_markup)
 			var/regex/matcher = entry[1]
-			message = matcher.Replace(message, "[entry[2]]$1[entry[3]]")
+			message = matcher.Replace(message, entry[2])
 	return message

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -681,14 +681,14 @@ var/list/gamemode_cache = list()
 
 				if ("chat_markup")
 					var/list/line = splittext(value, ";")
-					if (length(line) != 3)
+					if (length(line) != 2)
 						log_error("Invalid chat_markup entry length: [value]")
 					else
 						var/matcher = text2regex(line[1])
 						if (!matcher)
 							log_error("Invalid chat_markup regex: [value]")
 						else
-							LAZYADD(config.chat_markup, list(list(matcher, line[2], line[3])))
+							LAZYADD(config.chat_markup, list(list(matcher, line[2])))
 
 				if ("forbidden_message_regex")
 					config.forbidden_message_regex = text2regex(value)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -376,13 +376,13 @@ RADIATION_LOWER_LIMIT 0.15
 #MINIMUM_BYOND_BUILD
 
 ## Uncomment or create lines to add user-accessible chat markup
-## A chat markup line is in the form regex;start;end. The regular expression should have a SINGLE capture group
-## and be in the common /matcher/flags format. Start and end are inserted around the capture group, and the rest of
-## any match is discarded. The provided examples provide /italics/, *bold*, and _underline_ respectively. Using
-## multiple or complex markup options can get strange - do it at your own risk.
-#CHAT_MARKUP /\/([^\/]*)\//g;<i>;</i>
-#CHAT_MARKUP /\*([^\*]*)\*/g;<b>;</b>
-#CHAT_MARKUP /_([^_]*)_/g;<u>;</u>
+## A chat markup line is in the form regex;replacer. The regular expression should be in the common
+# /matcher/flags format. The replacer is a common regex replacer string, using $n ($1, $2, etc) to
+# reference capture groups. The provided examples allow for /italics/, *bold*, and _underline_
+# respectively. Using multiple or complex markup options can get strange - do it at your own risk.
+#CHAT_MARKUP /(^|\s)\/([^\/]+)\//g;$1<i>$2</i>
+#CHAT_MARKUP /(^|\s)\*([^\*]+)\*/g;$1<b>$2</b>
+#CHAT_MARKUP /(^|\s)_([^_]+)_/g;$1<u>$2</u>
 
 ## Prevents matching messages from being sent on any communication channel
 ## The provided example forbids byond:// and http/https:// unless followed by a permitted domain.


### PR DESCRIPTION
modifies configurable chat markup to be regex;replacer instead of regex;tag;tag
unfortunately necessary to avoid over-complicating expressions with lookaheads etc
