### PR TITLE
Reshuffles Petrov, EARM

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11,88 +11,27 @@
 /obj/item/weapon/pen/fancy,
 /turf/simulated/floor/lino,
 /area/command/pilot)
-"ad" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"ae" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Heat Exchanger Input"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"af" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Exterior Vent"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
 "ag" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/hangar)
 "ah" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1;
-	icon_state = "bordercolorhalf"
-	},
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 2;
-	name = "suit storage"
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"ai" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"aj" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Heat Exchanger Output"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "ak" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 8;
@@ -127,27 +66,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
-"ap" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Chamber Output"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"aq" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -202,50 +120,6 @@
 	icon_state = "walnut_broken3"
 	},
 /area/vacant/bar)
-"aw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"ax" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"ay" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/table/standard,
-/obj/random/tool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"az" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/air_sensor{
-	id_tag = "toxins_sensor"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "aA" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10;
@@ -303,21 +177,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
 "aG" = (
-/obj/machinery/computer/modular/preset/civilian{
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 8;
-	icon_state = "console"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/machinery/button/windowtint{
-	id = "rcheckinner_windows";
-	pixel_x = 10;
-	pixel_y = -21
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/area/aquila/mess)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -457,40 +326,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"aT" = (
-/obj/structure/sign/warning/airlock{
-	dir = 8;
-	icon_state = "doors"
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/maintenance/fifthdeck/aftstarboard)
-"aU" = (
-/obj/machinery/artifact_scanpad,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"aV" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/meter,
-/obj/effect/paint/silver,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "toxins_shutters";
-	name = "Mixing Chamber Blast Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "aW" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -511,33 +346,11 @@
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
-"bb" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/analysis)
-"bc" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/eva)
 "bd" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"be" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/effect/paint/silver,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "toxins_shutters";
-	name = "Mixing Chamber Blast Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "bf" = (
 /obj/machinery/light/spot{
 	pixel_y = 32
@@ -583,23 +396,6 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/crew)
-"bl" = (
-/obj/machinery/atmospherics/omni/mixer{
-	tag_east = 2;
-	tag_north = 1;
-	tag_north_con = 0.33;
-	tag_south = 1;
-	tag_south_con = 0.33;
-	tag_west = 1;
-	tag_west_con = 0.34
-	},
-/obj/machinery/button/ignition{
-	id_tag = "toxlab";
-	pixel_w = 6;
-	pixel_z = -23
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "bm" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8;
@@ -612,25 +408,6 @@
 /obj/structure/handrai,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"bn" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Chamber Input"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "toxin_exhaust";
-	name = "Chamber Vent";
-	pixel_w = 8;
-	pixel_y = -24
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "toxins_shutters";
-	name = "Chamber Protective Shutters";
-	pixel_w = -5;
-	pixel_z = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "bo" = (
 /obj/machinery/light/spot{
 	pixel_y = 32
@@ -674,50 +451,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
-"bs" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	frequency = 1441;
-	id = "toxins_in"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/sparker{
-	id_tag = "toxlab";
-	pixel_w = 1;
-	pixel_z = -23
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_dock_sensor";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
 "bu" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/maint)
+/obj/machinery/button/blast_door{
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters Control";
+	pixel_x = -32
+	},
+/obj/machinery/turretid/stun{
+	check_synth = 0;
+	name = "Aquila point defense control";
+	pixel_x = 32;
+	pixel_y = 0;
+	req_access = list("ACCESS_TORCH_AQUILA_HELM")
+	},
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "bv" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -919,25 +671,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "bP" = (
-/obj/effect/paint/silver,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
-/area/shuttle/petrov/security)
-"bQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
+/area/aquila/head)
 "bS" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2194,18 +1930,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
-"ec" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/valve/shutoff/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "ee" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
@@ -2349,6 +2073,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
+"ep" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Cockpit"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "eq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -2449,12 +2186,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
 "eB" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "eC" = (
@@ -2554,12 +2291,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "eW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "eX" = (
 /obj/machinery/camera/network/exploration_shuttle{
 	dir = 4;
@@ -2685,6 +2426,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"fk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
 "fl" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
@@ -2801,40 +2556,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"fD" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"fE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"fF" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/isolation)
-"fG" = (
-/obj/machinery/atmospherics/binary/pump,
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "fH" = (
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled,
@@ -2997,14 +2718,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
-"ge" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "gg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3100,21 +2813,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "gt" = (
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "gv" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 4;
@@ -3208,6 +2911,12 @@
 	dir = 5;
 	icon_state = "intact"
 	},
+/obj/machinery/door/airlock/glass/command{
+	id_tag = null;
+	name = "Aquila Dock";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH"));
+	secured_wires = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "gI" = (
@@ -3265,24 +2974,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"gZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"gX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"ha" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "hb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3331,20 +3029,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"hf" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	icon_state = "nosmoking";
-	pixel_x = 32
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "hg" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3505,11 +3189,22 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
-"hL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
+"hJ" = (
 /obj/structure/catwalk,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
+"hL" = (
+/obj/machinery/atmospherics/binary/pump,
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "hM" = (
@@ -3544,23 +3239,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
-"hP" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	icon_state = "nosmoking";
-	pixel_x = -32
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "hR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
@@ -3592,6 +3270,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"hV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
 "hY" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -4395,34 +4087,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
-"jP" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 1;
-	icon_state = "bordercolorhalf"
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	display_name = "Aft Dock (Petrov)";
-	frequency = 1380;
-	id_tag = "petrov_shuttle_dock_airlock";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access = list(list("ACCESS_SECURITY","ACCESS_EXTERNAL","ACCESS_TORCH_PETROV"));
-	tag_airpump = "petrov_shuttle_dock_pump";
-	tag_chamber_sensor = "petrov_shuttle_dock_sensor";
-	tag_exterior_door = "petrov_shuttle_dock_outer";
-	tag_interior_door = "petrov_shuttle_dock_inner"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
 "jQ" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4565,6 +4229,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"ka" = (
+/obj/random/soap,
+/obj/structure/hygiene/shower{
+	dir = 4;
+	icon_state = "shower"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "kb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/monotile,
@@ -5457,19 +5129,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"mm" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/spectrometer/adv,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "mn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5549,22 +5208,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "mv" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_dock_sensor";
-	pixel_x = -24;
-	pixel_y = 0
-	},
 /obj/machinery/oxygen_pump{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "aquila_shuttle_dock_sensor";
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -5937,6 +5592,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"nj" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
 "nk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6191,6 +5852,28 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"nE" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -7158,10 +6841,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "pw" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
 	icon_state = "techfloor_edges"
@@ -7173,6 +6852,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_dock_pump"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -7621,6 +7304,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
+"qw" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/airless,
+/area/aquila/secure_storage)
 "qy" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -7674,16 +7369,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "qC" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
 	icon_state = "intact"
+	},
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_dock_inner";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
@@ -7724,6 +7421,12 @@
 /area/hallway/primary/fifthdeck/aft)
 "qH" = (
 /obj/effect/floor_decal/corner/brown/half,
+/obj/machinery/door/airlock/glass/command{
+	id_tag = null;
+	name = "Aquila Dock";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH"));
+	secured_wires = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "qI" = (
@@ -8520,19 +8223,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"sb" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "sc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -8730,15 +8420,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "sA" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/table/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
+"sB" = (
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "sC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9168,43 +8856,39 @@
 /area/maintenance/fifthdeck/aftport)
 "tF" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	autoset_access = 0;
+	frequency = 1331;
 	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
+	id_tag = "aquila_shuttle_dock_inner";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "tG" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_outer";
-	locked = 0;
-	name = "Docking Port Airlock"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "tH" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_dock_pump"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "tJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "tQ" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -9220,27 +8904,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"tR" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "tT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/security)
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "tU" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -9465,6 +9132,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	display_name = "Bridge Deck Dock";
+	frequency = 1331;
+	id_tag = "aquila_shuttle_dock_airlock";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"));
+	tag_airpump = "aquila_shuttle_dock_pump";
+	tag_chamber_sensor = "aquila_shuttle_dock_sensor";
+	tag_exterior_door = "aquila_shuttle_dock_outer";
+	tag_interior_door = "aquila_shuttle_dock_inner"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
 "up" = (
@@ -9639,6 +9319,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"uG" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "uH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -9827,28 +9515,11 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
 "vc" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
-"ve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 8;
-	id_tag = "petrov_shuttle_dock_pump"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
+/area/aquila/medical)
 "vf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped{
@@ -9881,115 +9552,27 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"vo" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"vp" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"vq" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"vr" = (
-/obj/machinery/alarm{
+"vA" = (
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 1;
+	name = "north bump";
 	pixel_y = 24
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 4;
-	target_pressure = 200
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"vt" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
-"vA" = (
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"vC" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
+/obj/structure/bed/chair/shuttle/blue,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "vD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fifthdeck/aft)
-"vE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4;
-	icon_state = "map"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
 "vF" = (
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fifthdeck/aft)
-"vG" = (
-/obj/structure/dispenser/oxygen,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
 "vH" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -10070,6 +9653,28 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"wb" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "wc" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -10106,34 +9711,6 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"wl" = (
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"wm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"wn" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "wr" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -10154,49 +9731,38 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "wu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/hologram/holopad/longrange,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"wx" = (
-/obj/structure/table/standard,
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/debugger{
-	pixel_x = -5
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
+"wy" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/item/device/integrated_electronics/analyzer{
-	pixel_x = 6
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"wz" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Storage"
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"wz" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Cockpit"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "wA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10221,10 +9787,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"wE" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "wF" = (
 /turf/simulated/wall/prepainted,
 /area/command/pilot)
@@ -10238,45 +9800,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "wL" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "petrov_shuttle_airlock";
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"wU" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 8;
-	icon_state = "pdoor1";
-	id_tag = "toxin_exhaust";
-	name = "Toxins Exhaust Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
+/obj/structure/handrai,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "wW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10314,18 +9843,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"wY" = (
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "wZ" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -10336,18 +9853,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"xd" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 4;
-	icon_state = "comfyofficechair_preview"
-	},
-/obj/structure/cable/cyan{
+"xb" = (
+/obj/machinery/light/small,
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "xg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10355,18 +9870,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "xh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/cockpit)
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "xl" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -10379,28 +9891,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
-"xr" = (
-/obj/structure/table/standard,
-/obj/item/weapon/anodevice{
-	pixel_x = 3;
-	pixel_y = 3
+"xt" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/anodevice,
-/obj/item/device/scanner/health,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"xs" = (
-/obj/structure/closet/secure_closet/crew/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/item/weapon/folder/nt,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftport)
 "xu" = (
 /obj/machinery/floodlight,
 /obj/structure/handrai{
@@ -10417,32 +9919,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"xy" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "xA" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/bio_suit/anomaly,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/bio_hood/anomaly,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"xB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/protolathe,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
+/area/aquila/passenger)
+"xB" = (
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "xC" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -10454,14 +9940,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
+"xI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "xJ" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
 "xK" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "xL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10475,28 +9975,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"xM" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/passenger)
 "xN" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"xO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "xP" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -10513,48 +10007,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "xS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"xV" = (
-/obj/structure/closet/crate/secure/biohazard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/random/smokes,
 /obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
-"xX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"xY" = (
-/obj/structure/closet/toolcloset/excavation,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "ya" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10567,6 +10030,18 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/fore)
+"yb" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "yc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -10586,10 +10061,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
+"yh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10609,6 +10092,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"yj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftport)
 "yk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10623,67 +10125,17 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"yo" = (
-/obj/structure/sign/warning/hot_exhaust{
-	dir = 4;
-	icon_state = "fire"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
 "yq" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
-"yr" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"ys" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+"yt" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"yu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+/obj/structure/sign/warning/compressed_gas{
 	dir = 8;
-	id_tag = "petrov_shuttle_dock_pump"
+	icon_state = "hikpa";
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "yv" = (
 /obj/machinery/door/airlock/external{
@@ -10694,41 +10146,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/cargo)
-"yx" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/handrai,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"yy" = (
-/obj/structure/table/standard,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/flame/lighter/random,
-/obj/item/weapon/storage/box/evidence,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "yz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -10780,28 +10197,35 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"yC" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/fabricator,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
 "yG" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "yI" = (
 /turf/simulated/floor/plating,
 /area/vacant/bar)
 "yL" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_pump_out_internal"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/structure/handrai,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/airlock)
 "yM" = (
 /obj/machinery/camera/network/exploration_shuttle{
 	dir = 8;
@@ -10823,29 +10247,6 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"yO" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"yP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Analysis Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "yQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10869,23 +10270,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yR" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
-"yU" = (
-/obj/machinery/atmospherics/unary/heater,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "yW" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -10903,20 +10287,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"za" = (
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"zd" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"ze" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+"yZ" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "zf" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light/spot{
@@ -10930,53 +10304,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"zi" = (
-/obj/structure/bed,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"zk" = (
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "zl" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rnd)
-"zm" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/random/tool,
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell1";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Seating";
+	dir = 1
 	},
-/obj/machinery/button/ignition{
-	id_tag = "Isocell1";
-	pixel_x = -36;
-	pixel_y = -25
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "zn" = (
 /obj/random/tech_supply,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -10985,37 +10323,12 @@
 /obj/structure/largecrate,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
-"zo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"zp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"zs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "zv" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/button/blast_door{
@@ -11058,33 +10371,35 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "zB" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Cockpit"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
-"zC" = (
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"zH" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/table/rack,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/machinery/light/small{
 	dir = 4;
-	icon_state = "intact"
+	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"zK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
+"zD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "zL" = (
 /obj/structure/table/steel,
 /obj/item/device/flashlight/lamp/green,
@@ -11092,19 +10407,29 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"zO" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"zP" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+"zM" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
 	dir = 4;
-	icon_state = "intact"
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
 	},
-/obj/machinery/meter,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/cockpit)
+"zO" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/aquila/medical)
 "zS" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
@@ -11142,79 +10467,50 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
-"Ac" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
+"Aa" = (
+/obj/machinery/power/smes/buildable/preset/torch/shuttle{
+	RCon_tag = "Shuttle - Aquila"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"Ae" = (
-/obj/machinery/suit_cycler/science,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"Ag" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"Ah" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/catwalk,
+/obj/structure/cable/cyan,
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Ak" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
+/area/aquila/maintenance)
+"Aj" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/stack/medical/advanced/bruise_pack,
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "Al" = (
-/obj/effect/paint/silver,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 4;
+	id_tag = "aquila_shuttle_pump_out_external"
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	frequency = 1331;
+	id_tag = "aquila_shuttle_sensor_external";
+	pixel_x = 25;
+	pixel_y = -6
+	},
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1331;
+	master_tag = "aquila_shuttle";
+	name = "exterior access button";
+	pixel_x = 23;
+	pixel_y = 6
+	},
+/turf/simulated/floor/airless,
+/area/aquila/storage)
+"Am" = (
+/obj/effect/paint/red,
 /turf/simulated/wall/titanium,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/storage)
 "An" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11235,23 +10531,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ao" = (
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Ap" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Aq" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_inner";
+	locked = 1;
+	name = "Aquila External Access";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aquila/airlock)
 "Ar" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4;
@@ -11260,56 +10559,6 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
-"As" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/noticeboard{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"At" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell2";
-	pixel_x = -18
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"Ax" = (
-/obj/random/trash,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"Ay" = (
-/obj/structure/catwalk,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
 "AE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11329,41 +10578,42 @@
 /obj/machinery/firealarm,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"AK" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/artifact_analyser,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "AL" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
+/obj/machinery/bodyscanner{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "AM" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
-	icon_state = "console"
+	icon_state = "intact"
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"AP" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell3";
-	pixel_x = -18
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "AS" = (
-/obj/structure/table/glass,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/weapon/book/manual/nt_regs,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/machinery/door/airlock/hatch{
+	name = "Engineering"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/maintenance)
 "AT" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -11375,42 +10625,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "AY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/maint)
-"AZ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/binary/pump,
-/obj/structure/railing/mapped{
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "railing0-1"
+	pixel_x = 26
 	},
-/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
+"Ba" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Ba" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/computer/rdconsole/petrov{
-	dir = 4;
-	icon_state = "computer"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
+/area/aquila/medical)
 "Be" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11420,38 +10653,30 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "Bf" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
+/obj/machinery/light/small,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "aquila_shuttle_sensor";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Bg" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Bi" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell3";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/area/aquila/airlock)
 "Bk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11476,30 +10701,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Bn" = (
-/obj/machinery/artifact_analyser,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Bo" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Bp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11522,53 +10723,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Bs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Bu" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"Bx" = (
-/obj/structure/closet/l3closet/scientist/multi,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"By" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"BC" = (
-/turf/simulated/wall/r_wall/hull,
-/area/rnd/canister)
-"BD" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "BG" = (
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
@@ -11579,58 +10733,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"BH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"BJ" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "BL" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"BM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/obj/machinery/shipsensors,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/airless,
+/area/aquila/passenger)
 "BN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/single/cola,
+/obj/item/device/radio/intercom{
 	dir = 4;
-	level = 2
+	pixel_x = -21
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/area/aquila/mess)
 "BO" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/standard,
-/obj/item/stack/material/plastic/ten,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"BR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
+/area/aquila/medical)
 "BS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -11638,16 +10771,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"BT" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/custodial)
 "BX" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -11664,12 +10787,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"BY" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
+"BZ" = (
+/obj/machinery/alarm{
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/machinery/cryopod,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "Cf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -11686,19 +10812,36 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Ch" = (
+"Cg" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/airlock)
+"Cj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Ck" = (
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
+"Cl" = (
+/obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1;
+	icon_state = "map"
 	},
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/stack/material/phoron,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
+/turf/simulated/floor/airless,
+/area/aquila/secure_storage)
 "Cm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
 	dir = 4;
@@ -11708,16 +10851,14 @@
 /area/guppy_hangar/start)
 "Cn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10;
@@ -11759,105 +10900,64 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Cs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/junk,
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Cy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "CA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"CB" = (
-/obj/random/trash,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fifthdeck/aftstarboard)
-"CC" = (
-/obj/structure/closet/secure_closet/crew/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/item/weapon/folder/nt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"CE" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"CG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
+"CB" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fifthdeck/aftstarboard)
+"CJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/power/apc/hyper/shuttle/aquila{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"CH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/research{
-	id_tag = "";
-	name = "Sublimation Chamber"
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"CJ" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 1;
-	icon_state = "comfyofficechair_preview"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "CL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11888,40 +10988,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"CS" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/custodial)
 "CT" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/rd)
-"CV" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/health,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1;
+	icon_state = "map"
+	},
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
 "CW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Research Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "CX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11971,20 +11057,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
-"Dd" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
 "Df" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -11995,24 +11067,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Dh" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"Di" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
 "Dl" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -12042,28 +11096,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
-"Do" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Dq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Dr" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -12095,83 +11127,38 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/fore)
-"Dt" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"Du" = (
-/obj/structure/table/glass,
-/obj/item/device/paicard,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Dv" = (
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Dw" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"Dy" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Dz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/research{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8;
-	icon_state = "closed";
-	id_tag = "PetrovAccess";
-	name = "Petrov Access"
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"DE" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - EVA";
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "aquila_shuttle";
+	name = "interior access button";
+	pixel_x = -24;
+	pixel_y = -24;
+	req_access = newlist()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"DC" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/structure/table/rack,
-/obj/item/stack/flag/red,
-/obj/item/stack/flag/red,
-/obj/item/stack/flag/red,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "DF" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -12184,69 +11171,20 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/button/ignition{
-	id_tag = "Isocell3";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "DK" = (
-/obj/effect/paint/silver,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rd)
-"DN" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Anomaly Aft";
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 20
+	pixel_x = 21
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"DO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/button/ignition{
-	id_tag = "Isocell2";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"DQ" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/custodial)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "DT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12264,12 +11202,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+"DU" = (
+/obj/structure/closet/crate,
+/obj/random/toolbox,
+/obj/random/powercell,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/equipment)
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/random_multi/single_item/boombox,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "DY" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -12287,56 +11239,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DZ" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "Ea" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ec" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"Ed" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Equipment Storage"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Ee" = (
-/obj/machinery/atmospherics/tvalve/digital{
-	dir = 1;
-	icon_state = "map_tvalve0";
-	id_tag = "fuelmode"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Eg" = (
 /obj/structure/closet/secure_closet/prospector,
 /obj/effect/floor_decal/corner/brown/mono,
@@ -12361,29 +11266,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"El" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "Em" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
-"En" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Ep" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -12426,27 +11311,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Ex" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Toxins";
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/vending/phoronresearch{
-	dir = 4;
-	icon_state = "generic"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Ey" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12484,19 +11348,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"EE" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"EH" = (
-/obj/machinery/suit_storage_unit/science,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "EI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12508,22 +11359,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"EJ" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Desublimation";
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "EK" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -12547,19 +11382,6 @@
 /obj/effect/shuttle_landmark/merc/hanger,
 /turf/space,
 /area/space)
-"ER" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	alarm_id = "petrov3";
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "ET" = (
 /obj/structure/closet/medical_wall{
 	pixel_x = 0;
@@ -12576,32 +11398,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Fd" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"Ff" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "Fg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
+	dir = 9;
 	icon_state = "intact"
 	},
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Fh" = (
@@ -12627,55 +11440,62 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Fo" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/chemical_dispenser/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"Fu" = (
-/obj/structure/bed,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "Fw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
 "Fx" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cockpit)
-"Fy" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"FD" = (
-/obj/structure/table/standard,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
+"FF" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov2";
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 1900
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
+"FI" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 21
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/obj/structure/handrai,
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
+"FJ" = (
+/obj/machinery/computer/ship/helm{
+	req_access = list(list("ACCESS_TORCH_AQUILA_HELM"))
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
+"FM" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "FR" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
@@ -12684,102 +11504,84 @@
 /obj/effect/shuttle_landmark/skipjack/hanger,
 /turf/space,
 /area/space)
-"FU" = (
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Hallway Aft";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "FW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
+/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "FX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/crew,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "FZ" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Gb" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
+"Ga" = (
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
+"Gc" = (
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Gc" = (
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine/torch{
-	department = "Petrov - Chief Science Officer"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Science Officer's Desk";
-	departmentType = 5;
-	name = "Chief Science Officer RC";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/maintenance)
 "Ge" = (
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "Gh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	density = 1;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_outer";
+	locked = 1;
+	name = "Aquila External Access";
+	req_access = list("ACCESS_TORCH_CREW")
+	},
+/obj/machinery/shield_diffuser,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Gk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/cockpit)
+/area/aquila/airlock)
 "Gl" = (
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 1;
@@ -12793,29 +11595,58 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
 "Gm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
 	},
 /obj/item/device/radio/beacon/anchored{
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Gr" = (
-/obj/structure/table/standard,
-/obj/random/tool,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Gq" = (
+/obj/structure/table/rack,
+/obj/random/solgov,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
+	pixel_x = 11;
+	pixel_y = 1
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/secure_storage)
+"Gu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "Gv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12836,26 +11667,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Gx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Gy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "Gz" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -12863,57 +11674,23 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
-"GB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"GG" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"GI" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"GK" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "GL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/structure/closet/medical_wall{
+	pixel_x = -32
 	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rnd)
-"GM" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/obj/item/weapon/reagent_containers/syringe,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/structure/iv_drip,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/firstaid,
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "GO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -12962,120 +11739,94 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"GQ" = (
+"GR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"GU" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/storage)
+"GX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/machinery/vending/wallmed1{
+	dir = 1;
+	icon_state = "wallmed";
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
+"GZ" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Infirmary"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
+"Hb" = (
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Hf" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 1;
+	frequency = 1331;
+	id_tag = "aquila_shuttle";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list("ACCESS_TORCH_AQUILA");
+	tag_exterior_sensor = "aquila_shuttle_sensor_external"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_pump"
+	},
+/obj/structure/handrai,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aquila/airlock)
+"Hk" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"GR" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"GX" = (
-/obj/structure/bed/chair/padded/red,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Ha" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Hb" = (
-/obj/machinery/disposal,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "rd_windows";
-	pixel_x = 6;
-	pixel_y = 24;
-	range = 11
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Hc" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/emitter,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Hf" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Hk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Hl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "Hm" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -13093,33 +11844,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "Hr" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Ht" = (
-/obj/machinery/air_sensor{
-	id_tag = "phoron_sensor"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Hu" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/passenger)
 "Hv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -13135,35 +11862,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Hw" = (
-/obj/structure/table/standard,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/scanning_module,
-/obj/item/device/paicard,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"Hy" = (
-/obj/machinery/power/smes/buildable/preset/torch/shuttle{
-	RCon_tag = "Shuttle - Petrov"
-	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"Hz" = (
-/obj/structure/table/glass,
-/obj/item/weapon/pen,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"HB" = (
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
+/area/aquila/medical)
 "HC" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13193,36 +11896,6 @@
 "HG" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/storage)
-"HH" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"HJ" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8;
-	icon_state = "bordercolorhalf"
-	},
-/obj/machinery/alarm{
-	alarm_id = "xenobio2_alarm";
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
 "HK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13298,35 +11971,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"HT" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/sterilizine,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "HU" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/table/steel,
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"HV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"HX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
+"HW" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6;
 	icon_state = "intact"
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "HY" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -13336,50 +12003,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"HZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Suit Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Ia" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/vacant/bar)
-"Ib" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ic" = (
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/acid{
-	density = 0;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "Id" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -13396,24 +12023,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ij" = (
-/obj/machinery/artifact_harvester,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ik" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "In" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13441,64 +12050,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"It" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell1)
 "Iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Iv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"IA" = (
-/obj/machinery/lapvend,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"IB" = (
-/obj/machinery/disposal,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Fabrication";
-	dir = 2
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"IC" = (
-/obj/machinery/suspension_gen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "IF" = (
-/obj/machinery/computer/shuttle_control{
-	dir = 4;
-	icon_state = "computer";
-	req_access = list("ACCESS_TORCH_PETROV_HELM");
-	shuttle_tag = "Petrov"
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/crew,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "IH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13538,19 +12103,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"IR" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "IU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13588,14 +12140,6 @@
 /obj/effect/shuttle_landmark/ert/hanger,
 /turf/space,
 /area/space)
-"IY" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "Ja" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -13604,6 +12148,18 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
+"Jb" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/airless,
+/area/aquila/medical)
 "Jc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -13619,38 +12175,15 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Jh" = (
-/obj/structure/sign/warning/deathsposal,
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/maint)
-"Ji" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Jj" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
 "Jk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cockpit)
-"Jl" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/cell1)
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "Jn" = (
 /obj/effect/catwalk_plated,
 /obj/structure/closet/hydrant{
@@ -13659,22 +12192,17 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "Jo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Jt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13687,82 +12215,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ju" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Jv" = (
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_pump"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Jx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"Jz" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"JA" = (
-/obj/structure/closet/crate/secure/biohazard,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
-"JB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/airlock)
 "JG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13787,36 +12251,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"JH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell3";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"JK" = (
-/obj/structure/mopbucket,
-/obj/item/weapon/mop,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
 "JL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13830,53 +12264,45 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "JM" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
-"JO" = (
-/obj/structure/closet/bombcloset,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"JP" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"JS" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
+"JQ" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"JX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"JX" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "JY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -13904,73 +12330,45 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Kb" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell1";
-	pixel_x = -18
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Kc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/effect/paint/silver,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/rd)
+/area/aquila/maintenance)
 "Kh" = (
-/obj/structure/table/standard,
-/obj/item/weapon/folder/nt,
-/obj/item/stack/nanopaste,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/body_scanconsole{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
+/area/aquila/medical)
 "Ki" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Hallway Fore";
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Kj" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Kk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 9;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "Ko" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/port_gen/pacman{
@@ -13982,38 +12380,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
-"Kr" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Kt" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/custodial)
-"Ku" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/structure/sign/warning/compressed_gas{
-	dir = 8;
-	icon_state = "hikpa";
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Kw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "Ky" = (
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Charon"
@@ -14052,18 +12418,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"KD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "KI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -14083,41 +12437,39 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"KL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"KJ" = (
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"KN" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"KQ" = (
-/obj/machinery/light{
+/obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
+"KL" = (
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
+"KQ" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "KU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14128,20 +12480,7 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"KV" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "KW" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -14149,15 +12488,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"KY" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14201,59 +12531,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "Lg" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Crew Area"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/handrai,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Li" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "Lj" = (
 /turf/simulated/floor/wood/walnut{
 	icon_state = "walnut_broken5"
 	},
 /area/vacant/bar)
 "Lm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
@@ -14287,16 +12594,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition)
-"Lq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/wheelchair,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "Ls" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -14308,90 +12605,48 @@
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/airlock)
 "Lt" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rnd)
-"Lu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/bed/chair/shuttle/blue{
 	dir = 4;
-	icon_state = "intact"
+	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Lv" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/obj/machinery/computer/cryopod{
+	pixel_y = -32
 	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov3";
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/passenger)
 "LA" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rd)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "LB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"LC" = (
-/obj/structure/table/rack,
-/obj/item/device/flashlight,
-/obj/item/device/radio,
-/obj/item/weapon/crowbar,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"LJ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"LE" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"LF" = (
-/obj/structure/table/standard,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"LG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+/obj/machinery/hologram/holopad/longrange,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
-"LI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14404,28 +12659,19 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"LM" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
-"LN" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/equipment)
 "LP" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"LQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/hatch{
+	name = "Secure Storage"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/secure_storage)
 "LT" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -14440,20 +12686,9 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"LU" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "LW" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rd)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "LX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14473,10 +12708,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Mb" = (
-/obj/structure/table/steel,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Mc" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/structure/railing/mapped{
@@ -14487,10 +12726,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "Mg" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/scientist_torch,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
+"Mh" = (
+/obj/structure/table/rack,
+/obj/random/solgov,
+/obj/random/solgov,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/secure_storage)
 "Mj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14511,7 +12767,39 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Ml" = (
+"Mr" = (
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
+"Mu" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration_shuttle/cargo)
+"Mv" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/snack,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
+"My" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"MB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Passenger Seating"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14523,129 +12811,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"Mm" = (
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/analysis)
-"Mn" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan,
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"Mo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
-	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov1";
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Mr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/security)
-"Mt" = (
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Mu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/exploration_shuttle/cargo)
-"Mv" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/item/device/megaphone,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"Mx" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"My" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Mz" = (
-/obj/structure/stasis_cage,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Equipment";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"MB" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovBiohazard";
-	name = "Petrov Biohazard Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/passenger)
 "MC" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14666,10 +12834,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "MD" = (
-/obj/machinery/hologram/holopad/longrange,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
+/obj/structure/table/rack,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Storage";
+	dir = 1
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
 "ME" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -14680,21 +12864,45 @@
 /area/vacant/bar)
 "ML" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	autoset_access = 0;
+	frequency = 1331;
 	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
+	id_tag = "aquila_shuttle_dock_outer";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
-/obj/effect/shuttle_landmark/petrov/start,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"MN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/area/hallway/primary/fifthdeck/aft)
+"MM" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1;
+	sheets = 25
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
+"MN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/overmap/visitable/ship/landable/aquila,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "MO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14722,11 +12930,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"MQ" = (
-/obj/structure/table/standard,
-/obj/machinery/reagent_temperature,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fifthdeck/fore)
@@ -14742,46 +12945,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"MX" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Na" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "Nb" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/cockpit)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/storage)
 "Ne" = (
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
-"Nf" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ng" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/effect/paint/silver,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -14798,26 +12978,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ni" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	name = "Petrov Security Desk"
+/obj/machinery/door/airlock/hatch{
+	name = "Head"
 	},
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 1;
-	name = "Petrov Security Desk"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "concheckwindow2";
-	name = "Research Checkpoint Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "Nl" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -14838,28 +13014,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Nq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Nu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 4;
-	icon_state = "cap"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Nv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14883,54 +13037,15 @@
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftport)
-"Ny" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"NC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "ND" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rcheckinner_windows"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/security)
+/obj/machinery/computer/ship/engines,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "NF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14941,161 +13056,78 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"NG" = (
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "NI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/microwave,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Crew Compartment";
+	dir = 2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
-"NJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_inner";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
+/area/aquila/mess)
 "NL" = (
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
-"NO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rcheckinner_windows"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/security)
-"NP" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"NS" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
-"NW" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"NX" = (
-/obj/machinery/atmospherics/omni/filter{
-	tag_east = 2;
-	tag_south = 3;
-	tag_west = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"NY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"NN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
-"NZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"Od" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Of" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Custodial Closet"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/custodial)
-"Og" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
+"NO" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
+"NS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Oh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/area/aquila/medical)
+"NT" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	alarm_id = "petrov3";
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/structure/disposaloutlet{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"NY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"Oi" = (
-/obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/aquila/medical)
+"Oj" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/head)
 "Ol" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable{
@@ -15118,17 +13150,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Oq" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell1";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Ow" = (
 /obj/structure/handrai{
 	dir = 4;
@@ -15157,108 +13178,70 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
-"OC" = (
-/obj/structure/table/standard,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"OD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Isolation Chambers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "OG" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "OH" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 2;
+	id_tag = "aquila_shuttle_pump"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"OM" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
+/obj/machinery/oxygen_pump{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"ON" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/handrai,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/cockpit)
-"OO" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aquila/airlock)
+"OJ" = (
+/obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/turf/simulated/floor/airless,
+/area/aquila/maintenance)
+"OO" = (
+/obj/machinery/sleeper{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "OR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_inner";
-	locked = 0;
-	name = "Petrov Interior Access"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"OU" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/steel_reinforced,
+/obj/random/toolbox,
+/obj/machinery/power/apc/shuttle/aquila{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/device/radio,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
+/area/aquila/cockpit)
+"OU" = (
+/obj/structure/table/standard,
+/obj/item/weapon/defibrillator/loaded,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Infirmary";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "OW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15306,88 +13289,32 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Pa" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital{
-	dir = 1;
-	icon_state = "map_tvalvem0"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Pd" = (
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/tiled,
 /area/quartermaster/exploration)
-"Pe" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/analysis)
-"Pm" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"Pf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Pn" = (
-/obj/structure/hygiene/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Pr" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/item/weapon/folder/nt,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Anomaly Fore";
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "Pt" = (
-/obj/structure/sign/warning/airlock{
-	dir = 8;
-	icon_state = "doors"
-	},
-/obj/effect/paint/silver,
+/obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/airlock)
 "Pv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/bridge{
@@ -15403,15 +13330,6 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Px" = (
-/obj/machinery/radiocarbon_spectrometer,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "Py" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -15432,37 +13350,23 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "PC" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/passenger)
+"PL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
-"PE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"PK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/maintenance/fifthdeck/aftstarboard)
 "PM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -15483,39 +13387,57 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "PR" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
+"PU" = (
+/obj/structure/railing/mapped,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"PV" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
+"PY" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id_tag = "aquila_shutters";
+	name = "Protective Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/cockpit)
 "Qd" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/bar)
-"Qe" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Qg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15532,150 +13454,34 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Qi" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
-"Qj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Qk" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Qm" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell2)
 "Qn" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/expedition/eva)
 "Qo" = (
-/obj/structure/table/steel,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
+/obj/structure/hygiene/toilet{
+	pixel_y = 12
 	},
-/obj/machinery/button/alternate/door{
-	desc = "A remote control-switch for airlocks.";
-	id_tag = "PetrovAccess";
-	name = "Petrov Interior Door Control";
-	pixel_x = -5;
-	pixel_y = 6;
-	req_access = list("ACCESS_TORCH_PETROV_SEC")
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Security";
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
+"Qp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "concheckwindow2";
-	name = "Office Shutter Control";
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"Qp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Qr" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
-"Qz" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "QA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"QB" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "QE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -15687,44 +13493,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"QF" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/glass/fifty,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
 "QH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"QI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Phoron Sublimation Lab"
+/obj/structure/handrai,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "QJ" = (
 /obj/effect/paint/hull,
 /obj/structure/sign/solgov,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
-"QK" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "QL" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/blast/regular{
@@ -15740,14 +13528,12 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"QR" = (
-/obj/structure/closet/crate/secure/biohazard,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
+"QT" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
+/turf/simulated/floor/airless,
+/area/aquila/medical)
 "QV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -15760,23 +13546,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"QW" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "QX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15815,10 +13584,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Rc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Rd" = (
 /obj/machinery/light{
 	dir = 8
@@ -15853,21 +13618,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ri" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Cockpit"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "Rj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/largecrate,
@@ -15877,57 +13627,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
 "Rn" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/rnd)
-"Rp" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10;
 	icon_state = "intact"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"Rr" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Rt" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "Rv" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"Rx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/porta_turret{
+	dir = 8;
+	enabled = 0;
+	lethal = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/maint)
+/turf/simulated/floor/airless,
+/area/aquila/cockpit)
 "Ry" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15961,43 +13676,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"RB" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1441;
-	icon_state = "map_injector";
-	id = "phoron_in";
-	use_power = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"RE" = (
-/obj/machinery/suit_storage_unit/science,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"RG" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+"RM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"RN" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/shuttle_landmark/torch/hangar/aquila,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
 "RQ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/infirmary)
@@ -16009,57 +13700,16 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"RX" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"RZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+"RV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/anobattery{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/weapon/anobattery{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/anobattery{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/anobattery{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Analysis";
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Sb" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
+/obj/structure/railing/mapped{
 	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell2";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
+	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "Sc" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16086,37 +13736,29 @@
 "Sd" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
-"Sg" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/machinery/computer/atmoscontrol/laptop{
-	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
-	req_access = list("ACCESS_TORCH_PETROV_MAINT")
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"So" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
-"Sp" = (
-/obj/machinery/atmospherics/portables_connector{
+"Se" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	icon_state = "nosmoking";
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
+"Si" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/aquila/secure_storage)
 "Sr" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -16128,33 +13770,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"Ss" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
-"Su" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Sv" = (
 /obj/random/torchcloset,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
-"Sw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+"Sx" = (
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/maintenance)
 "Sy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -16165,40 +13792,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"Sz" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"SA" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"SB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
+"SC" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "SE" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16211,33 +13808,6 @@
 /obj/machinery/reagent_temperature,
 /turf/simulated/floor/plating,
 /area/vacant/infirmary)
-"SH" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"SI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "SJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16254,9 +13824,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
 "SK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/aquila/medical)
 "SM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16281,40 +13855,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"SN" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"SQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"SU" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "SV" = (
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
@@ -16334,28 +13874,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Tc" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/binary/pump,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
-"Tg" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16370,78 +13888,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Tp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/eva)
-"Tr" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_outer";
-	locked = 0;
-	name = "Petrov Exterior Access"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Ts" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Tt" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Tu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
+"Tn" = (
+/obj/effect/paint/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "Tw" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16452,22 +13906,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Tx" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/analysis)
 "TA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 8;
+	icon_state = "nosmoking";
+	pixel_x = 32
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -16481,53 +13924,24 @@
 	},
 /area/vacant/bar)
 "TD" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Docking Port";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"TF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_x = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"TG" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8;
-	icon_state = "bordercolorhalf"
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
-"TH" = (
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/weapon/screwdriver{
-	pixel_y = 15
-	},
-/obj/item/weapon/melee/baton/loaded,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/aquila/airlock)
 "TL" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -16543,23 +13957,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
 "TM" = (
-/obj/structure/table/glass,
-/obj/item/weapon/folder/nt,
-/obj/item/weapon/folder/nt,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"TO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	name = "south bump";
+	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "TP" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -16574,9 +13987,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"TR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+"TS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"Ub" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16586,57 +14006,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"TS" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"TY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"TZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"Ub" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/security/research{
-	name = "Checkpoint"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/mess)
 "Um" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16646,46 +14017,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"Un" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_outer";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"Uq" = (
-/obj/machinery/atmospherics/unary/vent_pump/tank{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "toxins_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"Ur" = (
-/obj/machinery/vending/assist,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Us" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -16699,37 +14030,36 @@
 "Ut" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"Uu" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Uw" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell3)
-"Uy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "UA" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"UC" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
+"UD" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/aquila/medical)
 "UE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -16740,11 +14070,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"UF" = (
-/obj/structure/table/standard,
-/obj/item/device/integrated_circuit_printer,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "UG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -16752,6 +14077,10 @@
 "UH" = (
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"UK" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monotile,
+/area/aquila/medical)
 "UL" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -16768,53 +14097,27 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
-"UM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Chief Science Officer";
-	secured_wires = 1
+"UO" = (
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fifthdeck/aft)
+"UT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rd)
-"UO" = (
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
-"UQ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"UT" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/passenger)
 "UW" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16823,30 +14126,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"UX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Va" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_sensor";
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_pump"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/obj/structure/sign/solgov,
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/airlock)
 "Vb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -16863,6 +14147,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
+"Vd" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/medical)
 "Ve" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -16874,64 +14163,34 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Vk" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "Vm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "petrov_shuttle_dock_outer";
-	locked = 0;
-	name = "Docking Port Airlock"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "Vo" = (
-/obj/item/weapon/stool/padded,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/porta_turret{
+	dir = 8;
+	enabled = 0;
+	lethal = 1
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/airless,
+/area/aquila/cockpit)
 "Vr" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftstarboard)
 "Vv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/hatch{
+	name = "Infirmary"
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"Vy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/medical)
 "Vz" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -16950,152 +14209,26 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"VB" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "PetrovBiohazard";
-	name = "Petrov Biohazard Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "VC" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"VD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell2";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"VF" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"VG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/aftstarboard)
-"VM" = (
-/obj/structure/noticeboard{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Chief Science Officer";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "VN" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"VO" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/weapon/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/weapon/pickaxe{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"VP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
 "VT" = (
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"VU" = (
-/obj/structure/table/rack,
-/obj/item/device/scanner/xenobio,
-/obj/item/device/scanner/xenobio,
-/obj/item/device/scanner/xenobio,
-/obj/item/weapon/storage/excavation,
-/obj/item/device/measuring_tape,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"VV" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "VX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -17136,6 +14269,11 @@
 /obj/effect/shuttle_landmark/ninja/hanger,
 /turf/space,
 /area/space)
+"Wf" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
+/turf/simulated/floor/tiled/monotile,
+/area/aquila/secure_storage)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17150,13 +14288,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Wl" = (
-/obj/effect/paint/silver,
+"Wk" = (
+/obj/effect/paint/red,
 /turf/simulated/wall/titanium,
-/area/shuttle/petrov/isolation)
-"Wn" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/maintenance)
 "Wo" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -17176,49 +14311,41 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Wp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/random/cash,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
-"Wt" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Wy" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/atmospherics/unary/vent_pump/tank{
+/turf/simulated/floor/tiled,
+/area/aquila/storage)
+"Wq" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
 	dir = 1;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "phoron_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 0
+	health = 1e+006
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Wz" = (
-/obj/machinery/computer/air_control{
-	dir = 2;
-	input_tag = "phoron_in";
-	name = "Test Chamber Gas Monitor";
-	output_tag = "phoron_out";
-	sensor_name = "Test Chamber";
-	sensor_tag = "phoron_sensor"
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1;
+	icon_state = "map"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/airless,
+/area/aquila/medical)
+"Wt" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/aquila/maintenance)
 "WD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -17235,58 +14362,35 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"WF" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
+"WE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/fifthdeck/aftstarboard)
+"WF" = (
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	icon_state = "nosmoking";
+	pixel_x = -32
 	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"WG" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "WH" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
-"WO" = (
-/obj/structure/table/standard,
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/weapon/disk/design_disk,
-/obj/item/weapon/disk/design_disk,
-/obj/item/weapon/reagent_containers/dropper{
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
-"WR" = (
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+"WL" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/cockpit)
 "WU" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/expedition)
-"Xa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/maint)
 "Xb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -17306,28 +14410,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Xc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/rnd)
-"Xd" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	icon_state = "nosmoking";
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"Xe" = (
-/obj/structure/bed/chair/office/comfy/red,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
 "Xf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -17383,19 +14465,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Xq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Xs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Xt" = (
 /obj/effect/paint/hull,
 /obj/structure/disposalpipe/segment{
@@ -17422,6 +14491,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"Xy" = (
+/obj/effect/paint/hull,
+/turf/simulated/wall/titanium,
+/area/aquila/secure_storage)
 "Xz" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -17430,19 +14503,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"XB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -17463,65 +14523,24 @@
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "XG" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/phoron)
-"XH" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/aquila/medical)
 "XI" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/bar)
 "XJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Cockpit";
+	dir = 8
 	},
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/computer/modular/preset/cardslot/command,
+/obj/item/device/radio/intercom/hailing{
 	dir = 8;
-	icon_state = "techfloor_edges"
+	pixel_x = 24
 	},
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "petrov_shuttle_pump"
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "petrov_shuttle_sensor";
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/maint)
-"XQ" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "XT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17551,13 +14570,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"XW" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Yb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Yc" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 8
@@ -17567,27 +14579,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
-"Yf" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Yg" = (
-/obj/structure/table/steel,
-/obj/item/weapon/book/manual/nt_regs,
-/obj/item/weapon/folder/nt,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/security)
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/hull,
+/turf/simulated/floor/plating,
+/area/aquila/cockpit)
 "Yi" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -17618,29 +14614,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Yk" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/phoron)
 "Ym" = (
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
-"Yn" = (
-/obj/machinery/disposal,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Yo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17656,42 +14632,6 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Yp" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Yr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/eva)
-"Ys" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Toxins Lab"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Yu" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17700,71 +14640,60 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Yw" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/dispenser,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Yz" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"YE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id_tag = "concheckwindow2";
-	name = "Research Checkpoint Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/security)
-"YG" = (
+/obj/structure/handrai,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/turf/simulated/floor/tiled/dark,
+/area/aquila/airlock)
+"YB" = (
+/obj/structure/hygiene/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/item/weapon/storage/mirror{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
+"YE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/power/apc/shuttle/aquila{
+	name = "south bump";
+	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
+"YF" = (
+/obj/machinery/computer/shuttle_control/explore/aquila,
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "YH" = (
 /obj/random/obstruction,
 /obj/structure/cable/cyan{
@@ -17774,9 +14703,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
-"YJ" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "YL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -17789,90 +14715,55 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
+"YM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/aquila/head)
 "YQ" = (
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"YS" = (
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Aft Passageway";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"YV" = (
-/obj/structure/hygiene/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/nanotrasen{
-	c_tag = "Petrov - Entry";
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 0;
-	dir = 4;
-	frequency = 1380;
-	id_tag = "petrov_shuttle_airlock";
-	pixel_x = -24;
-	pixel_y = 0;
-	req_access = list("ACCESS_TORCH_PETROV");
-	tag_airpump = "petrov_shuttle_pump";
-	tag_chamber_sensor = "petrov_shuttle_sensor";
-	tag_exterior_door = "petrov_shuttle_outer";
-	tag_exterior_sensor = null;
-	tag_interior_door = "petrov_shuttle_inner"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/aquila/airlock)
 "YW" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"YZ" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
-	icon_state = "freezer"
+"YX" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
+	dir = 1;
+	id_tag = "aquila_shuttle_dock_pump"
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/fifthdeck/aft)
 "Za" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17894,18 +14785,22 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "Zc" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_pump"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/techfloor,
 /obj/structure/handrai{
 	dir = 1;
 	icon_state = "handrail"
 	},
-/obj/machinery/light/small,
+/obj/effect/floor_decal/techfloor,
+/obj/item/device/radio/intercom/hailing{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
+/area/aquila/airlock)
 "Zd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -17919,18 +14814,22 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
 "Ze" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1;
-	icon_state = "bordercolorhalf"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/computer/modular/preset/civilian,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/security)
+/obj/structure/bed/chair/shuttle/blue{
+	dir = 1;
+	icon_state = "shuttle_chair_preview"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aquila/cockpit)
 "Zg" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"Zh" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "Zj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/prepainted,
@@ -17943,12 +14842,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
 "Zm" = (
+/obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Zn" = (
@@ -17986,91 +14885,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Zp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/computer/air_control{
-	dir = 8;
-	input_tag = "toxins_in";
-	name = "Toxins Gas Monitor";
-	output_tag = "toxins_out";
-	sensor_name = "Toxins Test Chamber";
-	sensor_tag = "toxins_sensor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Zr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
-"Zu" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/light/small{
+"Zt" = (
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_y = 8
+	pixel_x = 26
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/petrov/maint)
+/area/aquila/medical)
 "Zw" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "petrov_shuttle_pump"
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	density = 1;
+	frequency = 1331;
+	icon_state = "closed";
+	id_tag = "aquila_shuttle_outer";
+	locked = 1;
+	name = "Aquila External Access";
+	req_access = list("ACCESS_TORCH_CREW")
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
-	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Zx" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/crate/radiation,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"Zy" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
+/area/aquila/airlock)
 "ZA" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/canister)
-"ZB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"ZD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -18084,19 +14927,6 @@
 "ZG" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftstarboard)
-"ZJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/analysis)
 "ZL" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -18121,47 +14951,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"ZQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"ZT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"ZU" = (
-/obj/structure/table/standard,
-/obj/item/device/geiger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"ZV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"ZY" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 
 (1,1,1) = {"
 aa
@@ -40884,7 +37673,7 @@ sC
 ps
 Qg
 hj
-jP
+hj
 gH
 qH
 Fk
@@ -41066,16 +37855,16 @@ aa
 aa
 aa
 aa
-aa
+Zh
 ZG
-ZG
-ZG
-SB
+xI
+PL
+AU
 Cs
 Hk
 Fg
 Zm
-Lq
+wH
 wH
 wH
 wH
@@ -41096,19 +37885,19 @@ aC
 nH
 EI
 EI
+EI
+EI
 ub
 uc
 ud
 aC
 Ka
 aC
-aC
-aC
 Lm
+xt
+yj
 ws
 ws
-ws
-aa
 aa
 aa
 aa
@@ -41268,17 +38057,17 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
+gX
+yt
 TA
-Ku
-hf
 An
 wk
 Na
 HM
+ZG
+ZG
 ZG
 ZG
 ZG
@@ -41300,6 +38089,8 @@ ws
 ws
 ws
 ws
+ws
+ws
 ue
 zr
 zr
@@ -41309,8 +38100,6 @@ ug
 uj
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -41470,17 +38259,17 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
-GQ
+gX
 ZA
 ZA
 tf
 ZA
-ZA
-BC
+Ut
+ZG
+ZG
+ZG
 ZG
 ZG
 ZG
@@ -41491,9 +38280,11 @@ ZG
 ZG
 vF
 pw
-vE
+vD
 eB
 da
+ws
+ws
 ws
 ws
 ws
@@ -41511,8 +38302,6 @@ gI
 uk
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -41672,19 +38461,19 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
-GQ
+gX
 sW
 hc
 tg
 tn
-BC
-BC
 ZG
 ZG
+Zh
+Zh
+aa
+aa
 aa
 aa
 aa
@@ -41694,8 +38483,10 @@ aa
 zS
 da
 tG
-tG
+YX
 zS
+aa
+aa
 aa
 aa
 aa
@@ -41713,8 +38504,6 @@ we
 uH
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -41874,38 +38663,40 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
-GQ
+gX
 ZA
 sX
 tg
 tc
-BC
-BC
 ZG
+ZG
+Zh
 aa
 aa
-bP
-bP
-bP
-bP
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 Al
-Al
+da
 ML
-Tr
-Al
+ML
+da
+GU
+GU
+GU
+GU
+GU
+GU
+Am
+Am
+Am
 aa
-Fx
-Gk
-Gk
-Fx
-aa
-aa
-ws
 ws
 ws
 ok
@@ -41915,8 +38706,6 @@ vP
 uX
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42076,37 +38865,39 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
-GQ
+gX
 ZA
 hg
 th
 tk
-BC
-BC
+ZG
+ZG
 aa
 aa
-bP
-bP
-bP
-bP
-bP
 aa
-Al
+aa
+aa
+aa
+aa
+bP
+bP
+bP
+Oj
 Va
 Gh
 Zw
-Al
-aa
+GU
+GU
 xh
 FX
 IF
-Fx
-Fx
-aa
+Xy
+yh
+Gq
+qw
+Si
 aa
 ws
 ws
@@ -42117,8 +38908,6 @@ xv
 xv
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42278,37 +39067,39 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
-GQ
+gX
 ZA
 sY
 tl
 td
-BC
-BC
+ZG
+ZG
 aa
 aa
+aa
+aa
+aa
+aa
+aa
 bP
-bP
-bP
-bP
-bP
+ka
 Mr
-Al
+YB
 Jv
 yL
 Zc
-Al
+GU
 Jk
-xh
+hV
 Wp
 JM
 LP
-xh
-aa
+fk
+Mh
+Cl
+Si
 aa
 ws
 ws
@@ -42319,8 +39110,6 @@ wj
 Sv
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42474,43 +39263,45 @@ aa
 aa
 aa
 aa
+Zh
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+Zh
 ZG
-ZG
-GQ
+gX
 sW
 sZ
 ti
 te
-BC
-BC
+ZG
+ZG
 aa
 aa
-tT
-ND
-TG
-HJ
+aa
+aa
+aa
+aa
+aa
+bP
 bP
 NO
-Al
+YM
 Pt
 Hf
 Bf
-Al
+GU
 Nb
 Fx
 zB
 MD
-zo
-xh
-aa
+Xy
+FI
+Wf
+Cl
+Si
 aa
 ws
 ws
@@ -42521,8 +39312,6 @@ vS
 vY
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42676,43 +39465,45 @@ aa
 aa
 aa
 aa
+Zh
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+Zh
 ZG
-ZG
-aw
+WE
 ZA
 ZA
 tj
 ZA
-BC
-BC
+ZG
+ZG
 aa
 aa
-tT
-ND
+aa
+aa
+aa
+aa
 Vo
-zK
+bP
 Qo
 Mb
 YE
-YV
+Pt
 OH
 TD
-Ri
-Dw
+GU
+GU
 wz
-ON
-Mn
-Fx
-Fx
-aa
+GU
+GU
+Xy
+Xy
+HW
+uG
+SC
 aa
 ws
 ws
@@ -42723,8 +39514,6 @@ gI
 gI
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -42878,43 +39667,45 @@ aa
 aa
 aa
 aa
+Zh
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
+Zh
 ZG
-ZG
+wy
+RV
 WF
-HH
-hP
 BS
 eo
 ZG
 ZG
 aa
+aa
+aa
+aa
+WL
+WL
+WL
 bP
 bP
 bP
-LC
-NI
-zC
-Xe
 Ni
-Pn
-vp
+Pt
+Cg
 Ao
-LA
-LA
-LA
-LA
-LA
-LA
-LA
-LA
+Pt
+Ga
+Pf
+FM
+FF
+Sx
+Sx
+DC
+aa
+aa
 aa
 ws
 ws
@@ -42925,8 +39716,6 @@ vJ
 vL
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43080,43 +39869,45 @@ aa
 aa
 aa
 aa
+Zh
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-ZG
+Zh
 ZG
 ye
 BG
-ec
+PU
 BS
 Py
 ZG
 ZG
 aa
-tT
-ND
+WL
+zM
+zM
+WL
 ah
-xd
+WL
 NI
 BN
 aG
-bP
-Al
+Se
+Cg
 Qp
 Dz
 LA
-VM
+LA
 YQ
 Gc
 AM
 Wt
 Kc
-CT
+DC
+Wk
+aa
 aa
 ws
 ws
@@ -43127,8 +39918,6 @@ wd
 vM
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43288,18 +40077,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-ZG
+Zh
 ZG
 yY
 XU
-sb
+PU
 BS
 Py
 ZG
 ZG
 aa
+PY
+FJ
 tT
 ND
 Ze
@@ -43308,17 +40097,19 @@ Mv
 xN
 yG
 Ub
-JS
+Cg
 wL
 TS
 LW
-VT
+LW
 GX
-Hz
+FM
 CJ
 VT
-Kc
+DU
 CT
+nj
+aa
 aa
 ws
 ws
@@ -43329,8 +40120,6 @@ vK
 vN
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43490,38 +40279,40 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
 ZG
-ZG
-hL
+wy
 Xl
-AZ
-ZT
+hL
+JQ
+ye
 ZG
 ZG
-ZG
-ZG
+aa
+PY
+YF
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+Gu
+ep
+zD
+NN
+LJ
+nE
 Lg
 Gm
 MN
-LW
+RM
 eW
-GX
+wb
 AS
 PR
 wu
-LA
-LA
-ws
+Aa
+CT
+nj
+aa
+aa
 ws
 ws
 gI
@@ -43531,8 +40322,6 @@ gI
 gI
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43692,38 +40481,40 @@ aa
 aa
 aa
 aa
-aa
-aa
+Zh
+ZG
+ye
+ye
+ye
+ye
+ye
 ZG
 ZG
-Qj
-Sw
-Tt
-Od
-ai
-bt
-VG
+aa
+PY
 Vm
-bQ
+tT
 XJ
 CA
-Ah
+Yg
 Ju
 KL
 Cn
-Xa
-yx
+xN
+Cg
 Yz
 GR
-UM
-Pm
+LW
+LW
 UA
-BH
+FM
 QH
-VT
-Kc
-CT
-ws
+hJ
+yb
+OJ
+nj
+aa
+aa
 ws
 ws
 vZ
@@ -43733,8 +40524,6 @@ vK
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -43894,38 +40683,40 @@ aa
 aa
 aa
 aa
+Zh
+ZG
+ZG
+NT
+ye
+ye
+ye
+ZG
+ZG
 aa
-aa
-ZG
-ZG
-ZG
-ER
-AU
-AU
-NJ
-yu
-ve
-Un
-Ac
-TZ
+WL
+zM
+zM
+WL
 OR
-Rx
+WL
 vA
 xS
 Jo
 AY
-BD
+Cg
 JX
 DK
-LA
+Cj
 Hb
 TM
-Du
+FM
 xK
 KQ
-Kc
-CT
-ws
+xb
+DC
+Wk
+aa
+aa
 ws
 ws
 vK
@@ -43935,8 +40726,6 @@ vK
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -44096,49 +40885,49 @@ aa
 aa
 aa
 aa
+Zh
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
 aa
 aa
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-aT
-ZG
-ZG
-bu
-bu
-bu
-vr
+aa
+aa
+WL
+WL
+WL
 Hr
-ys
-bu
-Jh
-VB
+Hr
+Hr
+Hr
+Hr
 MB
-LA
-LA
-LA
-LW
-LW
-LW
-LA
-LA
-LA
-ws
-ws
-ws
-ws
-ws
-ws
-ws
-ws
-ws
-ws
+Hr
+yZ
+Vd
+GZ
+yZ
+UD
+Zt
+MM
+DC
 aa
 aa
+aa
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
 aa
 aa
 aa
@@ -44299,8 +41088,6 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 ZG
@@ -44310,25 +41097,29 @@ ZG
 ZG
 ZG
 aa
-bu
-bu
-So
+aa
+aa
+aa
+aa
+aa
 Rv
-Do
-Hy
-bu
+Hr
+Hr
+KJ
 Mg
 UT
 Ki
 Lt
-IB
+yZ
 gt
 Ba
-SN
-Xc
-QF
-GL
+yZ
+yZ
+yZ
+yZ
 Rn
+Tn
+XG
 aa
 ws
 ws
@@ -44338,8 +41129,6 @@ ws
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -44502,8 +41291,6 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 ZG
@@ -44512,15 +41299,17 @@ ZG
 ZG
 ZG
 aa
-bu
-bu
-So
-By
+aa
+aa
+aa
+aa
+aa
+aa
 BL
 PC
-bu
-ge
-YG
+Ck
+Ck
+Ck
 tJ
 CW
 Vv
@@ -44530,7 +41319,9 @@ SK
 FW
 BO
 GL
-Rn
+Aj
+Wq
+QT
 aa
 ws
 ws
@@ -44539,8 +41330,6 @@ ws
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -44705,8 +41494,6 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 ZG
@@ -44714,25 +41501,29 @@ ZG
 ZG
 ZG
 aa
-bu
-bu
-So
-Zu
-Ay
-Dd
-bu
+aa
+aa
+aa
+aa
+aa
+aa
+Hr
+Hr
+BZ
 xA
-Qz
-yl
+xA
+xA
 zl
-WO
+yZ
 AL
 vc
 xB
-HB
-yC
-GL
-Rn
+xB
+xB
+xB
+UK
+Wq
+QT
 aa
 ws
 ws
@@ -44740,8 +41531,6 @@ ws
 ws
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -44908,41 +41697,41 @@ aa
 aa
 aa
 aa
-aa
-aa
 ZG
 ZG
 Vr
 ZG
-ZG
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-xA
-BM
-Wn
-zl
-Ic
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Hr
+Hr
+Hr
+xM
+xM
+Hr
+Hr
+yZ
 Kh
 Hw
 OO
 OU
 zO
-Lt
-Lt
-Lt
-ws
-ws
+HT
+PV
+Jb
+QT
+aa
+aa
+aa
 Nx
 ws
 ws
-aa
-aa
 aa
 aa
 aa
@@ -45116,29 +41905,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-bb
-Hc
-RN
-AK
-RZ
-xr
-bb
-bb
-SA
-ze
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
 XG
 XG
 XG
-XG
-Yk
 aa
 aa
 aa
@@ -45318,29 +42107,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-aU
-Uy
-Uy
-Uy
-LE
-ZY
-Mt
-bb
-yr
-ZD
-Yk
-IR
-Dt
-EJ
-XQ
-Ff
-Ng
-Wy
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45520,29 +42309,29 @@ aa
 aa
 aa
 aa
-Pe
-ZJ
-Ij
-ZY
-Hl
-Ss
-xX
-Jx
-Gy
-yP
-YS
-Zr
-QI
-Cy
-KD
-wm
-LI
-WG
-CH
-Dv
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45722,29 +42511,29 @@ aa
 aa
 aa
 aa
-Pe
-ZJ
-Ib
-ZY
-ZY
-yy
-tR
-Ag
-ZV
-Mm
-As
-Wn
-Li
-Wz
-zs
-YJ
-YJ
-WG
-Rc
-Ht
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45924,29 +42713,29 @@ aa
 aa
 aa
 aa
-Pe
-ZJ
-Nf
-ZY
-DZ
-vo
-Fo
-Vk
-MQ
-Tx
-BM
-Wn
-Li
-wn
-El
-OC
-IY
-Tc
-Ng
-RB
-Dv
-XG
-Yk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46126,29 +42915,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-Px
-wl
-Ap
-TH
-Ch
-LF
-mm
-Tx
-QW
-FU
-Wl
-Wl
-Wl
-Wl
-Wl
-It
-Jl
-Jl
-Jl
-Jl
-It
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46328,29 +43117,29 @@ aa
 aa
 aa
 aa
-bb
-bb
-bb
-bb
-Tx
-Tx
-Tx
-bb
-bb
-bb
-QB
-Dq
-JP
-vq
-Pr
-Sg
-zm
-xO
-Nq
-Mo
-Kb
-Zy
-Oq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46530,29 +43319,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-IA
-MX
-Mx
-NP
-IC
-Mz
-wY
-yR
-Bo
-Yb
-JP
-Oi
-Ha
-JB
-Tu
-Dy
-SI
-SU
-KN
-Zy
-Oq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46732,29 +43521,29 @@ aa
 aa
 aa
 aa
-DX
-Qr
-UF
-Fd
-Fd
-XW
-Xs
-Fd
-QK
-yR
-Og
-Dq
-Ec
-ZU
-TF
-Lu
-fD
-xO
-Bn
-GG
-zk
-Zy
-Oq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46934,29 +43723,29 @@ aa
 aa
 aa
 aa
-DX
-Qr
-Bx
-Fd
-Zx
-xs
-Iv
-Fd
-Yn
-LN
-Ts
-Hu
-Wl
-Gr
-Rr
-zd
-DO
-It
-It
-It
-It
-It
-It
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47136,29 +43925,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-JO
-Ak
-wx
-CC
-Jz
-En
-Tg
-Ed
-CE
-TY
-OD
-PK
-XH
-EE
-VD
-gZ
-Dh
-Fy
-At
-RX
-Sb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47338,29 +44127,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-LN
-HZ
-LN
-LN
-GK
-Aq
-BJ
-LN
-TR
-Bg
-Wl
-Ur
-KV
-zH
-Bs
-RG
-HV
-WR
-LQ
-RX
-Sb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47540,29 +44329,29 @@ aa
 aa
 aa
 aa
-bc
-bc
-Ae
-Ny
-DE
-LN
-VV
-Sz
-Kr
-LN
-SQ
-Xd
-Wl
-Bu
-CV
-zP
-fE
-ha
-Fu
-FD
-zi
-RX
-Sb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47742,29 +44531,29 @@ aa
 aa
 aa
 aa
-Yr
-Tp
-xY
-GB
-VU
-NW
-NW
-NW
-NW
-NW
-Ys
-NW
-Wl
-Wl
-yU
-Uu
-DG
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47944,29 +44733,29 @@ aa
 aa
 aa
 aa
-Yr
-Tp
-EH
-NC
-VO
-NW
-BY
-Ee
-Yw
-Ex
-Rp
-Sp
-UQ
-Wl
-YZ
-Yf
-JH
-zp
-Di
-Vy
-AP
-GM
-Bi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48146,29 +44935,29 @@ aa
 aa
 aa
 aa
-Yr
-Tp
-EH
-Ik
-Kw
-NW
-Qe
-BR
-yO
-UX
-vC
-CG
-bl
-Wl
-ZB
-Qk
-Nu
-ZQ
-Gb
-TO
-Ji
-GM
-Bi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48348,29 +45137,29 @@ aa
 aa
 aa
 aa
-bc
-bc
-RE
-Ml
-vG
-NW
-OM
-Pa
-Yp
-yO
-XB
-Xq
-bn
-Wl
-NX
-NG
-Yf
-GI
-Gx
-Lv
-SH
-GM
-Bi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48550,29 +45339,29 @@ aa
 aa
 aa
 aa
-CS
-CS
-CS
-Of
-CS
-CS
-ad
-Su
-Kj
-KY
-ap
-Zp
-HX
-Wl
-DN
-xy
-fG
-VF
-Uw
-Uw
-Uw
-Uw
-Uw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48752,29 +45541,29 @@ aa
 aa
 aa
 aa
-DQ
-DQ
-xV
-Kk
-QR
-CS
-NW
-ay
-ax
-aj
-aV
-be
-aV
-Rt
-Wl
-Wl
-Wl
-wE
-Wl
-UC
-UC
-fF
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48955,27 +45744,27 @@ aa
 aa
 aa
 aa
-DQ
-JA
-JK
-JA
-CS
-NW
-ae
-af
-LG
-Uq
-az
-bs
-Rt
-Wl
-Wl
-Wl
-za
-za
-Ax
-za
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49157,27 +45946,27 @@ aa
 aa
 aa
 aa
-DQ
-DQ
-DQ
-DQ
-DQ
-DQ
-NZ
-Jj
-Qi
-aq
-yf
-LU
-Rt
-Wl
-Wl
-fF
-fF
-fF
-fF
-fF
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49359,27 +46148,27 @@ aa
 aa
 aa
 aa
-DQ
-BT
-BT
-BT
-BT
-DQ
-Oh
-PE
-yo
-wU
-wU
-wU
-yo
-VP
-VP
-fF
-vt
-vt
-vt
-vt
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49561,12 +46350,6 @@ aa
 aa
 aa
 aa
-DQ
-Kt
-Kt
-Kt
-Kt
-DQ
 aa
 aa
 aa
@@ -49576,12 +46359,18 @@ aa
 aa
 aa
 aa
-fF
-LM
-LM
-LM
-LM
-fF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1263,23 +1263,6 @@
 "acz" = (
 /turf/simulated/wall/prepainted,
 /area/medical/medicalhallway)
-"acB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/steel_reinforced,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Emergency Armory Desk"
-	},
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "acC" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -2553,7 +2536,7 @@
 /obj/machinery/door/airlock/glass/medical{
 	autoset_access = 0;
 	name = "Medical Foyer";
-	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
+	req_access = list(list("ACCESS_MEDICAL","ACCESS_MORGUE","ACCESS_FORENSICS"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
@@ -4368,11 +4351,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
-"ahL" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "ahM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4805,8 +4783,19 @@
 /turf/simulated/floor/carpet,
 /area/medical/counselor/therapy)
 "ais" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/medical{
+	id_tag = "counselortherapy";
+	name = "Counselor's Therapy Room"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/counselor/therapy)
 "aiu" = (
@@ -5726,6 +5715,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"aly" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "alD" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
@@ -5983,6 +5979,14 @@
 /obj/item/weapon/storage/box/syringes,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"amW" = (
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Aft";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/half,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/aft)
 "amZ" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/briefcase/crimekit,
@@ -6442,6 +6446,15 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
+"aqB" = (
+/obj/structure/closet/secure_closet/crew/research,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/item/weapon/folder/nt,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "aqL" = (
 /obj/effect/floor_decal/corner/paleblue,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6723,10 +6736,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
-"asl" = (
-/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "asq" = (
@@ -7449,14 +7458,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Emergency Armory Entrance";
+	c_tag = "First Deck Hallway - Aft Observation Windows";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "avy" = (
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -7612,65 +7620,31 @@
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5;
-	icon_state = "intact"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"awH" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+"awI" = (
+/obj/structure/bed/chair/comfy/beige{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"awI" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "awJ" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"awL" = (
-/obj/machinery/button/blast_door{
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutter Control";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/stamp/denied{
-	pixel_x = 5
-	},
-/obj/item/weapon/stamp,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "awM" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1;
@@ -7830,15 +7804,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "axF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "axK" = (
 /obj/structure/bed/chair/padded/red{
@@ -8256,33 +8230,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"ayF" = (
+"ayG" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "operation_hallway_shutters";
-	name = "Operation Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
-"ayG" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -8293,62 +8248,42 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/device/radio/beacon,
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "ayH" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/device/radio/beacon,
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "ayJ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"ayK" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
+/obj/effect/wallframe_spawn/reinforced/hull,
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/command/armoury/access)
-"ayL" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/area/hallway/primary/firstdeck/aft)
 "ayP" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 4;
@@ -8448,24 +8383,20 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "azR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "azS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -8477,19 +8408,6 @@
 /obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"azU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
 "azV" = (
 /obj/effect/shuttle_landmark/torch/deck4/guppy,
 /turf/space,
@@ -8620,166 +8538,48 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
 "aAU" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "aAV" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8;
-	icon_state = "corner_white"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aAW" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8;
-	icon_state = "loadingarea"
+/obj/structure/table/woodentable_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG,
+/obj/machinery/light,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aAX" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/airlock/command{
-	name = "Emergency Armory Access";
-	secured_wires = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aAY" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Emergency Armory - Access";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aAZ" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury/access)
-"aBa" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Emergency Armory"
-	},
-/obj/machinery/door/blast/regular/open{
-	density = 1;
-	dir = 4;
-	icon_state = "pdoor1";
-	id_tag = "armory_entrylock";
-	name = "Armory Lockdown Shutters";
-	opacity = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_grid,
-/area/command/armoury)
+/turf/simulated/floor/airless,
+/area/hallway/primary/firstdeck/aft)
 "aBb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/firstdeck/foreport)
 "aBc" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/tactical)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/security)
 "aBd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9020,16 +8820,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aCr" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_access = list("ACCESS_RESEARCH")
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "aCu" = (
 /obj/effect/floor_decal/corner/red/mono,
@@ -9223,10 +9031,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Petrov Access";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "aDB" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -9404,29 +9221,55 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "aED" = (
-/obj/structure/largecrate,
-/obj/random/maintenance/solgov,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/corner/research{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "aEG" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/dutyboots,
-/obj/item/clothing/accessory/storage/holster/thigh,
-/obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/suit/armor/pcarrier/blue/sol,
-/obj/item/clothing/head/helmet/solgov,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/effect/floor_decal/corner/red/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "aEH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9708,13 +9551,24 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "aFM" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9956,8 +9810,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "aGN" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/access)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/pointdefense,
+/turf/simulated/floor/airless,
+/area/hallway/primary/firstdeck/aft)
 "aGP" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/brig)
@@ -10062,6 +9921,14 @@
 "aHn" = (
 /turf/simulated/wall/prepainted,
 /area/rnd/locker)
+"aHo" = (
+/obj/structure/sign/warning/hot_exhaust{
+	dir = 4;
+	icon_state = "fire"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "aHQ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/misc_lab)
@@ -10100,8 +9967,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aHT" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "aHX" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -10392,6 +10263,49 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"aID" = (
+/obj/machinery/disposal,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Fabrication";
+	dir = 2
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
+"aIE" = (
+/obj/structure/table/standard,
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_electronics/debugger{
+	pixel_x = -5
+	},
+/obj/item/device/integrated_electronics/analyzer{
+	pixel_x = 6
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "aIG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -10450,15 +10364,48 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aJl" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/security/research{
+	name = "Checkpoint"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "aJm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "petrov_shuttle_airlock";
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "aJn" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 8;
@@ -10885,11 +10832,18 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "aLo" = (
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
 "aLu" = (
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "aLv" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/flasher/portable,
@@ -11163,37 +11117,21 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
-"aMy" = (
-/obj/structure/closet,
-/obj/random/action_figure,
-/obj/random/tech_supply,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/firstdeck/aftport)
 "aMB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/medical,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/stack/nanopaste,
-/obj/item/bodybag/rescue/loaded,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aMC" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -11446,6 +11384,27 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"aNx" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11468,8 +11427,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aNA" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/box/lights/mixed,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
 "aNB" = (
@@ -11477,10 +11438,13 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftport)
 "aNE" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aNG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -11530,6 +11494,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
+"aNR" = (
+/obj/structure/bed/chair/padded/red{
+	dir = 1;
+	icon_state = "chair_preview"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "aNV" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -12228,32 +12199,93 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aQq" = (
-/obj/machinery/shieldwallgen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aQr" = (
-/obj/machinery/deployable/barrier,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/valve/shutoff/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/hallwaya)
 "aQs" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_inner";
+	locked = 0;
+	name = "Petrov Interior Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/area/shuttle/petrov/hallwaya)
 "aQt" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "aQu" = (
-/obj/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 4;
+	icon_state = "console"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/item/modular_computer/tablet/lease/preset/command,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "aQx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -12525,16 +12557,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
-"aRm" = (
-/obj/machinery/deployable/barrier,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Emergency Armory - Port";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "aRo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14195,6 +14217,12 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/rnd/xenobiology)
+"aVd" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "aVe" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -14564,6 +14592,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
+"aXL" = (
+/obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "aYj" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -14583,6 +14618,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
+"aYW" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/door/firedoor,
+/obj/effect/paint/silver,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "toxins_shutters";
+	name = "Mixing Chamber Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
+"aZe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
+"bae" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "bbb" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 2
@@ -14629,6 +14688,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/foyer/storeroom)
+"bfZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "bhb" = (
 /obj/machinery/door/blast/regular{
 	dir = 1;
@@ -14675,6 +14740,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/storage)
+"bik" = (
+/obj/structure/table/standard,
+/obj/item/device/geiger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "biu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14743,10 +14816,30 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"ble" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "bmb" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
+"bms" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "bmB" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8;
@@ -14754,6 +14847,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"bmI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/hallway/primary/firstdeck/aft)
 "bmO" = (
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
@@ -14810,6 +14911,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"bpo" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "bpA" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -14844,6 +14965,20 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"bqd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"bqj" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "bqv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -14875,6 +15010,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"brP" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/isolation)
+"bsN" = (
+/obj/structure/dispenser/oxygen,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "bta" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 1;
@@ -14897,6 +15044,13 @@
 "btE" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"bui" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "bvI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -14945,6 +15099,14 @@
 /obj/structure/sign/warning/fire,
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1port)
+"bzm" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "bAb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/door/airlock/external,
@@ -14954,36 +15116,35 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"bAY" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/equipment)
 "bBb" = (
 /obj/structure/sign/solgov{
 	pixel_y = 32
 	},
 /turf/space,
 /area/space)
-"bBm" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "bBt" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
 "bBv" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 4;
-	icon_state = "corner_techfloor_grid"
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_inner";
+	locked = 0;
+	name = "Petrov Interior Access"
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "bCb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -14994,17 +15155,23 @@
 /area/rnd/xenobiology)
 "bCX" = (
 /obj/structure/table/steel,
-/obj/item/weapon/storage/box/cdeathalarm_kit,
-/obj/item/weapon/melee/telebaton,
-/obj/item/weapon/melee/telebaton,
-/obj/item/weapon/melee/telebaton,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/device/megaphone,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "bDb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -15059,6 +15226,17 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"bFj" = (
+/obj/machinery/suit_storage_unit/science,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"bFk" = (
+/obj/machinery/atmospherics/tvalve/mirrored/digital{
+	dir = 1;
+	icon_state = "map_tvalvem0"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "bGb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15169,17 +15347,6 @@
 "bMb" = (
 /turf/simulated/wall/prepainted,
 /area/engineering/hardstorage/aux)
-"bMB" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "bNb" = (
 /obj/machinery/status_display{
 	pixel_x = 32;
@@ -15214,6 +15381,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod13/station)
+"bOY" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "bOZ" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -15225,6 +15400,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"bPb" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "bPR" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -15271,6 +15449,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod13/station)
+"bRA" = (
+/obj/structure/table/glass,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/book/manual/nt_regs,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "bSz" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -15338,6 +15523,10 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod16/station)
+"bUq" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/isolation)
 "bUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15380,6 +15569,12 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
+"bVW" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "bWb" = (
 /obj/machinery/status_display{
 	pixel_x = -32;
@@ -15427,6 +15622,20 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod16/station)
+"bXd" = (
+/obj/structure/table/rack,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/glass/fifty,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
+"bXz" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "bYb" = (
 /obj/machinery/status_display{
 	pixel_x = -32;
@@ -15438,28 +15647,17 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
-"bYj" = (
-/obj/machinery/button/blast_door{
-	id_tag = "armory_entrylock";
-	name = "Armory Entry Lockdown Shutter Control";
-	pixel_x = 24;
-	pixel_y = 6
+"bYF" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "armory_lock";
-	name = "Armory Lockdown Shutter Control";
-	pixel_x = 24;
-	pixel_y = -6
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/button/blast_door{
-	id_tag = "operation_hallway_shutters";
-	name = "Hallway Checkpoint Shutters";
-	pixel_x = 35;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "bZb" = (
 /obj/machinery/cryopod{
 	dir = 1;
@@ -15533,6 +15731,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"cfL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "cgu" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -15547,6 +15752,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"che" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/beacon/anchored{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"chg" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "cib" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -15616,6 +15853,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"clg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "cmY" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -15658,6 +15901,39 @@
 /obj/item/weapon/bedsheet/blue,
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/safe_room/firstdeck)
+"csm" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Chamber Input"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "toxin_exhaust";
+	name = "Chamber Vent";
+	pixel_w = 8;
+	pixel_y = -24
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "toxins_shutters";
+	name = "Chamber Protective Shutters";
+	pixel_w = -5;
+	pixel_z = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"csr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "csy" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 1;
@@ -15705,6 +15981,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cuh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch/maintenance,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/maint)
 "cur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15818,6 +16105,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cyI" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/rd)
 "czb" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5;
@@ -15837,6 +16128,10 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"czW" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "cAb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -15849,12 +16144,24 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
 "cAh" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/machinery/door/airlock/research{
+	dir = 2;
+	id_tag = null;
+	name = "Cockpit"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "cAO" = (
 /obj/structure/table/standard,
 /obj/random/clipboard,
@@ -15867,6 +16174,30 @@
 /obj/item/device/destTagger,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"cBh" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell2";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "cBU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -15890,6 +16221,18 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
+"cCx" = (
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "cDb" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -15904,6 +16247,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cDo" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/folder/nt,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "cDO" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/box/evidence,
@@ -15948,6 +16301,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"cFi" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "cGd" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
@@ -15955,6 +16317,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
+"cGh" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "cGB" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -16065,18 +16444,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
-"cOH" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
 "cPY" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16101,6 +16468,18 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
+"cRk" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovBiohazard";
+	name = "Petrov Biohazard Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "cSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16150,6 +16529,21 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/development)
+"cUn" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Phoron Sublimation Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "cVb" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -16200,18 +16594,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"cYo" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "cYB" = (
-/obj/structure/dispenser,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"cYP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "cZb" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -16221,19 +16633,18 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
-"cZd" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "cZi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"cZP" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "cZS" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5;
@@ -16291,6 +16702,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"dbQ" = (
+/obj/machinery/suit_storage_unit/science,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "dcb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
@@ -16352,6 +16773,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"dfR" = (
+/obj/machinery/artifact_analyser,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "dfZ" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -16377,6 +16805,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"dgu" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/dispenser,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "dhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16392,6 +16834,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
+"dhi" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
+"dhM" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "dib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16406,6 +16863,19 @@
 /obj/structure/lattice,
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
+"djs" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
+"djt" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "dkb" = (
 /obj/machinery/optable,
 /obj/effect/floor_decal/floordetail/edgedrain{
@@ -16490,6 +16960,9 @@
 	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Miscellaneous Laboratory"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -16579,12 +17052,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"drH" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "dsd" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"dsh" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell1)
+"dsx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "dtb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16609,6 +17107,45 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"duS" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/item/weapon/folder/nt,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Anomaly Fore";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"dwK" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "dxm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16652,6 +17189,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"dDm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "dEb" = (
 /obj/random/torchcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -16664,6 +17213,15 @@
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"dFu" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "dFH" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
@@ -16674,6 +17232,21 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
+"dHk" = (
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 2;
+	icon_state = "freezer"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "dIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16711,31 +17284,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
-"dJp" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
-"dJv" = (
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "dJY" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 1;
@@ -16813,6 +17361,20 @@
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
+"dNJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Isolation Chambers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "dPA" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -16894,6 +17456,10 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"dTG" = (
+/obj/machinery/artifact_harvester,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "dUb" = (
 /obj/machinery/door/window/westleft{
 	name = "Autopsy"
@@ -16904,8 +17470,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
 "dVw" = (
-/turf/simulated/wall/r_wall/hull,
-/area/command/armoury/tactical)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/security)
 "dWb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -17050,6 +17617,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"ebi" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/custodial)
+"ebm" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/analysis)
 "ecI" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -17104,6 +17679,17 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/brig)
+"egd" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell3";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "ehT" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
@@ -17143,12 +17729,53 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
+"ejW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "ekb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
+"ekS" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 12
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Toxins";
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/phoronresearch{
+	dir = 4;
+	icon_state = "generic"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"eli" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "elT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/port_gen/pacman{
@@ -17217,6 +17844,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/physicianoffice)
+"eol" = (
+/obj/structure/bed/chair/office/comfy/red{
+	dir = 4;
+	icon_state = "comfyofficechair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "epb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -17245,6 +17884,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"erN" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "etb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -17284,6 +17931,18 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
+"evi" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "ewb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -17343,12 +18002,41 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
+"eyB" = (
+/obj/structure/stasis_cage,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Equipment";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"eyI" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "eyY" = (
 /turf/simulated/floor/tiled,
 /area/security/processing)
 "ezb" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"ezN" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "eAb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -17363,6 +18051,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"eBq" = (
+/obj/structure/closet/toolcloset/excavation,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"eBF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "eCb" = (
 /obj/machinery/alarm{
 	alarm_id = "xenobio4_alarm";
@@ -17377,19 +18085,41 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"eCA" = (
+/obj/structure/table/standard,
+/obj/item/device/integrated_circuit_printer,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"eCW" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Heat Exchanger Input"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"eEt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/computer/air_control{
+	dir = 8;
+	input_tag = "toxins_in";
+	name = "Toxins Gas Monitor";
+	output_tag = "toxins_out";
+	sensor_name = "Toxins Test Chamber";
+	sensor_tag = "toxins_sensor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "eEE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
-"eGb" = (
-/obj/structure/table/standard,
-/obj/item/stack/material/uranium,
-/obj/item/stack/material/uranium,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
 "eGl" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -17427,6 +18157,9 @@
 /obj/effect/floor_decal/corner/pink/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
+"eHc" = (
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
 "eIb" = (
 /obj/structure/curtain/open/shower,
 /obj/structure/hygiene/shower{
@@ -17466,6 +18199,26 @@
 /obj/item/stack/material/steel/fifty,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
+"eKj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"eKv" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "eLb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -17481,6 +18234,19 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"eLp" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "eMb" = (
 /obj/structure/morgue{
 	dir = 1;
@@ -17488,6 +18254,19 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
+"eOa" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
+"eOT" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/eva)
 "ePb" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Room 1"
@@ -17522,6 +18301,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"eRt" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "eRQ" = (
 /obj/machinery/door/airlock/medical{
 	autoset_access = 0;
@@ -17544,8 +18333,15 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/laboratory)
 "eRU" = (
-/turf/simulated/wall/r_wall/hull,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "eTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17598,6 +18394,28 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
+"eXf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Toxins Lab"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "eXk" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -17620,6 +18438,21 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/teleporter/firstdeck)
+"fbc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
+"fbo" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "fbQ" = (
 /obj/machinery/door/airlock/glass/civilian{
 	autoset_access = 0;
@@ -17630,6 +18463,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/brig)
+"fdt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Research Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "fdQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/space_heater,
@@ -17639,6 +18488,42 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"ffO" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"fjp" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovBiohazard";
+	name = "Petrov Biohazard Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "fkb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17653,11 +18538,44 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/foyer/storeroom)
+"fkN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "fll" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/flasher/portable,
+/obj/effect/floor_decal/techfloor,
+/obj/structure/handrai{
+	dir = 1;
+	icon_state = "handrail"
+	},
+/obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/area/shuttle/petrov/hallwaya)
 "flB" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/research{
@@ -17666,6 +18584,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"flE" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Heat Exchanger Output"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "fmb" = (
 /obj/structure/closet/secure_closet/medical_torch,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -17677,11 +18603,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
-"fnR" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/hos,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
 "foK" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
@@ -17726,6 +18647,19 @@
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/tiled/white,
 /area/medical/physicianoffice)
+"fqQ" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "frA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -17762,6 +18696,26 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
+"fwm" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
+"fwp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "fxb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -17771,12 +18725,57 @@
 "fxe" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery2)
-"fBb" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+"fxj" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/cell1)
+"fyg" = (
 /obj/structure/table/standard,
-/obj/item/device/integrated_circuit_printer,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
+	req_access = list("ACCESS_TORCH_PETROV_MAINT")
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"fyv" = (
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"fzl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"fAY" = (
+/obj/machinery/lapvend,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"fBb" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/weapon/storage/box/beakers,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "fCb" = (
@@ -17826,29 +18825,39 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"fIn" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5;
-	icon_state = "corner_techfloor_grid"
+"fHS" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"fIA" = (
+/obj/machinery/power/terminal{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "fKb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"fKv" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "fKJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17868,34 +18877,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"fLg" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 4
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/steel{
-	amount = 30
-	},
-/obj/item/stack/material/plasteel{
-	amount = 20
-	},
-/obj/item/stack/material/ocp{
-	amount = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "fMr" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/blast/shutters{
@@ -17923,18 +18904,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "fOr" = (
-/obj/structure/table/steel,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	icon_state = "wrecharger0";
-	pixel_x = 23;
-	pixel_y = -3
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/cockpit)
 "fOu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Locker Room"
@@ -17958,6 +18940,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"fQL" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "fRN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -17965,6 +18962,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
+"fSf" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"fSh" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"fSR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
+"fTj" = (
+/obj/structure/table/standard,
+/obj/random/tool,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "fTU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6
@@ -17995,6 +19020,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
+"fVv" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "fVw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
@@ -18033,6 +19062,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"fWF" = (
+/obj/structure/table/standard,
+/obj/machinery/reagent_temperature,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
+"fXv" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "fYb" = (
 /obj/machinery/door/airlock/medical{
 	id_tag = "examdoor";
@@ -18069,17 +19109,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
-"fZn" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "gab" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1;
@@ -18088,6 +19117,27 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"gaB" = (
+/obj/machinery/atmospherics/tvalve/digital{
+	dir = 1;
+	icon_state = "map_tvalve0";
+	id_tag = "fuelmode"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	dir = 1;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "gbb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18103,10 +19153,6 @@
 /area/engineering/hardstorage/aux)
 "gcY" = (
 /obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
 /obj/machinery/reagent_temperature/cooler,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
@@ -18117,6 +19163,21 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"gff" = (
+/obj/structure/hygiene/shower{
+	dir = 8;
+	icon_state = "shower"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "ggA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -18165,6 +19226,10 @@
 "gib" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
+"gie" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell3)
 "gig" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/research/mono,
@@ -18202,6 +19267,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"gjD" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "gkb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "or1"
@@ -18226,6 +19295,15 @@
 "gnC" = (
 /turf/simulated/wall/r_wall/hull,
 /area/security/detectives_office)
+"gnU" = (
+/obj/machinery/radiocarbon_spectrometer,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "goa" = (
 /obj/machinery/vending/security,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -18237,6 +19315,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
+"goc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "gos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18265,6 +19349,44 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/processing)
+"gtA" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"gul" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"guL" = (
+/obj/structure/bed/chair/padded/red,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "guP" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/firstaid/regular{
@@ -18278,6 +19400,22 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
+"gvk" = (
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	dir = 4;
+	id_tag = "researchdoor_interior";
+	name = "Research Division"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/rnd/research)
 "gvC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -18293,6 +19431,32 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/processing)
+"gxt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Suit Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"gxF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "gxX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18316,10 +19480,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"gyf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "gyj" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"gyy" = (
+/obj/structure/closet/l3closet/scientist/multi,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "gyP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18381,6 +19559,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
+"gzQ" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "gAU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -18390,6 +19572,22 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
+"gCT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/research{
+	dir = 8;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "gDb" = (
@@ -18427,6 +19625,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
+"gEy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "gEY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18449,6 +19661,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/physicianoffice)
+"gFj" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/custodial)
 "gGO" = (
 /obj/item/device/radio/intercom/department/security{
 	pixel_y = 23
@@ -18470,6 +19688,57 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"gHK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/anobattery{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/weapon/anobattery{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/anobattery{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/anobattery{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Analysis";
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"gNP" = (
+/obj/structure/table/standard,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/scanning_module,
+/obj/item/device/paicard,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "gQb" = (
 /obj/structure/dispenser{
 	oxygentanks = 0
@@ -18517,6 +19786,28 @@
 "gSb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/washroom)
+"gVl" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell2";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"gVP" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "gVR" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -18548,6 +19839,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/medicalhallway)
+"gWv" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "gWY" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -18599,6 +19898,29 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"hbH" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	display_name = "Aft Dock (Petrov)";
+	frequency = 1380;
+	id_tag = "petrov_shuttle_dock_airlock";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access = list(list("ACCESS_SECURITY","ACCESS_EXTERNAL","ACCESS_TORCH_PETROV"));
+	tag_airpump = "petrov_shuttle_dock_pump";
+	tag_chamber_sensor = "petrov_shuttle_dock_sensor";
+	tag_exterior_door = "petrov_shuttle_dock_outer";
+	tag_interior_door = "petrov_shuttle_dock_inner"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/aft)
 "hbP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18654,6 +19976,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
+"hes" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "hfb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18792,12 +20138,39 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"hmj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	dir = 8;
+	icon_state = "closed";
+	id_tag = "PetrovAccess";
+	name = "Petrov Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "hml" = (
 /obj/machinery/air_sensor{
 	id_tag = "d1so2_sensor"
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
+"hmq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "hmQ" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -18880,19 +20253,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/opscheck)
+"hre" = (
+/obj/effect/floor_decal/corner/red/half{
+	dir = 8;
+	icon_state = "bordercolorhalf"
+	},
+/obj/machinery/alarm{
+	alarm_id = "xenobio2_alarm";
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "hrE" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/item/weapon/storage/box/syringegun,
-/obj/item/weapon/gun/launcher/syringe,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"hrI" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "hsb" = (
 /obj/structure/sign/science_1{
 	dir = 1;
@@ -18932,21 +20326,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"htK" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 1
+"htS" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "petrov_shuttle_dock_pump"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/gun/energy/stunrevolver/rifle,
-/obj/item/weapon/gun/energy/taser/carbine,
-/obj/item/weapon/gun/energy/taser/carbine,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access = list("ACCESS_RESEARCH")
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/area/hallway/primary/firstdeck/aft)
 "hub" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -18988,24 +20393,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/entry)
-"hvY" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/weapon/storage/box/beakers,
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
 "hwb" = (
 /obj/structure/sign/science_1{
 	dir = 1;
@@ -19113,6 +20500,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"hAl" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/artifact_analyser,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"hAv" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_outer";
+	locked = 0;
+	name = "Petrov Exterior Access"
+	},
+/obj/effect/shuttle_landmark/petrov/start,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "hBb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -19142,6 +20545,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"hCG" = (
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "hDb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -19171,6 +20579,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
+"hDI" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "hDV" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10;
@@ -19216,18 +20635,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
-"hFu" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
+"hGa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/obj/item/weapon/gun/energy/laser/secure,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 4;
+	icon_state = "cap"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "hGb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -19254,6 +20677,10 @@
 /obj/structure/bed/chair/padded/blue,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
+"hIv" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/phoron)
 "hJb" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
@@ -19296,30 +20723,61 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
+"hKL" = (
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Hallway Aft";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "hLf" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
+"hLv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Equipment Storage"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "hLD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
-"hOb" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
+"hOk" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/gun/energy/ionrifle,
-/obj/item/weapon/gun/energy/ionrifle/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/research{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "hOZ" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -19357,6 +20815,13 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
+"hQZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "hUb" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -19479,10 +20944,48 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
+"ibP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/aftport)
 "iej" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"iep" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Petrov_Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/firstdeck/aft)
 "igb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19495,6 +20998,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"ihf" = (
+/obj/structure/window/reinforced,
+/obj/structure/closet/crate/radiation,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "iib" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19506,6 +21014,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"iie" = (
+/obj/machinery/vending/assist,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "ijb" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -19526,6 +21045,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"ijc" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 1;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve/shutoff/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
+"ijX" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "ikZ" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/effect/floor_decal/industrial/shutoff,
@@ -19597,6 +21140,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/command/conference)
+"inP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
 "ipc" = (
 /obj/structure/noticeboard{
 	pixel_x = 0;
@@ -19609,7 +21170,12 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/physicianoffice)
 "iqb" = (
-/obj/structure/bed/chair/comfy/lime,
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "irb" = (
@@ -19714,6 +21280,22 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/engineering/auxpower)
+"itJ" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "iui" = (
 /obj/machinery/door/airlock/command{
 	name = "First Deck Teleporter"
@@ -19803,6 +21385,10 @@
 /obj/item/weapon/book/manual/robotics_cyborgs,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"iyA" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "izb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19827,17 +21413,24 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "iAS" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/steel,
+/obj/item/weapon/book/manual/nt_regs,
+/obj/item/weapon/folder/nt,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/weapon/shield/riot/metal,
-/obj/item/weapon/shield/riot/metal,
-/obj/item/weapon/shield/riot/metal,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
+"iAV" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/rnd)
 "iAZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19857,24 +21450,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
-"iBb" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/item/weapon/screwdriver{
-	pixel_y = 15
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
 "iBT" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1port)
@@ -19900,6 +21475,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"iDT" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "iEb" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -19914,6 +21493,38 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
+"iFu" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
+"iFZ" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/acid{
+	density = 0;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
+"iGa" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 8;
+	icon_state = "pdoor1";
+	id_tag = "toxin_exhaust";
+	name = "Toxins Exhaust Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "iGb" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
 /obj/effect/floor_decal/corner/paleblue{
@@ -19950,6 +21561,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"iJs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/obj/machinery/papershredder,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "iKb" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -19964,12 +21587,32 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
+"iKi" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "heater"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/isolation)
 "iLb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
+"iLw" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1441;
+	icon_state = "map_injector";
+	id = "phoron_in";
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "iLA" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
@@ -19984,6 +21627,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"iMp" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "iMW" = (
 /obj/structure/bed/chair/padded/blue{
 	dir = 4;
@@ -20016,6 +21670,22 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"iOO" = (
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 4;
+	icon_state = "console"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "iPb" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -20086,20 +21756,31 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/development)
 "iSb" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/debugger{
-	pixel_x = -5
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
+"iSf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/button/ignition{
+	id_tag = "Isocell3";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"iSQ" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/weapon/screwdriver{
+	pixel_y = 15
+	},
+/obj/item/weapon/melee/baton/loaded,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "iTC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20147,6 +21828,19 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
+"iUj" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/spectrometer/adv,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "iVb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -20178,6 +21872,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"iXe" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/r_n_d/protolathe,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
+"iYE" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_outer";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "iZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -20189,6 +21902,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"iZv" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "jab" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -20237,6 +21958,12 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
+"jcd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/eva)
 "jcg" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -20322,6 +22049,19 @@
 /obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"jfA" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/table/standard,
+/obj/random/tool,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "jhb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
@@ -20387,6 +22127,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
+"jiO" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "jjb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
@@ -20444,38 +22195,12 @@
 /obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
-"jnd" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
+"jno" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/maint)
 "job" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -20486,6 +22211,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"joH" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "jpt" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -20513,16 +22244,11 @@
 /turf/simulated/floor/tiled,
 /area/security/locker)
 "jqn" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "operation_hallway_shutters";
-	name = "Operation Checkpoint Shutters";
-	opacity = 0
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "jqD" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -20538,14 +22264,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
-"jrH" = (
-/obj/structure/sign/warning/secure_area/armory{
-	dir = 8;
-	icon_state = "armory";
-	pixel_x = 0
+"jqI" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/armoury/access)
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "jsb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -20583,6 +22310,11 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/locker)
+"jtn" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "jub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20607,6 +22339,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"juv" = (
+/obj/structure/table/standard,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/storage/box/evidence,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "jvb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20638,6 +22377,12 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
+"jxx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "jxG" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 4;
@@ -20681,24 +22426,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"jAb" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
 "jAl" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
 	dir = 4;
-	icon_state = "techfloor_edges"
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/hallwaya)
 "jAr" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -20756,6 +22497,18 @@
 "jCM" = (
 /turf/simulated/wall/prepainted,
 /area/medical/morgue/autopsy)
+"jCO" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell2";
+	pixel_x = -18
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "jCU" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -20799,6 +22552,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
+"jEF" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
+"jFw" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "jGb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 5;
@@ -20813,6 +22580,10 @@
 /obj/structure/closet/secure_closet/hydroponics_torch,
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"jGn" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "jHb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 5;
@@ -20881,6 +22652,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jKN" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "jMb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/research{
@@ -20942,15 +22727,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "jPY" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/hallwaya)
 "jQb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 1;
@@ -20959,28 +22740,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "jQY" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Tactical";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "jRb" = (
 /obj/machinery/light{
 	dir = 1
@@ -21029,6 +22790,25 @@
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/prepainted,
 /area/security/bo)
+"jVC" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
+/obj/effect/paint/silver,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "toxins_shutters";
+	name = "Mixing Chamber Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "jWb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 5;
@@ -21064,6 +22844,9 @@
 	dir = 5;
 	icon_state = "corner_white"
 	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Mid Hallway"
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "jYD" = (
@@ -21093,23 +22876,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
+"jZx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "kab" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/monotile,
-/area/rnd/misc_lab)
-"kbb" = (
-/obj/structure/table/standard,
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 26
+/obj/effect/floor_decal/corner/research{
+	dir = 5;
+	icon_state = "corner_white"
 	},
-/obj/machinery/button/windowtint{
-	id = "misc_lab";
-	pixel_x = 4;
-	pixel_y = 26
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/rnd/misc_lab)
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
 "kcb" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 4;
@@ -21165,6 +22952,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
+"kdI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/unusual,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "kep" = (
 /obj/structure/table/standard,
 /obj/machinery/alarm{
@@ -21194,12 +22988,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"kfu" = (
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "kfG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/thruster/d1starboard)
+"kfY" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/rd)
 "kgi" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment{
@@ -21217,17 +23018,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
-"khb" = (
-/obj/structure/table/standard,
+"khy" = (
 /obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
+	dir = 1;
+	health = 1e+006
 	},
-/obj/item/device/integrated_electronics/analyzer{
-	pixel_x = 6
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/stack/material/phoron,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
+/area/shuttle/petrov/analysis)
 "kib" = (
 /obj/machinery/requests_console{
 	department = "Robotics";
@@ -21257,6 +23060,10 @@
 /obj/random_multi/single_item/summarydocuments/sec,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
+"kiS" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/phoron)
 "kku" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -21285,6 +23092,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
+"kkD" = (
+/obj/machinery/atmospherics/omni/mixer{
+	tag_east = 2;
+	tag_north = 1;
+	tag_north_con = 0.33;
+	tag_south = 1;
+	tag_south_con = 0.33;
+	tag_west = 1;
+	tag_west_con = 0.34
+	},
+/obj/machinery/button/ignition{
+	id_tag = "toxlab";
+	pixel_w = 6;
+	pixel_z = -23
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "kkN" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -21300,13 +23124,19 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "kmE" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "knb" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
@@ -21333,6 +23163,12 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/foreport)
+"kof" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "koX" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -21343,11 +23179,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
-"kpb" = (
-/obj/machinery/reagentgrinder,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
 "kqb" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -21406,27 +23237,10 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "ksK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Tactical Armory"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/table/steel,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "kvb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "roboticlab_window"
@@ -21474,17 +23288,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/assembly/robotics/laboratory)
-"kyt" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "kzy" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21499,9 +23302,51 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
+"kAb" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
+"kAY" = (
+/obj/machinery/suspension_gen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"kBv" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell1";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "kCb" = (
 /turf/simulated/wall/prepainted,
 /area/medical/surgery)
+"kCf" = (
+/obj/machinery/computer/air_control{
+	dir = 2;
+	input_tag = "phoron_in";
+	name = "Test Chamber Gas Monitor";
+	output_tag = "phoron_out";
+	sensor_name = "Test Chamber";
+	sensor_tag = "phoron_sensor"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "kCl" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -21593,6 +23438,16 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
+"kHm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "kIb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/corner/pink/mono,
@@ -21660,6 +23515,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"kOc" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "kPb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 2
@@ -21689,6 +23547,10 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
+"kPJ" = (
+/obj/machinery/door/airlock/hatch/maintenance,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "kQb" = (
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
@@ -21863,6 +23725,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"kXf" = (
+/obj/structure/table/standard,
+/obj/item/weapon/folder/nt,
+/obj/item/stack/nanopaste,
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "kYM" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8;
@@ -21886,6 +23758,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"lay" = (
+/obj/structure/hygiene/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_access = list("ACCESS_RESEARCH")
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "lbb" = (
 /obj/structure/curtain/open/privacy,
 /obj/machinery/firealarm{
@@ -21957,11 +23850,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/laboratory)
-"ldP" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+"ldY" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "leb" = (
 /turf/simulated/wall/prepainted,
 /area/medical/staging)
@@ -22054,16 +23946,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
 "lkp" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "llb" = (
 /obj/machinery/fabricator,
@@ -22076,6 +23965,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"llc" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/analysis)
 "llM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -22112,6 +24006,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lng" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "lob" = (
 /obj/machinery/computer/modular/preset/security,
 /turf/simulated/floor/tiled/dark,
@@ -22136,6 +24034,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lpu" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell2)
 "lqb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22144,29 +24046,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/development)
+"lqw" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "lsb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
 "lst" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6;
-	icon_state = "corner_techfloor_grid"
+/obj/structure/sign/warning/airlock{
+	dir = 8;
+	icon_state = "doors"
 	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"lsT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 1;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cockpit)
 "ltb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/rdconsole/core{
@@ -22239,6 +24139,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
+"lwQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/equipment)
 "lxb" = (
 /obj/structure/table/steel,
 /obj/item/weapon/paper_bin,
@@ -22303,6 +24209,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
+"lyd" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "lym" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -22428,30 +24340,42 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
-"lGw" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+"lEO" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 9;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner{
+/obj/machinery/firealarm{
 	dir = 8;
-	icon_state = "techfloor_corners"
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "lHO" = (
 /turf/simulated/wall/prepainted,
 /area/medical/sleeper)
+"lId" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Aft Hallway Petrov Access"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "Petrov_Biohazard";
+	name = "Petrov Biohazard Shutter Control";
+	pixel_x = 6;
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"lIj" = (
+/obj/structure/closet/crate/secure/biohazard,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "lJb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/luminol,
@@ -22485,9 +24409,41 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "lLD" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
+"lLJ" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/weapon/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/weapon/pickaxe{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "lMb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22517,6 +24473,14 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"lTr" = (
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 2;
+	tag_south = 3;
+	tag_west = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "lVb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -22550,6 +24514,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"lWj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
+"lWF" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
+"lYu" = (
+/obj/structure/closet/crate/secure/biohazard,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "lYS" = (
 /obj/machinery/computer/teleporter{
 	dir = 8;
@@ -22595,6 +24585,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/assembly/chargebay)
+"mcL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "mdv" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "processwindow"
@@ -22653,6 +24649,22 @@
 /obj/item/weapon/book/manual/solgov_law,
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"mgj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Chief Science Officer";
+	secured_wires = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rd)
+"mgP" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/fabricator,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "mhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22693,6 +24705,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"miy" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "miG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -22722,6 +24742,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
+"mjD" = (
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "mkb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22819,20 +24847,34 @@
 "mpy" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftstarboard)
+"mqM" = (
+/obj/structure/table/glass,
+/obj/item/device/paicard,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "mrr" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/effect/floor_decal/corner/red/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
-/obj/effect/floor_decal/techfloor{
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "techfloor_edges"
+	health = 1e+006
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 2;
+	name = "suit storage"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "mrW" = (
 /obj/structure/closet/secure_closet/medical_torchsenior,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -22861,6 +24903,10 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/foreport)
+"mty" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "mtB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -22919,6 +24965,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"mvH" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_outer";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "mvL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -22966,51 +25033,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"mwA" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 6;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"mwJ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "mwV" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 6;
@@ -23048,6 +25070,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
+"mxw" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/bio_suit/anomaly,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/bio_hood/anomaly,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "mzb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -23152,6 +25183,20 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1starboard)
+"mGD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "mHb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -23166,6 +25211,29 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
+"mIq" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "mJb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23181,22 +25249,20 @@
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "mJJ" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor/corner{
+/obj/structure/hygiene/shower{
 	dir = 4;
-	icon_state = "techfloor_corners"
+	icon_state = "shower";
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Entry";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "mJY" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/floor_decal/corner/beige/mono,
@@ -23237,6 +25303,14 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"mKA" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "mLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23274,6 +25348,20 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"mMI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Chamber Output"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "mMX" = (
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
@@ -23297,6 +25385,17 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"mOB" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
+"mQE" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/maint)
 "mRb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -23357,10 +25456,26 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"mUh" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/phoron)
 "mUm" = (
 /obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/entry)
+"mUZ" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "mVb" = (
 /obj/machinery/nuclearbomb/station{
 	name = "ship self-destruct terminal"
@@ -23390,6 +25505,23 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"mWn" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "mXb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -23412,6 +25544,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
+"nbq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
 "ncb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23442,12 +25586,38 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"ndQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "neb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/blackgrid,
 /area/security/nuke_storage)
+"neV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "nfb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -23470,6 +25640,24 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
+"ngE" = (
+/obj/machinery/atmospherics/unary/vent_pump/tank{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	id_tag = "toxins_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "nhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -23522,32 +25710,42 @@
 /turf/simulated/wall/prepainted,
 /area/command/conference)
 "njm" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
+/obj/structure/table/steel,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
 	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
+/obj/machinery/button/alternate/door{
+	desc = "A remote control-switch for airlocks.";
+	id_tag = "PetrovAccess";
+	name = "Petrov Interior Door Control";
+	pixel_x = -5;
+	pixel_y = 6;
+	req_access = list("ACCESS_TORCH_PETROV_SEC")
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Security";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/button/blast_door{
+	id_tag = "concheckwindow2";
+	name = "Office Shutter Control";
+	pixel_x = 5;
+	pixel_y = 6
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "njQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23641,6 +25839,14 @@
 "nli" = (
 /turf/simulated/wall/r_wall/hull,
 /area/security/storage)
+"nlS" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad/longrange,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "nmb" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -23650,6 +25856,11 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/processing)
+"nmc" = (
+/obj/structure/sign/warning/deathsposal,
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/maint)
 "nnb" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/keycard_auth/torch{
@@ -23661,6 +25872,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/blackgrid,
 /area/security/nuke_storage)
+"noZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "npb" = (
 /obj/structure/table/standard,
 /obj/item/device/radio/intercom{
@@ -23721,6 +25938,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
+"ntu" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "nub" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -23755,14 +25975,36 @@
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "nvX" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/machinery/hologram/holopad/longrange,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
+"nwb" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"nwP" = (
+/obj/structure/table/rack{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
+/area/shuttle/petrov/rnd)
+"nxC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "nxK" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
@@ -23825,6 +26067,10 @@
 /obj/random/action_figure,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"nAQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "nBb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
 	id = "exam_windows"
@@ -23928,6 +26174,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"nHH" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 1;
+	icon_state = "map"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "nIb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -24004,10 +26263,42 @@
 /obj/item/weapon/storage/pill_bottle,
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"nLO" = (
+/obj/effect/floor_decal/corner/research/half,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/rnd/misc_lab)
+"nNg" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov3";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "nOO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"nOZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	id_tag = "";
+	name = "Sublimation Chamber"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "nPb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -24048,6 +26339,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
+"nPY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "nQb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24077,6 +26382,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
+"nUo" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Anomaly Aft";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "nUp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24142,25 +26464,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "nWP" = (
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
-	icon_state = "techfloor_edges"
+	level = 2
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	icon_state = "wrecharger0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "nWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24175,6 +26484,14 @@
 /obj/random/assembly,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"nXX" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "nYb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24243,23 +26560,35 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
 "nZZ" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "concheckwindow2";
+	name = "Research Checkpoint Shutters";
+	opacity = 0
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/security)
+"oaJ" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "obb" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/disposalpipe/segment,
@@ -24414,12 +26743,47 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"oiX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/analysis)
 "ojb" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/research/mono,
 /obj/random_multi/single_item/summarydocuments/sci,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"ojD" = (
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"ojE" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"okg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/equipment)
 "okp" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -24454,9 +26818,20 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
 "onM" = (
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/structure/bed/chair/shuttle/black{
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
 "oox" = (
 /obj/effect/floor_decal/corner/research,
 /obj/machinery/firealarm{
@@ -24466,9 +26841,22 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "ooN" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "opg" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -24480,6 +26868,13 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
+"opF" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "oqp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24496,6 +26891,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"oqN" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/custodial)
+"oqY" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/chemical_dispenser/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "orb" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
@@ -24522,6 +26933,13 @@
 /obj/machinery/self_destruct,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"otn" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell3";
+	pixel_x = -18
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "ouI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -24564,6 +26982,50 @@
 "owb" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"owH" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"owK" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "oxa" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 10;
@@ -24621,6 +27083,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
+"ozb" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_dock_pump"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "petrov_shuttle_dock_sensor";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "ozm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24636,6 +27118,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
+"ozT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/misc_lab)
 "oAp" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -24674,9 +27163,31 @@
 /obj/effect/floor_decal/sign/d,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"oCP" = (
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "oDg" = (
 /turf/simulated/wall/prepainted,
 /area/security/questioning)
+"oDv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "oGG" = (
 /obj/structure/hygiene/shower{
 	dir = 8;
@@ -24684,6 +27195,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
+"oHy" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/equipment)
 "oHP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24723,6 +27238,30 @@
 "oJb" = (
 /turf/simulated/wall/prepainted,
 /area/assembly/robotics/laboratory)
+"oJH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 2;
+	injecting = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/maint)
+"oKg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"oKn" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "oLz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -25051,7 +27590,35 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"pao" = (
+/obj/structure/table/standard,
+/obj/item/weapon/anodevice{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/anodevice,
+/obj/item/device/scanner/health,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"paK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "pbb" = (
+/obj/machinery/chem_master,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "pcb" = (
@@ -25073,10 +27640,6 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_x = 0;
 	pixel_y = -32
-	},
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Hallway";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -25123,26 +27686,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"pfb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Miscellaneous Laboratory"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/rnd/misc_lab)
 "pgb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -25155,36 +27704,45 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/area/rnd/research)
+"pgR" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "phb" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/area/rnd/research)
 "pib" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
-"pjb" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
+"pjb" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/research)
 "pjR" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/detectives_office)
@@ -25234,16 +27792,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"pnb" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+"pmW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
 	},
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"poe" = (
+/obj/structure/sign/warning/airlock,
+/turf/simulated/wall/r_wall/hull,
+/area/hallway/primary/firstdeck/aft)
 "poS" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/safe_room/medical)
@@ -25266,6 +27830,14 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"pqB" = (
+/obj/structure/closet/crate/secure/biohazard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "prb" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -25279,6 +27851,14 @@
 /obj/structure/closet/secure_closet/scientist_torch,
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"prC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "psb" = (
 /obj/structure/closet/secure_closet/secure_closet/xenoarchaeologist_torch,
 /obj/effect/floor_decal/corner/research{
@@ -25292,6 +27872,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"pta" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "ptb" = (
 /obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet{
@@ -25319,9 +27903,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "puw" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
 "puL" = (
 /obj/machinery/power/apc{
@@ -25467,6 +28055,9 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/thruster/d1port)
+"pAB" = (
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
@@ -25474,6 +28065,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/misc_lab)
+"pBC" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "pBL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25491,29 +28087,17 @@
 /area/command/conference)
 "pCb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/door/airlock/research{
+	name = "Miscellaneous Laboratory"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
-"pDb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
-"pEb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "pEr" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -25535,31 +28119,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
-"pFb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/bed/chair/comfy/lime{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/misc_lab)
-"pGb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/chemical_dispenser/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/rnd/misc_lab)
+"pFj" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
+"pGX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "pHb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25670,6 +28240,14 @@
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Miscellaneous Laboratory"
 	},
+/obj/machinery/button/windowtint{
+	id = "misc_lab";
+	pixel_x = 8;
+	pixel_y = 26
+	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "pOb" = (
@@ -25699,12 +28277,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"pPb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+"pQa" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
+/area/shuttle/petrov/equipment)
 "pQb" = (
 /obj/machinery/botany/editor,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -25730,6 +28309,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"pRc" = (
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Petrov - Chief Science Officer"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Science Officer's Desk";
+	departmentType = 5;
+	name = "Chief Science Officer RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "pRm" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -25748,8 +28342,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "pUb" = (
-/obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftport)
 "pUr" = (
@@ -25834,26 +28431,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"pZj" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "pZy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -25894,27 +28471,19 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qbH" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Chief Science Officer";
 	dir = 4
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "qcb" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 2;
@@ -25932,9 +28501,23 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qcd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "qdb" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"qdD" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "qeb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8;
@@ -25961,6 +28544,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"qeC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/button/ignition{
+	id_tag = "Isocell2";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "qfa" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -25985,6 +28586,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"qfW" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "qgb" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_north = 1;
@@ -26023,6 +28635,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bo)
+"qiE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "qiL" = (
 /obj/effect/floor_decal/corner/blue/half{
 	dir = 1;
@@ -26036,6 +28660,10 @@
 	dir = 8;
 	icon_state = "tube1";
 	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
@@ -26062,6 +28690,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "qkc" = (
@@ -26074,11 +28711,38 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/processing)
+"qkf" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1441;
+	id = "toxins_in"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/sparker{
+	id_tag = "toxlab";
+	pixel_w = 1;
+	pixel_z = -23
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "qlb" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/uranium,
+/obj/item/stack/material/uranium,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "qmb" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -26092,6 +28756,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10;
 	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
@@ -26113,6 +28783,22 @@
 /obj/item/weapon/reagent_containers/ivbag/nanoblood,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"qol" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Analysis Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "qqb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/full{
 	id = "sci_office"
@@ -26126,6 +28812,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"qrn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/security)
 "qrq" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -26247,6 +28939,13 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
+"qyZ" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "qzb" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
@@ -26269,10 +28968,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"qBy" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "qCb" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"qCk" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "qCs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -26292,13 +29008,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
-"qDb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/assist{
+"qCV" = (
+/obj/machinery/computer/modular/preset/civilian{
 	dir = 8;
-	icon_state = "generic"
+	icon_state = "console"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/machinery/button/windowtint{
+	id = "rcheckinner_windows";
+	pixel_x = 10;
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
+"qDb" = (
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "qDJ" = (
 /obj/structure/bed/chair{
@@ -26332,6 +29066,26 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1port)
+"qDO" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "qEb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26450,6 +29204,39 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"qIk" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/handrai,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "qJb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
@@ -26492,23 +29279,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
 "qKQ" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/floor_decal/corner/red/half{
+	dir = 1;
+	icon_state = "bordercolorhalf"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/box/flashbangs,
-/obj/item/weapon/storage/box/smokes,
-/obj/item/weapon/storage/box/handcuffs,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/modular/preset/civilian,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "qKU" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -26529,6 +29307,15 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
+"qLh" = (
+/obj/structure/table/rack,
+/obj/item/device/scanner/xenobio,
+/obj/item/device/scanner/xenobio,
+/obj/item/device/scanner/xenobio,
+/obj/item/weapon/storage/excavation,
+/obj/item/device/measuring_tape,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "qLr" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/standard,
@@ -26551,6 +29338,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
+"qMA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "qNb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5;
@@ -26569,12 +29362,19 @@
 "qPb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "qQb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 8;
 	icon_state = "map_valve0"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
@@ -26645,29 +29445,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "qTX" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/item/stack/material/phoron{
-	amount = 25
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "qUb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -26676,6 +29458,17 @@
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"qUf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "qUl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -26692,13 +29485,14 @@
 /area/maintenance/firstdeck/foreport)
 "qWb" = (
 /obj/structure/table/standard,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
+/obj/item/device/integrated_circuit_printer,
+/obj/item/device/integrated_electronics/debugger,
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_electronics/analyzer,
 /obj/effect/floor_decal/corner/research/half,
-/obj/machinery/light/spot{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
@@ -26816,6 +29610,21 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rbg" = (
+/obj/structure/table/rack,
+/obj/item/device/flashlight,
+/obj/item/device/radio,
+/obj/item/weapon/crowbar,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "rcb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -26832,6 +29641,25 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"rcD" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "rdb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -26862,6 +29690,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"reU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/cockpit)
 "rfb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26883,6 +29730,21 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rhl" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov1";
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "rhO" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
@@ -26956,6 +29818,25 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"rlu" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "rmb" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1;
@@ -27000,12 +29881,22 @@
 	},
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/corner/research/mono,
+/obj/machinery/vending/assist{
+	dir = 1;
+	icon_state = "generic"
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
 "rpb" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/effect/floor_decal/corner/research/mono,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/floor_decal/corner/research/half,
+/obj/machinery/light/spot{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/research/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
@@ -27033,6 +29924,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
+"rqV" = (
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/analysis)
 "rrI" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -27102,6 +29996,13 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"rtw" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "rub" = (
 /obj/machinery/button/ignition{
 	id_tag = "Xenobio";
@@ -27130,24 +30031,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
-"ruz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/aft)
 "ruS" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -27161,6 +30044,14 @@
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"rvT" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/computer/rdconsole/petrov{
+	dir = 4;
+	icon_state = "computer"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "rvY" = (
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled,
@@ -27175,6 +30066,14 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
+"rwC" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "rxb" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -27196,20 +30095,6 @@
 "ryb" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
-"ryt" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "rzb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27225,6 +30110,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"rzg" = (
+/obj/structure/closet/secure_closet/scientist_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "rAb" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -27352,14 +30245,51 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
-"rFK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
+"rFd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"rFK" = (
+/obj/structure/hygiene/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"rFR" = (
+/obj/structure/table/standard,
+/obj/item/weapon/disk/tech_disk{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/disk/tech_disk{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "rGb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -27377,6 +30307,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
+"rGO" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "rGU" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
@@ -27511,6 +30446,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rNP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rd_windows"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rd)
 "rOb" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/white,
@@ -27546,20 +30496,86 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
+"rPZ" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "rQb" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"rQO" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "rRb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rRV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"rSa" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "rSb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"rSQ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "rTb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -27656,6 +30672,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/foreport)
+"rXM" = (
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "rYb" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -27757,6 +30783,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"sbE" = (
+/obj/machinery/artifact_scanpad,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "sbJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27821,6 +30855,18 @@
 "sde" = (
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"sdF" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rd_windows"
+	},
+/obj/effect/paint/silver,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rd)
 "seb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenoflora Lab Maintenance"
@@ -27848,6 +30894,31 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/entry)
+"sfs" = (
+/obj/machinery/disposal,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/button/windowtint{
+	id = "rd_windows";
+	pixel_x = 6;
+	pixel_y = 24;
+	range = 11
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "sgb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27923,6 +30994,24 @@
 /obj/item/auto_cpr,
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
+"siV" = (
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Custodial Closet"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/custodial)
 "sjb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
@@ -27936,6 +31025,13 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"sjr" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell1";
+	pixel_x = -18
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "skb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4;
@@ -27951,6 +31047,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"skm" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "slb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28005,6 +31119,15 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"smG" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "smX" = (
 /obj/structure/closet/crate/solar,
 /obj/random/tech_supply,
@@ -28053,10 +31176,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
-"snG" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/aft)
 "sob" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -28071,6 +31190,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"spi" = (
+/obj/machinery/power/smes/buildable/preset/torch/shuttle{
+	RCon_tag = "Shuttle - Petrov"
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "spj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5;
@@ -28189,16 +31315,32 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
 "svH" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/item/weapon/stool/padded,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
+"svN" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "swb" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
@@ -28214,25 +31356,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
-"swz" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
+"swE" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4;
-	icon_state = "techfloor_corners"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "sxb" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1;
@@ -28391,6 +31531,20 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
+"sCJ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "sCM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28421,6 +31575,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"sFv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "sGs" = (
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 4;
@@ -28453,27 +31621,33 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
+"sHE" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "sHN" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/armoury)
-"sJr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"sHO" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/door/firedoor,
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
+"sJG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "sLb" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -28562,6 +31736,11 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "sPb" = (
@@ -28592,6 +31771,18 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology)
+"sPH" = (
+/obj/machinery/atmospherics/unary/heater,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "sQb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28653,6 +31844,13 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology)
+"sSE" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rd_windows"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rd)
 "sTb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -28694,6 +31892,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"sUG" = (
+/obj/structure/sign/solgov,
+/turf/simulated/wall/r_wall/hull,
+/area/hallway/primary/firstdeck/aft)
 "sVb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -28820,6 +32022,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"tbO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "tcb" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -28849,6 +32062,12 @@
 /mob/living/carbon/slime,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tdx" = (
+/obj/machinery/air_sensor{
+	id_tag = "phoron_sensor"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "teb" = (
 /obj/structure/table/standard,
 /obj/machinery/button/blast_door{
@@ -28875,6 +32094,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"tfD" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "tgb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28937,6 +32159,10 @@
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"thM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "thO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -29044,6 +32270,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
+"tmv" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/health,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "tnb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -29051,6 +32287,17 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tnT" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "tnV" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -29082,6 +32329,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tpw" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "tqb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/window/southright{
@@ -29097,6 +32368,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tqx" = (
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 8;
+	icon_state = "nosmoking";
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "trb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -29142,6 +32425,23 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tup" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "tvb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29207,6 +32507,13 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"tzp" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/aftport)
 "tzv" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8;
@@ -29304,6 +32611,14 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"tGa" = (
+/obj/machinery/atmospherics/binary/pump,
+/obj/structure/handrai{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "tGe" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29375,6 +32690,22 @@
 /obj/item/device/tape,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"tLX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rcheckinner_windows"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/security)
 "tRX" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -29386,6 +32717,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"tSa" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "tTA" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/donkpockets,
@@ -29413,6 +32753,31 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"tUD" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"tUO" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/maint)
 "tVi" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 8;
@@ -29492,6 +32857,33 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
+"ubV" = (
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"ucP" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	icon_state = "nosmoking";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "udY" = (
 /obj/machinery/washing_machine,
 /obj/structure/closet/walllocker{
@@ -29537,6 +32929,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
+"ugZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
 "uhl" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -29544,6 +32950,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
+"uiS" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "uiY" = (
 /turf/simulated/wall/prepainted,
 /area/medical/equipstorage)
@@ -29590,6 +32999,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"uqR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "urd" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -29605,6 +33023,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
+"urD" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rnd)
+"urM" = (
+/obj/machinery/computer/shuttle_control{
+	dir = 4;
+	icon_state = "computer";
+	req_access = list("ACCESS_TORCH_PETROV_HELM");
+	shuttle_tag = "Petrov"
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/cockpit)
 "usV" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -29615,6 +33050,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
+"utD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "uuS" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/curtain/open/bed,
@@ -29637,6 +33087,34 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
+"uvZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell3";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"uwh" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"uzA" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "uBg" = (
 /obj/structure/sign/double/solgovflag/left{
 	pixel_y = 32
@@ -29644,16 +33122,42 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "uCe" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"uCu" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	icon_state = "intact"
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "uCA" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -29670,6 +33174,20 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/security/questioning)
+"uDz" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/custodial)
 "uFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -29741,6 +33259,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
+"uLz" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "heater"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/custodial)
 "uLB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -29766,45 +33294,45 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
-"uLQ" = (
-/obj/effect/floor_decal/corner/blue,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"uLH" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/isolation)
+"uMP" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
-"uMP" = (
-/obj/structure/closet/bombclosetsecurity,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	icon_state = "wrecharger0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
 "uPc" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
+"uRH" = (
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "uRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29819,9 +33347,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/storage)
+"uRZ" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
 "uSl" = (
 /turf/simulated/wall/prepainted,
 /area/assembly/chargebay)
+"uSy" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/isolation)
 "uUC" = (
 /obj/machinery/flasher{
 	id_tag = "permflash";
@@ -29930,21 +33476,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
-"uZi" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
-"uZO" = (
-/obj/structure/table/steel,
-/obj/machinery/recharger,
-/obj/item/weapon/pinpointer,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury)
 "uZY" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 0;
@@ -29956,39 +33487,68 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"vbL" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "vci" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
-"vcy" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"veT" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4;
-	icon_state = "techfloor_edges"
+"vcM" = (
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - EVA";
+	dir = 4
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8;
-	icon_state = "techfloor_edges"
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 12
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
-	pixel_y = 24
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/obj/structure/table/rack,
+/obj/item/stack/flag/red,
+/obj/item/stack/flag/red,
+/obj/item/stack/flag/red,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
+"vfA" = (
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "vfK" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/equipstorage)
+"vgi" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "vhs" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -29998,54 +33558,92 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/conference)
+"vhY" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/analysis)
 "vii" = (
 /obj/structure/closet/secure_closet/medical_torch,
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
-"vjY" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
+"vkM" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/unary/vent_pump/tank{
+	dir = 1;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	id_tag = "phoron_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 0
 	},
-/obj/item/weapon/gun/energy/gun/secure,
-/obj/item/weapon/gun/energy/gun/secure,
-/obj/item/weapon/gun/energy/gun/secure,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "vkW" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8;
-	icon_state = "techfloor_corners"
-	},
-/obj/effect/floor_decal/techfloor/corner,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/hallwaya)
 "vlw" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
-"vnz" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light,
-/obj/machinery/flasher/portable,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"vms" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"vne" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "vnC" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/structure/table/standard,
@@ -30062,10 +33660,39 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/exam_room)
+"voW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "vpA" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/security/brig)
+"vqB" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "vrM" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -30074,11 +33701,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/firstdeck/foreport)
 "vtY" = (
-/obj/structure/sign/warning/high_voltage{
-	dir = 8;
-	icon_state = "shock"
-	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/firstdeck/aft)
 "vvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30093,6 +33716,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
+"vxa" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "vzp" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/sortjunction/flipped{
@@ -30118,6 +33749,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
+"vzx" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/research{
+	dir = 8;
+	icon_state = "corner_white"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/aft)
 "vzy" = (
 /turf/simulated/wall/prepainted,
 /area/medical/surgery2)
@@ -30139,9 +33793,60 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d1starboard)
 "vBV" = (
-/obj/random/obstruction,
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_inner";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
+"vCL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "rcheckinner_windows"
+	},
+/obj/effect/paint/silver,
 /turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/area/shuttle/petrov/security)
+"vDr" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "vDD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30221,6 +33926,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
+"vJs" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/rnd)
 "vJO" = (
 /obj/structure/bed/chair/padded/red,
 /obj/effect/floor_decal/corner/red{
@@ -30228,6 +33937,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
+"vJX" = (
+/obj/machinery/atmospherics/tvalve/digital{
+	dir = 1;
+	icon_state = "map_tvalve0";
+	id_tag = "fuelmode"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "vMm" = (
 /obj/structure/closet/crate,
 /obj/random/tank,
@@ -30240,6 +33958,25 @@
 "vMH" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/locker)
+"vOl" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
+"vTm" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"vTx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
 "vTH" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "forensicswindow"
@@ -30284,30 +34021,82 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
 "vUD" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/box/lights/tubes,
-/obj/item/weapon/storage/box/lights/bulbs,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	cycle_to_external_air = 0;
+	dir = 4;
+	frequency = 1380;
+	id_tag = "petrov_shuttle_airlock";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access = list("ACCESS_TORCH_PETROV");
+	tag_airpump = "petrov_shuttle_pump";
+	tag_chamber_sensor = "petrov_shuttle_sensor";
+	tag_exterior_door = "petrov_shuttle_outer";
+	tag_exterior_sensor = null;
+	tag_interior_door = "petrov_shuttle_inner"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "vVe" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/thruster/d1starboard)
+"vXd" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_outer";
+	locked = 0;
+	name = "Petrov Exterior Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
+"vXE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/rnd)
+"vXN" = (
+/obj/structure/bed,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"vZs" = (
+/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov2";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "vZI" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -30340,6 +34129,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"waY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"wbO" = (
+/obj/structure/bed/chair/office/comfy/red,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/security)
 "wcQ" = (
 /obj/machinery/pager/security{
 	pixel_x = -25
@@ -30349,6 +34156,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"wgU" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "whd" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -30376,24 +34195,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
 "wjP" = (
-/obj/structure/table/rack{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "wkS" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -30486,12 +34298,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
+"wuy" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
 "wvZ" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
+"wwU" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/rnd/research)
 "wyb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30530,6 +34358,36 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"wzQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
+"wAI" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "petrov_shuttle_dock_inner";
+	locked = 0;
+	name = "Docking Port Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "wAK" = (
 /obj/machinery/door/airlock/civilian{
 	autoset_access = 0;
@@ -30539,6 +34397,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/security/brig)
+"wBh" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
 "wBV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -30551,6 +34416,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/centralport)
+"wCk" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/phoron)
 "wDm" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -30575,11 +34444,6 @@
 "wEw" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/thruster/d1port)
-"wGe" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
 "wHE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -30587,6 +34451,22 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
+"wLa" = (
+/obj/machinery/disposal,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "wMh" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/orange,
@@ -30602,6 +34482,16 @@
 	},
 /turf/simulated/open,
 /area/hallway/primary/firstdeck/fore)
+"wNq" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/phoron)
 "wNX" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -30609,13 +34499,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
-"wRs" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+"wVb" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Hallway Fore";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury/access)
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "wWc" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -30630,6 +34526,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
+"wWM" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
+	},
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/rnd)
 "wXc" = (
 /obj/item/device/radio/intercom/entertainment{
 	dir = 4;
@@ -30668,24 +34577,98 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
+"xaD" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
+"xaL" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"xct" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "xcW" = (
 /turf/simulated/wall/prepainted,
 /area/assembly/robotics/office)
-"xhX" = (
-/obj/structure/table/steel,
-/obj/random/clipboard,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/hand_labeler,
-/obj/machinery/light{
-	dir = 1
+"xdQ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/obj/machinery/alarm{
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/eva)
+"xfB" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/command/armoury/access)
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
+"xfV" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
+"xge" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/emitter,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"xhJ" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/random/tool,
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell1";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/machinery/button/ignition{
+	id_tag = "Isocell1";
+	pixel_x = -36;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"xhX" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cockpit)
 "xjr" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 4;
@@ -30693,6 +34676,47 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/firstdeck)
+"xly" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/rd)
+"xmI" = (
+/obj/machinery/suit_cycler/science,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	dir = 1;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
+"xmL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/standard,
+/obj/item/stack/material/plastic/ten,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "xoo" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -30724,18 +34748,65 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
+"xpA" = (
+/obj/effect/paint/silver,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/rd)
 "xqk" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/suit_cycler,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	name = "Petrov Security Desk"
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Starboard";
-	dir = 2
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 1;
+	name = "Petrov Security Desk"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury)
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "concheckwindow2";
+	name = "Research Checkpoint Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/security)
+"xqL" = (
+/obj/structure/bed,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"xqT" = (
+/obj/structure/closet/secure_closet/crew/research,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/item/weapon/folder/nt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
+"xtc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "xtq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
@@ -30776,9 +34847,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "xxB" = (
-/obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftport)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/hallway/primary/firstdeck/aft)
 "xxY" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -30798,13 +34869,25 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/office)
 "xzj" = (
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Port";
-	dir = 4
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "petrov_shuttle_sensor";
+	pixel_x = -24;
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
+/obj/machinery/oxygen_pump{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	dir = 2;
+	id_tag = "petrov_shuttle_pump"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/petrov/hallwaya)
 "xzK" = (
 /obj/structure/bed/chair/padded/red,
 /obj/machinery/camera/network/security{
@@ -30887,6 +34970,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
+"xEo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/prepainted,
+/area/hallway/primary/firstdeck/aft)
 "xEq" = (
 /obj/structure/sign/warning/pods/south,
 /turf/simulated/wall/r_wall/hull,
@@ -30894,6 +34981,34 @@
 "xFL" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
+"xGN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/handrai{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
+"xGT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/equipment)
+"xIn" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/toxins)
 "xJP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30925,6 +35040,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
+"xLY" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "xMy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -30932,8 +35065,25 @@
 "xMP" = (
 /obj/structure/table/standard,
 /obj/machinery/reagent_temperature,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/rnd/misc_lab)
+"xNf" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Exterior Vent"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "xPU" = (
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
@@ -31012,14 +35162,72 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
+"xUb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "xVt" = (
 /obj/machinery/computer/modular/preset/civilian,
 /obj/effect/floor_decal/corner/research/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/office)
+"xVx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
+"xVy" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/air_sensor{
+	id_tag = "toxins_sensor"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/toxins)
+"xXv" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/maint)
 "xYM" = (
 /turf/simulated/wall/prepainted,
 /area/medical/physicianoffice)
+"yaJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "ybv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31039,6 +35247,9 @@
 /area/hallway/primary/firstdeck/fore)
 "ycp" = (
 /obj/effect/floor_decal/corner/research/half,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
 "ycz" = (
@@ -31074,6 +35285,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
+"yfX" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/aft)
+"ygI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/maint)
 "ygK" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31090,6 +35309,38 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"ygO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"yhN" = (
+/obj/machinery/camera/network/nanotrasen{
+	c_tag = "Petrov - Desublimation";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/phoron)
 "yii" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -31098,6 +35349,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"yjH" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "ykr" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -55248,7 +59505,7 @@ aic
 ail
 cva
 jYb
-pdb
+inP
 jZb
 pKb
 qjb
@@ -55651,8 +59908,8 @@ abk
 aie
 abk
 cva
-jZb
-pfb
+jWb
+pdb
 aHQ
 pNb
 qmb
@@ -56055,9 +60312,9 @@ ahw
 aig
 aio
 aiu
-kbb
+jWb
 phb
-pPb
+jZb
 qlb
 aLo
 qQb
@@ -56257,12 +60514,12 @@ ahz
 ahz
 aip
 aiu
-hvY
+jWb
 pib
-pDb
+jZb
 fBb
 iSb
-qnb
+dhM
 rvb
 rmb
 aHQ
@@ -56450,21 +60707,21 @@ yii
 haV
 vii
 pWW
-vHB
-ayB
-azN
+hdb
+jAM
+amW
 ahe
 ahn
 ahn
 ahn
 aiq
 aiu
-kpb
+kab
 pjb
-pEb
+jZb
 iqb
-jAb
-aLo
+iSb
+ozT
 ycp
 rnb
 aHQ
@@ -56652,22 +60909,22 @@ fQf
 qKx
 vii
 pWW
-lsT
+ivT
 hnN
-uZi
+tiz
 ahe
 aho
 ahH
 ahn
 air
 aiu
-eGb
+jWb
+pjb
+jZb
 pbb
-pFb
-pbb
-khb
-aLo
-ycp
+iSb
+iSb
+nLO
 rob
 aHQ
 aRf
@@ -56854,18 +61111,18 @@ atm
 aug
 vii
 pWW
-bBm
-ruz
-dJp
+pmz
+hnN
+tiz
 ahd
 ahp
 ahJ
 aih
 ahn
 aiu
-aHQ
-pnb
-pGb
+lId
+pjb
+jZb
 xMP
 gcY
 qDb
@@ -57057,16 +61314,16 @@ pWW
 pWW
 pWW
 jqn
-ayF
-jqn
+ayB
+ejW
 ahd
 ahd
 ahd
 ahd
 ais
 aiu
-aHQ
-aHQ
+wwU
+gvk
 aHQ
 aHQ
 ivh
@@ -57266,16 +61523,16 @@ aCq
 aDA
 aEC
 aFL
-aFL
+gCT
+hOk
+itJ
+iep
+ibP
+aOC
+aOC
 aHR
 aJi
 pxb
-aFL
-aOC
-aOC
-aOC
-sJr
-aOC
 sOo
 jbk
 jbk
@@ -57459,25 +61716,25 @@ ask
 ato
 auk
 avy
-awH
 uoC
+sJG
 ayH
 azS
 aAV
 aCr
-auk
+hbH
 aED
-aFM
-aFM
+vzx
+lay
+gff
+eOa
+xEo
+pUb
+pUb
+aNA
 aHS
 aJj
 pyb
-pUb
-aMy
-aNA
-bDK
-bDK
-bDK
 xPU
 xPU
 rUh
@@ -57663,19 +61920,19 @@ aul
 vtY
 awI
 awJ
-awJ
-awJ
+drH
+bqj
 aAW
 vtY
 aul
-aTK
+wAI
 vBV
-aTK
-bDK
-bDK
-bDK
-bDK
-bDK
+aul
+vtY
+vtY
+vtY
+tzp
+tzp
 bDK
 bDK
 bDK
@@ -57858,21 +62115,21 @@ mpy
 mpy
 mpy
 mpy
-acL
-asl
-asl
-abL
-snG
+mpy
+mpy
+mpy
+mpy
+vtY
 lkp
 puw
 ayJ
-ayJ
-mwJ
-snG
-aDB
+yfX
+yfX
+vtY
+ozb
 xxB
-aLu
-ldP
+htS
+vtY
 bDK
 bDK
 bDK
@@ -58060,21 +62317,21 @@ mpy
 mpy
 mpy
 mpy
-uXe
-sde
-sde
-abL
+xfV
+xfV
+xfV
+xfV
 aGN
-aGN
-acB
-ayK
-jrH
+bmI
+aaa
+aaa
+aaa
 aAX
-aGN
+poe
 lLD
 aLu
-aLu
-fnR
+ijc
+vtY
 bDK
 bDK
 bDK
@@ -58260,25 +62517,25 @@ mpy
 mpy
 mpy
 mpy
-dVw
-dVw
-aBc
-aBc
-aBc
-aBc
-aGN
-awL
-wRs
-ayL
-azU
-aAY
-aGN
-aHT
-aHT
-aHT
-aHT
-eRU
-eRU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+sUG
+vtY
+iYE
+mvH
+sUG
+aaa
+aaa
 bDK
 bDK
 bDK
@@ -58459,31 +62716,31 @@ abN
 abM
 acd
 acd
-acd
-acd
+aaa
+aaa
+aaa
+aaa
+aaa
 dVw
 dVw
 dVw
-aBc
-aBc
-aBc
-aBc
-aGN
+dVw
+aaa
 xhX
 fOr
-cOH
-bYj
-aAZ
-aGN
-aHT
-aHT
-aHT
-aHT
-eRU
-eRU
-eRU
-acd
-acd
+fOr
+fOr
+xhX
+aaa
+vkW
+hAv
+vXd
+vkW
+aaa
+aaa
+aaa
+aaa
+aaa
 acd
 acd
 aLj
@@ -58661,31 +62918,31 @@ aet
 abN
 aaa
 acd
-acd
-acd
-acd
+aaa
+aaa
+aaa
+aaa
 dVw
 dVw
-htK
-hFu
-vjY
-hOb
-aBc
+dVw
+dVw
+dVw
+aaa
+xhX
 aHT
-aHT
-aHT
-aHT
-aBa
-aHT
-uZO
+reU
+urM
+xhX
+aaa
+vkW
 xzj
 aQr
-aRm
-eRU
-eRU
-acd
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
+aaa
 acd
 aaa
 xPU
@@ -58864,29 +63121,29 @@ bhb
 aaa
 aaa
 aaa
-acd
-acd
+aaa
+aaa
+aaa
 dVw
 dVw
-veT
-svH
-svH
-swz
+dVw
+dVw
+dVw
 aBc
-iBb
+xhX
 nvX
 kmE
 onM
-uLQ
+xhX
 jPY
-onM
+vkW
 ooN
 fll
-vnz
-eRU
-eRU
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59066,29 +63323,29 @@ abN
 aaa
 aaa
 aaa
-acd
-acd
+aaa
+aaa
+aaa
+qrn
+vCL
+aEG
+hre
 dVw
-dVw
-aEG
-aEG
-aEG
-dJv
-aBc
-bMB
+tLX
+xhX
 lst
 cAh
+xhX
+xhX
 jAl
-mwA
-jAl
-jAl
+vkW
 bBv
 aQs
-aQs
-eRU
-eRU
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -59268,29 +63525,29 @@ aiI
 ajJ
 aaa
 aaa
-acd
-acd
-dVw
-dVw
-ryt
+aaa
+aaa
+aaa
+qrn
+vCL
 svH
-svH
+nxC
 njm
 ksK
 nZZ
 mJJ
 cYB
 qTX
-pZj
-jnd
+qTX
+qTX
 vUD
-fZn
+qTX
 aQq
-aQq
-eRU
-eRU
-acd
-acd
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 aOD
@@ -59469,31 +63726,31 @@ ahB
 abN
 aaa
 aaa
-acd
-acd
-acd
+aaa
+aaa
+aaa
 dVw
 dVw
-aEG
-aEG
-aEG
+dVw
+rbg
+goc
 jQY
-aBc
+wbO
 xqk
 rFK
 aMB
 aNE
 vlw
-aMB
-ahL
-kyt
+miy
+miy
+miy
 aQt
-aQt
-eRU
-eRU
-acd
-acd
-acd
+fSh
+vkW
+vkW
+aaa
+aaa
+aaa
 aaa
 aaa
 xPU
@@ -59671,31 +63928,31 @@ aca
 abN
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
+aaa
+aaa
+aaa
+qrn
+vCL
 mrr
-svH
-svH
+eol
+goc
 nWP
-aBc
-cZd
+qCV
+dVw
 vkW
 uCe
-uCe
-lGw
-uCe
-uCe
-fIn
-wGe
-vcy
-eRU
-eRU
-acd
-acd
-acd
+hmj
+cyI
+cyI
+cyI
+cyI
+cyI
+cyI
+cyI
+cyI
+aaa
+aaa
+aaa
 aaa
 aaa
 xPU
@@ -59873,31 +64130,31 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
+aaa
+aaa
+aaa
+qrn
+vCL
 qKQ
 iAS
 bCX
 uMP
-aBc
+vOl
 aJl
-rFK
+mIq
 aJm
 wjP
-fLg
+cyI
 qbH
 hrE
-vlw
+pRc
 aQu
-aQu
-eRU
-eRU
-acd
-acd
-acd
+kdI
+rNP
+kfY
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60075,31 +64332,31 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-acd
-acd
-acd
+aaa
+aaa
+aaa
+tUO
+tUO
+tUO
+tUO
+tUO
+tUO
+tUO
+tUO
+qIk
+che
+ygO
+sdF
+pmW
+guL
+bpo
+aNR
+nlS
+cyI
+cyI
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60278,29 +64535,29 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-dVw
-dVw
-dVw
-dVw
-dVw
-dVw
+aaa
+aaa
+oJH
+mQE
+vJX
+pGX
+hmq
+xGN
+fkN
 eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-eRU
-acd
-acd
-acd
+vms
+eBF
+tbO
+mgj
+xly
+vTx
+vTx
+mcL
+fyv
+rNP
+kfY
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60481,27 +64738,27 @@ aaa
 aaa
 aaa
 aaa
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
 aaa
+jno
+tUO
+rtw
+tfD
+sHE
+jKN
+wzQ
+cuh
+aNx
+eKv
+xpA
+cyI
+sfs
+bRA
+mqM
+gzQ
+iJs
+rNP
+kfY
 aaa
-aaa
-aaa
-aaa
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
 aaa
 aaa
 aaa
@@ -60684,25 +64941,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUO
+tUO
+tUO
+rPZ
+bms
+wgU
+tUO
+nmc
+fjp
+cRk
+cyI
+cyI
+cyI
+sSE
+sSE
+sSE
+cyI
+cyI
+cyI
 aaa
 aaa
 aaa
@@ -60886,25 +65143,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-acd
-aaa
-acd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUO
+tUO
+pFj
+lyd
+vbL
+spi
+tUO
+jqI
+svN
+wVb
+vJs
+aID
+iOO
+rvT
+nwP
+bfZ
+bXd
+wWM
+iAV
 aaa
 aaa
 aaa
@@ -61088,25 +65345,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUO
+tUO
+pFj
+ygI
+cFi
+fIA
+tUO
+ezN
+rSQ
+fwp
+fdt
+mGD
+jZx
+xaD
+nAQ
+clg
+xmL
+wWM
+iAV
 aaa
 aaa
 aaa
@@ -61290,25 +65547,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUO
+tUO
+pFj
+jiO
+uRH
+xXv
+tUO
+mxw
+dwK
+gxF
+urD
+rFR
+lWF
+ble
+iXe
+eHc
+mgP
+wWM
+iAV
 aaa
 aaa
 aaa
@@ -61491,27 +65748,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUO
+tUO
+tUO
+tUO
+tUO
+tUO
+tUO
+tUO
+mxw
+tup
+fSh
+urD
+iFZ
+kXf
+gNP
+kAb
+vXE
+djt
+vJs
+vJs
+vJs
 aaa
 aaa
 aaa
@@ -61692,29 +65949,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebm
+ebm
+ebm
+xge
+pBC
+hAl
+gHK
+pao
+ebm
+ebm
+vDr
+vTm
+hIv
+hIv
+hIv
+hIv
+hIv
+hIv
+kiS
+kiS
+kiS
+kiS
+hIv
 aaa
 aaa
 aaa
@@ -61894,29 +66151,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebm
+ebm
+sbE
+xfB
+xfB
+xfB
+chg
+kOc
+ubV
+ebm
+qDO
+dsx
+hIv
+lEO
+hrI
+yhN
+ijX
+wNq
+sHO
+vkM
+uiS
+kiS
+hIv
 aaa
 aaa
 aaa
@@ -62096,29 +66353,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oiX
+vhY
+dTG
+kOc
+cYo
+aZe
+nbq
+kHm
+waY
+qol
+hes
+rFd
+cUn
+fSR
+qiE
+paK
+jxx
+pta
+nOZ
+uiS
+uiS
+kiS
+hIv
 aaa
 aaa
 aaa
@@ -62298,29 +66555,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oiX
+vhY
+bPb
+kOc
+kOc
+juv
+fQL
+hQZ
+utD
+rqV
+owH
+fSh
+mUh
+kCf
+qMA
+iFu
+iFu
+pta
+wCk
+tdx
+uiS
+kiS
+hIv
 aaa
 aaa
 aaa
@@ -62500,29 +66757,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oiX
+vhY
+rGO
+kOc
+iyA
+cDo
+oqY
+mOB
+fWF
+llc
+tup
+fSh
+mUh
+fwm
+nXX
+mUZ
+qdD
+djs
+sHO
+iLw
+uiS
+kiS
+hIv
 aaa
 aaa
 aaa
@@ -62702,29 +66959,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebm
+ebm
+gnU
+rXM
+ojE
+iSQ
+khy
+opF
+iUj
+llc
+cGh
+hKL
+brP
+brP
+brP
+brP
+brP
+dsh
+fxj
+fxj
+fxj
+fxj
+dsh
 aaa
 aaa
 aaa
@@ -62904,29 +67161,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebm
+ebm
+ebm
+ebm
+llc
+llc
+llc
+ebm
+ebm
+ebm
+owK
+lng
+joH
+eRt
+duS
+fyg
+xhJ
+oKg
+noZ
+rhl
+sjr
+gjD
+kBv
 aaa
 aaa
 aaa
@@ -63106,29 +67363,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oHy
+oHy
+fAY
+qcd
+bXz
+bOY
+kAY
+eyB
+ojD
+bAY
+vqB
+thM
+joH
+uwh
+xLY
+iMp
+oDv
+skm
+gEy
+bYF
+mKA
+gjD
+kBv
 aaa
 aaa
 aaa
@@ -63308,6 +67565,29 @@ aaa
 aaa
 aaa
 aaa
+lwQ
+okg
+eCA
+pAB
+pAB
+ntu
+pQa
+pAB
+yjH
+bAY
+swE
+lng
+fXv
+bik
+vgi
+xaL
+nHH
+oKg
+dfR
+vfA
+cCx
+gjD
+kBv
 aaa
 aaa
 aaa
@@ -63320,30 +67600,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+azV
 aaa
 aaa
 aaa
@@ -63510,29 +67767,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lwQ
+okg
+gyy
+pAB
+ihf
+aqB
+xGT
+pAB
+wLa
+oHy
+rcD
+smG
+brP
+fTj
+gVP
+kof
+qeC
+dsh
+dsh
+dsh
+dsh
+dsh
+dsh
 aaa
 aaa
 aaa
@@ -63712,29 +67969,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oHy
+oHy
+oCP
+ugZ
+aIE
+xqT
+oaJ
+evi
+sCJ
+hLv
+tpw
+rRV
+dNJ
+xUb
+xct
+fHS
+cBh
+gtA
+qfW
+tnT
+jCO
+qBy
+gVl
 aaa
 aaa
 aaa
@@ -63914,29 +68171,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oHy
+oHy
+oHy
+gxt
+oHy
+oHy
+qCk
+aXL
+pgR
+oHy
+gul
+eKj
+brP
+iie
+bqd
+cZP
+fzl
+eyI
+cfL
+fSf
+prC
+qBy
+gVl
 aaa
 aaa
 aaa
@@ -64116,29 +68373,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eOT
+eOT
+xmI
+rlu
+vcM
+oHy
+rzg
+hCG
+mjD
+oHy
+neV
+tqx
+brP
+vxa
+tmv
+gWv
+uqR
+oKn
+xqL
+vZs
+vXN
+qBy
+gVl
 aaa
 aaa
 aaa
@@ -64318,29 +68575,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azV
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jcd
+xdQ
+eBq
+voW
+qLh
+czW
+czW
+czW
+czW
+czW
+eXf
+czW
+brP
+brP
+sPH
+ldY
+iSf
+lpu
+lpu
+lpu
+lpu
+lpu
+lpu
 aaa
 aaa
 aaa
@@ -64520,29 +68777,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jcd
+xdQ
+bFj
+nPY
+lLJ
+czW
+aVd
+gaB
+dgu
+ekS
+tUD
+ucP
+ffO
+brP
+dHk
+bVW
+uvZ
+xtc
+vne
+ndQ
+otn
+fVv
+egd
 aaa
 aaa
 aaa
@@ -64722,29 +68979,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jcd
+xdQ
+bFj
+csr
+nwb
+czW
+eli
+jEF
+xIn
+fbc
+mWn
+aly
+kkD
+brP
+uCu
+hDI
+hGa
+gyf
+rQO
+yaJ
+bzm
+fVv
+egd
 aaa
 aaa
 aaa
@@ -64924,29 +69181,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eOT
+eOT
+dbQ
+xVx
+bsN
+czW
+tSa
+bFk
+uzA
+xIn
+eLp
+cYP
+csm
+brP
+lTr
+jGn
+bVW
+jtn
+bae
+nNg
+fqQ
+fVv
+egd
 aaa
 aaa
 aaa
@@ -65126,29 +69383,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oqN
+oqN
+oqN
+siV
+oqN
+oqN
+uRZ
+rSa
+rwC
+dFu
+mMI
+eEt
+qUf
+brP
+nUo
+erN
+tGa
+lqw
+gie
+gie
+gie
+gie
+gie
 aaa
 aaa
 aaa
@@ -65328,29 +69585,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebi
+ebi
+lYu
+sFv
+pqB
+oqN
+czW
+jfA
+iZv
+flE
+jVC
+aYW
+jVC
+iDT
+brP
+brP
+brP
+kPJ
+brP
+bui
+bui
+bUq
+bUq
 aaa
 aaa
 aaa
@@ -65531,27 +69788,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebi
+lIj
+uDz
+lIj
+oqN
+czW
+eCW
+xNf
+fKv
+ngE
+xVy
+qkf
+iDT
+brP
+brP
+brP
+kfu
+kfu
+mty
+kfu
+bUq
 aaa
 aaa
 aaa
@@ -65733,27 +69990,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebi
+ebi
+ebi
+ebi
+ebi
+ebi
+fbo
+jFw
+wuy
+qyZ
+dhi
+wBh
+iDT
+brP
+brP
+bUq
+bUq
+bUq
+bUq
+bUq
+bUq
 aaa
 aaa
 aaa
@@ -65935,27 +70192,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebi
+uLz
+uLz
+uLz
+uLz
+ebi
+dDm
+lWj
+aHo
+iGa
+iGa
+iGa
+aHo
+uSy
+uSy
+bUq
+iKi
+iKi
+iKi
+iKi
+bUq
 aaa
 aaa
 aaa
@@ -66137,6 +70394,12 @@ aaa
 aaa
 aaa
 aaa
+ebi
+gFj
+gFj
+gFj
+gFj
+ebi
 aaa
 aaa
 aaa
@@ -66146,18 +70409,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bUq
+uLH
+uLH
+uLH
+uLH
+bUq
 aaa
 aaa
 aaa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -9,15 +9,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"ac" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "ad" = (
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -361,14 +352,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"aM" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
 "aN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -623,12 +606,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"bk" = (
-/obj/effect/floor_decal/corner/white/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/command,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
 "bl" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/sticky_pad/random,
@@ -2349,15 +2326,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "eb" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/dutyboots,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
+/obj/machinery/camera/network/command{
+	c_tag = "Fire Control - Controls";
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"ec" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/cockpit)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "ed" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -2392,13 +2373,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"eg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2701,20 +2675,6 @@
 /obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"eH" = (
-/obj/machinery/computer/ship/helm{
-	req_access = list(list("ACCESS_TORCH_AQUILA_HELM"))
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"eI" = (
-/obj/machinery/computer/shuttle_control/explore/aquila,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"eJ" = (
-/obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "eK" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -3032,16 +2992,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "fj" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"fk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/armoury/tactical)
 "fl" = (
 /obj/structure/table/glass,
 /obj/random/clipboard,
@@ -3049,29 +3001,6 @@
 /obj/random_multi/single_item/summarydocuments/explo,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
-"fm" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"fn" = (
-/obj/machinery/button/blast_door{
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters Control";
-	pixel_x = -32
-	},
-/obj/machinery/turretid/stun{
-	check_synth = 0;
-	name = "Aquila point defense control";
-	pixel_x = 32;
-	pixel_y = 0;
-	req_access = list("ACCESS_TORCH_AQUILA_HELM")
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "fo" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3086,13 +3015,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"fp" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "fu" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -3259,52 +3181,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
-"fH" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 8;
-	name = "CE's Equipment Storage"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/item/weapon/rig/ce/equipped,
-/turf/simulated/floor/tiled/monotile,
-/area/aux_eva)
 "fI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/aft)
-"fJ" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"fK" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"fL" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Cockpit";
-	dir = 8
-	},
-/obj/machinery/computer/modular/preset/cardslot/command,
-/obj/item/device/radio/intercom/hailing{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "fM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3450,18 +3329,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/cmo)
-"fX" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/medical)
 "fY" = (
 /obj/effect/floor_decal/corner/red/half,
 /obj/machinery/vending/coffee{
@@ -3589,84 +3456,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"go" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"gs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/steel_reinforced,
-/obj/random/toolbox,
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
 "gv" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -3689,10 +3478,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
-"gw" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
 "gz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftstarboard)
@@ -3799,58 +3584,6 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/bridge/aft)
-"gY" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"gZ" = (
-/obj/machinery/porta_turret{
-	dir = 8;
-	enabled = 0;
-	lethal = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
-/area/aquila/cockpit)
-"ha" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/cockpit)
-"hb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cockpit"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/cockpit)
-"hc" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/porta_turret{
-	dir = 8;
-	enabled = 0;
-	lethal = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/cockpit)
-"hi" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aux_eva)
 "hj" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3981,55 +3714,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
-"hL" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/microwave,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Crew Compartment";
-	dir = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"hM" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/snack,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"hN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"hO" = (
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/bed/chair/shuttle/blue,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
 "hV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/sol{
@@ -4210,79 +3894,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
-"it" = (
-/obj/random/soap,
-/obj/structure/hygiene/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"iu" = (
-/obj/structure/hygiene/toilet{
-	pixel_y = 12
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"iv" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/single/cola,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"iw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"ix" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"iy" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/smokes,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"iz" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/passenger)
-"iA" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
 "iB" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -4317,6 +3928,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
+"iM" = (
+/obj/machinery/deployable/barrier,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "iP" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
@@ -4450,80 +4066,23 @@
 /obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
-"je" = (
-/obj/structure/handrai{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"jf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
 "jg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "jh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"jj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"jk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"jl" = (
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/obj/item/weapon/shield/riot/metal,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
+"ji" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "jw" = (
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/dark,
@@ -4736,112 +4295,41 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "kb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
+/obj/item/weapon/gun/energy/stunrevolver/rifle,
+/obj/item/weapon/gun/energy/taser/carbine,
+/obj/item/weapon/gun/energy/taser/carbine,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "kc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/power/apc/shuttle/aquila{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "ke" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/energy/ionrifle,
+/obj/item/weapon/gun/energy/ionrifle/small,
+/obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"kf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"kg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"kh" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 1;
-	icon_state = "shuttle_chair_preview"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"ki" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "kv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5001,23 +4489,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "kT" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "operation_hallway_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
-"kU" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/red/mono,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "kV" = (
 /obj/structure/cable/green,
@@ -5034,24 +4515,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/xo)
-"kW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "kX" = (
 /obj/machinery/light_switch{
 	pixel_x = -23;
@@ -5092,18 +4555,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"lp" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/secure_storage)
 "lq" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -5284,14 +4735,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/bridge)
-"lN" = (
+"lO" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "operation_hallway_shutters";
+	name = "Operation Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -5299,66 +4753,28 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/half{
-	dir = 4;
-	icon_state = "bordercolorhalf"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"lO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass/command{
-	id_tag = null;
-	name = "Aquila Dock";
-	secured_wires = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/bridge/aft)
 "lR" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "aquila_shuttle_dock_sensor";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 8;
-	id_tag = "aquila_shuttle_dock_pump"
+/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/item/device/radio/intercom/hailing{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/turf/simulated/floor/plating,
+/area/command/armoury/access)
 "lS" = (
 /obj/effect/floor_decal/scglogo{
 	dir = 4;
@@ -5393,59 +4809,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "lX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/cdeathalarm_kit,
+/obj/item/weapon/melee/telebaton,
+/obj/item/weapon/melee/telebaton,
+/obj/item/weapon/melee/telebaton,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"lZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "mc" = (
 /obj/structure/cable/green,
 /obj/machinery/door/firedoor,
@@ -5457,14 +4835,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"mx" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
+"mf" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "mz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -5713,34 +5086,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"nd" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
 "ne" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/blue/half,
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "nf" = (
 /obj/effect/floor_decal/corner/blue/mono,
@@ -5751,135 +5103,49 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "ni" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Docking Port";
-	dir = 1
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	icon_state = "wrecharger0";
+	pixel_y = -22
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "nj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "nk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "aquila_shuttle";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = -24;
-	req_access = newlist()
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"nl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"nm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/overmap/visitable/ship/landable/aquila,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"nn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"no" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"np" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4;
-	icon_state = "shuttle_chair_preview"
-	},
-/obj/machinery/computer/cryopod{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
-"nq" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Seating";
-	dir = 1
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
-"nr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"nE" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/techfloor{
 	dir = 1;
-	icon_state = "warningcorner"
+	icon_state = "techfloor_edges"
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Emergency Armory - Tactical Port";
+	dir = 8;
+	network = list("Command")
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "nG" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -6174,6 +5440,20 @@
 "oB" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
+"oE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark{
+	dir = 8
+	},
+/area/aux_eva)
 "oF" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6302,112 +5582,50 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"oU" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/medical)
 "oW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 23;
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"oZ" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
-"pa" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
 "pb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
-"pc" = (
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
+/area/command/armoury)
+"pc" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6;
+	icon_state = "corner_techfloor_grid"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
+"pd" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Emergency Armory"
+	},
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_entrylock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury)
 "pe" = (
 /obj/structure/lattice,
 /obj/machinery/light/navigation/delay5,
 /turf/space,
 /area/space)
-"pf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"ph" = (
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"pi" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"pj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"pk" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"pl" = (
-/obj/machinery/body_scanconsole{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "py" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -6514,156 +5732,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
-"pQ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
-"pR" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aux_eva)
-"pS" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
 "pT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"pU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/pinpointer,
+/obj/item/weapon/pinpointer,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "pW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Aft Passageway";
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
-	},
-/obj/machinery/vending/wallmed1{
-	dir = 1;
-	icon_state = "wallmed";
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pY" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
-"pZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+	alarm_id = "petrov2";
 	dir = 8;
-	icon_state = "warningcorner"
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "qa" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4;
@@ -6671,38 +5758,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/xo)
-"qb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"qc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"qd" = (
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"qe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "qf" = (
 /obj/effect/floor_decal/scglogo{
 	icon_state = "top-right"
@@ -6897,6 +5952,13 @@
 /obj/item/weapon/storage/lunchbox/cat,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"qy" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "qz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6925,48 +5987,23 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "qD" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "qE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"qF" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "qH" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/bridge/aftport)
-"qI" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "qO" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge/storage)
@@ -7204,58 +6241,53 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/meeting_room)
-"rv" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/crew,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/obj/random/maintenance/solgov/clean,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
-"rw" = (
-/obj/structure/table/rack,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Storage";
-	dir = 1
-	},
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
 "rx" = (
-/obj/machinery/atmospherics/unary/tank/air{
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 8;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
+"ry" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
-"ry" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/stack/material/steel{
+	amount = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
+/obj/item/stack/material/steel{
+	amount = 30
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/stack/material/steel{
+	amount = 30
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/ocp{
+	amount = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "rz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7289,19 +6321,6 @@
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
-"rE" = (
-/obj/structure/table/standard,
-/obj/item/weapon/defibrillator/loaded,
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Infirmary";
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "rI" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8;
@@ -7491,6 +6510,25 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"sg" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 4;
+	name = "CE's Equipment Storage"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/item/weapon/rig/ce/equipped,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/aux_eva)
 "sh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7536,58 +6574,28 @@
 /obj/machinery/shipsensors,
 /turf/simulated/floor/reinforced/airless,
 /area/bridge/storage)
-"sn" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Secure Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
 "so" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10;
-	icon_state = "intact"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/stack/material/glass/reinforced{
+	amount = 30
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
-"st" = (
-/obj/structure/hygiene/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+/obj/item/stack/material/glass/reinforced{
+	amount = 30
 	},
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/item/stack/material/glass/reinforced{
+	amount = 30
 	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"su" = (
-/obj/structure/table/standard,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 5
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "sx" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
@@ -7726,61 +6734,19 @@
 "sT" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/rd)
-"sU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"sY" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/weapon/gun/launcher/syringe,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
-"sV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
-"sW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/structure/handrai,
-/obj/machinery/power/apc/shuttle/aquila{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/secure_storage)
-"sY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "ta" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -7815,53 +6781,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/bridge)
-"tc" = (
-/obj/structure/catwalk,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
-"td" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1;
-	sheets = 25
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
-"te" = (
-/obj/structure/closet/medical_wall{
-	pixel_x = -32
-	},
-/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
-/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
-/obj/item/weapon/reagent_containers/syringe,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/latex,
-/obj/item/weapon/tank/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/structure/iv_drip,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
-"tf" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/sterilizine,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
 "tg" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/foreport)
@@ -7913,6 +6832,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
+"tq" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "ts" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -8060,57 +6984,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
 "tI" = (
-/obj/structure/table/rack,
-/obj/random/solgov,
-/obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/secure_storage)
+/obj/machinery/shieldwallgen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "tJ" = (
-/obj/structure/table/rack,
-/obj/random/solgov,
-/obj/random/solgov,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "tK" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/secure_storage)
-"tL" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
-"tM" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/stack/medical/advanced/bruise_pack,
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"tN" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
-"tO" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white/monotile,
-/area/aquila/medical)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "tR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -8367,19 +7254,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftport)
-"uv" = (
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1;
-	icon_state = "warningcee"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"uw" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
 "ux" = (
 /obj/structure/sign/double/icarus/solgovflag/left{
 	dir = 4;
@@ -8576,30 +7450,6 @@
 "uX" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/auxsolarbridge)
-"uY" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/auxsolarbridge)
-"uZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"vb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "vd" = (
 /obj/machinery/power/shield_generator,
 /obj/structure/cable/green{
@@ -8698,14 +7548,6 @@
 /obj/item/weapon/material/clipboard,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/sea)
-"vn" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
 "vp" = (
 /obj/structure/bed/chair/padded/blue{
 	dir = 8;
@@ -8822,19 +7664,12 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)
-"vK" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"vL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+"vM" = (
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/atmos/alt/sol,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "vO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -9182,14 +8017,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/auxsolarbridge)
-"wr" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "ws" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9810,16 +8637,6 @@
 	},
 /turf/space,
 /area/space)
-"xQ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 1900
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "xR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow{
@@ -9967,27 +8784,10 @@
 /obj/machinery/suit_storage_unit/security/alt,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
-"yk" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
-"yl" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
-/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
+"yv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "yw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -10035,9 +8835,21 @@
 /obj/effect/shuttle_landmark/ninja/deck5,
 /turf/space,
 /area/space)
-"yD" = (
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
+"yC" = (
+/obj/effect/floor_decal/corner/blue/half,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/aft)
 "yL" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	req_access = newlist()
@@ -10098,13 +8910,6 @@
 /obj/effect/shuttle_landmark/torch/deck5/guppy,
 /turf/space,
 /area/space)
-"zc" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "zf" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4;
@@ -10201,15 +9006,16 @@
 /turf/simulated/floor/plating,
 /area/space)
 "zz" = (
-/obj/effect/floor_decal/corner/white/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/command,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
 	dir = 4;
-	icon_state = "tube1"
+	id_tag = "armory_pass";
+	name = "EVA Pass Through Shutter"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/aux_eva)
+/area/command/armoury)
 "zC" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/PDAs{
@@ -10227,6 +9033,12 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
+"zE" = (
+/obj/effect/floor_decal/corner/white/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/command,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "zF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10349,26 +9161,6 @@
 /obj/effect/shuttle_landmark/merc/deck5,
 /turf/space,
 /area/space)
-"Ac" = (
-/obj/structure/closet/crate,
-/obj/random/toolbox,
-/obj/random/powercell,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/weapon/storage/bag/trash,
-/obj/item/weapon/storage/bag/trash,
-/obj/item/weapon/storage/bag/trash,
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/random_multi/single_item/boombox,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Ad" = (
 /obj/structure/bed/chair/office/comfy/blue{
 	dir = 8;
@@ -10387,19 +9179,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Ag" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/passenger)
 "Ah" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1;
@@ -10408,9 +9187,8 @@
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "Ai" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/structure/closet/bombclosetsecurity,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Aj" = (
@@ -10504,6 +9282,20 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/bridge)
+"Ax" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/dutyboots,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
+/obj/machinery/camera/network/command{
+	c_tag = "Emergency Armory - Tactical Starboard";
+	network = list("Command","Medical")
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "Ay" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -10604,8 +9396,8 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/hallway/port)
 "AN" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
+/turf/simulated/wall/r_wall/prepainted,
+/area/space)
 "AR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -10615,14 +9407,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"AU" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
 "AX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10637,6 +9421,14 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"AY" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "AZ" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -10654,25 +9446,41 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
-"Bc" = (
-/obj/machinery/power/smes/buildable/preset/torch/shuttle{
-	RCon_tag = "Shuttle - Aquila"
-	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Bd" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "Bp" = (
-/obj/effect/floor_decal/corner/red/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/security/alt,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
+	dir = 4;
+	name = "CO's suit storage";
+	req_access = list("ACCESS_CAPTAIN")
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/rig/command/co/equipped,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Auxilary EVA";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -10700,6 +9508,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
+"Bx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Emergency Armory Desk"
+	},
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "BB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/button/alternate/door/bolts{
@@ -10767,9 +9592,13 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/co)
 "BO" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
+"BP" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/armoury/access)
 "BR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
@@ -10829,18 +9658,6 @@
 /obj/effect/shuttle_landmark/torch/deck5/aquila,
 /turf/space,
 /area/space)
-"Cc" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Cd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
@@ -10878,22 +9695,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
-"Cg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad/longrange,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
 "Ch" = (
 /obj/structure/bed/chair/comfy/captain{
 	color = "#666666";
@@ -11015,19 +9816,48 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"CD" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
+"Cy" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/airlock)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Emergency Armory - Access";
+	dir = 1;
+	icon_state = "camera"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
+"CD" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "CE" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -11052,6 +9882,11 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/bridge/fore)
+"CL" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "CN" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/aftport)
@@ -11124,32 +9959,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/port)
 "Db" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Head"
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
-"Dc" = (
-/obj/machinery/light/small,
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "Dd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11175,36 +9991,9 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
-"Dq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/rig/command/xo/equipped,
-/obj/machinery/door/window/brigdoor/westright{
-	autoset_access = 0;
-	dir = 8;
-	name = "XO's suit storage";
-	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
-	},
+"Dn" = (
 /turf/simulated/floor/tiled/dark,
-/area/aux_eva)
+/area/command/armoury)
 "Dr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11214,7 +10003,7 @@
 "Dt" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/aux_eva)
 "Du" = (
 /obj/structure/extinguisher_cabinet{
@@ -11228,9 +10017,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Dw" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "Dx" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -11272,9 +10058,25 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "DR" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/head)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/dutyboots,
+/obj/item/clothing/accessory/storage/holster/thigh,
+/obj/item/clothing/glasses/tacgoggles,
+/obj/item/clothing/suit/armor/pcarrier/blue/sol,
+/obj/item/clothing/head/helmet/solgov,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
+"DV" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "DY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -11318,12 +10120,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shield/bridge)
-"Ec" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "Ed" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
@@ -11413,30 +10209,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "Ez" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
-"EE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/power/apc/shuttle/aquila{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
+/obj/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "EJ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
@@ -11495,31 +10271,35 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "Fc" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 4;
-	id_tag = "aquila_shuttle_pump_out_external"
-	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	frequency = 1331;
-	id_tag = "aquila_shuttle_sensor_external";
-	pixel_x = 25;
+/obj/machinery/button/blast_door{
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutter Control";
+	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/structure/handrai{
-	dir = 8;
-	icon_state = "handrail"
+/obj/structure/table/steel,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 5
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1331;
-	master_tag = "aquila_shuttle";
-	name = "exterior access button";
-	pixel_x = 23;
-	pixel_y = 6
+/obj/item/weapon/stamp,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/simulated/floor/airless,
-/area/aquila/airlock)
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/command{
+	c_tag = "Emergency Armory - Access";
+	network = list("Command","Medical")
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/armoury/access)
 "Ff" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -11542,9 +10322,14 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Fi" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Fj" = (
 /obj/machinery/computer/rdservercontrol{
@@ -11584,6 +10369,27 @@
 "Fp" = (
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
+"Fv" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/box/lights/tubes,
+/obj/item/weapon/storage/box/lights/bulbs,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "Fy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11621,9 +10427,17 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "FK" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/energy/laser/secure,
+/obj/item/weapon/gun/energy/laser/secure,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "FL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -11682,13 +10496,46 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Gc" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
+/obj/structure/table/steel,
+/obj/random/clipboard,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/hand_labeler,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/head)
+/obj/machinery/alarm{
+	alarm_id = "xenobio4_alarm";
+	dir = 2;
+	icon_state = "alarm0";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "operation_hallway_shutters";
+	name = "Hallway Checkpoint Shutters";
+	pixel_x = 35;
+	pixel_y = 6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "armory_pass";
+	name = "Armory EVA Pass Through Shutter Control";
+	pixel_x = 35;
+	pixel_y = -6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "armory_entrylock";
+	name = "Armory Entry Lockdown Shutter Control";
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "armory_lock";
+	name = "Armory Lockdown Shutter Control";
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/command/armoury/access)
 "Ge" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11773,6 +10620,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
+"Gt" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Emergency Armory - Fore";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "Gy" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -11813,6 +10671,9 @@
 	},
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"GL" = (
+/turf/simulated/wall/r_wall/hull,
+/area/command/armoury)
 "GU" = (
 /obj/structure/displaycase,
 /obj/item/weapon/gun/projectile/revolver/medium/captain{
@@ -11907,26 +10768,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Hg" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 1;
-	id_tag = "aquila_shuttle_pump_out_internal"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/structure/handrai,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
 "Hh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12224,18 +11065,6 @@
 /obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
-"Ib" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/cockpit)
 "Id" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12470,14 +11299,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
-"IJ" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
 "IK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -12492,17 +11313,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "IL" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/airless,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "IO" = (
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/carpet,
@@ -12531,12 +11346,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"IW" = (
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/atmos/alt/sol,
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
 "IY" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/blue{
@@ -12586,20 +11395,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
 "Jg" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "aquila_shuttle_pump"
-	},
-/obj/machinery/oxygen_pump{
-	pixel_y = 32
-	},
-/obj/structure/handrai,
 /obj/effect/floor_decal/techfloor{
-	dir = 1;
+	dir = 8;
 	icon_state = "techfloor_edges"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Jh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12647,26 +11449,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
 "JA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/aquila/storage)
-"JE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "JF" = (
 /obj/structure/grille,
 /obj/structure/railing/mapped{
@@ -12679,13 +11469,20 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
+"JM" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "JT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
-"JV" = (
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "Ka" = (
 /obj/structure/cable/green,
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -12699,11 +11496,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/rd)
-"Kc" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
 "Kd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12852,14 +11644,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"KN" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/medical)
 "KP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
@@ -12873,6 +11657,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
+"KQ" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/armoury)
+"KR" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/suit_cycler,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "KX" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -12932,30 +11725,28 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "Lg" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	icon_state = "wrecharger0";
+	pixel_y = -22
+	},
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
-	id_tag = "aquila_shuttle_sensor";
-	pixel_x = 0;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
-	},
-/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Lh" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -12965,29 +11756,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
-"Li" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
-	},
-/obj/item/device/radio/beacon/anchored{
-	level = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13108,15 +11876,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/storage)
-"LQ" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/turf/simulated/floor/airless,
-/area/aquila/maintenance)
 "Ma" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13135,26 +11894,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Mc" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	cycle_to_external_air = 1;
-	frequency = 1331;
-	id_tag = "aquila_shuttle";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list("ACCESS_TORCH_AQUILA");
-	tag_exterior_sensor = "aquila_shuttle_sensor_external"
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
-	dir = 2;
-	id_tag = "aquila_shuttle_pump"
-	},
-/obj/structure/handrai,
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
+/obj/item/weapon/gun/energy/gun/secure,
+/obj/item/weapon/gun/energy/gun/secure,
+/obj/item/weapon/gun/energy/gun/secure,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Mf" = (
 /obj/structure/table/woodentable_reinforced/walnut/maple,
 /obj/item/weapon/folder/envelope/captain,
@@ -13233,32 +11984,23 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
-"Mw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
 "Mz" = (
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/heads/office/co)
 "MA" = (
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
+"MB" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "MD" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
-"MU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 8;
-	icon_state = "shuttle_chair_preview"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "MV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13281,22 +12023,32 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
 "Nc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Emergency Armory"
 	},
-/obj/structure/handrai{
-	dir = 1;
-	icon_state = "handrail"
+/obj/machinery/door/blast/regular/open{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "armory_entrylock";
+	name = "Armory Lockdown Shutters";
+	opacity = 1
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/item/device/radio/intercom/hailing{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "Nd" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -13441,6 +12193,14 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
+"Nz" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "ND" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/alarm{
@@ -13509,19 +12269,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/foreport)
-"Ob" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Crew Area"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
 "Oc" = (
 /obj/structure/sign/solgov{
 	pixel_x = 32;
@@ -13637,14 +12384,24 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "Ok" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/rack{
+	dir = 4
 	},
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "Om" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -13714,29 +12471,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
-"OX" = (
-/obj/machinery/shipsensors,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
-/area/aquila/passenger)
-"Pb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Passenger Seating"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/passenger)
 "Pc" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -13815,6 +12549,16 @@
 "Pt" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
+"Pu" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "Py" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 4;
@@ -13843,24 +12587,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)
-"PC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/airlock)
 "PF" = (
 /obj/structure/sign/double/icarus/solgovflag/right{
 	dir = 4;
@@ -13869,34 +12595,33 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
-"PP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+"PU" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/item/stack/material/phoron{
+	amount = 25
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/item/stack/material/phoron{
+	amount = 25
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/medical)
-"Qb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/shuttle_landmark/torch/hangar/aquila,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/cyan{
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad/longrange,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
+/area/command/armoury)
 "Qc" = (
 /obj/machinery/door/airlock/glass/command{
-	name = "Auxiliary E.V.A.";
+	name = "Command Storage";
 	secured_wires = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14072,34 +12797,6 @@
 /obj/random_multi/single_item/summarydocuments/explo,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"Qz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/handrai,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"QE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aux_eva)
-"QF" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/passenger)
 "QK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -14113,9 +12810,14 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/bridge/fore)
 "QL" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/storage)
+/obj/machinery/door/airlock/glass/command{
+	name = "Emergency Armory";
+	secured_wires = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/command/armoury)
 "QN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -14201,17 +12903,6 @@
 /obj/machinery/computer/modular/preset/security,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
-"Rb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Infirmary"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/medical)
 "Rd" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -14266,10 +12957,6 @@
 "Rh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14369,14 +13056,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "Rz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -14422,10 +13108,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/fore)
-"RH" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/medical)
 "RK" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -14487,22 +13169,36 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/co)
 "Sb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Storage"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/aquila/storage)
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "Sd" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/device/flashlight/lamp,
@@ -14537,36 +13233,31 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "Sg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 8;
-	display_name = "Bridge Deck Dock";
-	frequency = 1331;
-	id_tag = "aquila_shuttle_dock_airlock";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_TORCH_CREW"));
-	tag_airpump = "aquila_shuttle_dock_pump";
-	tag_chamber_sensor = "aquila_shuttle_dock_sensor";
-	tag_exterior_door = "aquila_shuttle_dock_outer";
-	tag_interior_door = "aquila_shuttle_dock_inner"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/aft)
-"Sh" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/bridge/aft)
+"Sh" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/weapon/inflatable_dispenser,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Sj" = (
@@ -14582,6 +13273,33 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
+"Sl" = (
+/obj/machinery/camera/network/command{
+	c_tag = "Emergency Armory - Starboard";
+	network = list("Command","Medical")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
+"Sm" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/command{
+	name = "Emergency Armory Access";
+	secured_wires = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/command/armoury/access)
 "Sn" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -14592,28 +13310,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"So" = (
-/obj/machinery/alarm{
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/machinery/cryopod,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aquila/passenger)
-"SA" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "aquila_shutters";
-	name = "Protective Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/cockpit)
+"Sq" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/flasher/portable,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "SB" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/tape/random,
@@ -14682,22 +13383,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
-"SQ" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/medical)
 "SU" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
+/obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "SV" = (
@@ -14726,18 +13421,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"Tb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Infirmary"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/aquila/medical)
 "Tc" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -14798,47 +13481,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room/deliberation)
 "Tg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_dock_inner";
-	locked = 1;
-	name = "Docking Port Airlock";
-	req_access = list("ACCESS_TORCH_CREW")
-	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
-"Th" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/weapon/inflatable_dispenser,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Command";
-	dir = 2
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/aux_eva)
 "Ti" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/corner/research/mono,
@@ -14949,10 +13604,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "TQ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -14960,6 +13611,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/research/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -14985,23 +13639,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/office/cl/backroom)
+"TW" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10;
+	icon_state = "corner_techfloor_grid"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "TX" = (
 /turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room)
-"Ub" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/maintenance)
 "Uc" = (
 /obj/machinery/photocopier/faxmachine/torch{
 	department = "Torch - Corporate Liasion"
@@ -15047,52 +13697,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room/deliberation)
 "Ug" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_dock_outer";
-	locked = 1;
-	name = "Docking Port Airlock";
-	req_access = list("ACCESS_TORCH_CREW")
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
-"Uh" = (
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/westright{
-	autoset_access = 0;
-	dir = 8;
-	name = "CO's suit storage";
-	req_access = list("ACCESS_CAPTAIN")
-	},
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/rig/command/co/equipped,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/aux_eva)
+/area/command/armoury/access)
 "Ui" = (
 /obj/structure/sign/ecplaque{
 	pixel_y = 30
@@ -15184,18 +13801,36 @@
 /obj/effect/shuttle_landmark/ert/deck5,
 /turf/space,
 /area/space)
-"UW" = (
-/obj/structure/shuttle/engine/heater,
+"UV" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10;
-	icon_state = "intact"
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
 	},
-/turf/simulated/floor/airless,
-/area/aquila/medical)
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/rig/command/xo/equipped,
+/obj/machinery/door/window/brigdoor/westright{
+	autoset_access = 0;
+	dir = 4;
+	name = "XO's suit storage";
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/aux_eva)
 "UX" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/blue,
@@ -15205,28 +13840,6 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
-"Vb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/power/apc/hyper/shuttle/aquila{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "Vc" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
@@ -15255,25 +13868,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Vg" = (
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	density = 1;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_outer";
-	locked = 1;
-	name = "Aquila External Access";
-	req_access = list("ACCESS_TORCH_CREW")
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/shield_diffuser,
-/obj/structure/cable{
-	d1 = 4;
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "Vh" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random_multi/single_item/runtime,
@@ -15347,12 +13956,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
-"Vs" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/aquila/secure_storage)
 "Vw" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -15392,6 +13995,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
+"Vx" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/stack/nanopaste,
+/obj/item/bodybag/rescue/loaded,
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury)
 "VB" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -15464,33 +14091,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bridgecheck)
-"Wb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "Wd" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -15529,26 +14129,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "Wg" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	icon_state = "wrecharger0";
+	pixel_y = -22
 	},
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1331;
-	icon_state = "closed";
-	id_tag = "aquila_shuttle_inner";
-	locked = 1;
-	name = "Aquila External Access";
-	req_access = list("ACCESS_TORCH_CREW")
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/aquila/airlock)
+/area/command/armoury/tactical)
 "Wh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15594,18 +14189,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "Ws" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/aquila/secure_storage)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "Wv" = (
 /obj/structure/closet/secure_closet/bridgeofficer,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"Ww" = (
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
 "WK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -15669,21 +14263,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
-"Xb" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/obj/structure/handrai,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/aquila/maintenance)
 "Xe" = (
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/carpet/blue2,
@@ -15742,11 +14321,30 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
+"Xl" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2;
+	level = 2
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "Xp" = (
-/obj/structure/sign/solgov,
-/obj/effect/paint/hull,
-/turf/simulated/wall/titanium,
-/area/aquila/airlock)
+/obj/structure/table/steel,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/machinery/recharger/wallcharger{
+	dir = 8;
+	icon_state = "wrecharger0";
+	pixel_x = 23;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/armoury/access)
 "Xq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15768,6 +14366,12 @@
 "Xr" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/bridge/forestarboard)
+"Xs" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
+/obj/machinery/flasher/portable,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury)
 "Xx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/door/airlock/medical{
@@ -15808,10 +14412,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "XI" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/hull,
-/turf/simulated/floor/plating,
-/area/aquila/airlock)
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/flashbangs,
+/obj/item/weapon/storage/box/smokes,
+/obj/item/weapon/storage/box/handcuffs,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "XJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15885,16 +14505,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
-"Yb" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Yd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15963,15 +14573,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Yh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
@@ -16096,16 +14705,19 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/aft)
 "YW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6;
+	icon_state = "corner_techfloor_grid"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "YX" = (
@@ -16122,24 +14734,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
-"YY" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/aquila/mess)
-"Zb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/aquila/maintenance)
 "Ze" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16183,9 +14777,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "Zh" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/aux_eva)
 "Zi" = (
@@ -16204,24 +14796,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
-"Zj" = (
-/obj/structure/hygiene/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/mirror{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/aquila/head)
 "Zs" = (
 /obj/machinery/computer/account_database,
 /obj/machinery/recharger/wallcharger{
@@ -16254,29 +14828,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "Zy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/aux_eva)
-"ZA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/handrai,
-/turf/simulated/floor/tiled/dark,
-/area/aquila/airlock)
-"ZB" = (
-/obj/effect/paint/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/wall/titanium,
-/area/aquila/maintenance)
 "ZD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -32007,7 +30563,7 @@ on
 on
 on
 on
-uY
+on
 Pc
 wn
 wT
@@ -32205,11 +30761,11 @@ Qh
 Xh
 di
 qi
-yi
+UV
 Bp
-Ci
+sg
 on
-uY
+on
 vI
 wo
 wU
@@ -32405,13 +30961,13 @@ aX
 Qc
 Rh
 Yh
-Yh
+oE
 TQ
 Rz
 SU
 YW
 on
-dV
+CO
 vJ
 wp
 wV
@@ -32602,18 +31158,18 @@ hJ
 hJ
 jZ
 kS
-lN
+lH
 nc
 ol
 oW
 Zh
-hi
-pR
-yD
+Zh
+Zh
+Zh
 Fi
 Dt
 on
-dV
+CO
 dV
 wq
 wW
@@ -32805,17 +31361,17 @@ hK
 DN
 kT
 lO
-nd
+kT
 on
 Sh
-pQ
-pQ
-QE
+yi
+yi
+Ci
 Ai
-Ai
+Pu
 Zy
 on
-dV
+CO
 dV
 Tc
 dV
@@ -33005,19 +31561,19 @@ DN
 DN
 DN
 DN
-kU
+kP
 Sg
 ne
-on
-Th
-Dq
-Uh
-fH
-bk
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
 zz
-IW
-on
-dV
+KQ
+KQ
+GL
 dV
 ws
 dV
@@ -33207,19 +31763,19 @@ DN
 DN
 DN
 DN
-DN
+kM
 Tg
-DN
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-CO
-dV
+yC
+KQ
+Dn
+zE
+vM
+zE
+PU
+TW
+iM
+iM
+GL
 ad
 wt
 aH
@@ -33407,22 +31963,22 @@ DN
 DN
 DN
 DN
-DN
-DN
-DN
+BP
+BP
+Bx
 lR
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-DN
-dV
-vK
+Sm
+GL
+Dn
+Dn
+Dn
+Dn
+Dn
+TW
+Sq
+Xs
+GL
+ji
 cP
 ah
 av
@@ -33605,26 +32161,26 @@ ad
 ad
 ad
 ad
-ad
+ji
 fj
 eb
-eb
-Ec
+DV
+BP
 Fc
-DN
+MB
 Ug
-DN
+Cy
 QL
-QL
-QL
-QL
-QL
+yv
+KR
+AY
+tq
 BO
-BO
+TW
 Ws
-Ws
-Ws
-vL
+Gt
+KQ
+ji
 cP
 ah
 av
@@ -33807,26 +32363,26 @@ ad
 ad
 ad
 ad
-ad
-gY
+ji
+fj
 DR
-DR
-DR
+qy
+BP
 Gc
 Xp
 Vg
 CD
-QL
-oZ
-pS
+GL
+Dn
+Dn
 qD
-rv
-BO
-sU
+Dn
+Dn
+TW
 tI
-lp
-Vs
-vL
+tI
+KQ
+ji
 cP
 ah
 av
@@ -34009,26 +32565,26 @@ ad
 ad
 ad
 ad
-ad
-gY
+ji
+fj
 DR
-it
-je
-Zj
-Kc
-Hg
+qy
+BP
+BP
+BP
+BP
 Nc
-QL
-pa
+GL
+Dn
 pT
 qE
 JA
-sn
-sV
+Vx
+TW
 tJ
-IL
-Vs
-vL
+tJ
+KQ
+ji
 cP
 ah
 av
@@ -34211,26 +32767,26 @@ ad
 ad
 ad
 ad
+ji
 fj
-fk
 DR
-DR
-jf
+qy
+fj
 kb
 FK
 Mc
 Lg
-QL
+KQ
 pb
-pU
-qF
-rw
-BO
-sW
+Dn
+Dn
+Dn
+Dn
+TW
 tK
 IL
-Vs
-vL
+KQ
+ji
 cP
 ah
 av
@@ -34411,28 +32967,28 @@ cP
 ad
 ad
 ad
+ad
+ad
+ji
 fj
-eb
-fk
-gZ
 DR
-iu
+qy
 jg
 kc
-FK
+Xl
 Jg
 ni
-QL
-QL
+KQ
+Sl
 Sb
-QL
-QL
-BO
-BO
+Vx
+CL
+Fv
+TW
 Ez
-IJ
-Ws
-vL
+Ez
+KQ
+ji
 cP
 ah
 av
@@ -34610,31 +33166,31 @@ ah
 av
 aI
 cP
+ad
+ad
+ad
+ad
+ad
+ji
 fj
-eb
-eb
-fk
-ec
-ec
-ec
-DR
-DR
-DR
+Ax
+JM
+Nz
 Db
-FK
-XI
+Db
+Db
 Wg
-FK
+KQ
 pc
-PC
-Ww
-xQ
+pc
+pc
+pc
+pc
 rx
-rx
-ZB
-uv
-uZ
-nE
+KQ
+KQ
+KQ
+ji
 cP
 ah
 av
@@ -34812,31 +33368,31 @@ ah
 av
 aI
 cP
-gY
-ec
-SA
-SA
-ec
-go
-ec
-hL
-iv
+ad
+ad
+ad
+ad
+ad
+ji
+fj
+fj
+fj
 jh
 ke
 XI
 lX
 nk
 pd
-pd
+mf
 pW
 Ok
 ry
 so
 sY
-ZB
-yk
-vL
-ad
+KQ
+KQ
+ji
+ji
 cP
 ah
 av
@@ -35014,30 +33570,30 @@ ah
 av
 aI
 cP
-gY
-Ib
-eH
-fm
-fJ
-gp
-ha
-hM
+ad
+ad
+ad
+ad
+ad
+ji
+ji
+ji
 AN
-Mw
-kf
-XI
-ZA
-nl
-Dw
-Dw
-pX
-Ww
-Vb
-Zb
-Ac
-tL
-uw
-vL
+fj
+fj
+fj
+fj
+fj
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+GL
+ji
+ji
 ad
 cP
 ah
@@ -35216,30 +33772,30 @@ ah
 av
 aI
 cP
-gY
-Ib
-eI
-fn
-fK
-gq
-hb
-hN
-iw
-Cg
-kg
-Ob
-Li
-nm
-Qb
-pf
-pY
-Ub
-Wb
-ac
-Bc
-tL
-uw
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ji
+ad
+ad
+ad
 ad
 cP
 ah
@@ -35418,30 +33974,30 @@ ah
 av
 aI
 cP
-gY
-Ib
-eJ
-fm
-fL
-gr
-ha
-YY
-ix
-jj
-AN
-XI
-Qz
-nn
-Dw
-Dw
-pZ
-Ww
-Xb
-tc
-Cc
-LQ
-uw
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 cP
 ah
@@ -35620,30 +34176,30 @@ ah
 av
 aI
 cP
-gY
-ec
-SA
-SA
-ec
-gs
-ec
-hO
-iy
-jk
-kh
-XI
-lZ
-no
-MU
-ph
-EE
-Ww
-Yb
-zc
-Dc
-ZB
-yk
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 ad
 cP
 ah
@@ -35822,31 +34378,31 @@ ah
 av
 aI
 cP
-fp
-eg
-eg
-nr
-ec
-ec
-ec
-QF
-QF
-QF
-QF
-QF
-Pb
-QF
-gw
-oU
-Tb
-gw
-KN
-PP
-td
-ZB
-uv
-vb
-vK
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36027,28 +34583,28 @@ cP
 ad
 ad
 ad
-fp
-eg
-nr
-hc
-QF
-QF
-jl
-ki
-kW
-mb
-np
-gw
-pi
-qb
-gw
-gw
-gw
-gw
-AU
-mx
-RH
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36231,26 +34787,26 @@ ad
 ad
 ad
 ad
-fp
-nr
-OX
-iz
-JV
-JV
-JV
-wr
-vn
-Rb
-pj
-qc
-aM
-yl
-st
-te
-tM
-fX
-SQ
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36434,25 +34990,25 @@ ad
 ad
 ad
 ad
-gY
-QF
-QF
-So
-iA
-iA
-iA
-nq
-gw
-pk
-JE
-qd
-qd
-qd
-qd
-tN
-fX
-SQ
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36636,25 +35192,25 @@ ad
 ad
 ad
 ad
-gY
-QF
-QF
-QF
-Ag
-Ag
-QF
-QF
-gw
-pl
-qe
-qI
-rE
-su
-tf
-tO
-UW
-SQ
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -36838,25 +35394,25 @@ ad
 ad
 ad
 ad
-fp
-eg
-eg
-eg
-eg
-eg
-eg
-nr
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-RH
-RH
-RH
-vL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av
@@ -37047,18 +35603,18 @@ ad
 ad
 ad
 ad
-fp
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-eg
-nE
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
 cP
 ah
 av

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -621,8 +621,6 @@
 
 /area/command/armoury/tactical
 	name = "\improper Emergency Armory - Tactical"
-	icon_state = "Tactical"
-	req_access = list(access_emergency_armory)
 
 /area/command/disperser
 	name = "\improper Obstruction Field Disperser"
@@ -1187,7 +1185,7 @@
 	req_access = list(access_eva)
 
 /area/aux_eva
-	name = "\improper Command EVA Storage"
+	name = "\improper Auxilary EVA Storage"
 	icon_state = "eva"
 	req_access = list(access_eva)
 

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -447,7 +447,6 @@ TORCH_ESCAPE_POD(17)
 	name = "Aquila Hangar"
 	landmark_tag = "nav_hangar_aquila"
 	docking_controller = "aquila_shuttle_dock_airlock"
-	base_turf = /turf/simulated/floor/reinforced/airless
 
 /obj/effect/shuttle_landmark/torch/deck1/aquila
 	name = "Space near Forth Deck"


### PR DESCRIPTION
:cl:
maptweak: Petrov has been moved to D1 aft. Research has been altered to have a back entrance that connects petrov to research.
maptweak: Emergency Armory has been moved to D4. The contents of the soft armory have been added to the storage bays previously unused. The tactical armory has replaced pathfinders office a short walk aft of the elevator.
maptweak: Pathfinder's office has been moved to D5

