### PR TITLE
add rings and gcc ranks to wallet can_hold

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -40,7 +40,8 @@
 		/obj/item/clothing/accessory/badge,
 		/obj/item/clothing/accessory/medal,
 		/obj/item/clothing/accessory/armor/tag,
-		)
+		/obj/item/clothing/ring
+	)
 	slot_flags = SLOT_ID
 
 	var/obj/item/weapon/card/id/front_id = null

--- a/maps/torch/items/weapon/storage/wallets.dm
+++ b/maps/torch/items/weapon/storage/wallets.dm
@@ -3,4 +3,5 @@
 	can_hold |= list(
 		/obj/item/clothing/accessory/solgov,
 		/obj/item/clothing/accessory/ribbon,
+		/obj/item/clothing/accessory/terran
 	)


### PR DESCRIPTION
:cl:
tweak: You can store rings in wallets.
/:cl:

Not bothering with a changelog entry for the gcc ranks since it's a bugfix based on insane pathing that nobody will actually see in practice