### PR TITLE
Assorted description fixes

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -13,7 +13,7 @@
 
 /datum/uplink_item/item/ammo/empslug
 	name = "Haywire Slug"
-	desc = "Single 12-gauge shotgun slug fitted with a single-use ion pulse generator"
+	desc = "Single 12-gauge shotgun slug fitted with a single-use ion pulse generator."
 	item_cost = 1
 	path = /obj/item/ammo_casing/shotgun/emp
 

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -25,7 +25,7 @@
 
 /datum/uplink_item/item/badassery/crayonmre
 	name = "Crayon MRE"
-	desc = "Exceptionally robust MRE"
+	desc = "An exceptionally robust MRE."
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
 	path = /obj/item/weapon/storage/mre/menu11/special
 

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -75,7 +75,7 @@
 
 /datum/uplink_item/item/visible_weapons/grenade_launcher
 	name = "Grenade Launcher"
-	desc = "A pump action grenade launcher loaded with a random assortment of grenades"
+	desc = "A pump action grenade launcher loaded with a random assortment of grenades."
 	item_cost = 60
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/gun/launcher/grenade/loaded

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -143,7 +143,7 @@ var/global/list/narsie_list = list()
 /obj/singularity/narsie/proc/narsiefloor(var/turf/T)//leaving "footprints"
 	if(!(istype(T, /turf/simulated/wall/cult)||istype(T, /turf/space)))
 		if(T.icon_state != "cult-narsie")
-			T.desc = "something that goes beyond your understanding went this way"
+			T.desc = "Something that goes beyond your understanding went this way."
 			T.icon = 'icons/turf/flooring/cult.dmi'
 			T.icon_state = "cult-narsie"
 			T.set_light(1)

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -4,7 +4,7 @@
 /datum/game_mode/malfunction/verb/ai_select_hardware()
 	set category = "Hardware"
 	set name = "Select Hardware"
-	set desc = "Allows you to select hardware piece to install"
+	set desc = "Allows you to select a hardware piece to install."
 	var/mob/living/silicon/ai/user = usr
 
 	if(!ability_prechecks(user, 0, 1))

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -41,7 +41,7 @@
 /mob/living/silicon/ai/proc/ai_store_location(loc as text)
 	set category = "Silicon Commands"
 	set name = "Store Camera Location"
-	set desc = "Stores your current camera location by the given name"
+	set desc = "Stores your current camera location by the given name."
 
 	loc = sanitize(loc)
 	if(!loc)
@@ -70,7 +70,7 @@
 /mob/living/silicon/ai/proc/ai_goto_location(loc in sorted_stored_locations())
 	set category = "Silicon Commands"
 	set name = "Goto Camera Location"
-	set desc = "Returns to the selected camera location"
+	set desc = "Returns to the selected camera location."
 
 	if (!(loc in stored_locations))
 		to_chat(src, "<span class='warning'>Location [loc] not found</span>")
@@ -82,7 +82,7 @@
 /mob/living/silicon/ai/proc/ai_remove_location(loc in sorted_stored_locations())
 	set category = "Silicon Commands"
 	set name = "Delete Camera Location"
-	set desc = "Deletes the selected camera location"
+	set desc = "Deletes the selected camera location."
 
 	if (!(loc in stored_locations))
 		to_chat(src, "<span class='warning'>Location [loc] not found</span>")

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -56,12 +56,12 @@
 
 /decl/public_access/public_method/driver_drive
 	name = "launch"
-	desc = "Makes the mass driver launch immediately"
+	desc = "Makes the mass driver launch immediately."
 	call_proc = /obj/machinery/mass_driver/proc/drive
 
 /decl/public_access/public_method/driver_drive_delayed
 	name = "delayed launch"
-	desc = "Makes the mass driver launch after a short delay"
+	desc = "Makes the mass driver launch after a short delay."
 	call_proc = /obj/machinery/mass_driver/proc/delayed_drive
 
 /decl/stock_part_preset/radio/receiver/driver

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -21,7 +21,7 @@
 
 /obj/item/blueprints/Initialize()
 	. = ..()
-	desc = "Blueprints of the [station_name()]. There is a \"Classified\" stamp and several coffee stains on it."
+	desc = "Blueprints of \the [station_name()]. There is a \"Classified\" stamp and several coffee stains on it."
 
 /obj/item/blueprints/attack_self(mob/M as mob)
 	if (!istype(M,/mob/living/carbon/human))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -445,30 +445,30 @@
 	light_color = COLOR_RED
 
 /obj/item/device/flashlight/lamp/lava/blue
-	desc = "A kitchy blue decorative light"
+	desc = "A kitchy blue decorative light."
 	light_color = COLOR_BLUE
 
 /obj/item/device/flashlight/lamp/lava/cyan
-	desc = "A kitchy cyan decorative light"
+	desc = "A kitchy cyan decorative light."
 	light_color = COLOR_CYAN
 
 /obj/item/device/flashlight/lamp/lava/green
-	desc = "A kitchy green decorative light"
+	desc = "A kitchy green decorative light."
 	light_color = COLOR_GREEN
 
 /obj/item/device/flashlight/lamp/lava/orange
-	desc = "A kitchy orange decorative light"
+	desc = "A kitchy orange decorative light."
 	light_color = COLOR_ORANGE
 
 /obj/item/device/flashlight/lamp/lava/purple
