### PR TITLE
Fix airlock idscan wire functionality

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -499,6 +499,12 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/requiresID()
 	return !(src.isWireCut(AIRLOCK_WIRE_IDSCAN) || aiDisabledIdScanner)
 
+/obj/machinery/door/airlock/check_access()
+	if (isWireCut(AIRLOCK_WIRE_IDSCAN) || aiDisabledIdScanner)
+		return !secured_wires
+	return ..()
+
+
 /obj/machinery/door/airlock/proc/isAllPowerLoss()
 	if(stat & (NOPOWER|BROKEN))
 		return 1


### PR DESCRIPTION
The ID Scan wire's intended to allow access when it's toggled. That's been broken for awhile.

:cl:
bugfix: The ID Scan wire on airlocks now removes access restrictions when pulsed or cut, except for secure airlocks which become permanently access-locked to everyone until fixed.
/:cl: