### PR TITLE
fix some loadout items not working with JSON saves

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -59,13 +59,17 @@
 	var/list/duplicate_values = duplicates(list_values(valid_paths))
 	if(duplicate_values.len)
 		CRASH("Duplicate types found: [english_list(duplicate_values)]")
+	// valid_paths, but with names sanitized to remove \improper
+	var/list/valid_paths_san = list()
 	for(var/path_name in valid_paths)
 		if(!istext(path_name))
 			CRASH("Expected a text key, was [log_info_line(path_name)]")
 		var/selection_type = valid_paths[path_name]
 		if(!ispath(selection_type, /obj/item))
 			CRASH("Expected an /obj/item path, was [log_info_line(selection_type)]")
-	src.valid_paths = sortAssoc(valid_paths)
+		var/path_name_san = replacetext(path_name, "\improper", "")
+		valid_paths_san[path_name_san] = selection_type
+	src.valid_paths = sortAssoc(valid_paths_san)
 
 /datum/gear_tweak/path/type/New(var/type_path)
 	..(atomtype2nameassoclist(type_path))


### PR DESCRIPTION
For any loadout item that customized paths, if one of the paths had an
\improper name, that path would break.
This is because saving to JSON strips the  \improper part, while
savefiles mainain it.
Fixed by stripping \improper from the internal representation entirely.
I guess this might cause weirdness in the UI if someone tries to do \the
on a loadout entry in the future, but that doesn't happen currently.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->