### PR TITLE
Fix exploit resulting from trying to leap to a different z-level

### DIFF
--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -28,6 +28,10 @@
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You are too exhausted to maneuver right now."))
 		return FALSE
+	if ((get_turf(user)).z != (get_turf(target)).z)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("You cannot manuever to a different z-level!"))
+		return FALSE
 	return TRUE
 
 /decl/maneuver/proc/show_initial_message(var/mob/user, var/atom/target)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fix players being able to walk through railings, onto tables, after attempting to leap to a different z-level.
/:cl:

Fixes players being put in a state that allowed them to walk through railings, up tables, etc, after trying to ctrl + click jump to a different z-level. This basically just prevents them from performing the leap if they're trying to jump to a different z-level than the one they're currently on.

From what I can tell, the callback wasn't working when the user attempted to jump to a different z-level. When testing, I noticed the `end_leap` proc wasn't being called when it should had been, resulting in the players flags not being reset, and keeping them in the 'leap' state indefinitely.

Closes #29647