-	desc = "A kitchy purple decorative light"
+	desc = "A kitchy purple decorative light."
 	light_color = COLOR_PURPLE
 /obj/item/device/flashlight/lamp/lava/pink
-	desc = "A kitchy pink decorative light"
+	desc = "A kitchy pink decorative light."
 	light_color = COLOR_PINK
 
 /obj/item/device/flashlight/lamp/lava/yellow
-	desc = "A kitchy yellow decorative light"
+	desc = "A kitchy yellow decorative light."
 	light_color = COLOR_YELLOW
 
 #undef FLASHLIGHT_ALWAYS_ON

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -106,7 +106,7 @@
 Using robohead because of restricting to roboticist */
 /obj/item/weapon/TVAssembly
 	name = "TV Camera assembly"
-	desc = "A robotic head with an infrared sensor inside"
+	desc = "A robotic head with an infrared sensor inside."
 	icon = 'icons/obj/robot_parts.dmi'
 	icon_state = "head"
 	item_state = "head"
@@ -137,7 +137,7 @@ Using robohead because of restricting to roboticist */
 					return
 				buildstep++
 				to_chat(user, "<span class='notice'>You wire the assembly</span>")
-				desc = "This TV camera assembly has wires sticking out"
+				desc = "This TV camera assembly has wires sticking out."
 				return
 		if(3)
 			if(isWirecutter(W))

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -581,7 +581,7 @@
 */
 
 /obj/item/weapon/shockpaddles/standalone
-	desc = "A pair of shockpaddles powered by an experimental miniaturized reactor" //Inspired by the advanced e-gun
+	desc = "A pair of shockpaddles powered by an experimental miniaturized reactor." //Inspired by the advanced e-gun
 	var/fail_counter = 0
 
 /obj/item/weapon/shockpaddles/standalone/Destroy()

--- a/code/game/objects/items/weapons/material/folding.dm
+++ b/code/game/objects/items/weapons/material/folding.dm
@@ -92,7 +92,7 @@
 
 /obj/item/weapon/material/knife/folding/combat //master obj
 	name = "the concept of a fighting knife in which the blade can be stowed in its own handle"
-	desc = "This is a master item - berate the admin or mapper who spawned this"
+	desc = "This is a master item - berate the admin or mapper who spawned this!"
 	max_force = 15
 	force_divisor = 0.25
 	thrown_force_divisor = 0.25

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -1,7 +1,7 @@
 //knives for stabbing and slashing and so on and so forth
 /obj/item/weapon/material/knife //master obj
 	name = "the concept of a knife"
-	desc = "You call that a knife? This is a master item - berate the admin or mapper who spawned this"
+	desc = "You call that a knife? This is a master item - berate the admin or mapper who spawned this!"
 	icon = 'icons/obj/knife.dmi'
 	icon_state = "knife"
 	item_state = "knife"

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -169,7 +169,7 @@ Single Use Emergency Pouches
 
 /obj/item/weapon/reagent_containers/pill/pouch_pill
 	name = "emergency pill"
-	desc = "An emergency pill from an emergency medical pouch"
+	desc = "An emergency pill from an emergency medical pouch."
 	icon_state = "pill2"
 	var/datum/reagent/chem_type
 	var/chem_amount = 15
@@ -194,7 +194,7 @@ Single Use Emergency Pouches
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto
 	name = "emergency autoinjector"
-	desc = "An emergency autoinjector from an emergency medical pouch"
+	desc = "An emergency autoinjector from an emergency medical pouch."
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline
 	name = "emergency inaprovaline autoinjector"

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -44,7 +44,7 @@
 
 /obj/item/weapon/crowbar/emergency_forcing_tool
 	name = "emergency forcing tool"
-	desc = "This is an emergency forcing tool, made of steel bar with a wedge on one end, and a hatchet on the other end. It has a blue plastic grip"
+	desc = "This is an emergency forcing tool, made of steel bar with a wedge on one end, and a hatchet on the other end. It has a blue plastic grip."
 	icon_state = "emergency_forcing_tool"
 	item_state = "emergency_forcing_tool"
 	force = 12

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1295,7 +1295,7 @@ var/list/random_useful_
 
 /obj/random/mre/spread/vegan
 	name = "random vegan MRE spread"
-	desc = "This is a random vegan spread packet for MREs"
+	desc = "This is a random vegan spread packet for MREs."
 
 /obj/random/mre/spread/vegan/spawn_choices()
 	return list(/obj/item/weapon/reagent_containers/food/condiment/small/packet/jelly)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -117,7 +117,7 @@
 
 /obj/item/clothing/gloves/latex/nitrile
 	name = "nitrile gloves"
-	desc = "Sterile nitrile gloves"
+	desc = "Sterile nitrile gloves."
 	icon_state = "nitrile"
 	item_state = "ngloves"
 

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -87,7 +87,7 @@ obj/item/clothing/mask/chewable/Destroy()
 
 /obj/item/clothing/mask/chewable/tobacco/redlady
 	name = "chewing tobacco"
-	desc = "A chewy wad of fine tobacco. Cut in long strands and treated with syrups so it doesn't taste like a ash-tray when you stuff it into your face"
+	desc = "A chewy wad of fine tobacco. Cut in long strands and treated with syrups so it doesn't taste like a ash-tray when you stuff it into your face."
 	filling = list(/datum/reagent/tobacco/fine = 2)
 
 /obj/item/clothing/mask/chewable/tobacco/nico

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -191,7 +191,7 @@
 
 /obj/item/clothing/mask/gas/vox
 	name = "vox breathing mask"
