### PR TITLE
Removes traitor from department heads

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -5,7 +5,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 	id = MODE_TRAITOR
 	antaghud_indicator = "hud_traitor"
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/submap)
-	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	skill_setter = /datum/antag_skill_setter/station
 


### PR DESCRIPTION
🆑 
tweak: Department heads cannot be traitors anymore.
/ 🆑 

Department heads (CE, CMO, CSO and the COS) hold extensive amounts of power. The CE has total control over ship systems, the CMO can declare anyone unfit for duty, the CSO can print firearms en masse - to be short, they all have extensive potential to hurt other people's rounds w/out adding anything more interesting by their being antags. There's reasons the CO, XO and COS can't be traitors. The leadership position can leave you accountable to none.

Nevermind that these are trusted officers of the fleet or EC, who've proven they can be trusted and are (relatively) well-behaved individuals. I find it hard to justify someone who's been placed in charge of a ship's entire department suddenly jumping turncoat in the manner that most traitor rounds go down.

I toyed with giving them back head loyalist in exchange, but that change was made by staff and I'm reluctant to throw that in this PR.
