### PR TITLE
CE suit storage finally has access requirements

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3263,8 +3263,9 @@
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/brigdoor/westright{
-	dir = 8;
-	name = "CE's Equipment Storage"
+	autoset_access = 0;
+	name = "CE's suit storage";
+	req_access = list("ACCESS_CHIEF_ENGINEER")
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/window/reinforced{


### PR DESCRIPTION
🆑
bugfix: Bridge EVA Chief Engineer suit storage now requires Chief Engineer access.
/🆑

Reminded to do this by a recent round. 