-	desc = "A small oxygen filter for use by Vox"
+	desc = "A small oxygen filter for use by Vox."
 	icon_state = "respirator"
 	item_state = "respirator"
 	flags_inv = 0

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -391,7 +391,7 @@
 	camera = null
 	species_restricted = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_IPC)
 	light_overlay = "null_light"
-	desc = "A bubble helmet that maximizes the field of view. A state of the art holographic display provides a stream of information"
+	desc = "A bubble helmet that maximizes the field of view. A state of the art holographic display provides a stream of information."
 
 //All in one suit
 /obj/item/clothing/suit/space/rig/zero

--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -66,7 +66,7 @@
 
 /obj/item/clothing/accessory/shouldercape/command
 	name = "command cape"
-	desc = "A heavily decorated cape with rank emblems on the shoulders signifying prestige. An ornate runed design has been woven into the fabric of it"
+	desc = "A heavily decorated cape with rank emblems on the shoulders signifying prestige. An ornate runed design has been woven into the fabric of it."
 	icon_state = "commandcape"
 
 /obj/item/clothing/accessory/shouldercape/general

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -1,6 +1,6 @@
 /datum/codex_category
 	var/name = "Generic Category"
-	var/desc = "Some description for category's codex entry"
+	var/desc = "Some description for a category's codex entry."
 	var/list/items = list()
 
 //Children should call ..() at the end after filling the items list

--- a/code/modules/detectivework/tools/scene_cards.dm
+++ b/code/modules/detectivework/tools/scene_cards.dm
@@ -30,7 +30,7 @@
 
 /obj/item/weapon/csi_marker/Initialize(mapload)
 	. = ..()
-	desc += " This one is marked with [number]"
+	desc += " This one is marked with [number]."
 	update_icon()
 
 /obj/item/weapon/csi_marker/on_update_icon()

--- a/code/modules/integrated_electronics/subtypes/filter.dm
+++ b/code/modules/integrated_electronics/subtypes/filter.dm
@@ -39,13 +39,13 @@
 
 /obj/item/integrated_circuit/filter/ref/mob
 	name = "life filter"
-	desc = "Only allow refs belonging to more complex, currently or formerly, living but not necessarily biological entities through"
+	desc = "Only allow refs belonging to more complex, currently or formerly, living but not necessarily biological entities through."
 	icon_state = "filter_mob"
 	filter_type = /mob/living
 
 /obj/item/integrated_circuit/filter/ref/mob/humanoid
 	name = "humanoid filter"
-	desc = "Only allow refs belonging to humanoids (dead or alive) through"
+	desc = "Only allow refs belonging to humanoids (dead or alive) through."
 	icon_state = "filter_humanoid"
 	filter_type = /mob/living/carbon/human
 

--- a/code/modules/integrated_electronics/subtypes/time.dm
+++ b/code/modules/integrated_electronics/subtypes/time.dm
@@ -172,7 +172,7 @@
 
 /obj/item/integrated_circuit/time/clock/station
 	name = "integrated clock (Station Time)"
-	desc = "Tells you what the time is, in terms and adjusted for your local station or planet"
+	desc = "Tells you what the time is, in terms and adjusted for your local station or planet."
 
 /obj/item/integrated_circuit/time/clock/station/get_time()
 	return stationtime2text()

--- a/code/modules/mechs/components/armour.dm
+++ b/code/modules/mechs/components/armour.dm
@@ -16,7 +16,7 @@
 
 /obj/item/robot_parts/robot_component/armour/exosuit/radproof
 	name = "radiation-proof armour plating"
-	desc = "A fully enclosed radiation hardened shell designed to protect the pilot from radiation"
+	desc = "A fully enclosed radiation hardened shell designed to protect the pilot from radiation."
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT, 
 		bullet = ARMOR_BALLISTIC_PISTOL, 
@@ -30,7 +30,7 @@
 
 /obj/item/robot_parts/robot_component/armour/exosuit/em
 	name = "EM-shielded armour plating"
-	desc = "A shielded plating that sorrounds the eletronics and protects them from electromagnetic radiation"
+	desc = "A shielded plating that sorrounds the eletronics and protects them from electromagnetic radiation."
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT , 
 		bullet = ARMOR_BALLISTIC_SMALL, 
@@ -44,7 +44,7 @@
 
 /obj/item/robot_parts/robot_component/armour/exosuit/combat
 	name = "heavy combat plating"
-	desc = "Plating designed to deflect incoming attacks and explosions"
+	desc = "Plating designed to deflect incoming attacks and explosions."
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR, 
 		bullet = ARMOR_BALLISTIC_RESISTANT, 

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -1,7 +1,7 @@
 // Noise "language", for audible emotes.
 /datum/language/noise
 	name = "Noise"
-	desc = "Noises"
+	desc = "Noises."
 	key = ""
 	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
 	hidden_from_codex = 1

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/building_datum.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/building_datum.dm
@@ -1,5 +1,5 @@
 /datum/chorus_building
-	var/desc = "Stuff"
+	var/desc = "Stuff."
 	var/building_type_to_build
 	var/build_level = 1 //What row to show them on
 	var/unique = FALSE //Can only be built once?

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
@@ -1,6 +1,6 @@
 /obj/structure/chorus/processor
 	name = "Processor"
