### PR TITLE
Moves Petrov to D1 Aft. Moves EARM to bridge deck aft. Moves Aquila to D5 aft. 

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11,88 +11,27 @@
 /obj/item/weapon/pen/fancy,
 /turf/simulated/floor/lino,
 /area/command/pilot)
-"ad" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"ae" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Heat Exchanger Input"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"af" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Exterior Vent"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
 "ag" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/hangar)
 "ah" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1;
-	icon_state = "bordercolorhalf"
-	},
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 2;
-	name = "suit storage"
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"ai" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"aj" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Heat Exchanger Output"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "ak" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 8;
@@ -127,27 +66,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
-"ap" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Chamber Output"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"aq" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -202,50 +120,6 @@
 	icon_state = "walnut_broken3"
 	},
 /area/vacant/bar)
-"aw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"ax" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"ay" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/table/standard,
-/obj/random/tool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"az" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/air_sensor{
-	id_tag = "toxins_sensor"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "aA" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10;
@@ -303,21 +177,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
 "aG" = (
-/obj/machinery/computer/modular/preset/civilian{
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 8;
-	icon_state = "console"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/machinery/button/windowtint{
-	id = "rcheckinner_windows";
-	pixel_x = 10;
-	pixel_y = -21
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/area/aquila/mess)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -457,40 +326,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"aT" = (
-/obj/structure/sign/warning/airlock{
-	dir = 8;
-	icon_state = "doors"
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/maintenance/fifthdeck/aftstarboard)
-"aU" = (
-/obj/machinery/artifact_scanpad,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"aV" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/meter,
-/obj/effect/paint/silver,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "toxins_shutters";
-	name = "Mixing Chamber Blast Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "aW" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -511,33 +346,11 @@
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
-"bb" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/analysis)
-"bc" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/eva)
 "bd" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"be" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/effect/paint/silver,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "toxins_shutters";
-	name = "Mixing Chamber Blast Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "bf" = (
 /obj/machinery/light/spot{
 	pixel_y = 32
@@ -583,23 +396,6 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/crew)
-"bl" = (
-/obj/machinery/atmospherics/omni/mixer{
-	tag_east = 2;
-	tag_north = 1;
-	tag_north_con = 0.33;
-	tag_south = 1;
-	tag_south_con = 0.33;
-	tag_west = 1;
-	tag_west_con = 0.34
-	},
-/obj/machinery/button/ignition{
-	id_tag = "toxlab";
-	pixel_w = 6;
-	pixel_z = -23
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "bm" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8;
@@ -612,25 +408,6 @@
 /obj/structure/handrai,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"bn" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Chamber Input"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "toxin_exhaust";
-	name = "Chamber Vent";
-	pixel_w = 8;
-	pixel_y = -24
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "toxins_shutters";
-	name = "Chamber Protective Shutters";
-	pixel_w = -5;
-	pixel_z = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "bo" = (
 /obj/machinery/light/spot{
 	pixel_y = 32
@@ -674,50 +451,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
-"bs" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	frequency = 1441;
-	id = "toxins_in"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/sparker{
-	id_tag = "toxlab";
-	pixel_w = 1;
-	pixel_z = -23
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_dock_sensor";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
 "bu" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/maint)
+/obj/machinery/button/blast_door{
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters Control";
+	pixel_x = -32
+	},
+/obj/machinery/turretid/stun{
+	check_synth = 0;
+	name = "Aquila point defense control";
+	pixel_x = 32;
+	pixel_y = 0;
+	req_access = list("ACCESS_TORCH_AQUILA_HELM")
+	},
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "bv" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -919,25 +671,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "bP" = (
-/obj/effect/paint/silver,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
-/area/shuttle/petrov/security)
-"bQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
+/area/aquila/head)
 "bS" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1823,6 +1559,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
+"dr" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/medical)
 "du" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -2194,18 +1935,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
-"ec" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/valve/shutoff/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
+"ed" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "ee" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
@@ -2449,12 +2182,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
 "eB" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "eC" = (
@@ -2477,6 +2210,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
+"eD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/shuttle_landmark/torch/hangar/aquila,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "eE" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2554,12 +2300,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "eW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "eX" = (
 /obj/machinery/camera/network/exploration_shuttle{
 	dir = 4;
@@ -2668,6 +2418,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fh" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/fifthdeck/aft)
 "fi" = (
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/plating,
@@ -2749,6 +2506,16 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/power)
+"fv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "fx" = (
 /obj/machinery/power/apc/shuttle/charon{
 	dir = 4;
@@ -2801,40 +2568,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"fD" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"fE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"fF" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/isolation)
-"fG" = (
-/obj/machinery/atmospherics/binary/pump,
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "fH" = (
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled,
@@ -2949,6 +2682,26 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
+"fV" = (
+/obj/structure/closet/crate,
+/obj/random/toolbox,
+/obj/random/powercell,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/random_multi/single_item/boombox,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "fW" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 4;
@@ -2997,14 +2750,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
-"ge" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "gg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3100,21 +2845,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "gt" = (
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "gv" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 4;
@@ -3208,6 +2943,12 @@
 	dir = 5;
 	icon_state = "intact"
 	},
+/obj/machinery/door/airlock/glass/command{
+	id_tag = null;
+	name = "Aquila Dock";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH"));
+	secured_wires = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "gI" = (
@@ -3248,6 +2989,42 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
+"gQ" = (
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
+"gS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "gT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/floodlight,
@@ -3265,24 +3042,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"gZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"ha" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "hb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3331,18 +3090,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"hf" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	icon_state = "nosmoking";
-	pixel_x = 32
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+"he" = (
 /obj/structure/catwalk,
+/obj/machinery/alarm{
+	alarm_id = "petrov3";
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "hg" = (
@@ -3506,10 +3261,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
 "hL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/binary/pump,
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
 	},
-/obj/structure/catwalk,
+/obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "hM" = (
@@ -3544,23 +3301,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
-"hP" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	icon_state = "nosmoking";
-	pixel_x = -32
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "hR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
@@ -3638,6 +3378,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
+"ik" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/aquila/medical)
 "im" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4395,34 +4141,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
-"jP" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 1;
-	icon_state = "bordercolorhalf"
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	display_name = "Aft Dock (Petrov)";
-	frequency = 1380;
-	id_tag = "petrov_shuttle_dock_airlock";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access = list(list("ACCESS_SECURITY","ACCESS_EXTERNAL","ACCESS_TORCH_PETROV"));
-	tag_airpump = "petrov_shuttle_dock_pump";
-	tag_chamber_sensor = "petrov_shuttle_dock_sensor";
-	tag_exterior_door = "petrov_shuttle_dock_outer";
-	tag_interior_door = "petrov_shuttle_dock_inner"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
 "jQ" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4858,6 +4576,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
+"kH" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
 "kI" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5457,19 +5181,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"mm" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/spectrometer/adv,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "mn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5524,6 +5235,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"mr" = (
+/obj/structure/catwalk,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "ms" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5549,22 +5269,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "mv" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_dock_sensor";
-	pixel_x = -24;
-	pixel_y = 0
-	},
 /obj/machinery/oxygen_pump{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "aquila_shuttle_dock_sensor";
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -7033,6 +6749,19 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
+"pj" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/cockpit)
 "pk" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4;
@@ -7158,10 +6887,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "pw" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
 	icon_state = "techfloor_edges"
@@ -7173,6 +6898,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_dock_pump"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -7674,16 +7403,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "qC" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
 	icon_state = "intact"
+	},
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_dock_inner";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -7724,6 +7455,12 @@
 /area/hallway/primary/fifthdeck/aft)
 "qH" = (
 /obj/effect/floor_decal/corner/brown/half,
+/obj/machinery/door/airlock/glass/command{
+	id_tag = null;
+	name = "Aquila Dock";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH"));
+	secured_wires = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "qI" = (
@@ -8022,6 +7759,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/substation/fifthdeck)
+"rf" = (
+/obj/structure/table/rack,
+/obj/random/solgov,
+/obj/random/solgov,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/secure_storage)
 "rg" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8520,19 +8263,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"sb" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -8730,11 +8460,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "sA" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/table/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -8753,6 +8478,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"sD" = (
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "sI" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -9168,43 +8903,48 @@
 /area/maintenance/fifthdeck/aftport)
 "tF" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	autoset_access = 0;
+	frequency = 1331;
 	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
+	id_tag = "aquila_shuttle_dock_inner";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "tG" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_outer";
-	locked = 0;
-	name = "Docking Port Airlock"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "tH" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "tJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
+"tM" = (
+/obj/machinery/alarm{
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/machinery/cryopod,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "tQ" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -9220,27 +8960,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"tR" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "tT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/security)
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "tU" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -9464,6 +9187,19 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	display_name = "Bridge Deck Dock";
+	frequency = 1331;
+	id_tag = "aquila_shuttle_dock_airlock";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"));
+	tag_airpump = "aquila_shuttle_dock_pump";
+	tag_chamber_sensor = "aquila_shuttle_dock_sensor";
+	tag_exterior_door = "aquila_shuttle_dock_outer";
+	tag_interior_door = "aquila_shuttle_dock_inner"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
@@ -9827,28 +9563,11 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
 "vc" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
-"ve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 8;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
+/area/aquila/medical)
 "vf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped{
@@ -9857,6 +9576,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"vi" = (
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -9881,115 +9603,37 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"vo" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"vp" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
+"vu" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"vq" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"vr" = (
-/obj/machinery/alarm{
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"vA" = (
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 1;
+	name = "north bump";
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 4;
-	target_pressure = 200
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"vt" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
-"vA" = (
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"vC" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
+/obj/structure/bed/chair/shuttle/blue,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "vD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fifthdeck/aft)
-"vE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4;
-	icon_state = "map"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "vF" = (
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fifthdeck/aft)
-"vG" = (
-/obj/structure/dispenser/oxygen,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
 "vH" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -10053,6 +9697,14 @@
 /obj/item/weapon/light/tube,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"vV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/fifthdeck/aftstarboard)
 "vW" = (
 /obj/item/weapon/material/minihoe,
 /turf/simulated/floor/plating,
@@ -10106,34 +9758,6 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"wl" = (
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"wm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"wn" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "wr" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -10154,49 +9778,31 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "wu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/hologram/holopad/longrange,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"wx" = (
-/obj/structure/table/standard,
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/debugger{
-	pixel_x = -5
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
+"wz" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Storage"
 	},
-/obj/item/device/integrated_electronics/analyzer{
-	pixel_x = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"wz" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Cockpit"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "wA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10221,10 +9827,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"wE" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "wF" = (
 /turf/simulated/wall/prepainted,
 /area/command/pilot)
@@ -10238,45 +9840,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "wL" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "petrov_shuttle_airlock";
-	pixel_x = -24;
-	pixel_y = 32
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"wQ" = (
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"wU" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 8;
-	icon_state = "pdoor1";
-	id_tag = "toxin_exhaust";
-	name = "Toxins Exhaust Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "wW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10314,18 +9890,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"wY" = (
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "wZ" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -10336,18 +9900,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"xd" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 4;
-	icon_state = "comfyofficechair_preview"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
 "xg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10355,18 +9907,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "xh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/cockpit)
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "xl" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -10379,28 +9928,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
-"xr" = (
-/obj/structure/table/standard,
-/obj/item/weapon/anodevice{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/anodevice,
-/obj/item/device/scanner/health,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"xs" = (
-/obj/structure/closet/secure_closet/crew/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/item/weapon/folder/nt,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "xu" = (
 /obj/machinery/floodlight,
 /obj/structure/handrai{
@@ -10417,32 +9944,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"xy" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "xA" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/bio_suit/anomaly,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/bio_hood/anomaly,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"xB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/protolathe,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
+/area/aquila/passenger)
+"xB" = (
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "xC" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -10454,14 +9965,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
+"xE" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
 "xJ" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
 "xK" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "xL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10476,27 +10005,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "xN" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"xO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "xP" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -10513,48 +10023,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "xS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"xV" = (
-/obj/structure/closet/crate/secure/biohazard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/random/smokes,
 /obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
-"xX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"xY" = (
-/obj/structure/closet/toolcloset/excavation,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "ya" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10586,10 +10065,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10623,68 +10098,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"yo" = (
-/obj/structure/sign/warning/hot_exhaust{
-	dir = 4;
-	icon_state = "fire"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
 "yq" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
-"yr" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"ys" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"yu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 8;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
 "yv" = (
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
@@ -10694,41 +10110,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/cargo)
-"yx" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/handrai,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"yy" = (
-/obj/structure/table/standard,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/flame/lighter/random,
-/obj/item/weapon/storage/box/evidence,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "yz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -10780,28 +10161,35 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"yC" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/fabricator,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
 "yG" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "yI" = (
 /turf/simulated/floor/plating,
 /area/vacant/bar)
 "yL" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_pump_out_internal"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/structure/handrai,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/airlock)
 "yM" = (
 /obj/machinery/camera/network/exploration_shuttle{
 	dir = 8;
@@ -10823,29 +10211,6 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"yO" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"yP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Analysis Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "yQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10869,23 +10234,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yR" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
-"yU" = (
-/obj/machinery/atmospherics/unary/heater,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "yW" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -10903,20 +10251,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"za" = (
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"zd" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
+"yZ" = (
+/obj/machinery/power/smes/buildable/preset/torch/shuttle{
+	RCon_tag = "Shuttle - Aquila"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"ze" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/structure/cable/cyan,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "zf" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light/spot{
@@ -10930,53 +10271,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"zi" = (
-/obj/structure/bed,
+"zj" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad/longrange,
 /obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"zk" = (
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "zl" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rnd)
-"zm" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/random/tool,
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell1";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Seating";
+	dir = 1
 	},
-/obj/machinery/button/ignition{
-	id_tag = "Isocell1";
-	pixel_x = -36;
-	pixel_y = -25
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "zn" = (
 /obj/random/tech_supply,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -10985,37 +10306,12 @@
 /obj/structure/largecrate,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
-"zo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"zp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"zs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "zv" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/button/blast_door{
@@ -11058,33 +10354,17 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "zB" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Cockpit"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
-"zC" = (
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"zH" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/table/rack,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/machinery/light/small{
 	dir = 4;
-	icon_state = "intact"
+	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"zK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
 "zL" = (
 /obj/structure/table/steel,
 /obj/item/device/flashlight/lamp/green,
@@ -11092,23 +10372,36 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"zO" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"zP" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
+"zN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/meter,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"zO" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/aquila/medical)
 "zS" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fifthdeck/aft)
+"zT" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
 "zV" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11136,85 +10429,42 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
+"zX" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/storage)
 "zZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
-"Ac" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"Ae" = (
-/obj/machinery/suit_cycler/science,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"Ag" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"Ah" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Ak" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Al" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/hallwaya)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 4;
+	id_tag = "aquila_shuttle_pump_out_external"
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	frequency = 1331;
+	id_tag = "aquila_shuttle_sensor_external";
+	pixel_x = 25;
+	pixel_y = -6
+	},
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1331;
+	master_tag = "aquila_shuttle";
+	name = "exterior access button";
+	pixel_x = 23;
+	pixel_y = 6
+	},
+/turf/simulated/floor/airless,
+/area/aquila/storage)
 "An" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11235,23 +10485,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ao" = (
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Ap" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Aq" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_inner";
+	locked = 1;
+	name = "Aquila External Access";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aquila/airlock)
 "Ar" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4;
@@ -11260,56 +10513,13 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
-"As" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"AC" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/noticeboard{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"At" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell2";
-	pixel_x = -18
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"Ax" = (
-/obj/random/trash,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"Ay" = (
-/obj/structure/catwalk,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "AE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11329,41 +10539,42 @@
 /obj/machinery/firealarm,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"AK" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/artifact_analyser,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "AL" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
+/obj/machinery/bodyscanner{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "AM" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
-	icon_state = "console"
+	icon_state = "intact"
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"AP" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell3";
-	pixel_x = -18
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "AS" = (
-/obj/structure/table/glass,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/weapon/book/manual/nt_regs,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/machinery/door/airlock/hatch{
+	name = "Engineering"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/maintenance)
 "AT" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -11374,43 +10585,33 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"AY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/maint)
-"AZ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/binary/pump,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"AW" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ba" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/computer/rdconsole/petrov{
+"AY" = (
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
+	},
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "computer"
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
+"Ba" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
+/area/aquila/medical)
 "Be" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11420,38 +10621,30 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "Bf" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
+/obj/machinery/light/small,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "aquila_shuttle_sensor";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Bg" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Bi" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell3";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/area/aquila/airlock)
 "Bk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11476,30 +10669,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Bn" = (
-/obj/machinery/artifact_analyser,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Bo" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Bp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11522,53 +10691,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Bs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+"BB" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
+"BC" = (
+/turf/simulated/wall/r_wall/hull,
+/area/rnd/canister)
+"BF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Bu" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"Bx" = (
-/obj/structure/closet/l3closet/scientist/multi,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"By" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"BC" = (
-/turf/simulated/wall/r_wall/hull,
-/area/rnd/canister)
-"BD" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/medical)
 "BG" = (
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
@@ -11579,58 +10721,59 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"BH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"BJ" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "BL" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"BM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/obj/machinery/shipsensors,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/airless,
+/area/aquila/passenger)
 "BN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/single/cola,
+/obj/item/device/radio/intercom{
 	dir = 4;
-	level = 2
+	pixel_x = -21
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/area/aquila/mess)
 "BO" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/standard,
-/obj/item/stack/material/plastic/ten,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"BR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
+/area/aquila/medical)
+"BP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "BS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -11638,16 +10781,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"BT" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
+"BW" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 1900
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/custodial)
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "BX" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -11664,12 +10807,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"BY" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Cf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -11686,19 +10823,6 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Ch" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/stack/material/phoron,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "Cm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
 	dir = 4;
@@ -11708,16 +10832,14 @@
 /area/guppy_hangar/start)
 "Cn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10;
@@ -11759,105 +10881,63 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Cs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/junk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Cy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "CA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"CB" = (
-/obj/random/trash,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fifthdeck/aftstarboard)
-"CC" = (
-/obj/structure/closet/secure_closet/crew/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/item/weapon/folder/nt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"CE" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"CG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
+"CB" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fifthdeck/aftstarboard)
+"CJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/power/apc/hyper/shuttle/aquila{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"CH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/research{
-	id_tag = "";
-	name = "Sublimation Chamber"
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"CJ" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 1;
-	icon_state = "comfyofficechair_preview"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "CL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11888,40 +10968,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"CS" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/custodial)
 "CT" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/rd)
-"CV" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/health,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1;
+	icon_state = "map"
+	},
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
 "CW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Research Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "CX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11971,20 +11037,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
-"Dd" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
 "Df" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -11995,24 +11047,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Dh" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"Di" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
 "Dl" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -12042,28 +11076,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
-"Do" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Dq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Dr" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -12095,83 +11107,31 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/fore)
-"Dt" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"Du" = (
-/obj/structure/table/glass,
-/obj/item/device/paicard,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Dv" = (
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Dw" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"Dy" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Dz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/research{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8;
-	icon_state = "closed";
-	id_tag = "PetrovAccess";
-	name = "Petrov Access"
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"DE" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - EVA";
-	dir = 4
-	},
-/obj/machinery/light_switch{
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "aquila_shuttle";
+	name = "interior access button";
 	pixel_x = -24;
-	pixel_y = 12
+	pixel_y = -24;
+	req_access = newlist()
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
 	},
-/obj/structure/table/rack,
-/obj/item/stack/flag/red,
-/obj/item/stack/flag/red,
-/obj/item/stack/flag/red,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "DF" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -12184,69 +11144,51 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"DH" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10;
+	icon_state = "intact"
 	},
-/obj/machinery/button/ignition{
-	id_tag = "Isocell3";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"DK" = (
-/obj/effect/paint/silver,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rd)
-"DN" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light{
+/turf/simulated/floor/airless,
+/area/aquila/medical)
+"DI" = (
+/obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Anomaly Aft";
+/turf/simulated/floor/airless,
+/area/aquila/secure_storage)
+"DK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 20
+	pixel_x = 21
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"DO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"DR" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/airlock)
+"DS" = (
+/obj/random/soap,
+/obj/structure/hygiene/shower{
+	dir = 4;
+	icon_state = "shower"
 	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/button/ignition{
-	id_tag = "Isocell2";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"DQ" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/custodial)
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "DT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12264,12 +11206,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/equipment)
 "DY" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -12287,56 +11223,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DZ" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "Ea" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ec" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"Ed" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Equipment Storage"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Ee" = (
-/obj/machinery/atmospherics/tvalve/digital{
-	dir = 1;
-	icon_state = "map_tvalve0";
-	id_tag = "fuelmode"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Eg" = (
 /obj/structure/closet/secure_closet/prospector,
 /obj/effect/floor_decal/corner/brown/mono,
@@ -12361,29 +11250,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"El" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "Em" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
-"En" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Ep" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -12426,27 +11295,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Ex" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Toxins";
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/vending/phoronresearch{
-	dir = 4;
-	icon_state = "generic"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Ey" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12484,19 +11332,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"EE" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"EH" = (
-/obj/machinery/suit_storage_unit/science,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "EI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12508,22 +11343,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"EJ" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Desublimation";
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "EK" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -12547,19 +11366,14 @@
 /obj/effect/shuttle_landmark/merc/hanger,
 /turf/space,
 /area/space)
-"ER" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+"EP" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
 	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	alarm_id = "petrov3";
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/head)
 "ET" = (
 /obj/structure/closet/medical_wall{
 	pixel_x = 0;
@@ -12576,34 +11390,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Fd" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"Ff" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
-"Fg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "Fh" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -12613,6 +11399,10 @@
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"Fi" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "Fk" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
@@ -12627,55 +11417,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Fo" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/chemical_dispenser/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"Fu" = (
-/obj/structure/bed,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "Fw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
 "Fx" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cockpit)
-"Fy" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"FD" = (
-/obj/structure/table/standard,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
+"FE" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov2";
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/turf/simulated/floor/airless,
+/area/aquila/secure_storage)
 "FR" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
@@ -12684,102 +11453,74 @@
 /obj/effect/shuttle_landmark/skipjack/hanger,
 /turf/space,
 /area/space)
-"FU" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Hallway Aft";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "FW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
+/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "FX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/crew,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "FZ" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Gb" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
+"Gc" = (
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Gc" = (
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine/torch{
-	department = "Petrov - Chief Science Officer"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Science Officer's Desk";
-	departmentType = 5;
-	name = "Chief Science Officer RC";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "Ge" = (
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "Gh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	density = 1;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_outer";
+	locked = 1;
+	name = "Aquila External Access";
+	req_access = list("ACCESS_TORCH_CREW")
+	},
+/obj/machinery/shield_diffuser,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Gk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/cockpit)
+/area/aquila/airlock)
 "Gl" = (
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 1;
@@ -12793,29 +11534,28 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
 "Gm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
 	},
 /obj/item/device/radio/beacon/anchored{
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Gr" = (
-/obj/structure/table/standard,
-/obj/random/tool,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "Gv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12836,26 +11576,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Gx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Gy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "Gz" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -12863,57 +11583,23 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
-"GB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"GG" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"GI" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"GK" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "GL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/structure/closet/medical_wall{
+	pixel_x = -32
 	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rnd)
-"GM" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/obj/item/weapon/reagent_containers/syringe,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/structure/iv_drip,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/firstaid,
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "GO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -12962,120 +11648,66 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"GQ" = (
+"GR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"GX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"GR" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"GX" = (
-/obj/structure/bed/chair/padded/red,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/vending/wallmed1{
+	dir = 1;
+	icon_state = "wallmed";
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Ha" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "Hb" = (
-/obj/machinery/disposal,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
 	},
-/obj/machinery/button/windowtint{
-	id = "rd_windows";
-	pixel_x = 6;
-	pixel_y = 24;
-	range = 11
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Hc" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/emitter,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "Hf" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1331;
+	id_tag = "aquila_shuttle";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list("ACCESS_TORCH_AQUILA");
+	tag_exterior_sensor = "aquila_shuttle_sensor_external"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_pump"
+	},
+/obj/structure/handrai,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Hk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Hl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
+/area/aquila/airlock)
 "Hm" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -13093,33 +11725,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "Hr" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Ht" = (
-/obj/machinery/air_sensor{
-	id_tag = "phoron_sensor"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Hu" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/passenger)
 "Hv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -13135,35 +11743,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Hw" = (
-/obj/structure/table/standard,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/scanning_module,
-/obj/item/device/paicard,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"Hy" = (
-/obj/machinery/power/smes/buildable/preset/torch/shuttle{
-	RCon_tag = "Shuttle - Petrov"
+/area/aquila/medical)
+"Hx" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/sterilizine,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Hz" = (
-/obj/structure/table/glass,
-/obj/item/weapon/pen,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"HB" = (
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "HC" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13193,36 +11786,6 @@
 "HG" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/storage)
-"HH" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"HJ" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8;
-	icon_state = "bordercolorhalf"
-	},
-/obj/machinery/alarm{
-	alarm_id = "xenobio2_alarm";
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
 "HK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13300,33 +11863,10 @@
 /area/maintenance/fifthdeck/aftport)
 "HU" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/table/steel,
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"HV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"HX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "HY" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -13336,50 +11876,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"HZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Suit Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Ia" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/vacant/bar)
-"Ib" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ic" = (
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/acid{
-	density = 0;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "Id" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -13396,24 +11896,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ij" = (
-/obj/machinery/artifact_harvester,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ik" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "In" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13441,64 +11923,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"It" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell1)
 "Iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Iv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"IA" = (
-/obj/machinery/lapvend,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"IB" = (
-/obj/machinery/disposal,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Fabrication";
-	dir = 2
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"IC" = (
-/obj/machinery/suspension_gen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "IF" = (
-/obj/machinery/computer/shuttle_control{
-	dir = 4;
-	icon_state = "computer";
-	req_access = list("ACCESS_TORCH_PETROV_HELM");
-	shuttle_tag = "Petrov"
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/crew,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "IH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13538,19 +11976,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"IR" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "IU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13588,14 +12013,6 @@
 /obj/effect/shuttle_landmark/ert/hanger,
 /turf/space,
 /area/space)
-"IY" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "Ja" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -13609,6 +12026,19 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
+"Je" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/cockpit)
 "Jf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13619,38 +12049,15 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Jh" = (
-/obj/structure/sign/warning/deathsposal,
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/maint)
-"Ji" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Jj" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
 "Jk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cockpit)
-"Jl" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/cell1)
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "Jn" = (
 /obj/effect/catwalk_plated,
 /obj/structure/closet/hydrant{
@@ -13659,22 +12066,17 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "Jo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Jt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13687,82 +12089,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ju" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Jv" = (
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Jx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"Jz" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"JA" = (
-/obj/structure/closet/crate/secure/biohazard,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
-"JB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/airlock)
 "JG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13787,36 +12125,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"JH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell3";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"JK" = (
-/obj/structure/mopbucket,
-/obj/item/weapon/mop,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
 "JL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13830,53 +12138,46 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "JM" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
-"JO" = (
-/obj/structure/closet/bombcloset,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"JP" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"JS" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
+"JW" = (
+/obj/structure/catwalk,
+/obj/structure/sign/warning/compressed_gas{
 	dir = 8;
-	icon_state = "warningcorner"
+	icon_state = "hikpa";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"JX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"JX" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "JY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -13904,73 +12205,45 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Kb" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell1";
-	pixel_x = -18
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Kc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/effect/paint/silver,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/rd)
+/area/aquila/maintenance)
 "Kh" = (
-/obj/structure/table/standard,
-/obj/item/weapon/folder/nt,
-/obj/item/stack/nanopaste,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/body_scanconsole{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
+/area/aquila/medical)
 "Ki" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Hallway Fore";
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Kj" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Kk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 9;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "Ko" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/port_gen/pacman{
@@ -13982,38 +12255,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
-"Kr" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Kt" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/custodial)
-"Ku" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/structure/sign/warning/compressed_gas{
-	dir = 8;
-	icon_state = "hikpa";
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Kw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
+"Ks" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "Ky" = (
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Charon"
@@ -14052,18 +12297,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"KD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+"KB" = (
+/obj/machinery/computer/ship/helm{
+	req_access = list(list("ACCESS_TORCH_AQUILA_HELM"))
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
+"KC" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1;
+	icon_state = "map"
+	},
+/turf/simulated/floor/airless,
+/area/aquila/secure_storage)
 "KI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -14084,40 +12335,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "KL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/handrai{
+/obj/structure/bed/chair/shuttle/blue{
 	dir = 4;
-	icon_state = "handrail"
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"KN" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "KQ" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "KU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14128,20 +12358,7 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"KV" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "KW" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -14149,15 +12366,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"KY" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14201,59 +12409,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "Lg" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Crew Area"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/handrai,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Li" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "Lj" = (
 /turf/simulated/floor/wood/walnut{
 	icon_state = "walnut_broken5"
 	},
 /area/vacant/bar)
 "Lm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
@@ -14308,90 +12493,40 @@
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/airlock)
 "Lt" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rnd)
-"Lu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/bed/chair/shuttle/blue{
 	dir = 4;
-	icon_state = "intact"
+	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Lv" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/obj/machinery/computer/cryopod{
+	pixel_y = -32
 	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov3";
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "LA" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rd)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "LB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"LC" = (
-/obj/structure/table/rack,
-/obj/item/device/flashlight,
-/obj/item/device/radio,
-/obj/item/weapon/crowbar,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"LE" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"LF" = (
-/obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"LG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
+"LH" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9;
 	icon_state = "intact"
 	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
-"LI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14404,28 +12539,19 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"LM" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
-"LN" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/equipment)
 "LP" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"LQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/hatch{
+	name = "Secure Storage"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
 "LT" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -14440,20 +12566,13 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"LU" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
+"LV" = (
+/obj/machinery/computer/shuttle_control/explore/aquila,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "LW" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "LX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14473,10 +12592,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Mb" = (
-/obj/structure/table/steel,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Mc" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/structure/railing/mapped{
@@ -14487,10 +12610,38 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Mg" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/scientist_torch,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
+"Mi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Mj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14511,7 +12662,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Ml" = (
+"Mq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14523,66 +12674,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"Mm" = (
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/analysis)
-"Mn" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan,
-/obj/machinery/light,
-/obj/machinery/alarm{
+/obj/machinery/firealarm{
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"Mo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
-	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov1";
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "Mr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/security)
-"Mt" = (
 /obj/structure/handrai{
 	dir = 4;
 	icon_state = "handrail"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Mu" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -14592,32 +12696,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "Mv" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/item/device/megaphone,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
+/obj/random/snack,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"Mx" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
+/area/aquila/mess)
 "My" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14625,27 +12709,24 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Mz" = (
-/obj/structure/stasis_cage,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Equipment";
+"MB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Passenger Seating"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"MB" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovBiohazard";
-	name = "Petrov Biohazard Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "MC" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14666,10 +12747,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "MD" = (
-/obj/machinery/hologram/holopad/longrange,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
+/obj/structure/table/rack,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Storage";
+	dir = 1
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
 "ME" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -14680,21 +12777,33 @@
 /area/vacant/bar)
 "ML" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	autoset_access = 0;
+	frequency = 1331;
 	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
+	id_tag = "aquila_shuttle_dock_outer";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
-/obj/effect/shuttle_landmark/petrov/start,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/area/hallway/primary/fifthdeck/aft)
 "MN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/overmap/visitable/ship/landable/aquila,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "MO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14722,11 +12831,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"MQ" = (
-/obj/structure/table/standard,
-/obj/machinery/reagent_temperature,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fifthdeck/fore)
@@ -14742,46 +12846,49 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"MX" = (
-/obj/machinery/light{
-	dir = 8
+"MZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "Na" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "Nb" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/effect/paint/silver,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
+"Nc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/cockpit)
+/area/maintenance/fifthdeck/aftport)
 "Ne" = (
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
-"Nf" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ng" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/effect/paint/silver,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -14798,26 +12905,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ni" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	name = "Petrov Security Desk"
+/obj/machinery/door/airlock/hatch{
+	name = "Head"
 	},
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 1;
-	name = "Petrov Security Desk"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "concheckwindow2";
-	name = "Research Checkpoint Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Nl" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -14838,28 +12941,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Nq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Nu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 4;
-	icon_state = "cap"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Nv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14883,54 +12964,28 @@
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftport)
-"Ny" = (
+"NB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Cockpit"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"NC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "ND" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rcheckinner_windows"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/security)
+/obj/machinery/computer/ship/engines,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "NF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14941,161 +12996,50 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"NG" = (
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "NI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/microwave,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Crew Compartment";
+	dir = 2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"NJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
+/area/aquila/mess)
 "NL" = (
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
 "NO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rcheckinner_windows"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/security)
-"NP" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "NS" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
-"NW" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"NX" = (
-/obj/machinery/atmospherics/omni/filter{
-	tag_east = 2;
-	tag_south = 3;
-	tag_west = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"NY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
-"NZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"Od" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Of" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Custodial Closet"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/custodial)
-"Og" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Oh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/area/aquila/medical)
+"NY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"Oi" = (
-/obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/aquila/medical)
 "Ol" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable{
@@ -15118,17 +13062,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Oq" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell1";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+"Ot" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "Ow" = (
 /obj/structure/handrai{
 	dir = 4;
@@ -15157,108 +13093,74 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
-"OC" = (
-/obj/structure/table/standard,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
+"OF" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"OD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Isolation Chambers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/medical)
 "OG" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "OH" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_pump"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"OM" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
+/obj/machinery/oxygen_pump{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"ON" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"OO" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
-/obj/structure/window/reinforced{
+/obj/structure/handrai,
+/obj/effect/floor_decal/techfloor{
 	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"OR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"OU" = (
-/obj/machinery/light{
-	dir = 4
+/area/aquila/airlock)
+"OJ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/secure_storage)
+"OO" = (
+/obj/machinery/sleeper{
+	dir = 8
 	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
+"OR" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table/steel_reinforced,
+/obj/random/toolbox,
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/device/radio,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
+/area/aquila/cockpit)
+"OU" = (
+/obj/structure/table/standard,
+/obj/item/weapon/defibrillator/loaded,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Infirmary";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "OW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15306,88 +13208,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Pa" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital{
-	dir = 1;
-	icon_state = "map_tvalvem0"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
+"Pc" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "Pd" = (
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
-"Pe" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/analysis)
-"Pm" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Pn" = (
-/obj/structure/hygiene/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Pr" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/item/weapon/folder/nt,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Anomaly Fore";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Pt" = (
-/obj/structure/sign/warning/airlock{
-	dir = 8;
-	icon_state = "doors"
-	},
-/obj/effect/paint/silver,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/airlock)
 "Pv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/bridge{
@@ -15403,15 +13235,12 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Px" = (
-/obj/machinery/radiocarbon_spectrometer,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+"Pw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/junk,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "Py" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -15432,37 +13261,17 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "PC" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/catwalk,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"PE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"PK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/aquila/passenger)
 "PM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -15483,39 +13292,47 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "PR" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
+"PW" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "Qd" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/bar)
-"Qe" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Qg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15532,150 +13349,86 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Qi" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
-"Qj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+"Qh" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Qk" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
 	},
+/obj/structure/handrai,
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
+"Qn" = (
+/turf/simulated/wall/prepainted,
+/area/quartermaster/expedition/eva)
+"Qo" = (
+/obj/structure/hygiene/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
+"Qp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Qq" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Qm" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell2)
-"Qn" = (
-/turf/simulated/wall/prepainted,
-/area/quartermaster/expedition/eva)
-"Qo" = (
-/obj/structure/table/steel,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/button/alternate/door{
-	desc = "A remote control-switch for airlocks.";
-	id_tag = "PetrovAccess";
-	name = "Petrov Interior Door Control";
-	pixel_x = -5;
-	pixel_y = 6;
-	req_access = list("ACCESS_TORCH_PETROV_SEC")
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Security";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "concheckwindow2";
-	name = "Office Shutter Control";
-	pixel_x = 5;
-	pixel_y = 6
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"Qp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
+/area/aquila/airlock)
+"Qt" = (
+/obj/machinery/light/small,
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Qr" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
-"Qz" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/maintenance)
 "QA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"QB" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "QE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -15687,44 +13440,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"QF" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/glass/fifty,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
 "QH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"QI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Phoron Sublimation Lab"
+/obj/structure/handrai,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "QJ" = (
 /obj/effect/paint/hull,
 /obj/structure/sign/solgov,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
-"QK" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "QL" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/blast/regular{
@@ -15740,14 +13475,24 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"QR" = (
-/obj/structure/closet/crate/secure/biohazard,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
+"QU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "QV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -15760,23 +13505,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"QW" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "QX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15815,10 +13543,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Rc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Rd" = (
 /obj/machinery/light{
 	dir = 8
@@ -15853,21 +13577,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ri" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Cockpit"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "Rj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/largecrate,
@@ -15876,58 +13585,46 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
+"Rl" = (
+/obj/structure/table/rack,
+/obj/random/solgov,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/secure_storage)
 "Rn" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/rnd)
-"Rp" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10;
 	icon_state = "intact"
 	},
-/obj/structure/disposalpipe/segment{
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
+"Rs" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"Rr" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Rt" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Rv" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"Rx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/porta_turret{
+	dir = 8;
+	enabled = 0;
+	lethal = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/airless,
+/area/aquila/cockpit)
 "Ry" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15961,43 +13658,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"RB" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1441;
-	icon_state = "map_injector";
-	id = "phoron_in";
-	use_power = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"RE" = (
-/obj/machinery/suit_storage_unit/science,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"RG" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"RN" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+"RI" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/storage)
 "RQ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/infirmary)
@@ -16009,57 +13673,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"RX" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"RZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/anobattery{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/weapon/anobattery{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/anobattery{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/anobattery{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Analysis";
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Sb" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell2";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+"RV" = (
+/obj/structure/railing/mapped,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "Sc" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16086,37 +13703,34 @@
 "Sd" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
-"Sg" = (
+"Si" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/machinery/computer/atmoscontrol/laptop{
-	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
-	req_access = list("ACCESS_TORCH_PETROV_MAINT")
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/stack/medical/advanced/bruise_pack,
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"So" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"Sp" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/area/aquila/medical)
+"Sk" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5;
+	icon_state = "intact"
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/sign/warning/nosmoking_1{
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
+"Sl" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
 	dir = 4;
-	icon_state = "nosmoking";
-	pixel_x = -32
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/passenger)
 "Sr" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -16128,33 +13742,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"Ss" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"Su" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Sv" = (
 /obj/random/torchcloset,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
-"Sw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "Sy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -16165,40 +13757,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"Sz" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"SA" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"SB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "SE" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16211,33 +13769,6 @@
 /obj/machinery/reagent_temperature,
 /turf/simulated/floor/plating,
 /area/vacant/infirmary)
-"SH" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"SI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "SJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16254,9 +13785,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "SK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "SM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16281,40 +13816,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"SN" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"SQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"SU" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "SV" = (
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
@@ -16334,28 +13835,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Tc" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/binary/pump,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
-"Tg" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16370,78 +13849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Tp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/eva)
-"Tr" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Ts" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Tt" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Tu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Tw" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16452,26 +13859,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Tx" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/analysis)
 "TA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 8;
+	icon_state = "nosmoking";
+	pixel_x = 32
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"TB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
 "TC" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/box/glasses,
@@ -16481,53 +13891,24 @@
 	},
 /area/vacant/bar)
 "TD" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Docking Port";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"TF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_x = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"TG" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8;
-	icon_state = "bordercolorhalf"
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"TH" = (
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/weapon/screwdriver{
-	pixel_y = 15
-	},
-/obj/item/weapon/melee/baton/loaded,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aquila/airlock)
 "TL" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -16543,23 +13924,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
 "TM" = (
-/obj/structure/table/glass,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/nt,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"TO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	name = "south bump";
+	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "TP" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -16574,9 +13954,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"TR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+"TS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Ub" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16586,57 +13973,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"TS" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"TY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"TZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"Ub" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/security/research{
-	name = "Checkpoint"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Um" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16646,46 +13984,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"Un" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_outer";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"Uq" = (
-/obj/machinery/atmospherics/unary/vent_pump/tank{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "toxins_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"Ur" = (
-/obj/machinery/vending/assist,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Us" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -16699,37 +13997,28 @@
 "Ut" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"Uu" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Uw" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell3)
-"Uy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "UA" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"UC" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "UE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -16740,11 +14029,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"UF" = (
-/obj/structure/table/standard,
-/obj/item/device/integrated_circuit_printer,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "UG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -16752,6 +14036,26 @@
 "UH" = (
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"UI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftport)
+"UJ" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "UL" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -16768,53 +14072,27 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
-"UM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Chief Science Officer";
-	secured_wires = 1
+"UO" = (
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fifthdeck/aft)
+"UT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rd)
-"UO" = (
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
-"UQ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"UT" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "UW" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16823,30 +14101,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"UX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Va" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_sensor";
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_pump"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/obj/structure/sign/solgov,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/airlock)
 "Vb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -16874,64 +14133,38 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Vk" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "Vm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_outer";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "Vo" = (
-/obj/item/weapon/stool/padded,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/porta_turret{
+	dir = 8;
+	enabled = 0;
+	lethal = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/airless,
+/area/aquila/cockpit)
 "Vr" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftstarboard)
+"Vt" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/cockpit)
 "Vv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/hatch{
+	name = "Infirmary"
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"Vy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/medical)
 "Vz" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -16950,152 +14183,38 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"VB" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovBiohazard";
-	name = "Petrov Biohazard Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "VC" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"VD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell2";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"VF" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"VG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"VM" = (
-/obj/structure/noticeboard{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Chief Science Officer";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "VN" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"VO" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/weapon/pickaxe{
-	pixel_x = 5
+"VQ" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1;
+	sheets = 25
 	},
-/obj/item/weapon/pickaxe{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"VP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "VT" = (
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"VU" = (
-/obj/structure/table/rack,
-/obj/item/device/scanner/xenobio,
-/obj/item/device/scanner/xenobio,
-/obj/item/device/scanner/xenobio,
-/obj/item/weapon/storage/excavation,
-/obj/item/device/measuring_tape,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"VV" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "VX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -17136,6 +14255,10 @@
 /obj/effect/shuttle_landmark/ninja/hanger,
 /turf/space,
 /area/space)
+"Wd" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17150,13 +14273,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Wl" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/isolation)
-"Wn" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+"Wh" = (
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "Wo" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -17176,49 +14295,37 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Wp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/random/cash,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
 "Wt" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
 	},
-/obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Wy" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/atmospherics/unary/vent_pump/tank{
-	dir = 1;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "phoron_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 0
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Wz" = (
-/obj/machinery/computer/air_control{
-	dir = 2;
-	input_tag = "phoron_in";
-	name = "Test Chamber Gas Monitor";
-	output_tag = "phoron_out";
-	sensor_name = "Test Chamber";
-	sensor_tag = "phoron_sensor"
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
+"WB" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "WD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -17236,57 +14343,54 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "WF" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	icon_state = "nosmoking";
+	pixel_x = -32
 	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"WG" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "WH" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
-"WO" = (
-/obj/structure/table/standard,
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
+"WN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/item/weapon/disk/design_disk,
-/obj/item/weapon/disk/design_disk,
-/obj/item/weapon/reagent_containers/dropper{
-	pixel_y = -4
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"WR" = (
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
 "WU" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/expedition)
-"Xa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/maint)
+"WZ" = (
+/obj/structure/hygiene/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/mirror{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Xb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -17306,28 +14410,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Xc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
-"Xd" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	icon_state = "nosmoking";
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Xe" = (
-/obj/structure/bed/chair/office/comfy/red,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
 "Xf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -17343,6 +14425,16 @@
 "Xi" = (
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"Xj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "Xk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17383,19 +14475,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Xq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Xs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Xt" = (
 /obj/effect/paint/hull,
 /obj/structure/disposalpipe/segment{
@@ -17430,19 +14509,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"XB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -17463,65 +14529,24 @@
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "XG" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/phoron)
-"XH" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "XI" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/bar)
 "XJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Cockpit";
+	dir = 8
 	},
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/computer/modular/preset/cardslot/command,
+/obj/item/device/radio/intercom/hailing{
 	dir = 8;
-	icon_state = "techfloor_edges"
+	pixel_x = 24
 	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_pump"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_sensor";
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"XQ" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "XT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17551,13 +14576,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"XW" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Yb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Yc" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 8
@@ -17567,27 +14585,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
-"Yf" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+"Yd" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "Yg" = (
-/obj/structure/table/steel,
-/obj/item/weapon/book/manual/nt_regs,
-/obj/item/weapon/folder/nt,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/cockpit)
 "Yi" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -17618,29 +14624,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Yk" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/phoron)
 "Ym" = (
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
-"Yn" = (
-/obj/machinery/disposal,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Yo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17656,42 +14642,6 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Yp" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Yr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/eva)
-"Ys" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Toxins Lab"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Yu" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17700,71 +14650,38 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Yw" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/dispenser,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Yz" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"YE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "concheckwindow2";
-	name = "Research Checkpoint Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/security)
-"YG" = (
+/obj/structure/handrai,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"YE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	name = "south bump";
+	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "YH" = (
 /obj/random/obstruction,
 /obj/structure/cable/cyan{
@@ -17774,9 +14691,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
-"YJ" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "YL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -17789,90 +14703,62 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
+"YN" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/medical)
 "YQ" = (
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"YS" = (
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Aft Passageway";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"YV" = (
-/obj/structure/hygiene/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Entry";
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 0;
-	dir = 4;
-	frequency = 1380;
-	id_tag = "petrov_shuttle_airlock";
-	pixel_x = -24;
-	pixel_y = 0;
-	req_access = list("ACCESS_TORCH_PETROV");
-	tag_airpump = "petrov_shuttle_pump";
-	tag_chamber_sensor = "petrov_shuttle_sensor";
-	tag_exterior_door = "petrov_shuttle_outer";
-	tag_exterior_sensor = null;
-	tag_interior_door = "petrov_shuttle_inner"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "YW" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"YZ" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
-	icon_state = "freezer"
+"YY" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1;
+	icon_state = "map"
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/airless,
+/area/aquila/medical)
 "Za" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17894,18 +14780,22 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "Zc" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_pump"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/techfloor,
 /obj/structure/handrai{
 	dir = 1;
 	icon_state = "handrail"
 	},
-/obj/machinery/light/small,
+/obj/effect/floor_decal/techfloor,
+/obj/item/device/radio/intercom/hailing{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/airlock)
 "Zd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -17919,14 +14809,15 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
 "Ze" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1;
-	icon_state = "bordercolorhalf"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/computer/modular/preset/civilian,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "Zg" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -17986,91 +14877,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Zp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/computer/air_control{
-	dir = 8;
-	input_tag = "toxins_in";
-	name = "Toxins Gas Monitor";
-	output_tag = "toxins_out";
-	sensor_name = "Toxins Test Chamber";
-	sensor_tag = "toxins_sensor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Zr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Zu" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
 "Zw" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_pump"
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	density = 1;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_outer";
+	locked = 1;
+	name = "Aquila External Access";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
-	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Zx" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/crate/radiation,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"Zy" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/area/aquila/airlock)
 "ZA" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/canister)
-"ZB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"ZD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -18084,19 +14907,6 @@
 "ZG" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftstarboard)
-"ZJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/analysis)
 "ZL" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -18121,47 +14931,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"ZQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"ZT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"ZU" = (
-/obj/structure/table/standard,
-/obj/item/device/geiger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"ZV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"ZY" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 
 (1,1,1) = {"
 aa
@@ -40884,7 +37653,7 @@ sC
 ps
 Qg
 hj
-jP
+hj
 gH
 qH
 Fk
@@ -41066,16 +37835,16 @@ aa
 aa
 aa
 aa
-aa
+Ot
 ZG
-ZG
-ZG
-SB
+MZ
+Pw
+AU
 Cs
-Hk
-Fg
 Zm
 Lq
+wH
+wH
 wH
 wH
 wH
@@ -41096,19 +37865,19 @@ aC
 nH
 EI
 EI
+EI
+EI
 ub
 uc
 ud
 aC
 Ka
 aC
-aC
-aC
 Lm
+UI
+Nc
 ws
 ws
-ws
-aa
 aa
 aa
 aa
@@ -41268,17 +38037,17 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
+zN
+JW
 TA
-Ku
-hf
 An
 wk
 Na
 HM
+ZG
+ZG
 ZG
 ZG
 ZG
@@ -41300,6 +38069,8 @@ ws
 ws
 ws
 ws
+ws
+ws
 ue
 zr
 zr
@@ -41309,8 +38080,6 @@ ug
 uj
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -41470,11 +38239,9 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
-GQ
+zN
 ZA
 ZA
 tf
@@ -41489,11 +38256,15 @@ ZG
 ZG
 ZG
 ZG
+ZG
+ZG
 vF
 pw
-vE
+vD
 eB
 da
+ws
+ws
 ws
 ws
 ws
@@ -41511,8 +38282,6 @@ gI
 uk
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -41672,19 +38441,19 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
-GQ
+zN
 sW
 hc
 tg
 tn
 BC
 BC
-ZG
-ZG
+Ot
+Ot
+aa
+aa
 aa
 aa
 aa
@@ -41694,8 +38463,10 @@ aa
 zS
 da
 tG
-tG
+fh
 zS
+aa
+aa
 aa
 aa
 aa
@@ -41713,8 +38484,6 @@ we
 uH
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -41874,38 +38643,40 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
-GQ
+zN
 ZA
 sX
 tg
 tc
 BC
 BC
-ZG
+Ot
 aa
 aa
-bP
-bP
-bP
-bP
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 Al
-Al
+da
 ML
-Tr
-Al
+ML
+da
+zX
+zX
+zX
+zX
+zX
+zX
+RI
+RI
+RI
 aa
-Fx
-Gk
-Gk
-Fx
-aa
-aa
-ws
 ws
 ws
 ok
@@ -41915,8 +38686,6 @@ vP
 uX
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42076,11 +38845,9 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
-GQ
+zN
 ZA
 hg
 th
@@ -42089,24 +38856,28 @@ BC
 BC
 aa
 aa
-bP
-bP
-bP
-bP
-bP
 aa
-Al
+aa
+aa
+aa
+aa
+bP
+bP
+bP
+EP
 Va
 Gh
 Zw
-Al
-aa
+zX
+zX
 xh
 FX
 IF
-Fx
-Fx
-aa
+Ks
+xE
+Rl
+FE
+DI
 aa
 ws
 ws
@@ -42117,8 +38888,6 @@ xv
 xv
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42278,11 +39047,9 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
-GQ
+zN
 ZA
 sY
 tl
@@ -42291,24 +39058,28 @@ BC
 BC
 aa
 aa
+aa
+aa
+aa
+aa
+aa
 bP
-bP
-bP
-bP
-bP
+DS
 Mr
-Al
+WZ
 Jv
 yL
 Zc
-Al
+zX
 Jk
-xh
+WN
 Wp
 JM
 LP
-xh
-aa
+TB
+rf
+KC
+DI
 aa
 ws
 ws
@@ -42319,8 +39090,6 @@ wj
 Sv
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42474,17 +39243,15 @@ aa
 aa
 aa
 aa
+Ot
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+Ot
 ZG
-ZG
-GQ
+zN
 sW
 sZ
 ti
@@ -42493,24 +39260,28 @@ BC
 BC
 aa
 aa
-tT
-ND
-TG
-HJ
+aa
+aa
+aa
+aa
+aa
+bP
 bP
 NO
-Al
+Rs
 Pt
 Hf
 Bf
-Al
+zX
 Nb
 Fx
 zB
 MD
-zo
-xh
-aa
+Ks
+Qh
+OJ
+KC
+DI
 aa
 ws
 ws
@@ -42521,8 +39292,6 @@ vS
 vY
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42676,17 +39445,15 @@ aa
 aa
 aa
 aa
+Ot
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+Ot
 ZG
-ZG
-aw
+vV
 ZA
 ZA
 tj
@@ -42695,24 +39462,28 @@ BC
 BC
 aa
 aa
-tT
-ND
+aa
+aa
+aa
+aa
 Vo
-zK
+bP
 Qo
 Mb
 YE
-YV
+Pt
 OH
 TD
-Ri
-Dw
+zX
+zX
 wz
-ON
-Mn
-Fx
-Fx
-aa
+zX
+zX
+Ks
+Ks
+UJ
+LH
+Fi
 aa
 ws
 ws
@@ -42723,8 +39494,6 @@ gI
 gI
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42878,43 +39647,45 @@ aa
 aa
 aa
 aa
+Ot
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+Ot
 ZG
-ZG
+AW
+Xj
 WF
-HH
-hP
 BS
 eo
 ZG
 ZG
 aa
+aa
+aa
+aa
+Vt
+Vt
+Vt
 bP
 bP
 bP
-LC
-NI
-zC
-Xe
 Ni
-Pn
-vp
+Pt
+DR
 Ao
-LA
-LA
-LA
-LA
-LA
-LA
-LA
-LA
+Pt
+sD
+Mq
+Pc
+BW
+wQ
+wQ
+AC
+aa
+aa
 aa
 ws
 ws
@@ -42925,8 +39696,6 @@ vJ
 vL
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43080,43 +39849,45 @@ aa
 aa
 aa
 aa
+Ot
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-ZG
+Ot
 ZG
 ye
 BG
-ec
+RV
 BS
 Py
 ZG
 ZG
 aa
-tT
-ND
+Vt
+Je
+Je
+Vt
 ah
-xd
+Vt
 NI
 BN
 aG
-bP
-Al
+Mi
+DR
 Qp
 Dz
 LA
-VM
+LA
 YQ
 Gc
 AM
 Wt
 Kc
-CT
+AC
+Yd
+aa
 aa
 ws
 ws
@@ -43127,8 +39898,6 @@ wd
 vM
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43288,18 +40057,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-ZG
+Ot
 ZG
 yY
 XU
-sb
+RV
 BS
 Py
 ZG
 ZG
 aa
+pj
+KB
 tT
 ND
 Ze
@@ -43308,17 +40077,19 @@ Mv
 xN
 yG
 Ub
-JS
+DR
 wL
 TS
 LW
-VT
+LW
 GX
-Hz
+Pc
 CJ
 VT
-Kc
+fV
 CT
+kH
+aa
 aa
 ws
 ws
@@ -43329,8 +40100,6 @@ vK
 vN
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43490,38 +40259,40 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
 ZG
-ZG
-hL
+AW
 Xl
-AZ
-ZT
+hL
+WB
+ye
 ZG
 ZG
-ZG
-ZG
+aa
+pj
+LV
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+vi
+gS
+NB
+QU
+fv
+zj
+BP
 Lg
 Gm
 MN
-LW
+eD
 eW
-GX
+Qq
 AS
 PR
 wu
-LA
-LA
-ws
+yZ
+CT
+kH
+aa
+aa
 ws
 ws
 gI
@@ -43531,8 +40302,6 @@ gI
 gI
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43692,38 +40461,40 @@ aa
 aa
 aa
 aa
-aa
-aa
+Ot
+ZG
+ye
+ye
+ye
+ye
+ye
 ZG
 ZG
-Qj
-Sw
-Tt
-Od
-ai
-bt
-VG
+aa
+pj
 Vm
-bQ
+tT
 XJ
 CA
-Ah
+Yg
 Ju
 KL
 Cn
-Xa
-yx
+xN
+DR
 Yz
 GR
-UM
-Pm
+LW
+LW
 UA
-BH
+Pc
 QH
-VT
-Kc
-CT
-ws
+mr
+PW
+zT
+kH
+aa
+aa
 ws
 ws
 vZ
@@ -43733,8 +40504,6 @@ vK
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43894,38 +40663,40 @@ aa
 aa
 aa
 aa
+Ot
+ZG
+ZG
+he
+ye
+ye
+ye
+ZG
+ZG
 aa
-aa
-ZG
-ZG
-ZG
-ER
-AU
-AU
-NJ
-yu
-ve
-Un
-Ac
-TZ
+Vt
+Je
+Je
+Vt
 OR
-Rx
+Vt
 vA
 xS
 Jo
 AY
-BD
+DR
 JX
 DK
-LA
+vu
 Hb
 TM
-Du
+Pc
 xK
 KQ
-Kc
-CT
-ws
+Qt
+AC
+Yd
+aa
+aa
 ws
 ws
 vK
@@ -43935,8 +40706,6 @@ vK
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -44096,49 +40865,49 @@ aa
 aa
 aa
 aa
+Ot
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
 aa
 aa
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-aT
-ZG
-ZG
-bu
-bu
-bu
-vr
+aa
+aa
+Vt
+Vt
+Vt
 Hr
-ys
-bu
-Jh
-VB
+Hr
+Hr
+Hr
+Hr
 MB
-LA
-LA
-LA
-LW
-LW
-LW
-LA
-LA
-LA
-ws
-ws
-ws
-ws
-ws
-ws
-ws
-ws
-ws
-ws
+Hr
+Wd
+dr
+BF
+Wd
+OF
+YN
+VQ
+AC
 aa
 aa
+aa
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
 aa
 aa
 aa
@@ -44299,8 +41068,6 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 ZG
@@ -44310,25 +41077,29 @@ ZG
 ZG
 ZG
 aa
-bu
-bu
-So
+aa
+aa
+aa
+aa
+aa
 Rv
-Do
-Hy
-bu
+Hr
+Hr
+gQ
 Mg
 UT
 Ki
 Lt
-IB
+Wd
 gt
 Ba
-SN
-Xc
-QF
-GL
+Wd
+Wd
+Wd
+Wd
 Rn
+Sk
+XG
 aa
 ws
 ws
@@ -44336,10 +41107,8 @@ ws
 ws
 ws
 ws
-ws
-ws
-aa
-aa
+ZG
+ZG
 aa
 aa
 aa
@@ -44502,8 +41271,6 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 ZG
@@ -44512,15 +41279,17 @@ ZG
 ZG
 ZG
 aa
-bu
-bu
-So
-By
+aa
+aa
+aa
+aa
+aa
+aa
 BL
 PC
-bu
-ge
-YG
+Wh
+Wh
+Wh
 tJ
 CW
 Vv
@@ -44530,17 +41299,17 @@ SK
 FW
 BO
 GL
-Rn
+Si
+YY
+ik
 aa
 ws
 ws
 ws
 ws
 ws
-ws
-ws
-aa
-aa
+ZG
+ZG
 aa
 aa
 aa
@@ -44705,8 +41474,6 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 ZG
@@ -44714,34 +41481,36 @@ ZG
 ZG
 ZG
 aa
-bu
-bu
-So
-Zu
-Ay
-Dd
-bu
+aa
+aa
+aa
+aa
+aa
+aa
+Hr
+Hr
+tM
 xA
-Qz
-yl
+xA
+xA
 zl
-WO
+Wd
 AL
 vc
 xB
-HB
-yC
-GL
-Rn
+xB
+xB
+xB
+ed
+YY
+ik
 aa
 ws
 ws
 ws
 ws
-ws
-ws
-aa
-aa
+ZG
+ZG
 aa
 aa
 aa
@@ -44908,41 +41677,41 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 Vr
 ZG
-ZG
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-xA
-BM
-Wn
-zl
-Ic
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Hr
+Hr
+Hr
+Sl
+Sl
+Hr
+Hr
+Wd
 Kh
 Hw
 OO
 OU
 zO
-Lt
-Lt
-Lt
-ws
-ws
+Hx
+BB
+DH
+ik
+aa
+aa
+aa
 Nx
-ws
-ws
-aa
-aa
+ZG
+ZG
 aa
 aa
 aa
@@ -45116,29 +41885,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-bb
-Hc
-RN
-AK
-RZ
-xr
-bb
-bb
-SA
-ze
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Wd
+Wd
+Wd
+Wd
+Wd
+Wd
+Wd
 XG
 XG
 XG
-XG
-Yk
 aa
 aa
 aa
@@ -45318,29 +42087,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-aU
-Uy
-Uy
-Uy
-LE
-ZY
-Mt
-bb
-yr
-ZD
-Yk
-IR
-Dt
-EJ
-XQ
-Ff
-Ng
-Wy
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45520,29 +42289,29 @@ aa
 aa
 aa
 aa
-Pe
-ZJ
-Ij
-ZY
-Hl
-Ss
-xX
-Jx
-Gy
-yP
-YS
-Zr
-QI
-Cy
-KD
-wm
-LI
-WG
-CH
-Dv
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45722,29 +42491,29 @@ aa
 aa
 aa
 aa
-Pe
-ZJ
-Ib
-ZY
-ZY
-yy
-tR
-Ag
-ZV
-Mm
-As
-Wn
-Li
-Wz
-zs
-YJ
-YJ
-WG
-Rc
-Ht
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45924,29 +42693,29 @@ aa
 aa
 aa
 aa
-Pe
-ZJ
-Nf
-ZY
-DZ
-vo
-Fo
-Vk
-MQ
-Tx
-BM
-Wn
-Li
-wn
-El
-OC
-IY
-Tc
-Ng
-RB
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46126,29 +42895,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-Px
-wl
-Ap
-TH
-Ch
-LF
-mm
-Tx
-QW
-FU
-Wl
-Wl
-Wl
-Wl
-Wl
-It
-Jl
-Jl
-Jl
-Jl
-It
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46328,29 +43097,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-bb
-bb
-Tx
-Tx
-Tx
-bb
-bb
-bb
-QB
-Dq
-JP
-vq
-Pr
-Sg
-zm
-xO
-Nq
-Mo
-Kb
-Zy
-Oq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46530,29 +43299,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-IA
-MX
-Mx
-NP
-IC
-Mz
-wY
-yR
-Bo
-Yb
-JP
-Oi
-Ha
-JB
-Tu
-Dy
-SI
-SU
-KN
-Zy
-Oq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46732,29 +43501,29 @@ aa
 aa
 aa
 aa
-DX
-Qr
-UF
-Fd
-Fd
-XW
-Xs
-Fd
-QK
-yR
-Og
-Dq
-Ec
-ZU
-TF
-Lu
-fD
-xO
-Bn
-GG
-zk
-Zy
-Oq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46934,29 +43703,29 @@ aa
 aa
 aa
 aa
-DX
-Qr
-Bx
-Fd
-Zx
-xs
-Iv
-Fd
-Yn
-LN
-Ts
-Hu
-Wl
-Gr
-Rr
-zd
-DO
-It
-It
-It
-It
-It
-It
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47136,29 +43905,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-JO
-Ak
-wx
-CC
-Jz
-En
-Tg
-Ed
-CE
-TY
-OD
-PK
-XH
-EE
-VD
-gZ
-Dh
-Fy
-At
-RX
-Sb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47338,29 +44107,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-LN
-HZ
-LN
-LN
-GK
-Aq
-BJ
-LN
-TR
-Bg
-Wl
-Ur
-KV
-zH
-Bs
-RG
-HV
-WR
-LQ
-RX
-Sb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47540,29 +44309,29 @@ aa
 aa
 aa
 aa
-bc
-bc
-Ae
-Ny
-DE
-LN
-VV
-Sz
-Kr
-LN
-SQ
-Xd
-Wl
-Bu
-CV
-zP
-fE
-ha
-Fu
-FD
-zi
-RX
-Sb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47742,29 +44511,29 @@ aa
 aa
 aa
 aa
-Yr
-Tp
-xY
-GB
-VU
-NW
-NW
-NW
-NW
-NW
-Ys
-NW
-Wl
-Wl
-yU
-Uu
-DG
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47944,29 +44713,29 @@ aa
 aa
 aa
 aa
-Yr
-Tp
-EH
-NC
-VO
-NW
-BY
-Ee
-Yw
-Ex
-Rp
-Sp
-UQ
-Wl
-YZ
-Yf
-JH
-zp
-Di
-Vy
-AP
-GM
-Bi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48146,29 +44915,29 @@ aa
 aa
 aa
 aa
-Yr
-Tp
-EH
-Ik
-Kw
-NW
-Qe
-BR
-yO
-UX
-vC
-CG
-bl
-Wl
-ZB
-Qk
-Nu
-ZQ
-Gb
-TO
-Ji
-GM
-Bi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48348,29 +45117,29 @@ aa
 aa
 aa
 aa
-bc
-bc
-RE
-Ml
-vG
-NW
-OM
-Pa
-Yp
-yO
-XB
-Xq
-bn
-Wl
-NX
-NG
-Yf
-GI
-Gx
-Lv
-SH
-GM
-Bi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48550,29 +45319,29 @@ aa
 aa
 aa
 aa
-CS
-CS
-CS
-Of
-CS
-CS
-ad
-Su
-Kj
-KY
-ap
-Zp
-HX
-Wl
-DN
-xy
-fG
-VF
-Uw
-Uw
-Uw
-Uw
-Uw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48752,29 +45521,29 @@ aa
 aa
 aa
 aa
-DQ
-DQ
-xV
-Kk
-QR
-CS
-NW
-ay
-ax
-aj
-aV
-be
-aV
-Rt
-Wl
-Wl
-Wl
-wE
-Wl
-UC
-UC
-fF
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48955,27 +45724,27 @@ aa
 aa
 aa
 aa
-DQ
-JA
-JK
-JA
-CS
-NW
-ae
-af
-LG
-Uq
-az
-bs
-Rt
-Wl
-Wl
-Wl
-za
-za
-Ax
-za
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49157,27 +45926,27 @@ aa
 aa
 aa
 aa
-DQ
-DQ
-DQ
-DQ
-DQ
-DQ
-NZ
-Jj
-Qi
-aq
-yf
-LU
-Rt
-Wl
-Wl
-fF
-fF
-fF
-fF
-fF
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49359,27 +46128,27 @@ aa
 aa
 aa
 aa
-DQ
-BT
-BT
-BT
-BT
-DQ
-Oh
-PE
-yo
-wU
-wU
-wU
-yo
-VP
-VP
-fF
-vt
-vt
-vt
-vt
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49561,12 +46330,6 @@ aa
 aa
 aa
 aa
-DQ
-Kt
-Kt
-Kt
-Kt
-DQ
 aa
 aa
 aa
@@ -49576,12 +46339,18 @@ aa
 aa
 aa
 aa
-fF
-LM
-LM
-LM
-LM
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1263,23 +1263,6 @@
 "acz" = (
 /turf/simulated/wall/prepainted,
 /area/medical/medicalhallway)
-"acB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel_reinforced,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Emergency Armory Desk"
-	},
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "acC" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -2553,7 +2536,7 @@
 /obj/machinery/door/airlock/glass/medical{
 	autoset_access = 0;
 	name = "Medical Foyer";
-	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
+	req_access = list(list("ACCESS_MEDICAL","ACCESS_MORGUE","ACCESS_FORENSICS"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
@@ -4368,11 +4351,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
-"ahL" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "ahM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4807,6 +4785,14 @@
 "ais" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/counselor/therapy)
 "aiu" = (
@@ -5303,6 +5289,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod12/station)
+"akd" = (
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "ake" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "First Deck Substation Bypass"
@@ -6725,10 +6714,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"asl" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "asq" = (
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
@@ -7456,7 +7441,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "avy" = (
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -7612,65 +7596,31 @@
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5;
-	icon_state = "intact"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"awH" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+"awI" = (
+/obj/structure/bed/chair/comfy/beige{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"awI" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "awJ" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"awL" = (
-/obj/machinery/button/blast_door{
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutter Control";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/stamp/denied{
-	pixel_x = 5
-	},
-/obj/item/weapon/stamp,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "awM" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
@@ -7830,15 +7780,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "axF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "axK" = (
 /obj/structure/bed/chair/padded/red{
@@ -8256,33 +8206,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"ayF" = (
+"ayG" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "operation_hallway_shutters";
-	name = "Operation Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
-"ayG" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -8293,62 +8228,37 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/item/device/radio/beacon,
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "ayH" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/device/radio/beacon,
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "ayJ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"ayK" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
+/obj/effect/wallframe_spawn/reinforced/hull,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/command/armoury/access)
-"ayL" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/area/hallway/primary/firstdeck/aft)
 "ayP" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 4;
@@ -8447,25 +8357,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"azR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "azS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -8477,19 +8371,6 @@
 /obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"azU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "azV" = (
 /obj/effect/shuttle_landmark/torch/deck4/guppy,
 /turf/space,
@@ -8620,166 +8501,48 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
 "aAU" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "aAV" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8;
-	icon_state = "corner_white"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aAW" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8;
-	icon_state = "loadingarea"
+/obj/structure/table/woodentable_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG,
+/obj/machinery/light,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aAX" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/airlock/command{
-	name = "Emergency Armory Access";
-	secured_wires = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aAY" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Emergency Armory - Access";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aAZ" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aBa" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Emergency Armory"
-	},
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_entrylock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury)
+/turf/simulated/floor/airless,
+/area/hallway/primary/firstdeck/aft)
 "aBb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/firstdeck/foreport)
 "aBc" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/tactical)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/security)
 "aBd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9020,16 +8783,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aCr" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_access = list("ACCESS_RESEARCH")
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aCu" = (
 /obj/effect/floor_decal/corner/red/mono,
@@ -9223,10 +8994,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Emergency Armory Entrance";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "aDB" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -9397,6 +9177,9 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"aEq" = (
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/analysis)
 "aEC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9404,29 +9187,55 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "aED" = (
-/obj/structure/largecrate,
-/obj/random/maintenance/solgov,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/corner/research{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "aEG" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/dutyboots,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/suit/armor/pcarrier/blue/sol,
-/obj/item/clothing/head/helmet/solgov,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/effect/floor_decal/corner/red/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "aEH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9708,13 +9517,24 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "aFM" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9956,8 +9776,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "aGN" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/access)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/pointdefense,
+/turf/simulated/floor/airless,
+/area/hallway/primary/firstdeck/aft)
 "aGP" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/brig)
@@ -10100,8 +9925,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aHT" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "aHX" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -10450,15 +10279,48 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aJl" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/security/research{
+	name = "Checkpoint"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "aJm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "petrov_shuttle_airlock";
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "aJn" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 8;
@@ -10885,11 +10747,18 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "aLo" = (
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
 "aLu" = (
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "aLv" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/flasher/portable,
@@ -11163,37 +11032,21 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
-"aMy" = (
-/obj/structure/closet,
-/obj/random/action_figure,
-/obj/random/tech_supply,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
 "aMB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/medical,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/stack/nanopaste,
-/obj/item/bodybag/rescue/loaded,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aMC" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -11235,6 +11088,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
+"aMG" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "aMJ" = (
 /obj/machinery/door_timer/cell_2{
 	name = "Cell Two";
@@ -11446,6 +11307,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"aNx" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "aNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11468,8 +11337,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aNA" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/box/lights/mixed,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
 "aNB" = (
@@ -11477,10 +11348,13 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftport)
 "aNE" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aNG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -11855,6 +11729,17 @@
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
+"aPy" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "aPC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12228,32 +12113,93 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aQq" = (
-/obj/machinery/shieldwallgen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aQr" = (
-/obj/machinery/deployable/barrier,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/valve/shutoff/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/hallwaya)
 "aQs" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_inner";
+	locked = 0;
+	name = "Petrov Interior Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/area/shuttle/petrov/hallwaya)
 "aQt" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aQu" = (
-/obj/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 4;
+	icon_state = "console"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "aQx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -12525,16 +12471,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
-"aRm" = (
-/obj/machinery/deployable/barrier,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Emergency Armory - Port";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aRo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14583,12 +14519,53 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
+"baC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport)
 "bbb" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 2
 	},
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1starboard)
+"bcv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell2";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "bdb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/door/airlock/external,
@@ -14598,6 +14575,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
+"bdd" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "bdo" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "processwindow"
@@ -14629,6 +14610,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/foyer/storeroom)
+"bgw" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"bgz" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "bhb" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
@@ -14665,6 +14656,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/brig)
+"bhU" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell2)
 "bii" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14725,6 +14720,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"bky" = (
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - EVA";
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/structure/table/rack,
+/obj/item/stack/flag/red,
+/obj/item/stack/flag/red,
+/obj/item/stack/flag/red,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "bkG" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -14743,6 +14757,17 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"blI" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "bmb" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
@@ -14810,6 +14835,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"bpj" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Anomaly Aft";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "bpA" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -14853,6 +14895,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
+"bqy" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"bqI" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/equipment)
 "brb" = (
 /obj/structure/closet/crate,
 /obj/random/tank,
@@ -14861,6 +14919,20 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
+"brg" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_inner";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "brj" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment,
@@ -14875,6 +14947,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"brM" = (
+/obj/machinery/vending/assist,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "bta" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 1;
@@ -14919,6 +15002,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
+"bwh" = (
+/obj/structure/table/glass,
+/obj/item/device/paicard,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "bxz" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -14960,30 +15048,24 @@
 	},
 /turf/space,
 /area/space)
-"bBm" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "bBt" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "bBv" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 4;
-	icon_state = "corner_techfloor_grid"
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_inner";
+	locked = 0;
+	name = "Petrov Interior Access"
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "bCb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -14994,17 +15076,23 @@
 /area/rnd/xenobiology)
 "bCX" = (
 /obj/structure/table/steel,
-/obj/item/weapon/storage/box/cdeathalarm_kit,
-/obj/item/weapon/melee/telebaton,
-/obj/item/weapon/melee/telebaton,
-/obj/item/weapon/melee/telebaton,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/device/megaphone,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "bDb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -15024,6 +15112,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"bEC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "bEQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15126,6 +15221,13 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/escape_pod13/station)
+"bIv" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "bLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -15169,17 +15271,21 @@
 "bMb" = (
 /turf/simulated/wall/prepainted,
 /area/engineering/hardstorage/aux)
-"bMB" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6;
-	icon_state = "corner_techfloor_grid"
+"bMd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rcheckinner_windows"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/security)
 "bNb" = (
 /obj/machinery/status_display{
 	pixel_x = 32;
@@ -15194,6 +15300,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod12/station)
+"bNt" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/isolation)
 "bNL" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
@@ -15251,6 +15361,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod12/station)
+"bQT" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "bRb" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -15380,6 +15493,24 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
+"bVA" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/stack/material/phoron,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
+"bVD" = (
+/obj/structure/table/standard,
+/obj/machinery/reagent_temperature,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "bWb" = (
 /obj/machinery/status_display{
 	pixel_x = -32;
@@ -15391,6 +15522,17 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod15/station)
+"bWl" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "bWw" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -15438,28 +15580,6 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
-"bYj" = (
-/obj/machinery/button/blast_door{
-	id_tag = "armory_entrylock";
-	name = "Armory Entry Lockdown Shutter Control";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutter Control";
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/button/blast_door{
-	id_tag = "operation_hallway_shutters";
-	name = "Hallway Checkpoint Shutters";
-	pixel_x = 35;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "bZb" = (
 /obj/machinery/cryopod{
 	dir = 1;
@@ -15543,10 +15663,47 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"cgM" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "chb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"chm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/button/ignition{
+	id_tag = "Isocell2";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "cib" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -15575,6 +15732,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"ciB" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "cjb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15601,6 +15762,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"cjp" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "ckb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15633,6 +15798,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"cng" = (
+/obj/effect/floor_decal/corner/research/half,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/rnd/misc_lab)
 "cob" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random_multi/single_item/skelestand/maint,
@@ -15665,6 +15841,20 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/armoury)
+"csH" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/door/firedoor,
+/obj/effect/paint/silver,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "toxins_shutters";
+	name = "Mixing Chamber Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "ctb" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 8;
@@ -15689,6 +15879,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
+"ctr" = (
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Aft";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/half,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/aft)
 "cub" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9;
@@ -15711,6 +15909,27 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/brig)
+"cuN" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_outer";
+	locked = 0;
+	name = "Petrov Exterior Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "cva" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/counselor)
@@ -15741,6 +15960,38 @@
 /obj/item/weapon/reagent_containers/food/snacks/proteinbar,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cwn" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Phoron Sublimation Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
+"cwC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "cwQ" = (
 /obj/machinery/computer/modular/preset/security{
 	dir = 4;
@@ -15818,6 +16069,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cyJ" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "czb" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5;
@@ -15832,6 +16103,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"czy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "czN" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/reagent_dispensers/watertank,
@@ -15849,12 +16131,18 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
 "cAh" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/machinery/door/airlock/research{
+	dir = 2;
+	id_tag = null;
+	name = "Cockpit"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "cAO" = (
 /obj/structure/table/standard,
 /obj/random/clipboard,
@@ -15944,6 +16232,14 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
+"cEn" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "cFb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
@@ -15990,6 +16286,24 @@
 /obj/effect/floor_decal/corner/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/medical_lift)
+"cJU" = (
+/obj/machinery/atmospherics/unary/vent_pump/tank{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	id_tag = "toxins_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "cKh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16005,6 +16319,27 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/centralport)
+"cKk" = (
+/obj/structure/hygiene/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_access = list("ACCESS_RESEARCH")
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "cKO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -16031,6 +16366,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cMM" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "cNb" = (
 /obj/item/usedcryobag,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16065,18 +16408,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
-"cOH" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+"cOo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "cPY" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16097,6 +16440,20 @@
 "cQo" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"cQY" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "cRb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -16201,17 +16558,27 @@
 /turf/simulated/floor/plating,
 /area/security/wing)
 "cYB" = (
-/obj/structure/dispenser,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "cZb" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -16221,19 +16588,23 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
-"cZd" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "cZi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"cZN" = (
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "cZS" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5;
@@ -16291,6 +16662,10 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"dbM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "dcb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
@@ -16306,6 +16681,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
+"ddK" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/analysis)
 "ddP" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -16320,6 +16700,20 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"deg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "deo" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -16491,8 +16885,19 @@
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
 	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Miscellaneous Laboratory"
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"dlw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
+"dlB" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "dmb" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 1;
@@ -16536,6 +16941,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"dnO" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Hallway Fore";
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "dob" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/table/standard,
@@ -16554,6 +16972,20 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
+"dpD" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "dqb" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -16565,6 +16997,18 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
+"dqJ" = (
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 8;
+	icon_state = "nosmoking";
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "dqU" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -16585,6 +17029,18 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"dsi" = (
+/obj/structure/table/standard,
+/obj/random/tool,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "dtb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16639,6 +17095,37 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"dCg" = (
+/obj/machinery/lapvend,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"dCj" = (
+/obj/structure/table/standard,
+/obj/item/weapon/folder/nt,
+/obj/item/stack/nanopaste,
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
+"dCn" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/weapon/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/weapon/pickaxe{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "dDb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/chemistry)
@@ -16652,10 +17139,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"dDF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "dEb" = (
 /obj/random/torchcloset,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"dEN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "dFb" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 9;
@@ -16674,6 +17176,17 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
+"dGw" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "dIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16711,31 +17224,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
-"dJp" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"dJv" = (
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "dJY" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 1;
@@ -16749,6 +17237,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
+"dKw" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "dMb" = (
 /obj/item/weapon/storage/box/syringes{
 	pixel_x = 4;
@@ -16803,6 +17298,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"dMD" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "dNb" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/alarm{
@@ -16903,9 +17404,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
+"dUh" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "dVw" = (
-/turf/simulated/wall/r_wall/hull,
-/area/command/armoury/tactical)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/security)
 "dWb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -17104,6 +17610,40 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/brig)
+"eeU" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	dir = 8;
+	icon_state = "closed";
+	id_tag = "PetrovAccess";
+	name = "Petrov Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"egg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/prepainted,
+/area/hallway/primary/firstdeck/aft)
+"egK" = (
+/obj/structure/hygiene/shower{
+	dir = 8;
+	icon_state = "shower"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "ehT" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
@@ -17130,6 +17670,26 @@
 /obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
+"eiT" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve/shutoff/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
 "ejb" = (
 /obj/structure/curtain/open/shower,
 /obj/structure/hygiene/shower{
@@ -17149,6 +17709,29 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
+"elP" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/research{
+	dir = 8;
+	icon_state = "corner_white"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "elT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/port_gen/pacman{
@@ -17208,6 +17791,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/aux)
+"eoc" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "eoj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17217,6 +17803,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/physicianoffice)
+"eot" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "epb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -17284,6 +17884,21 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
+"evl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "ewb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -17343,12 +17958,36 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
+"exB" = (
+/obj/structure/table/standard,
+/obj/item/device/geiger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"eyk" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "eyY" = (
 /turf/simulated/floor/tiled,
 /area/security/processing)
 "ezb" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"ezH" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/table/standard,
+/obj/random/tool,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "eAb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -17377,19 +18016,32 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"eCo" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/custodial)
+"eDR" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
+"eEb" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "eEE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
-"eGb" = (
-/obj/structure/table/standard,
-/obj/item/stack/material/uranium,
-/obj/item/stack/material/uranium,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
 "eGl" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -17466,6 +18118,15 @@
 /obj/item/stack/material/steel/fifty,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
+"eKo" = (
+/obj/structure/stasis_cage,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Equipment";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "eLb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -17488,6 +18149,12 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"eOT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "ePb" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Room 1"
@@ -17544,8 +18211,22 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/laboratory)
 "eRU" = (
-/turf/simulated/wall/r_wall/hull,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
+"eSA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "eTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17560,6 +18241,34 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"eTu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
+"eTv" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Chamber Output"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "eUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
@@ -17613,6 +18322,33 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
+"eYp" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_outer";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
+"eZF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "eZQ" = (
 /obj/machinery/lapvend{
 	dir = 4;
@@ -17639,6 +18375,59 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"fdU" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
+"feo" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/maint)
+"fgI" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/phoron)
+"fhj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"fhx" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "fkb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17653,11 +18442,34 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/foyer/storeroom)
+"fko" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "fll" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/flasher/portable,
+/obj/effect/floor_decal/techfloor,
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/area/shuttle/petrov/hallwaya)
 "flB" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/research{
@@ -17677,11 +18489,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
-"fnR" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/hos,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+"fon" = (
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "foK" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
@@ -17705,6 +18517,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/office)
+"fpb" = (
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "fps" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -17726,6 +18546,10 @@
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/physicianoffice)
+"fql" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "frA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -17745,6 +18569,41 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/locker)
+"frL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"ftb" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "fuV" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 2;
@@ -17762,6 +18621,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
+"fwo" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/rd)
 "fxb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -17771,12 +18634,45 @@
 "fxe" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
-"fBb" = (
-/obj/structure/window/reinforced{
-	dir = 8
+"fzo" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"fAN" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"fBb" = (
 /obj/structure/table/standard,
-/obj/item/device/integrated_circuit_printer,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/weapon/storage/box/beakers,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "fCb" = (
@@ -17794,6 +18690,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"fCY" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/rnd)
 "fDJ" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -17817,6 +18717,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"fFB" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "fHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -17826,25 +18729,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"fIn" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5;
-	icon_state = "corner_techfloor_grid"
+"fIV" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"fJk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "fKb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
@@ -17868,34 +18772,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"fLg" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 4
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/plasteel{
-	amount = 20
-	},
-/obj/item/stack/material/ocp{
-	amount = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "fMr" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/blast/shutters{
@@ -17915,6 +18791,16 @@
 /obj/random/material,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
+"fNG" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "heater"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/custodial)
 "fOb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -17923,18 +18809,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "fOr" = (
-/obj/structure/table/steel,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	icon_state = "wrecharger0";
-	pixel_x = 23;
-	pixel_y = -3
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/cockpit)
 "fOu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Locker Room"
@@ -17949,6 +18836,22 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"fOB" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Miscellaneous Laboratory"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 6;
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
 "fQf" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -18033,6 +18936,30 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"fWf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"fWS" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "fYb" = (
 /obj/machinery/door/airlock/medical{
 	id_tag = "examdoor";
@@ -18069,17 +18996,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
-"fZn" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
+"fZf" = (
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "gab" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1;
@@ -18103,10 +19031,6 @@
 /area/engineering/hardstorage/aux)
 "gcY" = (
 /obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
 /obj/machinery/reagent_temperature/cooler,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
@@ -18189,6 +19113,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"giM" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/standard,
+/obj/item/stack/material/plastic/ten,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "gjb" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/adv,
@@ -18250,6 +19180,51 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"goZ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"gqF" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"gqM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "grI" = (
 /obj/structure/table/steel,
 /obj/item/device/taperecorder{
@@ -18265,6 +19240,25 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/processing)
+"gsT" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"gti" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"gux" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "guP" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/firstaid/regular{
@@ -18278,6 +19272,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"guQ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "gvC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -18288,6 +19287,18 @@
 "gvJ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/questioning)
+"gwX" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/chemical_dispenser/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "gxi" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -18427,6 +19438,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
+"gES" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "gEY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18449,6 +19471,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/physicianoffice)
+"gGe" = (
+/obj/structure/bed/chair/padded/red,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "gGO" = (
 /obj/item/device/radio/intercom/department/security{
 	pixel_y = 23
@@ -18470,6 +19501,47 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"gKv" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"gLK" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "heater"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/isolation)
+"gMo" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovBiohazard";
+	name = "Petrov Biohazard Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"gNw" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/air_sensor{
+	id_tag = "toxins_sensor"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "gQb" = (
 /obj/structure/dispenser{
 	oxygentanks = 0
@@ -18517,6 +19589,37 @@
 "gSb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/washroom)
+"gSM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
+"gTQ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"gUs" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "gVR" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -18585,6 +19688,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"hah" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "haT" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 1;
@@ -18654,6 +19769,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
+"hew" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "hfb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18766,6 +19887,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"hjc" = (
+/obj/structure/table/rack,
+/obj/item/device/flashlight,
+/obj/item/device/radio,
+/obj/item/weapon/crowbar,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "hjk" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/device/radio/headset,
@@ -18783,6 +19919,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
+"hla" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "hlb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -18806,6 +19957,10 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1port)
+"hnu" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "hnL" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -18842,6 +19997,19 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"hoc" = (
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "hqb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -18881,18 +20049,17 @@
 /turf/simulated/floor/plating,
 /area/security/opscheck)
 "hrE" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/item/weapon/storage/box/syringegun,
-/obj/item/weapon/gun/launcher/syringe,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "hsb" = (
 /obj/structure/sign/science_1{
 	dir = 1;
@@ -18910,6 +20077,28 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/opscheck)
+"hsq" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "htb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -18932,21 +20121,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"htK" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/item/weapon/gun/energy/stunrevolver/rifle,
-/obj/item/weapon/gun/energy/taser/carbine,
-/obj/item/weapon/gun/energy/taser/carbine,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "hub" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -18988,24 +20162,40 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/entry)
-"hvY" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
+"hvC" = (
+/obj/machinery/suit_cycler/science,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/weapon/storage/box/beakers,
-/obj/machinery/light/spot{
-	dir = 1
+/obj/structure/cable/cyan{
+	d2 = 2;
+	dir = 1;
+	icon_state = "0-2"
 	},
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
+"hvQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "hwb" = (
 /obj/structure/sign/science_1{
 	dir = 1;
@@ -19158,6 +20348,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/opscheck)
+"hDh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "hDp" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light_switch{
@@ -19216,18 +20412,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
-"hFu" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
+"hFB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "hGb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -19254,6 +20450,19 @@
 /obj/structure/bed/chair/padded/blue,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"hIz" = (
+/obj/structure/closet/crate/secure/biohazard,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
+"hIA" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "hJb" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
@@ -19276,6 +20485,15 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/development)
+"hJp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "hJq" = (
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 1
@@ -19308,18 +20526,41 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"hOb" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
+"hOB" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/weapon/gun/energy/ionrifle,
-/obj/item/weapon/gun/energy/ionrifle/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/reagent_dispensers/acid{
+	density = 0;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
+"hOU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "hOZ" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -19357,6 +20598,13 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"hRg" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "hUb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -19390,6 +20638,17 @@
 /obj/item/weapon/storage/box/handcuffs,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"hUB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 2;
+	injecting = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/maint)
 "hUE" = (
 /obj/machinery/atmospherics/tvalve/digital{
 	dir = 4;
@@ -19421,6 +20680,14 @@
 "hVG" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/firstdeck/center)
+"hVQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "hWb" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -19435,6 +20702,11 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"hYo" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "hYM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19479,10 +20751,60 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
+"ibO" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"icr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/obj/machinery/papershredder,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"idc" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/fabricator,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
+"ieh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "iej" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"ieX" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "igb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19495,6 +20817,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"igm" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "iib" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19506,6 +20833,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"iif" = (
+/turf/space,
+/area/command/armoury)
 "ijb" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -19526,6 +20856,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"ijY" = (
+/obj/machinery/atmospherics/omni/mixer{
+	tag_east = 2;
+	tag_north = 1;
+	tag_north_con = 0.33;
+	tag_south = 1;
+	tag_south_con = 0.33;
+	tag_west = 1;
+	tag_west_con = 0.34
+	},
+/obj/machinery/button/ignition{
+	id_tag = "toxlab";
+	pixel_w = 6;
+	pixel_z = -23
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "ikZ" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/effect/floor_decal/industrial/shutoff,
@@ -19580,6 +20927,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"ilP" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "imb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -19597,6 +20967,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/command/conference)
+"inO" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell3";
+	pixel_x = -18
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "ipc" = (
 /obj/structure/noticeboard{
 	pixel_x = 0;
@@ -19609,7 +20986,12 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/physicianoffice)
 "iqb" = (
-/obj/structure/bed/chair/comfy/lime,
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "irb" = (
@@ -19646,6 +21028,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/development)
+"irV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "isb" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19740,6 +21126,13 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/misc_lab)
+"ivt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "ivT" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -19827,17 +21220,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "iAS" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/steel,
+/obj/item/weapon/book/manual/nt_regs,
+/obj/item/weapon/folder/nt,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/weapon/shield/riot/metal,
-/obj/item/weapon/shield/riot/metal,
-/obj/item/weapon/shield/riot/metal,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "iAZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19857,24 +21253,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
-"iBb" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/item/weapon/screwdriver{
-	pixel_y = 15
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
+"iBE" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/maint)
 "iBT" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
@@ -19914,6 +21296,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"iFJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "iGb" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
 /obj/effect/floor_decal/corner/paleblue{
@@ -19950,6 +21350,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"iIc" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "iKb" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19984,6 +21394,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"iMy" = (
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"iMF" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "iMW" = (
 /obj/structure/bed/chair/padded/blue{
 	dir = 4;
@@ -20085,19 +21517,18 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/development)
+"iRx" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Heat Exchanger Input"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "iSb" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/debugger{
-	pixel_x = -5
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
 "iTC" = (
@@ -20167,6 +21598,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"iWu" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "iXb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -20178,6 +21617,55 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"iXz" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rnd)
+"iXA" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/anobattery{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/weapon/anobattery{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/anobattery{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/anobattery{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Analysis";
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "iZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -20189,6 +21677,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"iZt" = (
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 2;
+	tag_south = 3;
+	tag_west = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"iZC" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "jab" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -20258,6 +21766,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"jcB" = (
+/obj/structure/closet/toolcloset/excavation,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "jcO" = (
 /obj/structure/sign/xenobio_1{
 	dir = 1;
@@ -20265,6 +21778,14 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/research)
+"jdc" = (
+/obj/structure/dispenser/oxygen,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "jeb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20322,6 +21843,16 @@
 /obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"jgY" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "jhb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
@@ -20352,6 +21883,16 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
+"jhI" = (
+/obj/machinery/suit_storage_unit/science,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "jhS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20414,6 +21955,14 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
+"jka" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/hallway/primary/firstdeck/aft)
 "jkb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -20444,38 +21993,23 @@
 /obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"jnd" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
+"jlC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "job" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -20513,16 +22047,11 @@
 /turf/simulated/floor/tiled,
 /area/security/locker)
 "jqn" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "operation_hallway_shutters";
-	name = "Operation Checkpoint Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "jqD" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -20538,14 +22067,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
-"jrH" = (
-/obj/structure/sign/warning/secure_area/armory{
-	dir = 8;
-	icon_state = "armory";
-	pixel_x = 0
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/access)
 "jsb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -20583,6 +22104,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/locker)
+"jtO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "jub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20621,6 +22146,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jwD" = (
+/obj/structure/bed/chair/office/comfy/red{
+	dir = 4;
+	icon_state = "comfyofficechair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "jxa" = (
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
@@ -20658,6 +22195,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jyX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/analysis)
 "jzb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -20681,24 +22231,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"jAb" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
+"jzd" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/cell1)
 "jAl" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
 	dir = 4;
-	icon_state = "techfloor_edges"
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/hallwaya)
 "jAr" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -20822,6 +22372,17 @@
 /obj/structure/closet/l3closet/scientist/multi,
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"jHw" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Chief Science Officer";
+	secured_wires = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rd)
 "jIb" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -20907,6 +22468,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jOn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "jON" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20942,15 +22512,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "jPY" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/hallwaya)
 "jQb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 1;
@@ -20959,28 +22525,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "jQY" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Tactical";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "jRb" = (
 /obj/machinery/light{
 	dir = 1
@@ -20991,6 +22537,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jRW" = (
+/obj/structure/table/standard,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/storage/box/evidence,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "jSb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 5;
@@ -21001,6 +22554,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jSQ" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/rd)
 "jTb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 4;
@@ -21036,6 +22593,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jWK" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "jXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21049,6 +22615,22 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jXf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "jXp" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Emergency Storage"
@@ -21063,6 +22645,9 @@
 /obj/effect/floor_decal/corner/research{
 	dir = 5;
 	icon_state = "corner_white"
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Miscellaneous Laboratory"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -21094,22 +22679,16 @@
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
 "kab" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/monotile,
-/area/rnd/misc_lab)
-"kbb" = (
-/obj/structure/table/standard,
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 26
+/obj/effect/floor_decal/corner/research{
+	dir = 5;
+	icon_state = "corner_white"
 	},
-/obj/machinery/button/windowtint{
-	id = "misc_lab";
-	pixel_x = 4;
-	pixel_y = 26
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/rnd/misc_lab)
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
 "kcb" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 4;
@@ -21133,6 +22712,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"kct" = (
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Desublimation";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
+"kda" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/analysis)
 "kdb" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -21180,6 +22779,27 @@
 /obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/laboratory)
+"ket" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"keJ" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "kfb" = (
 /obj/structure/table/steel,
 /obj/item/weapon/paper_bin,
@@ -21217,17 +22837,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
-"khb" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
+"kgC" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
+"khl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/item/device/integrated_electronics/analyzer{
-	pixel_x = 6
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "kib" = (
 /obj/machinery/requests_console{
 	department = "Robotics";
@@ -21257,6 +22881,19 @@
 /obj/random_multi/single_item/summarydocuments/sec,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
+"kkr" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "kku" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -21300,13 +22937,21 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "kmE" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
+"kmS" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "knb" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
@@ -21333,6 +22978,26 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/foreport)
+"knQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "petrov_shuttle_dock_sensor";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "koX" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -21343,11 +23008,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
-"kpb" = (
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
+"kpe" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access = list("ACCESS_RESEARCH")
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "kqb" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -21406,27 +23092,10 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "ksK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Tactical Armory"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/table/steel,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "kvb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "roboticlab_window"
@@ -21474,17 +23143,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/robotics/laboratory)
-"kyt" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "kzy" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21499,9 +23157,41 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
+"kAh" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/rnd/research)
 "kCb" = (
 /turf/simulated/wall/prepainted,
 /area/medical/surgery)
+"kCj" = (
+/obj/machinery/disposal,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Fabrication";
+	dir = 2
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "kCl" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -21537,6 +23227,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
+"kFJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "kFT" = (
 /obj/machinery/button/windowtint{
 	id = "exam_windows";
@@ -21571,6 +23267,46 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/brig)
+"kGd" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
+"kGf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
+"kGp" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
+/obj/effect/paint/silver,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "toxins_shutters";
+	name = "Mixing Chamber Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "kGX" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -21593,6 +23329,16 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
+"kHk" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "kIb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/pink/mono,
@@ -21618,6 +23364,22 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
+"kKa" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/cockpit)
 "kKb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "postop_window"
@@ -21635,10 +23397,31 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
+"kLD" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "kLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
+"kMT" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
+"kMX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/security)
 "kNb" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/yellow{
@@ -21646,6 +23429,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"kNm" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "kOb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -21660,6 +23455,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"kOA" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "kPb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 2
@@ -21674,6 +23477,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"kPk" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "kPp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
@@ -21771,6 +23580,16 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
+"kSU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "kTb" = (
 /obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -21853,6 +23672,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"kWF" = (
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Custodial Closet"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/custodial)
 "kXb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21877,6 +23714,12 @@
 "kZb" = (
 /turf/simulated/wall/prepainted,
 /area/medical/foyer/storeroom)
+"kZW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "lab" = (
 /obj/machinery/button/windowtint{
 	id = "postop_window";
@@ -21957,11 +23800,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/laboratory)
-"ldP" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
 "leb" = (
 /turf/simulated/wall/prepainted,
 /area/medical/staging)
@@ -21973,6 +23811,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
+"lfj" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "lfM" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -22006,6 +23853,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"lgw" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
+"lgP" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "lhb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -22036,6 +23902,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
+"lip" = (
+/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov2";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "ljb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -22053,17 +23933,30 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
+"lkf" = (
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	dir = 4;
+	id_tag = "researchdoor_interior";
+	name = "Research Division"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/rnd/research)
 "lkp" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "llb" = (
 /obj/machinery/fabricator,
@@ -22095,6 +23988,25 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lmq" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/equipment)
+"lmJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "lnb" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
@@ -22112,6 +24024,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lnO" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "lob" = (
 /obj/machinery/computer/modular/preset/security,
 /turf/simulated/floor/tiled/dark,
@@ -22122,6 +24048,13 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
+"loF" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "lpb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -22144,29 +24077,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lqk" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "lsb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
 "lst" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6;
-	icon_state = "corner_techfloor_grid"
+/obj/structure/sign/warning/airlock{
+	dir = 8;
+	icon_state = "doors"
 	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"lsT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 1;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cockpit)
 "ltb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/rdconsole/core{
@@ -22312,6 +24239,23 @@
 /obj/machinery/microscope,
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"lzt" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/phoron)
+"lzu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "lAb" = (
 /obj/machinery/button/blast_door{
 	id_tag = "Biohazard";
@@ -22415,12 +24359,35 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/aux)
+"lCi" = (
+/obj/machinery/atmospherics/binary/pump,
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "lCN" = (
 /obj/structure/table/standard,
 /obj/item/device/tape/random,
 /obj/item/device/tape/random,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"lDc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"lDA" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_outer";
+	locked = 0;
+	name = "Petrov Exterior Access"
+	},
+/obj/effect/shuttle_landmark/petrov/start,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "lEb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -22428,27 +24395,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
-"lGw" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+"lEv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Equipment Storage"
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9;
-	icon_state = "corner_techfloor_grid"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "lHO" = (
 /turf/simulated/wall/prepainted,
 /area/medical/sleeper)
@@ -22485,9 +24447,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "lLD" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "lMb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22499,6 +24476,22 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/aux)
+"lML" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Research Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "lNb" = (
 /obj/structure/closet/crate/solar,
 /obj/machinery/light/small,
@@ -22510,6 +24503,36 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"lQJ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/emitter,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"lQW" = (
+/obj/structure/table/standard,
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_electronics/debugger{
+	pixel_x = -5
+	},
+/obj/item/device/integrated_electronics/analyzer{
+	pixel_x = 6
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "lRa" = (
 /obj/machinery/light_switch{
 	pixel_x = -6;
@@ -22517,6 +24540,24 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"lRJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
+"lSp" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell3";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "lVb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -22614,6 +24655,12 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/processing)
+"mdT" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "mer" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 5
@@ -22626,6 +24673,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
+"mev" = (
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "mfb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22693,6 +24744,16 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"min" = (
+/obj/effect/paint/silver,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/rd)
 "miG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -22744,6 +24805,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
+"mkw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/eva)
 "mlb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -22819,20 +24886,54 @@
 "mpy" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftstarboard)
-"mrr" = (
-/obj/effect/floor_decal/techfloor{
+"mqc" = (
+/obj/machinery/disposal,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/button/windowtint{
+	id = "rd_windows";
+	pixel_x = 6;
+	pixel_y = 24;
+	range = 11
+	},
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "techfloor_edges"
+	pixel_x = 26
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"mrr" = (
+/obj/effect/floor_decal/corner/red/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
+	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 2;
+	name = "suit storage"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "mrW" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -22861,6 +24962,14 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/foreport)
+"mtA" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "mtB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -22966,51 +25075,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"mwA" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"mwJ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "mwV" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 6;
@@ -23048,6 +25112,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
+"mwW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
+"mxa" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Exterior Vent"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"myO" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "mzb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -23061,6 +25147,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"mzN" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "mBb" = (
 /obj/structure/bed/chair/office/comfy/red{
 	dir = 8;
@@ -23069,6 +25164,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"mBe" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov3";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "mCe" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/fingerprints,
@@ -23119,6 +25227,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"mEH" = (
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Hallway Aft";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "mEV" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d1starboard)
@@ -23136,6 +25255,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"mFJ" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell1)
 "mGb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -23152,6 +25275,23 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1starboard)
+"mGq" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "mHb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -23181,22 +25321,20 @@
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "mJJ" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor/corner{
+/obj/structure/hygiene/shower{
 	dir = 4;
-	icon_state = "techfloor_corners"
+	icon_state = "shower";
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Entry";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "mJY" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/floor_decal/corner/beige/mono,
@@ -23253,6 +25391,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/firstdeck/fore)
+"mLn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "mLu" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -23394,6 +25536,28 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/firstdeck)
+"mZP" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/item/weapon/folder/nt,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Anomaly Fore";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "nbb" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -23442,12 +25606,40 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"ndL" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "neb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/blackgrid,
 /area/security/nuke_storage)
+"neC" = (
+/obj/effect/floor_decal/corner/red/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/alarm{
+	alarm_id = "xenobio2_alarm";
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "nfb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -23474,6 +25666,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/firstdeck)
+"nhG" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	icon_state = "intact"
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "nib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23483,6 +25694,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"nii" = (
+/obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "njb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23522,32 +25740,42 @@
 /turf/simulated/wall/prepainted,
 /area/command/conference)
 "njm" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
+/obj/structure/table/steel,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
 	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
+/obj/machinery/button/alternate/door{
+	desc = "A remote control-switch for airlocks.";
+	id_tag = "PetrovAccess";
+	name = "Petrov Interior Door Control";
+	pixel_x = -5;
+	pixel_y = 6;
+	req_access = list("ACCESS_TORCH_PETROV_SEC")
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Security";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/button/blast_door{
+	id_tag = "concheckwindow2";
+	name = "Office Shutter Control";
+	pixel_x = 5;
+	pixel_y = 6
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "njQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23692,6 +25920,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
+"nqv" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
+"nry" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"nrB" = (
+/turf/space,
+/area/command/armoury/access)
 "nrF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23754,15 +26006,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
-"nvX" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/alarm{
+"nvI" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/item/device/radio/intercom{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"nvX" = (
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "nxK" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
@@ -23903,6 +26170,13 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
+"nEk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/unusual,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "nFh" = (
 /obj/structure/table/steel,
 /obj/machinery/photocopier/faxmachine/torch{
@@ -23917,6 +26191,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
+"nGz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "nHf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24004,6 +26282,26 @@
 /obj/item/weapon/storage/pill_bottle,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"nNv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/button/ignition{
+	id_tag = "Isocell3";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"nOn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "nOO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -24071,6 +26369,25 @@
 /obj/effect/floor_decal/torchltdlogo,
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
+"nRJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Suit Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "nSb" = (
 /obj/effect/floor_decal/torchltdlogo{
 	icon_state = "bottomright"
@@ -24142,25 +26459,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "nWP" = (
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
-	icon_state = "techfloor_edges"
+	level = 2
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	icon_state = "wrecharger0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "nWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24216,6 +26520,29 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
+"nZf" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	display_name = "Aft Dock (Petrov)";
+	frequency = 1380;
+	id_tag = "petrov_shuttle_dock_airlock";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access = list(list("ACCESS_SECURITY","ACCESS_EXTERNAL","ACCESS_TORCH_PETROV"));
+	tag_airpump = "petrov_shuttle_dock_pump";
+	tag_chamber_sensor = "petrov_shuttle_dock_sensor";
+	tag_exterior_door = "petrov_shuttle_dock_outer";
+	tag_interior_door = "petrov_shuttle_dock_inner"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/aft)
 "nZm" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -24243,23 +26570,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "nZZ" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "concheckwindow2";
+	name = "Research Checkpoint Shutters";
+	opacity = 0
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/security)
 "obb" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/disposalpipe/segment,
@@ -24345,6 +26667,24 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
+"odx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "oeb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24414,12 +26754,54 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"ois" = (
+/obj/structure/table/rack,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/glass/fifty,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "ojb" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/research/mono,
 /obj/random_multi/single_item/summarydocuments/sci,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"ojm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"ojn" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovBiohazard";
+	name = "Petrov Biohazard Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "okp" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -24438,6 +26820,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
+"olD" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/maint)
 "omb" = (
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
@@ -24453,10 +26840,36 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
+"onE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rd_windows"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rd)
 "onM" = (
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/structure/bed/chair/shuttle/black{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "oox" = (
 /obj/effect/floor_decal/corner/research,
 /obj/machinery/firealarm{
@@ -24466,9 +26879,22 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "ooN" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "opg" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -24480,6 +26906,10 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
+"oqk" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "oqp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24500,6 +26930,22 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"orR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rcheckinner_windows"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/security)
 "osb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/self_destruct,
@@ -24677,6 +27123,27 @@
 "oDg" = (
 /turf/simulated/wall/prepainted,
 /area/security/questioning)
+"oDq" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "oGG" = (
 /obj/structure/hygiene/shower{
 	dir = 8;
@@ -24720,9 +27187,49 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/foreport)
+"oID" = (
+/obj/machinery/atmospherics/tvalve/digital{
+	dir = 1;
+	icon_state = "map_tvalve0";
+	id_tag = "fuelmode"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	dir = 1;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "oJb" = (
 /turf/simulated/wall/prepainted,
 /area/assembly/robotics/laboratory)
+"oJi" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"oJT" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "oLz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -24873,6 +27380,17 @@
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"oQo" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"oQB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "oRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24942,6 +27460,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"oTq" = (
+/obj/structure/table/standard,
+/obj/item/device/integrated_circuit_printer,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"oTW" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "oUb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24979,6 +27510,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
+"oWn" = (
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Petrov - Chief Science Officer"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Science Officer's Desk";
+	departmentType = 5;
+	name = "Chief Science Officer RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "oWF" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -24997,6 +27543,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"oWU" = (
+/obj/structure/bed,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "oXb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25052,6 +27611,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "pbb" = (
+/obj/machinery/chem_master,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "pcb" = (
@@ -25080,6 +27645,33 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"pcu" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/health,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"pcV" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "pdb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25123,26 +27715,53 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"pfb" = (
+"pec" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch/maintenance,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/maint)
+"pee" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
+"pfH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Toxins Lab"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	name = "Miscellaneous Laboratory"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/rnd/misc_lab)
+/area/shuttle/petrov/toxins)
 "pgb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -25155,36 +27774,45 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/area/rnd/research)
 "phb" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/area/rnd/research)
 "pib" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
-"pjb" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"piH" = (
+/obj/machinery/suit_storage_unit/science,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"pjb" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
 "pjR" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/detectives_office)
@@ -25206,6 +27834,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"pjW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/equipment)
 "pkb" = (
 /turf/simulated/wall/prepainted,
 /area/rnd/research)
@@ -25234,19 +27868,35 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"pnb" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+"pmM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
+"pmR" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"pnY" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/isolation)
 "poS" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/medical)
+"ppf" = (
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "pqb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -25279,6 +27929,16 @@
 /obj/structure/closet/secure_closet/scientist_torch,
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"prB" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_outer";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "psb" = (
 /obj/structure/closet/secure_closet/secure_closet/xenoarchaeologist_torch,
 /obj/effect/floor_decal/corner/research{
@@ -25319,9 +27979,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "puw" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "puL" = (
 /obj/machinery/power/apc{
@@ -25433,6 +28097,22 @@
 "pzb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/research)
+"pzf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell3";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "pzH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -25489,32 +28169,33 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/conference)
+"pBT" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/crate/radiation,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "pCb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/door/airlock/research{
+	name = "Miscellaneous Laboratory"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
-"pDb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
-"pEb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
+"pCg" = (
+/obj/machinery/artifact_harvester,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"pDs" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/custodial)
 "pEr" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -25535,31 +28216,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
-"pFb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/bed/chair/comfy/lime{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
-"pGb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/chemical_dispenser/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
 "pHb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25572,6 +28228,30 @@
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"pHE" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "pIb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -25643,6 +28323,13 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"pKv" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "pLb" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -25669,6 +28356,14 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Miscellaneous Laboratory"
+	},
+/obj/machinery/button/windowtint{
+	id = "misc_lab";
+	pixel_x = 8;
+	pixel_y = 26
+	},
+/obj/machinery/light_switch{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
@@ -25699,12 +28394,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"pPb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
 "pQb" = (
 /obj/machinery/botany/editor,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -25748,8 +28437,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "pUb" = (
-/obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
 "pUr" = (
@@ -25768,6 +28460,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/processing)
+"pUT" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "pVv" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -25816,6 +28526,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"pYs" = (
+/obj/structure/bed,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "pZb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25834,26 +28548,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"pZj" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "pZy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -25887,34 +28581,68 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qae" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "qbb" = (
 /obj/machinery/air_sensor{
 	id_tag = "xenobot_sensor"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qbv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/research{
+	dir = 8;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "qbH" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Chief Science Officer";
 	dir = 4
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"qbQ" = (
+/turf/space,
+/area/hallway/primary/firstdeck/aft)
 "qcb" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 2;
@@ -25932,6 +28660,22 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qcS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Analysis Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "qdb" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
@@ -25961,6 +28705,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"qeW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "qfa" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -26037,6 +28793,10 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "qju" = (
@@ -26062,6 +28822,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "qkc" = (
@@ -26075,10 +28844,20 @@
 /turf/simulated/floor/tiled,
 /area/security/processing)
 "qlb" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/uranium,
+/obj/item/stack/material/uranium,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "qmb" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -26093,8 +28872,22 @@
 	dir = 10;
 	icon_state = "intact"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"qnw" = (
+/obj/machinery/artifact_scanpad,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "qnz" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "or2"
@@ -26133,6 +28926,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"qsn" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
+	req_access = list("ACCESS_TORCH_PETROV_MAINT")
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "qsO" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
@@ -26151,6 +28957,21 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
+"qvU" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "qvX" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -26263,6 +29084,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qAG" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "qBb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -26293,12 +29122,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "qDb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/assist{
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/machinery/alarm{
 	dir = 8;
-	icon_state = "generic"
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "qDJ" = (
 /obj/structure/bed/chair{
@@ -26350,6 +29181,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"qEs" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "qFb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26446,6 +29288,16 @@
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
+"qHX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "qIb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/white,
@@ -26492,23 +29344,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
 "qKQ" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/floor_decal/corner/red/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/box/flashbangs,
-/obj/item/weapon/storage/box/smokes,
-/obj/item/weapon/storage/box/handcuffs,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/modular/preset/civilian,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "qKU" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -26566,15 +29409,47 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"qOc" = (
+/obj/structure/closet/crate/secure/biohazard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
+"qOr" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/dispenser,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "qPb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"qPK" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "qQb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 8;
 	icon_state = "map_valve0"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
@@ -26644,30 +29519,19 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"qSM" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/door/firedoor,
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "qTX" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "qUb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -26685,6 +29549,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"qUN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/computer/air_control{
+	dir = 8;
+	input_tag = "toxins_in";
+	name = "Toxins Gas Monitor";
+	output_tag = "toxins_out";
+	sensor_name = "Toxins Test Chamber";
+	sensor_tag = "toxins_sensor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "qVb" = (
 /obj/random/junk,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -26692,13 +29570,14 @@
 /area/maintenance/firstdeck/foreport)
 "qWb" = (
 /obj/structure/table/standard,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
+/obj/item/device/integrated_circuit_printer,
+/obj/item/device/integrated_electronics/debugger,
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_electronics/analyzer,
 /obj/effect/floor_decal/corner/research/half,
-/obj/machinery/light/spot{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
@@ -26754,6 +29633,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"qYS" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/r_n_d/protolathe,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "qZb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -26792,6 +29680,23 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rag" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/random/tool,
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell1";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/machinery/button/ignition{
+	id_tag = "Isocell1";
+	pixel_x = -36;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "rap" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -26816,6 +29721,23 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rbC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "rcb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -26828,6 +29750,13 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rct" = (
+/obj/machinery/artifact_analyser,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "rcx" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
@@ -26862,6 +29791,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rez" = (
+/obj/machinery/power/smes/buildable/preset/torch/shuttle{
+	RCon_tag = "Shuttle - Petrov"
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "rfb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26890,6 +29826,10 @@
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
+"rid" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "riC" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/firedoor,
@@ -26994,18 +29934,37 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
+"rnU" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/bio_suit/anomaly,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/bio_hood/anomaly,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "rob" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/corner/research/mono,
+/obj/machinery/vending/assist{
+	dir = 1;
+	icon_state = "generic"
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
 "rpb" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/effect/floor_decal/corner/research/mono,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/floor_decal/corner/research/half,
+/obj/machinery/light/spot{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/research/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
@@ -27033,6 +29992,23 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
+"rqC" = (
+/obj/machinery/computer/air_control{
+	dir = 2;
+	input_tag = "phoron_in";
+	name = "Test Chamber Gas Monitor";
+	output_tag = "phoron_out";
+	sensor_name = "Test Chamber";
+	sensor_tag = "phoron_sensor"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
+"rrp" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "rrI" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -27102,6 +30078,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"rtA" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "rub" = (
 /obj/machinery/button/ignition{
 	id_tag = "Xenobio";
@@ -27130,24 +30112,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
-"ruz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "ruS" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -27196,20 +30160,6 @@
 "ryb" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
-"ryt" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "rzb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27225,6 +30175,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"rzO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "rAb" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -27248,6 +30210,12 @@
 "rAu" = (
 /turf/simulated/wall/prepainted,
 /area/medical/washroom)
+"rAZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/isolation)
 "rBb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -27353,13 +30321,23 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "rFK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
+/obj/structure/hygiene/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "rGb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -27406,6 +30384,30 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
+"rIv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	id_tag = "";
+	name = "Sublimation Chamber"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
+"rIK" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell2";
+	pixel_x = -18
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"rIM" = (
+/obj/structure/closet/l3closet/scientist/multi,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "rJb" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -27511,10 +30513,85 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rNC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/handrai,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"rNU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 4;
+	icon_state = "cap"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"rNV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "rOb" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rOy" = (
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 2;
+	icon_state = "freezer"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "rOE" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -27546,12 +30623,48 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
+"rPN" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "rQb" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"rQi" = (
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
+"rQH" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"rQL" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "rRb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
@@ -27560,6 +30673,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rSq" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "rTb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -27578,6 +30698,17 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rTt" = (
+/obj/structure/closet/crate/secure/biohazard,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "rUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27775,6 +30906,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
+"sbX" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "scb" = (
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/r_wall/prepainted,
@@ -27804,6 +30941,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"scL" = (
+/obj/structure/sign/warning/hot_exhaust{
+	dir = 4;
+	icon_state = "fire"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "sdb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -28005,11 +31150,28 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"smW" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/rnd)
 "smX" = (
 /obj/structure/closet/crate/solar,
 /obj/random/tech_supply,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
+"sna" = (
+/obj/structure/table/standard,
+/obj/item/weapon/anodevice{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/anodevice,
+/obj/item/device/scanner/health,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "snb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28053,10 +31215,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
-"snG" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/aft)
 "sob" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -28064,6 +31222,19 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"soj" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "spb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 8;
@@ -28189,16 +31360,14 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
 "svH" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/item/weapon/stool/padded,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "swb" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
@@ -28214,25 +31383,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"swz" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "sxb" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1;
@@ -28261,6 +31411,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"sxR" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad/longrange,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "sxT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28324,6 +31482,12 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
+"sAP" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "sBb" = (
 /obj/machinery/portable_atmospherics/hydroponics{
 	closed_system = 1;
@@ -28407,6 +31571,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
+"sEI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 1;
+	icon_state = "map"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "sFb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28435,6 +31612,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"sGy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "sHb" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -28456,24 +31639,6 @@
 "sHN" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/armoury)
-"sJr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
 "sLb" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -28522,6 +31687,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
+"sNN" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/isolation)
 "sOb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28541,6 +31710,11 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"sOl" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/artifact_analyser,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "sOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -28562,6 +31736,11 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "sPb" = (
@@ -28592,6 +31771,15 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology)
+"sPk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "sQb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28634,6 +31822,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology)
+"sRy" = (
+/obj/structure/bed/chair/office/comfy/red,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "sRV" = (
 /turf/simulated/wall/r_wall/hull,
 /area/rnd/xenobiology)
@@ -28694,6 +31886,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"sUV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/research{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "sVb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -28710,6 +31918,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"sVQ" = (
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 4;
+	icon_state = "console"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "sWb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28832,6 +32056,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"tcm" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "tcA" = (
 /obj/machinery/sleeper{
 	dir = 2
@@ -28868,6 +32095,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"tel" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/phoron)
 "tfb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -29044,6 +32275,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
+"tme" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/weapon/screwdriver{
+	pixel_y = 15
+	},
+/obj/item/weapon/melee/baton/loaded,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "tnb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -29051,6 +32291,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tnh" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "tnV" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -29082,6 +32326,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tpr" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Heat Exchanger Output"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "tqb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/window/southright{
@@ -29097,6 +32349,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tqI" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/eva)
+"tra" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/beacon/anchored{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "trb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -29179,6 +32452,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"txS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "tyb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29207,6 +32488,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"tzr" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "tzv" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8;
@@ -29304,6 +32593,15 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"tFs" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "tGe" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29330,6 +32628,11 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
+"tIT" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "tJM" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -29356,6 +32659,24 @@
 "tJO" = (
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"tKa" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"tKl" = (
+/obj/machinery/atmospherics/tvalve/digital{
+	dir = 1;
+	icon_state = "map_tvalve0";
+	id_tag = "fuelmode"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "tKE" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -29375,6 +32696,38 @@
 /obj/item/device/tape,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"tNt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/eva)
+"tQX" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Chamber Input"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "toxin_exhaust";
+	name = "Chamber Vent";
+	pixel_w = 8;
+	pixel_y = -24
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "toxins_shutters";
+	name = "Chamber Protective Shutters";
+	pixel_w = -5;
+	pixel_z = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "tRX" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -29386,6 +32739,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"tSK" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "tTA" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/donkpockets,
@@ -29413,6 +32772,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"tUq" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "tVi" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 8;
@@ -29420,6 +32786,15 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/firstdeck/aftstarboard)
+"tVn" = (
+/turf/space,
+/area/maintenance/firstdeck/aftport)
+"tVq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/analysis)
 "tWo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -29485,6 +32860,20 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"uaq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "ubf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -29492,6 +32881,9 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"uch" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "udY" = (
 /obj/machinery/washing_machine,
 /obj/structure/closet/walllocker{
@@ -29544,6 +32936,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
+"uhz" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "uiY" = (
 /turf/simulated/wall/prepainted,
 /area/medical/equipstorage)
@@ -29553,6 +32955,27 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"ulM" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "umz" = (
 /obj/structure/table/rack,
 /obj/item/weapon/gun/energy/ionrifle,
@@ -29590,6 +33013,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"uqr" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "urd" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -29637,28 +33067,101 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"uvF" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
+"uxP" = (
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"uAb" = (
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "uBg" = (
 /obj/structure/sign/double/solgovflag/left{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"uBs" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rd_windows"
+	},
+/obj/effect/paint/silver,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rd)
 "uCe" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "uCA" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
+"uDb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "uDu" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "interviewwindow"
@@ -29670,6 +33173,22 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/questioning)
+"uDO" = (
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 8;
+	icon_state = "console"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/machinery/button/windowtint{
+	id = "rcheckinner_windows";
+	pixel_x = 10;
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "uFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -29700,6 +33219,10 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/evidence)
+"uGQ" = (
+/obj/structure/sign/warning/airlock,
+/turf/simulated/wall/r_wall/hull,
+/area/hallway/primary/firstdeck/aft)
 "uHz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29766,40 +33289,49 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"uLQ" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"uMP" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"uMP" = (
-/obj/structure/closet/bombclosetsecurity,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
+"uNj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
-	icon_state = "wrecharger0";
-	pixel_y = -22
+	level = 2
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"uND" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Isolation Chambers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"uOw" = (
+/obj/structure/bed/chair/padded/red{
+	dir = 1;
+	icon_state = "chair_preview"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "uPc" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/half,
@@ -29874,6 +33406,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
+"uVH" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rnd)
 "uWa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -29930,21 +33467,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
-"uZi" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
-"uZO" = (
-/obj/structure/table/steel,
-/obj/machinery/recharger,
-/obj/item/weapon/pinpointer,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
+"uZG" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "uZY" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 0;
@@ -29956,39 +33482,61 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"var" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/custodial)
 "vci" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"vcy" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"veT" = (
-/obj/effect/floor_decal/techfloor{
+"vcs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/handrai{
 	dir = 4;
-	icon_state = "techfloor_edges"
+	icon_state = "handrail"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
-	pixel_y = 24
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
+"vcN" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 12
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Toxins";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/phoronresearch{
+	dir = 4;
+	icon_state = "generic"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "vfK" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/equipstorage)
+"vgA" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rd_windows"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rd)
 "vhs" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -30004,48 +33552,32 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
-"vjY" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/item/weapon/gun/energy/gun/secure,
-/obj/item/weapon/gun/energy/gun/secure,
-/obj/item/weapon/gun/energy/gun/secure,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "vkW" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor/corner,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/hallwaya)
 "vlw" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"vnz" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light,
-/obj/machinery/flasher/portable,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"vly" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
+"vlB" = (
+/obj/machinery/suspension_gen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "vnC" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/standard,
@@ -30066,6 +33598,19 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/security/brig)
+"vqP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/equipment)
 "vrM" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -30074,12 +33619,20 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/firstdeck/foreport)
 "vtY" = (
-/obj/structure/sign/warning/high_voltage{
-	dir = 8;
-	icon_state = "shock"
-	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/firstdeck/aft)
+"vui" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "vvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -30093,6 +33646,43 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
+"vvJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"vxP" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"vya" = (
+/obj/machinery/atmospherics/unary/heater,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"vyF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "vzp" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/sortjunction/flipped{
@@ -30121,6 +33711,9 @@
 "vzy" = (
 /turf/simulated/wall/prepainted,
 /area/medical/surgery2)
+"vzA" = (
+/turf/space,
+/area/maintenance/firstdeck/aftstarboard)
 "vBa" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 8;
@@ -30139,15 +33732,40 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
 "vBV" = (
-/obj/random/obstruction,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_inner";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "vDD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"vDL" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "vEa" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -30213,6 +33831,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"vIN" = (
+/turf/space,
+/area/command/armoury/tactical)
 "vIP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/camera/network/security{
@@ -30221,6 +33842,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"vIR" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/spectrometer/adv,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "vJO" = (
 /obj/structure/bed/chair/padded/red,
 /obj/effect/floor_decal/corner/red{
@@ -30228,6 +33862,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"vKr" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"vLZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "vMm" = (
 /obj/structure/closet/crate,
 /obj/random/tank,
@@ -30284,30 +33938,44 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "vUD" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/box/lights/tubes,
-/obj/item/weapon/storage/box/lights/bulbs,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 0;
+	dir = 4;
+	frequency = 1380;
+	id_tag = "petrov_shuttle_airlock";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access = list("ACCESS_TORCH_PETROV");
+	tag_airpump = "petrov_shuttle_pump";
+	tag_chamber_sensor = "petrov_shuttle_sensor";
+	tag_exterior_door = "petrov_shuttle_outer";
+	tag_exterior_sensor = null;
+	tag_interior_door = "petrov_shuttle_inner"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "vVe" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1starboard)
+"vVB" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell3)
+"vYO" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "vZI" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -30340,6 +34008,29 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"was" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"wcq" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "wcQ" = (
 /obj/machinery/pager/security{
 	pixel_x = -25
@@ -30371,29 +34062,82 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"wiy" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/computer/rdconsole/petrov{
+	dir = 4;
+	icon_state = "computer"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "wiT" = (
 /obj/random_multi/single_item/skelestand/maint,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"wjN" = (
+/obj/structure/table/standard,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/scanning_module,
+/obj/item/device/paicard,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "wjP" = (
-/obj/structure/table/rack{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"wka" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell1";
+	pixel_x = -18
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"wkm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"wkO" = (
+/obj/structure/closet/secure_closet/crew/research,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/item/weapon/folder/nt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "wkS" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -30439,6 +34183,13 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"wmB" = (
+/obj/structure/table/glass,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/book/manual/nt_regs,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "wmK" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -30463,6 +34214,60 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"wmO" = (
+/obj/structure/table/standard,
+/obj/item/weapon/disk/tech_disk{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/disk/tech_disk{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
+"wqO" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
+"wsn" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
+"wsD" = (
+/obj/machinery/atmospherics/tvalve/mirrored/digital{
+	dir = 1;
+	icon_state = "map_tvalvem0"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "wtS" = (
 /obj/random/medical,
 /obj/random/medical,
@@ -30486,12 +34291,40 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"wuY" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1441;
+	id = "toxins_in"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/sparker{
+	id_tag = "toxlab";
+	pixel_w = 1;
+	pixel_z = -23
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "wvZ" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"wwf" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "wyb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30523,6 +34356,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"wzA" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/unary/vent_pump/tank{
+	dir = 1;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	id_tag = "phoron_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "wzN" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -30575,11 +34426,6 @@
 "wEw" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d1port)
-"wGe" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "wHE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -30587,6 +34433,37 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"wIz" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"wIB" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
+"wJP" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/aftport)
 "wMh" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/orange,
@@ -30609,13 +34486,72 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
-"wRs" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+"wOa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"wPe" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
+"wPs" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	icon_state = "nosmoking";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"wPt" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"wVw" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1441;
+	icon_state = "map_injector";
+	id = "phoron_in";
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "wWc" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -30668,24 +34604,42 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
+"xcE" = (
+/obj/machinery/door/airlock/hatch/maintenance,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "xcW" = (
 /turf/simulated/wall/prepainted,
 /area/assembly/robotics/office)
+"xgs" = (
+/obj/structure/closet/secure_closet/crew/research,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/item/weapon/folder/nt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"xgJ" = (
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"xgS" = (
+/obj/structure/sign/solgov,
+/turf/simulated/wall/r_wall/hull,
+/area/hallway/primary/firstdeck/aft)
+"xhG" = (
+/obj/structure/table/rack,
+/obj/item/device/scanner/xenobio,
+/obj/item/device/scanner/xenobio,
+/obj/item/device/scanner/xenobio,
+/obj/item/weapon/storage/excavation,
+/obj/item/device/measuring_tape,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "xhX" = (
-/obj/structure/table/steel,
-/obj/random/clipboard,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/hand_labeler,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cockpit)
 "xjr" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 4;
@@ -30693,6 +34647,46 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/firstdeck)
+"xkb" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"xlZ" = (
+/obj/machinery/computer/shuttle_control{
+	dir = 4;
+	icon_state = "computer";
+	req_access = list("ACCESS_TORCH_PETROV_HELM");
+	shuttle_tag = "Petrov"
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/cockpit)
+"xmZ" = (
+/obj/machinery/air_sensor{
+	id_tag = "phoron_sensor"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
+"xod" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "xoo" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -30713,6 +34707,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
+"xoq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "xoV" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -30725,17 +34723,37 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "xqk" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_cycler,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	name = "Petrov Security Desk"
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Starboard";
-	dir = 2
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 1;
+	name = "Petrov Security Desk"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "concheckwindow2";
+	name = "Research Checkpoint Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
+"xra" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 8;
+	icon_state = "pdoor1";
+	id_tag = "toxin_exhaust";
+	name = "Toxins Exhaust Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "xtq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
@@ -30776,9 +34794,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "xxB" = (
-/obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "xxY" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -30798,13 +34816,25 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/office)
 "xzj" = (
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Port";
-	dir = 4
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "petrov_shuttle_sensor";
+	pixel_x = -24;
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_pump"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "xzK" = (
 /obj/structure/bed/chair/padded/red,
 /obj/machinery/camera/network/security{
@@ -30829,6 +34859,11 @@
 /obj/random_multi/single_item/summarydocuments/med,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/physicianoffice)
+"xAj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "xBk" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -30894,6 +34929,13 @@
 "xFL" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
+"xHu" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"xHQ" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "xJP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30903,6 +34945,21 @@
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"xJR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov1";
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "xKq" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -30925,6 +34982,41 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"xLd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"xLu" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell2";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "xMy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -30932,11 +35024,29 @@
 "xMP" = (
 /obj/structure/table/standard,
 /obj/machinery/reagent_temperature,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
 "xPU" = (
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
+"xRb" = (
+/obj/machinery/radiocarbon_spectrometer,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "xRh" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/processing)
@@ -31006,17 +35116,70 @@
 /obj/effect/floor_decal/corner/paleblue/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
+"xTy" = (
+/obj/structure/sign/warning/deathsposal,
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/maint)
 "xTT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/emcloset,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"xUa" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
+"xUn" = (
+/obj/machinery/disposal,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "xVt" = (
 /obj/machinery/computer/modular/preset/civilian,
 /obj/effect/floor_decal/corner/research/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"xXi" = (
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"xYu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
+"xYB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"xYE" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "xYM" = (
 /turf/simulated/wall/prepainted,
 /area/medical/physicianoffice)
@@ -31039,6 +35202,9 @@
 /area/hallway/primary/firstdeck/fore)
 "ycp" = (
 /obj/effect/floor_decal/corner/research/half,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
 "ycz" = (
@@ -31047,6 +35213,36 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
+"ycB" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"yed" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "yeI" = (
 /obj/structure/bed/chair/office/comfy/red,
 /obj/structure/disposalpipe/segment{
@@ -31074,6 +35270,27 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
+"ygB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/firstdeck/aft)
 "ygK" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31098,10 +35315,42 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"yip" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell1";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "ykr" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
+"ykB" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 
 (1,1,1) = {"
 aaa
@@ -55248,7 +59497,7 @@ aic
 ail
 cva
 jYb
-pdb
+nry
 jZb
 pKb
 qjb
@@ -55651,8 +59900,8 @@ abk
 aie
 abk
 cva
-jZb
-pfb
+jWb
+pdb
 aHQ
 pNb
 qmb
@@ -56055,9 +60304,9 @@ ahw
 aig
 aio
 aiu
-kbb
+jWb
 phb
-pPb
+jZb
 qlb
 aLo
 qQb
@@ -56257,12 +60506,12 @@ ahz
 ahz
 aip
 aiu
-hvY
+jWb
 pib
-pDb
+jZb
 fBb
 iSb
-qnb
+rNV
 rvb
 rmb
 aHQ
@@ -56450,21 +60699,21 @@ yii
 haV
 vii
 pWW
-vHB
-ayB
-azN
+hdb
+jAM
+ctr
 ahe
 ahn
 ahn
 ahn
 aiq
 aiu
-kpb
+kab
 pjb
-pEb
+jZb
 iqb
-jAb
-aLo
+iSb
+lRJ
 ycp
 rnb
 aHQ
@@ -56652,22 +60901,22 @@ fQf
 qKx
 vii
 pWW
-lsT
+ivT
 hnN
-uZi
+tiz
 ahe
 aho
 ahH
 ahn
 air
 aiu
-eGb
+jWb
+pjb
+jZb
 pbb
-pFb
-pbb
-khb
-aLo
-ycp
+iSb
+iSb
+cng
 rob
 aHQ
 aRf
@@ -56854,18 +61103,18 @@ atm
 aug
 vii
 pWW
-bBm
-ruz
-dJp
+pmz
+hnN
+tiz
 ahd
 ahp
 ahJ
 aih
 ahn
 aiu
-aHQ
-pnb
-pGb
+fOB
+pjb
+jZb
 xMP
 gcY
 qDb
@@ -57057,16 +61306,16 @@ pWW
 pWW
 pWW
 jqn
-ayF
-jqn
+ayB
+vyF
 ahd
 ahd
 ahd
 ahd
 ais
 aiu
-aHQ
-aHQ
+kAh
+lkf
 aHQ
 aHQ
 ivh
@@ -57260,22 +61509,22 @@ avx
 awG
 axF
 ayG
-azR
+axF
 aAU
 aCq
 aDA
 aEC
 aFL
-aFL
+qbv
+sUV
+wqO
+ygB
+baC
+aOC
+aOC
 aHR
 aJi
 pxb
-aFL
-aOC
-aOC
-aOC
-sJr
-aOC
 sOo
 jbk
 jbk
@@ -57459,25 +61708,25 @@ ask
 ato
 auk
 avy
-awH
 uoC
+irV
 ayH
 azS
 aAV
 aCr
-auk
+nZf
 aED
-aFM
-aFM
+elP
+cKk
+egK
+jWK
+egg
+pUb
+pUb
+aNA
 aHS
 aJj
 pyb
-pUb
-aMy
-aNA
-bDK
-bDK
-bDK
 xPU
 xPU
 rUh
@@ -57663,19 +61912,19 @@ aul
 vtY
 awI
 awJ
-awJ
-awJ
+lnO
+tSK
 aAW
 vtY
 aul
-aTK
+brg
 vBV
-aTK
-bDK
-bDK
-bDK
-bDK
-bDK
+aul
+vtY
+vtY
+vtY
+wJP
+wJP
 bDK
 bDK
 bDK
@@ -57858,21 +62107,21 @@ mpy
 mpy
 mpy
 mpy
-acL
-asl
-asl
-abL
-snG
+mpy
+mpy
+mpy
+mpy
+vtY
 lkp
 puw
 ayJ
-ayJ
-mwJ
-snG
-aDB
+lgw
+lgw
+vtY
+knQ
 xxB
-aLu
-ldP
+kpe
+vtY
 bDK
 bDK
 bDK
@@ -58060,21 +62309,21 @@ mpy
 mpy
 mpy
 mpy
-uXe
-sde
-sde
-abL
+fFB
+fFB
+fFB
+fFB
 aGN
-aGN
-acB
-ayK
-jrH
+jka
+aaa
+aaa
+aaa
 aAX
-aGN
+uGQ
 lLD
 aLu
-aLu
-fnR
+eiT
+vtY
 bDK
 bDK
 bDK
@@ -58260,25 +62509,25 @@ mpy
 mpy
 mpy
 mpy
-dVw
-dVw
-aBc
-aBc
-aBc
-aBc
-aGN
-awL
-wRs
-ayL
-azU
-aAY
-aGN
-aHT
-aHT
-aHT
-aHT
-eRU
-eRU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+xgS
+vtY
+prB
+eYp
+xgS
+aaa
+aaa
 bDK
 bDK
 bDK
@@ -58459,31 +62708,31 @@ abN
 abM
 acd
 acd
-acd
-acd
+aaa
+aaa
+aaa
+aaa
+aaa
 dVw
 dVw
 dVw
-aBc
-aBc
-aBc
-aBc
-aGN
+dVw
+aaa
 xhX
 fOr
-cOH
-bYj
-aAZ
-aGN
-aHT
-aHT
-aHT
-aHT
-eRU
-eRU
-eRU
-acd
-acd
+fOr
+fOr
+xhX
+aaa
+vkW
+lDA
+cuN
+vkW
+aaa
+aaa
+aaa
+aaa
+aaa
 acd
 acd
 aLj
@@ -58661,31 +62910,31 @@ aet
 abN
 aaa
 acd
-acd
-acd
-acd
+aaa
+aaa
+aaa
+aaa
 dVw
 dVw
-htK
-hFu
-vjY
-hOb
-aBc
+dVw
+dVw
+dVw
+aaa
+xhX
 aHT
-aHT
-aHT
-aHT
-aBa
-aHT
-uZO
+kKa
+xlZ
+xhX
+aaa
+vkW
 xzj
 aQr
-aRm
-eRU
-eRU
-acd
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
+aaa
 acd
 aaa
 xPU
@@ -58864,29 +63113,29 @@ bhb
 aaa
 aaa
 aaa
-acd
-acd
+aaa
+aaa
+aaa
 dVw
 dVw
-veT
-svH
-svH
-swz
+dVw
+dVw
+dVw
 aBc
-iBb
+xhX
 nvX
 kmE
 onM
-uLQ
+xhX
 jPY
-onM
+vkW
 ooN
 fll
-vnz
-eRU
-eRU
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59066,29 +63315,29 @@ abN
 aaa
 aaa
 aaa
-acd
-acd
+aaa
+aaa
+aaa
+kMX
+bMd
+aEG
+neC
 dVw
-dVw
-aEG
-aEG
-aEG
-dJv
-aBc
-bMB
+orR
+xhX
 lst
 cAh
+xhX
+xhX
 jAl
-mwA
-jAl
-jAl
+vkW
 bBv
 aQs
-aQs
-eRU
-eRU
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59268,29 +63517,29 @@ aiI
 ajJ
 aaa
 aaa
-acd
-acd
-dVw
-dVw
-ryt
+aaa
+aaa
+aaa
+kMX
+bMd
 svH
-svH
+hDh
 njm
 ksK
 nZZ
 mJJ
 cYB
 qTX
-pZj
-jnd
+qTX
+qTX
 vUD
-fZn
+qTX
 aQq
-aQq
-eRU
-eRU
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 aOD
@@ -59469,31 +63718,31 @@ ahB
 abN
 aaa
 aaa
-acd
-acd
-acd
+aaa
+aaa
+aaa
 dVw
 dVw
-aEG
-aEG
-aEG
+dVw
+hjc
+nOn
 jQY
-aBc
+sRy
 xqk
 rFK
 aMB
 aNE
 vlw
-aMB
-ahL
-kyt
+txS
+txS
+txS
 aQt
-aQt
-eRU
-eRU
-acd
-acd
-acd
+tcm
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 xPU
@@ -59671,31 +63920,31 @@ aca
 abN
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
+aaa
+aaa
+aaa
+kMX
+bMd
 mrr
-svH
-svH
+jwD
+nOn
 nWP
-aBc
-cZd
+uDO
+dVw
 vkW
 uCe
-uCe
-lGw
-uCe
-uCe
-fIn
-wGe
-vcy
-eRU
-eRU
-acd
-acd
-acd
+eeU
+jSQ
+jSQ
+jSQ
+jSQ
+jSQ
+jSQ
+jSQ
+jSQ
+aaa
+aaa
+aaa
 aaa
 aaa
 xPU
@@ -59873,31 +64122,31 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
+aaa
+aaa
+aaa
+kMX
+bMd
 qKQ
 iAS
 bCX
 uMP
-aBc
+uhz
 aJl
-rFK
+qae
 aJm
 wjP
-fLg
+jSQ
 qbH
 hrE
-vlw
+oWn
 aQu
-aQu
-eRU
-eRU
-acd
-acd
-acd
+nEk
+onE
+fwo
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60075,31 +64324,31 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-acd
-acd
-acd
+aaa
+aaa
+aaa
+iBE
+iBE
+iBE
+iBE
+iBE
+iBE
+iBE
+iBE
+rNC
+tra
+jXf
+uBs
+vLZ
+gGe
+cyJ
+uOw
+sxR
+jSQ
+jSQ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60278,29 +64527,29 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
+aaa
+aaa
+hUB
+olD
+tKl
+xAj
+vcs
+evl
+rbC
 eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-acd
-acd
-acd
+goZ
+uDb
+czy
+jHw
+hFB
+xoq
+xoq
+was
+xgJ
+onE
+fwo
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60481,27 +64730,27 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
 aaa
+feo
+iBE
+fko
+eyk
+iZC
+dpD
+ieh
+pec
+ulM
+mtA
+min
+jSQ
+mqc
+wmB
+bwh
+ciB
+icr
+onE
+fwo
 aaa
-aaa
-aaa
-aaa
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
 aaa
 aaa
 aaa
@@ -60684,25 +64933,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iBE
+iBE
+iBE
+wIB
+soj
+fZf
+iBE
+xTy
+ojn
+gMo
+jSQ
+jSQ
+jSQ
+vgA
+vgA
+vgA
+jSQ
+jSQ
+jSQ
 aaa
 aaa
 aaa
@@ -60886,25 +65135,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-acd
-aaa
-acd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iBE
+iBE
+dMD
+rrp
+wPe
+rez
+iBE
+nvI
+wIz
+dnO
+smW
+kCj
+sVQ
+wiy
+vly
+eZF
+ois
+iXz
+fCY
 aaa
 aaa
 aaa
@@ -61088,25 +65337,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iBE
+iBE
+dMD
+dUh
+tFs
+vYO
+iBE
+qAG
+ilP
+hvQ
+lML
+deg
+gqM
+pee
+dbM
+gux
+giM
+iXz
+fCY
 aaa
 aaa
 aaa
@@ -61290,25 +65539,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iBE
+iBE
+dMD
+aPy
+hoc
+cQY
+iBE
+rnU
+jlC
+uNj
+uVH
+wmO
+sAP
+rQL
+qYS
+akd
+idc
+iXz
+fCY
 aaa
 aaa
 aaa
@@ -61491,27 +65740,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iBE
+iBE
+iBE
+iBE
+iBE
+iBE
+iBE
+iBE
+rnU
+wcq
+tcm
+uVH
+hOB
+dCj
+wjN
+hla
+kGf
+guQ
+smW
+smW
+smW
 aaa
 aaa
 aaa
@@ -61692,29 +65941,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kda
+kda
+kda
+lQJ
+hYo
+sOl
+iXA
+sna
+kda
+kda
+cgM
+vxP
+fgI
+fgI
+fgI
+fgI
+fgI
+fgI
+tel
+tel
+tel
+tel
+fgI
 aaa
 aaa
 aaa
@@ -61894,29 +66143,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kda
+kda
+qnw
+oQB
+oQB
+oQB
+qvU
+qPK
+iMy
+kda
+gTQ
+xYB
+fgI
+rPN
+oTW
+kct
+kgC
+kHk
+qSM
+wzA
+bQT
+tel
+fgI
 aaa
 aaa
 aaa
@@ -62096,29 +66345,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tVq
+jyX
+pCg
+qPK
+dlw
+pmM
+cOo
+mwW
+wkm
+qcS
+xLd
+qHX
+cwn
+kSU
+qeW
+jOn
+gSM
+bdd
+rIv
+bQT
+bQT
+tel
+fgI
 aaa
 aaa
 aaa
@@ -62298,29 +66547,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tVq
+jyX
+xkb
+qPK
+qPK
+jRW
+lgP
+pKv
+kGd
+aEq
+ykB
+tcm
+lzt
+rqC
+hew
+nqv
+nqv
+bdd
+rid
+xmZ
+bQT
+tel
+fgI
 aaa
 aaa
 aaa
@@ -62500,29 +66749,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tVq
+jyX
+gsT
+qPK
+tnh
+iIc
+gwX
+xUa
+bVD
+ddK
+wcq
+tcm
+lzt
+eDR
+keJ
+qEs
+kmS
+vDL
+qSM
+wVw
+bQT
+tel
+fgI
 aaa
 aaa
 aaa
@@ -62702,29 +66951,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kda
+kda
+xRb
+uAb
+xHu
+tme
+bVA
+hRg
+vIR
+ddK
+mGq
+mEH
+bNt
+bNt
+bNt
+bNt
+bNt
+mFJ
+jzd
+jzd
+jzd
+jzd
+mFJ
 aaa
 aaa
 aaa
@@ -62904,29 +67153,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kda
+kda
+kda
+kda
+ddK
+ddK
+ddK
+kda
+kda
+kda
+ftb
+jtO
+mdT
+fAN
+mZP
+qsn
+rag
+rSq
+kZW
+xJR
+wka
+cjp
+yip
 aaa
 aaa
 aaa
@@ -63106,29 +67355,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bqI
+bqI
+dCg
+xYu
+cMM
+cEn
+vlB
+eKo
+uxP
+lmq
+cwC
+lDc
+mdT
+hnu
+odx
+dGw
+iFJ
+pUT
+fJk
+blI
+vKr
+cjp
+yip
 aaa
 aaa
 aaa
@@ -63308,6 +67557,29 @@ aaa
 aaa
 aaa
 aaa
+pjW
+vqP
+oTq
+xHQ
+xHQ
+eoc
+bEC
+xHQ
+bgw
+lmq
+wPt
+jtO
+rtA
+exB
+hah
+eSA
+sEI
+rSq
+rct
+mev
+cZN
+cjp
+yip
 aaa
 aaa
 aaa
@@ -63320,30 +67592,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+azV
 aaa
 aaa
 aaa
@@ -63486,6 +67735,9 @@ aaa
 aaa
 aaa
 aaa
+qbQ
+qbQ
+qbQ
 aaa
 aaa
 aaa
@@ -63507,32 +67759,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pjW
+vqP
+rIM
+xHQ
+pBT
+xgs
+dDF
+xHQ
+xUn
+bqI
+ycB
+xYE
+bNt
+dsi
+bWl
+sbX
+chm
+mFJ
+mFJ
+mFJ
+mFJ
+mFJ
+mFJ
 aaa
 aaa
 aaa
@@ -63688,6 +67937,9 @@ aaa
 aaa
 aaa
 aaa
+qbQ
+qbQ
+qbQ
 aaa
 aaa
 aaa
@@ -63709,32 +67961,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bqI
+bqI
+xXi
+eTu
+lQW
+wkO
+pcV
+fdU
+ndL
+lEv
+pHE
+dEN
+uND
+yed
+hsq
+hIA
+bcv
+gKv
+kLD
+oJi
+rIK
+oqk
+xLu
 aaa
 aaa
 aaa
@@ -63881,6 +68130,27 @@ aaa
 aaa
 aaa
 aaa
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
 aaa
 aaa
 aaa
@@ -63893,50 +68163,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bqI
+bqI
+bqI
+nRJ
+bqI
+bqI
+rQH
+nii
+dlB
+bqI
+fWf
+frL
+bNt
+brM
+kOA
+uqr
+tKa
+vui
+ivt
+uch
+oJT
+oqk
+xLu
 aaa
 aaa
 aaa
@@ -64083,6 +68332,27 @@ aaa
 aaa
 aaa
 aaa
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
 aaa
 aaa
 aaa
@@ -64095,50 +68365,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tqI
+tqI
+hvC
+xod
+bky
+bqI
+fpb
+fon
+ppf
+bqI
+hOU
+dqJ
+bNt
+eEb
+pcu
+gti
+wOa
+sGy
+pYs
+lip
+oWU
+oqk
+xLu
 aaa
 aaa
 aaa
@@ -64285,6 +68534,27 @@ aaa
 aaa
 aaa
 aaa
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
 aaa
 aaa
 aaa
@@ -64297,50 +68567,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azV
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mkw
+tNt
+jcB
+lzu
+xhG
+oQo
+oQo
+oQo
+oQo
+oQo
+pfH
+oQo
+bNt
+bNt
+vya
+nGz
+nNv
+bhU
+bhU
+bhU
+bhU
+bhU
+bhU
 aaa
 aaa
 aaa
@@ -64487,6 +68736,27 @@ aaa
 aaa
 aaa
 aaa
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
 aaa
 aaa
 aaa
@@ -64499,50 +68769,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mkw
+tNt
+piH
+lmJ
+dCn
+oQo
+kPk
+oID
+qOr
+vcN
+oDq
+wPs
+jgY
+bNt
+rOy
+fIV
+pzf
+hVQ
+loF
+hJp
+inO
+uZG
+lSp
 aaa
 aaa
 aaa
@@ -64689,6 +68938,27 @@ aaa
 aaa
 aaa
 aaa
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+nrB
+nrB
+nrB
+nrB
+nrB
+nrB
+nrB
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
+tVn
 aaa
 aaa
 aaa
@@ -64701,50 +68971,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mkw
+tNt
+piH
+fhj
+myO
+oQo
+fzo
+igm
+dKw
+mLn
+uvF
+tUq
+ijY
+bNt
+nhG
+wwf
+rNU
+ojm
+fhx
+bqy
+pmR
+uZG
+lSp
 aaa
 aaa
 aaa
@@ -64891,6 +69140,27 @@ aaa
 aaa
 aaa
 aaa
+vzA
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+nrB
+nrB
+nrB
+nrB
+nrB
+nrB
+nrB
+iif
+iif
+iif
+iif
+iif
+iif
+tVn
 aaa
 aaa
 aaa
@@ -64903,50 +69173,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tqI
+tqI
+jhI
+eot
+jdc
+oQo
+ieX
+wsD
+aMG
+dKw
+kkr
+eOT
+tQX
+bNt
+iZt
+bgz
+fIV
+gUs
+kFJ
+mBe
+ket
+uZG
+lSp
 aaa
 aaa
 aaa
@@ -65093,6 +69342,27 @@ aaa
 aaa
 aaa
 aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+nrB
+nrB
+nrB
+nrB
+nrB
+nrB
+nrB
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -65105,50 +69375,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eCo
+eCo
+eCo
+kWF
+eCo
+eCo
+kNm
+gES
+aNx
+lfj
+eTv
+qUN
+khl
+bNt
+bpj
+iWu
+lCi
+gqF
+vVB
+vVB
+vVB
+vVB
+vVB
 aaa
 aaa
 aaa
@@ -65296,6 +69545,25 @@ aaa
 aaa
 aaa
 aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -65309,48 +69577,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDs
+pDs
+rTt
+uaq
+qOc
+eCo
+oQo
+ezH
+ibO
+tpr
+kGp
+csH
+kGp
+kMT
+bNt
+bNt
+bNt
+xcE
+bNt
+bIv
+bIv
+sNN
+sNN
 aaa
 aaa
 aaa
@@ -65498,6 +69747,25 @@ aaa
 aaa
 aaa
 aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -65512,46 +69780,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDs
+hIz
+wsn
+hIz
+eCo
+oQo
+iRx
+mxa
+tzr
+cJU
+gNw
+wuY
+kMT
+bNt
+bNt
+bNt
+rQi
+rQi
+fql
+rQi
+sNN
 aaa
 aaa
 aaa
@@ -65700,6 +69949,25 @@ aaa
 aaa
 aaa
 aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -65714,46 +69982,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDs
+pDs
+pDs
+pDs
+pDs
+pDs
+vvJ
+mzN
+tIT
+fWS
+lqk
+iMF
+kMT
+bNt
+bNt
+sNN
+sNN
+sNN
+sNN
+sNN
+sNN
 aaa
 aaa
 aaa
@@ -65902,6 +70151,25 @@ aaa
 aaa
 aaa
 aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -65916,46 +70184,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDs
+fNG
+fNG
+fNG
+fNG
+pDs
+rzO
+sPk
+scL
+xra
+xra
+xra
+scL
+rAZ
+rAZ
+sNN
+gLK
+gLK
+gLK
+gLK
+sNN
 aaa
 aaa
 aaa
@@ -66104,6 +70353,25 @@ aaa
 aaa
 aaa
 aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -66118,6 +70386,12 @@ aaa
 aaa
 aaa
 aaa
+pDs
+var
+var
+var
+var
+pDs
 aaa
 aaa
 aaa
@@ -66127,37 +70401,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sNN
+pnY
+pnY
+pnY
+pnY
+sNN
 aaa
 aaa
 aaa
@@ -66306,25 +70555,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -66508,25 +70757,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -66710,25 +70959,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa
@@ -66913,23 +71162,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vIN
+vIN
+vIN
+vIN
+vIN
+vIN
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
+iif
 aaa
 aaa
 aaa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -9,15 +9,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"ac" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "ad" = (
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -361,14 +352,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"aM" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
 "aN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -623,12 +606,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"bk" = (
-/obj/effect/floor_decal/corner/white/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/command,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
 "bl" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/sticky_pad/random,
@@ -2349,15 +2326,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "eb" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/dutyboots,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
+/obj/machinery/camera/network/command{
+	c_tag = "Fire Control - Controls";
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"ec" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/cockpit)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "ed" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -2392,13 +2373,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"eg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2701,20 +2675,6 @@
 /obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"eH" = (
-/obj/machinery/computer/ship/helm{
-	req_access = list(list("ACCESS_TORCH_AQUILA_HELM"))
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"eI" = (
-/obj/machinery/computer/shuttle_control/explore/aquila,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"eJ" = (
-/obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "eK" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -3032,16 +2992,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "fj" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"fk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/armoury/tactical)
 "fl" = (
 /obj/structure/table/glass,
 /obj/random/clipboard,
@@ -3049,29 +3001,6 @@
 /obj/random_multi/single_item/summarydocuments/explo,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"fm" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"fn" = (
-/obj/machinery/button/blast_door{
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters Control";
-	pixel_x = -32
-	},
-/obj/machinery/turretid/stun{
-	check_synth = 0;
-	name = "Aquila point defense control";
-	pixel_x = 32;
-	pixel_y = 0;
-	req_access = list("ACCESS_TORCH_AQUILA_HELM")
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "fo" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3086,13 +3015,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"fp" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "fu" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -3259,52 +3181,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"fH" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 8;
-	name = "CE's Equipment Storage"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/item/weapon/rig/ce/equipped,
-/turf/simulated/floor/tiled/monotile,
-/area/aux_eva)
 "fI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
-"fJ" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"fK" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"fL" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Cockpit";
-	dir = 8
-	},
-/obj/machinery/computer/modular/preset/cardslot/command,
-/obj/item/device/radio/intercom/hailing{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "fM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3450,18 +3329,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cmo)
-"fX" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/medical)
 "fY" = (
 /obj/effect/floor_decal/corner/red/half,
 /obj/machinery/vending/coffee{
@@ -3470,6 +3337,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"fZ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2;
+	level = 2
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "ga" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -3483,6 +3361,30 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"gb" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "gc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3589,84 +3491,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"go" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/steel_reinforced,
-/obj/random/toolbox,
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "gv" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -3689,10 +3513,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
-"gw" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
 "gz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftstarboard)
@@ -3799,57 +3619,12 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/bridge/aft)
-"gY" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"gZ" = (
-/obj/machinery/porta_turret{
-	dir = 8;
-	enabled = 0;
-	lethal = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
-/area/aquila/cockpit)
-"ha" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/cockpit)
-"hb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cockpit"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"hc" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/porta_turret{
-	dir = 8;
-	enabled = 0;
-	lethal = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/cockpit)
 "hi" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "hj" = (
 /obj/machinery/light{
@@ -3883,6 +3658,36 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"hw" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/rig/command/xo/equipped,
+/obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
+	dir = 4;
+	name = "XO's suit storage";
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "hx" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 1;
@@ -3981,55 +3786,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
-"hL" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/microwave,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Crew Compartment";
-	dir = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"hM" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/snack,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"hN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"hO" = (
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/bed/chair/shuttle/blue,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
+"hS" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/flasher/portable,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "hV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/sol{
@@ -4210,79 +3971,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
-"it" = (
-/obj/random/soap,
-/obj/structure/hygiene/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"iu" = (
-/obj/structure/hygiene/toilet{
-	pixel_y = 12
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"iv" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/single/cola,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"iw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"ix" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"iy" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/smokes,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"iz" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/passenger)
-"iA" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
 "iB" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -4450,80 +4138,20 @@
 /obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
-"je" = (
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"jf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
 "jg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "jh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"jj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"jk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"jl" = (
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "jw" = (
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
@@ -4612,6 +4240,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
+"jK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark{
+	dir = 8
+	},
+/area/aux_eva)
 "jM" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -4736,112 +4380,41 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "kb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
+/obj/item/weapon/gun/energy/stunrevolver/rifle,
+/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/taser/carbine,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "kc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/power/apc/shuttle/aquila{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "ke" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/energy/ionrifle,
+/obj/item/weapon/gun/energy/ionrifle/small,
+/obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"kf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"kg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"kh" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"ki" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "kv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5001,23 +4574,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "kT" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "operation_hallway_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
-"kU" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "kV" = (
 /obj/structure/cable/green,
@@ -5034,24 +4600,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/xo)
-"kW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "kX" = (
 /obj/machinery/light_switch{
 	pixel_x = -23;
@@ -5092,18 +4640,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"lp" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/secure_storage)
 "lq" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -5284,14 +4820,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/bridge)
-"lN" = (
+"lO" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "operation_hallway_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -5299,66 +4838,28 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/half{
-	dir = 4;
-	icon_state = "bordercolorhalf"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"lO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass/command{
-	id_tag = null;
-	name = "Aquila Dock";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/bridge/aft)
 "lR" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "aquila_shuttle_dock_sensor";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 8;
-	id_tag = "aquila_shuttle_dock_pump"
+/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/item/device/radio/intercom/hailing{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/turf/simulated/floor/plating,
+/area/command/armoury/access)
 "lS" = (
 /obj/effect/floor_decal/scglogo{
 	dir = 4;
@@ -5393,59 +4894,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "lX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/cdeathalarm_kit,
+/obj/item/weapon/melee/telebaton,
+/obj/item/weapon/melee/telebaton,
+/obj/item/weapon/melee/telebaton,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"lZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "mc" = (
 /obj/structure/cable/green,
 /obj/machinery/door/firedoor,
@@ -5457,14 +4920,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"mx" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
+"mr" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "mz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -5713,34 +5173,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"nd" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
 "ne" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/blue/half,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "nf" = (
 /obj/effect/floor_decal/corner/blue/mono,
@@ -5751,135 +5190,70 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "ni" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Docking Port";
-	dir = 1
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	icon_state = "wrecharger0";
+	pixel_y = -22
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "nj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "nk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "aquila_shuttle";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = -24;
-	req_access = newlist()
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"nl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"nm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/overmap/visitable/ship/landable/aquila,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"nn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"no" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"np" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/obj/machinery/computer/cryopod{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
-"nq" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Seating";
-	dir = 1
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
-"nr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"nE" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/techfloor{
 	dir = 1;
-	icon_state = "warningcorner"
+	icon_state = "techfloor_edges"
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Corporate Liaison - Office";
+	dir = 8;
+	network = list("Command")
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
+"nw" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/box/lights/tubes,
+/obj/item/weapon/storage/box/lights/bulbs,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "nG" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -6302,112 +5676,44 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"oU" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/medical)
 "oW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 23;
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"oZ" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
-"pa" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
-"pb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
 "pc" = (
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6;
+	icon_state = "corner_techfloor_grid"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
+/area/aux_eva)
+"pd" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Emergency Armory"
+	},
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_entrylock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/aux_eva)
 "pe" = (
 /obj/structure/lattice,
 /obj/machinery/light/navigation/delay5,
 /turf/space,
 /area/space)
-"pf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"ph" = (
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"pi" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"pj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"pk" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"pl" = (
-/obj/machinery/body_scanconsole{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -6514,156 +5820,58 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"pQ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+"pO" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = -4;
+	pixel_y = -4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/stack/nanopaste,
+/obj/item/bodybag/rescue/loaded,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"pR" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
+"pQ" = (
+/obj/effect/floor_decal/corner/red/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/security/alt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"pS" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
 "pT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"pU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/pinpointer,
+/obj/item/weapon/pinpointer,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "pW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Aft Passageway";
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
-	},
-/obj/machinery/vending/wallmed1{
-	dir = 1;
-	icon_state = "wallmed";
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pY" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+	alarm_id = "petrov2";
 	dir = 8;
-	icon_state = "warningcorner"
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "qa" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4;
@@ -6671,38 +5879,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"qb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"qc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"qd" = (
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"qe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "qf" = (
 /obj/effect/floor_decal/scglogo{
 	icon_state = "top-right"
@@ -6925,48 +6101,23 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "qD" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "qE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"qF" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "qH" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/bridge/aftport)
-"qI" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "qO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/storage)
@@ -7181,6 +6332,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"ro" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "rp" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -7204,58 +6365,57 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
-"rv" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
-"rw" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Storage";
+"rx" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 8;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Disciplinary Board Room - Deliberations";
 	dir = 1
 	},
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"rx" = (
-/obj/machinery/atmospherics/unary/tank/air{
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"ry" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
-"ry" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/stack/material/steel{
+	amount = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
+/obj/item/stack/material/steel{
+	amount = 30
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/stack/material/steel{
+	amount = 30
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/ocp{
+	amount = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "rz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7289,19 +6449,6 @@
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
-"rE" = (
-/obj/structure/table/standard,
-/obj/item/weapon/defibrillator/loaded,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Infirmary";
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "rI" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8;
@@ -7413,6 +6560,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"rX" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "rY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7536,58 +6686,28 @@
 /obj/machinery/shipsensors,
 /turf/simulated/floor/reinforced/airless,
 /area/bridge/storage)
-"sn" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Secure Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
 "so" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10;
-	icon_state = "intact"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/stack/material/glass/reinforced{
+	amount = 30
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
-"st" = (
-/obj/structure/hygiene/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+/obj/item/stack/material/glass/reinforced{
+	amount = 30
 	},
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/item/stack/material/glass/reinforced{
+	amount = 30
 	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"su" = (
-/obj/structure/table/standard,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 5
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "sx" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -7726,61 +6846,19 @@
 "sT" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/rd)
-"sU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"sY" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/weapon/gun/launcher/syringe,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
-"sV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
-"sW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/structure/handrai,
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
-"sY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "ta" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -7815,53 +6893,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
-"tc" = (
-/obj/structure/catwalk,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
-"td" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1;
-	sheets = 25
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
-"te" = (
-/obj/structure/closet/medical_wall{
-	pixel_x = -32
-	},
-/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
-/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
-/obj/item/weapon/reagent_containers/syringe,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/latex,
-/obj/item/weapon/tank/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/structure/iv_drip,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"tf" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/sterilizine,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "tg" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/foreport)
@@ -8045,6 +7076,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
+"tG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Emergency Armory Desk"
+	},
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "tH" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -8060,57 +7108,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
 "tI" = (
-/obj/structure/table/rack,
-/obj/random/solgov,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/secure_storage)
+/obj/machinery/shieldwallgen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "tJ" = (
-/obj/structure/table/rack,
-/obj/random/solgov,
-/obj/random/solgov,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "tK" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/secure_storage)
-"tL" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
-"tM" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/stack/medical/advanced/bruise_pack,
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"tN" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"tO" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "tR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -8367,19 +7378,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"uv" = (
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1;
-	icon_state = "warningcee"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"uw" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
 "ux" = (
 /obj/structure/sign/double/icarus/solgovflag/left{
 	dir = 4;
@@ -8496,6 +7494,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"uL" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "uM" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Sol Government Representative - Office";
@@ -8530,6 +7538,14 @@
 /obj/item/weapon/tableflag,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
+"uS" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "uT" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -8576,30 +7592,6 @@
 "uX" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarbridge)
-"uY" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/auxsolarbridge)
-"uZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"vb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "vd" = (
 /obj/machinery/power/shield_generator,
 /obj/structure/cable/green{
@@ -8698,14 +7690,6 @@
 /obj/item/weapon/material/clipboard,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
-"vn" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
 "vp" = (
 /obj/structure/bed/chair/padded/blue{
 	dir = 8;
@@ -8822,19 +7806,6 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)
-"vK" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"vL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "vO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -9182,14 +8153,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/auxsolarbridge)
-"wr" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "ws" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9810,16 +8773,6 @@
 	},
 /turf/space,
 /area/space)
-"xQ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 1900
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "xR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow{
@@ -9967,27 +8920,6 @@
 /obj/machinery/suit_storage_unit/security/alt,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"yk" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
-"yl" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
-/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
 "yw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -10089,6 +9021,11 @@
 "yW" = (
 /turf/simulated/wall/prepainted,
 /area/security/bridgecheck)
+"yX" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_cycler,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "za" = (
 /obj/structure/closet/secure_closet/XO,
 /obj/random/drinkbottle,
@@ -10098,13 +9035,6 @@
 /obj/effect/shuttle_landmark/torch/deck5/guppy,
 /turf/space,
 /area/space)
-"zc" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "zf" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4;
@@ -10200,16 +9130,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
-"zz" = (
-/obj/effect/floor_decal/corner/white/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/command,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
 "zC" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/PDAs{
@@ -10349,26 +9269,6 @@
 /obj/effect/shuttle_landmark/merc/deck5,
 /turf/space,
 /area/space)
-"Ac" = (
-/obj/structure/closet/crate,
-/obj/random/toolbox,
-/obj/random/powercell,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/weapon/storage/bag/trash,
-/obj/item/weapon/storage/bag/trash,
-/obj/item/weapon/storage/bag/trash,
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/random_multi/single_item/boombox,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Ad" = (
 /obj/structure/bed/chair/office/comfy/blue{
 	dir = 8;
@@ -10387,19 +9287,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Ag" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/passenger)
 "Ah" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1;
@@ -10408,9 +9295,8 @@
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "Ai" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/structure/closet/bombclosetsecurity,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Aj" = (
@@ -10604,8 +9490,8 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/port)
 "AN" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
+/turf/simulated/wall/r_wall/prepainted,
+/area/space)
 "AR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -10615,14 +9501,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"AU" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
 "AX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10654,25 +9532,41 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
-"Bc" = (
-/obj/machinery/power/smes/buildable/preset/torch/shuttle{
-	RCon_tag = "Shuttle - Aquila"
-	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Bd" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "Bp" = (
-/obj/effect/floor_decal/corner/red/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/security/alt,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
+	dir = 4;
+	name = "CO's suit storage";
+	req_access = list("ACCESS_CAPTAIN")
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/rig/command/co/equipped,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Emergency Armory - Port";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -10716,6 +9610,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
+"BC" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "BE" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -10767,9 +9666,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/co)
 "BO" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "BR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
@@ -10829,18 +9729,6 @@
 /obj/effect/shuttle_landmark/torch/deck5/aquila,
 /turf/space,
 /area/space)
-"Cc" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Cd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
@@ -10878,22 +9766,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
-"Cg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad/longrange,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
 "Ch" = (
 /obj/structure/bed/chair/comfy/captain{
 	color = "#666666";
@@ -11015,19 +9887,36 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"CD" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
+"CB" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
 	},
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/airlock)
+/obj/machinery/camera/network/command{
+	c_tag = "Disciplinary Board Room - Deliberations";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
+"CD" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "CE" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -11124,32 +10013,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/port)
 "Db" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Head"
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"Dc" = (
-/obj/machinery/light/small,
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "Dd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11175,36 +10045,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"Dq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/rig/command/xo/equipped,
-/obj/machinery/door/window/brigdoor/westright{
-	autoset_access = 0;
-	dir = 8;
-	name = "XO's suit storage";
-	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
 "Dr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11214,7 +10054,7 @@
 "Dt" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/aux_eva)
 "Du" = (
 /obj/structure/extinguisher_cabinet{
@@ -11228,9 +10068,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Dw" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "Dx" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -11241,6 +10078,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/co)
+"DA" = (
+/obj/machinery/deployable/barrier,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Emergency Armory - Port";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "DE" = (
 /obj/structure/cable/green,
 /obj/machinery/door/firedoor,
@@ -11263,6 +10110,26 @@
 "DN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/bridge/aft)
+"DP" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/command{
+	name = "Emergency Armory Access";
+	secured_wires = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "DQ" = (
 /obj/structure/bed/chair/comfy/captain{
 	color = "#666666";
@@ -11272,9 +10139,15 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "DR" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/head)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/dutyboots,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "DY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -11318,12 +10191,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shield/bridge)
-"Ec" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "Ed" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
@@ -11413,30 +10280,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "Ez" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
-"EE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/power/apc/shuttle/aquila{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
+/obj/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "EJ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
@@ -11495,31 +10342,35 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "Fc" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 4;
-	id_tag = "aquila_shuttle_pump_out_external"
-	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "aquila_shuttle_sensor_external";
-	pixel_x = 25;
+/obj/machinery/button/blast_door{
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutter Control";
+	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
+/obj/structure/table/steel,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 5
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1331;
-	master_tag = "aquila_shuttle";
-	name = "exterior access button";
-	pixel_x = 23;
-	pixel_y = 6
+/obj/item/weapon/stamp,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/simulated/floor/airless,
-/area/aquila/airlock)
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Medical Officer - Office";
+	network = list("Command","Medical")
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/armoury/access)
 "Ff" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -11542,9 +10393,14 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Fi" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Fj" = (
 /obj/machinery/computer/rdservercontrol{
@@ -11621,9 +10477,17 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "FK" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/energy/laser/secure,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "FL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -11682,13 +10546,40 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Gc" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
+/obj/structure/table/steel,
+/obj/random/clipboard,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/hand_labeler,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/head)
+/obj/machinery/alarm{
+	alarm_id = "xenobio4_alarm";
+	dir = 2;
+	icon_state = "alarm0";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "operation_hallway_shutters";
+	name = "Hallway Checkpoint Shutters";
+	pixel_x = 35;
+	pixel_y = 6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutter Control";
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "armory_entrylock";
+	name = "Armory Entry Lockdown Shutter Control";
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/armoury/access)
 "Ge" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11813,6 +10704,19 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"GK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"GO" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "GU" = (
 /obj/structure/displaycase,
 /obj/item/weapon/gun/projectile/revolver/medium/captain{
@@ -11907,26 +10811,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Hg" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 1;
-	id_tag = "aquila_shuttle_pump_out_internal"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/structure/handrai,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
 "Hh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11947,6 +10831,9 @@
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
+"Hn" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "Ho" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "hopdoor";
@@ -12224,18 +11111,6 @@
 /obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
-"Ib" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/cockpit)
 "Id" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12470,14 +11345,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"IJ" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
 "IK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -12492,21 +11359,29 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "IL" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "IO" = (
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
+"IQ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/dutyboots,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Medical Officer - Office";
+	network = list("Command","Medical")
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "IT" = (
 /obj/structure/table/glass,
 /obj/machinery/keycard_auth/torch{
@@ -12532,10 +11407,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "IW" = (
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/atmos/alt/sol,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/inflatable_dispenser,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/aux_eva)
 "IY" = (
 /obj/structure/table/glass,
@@ -12551,6 +11434,21 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
+"Ja" = (
+/obj/effect/floor_decal/corner/blue/half,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/aft)
 "Jb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -12586,20 +11484,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "Jg" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "aquila_shuttle_pump"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/structure/handrai,
 /obj/effect/floor_decal/techfloor{
-	dir = 1;
+	dir = 8;
 	icon_state = "techfloor_edges"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Jh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12647,26 +11538,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "JA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"JE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "JF" = (
 /obj/structure/grille,
 /obj/structure/railing/mapped{
@@ -12683,9 +11562,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
-"JV" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "Ka" = (
 /obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -12699,11 +11575,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/rd)
-"Kc" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
 "Kd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12852,14 +11723,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"KN" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/medical)
 "KP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -12932,30 +11795,28 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Lg" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	icon_state = "wrecharger0";
+	pixel_y = -22
+	},
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "aquila_shuttle_sensor";
-	pixel_x = 0;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
-	},
-/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Lh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -12965,29 +11826,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"Li" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
-	},
-/obj/item/device/radio/beacon/anchored{
-	level = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13108,15 +11946,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
-"LQ" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
 "Ma" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13135,26 +11964,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Mc" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
-	frequency = 1331;
-	id_tag = "aquila_shuttle";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list("ACCESS_TORCH_AQUILA");
-	tag_exterior_sensor = "aquila_shuttle_sensor_external"
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "aquila_shuttle_pump"
-	},
-/obj/structure/handrai,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
+/obj/item/weapon/gun/energy/gun/secure,
+/obj/item/weapon/gun/energy/gun/secure,
+/obj/item/weapon/gun/energy/gun/secure,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Mf" = (
 /obj/structure/table/woodentable_reinforced/walnut/maple,
 /obj/item/weapon/folder/envelope/captain,
@@ -13233,12 +12054,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"Mw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
 "Mz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/heads/office/co)
@@ -13249,16 +12064,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"MU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "MV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13271,6 +12076,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
+"MY" = (
+/obj/machinery/deployable/barrier,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "Nb" = (
 /obj/structure/bed/chair/comfy/captain{
 	color = "#666666";
@@ -13281,22 +12091,32 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
 "Nc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Emergency Armory"
 	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_entrylock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/item/device/radio/intercom/hailing{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "Nd" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -13502,6 +12322,13 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
+"NQ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "NW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -13509,19 +12336,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
-"Ob" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Crew Area"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "Oc" = (
 /obj/structure/sign/solgov{
 	pixel_x = 32;
@@ -13637,14 +12451,24 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Ok" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/rack{
+	dir = 4
 	},
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "Om" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -13714,29 +12538,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"OX" = (
-/obj/machinery/shipsensors,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
-/area/aquila/passenger)
-"Pb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Passenger Seating"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "Pc" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -13812,6 +12613,29 @@
 "Pi" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/disciplinary_board_room)
+"Pm" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Emergency Armory - Access";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "Pt" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
@@ -13843,24 +12667,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
-"PC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
 "PF" = (
 /obj/structure/sign/double/icarus/solgovflag/right{
 	dir = 4;
@@ -13869,34 +12675,22 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
-"PP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+"PJ" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10;
+	icon_state = "corner_techfloor_grid"
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/medical)
-"Qb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/shuttle_landmark/torch/hangar/aquila,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
+/area/aux_eva)
+"PY" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/armoury/access)
 "Qc" = (
 /obj/machinery/door/airlock/glass/command{
-	name = "Auxiliary E.V.A.";
+	name = "Command Storage";
 	secured_wires = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14033,6 +12827,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
+"Qn" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
+/obj/machinery/flasher/portable,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "Qp" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "captaindoorfore";
@@ -14072,34 +12872,6 @@
 /obj/random_multi/single_item/summarydocuments/explo,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Qz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/handrai,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"QE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
-"QF" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/passenger)
 "QK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -14113,9 +12885,13 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "QL" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/storage)
+/obj/machinery/door/airlock/glass/command{
+	name = "Command Storage";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/aux_eva)
 "QN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -14201,17 +12977,6 @@
 /obj/machinery/computer/modular/preset/security,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"Rb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Infirmary"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/medical)
 "Rd" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -14266,10 +13031,6 @@
 "Rh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14369,14 +13130,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "Rz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -14422,10 +13182,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"RH" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
 "RK" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -14487,22 +13243,55 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/co)
 "Sb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Storage"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
+"Sc" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 4;
+	name = "CE's Equipment Storage"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/item/weapon/rig/ce/equipped,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
+/area/aux_eva)
 "Sd" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/device/flashlight/lamp,
@@ -14537,35 +13326,22 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "Sg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	display_name = "Bridge Deck Dock";
-	frequency = 1331;
-	id_tag = "aquila_shuttle_dock_airlock";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"));
-	tag_airpump = "aquila_shuttle_dock_pump";
-	tag_chamber_sensor = "aquila_shuttle_dock_sensor";
-	tag_exterior_door = "aquila_shuttle_dock_outer";
-	tag_interior_door = "aquila_shuttle_dock_inner"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/aft)
-"Sh" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/aft)
+"Sh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -14582,6 +13358,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"Sl" = (
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/atmos/alt/sol,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "Sn" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -14592,28 +13377,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"So" = (
-/obj/machinery/alarm{
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/machinery/cryopod,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
-"SA" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
+"Sv" = (
+/obj/effect/floor_decal/techfloor{
 	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
+	icon_state = "techfloor_edges"
 	},
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/cockpit)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "SB" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/tape/random,
@@ -14682,22 +13453,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
-"SQ" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/medical)
 "SU" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
+/obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "SV" = (
@@ -14726,18 +13491,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Tb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Infirmary"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
 "Tc" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -14798,46 +13551,25 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room/deliberation)
 "Tg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_dock_inner";
-	locked = 1;
-	name = "Docking Port Airlock";
-	req_access = list("ACCESS_TORCH_CREW")
-	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "Th" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/inflatable_dispenser,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
 /obj/machinery/camera/network/command{
-	c_tag = "EVA - Command";
-	dir = 2
+	c_tag = "Chief Medical Officer - Office";
+	network = list("Command","Medical")
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Ti" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -14949,10 +13681,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "TQ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -14960,6 +13688,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/research/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -14988,20 +13719,6 @@
 "TX" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room)
-"Ub" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/maintenance)
 "Uc" = (
 /obj/machinery/photocopier/faxmachine/torch{
 	department = "Torch - Corporate Liasion"
@@ -15047,50 +13764,23 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room/deliberation)
 "Ug" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_dock_outer";
-	locked = 1;
-	name = "Docking Port Airlock";
-	req_access = list("ACCESS_TORCH_CREW")
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "Uh" = (
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor/westright{
-	autoset_access = 0;
-	dir = 8;
-	name = "CO's suit storage";
-	req_access = list("ACCESS_CAPTAIN")
-	},
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/rig/command/co/equipped,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Ui" = (
@@ -15163,6 +13853,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
+"UK" = (
+/obj/effect/floor_decal/corner/white/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/command,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "UL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15184,18 +13880,6 @@
 /obj/effect/shuttle_landmark/ert/deck5,
 /turf/space,
 /area/space)
-"UW" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/medical)
 "UX" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/blue,
@@ -15205,28 +13889,6 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
-"Vb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/power/apc/hyper/shuttle/aquila{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "Vc" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
@@ -15255,25 +13917,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Vg" = (
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	density = 1;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_outer";
-	locked = 1;
-	name = "Aquila External Access";
-	req_access = list("ACCESS_TORCH_CREW")
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/shield_diffuser,
-/obj/structure/cable{
-	d1 = 4;
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "Vh" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random_multi/single_item/runtime,
@@ -15347,12 +14005,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"Vs" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/secure_storage)
 "Vw" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -15464,33 +14116,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
-"Wb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "Wd" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -15529,26 +14154,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "Wg" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	icon_state = "wrecharger0";
+	pixel_y = -22
 	},
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_inner";
-	locked = 1;
-	name = "Aquila External Access";
-	req_access = list("ACCESS_TORCH_CREW")
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Wh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15594,18 +14214,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "Ws" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aux_eva)
 "Wv" = (
 /obj/structure/closet/secure_closet/bridgeofficer,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Ww" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
 "WK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -15669,21 +14288,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
-"Xb" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/obj/structure/handrai,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "Xe" = (
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/carpet/blue2,
@@ -15743,10 +14347,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Xp" = (
-/obj/structure/sign/solgov,
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
+/obj/structure/table/steel,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/machinery/recharger/wallcharger{
+	dir = 8;
+	icon_state = "wrecharger0";
+	pixel_x = 23;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "Xq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15808,10 +14420,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "XI" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/airlock)
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/flashbangs,
+/obj/item/weapon/storage/box/smokes,
+/obj/item/weapon/storage/box/handcuffs,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "XJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15885,16 +14513,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
-"Yb" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Yd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15963,15 +14581,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Yh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -16096,16 +14713,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "YW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6;
+	icon_state = "corner_techfloor_grid"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "YX" = (
@@ -16122,24 +14742,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"YY" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"Zb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Ze" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16183,9 +14785,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "Zh" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Zi" = (
@@ -16204,24 +14804,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"Zj" = (
-/obj/structure/hygiene/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/mirror{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
 "Zs" = (
 /obj/machinery/computer/account_database,
 /obj/machinery/recharger/wallcharger{
@@ -16254,29 +14836,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "Zy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/aux_eva)
-"ZA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/handrai,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"ZB" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
 "ZD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -32007,7 +30571,7 @@ on
 on
 on
 on
-uY
+on
 Pc
 wn
 wT
@@ -32205,11 +30769,11 @@ Qh
 Xh
 di
 qi
-yi
+hw
 Bp
-Ci
+Sc
 on
-uY
+on
 vI
 wo
 wU
@@ -32405,13 +30969,13 @@ aX
 Qc
 Rh
 Yh
-Yh
+jK
 TQ
 Rz
 SU
 YW
 on
-dV
+CO
 vJ
 wp
 wV
@@ -32602,18 +31166,18 @@ hJ
 hJ
 jZ
 kS
-lN
+lH
 nc
 ol
 oW
 Zh
 hi
-pR
-yD
+Zh
+Zh
 Fi
 Dt
 on
-dV
+CO
 dV
 wq
 wW
@@ -32805,17 +31369,17 @@ hK
 DN
 kT
 lO
-nd
+kT
 on
 Sh
+yi
 pQ
-pQ
-QE
+Ci
 Ai
-Ai
+PJ
 Zy
 on
-dV
+CO
 dV
 Tc
 dV
@@ -33005,19 +31569,19 @@ DN
 DN
 DN
 DN
-kU
+kP
 Sg
 ne
 on
 Th
-Dq
+yD
 Uh
-fH
-bk
-zz
+yD
+yD
+PJ
 IW
 on
-dV
+CO
 dV
 ws
 dV
@@ -33207,19 +31771,19 @@ DN
 DN
 DN
 DN
-DN
+kM
 Tg
-DN
+Ja
+on
+GK
+UK
+Sl
+UK
+gb
+PJ
+MY
+DA
 CO
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-dV
 ad
 wt
 aH
@@ -33407,22 +31971,22 @@ DN
 DN
 DN
 DN
-DN
-DN
-DN
+PY
+PY
+tG
 lR
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-dV
-vK
+DP
+CO
+yD
+yD
+Uh
+yD
+yD
+PJ
+hS
+Qn
+CO
+Hn
 cP
 ah
 av
@@ -33605,26 +32169,26 @@ ad
 ad
 ad
 ad
-ad
+Hn
 fj
 eb
-eb
-Ec
+uL
+PY
 Fc
-DN
+GO
 Ug
-DN
+Pm
 QL
-QL
-QL
-QL
-QL
+yD
+yX
+uS
+BC
 BO
-BO
+PJ
 Ws
-Ws
-Ws
-vL
+CB
+on
+Hn
 cP
 ah
 av
@@ -33807,26 +32371,26 @@ ad
 ad
 ad
 ad
-ad
-gY
+Hn
+fj
 DR
-DR
-DR
+NQ
+PY
 Gc
 Xp
 Vg
 CD
-QL
-oZ
-pS
+CO
+yD
+yD
 qD
-rv
-BO
-sU
+yD
+yD
+PJ
 tI
-lp
-Vs
-vL
+tI
+on
+Hn
 cP
 ah
 av
@@ -34009,26 +32573,26 @@ ad
 ad
 ad
 ad
-ad
-gY
+Hn
+fj
 DR
-it
-je
-Zj
-Kc
-Hg
+NQ
+PY
+PY
+PY
+PY
 Nc
-QL
-pa
+CO
+yD
 pT
 qE
 JA
-sn
-sV
+pO
+PJ
 tJ
-IL
-Vs
-vL
+tJ
+on
+Hn
 cP
 ah
 av
@@ -34211,26 +32775,26 @@ ad
 ad
 ad
 ad
+Hn
 fj
-fk
 DR
-DR
-jf
+NQ
+fj
 kb
 FK
 Mc
 Lg
-QL
-pb
-pU
-qF
-rw
-BO
-sW
+on
+GK
+yD
+yD
+yD
+yD
+PJ
 tK
 IL
-Vs
-vL
+on
+Hn
 cP
 ah
 av
@@ -34411,28 +32975,28 @@ cP
 ad
 ad
 ad
+ad
+ad
+Hn
 fj
-eb
-fk
-gZ
 DR
-iu
+NQ
 jg
 kc
-FK
+fZ
 Jg
 ni
-QL
-QL
+on
+Th
 Sb
-QL
-QL
-BO
-BO
+pO
+mr
+nw
+PJ
 Ez
-IJ
-Ws
-vL
+Ez
+on
+Hn
 cP
 ah
 av
@@ -34610,31 +33174,31 @@ ah
 av
 aI
 cP
+ad
+ad
+ad
+ad
+ad
+Hn
 fj
-eb
-eb
-fk
-ec
-ec
-ec
-DR
-DR
-DR
+IQ
+ro
+Sv
 Db
-FK
-XI
+Db
+Db
 Wg
-FK
+on
 pc
-PC
-Ww
-xQ
+pc
+pc
+pc
+pc
 rx
-rx
-ZB
-uv
-uZ
-nE
+on
+on
+on
+Hn
 cP
 ah
 av
@@ -34812,31 +33376,31 @@ ah
 av
 aI
 cP
-gY
-ec
-SA
-SA
-ec
-go
-ec
-hL
-iv
+ad
+ad
+ad
+ad
+ad
+Hn
+fj
+fj
+fj
 jh
 ke
 XI
 lX
 nk
 pd
-pd
+rX
 pW
 Ok
 ry
 so
 sY
-ZB
-yk
-vL
-ad
+on
+on
+Hn
+Hn
 cP
 ah
 av
@@ -35014,30 +33578,30 @@ ah
 av
 aI
 cP
-gY
-Ib
-eH
-fm
-fJ
-gp
-ha
-hM
+ad
+ad
+ad
+ad
+ad
+Hn
+Hn
+Hn
 AN
-Mw
-kf
-XI
-ZA
-nl
-Dw
-Dw
-pX
-Ww
-Vb
-Zb
-Ac
-tL
-uw
-vL
+fj
+fj
+fj
+fj
+fj
+on
+on
+on
+on
+on
+on
+on
+CO
+Hn
+Hn
 ad
 cP
 ah
@@ -35216,30 +33780,30 @@ ah
 av
 aI
 cP
-gY
-Ib
-eI
-fn
-fK
-gq
-hb
-hN
-iw
-Cg
-kg
-Ob
-Li
-nm
-Qb
-pf
-pY
-Ub
-Wb
-ac
-Bc
-tL
-uw
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+ad
+ad
+ad
 ad
 cP
 ah
@@ -35418,30 +33982,30 @@ ah
 av
 aI
 cP
-gY
-Ib
-eJ
-fm
-fL
-gr
-ha
-YY
-ix
-jj
-AN
-XI
-Qz
-nn
-Dw
-Dw
-pZ
-Ww
-Xb
-tc
-Cc
-LQ
-uw
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 cP
 ah
@@ -35620,30 +34184,30 @@ ah
 av
 aI
 cP
-gY
-ec
-SA
-SA
-ec
-gs
-ec
-hO
-iy
-jk
-kh
-XI
-lZ
-no
-MU
-ph
-EE
-Ww
-Yb
-zc
-Dc
-ZB
-yk
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 cP
 ah
@@ -35822,31 +34386,31 @@ ah
 av
 aI
 cP
-fp
-eg
-eg
-nr
-ec
-ec
-ec
-QF
-QF
-QF
-QF
-QF
-Pb
-QF
-gw
-oU
-Tb
-gw
-KN
-PP
-td
-ZB
-uv
-vb
-vK
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36027,28 +34591,28 @@ cP
 ad
 ad
 ad
-fp
-eg
-nr
-hc
-QF
-QF
-jl
-ki
-kW
-mb
-np
-gw
-pi
-qb
-gw
-gw
-gw
-gw
-AU
-mx
-RH
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36231,26 +34795,26 @@ ad
 ad
 ad
 ad
-fp
-nr
-OX
-iz
-JV
-JV
-JV
-wr
-vn
-Rb
-pj
-qc
-aM
-yl
-st
-te
-tM
-fX
-SQ
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36434,25 +34998,25 @@ ad
 ad
 ad
 ad
-gY
-QF
-QF
-So
-iA
-iA
-iA
-nq
-gw
-pk
-JE
-qd
-qd
-qd
-qd
-tN
-fX
-SQ
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36636,25 +35200,25 @@ ad
 ad
 ad
 ad
-gY
-QF
-QF
-QF
-Ag
-Ag
-QF
-QF
-gw
-pl
-qe
-qI
-rE
-su
-tf
-tO
-UW
-SQ
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36838,25 +35402,25 @@ ad
 ad
 ad
 ad
-fp
-eg
-eg
-eg
-eg
-eg
-eg
-nr
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-RH
-RH
-RH
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -37047,18 +35611,18 @@ ad
 ad
 ad
 ad
-fp
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-nE
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -447,7 +447,6 @@ TORCH_ESCAPE_POD(17)
 	name = "Aquila Hangar"
 	landmark_tag = "nav_hangar_aquila"
 	docking_controller = "aquila_shuttle_dock_airlock"
-	base_turf = /turf/simulated/floor/reinforced/airless
 
 /obj/effect/shuttle_landmark/torch/deck1/aquila
 	name = "Space near Forth Deck"


### PR DESCRIPTION
:cl: YourName (This autofills from your GitHub name, if not set)
maptweak: Bridge deck's Aquila has been replaced with the emergency armory. The soft armory has been merged with the command EVA storage. 
maptweak: Aquila has been moved to D5 aft, with the rest of the shuttles where it belongs
maptweak: Petrov has been moved to D1 aft. Research has been altered to have a back entrance that connects petrov to research. 
/:cl:

Reasoning:
Aquila is wrongly used and abused by command as "command" shuttle. It isn't, and never has been. Putting it on D5 brings it in line with other shuttles, makes it more accessible for organizing rescues (due to proximity to ladders), and stops command from using it as a personal escape boat (or at least too easily).

EArm... I didn't have too much of an issue with EARM's location on D1, but moving it to bridge deck makes things a bit more interesting. Bridge becomes more important for security to... secure. The weird pre-armory room filled with random shit is now merged with command EVA meaning it will hopefully be used at least a tiny bit more. Overall I expect this to be the change that causes the most amount of balance changes, but if it makes it too hard (or too easy) for antags to rob the earm, I am willing to adjust accordingly.

Petrov I hope to at some point remap. I hated the idea of it being a special snowflake research base that it kinda ended up being, and with it also expanding 10000 fold in size. Bringing it in line with the rest of research will hopefully make those that use the Petrov less isolated, and far more connected to the rest of research. 

Map merger was used, but did not work. 