### PR TITLE
Torch's starting location is known

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -24,11 +24,15 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 		if (S.known)
 			add_known_sector(S)
 
-/obj/machinery/computer/ship/helm/proc/add_known_sector(obj/effect/overmap/visitable/sector/S, notify = FALSE)
+		for(var/obj/effect/overmap/visitable/ship/J in map)
+		if (J.initial_position_known)
+			add_known_sector(J, FALSE, initial_sensor_name, start_x, start_y)
+
+/obj/machinery/computer/ship/helm/proc/add_known_sector(obj/effect/overmap/visitable/sector/S, notify = FALSE, name, start_x, start_y)
 	var/datum/computer_file/data/waypoint/R = new()
-	R.fields["name"] = S.name
-	R.fields["x"] = S.x
-	R.fields["y"] = S.y
+	R.fields["name"] = name || S.name
+	R.fields["x"] = start_x || S.x
+	R.fields["y"] = start_y || S.y
 	known_sectors[S.name] = R
 
 	if (notify)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -33,6 +33,8 @@
 	var/halted = 0        //admin halt or other stop.
 	var/skill_needed = SKILL_ADEPT  //piloting skill needed to steer it without going in random dir
 	var/operator_skill
+	var/initial_position_known = FALSE //whether or not other ships should start with this ships location.
+	var/initial_sensor_name = "Unidentified Ship" //the name to be put on sensor consoles if spawn_position is set.
 
 /obj/effect/overmap/visitable/ship/Initialize()
 	. = ..()

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -5,6 +5,9 @@
 	vessel_mass = 100000
 	burn_delay = 2 SECONDS
 	base = TRUE
+	initial_position_known = TRUE
+	initial_sensor_name = "Bluespace Residue"
+
 
 	initial_restricted_waypoints = list(
 		"Charon" = list("nav_hangar_calypso"), 	//can't have random shuttles popping inside the ship
@@ -77,22 +80,6 @@
 		"nav_ert_dock",
 		"nav_verne_5",
 	)
-
-/datum/map/torch/get_map_info()
-	. = list()
-
-/obj/machinery/computer/ship/helm/proc/add_torch_spawn(obj/effect/overmap/visitable/sector/S, notify = FALSE)
-	var/datum/computer_file/data/waypoint/R = new()
-	R.fields["name"] = "Bluespace Residue"
-	R.fields["x"] = torch.x
-	R.fields["y"] = torch.y
-	known_sectors[S.name] = R
-
-/obj/machinery/computer/ship/helm/Initialize()
-	. = ..()
-
-	for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
-		H.add_torch_spawn(src, FALSE)
 
 /obj/effect/overmap/visitable/ship/landable/exploration_shuttle
 	name = "Charon"

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -78,6 +78,22 @@
 		"nav_verne_5",
 	)
 
+/datum/map/torch/get_map_info()
+	. = list()
+
+/obj/machinery/computer/ship/helm/proc/add_torch_spawn(obj/effect/overmap/visitable/sector/S, notify = FALSE)
+	var/datum/computer_file/data/waypoint/R = new()
+	R.fields["name"] = "Bluespace Residue"
+	R.fields["x"] = torch.x
+	R.fields["y"] = torch.y
+	known_sectors[S.name] = R
+
+/obj/machinery/computer/ship/helm/Initialize()
+	. = ..()
+
+	for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
+		H.add_torch_spawn(src, FALSE)
+
 /obj/effect/overmap/visitable/ship/landable/exploration_shuttle
 	name = "Charon"
 	desc = "An SSE-U11 long range shuttle, broadcasting SCGEC codes and the callsign \"Torch-2 Charon\"."


### PR DESCRIPTION
🆑 
tweak: The Torch's roundstart location is now listed in all helm consoles as "bluespace residue"
/🆑 

While mostly intended for Mercs to give them some inkling of the Torch's location, should help any provacs that want to interact with the Torch. 
Flavor justification is that a big ship tearing a hole in realspace to move faster-than-light would probably leave *some* sort of signal or residue at the jump start and finish.

Thanks to Mucker for the lines of code that made this work.