### PR TITLE
Tweaks to top mounted & merc smg's, machine pistol

### DIFF
--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -119,7 +119,7 @@
 /datum/uplink_item/item/visible_weapons/machine_pistol
 	name = "Standard Machine Pistol"
 	desc = "A high rate of fire weapon in a smaller form factor, able to sling standard ammunition almost as quick as a submachine gun."
-	item_cost = 45
+	item_cost = 42
 	path = /obj/item/weapon/gun/projectile/automatic/machine_pistol
 
 /datum/uplink_item/item/visible_weapons/combat_shotgun

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -102,7 +102,7 @@
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/pistol
 	matter = list(MATERIAL_STEEL = 1200)
-	caliber = CALIBER_PISTOL
+	caliber = CALIBER_PISTOL_SMALL
 	max_ammo = 16
 	multiple_sprites = 1
 
@@ -114,9 +114,9 @@
 	icon_state = "smg_top"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/pistol/small
-	matter = list(MATERIAL_STEEL = 1200)
-	caliber = CALIBER_PISTOL_SMALL
-	max_ammo = 20
+	matter = list(MATERIAL_STEEL = 1350)
+	caliber = CALIBER_PISTOL
+	max_ammo = 18
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/smg_top/empty
@@ -124,11 +124,11 @@
 
 /obj/item/ammo_magazine/smg_top/rubber
 	labels = list("rubber")
-	ammo_type = /obj/item/ammo_casing/pistol/small/rubber
+	ammo_type = /obj/item/ammo_casing/pistol/rubber
 
 /obj/item/ammo_magazine/smg_top/practice
 	labels = list("practice")
-	ammo_type = /obj/item/ammo_casing/pistol/small/practice
+	ammo_type = /obj/item/ammo_casing/pistol/practice
 
 /obj/item/ammo_magazine/smg
 	name = "box magazine"
@@ -136,9 +136,9 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = CALIBER_PISTOL
-	matter = list(MATERIAL_STEEL = 1500)
+	matter = list(MATERIAL_STEEL = 1600)
 	ammo_type = /obj/item/ammo_casing/pistol
-	max_ammo = 20
+	max_ammo = 25
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/smg/empty

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -32,7 +32,7 @@
 	icon_state = "mpistolen"
 	safety_icon = "safety"
 	item_state = "mpistolen"
-	caliber = CALIBER_PISTOL
+	caliber = CALIBER_PISTOL_SMALL
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2, TECH_ESOTERIC = 3)
 	ammo_type = /obj/item/ammo_casing/pistol
 	magazine_type = /obj/item/ammo_magazine/machine_pistol
@@ -141,10 +141,10 @@
 	item_state = "wt550"
 	safety_icon = "safety"
 	w_class = ITEM_SIZE_NORMAL
-	caliber = CALIBER_PISTOL_SMALL
+	caliber = CALIBER_PISTOL
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT
-	ammo_type = /obj/item/ammo_casing/pistol/small
+	ammo_type = /obj/item/ammo_casing/pistol
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/smg_top/rubber
 	allowed_magazines = /obj/item/ammo_magazine/smg_top
@@ -265,7 +265,7 @@
 	mag_insert_sound = 'sound/weapons/guns/interaction/lmg_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/lmg_magout.ogg'
 	can_special_reload = FALSE
-	
+
 	//LMG, better sustained fire accuracy than assault rifles (comparable to SMG), higer move delay and one-handing penalty
 	//No single-shot or 3-round-burst modes since using this weapon should come at a cost to flexibility.
 	firemodes = list(


### PR DESCRIPTION
🆑 
tweak: The top-mounted SMG uses 10mm ammo, and has a slightly lower capacity & higher steel cost
tweak: The merc SMG has a slightly higher ammo capacity and steel cost.
tweak: The machine pistol no longer uses 10mm ammo, and has a slightly lower TC cost to compensate.
/🆑

Made after a code dive noticed the top-mounted uses the tiny ammo found in in holdout weapons, while the automatic pistol uses the higher caliber found in larger pistols and the merc SMG. Open to using a different ammo type, but there's no real reason for it to be doing less damage than a pistol that sports better one-handed accuracy, smaller ammo magazine size and keeps the burst power. Tweaked the merc SMG magazine size so it still has a leg up on the top-mounted - again, open to tweaking these more.
