### PR TITLE
Adds chat colours for most human languages to goonchat: Take 2

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -345,19 +345,19 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .tajaran_signlang		{color: #941c1c;}
 .skrell					{color: #00ced1;}
 .soghun					{color: #228b22;}
+.yeosa 					{color: #218b89;}
 .nabber_lang			{color: #525252;}
 .solcom					{color: #22228b;}
 .vox					{color: #aa00aa;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif; color: #7c6256}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-.terran					{color: #9c250b;}
+.russian				{color: #9c250b;}
 .moon					{color: #422863;}
 .spacer					{color: #ff6600;}
-.selenian				{color: #5a83c5;}
-.arabic					{color: #95d16c;}
-.chinese				{color: #7d60cc;}
-.indian					{color: #5dbba4;}
-.russian				{color: #c45c72;}
+.selenian				{color: #324bbd;}
+.arabic					{color: #5a853e;}
+.chinese				{color: #d4a52a;}
+.indian					{color: #634c81;}
 .iberian				{color: #be4ac9;}
 
 .interface				{color: #750e75;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -342,14 +342,20 @@ h1.alert, h2.alert		{color: #000080;}
 .tajaran_signlang		{color: #941c1c;}
 .skrell					{color: #00ced1;}
 .soghun					{color: #228b22;}
+.yeosa 					{color: #218b89;}
 .nabber_lang			{color: #525252;}
 .solcom					{color: #22228b;}
 .vox					{color: #aa00aa;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-.terran					{color: #9c250b;}
+.russian				{color: #9c250b;}
 .moon					{color: #422863;}
 .spacer					{color: #ff6600;}
+.selenian				{color: #324bbd;}
+.arabic					{color: #5a853e;}
+.chinese				{color: #d4a52a;}
+.indian					{color: #634c81;}
+.iberian				{color: #be4ac9;}
 
 .interface				{color: #750e75;}
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Alright! Now I'm awake and feeling more sensible, let's have another go at this.
This PR adds chat colours for most human languages to goonchat, making it easier to distinguish when someone is speaking a different language. The chat colours are mostly the same as oldchat, with the exception of spacer, which keeps the new 'bright orange' colour.
This PR also adds a chat colour for Yeosa'unathi in the form of the same light blue it has in oldchat.
Fixes #29610

:cl: SealCure
rscadd: Most human languages now have chat colours when using goonchat.
bugfix: Yeosa'unathi now has the same chat colour in goonchat as oldchat.
/:cl: