### PR TITLE
Adds an exploration-specific tcomms server to the map

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -23,8 +23,7 @@
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub", "relay", "c_relay", "s_relay", "m_relay", "r_relay", "b_relay", "1_relay", "2_relay", "3_relay", "4_relay", "5_relay", "s_relay", "science", "medical",
-	"supply", "service", "common", "command", "engineering", "security", "unused",
-	"receiverA", "broadcasterA")
+	"supply", "service", "common", "command", "engineering", "security", "receiverA", "broadcasterA")
 
 /obj/machinery/telecomms/hub/preset_cent
 	id = "CentComm Hub"
@@ -102,14 +101,7 @@
 	id = "Bus 2"
 	network = "tcommsat"
 	freq_listening = list(SUP_FREQ, SRV_FREQ)
-	autolinkers = list("processor2", "supply", "service", "unused")
-
-/obj/machinery/telecomms/bus/preset_two/New()
-	for(var/i = PUBLIC_LOW_FREQ, i < PUBLIC_HIGH_FREQ, i += 2)
-		if(i == AI_FREQ || i == PUB_FREQ || i == MED_I_FREQ || i == SEC_I_FREQ || i == HAIL_FREQ)
-			continue
-		freq_listening |= i
-	..()
+	autolinkers = list("processor2", "supply", "service")
 
 /obj/machinery/telecomms/bus/preset_three
 	id = "Bus 3"
@@ -122,6 +114,13 @@
 	network = "tcommsat"
 	freq_listening = list(ENG_FREQ, AI_FREQ, PUB_FREQ, ENT_FREQ, MED_I_FREQ, SEC_I_FREQ, HAIL_FREQ)
 	autolinkers = list("processor4", "engineering", "common")
+
+/obj/machinery/telecomms/bus/preset_four/New()
+	for(var/i = PUBLIC_LOW_FREQ, i < PUBLIC_HIGH_FREQ, i += 2)
+		if(i == AI_FREQ || i == PUB_FREQ || i == MED_I_FREQ || i == SEC_I_FREQ || i == HAIL_FREQ)
+			continue
+		freq_listening |= i
+	..()
 
 /obj/machinery/telecomms/bus/preset_cent
 	id = "CentComm Bus"
@@ -241,12 +240,7 @@
 	autolinkers = list("common")
 
 // "Unused" channels, AKA all others.
-/obj/machinery/telecomms/server/presets/unused
-	id = "Unused Server"
-	freq_listening = list()
-	autolinkers = list("unused")
-
-/obj/machinery/telecomms/server/presets/unused/New()
+/obj/machinery/telecomms/server/presets/common/New()
 	for(var/i = PUBLIC_LOW_FREQ, i < PUBLIC_HIGH_FREQ, i += 2)
 		if(i == AI_FREQ || i == PUB_FREQ || i == MED_I_FREQ || i == SEC_I_FREQ || i == HAIL_FREQ)
 			continue

--- a/maps/torch/items/machinery.dm
+++ b/maps/torch/items/machinery.dm
@@ -17,30 +17,28 @@
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub", "relay", "c_relay", "s_relay", "m_relay", "r_relay", "b_relay", "1_relay", "2_relay", "3_relay", "4_relay", "5_relay", "s_relay", "science", "medical",
-	"supply", "service", "common", "command", "engineering", "security", "exploration", "unused",
- 	"receiverA", "broadcasterA")
+	"supply", "service", "common", "command", "engineering", "security", "exploration", "receiverA", "broadcasterA")
 
 /obj/machinery/telecomms/receiver/preset_right
 	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, EXP_FREQ, MED_I_FREQ, SEC_I_FREQ)
 
 /obj/machinery/telecomms/bus/preset_two
 	freq_listening = list(SUP_FREQ, SRV_FREQ, EXP_FREQ)
-	autolinkers = list("processor2", "supply", "service", "exploration", "unused")
+	autolinkers = list("processor2", "supply", "service", "exploration")
 
 /obj/machinery/telecomms/server/presets/service
-	id = "Service and Exploration Server"
-	freq_listening = list(SRV_FREQ, EXP_FREQ)
+	id = "Service Server"
+	freq_listening = list(SRV_FREQ)
 	channel_tags = list(
 		list(SRV_FREQ, "Service", COMMS_COLOR_SERVICE),
-		list(EXP_FREQ, "Exploration", COMMS_COLOR_EXPLORER)
 	)
-	autolinkers = list("service", "exploration")
+	autolinkers = list("service")
 
 /obj/machinery/telecomms/server/presets/exploration
-	id = "Utility Server"
+	id = "Exploration Server"
 	freq_listening = list(EXP_FREQ)
 	channel_tags = list(list(EXP_FREQ, "Exploration", COMMS_COLOR_EXPLORER))
-	autolinkers = list("Exploration")
+	autolinkers = list("exploration")
 
 // Suit cyclers and storage
 /obj/machinery/suit_cycler/exploration

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3495,8 +3495,8 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hc" = (
-/obj/machinery/telecomms/server/presets/unused,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/telecomms/server/presets/exploration,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hd" = (


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
While attempting to wrap my head around tcomms code, I noticed that there seemed to be no references at all to an Exploration server. Turns out the Exploration channel is handled by the same server as the Service channel, being the only such channel to not get its own dedicated tcomms server. In its place on the map there's the 'unused' tcomms server, which appears to serve no purpose at all from what I can tell. This PR adds a dedicated Exploration server to the tcomms room in place of the unused server, and moves handling of the exploration channel from the Service server to this new dedicated server.

:cl: SealCure
tweak: Moves handling of the Exploration comms channel from the Service server to a dedicated server. Moves the functions of the 'unused' server into the Common server.
maptweak: Replaces the 'unused' tcomms server with the dedicated Exploration server.
/:cl: