### PR TITLE
Make minor noticeable in body scans

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -352,7 +352,7 @@
 			else if(I["is_bruised"])
 				row += "<td><span class='average'>Moderate</span></td>"
 			else if(I["is_damaged"])
-				row += "<td>Minor</td>"
+				row += "<td><span class='mild'>Minor</span></td>"
 			else
 				row += "<td>None</td>"
 			row += "<td>"
@@ -407,7 +407,7 @@
 /proc/get_severity(amount, var/tag = FALSE)
 	if(!amount)
 		return "none"
-	. = "minor"
+
 	if(amount > 50)
 		if(tag)
 			. = "<span class='bad'>severe</span>"
@@ -423,3 +423,8 @@
 			. = "<span class='average'>moderate</span>"
 		else
 			. = "moderate"
+	else
+		if (tag)
+			. = "<span class='mild'>minor</span>"
+		else
+			. = "minor"

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -1,5 +1,5 @@
-body 
-{ 
+body
+{
 	padding: 0;
 	margin: 0;
 	background-color: #272727;
@@ -15,8 +15,8 @@ hr
 }
 
 a, a:link, a:visited, a:active, .linkOn, .linkOff, input
-{ 
-	color: #ffffff; 
+{
+	color: #ffffff;
 	text-decoration: none;
 	background: #40628a;
 	border: 1px solid #161616;
@@ -26,15 +26,15 @@ a, a:link, a:visited, a:active, .linkOn, .linkOff, input
 	white-space:nowrap;
 }
 
-a:hover 
-{ 
+a:hover
+{
 	color: #40628a;
 	background: #ffffff;
 }
 
 a.white, a.white:link, a.white:visited, a.white:active
-{ 
-	color: #40628a; 
+{
+	color: #40628a;
 	text-decoration: none;
 	background: #ffffff;
 	border: 1px solid #161616;
@@ -43,22 +43,22 @@ a.white, a.white:link, a.white:visited, a.white:active
 	cursor:default;
 }
 
-a.white:hover 
-{ 
+a.white:hover
+{
 	color: #ffffff;
 	background: #40628a;
 }
 
 .linkOn, a.linkOn:link, a.linkOn:visited, a.linkOn:active, a.linkOn:hover
-{ 
-	color: #ffffff; 
+{
+	color: #ffffff;
 	background: #2f943c;
 	border-color: #24722e;
 }
 
 .linkOff, a.linkOff:link, a.linkOff:visited, a.linkOff:active, a.linkOff:hover
-{ 
-	color: #ffffff; 
+{
+	color: #ffffff;
 	background: #999999;
 	border-color: #666666;
 }
@@ -90,15 +90,15 @@ li
 	padding: 0 0 2px 0;
 }
 
-img, a img 
-{ 
-	border-style:none; 
+img, a img
+{
+	border-style:none;
 }
 
 h1, h2, h3, h4, h5, h6
 {
 	margin: 0;
-	padding: 16px 0 8px 0; 
+	padding: 16px 0 8px 0;
 	color: #517087;
 }
 
@@ -148,7 +148,7 @@ h4
  	right:0px;
  	z-index: 10
  }
- 
+
  .uiTitleButtons
  {
  	position:fixed;
@@ -167,7 +167,7 @@ h4
 }
 
 .uiContent
-{	
+{
 	clear: both;
 	padding: 8px;
 	font-family: Verdana, Geneva, sans-serif;
@@ -178,9 +178,13 @@ h4
 	color: #00ff00;
 }
 
+.mild {
+	color: #e0d000;
+}
+
 .average
 {
-	color: #d09000;
+	color: #f09000;
 }
 
 .bad
@@ -210,7 +214,7 @@ h4
 }
 
 .notice.icon
-{	
+{
 	padding: 2px 4px 0 20px;
 }
 
@@ -274,10 +278,16 @@ div.notice
 	background: #00ff00;
 }
 
+.progressFill.mild
+{
+	color: #ffffff;
+	background: #e0d000;
+}
+
 .progressFill.average
 {
 	color: #ffffff;
-	background: #d09000;
+	background: #f09000;
 }
 
 .progressFill.bad

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -162,6 +162,11 @@ abbr {
     font-weight: bold;
 }
 
+.mild {
+	color: #cda500;
+	font-weight: bold;
+}
+
 .average {
     color: #cd6500;
     font-weight: bold;
@@ -574,7 +579,7 @@ div.notice {
     text-align: center;
 }
 
-table.fixed { 
+table.fixed {
 	table-layout:fixed;
 }
 


### PR DESCRIPTION
Also adds a new `.mild` CSS class that makes things yellow, and serves as a point between `.good` (Green) and `.average` (Orange)

:cl:
tweak: Medical body scanners now highlight 'minor' things in yellow to make them more noticeable.
/:cl:

NOTE: Minor physical trauma is red because physical trauma is red and burns are orange-yellow.

![1H6RHftp5E](https://user-images.githubusercontent.com/11140088/97206338-d198da00-1775-11eb-9e42-6ae26c7c2889.png)