-	desc = "Activates through process, not clicking"
+	desc = "Activates through process, not clicking."
 	var/warning = TRUE
 
 /obj/structure/chorus/processor/Initialize()
@@ -18,7 +18,7 @@
 
 /obj/structure/chorus/processor/clicker
 	name = "Clicker"
-	desc = "A strange structure that invokes the power of structures around it"
+	desc = "A strange structure that invokes the power of structures around it."
 	click_cooldown = 6 SECONDS
 
 /obj/structure/chorus/processor/clicker/Process()
@@ -33,7 +33,7 @@
 
 /obj/structure/chorus/processor/sentry
 	name = "Sentry"
-	desc = "Stands guard and attacks/does things every few seconds"
+	desc = "Stands guard and attacks/does things every few seconds."
 	var/range = 1
 
 /obj/structure/chorus/processor/sentry/Process()

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_five.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_five.dm
@@ -12,7 +12,7 @@
 
 /obj/structure/chorus/spawner/growth_womb
 	name = "womb"
-	desc = "A disgusting accumulation of flesh and bone pulsing with life"
+	desc = "A disgusting accumulation of flesh and bone pulsing with life."
 	icon_state = "growth_womb"
 	activation_cost_resource = /datum/chorus_resource/growth_meat
 	activation_cost_amount = 100

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_four.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_four.dm
@@ -1,5 +1,5 @@
 /datum/chorus_building/set_to_turf/growth/tendril_thorned
-	desc = "An upgraded tendril with a large boney spike at the end"
+	desc = "An upgraded tendril with a large boney spike at the end."
 	building_type_to_build = /obj/structure/chorus/processor/sentry/tendril/thorned
 	build_time = 45
 	build_level = 4
@@ -23,7 +23,7 @@
 
 /obj/structure/chorus/processor/sentry/tendrdil/thorned/Initialize()
 	. = ..()
-	desc += SPAN_NOTICE("This one has a large spike on the end")
+	desc += SPAN_NOTICE("This one has a large spike on the end.")
 
 /datum/chorus_building/set_to_turf/growth/gastric_emitter
 	desc = "Activate to spill acid on nearby tiles: watch out for your allies!"

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_one.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_one.dm
@@ -7,7 +7,7 @@
 
 /obj/structure/chorus/nutrient_syphon
 	name = "nutrient syphon"
-	desc = "Extracts vitamins and minerals straight from the air"
+	desc = "Extracts vitamins and minerals straight from the air."
 	icon_state = "growth_syphon"
 	click_cooldown = 5 SECONDS
 
@@ -17,7 +17,7 @@
 	flick("growth_syphon_exert", src)
 
 /datum/chorus_building/set_to_turf/growth/bitter
-	desc = "A small teeth-filled hole, used to injure prey"
+	desc = "A small teeth-filled hole, used to injure prey."
 	building_type_to_build = /obj/structure/chorus/biter
 	build_time = 20
 	build_level = 1

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_three.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_three.dm
@@ -1,5 +1,5 @@
 /datum/chorus_building/set_to_turf/growth/tendril
-	desc = "A fleshy appendage adapt at wacking nearby foreign agents"
+	desc = "A fleshy appendage adapt at wacking nearby foreign agents."
 	building_type_to_build = /obj/structure/chorus/processor/sentry/tendril
 	build_time = 30
 	build_level = 3
@@ -9,7 +9,7 @@
 
 /obj/structure/chorus/processor/sentry/tendril
 	name = "tendril"
-	desc = "A large mucus covered tentacle"
+	desc = "A large mucus covered tentacle."
 	icon_state = "growth_tendril"
 	health = 100
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_two.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_two.dm
@@ -1,5 +1,5 @@
 /datum/chorus_building/set_to_turf/growth/gastrointestional_tract
-	desc = "Processes nutrition into flesh"
+	desc = "Processes nutrition into flesh."
 	building_type_to_build = /obj/structure/chorus/gastrointestional_tract
 	build_time = 60
 	build_level = 2
@@ -8,7 +8,7 @@
 
 /obj/structure/chorus/gastrointestional_tract
 	name = "gastrointestional tract"
-	desc = "A gross lump of organ meat"
+	desc = "A gross lump of organ meat."
 	icon_state = "growth_stomach"
 	health = 30
 	click_cooldown = 5 SECONDS
@@ -21,7 +21,7 @@
 	flick("growth_stomach_exert", src)
 
 /datum/chorus_building/set_to_turf/growth/ossifier
-	desc = "Makes bones from nutritional substances"
+	desc = "Makes bones from nutritional substances."
 	building_type_to_build = /obj/structure/chorus/ossifier
 	build_time = 60
 	build_level = 2
@@ -30,7 +30,7 @@
 
 /obj/structure/chorus/ossifier
 	name = "ossifier"
-	desc = "A brittle mix of bones and flesh"
+	desc = "A brittle mix of bones and flesh."
 	icon_state = "growth_bone"
 	health = 30
 	click_cooldown = 5 SECONDS
@@ -43,7 +43,7 @@
 	flick("growth_bone_exert", src)
 
 /datum/chorus_building/set_to_turf/growth/sinoatrial_node
-	desc = "An automatic nerve-firer, activates nearby organs every few seconds automatically"
+	desc = "An automatic nerve-firer, activates nearby organs every few seconds automatically."
 	building_type_to_build = /obj/structure/chorus/processor/clicker/growth
 	build_time = 100
 	build_level = 2
@@ -51,12 +51,12 @@
 
 /obj/structure/chorus/processor/clicker/growth
 	name = "sinoatrial node"
-	desc = "A large fan of what appears to be some sort of organic wire"
+	desc = "A large fan of what appears to be some sort of organic wire."
 	icon_state = "growth_node"
 	health = 50
 
 /datum/chorus_building/muscular_coat
-	desc = "Every beast needs an outside"
+	desc = "Every beast needs an outside."
 	building_type_to_build = /turf/simulated/wall/growth
 	build_time = 100
 	build_level = 2
@@ -72,7 +72,7 @@
 	return "growth_wall"
 
 /datum/chorus_building/set_to_turf/growth/maw
-	desc = "A maw to let things in or keep them out"
+	desc = "A maw to let things in or keep them out."
 	building_type_to_build = /obj/structure/chorus/maw
 	build_time = 60
 	build_level = 2
@@ -84,7 +84,7 @@
 
 /obj/structure/chorus/maw
 	name = "maw"
-	desc = "A neck high wall made of teeth and meat"
+	desc = "A neck high wall made of teeth and meat."
 	click_cooldown = 3 SECONDS
 	health = 200
 	icon_state = "growth_maw_closed"
@@ -100,7 +100,7 @@
 		flick("growth_maw_close", src)
 
 /datum/chorus_building/set_to_turf/growth/spinal_column
-	desc = "For growths that must grow up and out"
+	desc = "For growths that must grow up and out."
 	building_type_to_build = /obj/structure/chorus/zleveler/spinal_column
 	build_time = 120
 	build_level = 2
@@ -111,7 +111,7 @@
 
 /obj/structure/chorus/zleveler/spinal_column
 	name = "spinal column"
-	desc = "A thick pillar of bone and marrow extending from floor to ceiling"
+	desc = "A thick pillar of bone and marrow extending from floor to ceiling."
 	health = 125
 	icon_state = "growth_spine"
 	activation_cost_resource = /datum/chorus_resource/growth_bones
@@ -120,7 +120,7 @@
 	turf_type_to_add = /turf/simulated/floor/scales
 
 /datum/chorus_building/set_to_turf/growth/bone_shooter
-	desc = "Automatically shoots bone fragments at enemies"
+	desc = "Automatically shoots bone fragments at enemies."
 	building_type_to_build = /obj/structure/chorus/processor/sentry/bone_shooter
 	build_time = 60
 	build_level = 2
@@ -132,7 +132,7 @@
 
 /obj/structure/chorus/processor/sentry/bone_shooter
 	name = "bone spitter"
-	desc = "A group of meat fashioned together into a form not unsimilar to a turret"
+	desc = "A group of meat fashioned together into a form not unsimilar to a turret."
 	icon_state = "growth_bone_shooter"
 	health = 20
 	range = 7

--- a/code/modules/mob/living/carbon/alien/chorus/form/growth.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/form/growth.dm
@@ -1,6 +1,6 @@
 /datum/chorus_form/growth
 	name = "Growth"
