### PR TITLE
Opens up formal loadout options for certain roles

### DIFF
--- a/maps/torch/loadout/loadout_uniform.dm
+++ b/maps/torch/loadout/loadout_uniform.dm
@@ -16,7 +16,7 @@
 	allowed_roles = list(/datum/job/roboticist)
 
 /datum/gear/uniform/suit
-	allowed_roles = FORMAL_ROLES
+	allowed_roles = SEMIANDFORMAL_ROLES
 
 /datum/gear/uniform/scrubs
 	allowed_roles = STERILE_ROLES
@@ -32,10 +32,10 @@
 	allowed_roles = FORMAL_ROLES
 
 /datum/gear/uniform/skirt
-	allowed_roles = FORMAL_ROLES
+	allowed_roles = SEMIANDFORMAL_ROLES
 
 /datum/gear/uniform/skirt_c
-	allowed_roles = FORMAL_ROLES
+	allowed_roles = SEMIANDFORMAL_ROLES
 
 /datum/gear/uniform/skirt_c/dress
 	allowed_roles = FORMAL_ROLES
@@ -44,13 +44,13 @@
 	allowed_roles = SEMIFORMAL_ROLES
 
 /datum/gear/uniform/formal_pants
-	allowed_roles = FORMAL_ROLES
+	allowed_roles = SEMIANDFORMAL_ROLES
 
 /datum/gear/uniform/formal_pants/custom
-	allowed_roles = FORMAL_ROLES
+	allowed_roles = SEMIANDFORMAL_ROLES
 
 /datum/gear/uniform/formal_pants/baggycustom
-	allowed_roles = FORMAL_ROLES
+	allowed_roles = SEMIANDFORMAL_ROLES
 
 /datum/gear/uniform/shorts
 	allowed_roles = CASUAL_ROLES


### PR DESCRIPTION
Changes the loadout restriction for suits, suit pants, and skirts, allowing more jobs to select them from the loadout menu.

:cl:
tweak: The "baggy suit pants, colour select," "clothes selection," "formal pants selection," "short skirt, colour select," "skirt selection," and "suit pants, colour select" items in the loadout menu have all had their allowed_roles changed from FORMAL_ROLES to SEMIANDFORMAL_ROLES.
/:cl:
