### PR TITLE
Changes the kitchen area access to SolGov crew

### DIFF
--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -948,12 +948,12 @@
 /area/crew_quarters/galley
 	name = "\improper Galley"
 	icon_state = "kitchen"
-	req_access = list(access_kitchen)
+	req_access = list(access_solgov_crew)
 
 /area/crew_quarters/galleybackroom
 	name = "\improper Galley Cold Storage"
 	icon_state = "kitchen"
-	req_access = list(access_kitchen)
+	req_access = list(access_solgov_crew)
 
 /area/crew_quarters/commissary
 	name = "\improper Commissary"


### PR DESCRIPTION
🆑 
tweak: The Torch's kitchen areas now require SolGov crew access instead of Kitchen access
/🆑

Made after it was brought up in baycord. Doesn't touch job-given access levels or machines - will adjust as necessary, I just need to be pointed in the direction required. 

 