-	desc = "A parasite adapted to life on ships and stations"
+	desc = "A parasite adapted to life on ships and stations."
 	form_state = "growth"
 	resources = list(
 			/datum/chorus_resource/growth_nutrients,
@@ -28,4 +28,4 @@
 	c.icon_living = "livingflesh"
 	c.icon_dead = "livingflesh_dead"
 	c.icon_state = "livingflesh"
-	c.desc = "A fleshy, disgusting creature full of blood and teeth"
+	c.desc = "A fleshy, disgusting creature full of blood and teeth."

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -650,7 +650,7 @@ var/list/ai_verbs_default = list(
 /mob/living/silicon/ai/proc/sensor_mode()
 	set name = "Set Sensor Augmentation"
 	set category = "Silicon Commands"
-	set desc = "Augment visual feed with internal sensor overlays"
+	set desc = "Augment visual feed with internal sensor overlays."
 	toggle_sensor_mode()
 
 /mob/living/silicon/ai/proc/toggle_hologram_movement()

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -100,7 +100,7 @@
 /mob/living/simple_animal/construct/armoured
 	name = "Juggernaut"
 	real_name = "Juggernaut"
-	desc = "A possessed suit of armour driven by the will of the restless dead"
+	desc = "A possessed suit of armour driven by the will of the restless dead."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "behemoth"
 	icon_living = "behemoth"
@@ -156,7 +156,7 @@
 /mob/living/simple_animal/construct/wraith
 	name = "Wraith"
 	real_name = "Wraith"
-	desc = "A wicked bladed shell contraption piloted by a bound spirit"
+	desc = "A wicked bladed shell contraption piloted by a bound spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "floating"
 	icon_living = "floating"
@@ -180,7 +180,7 @@
 /mob/living/simple_animal/construct/builder
 	name = "Artificer"
 	real_name = "Artificer"
-	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies"
+	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "artificer"
 	icon_living = "artificer"
@@ -236,7 +236,7 @@
 /mob/living/simple_animal/construct/harvester
 	name = "Harvester"
 	real_name = "Harvester"
-	desc = "The promised reward of the livings who follow Nar-Sie. Obtained by offering their bodies to the geometer of blood"
+	desc = "The promised reward of the livings who follow Nar-Sie. Obtained by offering their bodies to the geometer of blood."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "harvester"
 	icon_living = "harvester"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -227,7 +227,7 @@
 
 /mob/living/simple_animal/cat/kitten
 	name = "kitten"
-	desc = "D'aaawwww"
+	desc = "D'aaawwww."
 	icon_state = "kitten"
 	item_state = "kitten"
 	icon_living = "kitten"

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/faithless
 	name = "Faithless"
-	desc = "The Wish Granter's faith in humanity, incarnate"
+	desc = "The Wish Granter's faith in humanity, incarnate."
 	icon_state = "faithless"
 	icon_living = "faithless"
 	icon_dead = "faithless_dead"

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/shade
 	name = "Shade"
 	real_name = "Shade"
-	desc = "A bound spirit"
+	desc = "A bound spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "shade"
 	icon_living = "shade"

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -216,7 +216,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/verb/toggle_medHUD()
 	set category = "Ghost"
 	set name = "Toggle MedicHUD"
-	set desc = "Toggles Medical HUD allowing you to see how everyone is doing"
+	set desc = "Toggles Medical HUD, allowing you to see how everyone is doing."
 	if(!client)
 		return
 	if(medHUD)
@@ -229,7 +229,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/verb/toggle_antagHUD()
 	set category = "Ghost"
 	set name = "Toggle AntagHUD"
-	set desc = "Toggles AntagHUD allowing you to see who is the antagonist"
+	set desc = "Toggles AntagHUD, allowing you to see who is the antagonist."
 
 	if(!client)
 		return

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -102,16 +102,16 @@
 		return
 	if(processor_unit && (apc_power(0) || battery_power(0))) // Battery-run and charged or non-battery but powered by APC.
 		if(issynth)
-			to_chat(user, "You send an activation signal to \the [src], turning it on")
+			to_chat(user, "You send an activation signal to \the [src], turning it on.")
 		else
-			to_chat(user, "You press the power button and start up \the [src]")
+			to_chat(user, "You press the power button and start up \the [src].")
 		enable_computer(user)
 
 	else // Unpowered
 		if(issynth)
-			to_chat(user, "You send an activation signal to \the [src] but it does not respond")
+			to_chat(user, "You send an activation signal to \the [src] but it does not respond.")
 		else
-			to_chat(user, "You press the power button but \the [src] does not respond")
+			to_chat(user, "You press the power button but \the [src] does not respond.")
 
 /obj/item/modular_computer/proc/shutdown_computer(var/loud = 1)
 	QDEL_NULL_LIST(terminals)

--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -54,7 +54,7 @@
 		if(ntnet_global.intrusion_detection_enabled && !prob(get_sneak_chance()))
 			ntnet_global.add_log("IDS WARNING - Unauthorised access to primary keycode database from device: [computer.get_network_tag()]  - downloaded access codes for: [target_access.desc].")
 			ntnet_global.intrusion_detection_alarm = 1
-		message = "Successfully decrypted and saved operational key codes. Downloaded access codes for: [target_access.desc]"
+		message = "Successfully decrypted and saved operational key codes. Downloaded access codes for: [target_access.desc]."
 		target_access = null
 		reset()
 

--- a/code/modules/overmap/exoplanets/planet_types/garbage.dm
+++ b/code/modules/overmap/exoplanets/planet_types/garbage.dm
@@ -105,7 +105,7 @@
 
 /turf/simulated/floor/exoplanet/concrete/reinforced
 	name = "reinforced concrete"
-	desc = "Stone-like artificial material. It has been reinforced with an unknown compound"
+	desc = "Stone-like artificial material. It has been reinforced with an unknown compound."
 	icon_state = "hexacrete"
 
 /turf/simulated/floor/exoplanet/concrete/reinforced/road

--- a/code/modules/power/debug_items.dm
+++ b/code/modules/power/debug_items.dm
@@ -26,7 +26,7 @@
 // An infinite power generator. Adds energy to connected cable.
 /obj/machinery/power/debug_items/infinite_generator
 	name = "Fractal Energy Reactor"
-	desc = "An experimental power generator"
+	desc = "An experimental power generator."
 	var/power_generation_rate = 1000000
 
 /obj/machinery/power/debug_items/infinite_generator/Process()

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -137,6 +137,6 @@
 
 /obj/item/weapon/gun/launcher/pneumatic/small
 	name = "small pneumatic cannon"
-	desc = "It looks smaller than your garden variety cannon"
+	desc = "It looks smaller than your garden variety cannon."
 	max_w_class = ITEM_SIZE_TINY
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/storage/box/mixedglasses
 	name = "glassware box"
-	desc = "A box of assorted glassware"
+	desc = "A box of assorted glassware."
 	can_hold = list(/obj/item/weapon/reagent_containers/food/drinks/glass2)
 
 	startswith = list(

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -188,7 +188,7 @@
 
 /obj/item/weapon/reagent_containers/food/condiment/small/sugar
 	name = "sugar"
-	desc = "Sweetness in a bottle"
+	desc = "Sweetness in a bottle."
 	icon_state = "sugarsmall"
 	center_of_mass = "x=17;y=9"
 	starting_reagents = list(/datum/reagent/sugar = 20)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3795,7 +3795,7 @@ obj/item/weapon/reagent_containers/food/snacks/dango
 
 /obj/item/weapon/reagent_containers/food/snacks/old
 	name = "master old-food"
-	desc = "they're all inedible and potentially dangerous items"
+	desc = "They're all inedible and potentially dangerous items."
 	center_of_mass = "x=15;y=12"
 	nutriment_desc = list("rot" = 5, "mold" = 5)
 	nutriment_amt = 10

--- a/code/modules/research/designs/designs_medical.dm
+++ b/code/modules/research/designs/designs_medical.dm
@@ -58,7 +58,7 @@
 	sort_string = "MADAA"
 
 /datum/design/item/medical/hypospray
-	desc = "A sterile, air-needle autoinjector for rapid administration of drugs"
+	desc = "A sterile, air-needle autoinjector for rapid administration of drugs."
 	id = "hypospray"
 	req_tech = list(TECH_MATERIAL = 4, TECH_BIO = 5)
 	materials = list(MATERIAL_STEEL = 8000, MATERIAL_GLASS = 8000, MATERIAL_SILVER = 2000)

--- a/code/modules/research/designs/designs_syringe.dm
+++ b/code/modules/research/designs/designs_syringe.dm
@@ -12,7 +12,7 @@
 
 /datum/design/item/syringe/bluespacesyringe
 	name = "Bluespace Syringe"
-	desc = "An advanced syringe that can hold 60 units of chemicals"
+	desc = "An advanced syringe that can hold 60 units of chemicals."
 	id = "bluespacesyringe"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MATERIAL_GLASS = 2000, MATERIAL_PHORON = 1000, MATERIAL_DIAMOND = 1000)

--- a/code/modules/spells/aoe_turf/conjure/construct.dm
+++ b/code/modules/spells/aoe_turf/conjure/construct.dm
@@ -23,7 +23,7 @@
 
 /spell/aoe_turf/conjure/floor
 	name = "Floor Construction"
-	desc = "This spell constructs a cult floor"
+	desc = "This spell constructs a cult floor."
 
 	charge_max = 20
 	spell_flags = Z2NOCAST | CONSTRUCT_CHECK
@@ -36,7 +36,7 @@
 
 /spell/aoe_turf/conjure/wall
 	name = "Lesser Construction"
-	desc = "This spell constructs a cult wall"
+	desc = "This spell constructs a cult wall."
 
 	charge_max = 100
 	spell_flags = Z2NOCAST | CONSTRUCT_CHECK
@@ -49,7 +49,7 @@
 
 /spell/aoe_turf/conjure/wall/reinforced
 	name = "Greater Construction"
-	desc = "This spell constructs a reinforced metal wall"
+	desc = "This spell constructs a reinforced metal wall."
 
 	charge_max = 300
 	spell_flags = Z2NOCAST
@@ -62,7 +62,7 @@
 
 /spell/aoe_turf/conjure/soulstone
 	name = "Summon Soulstone"
-	desc = "This spell reaches into Nar-Sie's realm, summoning one of the legendary fragments across time and space"
+	desc = "This spell reaches into Nar-Sie's realm, summoning one of the legendary fragments across time and space."
 
 	charge_max = 3000
 	spell_flags = 0

--- a/code/modules/spells/general/return_master.dm
+++ b/code/modules/spells/general/return_master.dm
@@ -1,6 +1,6 @@
 /spell/contract/return_master
 	name = "Return to Master"
-	desc = "Teleport back to your master"
+	desc = "Teleport back to your master."
 
 	school = "conjuration"
 	charge_max = 600

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -93,7 +93,7 @@
 //UNATHI
 /spell/moghes_blessing
 	name = "Moghes Blessing"
-	desc = "Imbue your weapon with memories of Moghes"
+	desc = "Imbue your weapon with memories of Moghes."
 
 	school = "racial"
 	spell_flags = 0

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -2,7 +2,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell
 	var/name = "Spell"
-	var/desc = "A spell"
+	var/desc = "A spell."
 	var/feedback = "" //what gets sent if this spell gets chosen by the spellbook.
 	parent_type = /datum
 	var/panel = "Spells"//What panel the proc holder needs to go on.

--- a/code/modules/spells/targeted/exhude_pleasantness.dm
+++ b/code/modules/spells/targeted/exhude_pleasantness.dm
@@ -1,6 +1,6 @@
 /spell/targeted/exhude_pleasantness
 	name = "Exhude Pleasantness"
-	desc = "A simple spell used to make friends with people. Be warned, this spell only has a subtle effect"
+	desc = "A simple spell used to make friends with people. Be warned, this spell only has a subtle effect."
 	feedback = "AP"
 	school = "Illusion"
 	spell_flags = INCLUDEUSER

--- a/code/modules/spells/targeted/shift.dm
+++ b/code/modules/spells/targeted/shift.dm
@@ -1,6 +1,6 @@
 /spell/targeted/ethereal_jaunt/shift
 	name = "Phase Shift"
-	desc = "This spell allows you to pass through walls"
+	desc = "This spell allows you to pass through walls."
 
 	charge_max = 200
 	spell_flags = Z2NOCAST | INCLUDEUSER | CONSTRUCT_CHECK

--- a/code/modules/synthesized_instruments/real_instruments/Piano/piano.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Piano/piano.dm
@@ -1,6 +1,6 @@
 /obj/structure/synthesized_instrument/synthesizer/piano
 	name = "space piano"
-	desc = "A surprisingly high-tech piano with a digital display for modifying sound output"
+	desc = "A surprisingly high-tech piano with a digital display for modifying sound output."
 	icon_state = "piano"
 	path = /datum/instrument/piano
 

--- a/code/modules/synthesized_instruments/real_instruments/Trumpet/trumpet.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Trumpet/trumpet.dm
@@ -1,6 +1,6 @@
 /obj/item/device/synthesized_instrument/trumpet
 	name = "Omnitrumpet"
-	desc = "The Omnitrumptet series 400 with more than 30 sound samples and fully customizable high fidelity output provides the ultimate means to toot your own horn"
+	desc = "The Omnitrumptet series 400 with more than 30 sound samples and fully customizable high fidelity output provides the ultimate means to toot your own horn."
 	icon_state = "trumpet"
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/brass

--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -57,7 +57,7 @@
 
 /obj/structure/table/proc/do_put()
 	set name = "Put table back"
-	set desc = "Puts flipped table back"
+	set desc = "Puts a flipped table back"
 	set category = "Object"
 	set src in oview(1)
 

--- a/code/modules/xenoarcheaology/tools/coolant_tank.dm
+++ b/code/modules/xenoarcheaology/tools/coolant_tank.dm
@@ -1,6 +1,6 @@
 /obj/structure/reagent_dispensers/coolanttank
 	name = "coolant tank"
-	desc = "A tank of industrial coolant"
+	desc = "A tank of industrial coolant."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "coolanttank"
 	amount_per_transfer_from_this = 10

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -179,8 +179,8 @@ var/ascii_reset = "[ascii_esc]\[0m"
 
 /obj/effect/landmark/test/safe_turf
 	name = "safe_turf" // At creation, landmark tags are set to: "landmark*[name]"
-	desc = "A safe turf should be an as large block as possible of livable, passable turfs, preferably at least 3x3 with the marked turf as the center"
+	desc = "A safe turf should be an as large block as possible of livable, passable turfs, preferably at least 3x3 with the marked turf as the center."
 
 /obj/effect/landmark/test/space_turf
 	name = "space_turf"
-	desc = "A space turf should be an as large block as possible of space, preferably at least 3x3 with the marked turf as the center"
+	desc = "A space turf should be an as large block as possible of space, preferably at least 3x3 with the marked turf as the center."

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -125,7 +125,7 @@
 
 /turf/simulated/floor/away/blueriver/alienfloor
 	name = "glowing floor"
-	desc = "The floor glows without any apparent reason"
+	desc = "The floor glows without any apparent reason."
 	icon = 'riverturfs.dmi'
 	icon_state = "floor"
 	temperature = 233

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -1572,7 +1572,7 @@
 "eo" = (
 /obj/effect/shuttle_landmark/nav_casino/cutter_hangar,
 /obj/machinery/door/unpowered/shuttle{
-	desc = "Cutter door. It opens and closes. It has no safety devices so be careful";
+	desc = "Cutter door. It opens and closes. It has no safety devices so be careful.";
 	name = "cutter door"
 	},
 /obj/structure/cable/green{

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -248,7 +248,7 @@
 /obj/machinery/light/skrell
 	name = "skrellian light"
 	light_type = /obj/item/weapon/light/tube/skrell
-	desc = "Some kind of strange alien lighting technology"
+	desc = "Some kind of strange alien lighting technology."
 
 
 /obj/item/weapon/light/tube/skrell

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -2,7 +2,7 @@
 
 /obj/effect/overmap/visitable/ship/yacht
 	name = "private yacht"
-	desc = "Sensor array is detecting a small vessel with unknown lifeforms on board"
+	desc = "Sensor array is detecting a small vessel with unknown lifeforms on board."
 	color = "#ffc966"
 	vessel_mass = 3000
 	max_speed = 1/(2 SECONDS)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -6625,7 +6625,7 @@
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "d3fore_shutters";
-	name = "Garden shutter controll";
+	name = "Garden Shutter Control";
 	pixel_x = -23;
 	pixel_y = -9
 	},
@@ -14478,7 +14478,7 @@
 /obj/effect/floor_decal/corner/green/half,
 /obj/machinery/button/blast_door{
 	id_tag = "d3fore_shutters";
-	name = "Garden shutter controll";
+	name = "Garden Shutter Control";
 	pixel_x = -7;
 	pixel_y = -23
 	},
@@ -18823,7 +18823,7 @@
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "d3fore_shutters";
-	name = "Garden shutter controll";
+	name = "Garden Shutter Control";
 	pixel_x = -7;
 	pixel_y = 23
 	},

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -15143,21 +15143,21 @@
 /area/vacant/prototype/engine)
 "Mi" = (
 /obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the prototype exhaust";
+	desc = "A remote control-switch for the prototype exhaust.";
 	id_tag = "prototype_exhaust";
 	name = "Chamber Exhaust";
 	pixel_x = -11;
 	pixel_y = 29
 	},
 /obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the engine containment doors";
+	desc = "A remote control-switch for the engine containment doors.";
 	id_tag = "prototype_chamber_blast";
 	name = "Chamber Containment";
 	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the observation shutters";
+	desc = "A remote control-switch for the observation shutters.";
 	id_tag = "fusion_observation";
 	name = "Chamber Observation";
 	pixel_x = 11;


### PR DESCRIPTION
This PR is all about fixing descriptions in items. Specifically, adding punctuation where needed and a couple of other things here and there. In cases where punctuation is obviously not desired or in a few cases where there's no way it would be shown ingame, I didn't change anything. The standard for verbs appears to be not to include punctuation, so with few exceptions, those were left untouched as well.

And thank the lord for regex.

:cl:
spellcheck: A bunch of grammatical fixes to objects' descriptions.
/:cl: