### PR TITLE
Fix medical safe room bolt control button

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15713,7 +15713,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/button/alternate/door/bolts{
-	id_tag = "medsafe_aft";
+	id_tag = "medsafe_fore";
 	name = "safe room door-control";
 	pixel_x = -25
 	},


### PR DESCRIPTION
:cl:
maptweak: The medical safe room fore bolt button now toggles the fore door instead of the aft door.
/:cl: