### PR TITLE
Add an area flag to prevent modification of turfs within it

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -75,10 +75,11 @@
 #define DEFAULT_JOB_TYPE /datum/job/assistant
 
 //Area flags, possibly more to come
-#define AREA_FLAG_RAD_SHIELDED      1 // shielded from radiation, clearly
-#define AREA_FLAG_EXTERNAL          2 // External as in exposed to space, not outside in a nice, green, forest
-#define AREA_FLAG_ION_SHIELDED      4 // shielded from ionospheric anomalies as an FBP / IPC
-#define AREA_FLAG_IS_NOT_PERSISTENT 8 // SSpersistence will not track values from this area.
+#define AREA_FLAG_RAD_SHIELDED      1  // shielded from radiation, clearly
+#define AREA_FLAG_EXTERNAL          2  // External as in exposed to space, not outside in a nice, green, forest
+#define AREA_FLAG_ION_SHIELDED      4  // shielded from ionospheric anomalies as an FBP / IPC
+#define AREA_FLAG_IS_NOT_PERSISTENT 8  // SSpersistence will not track values from this area.
+#define AREA_FLAG_NO_MODIFY         16 // turf in this area cannot be dismantled.
 
 //Map template flags
 #define TEMPLATE_FLAG_ALLOW_DUPLICATES 1 // Lets multiple copies of the template to be spawned

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -330,3 +330,8 @@ var/list/mob/living/forced_ambiance_list = new
 
 /area/proc/has_turfs()
 	return !!(locate(/turf) in src)
+
+/area/proc/can_modify_area()
+	if (src && src.area_flags & AREA_FLAG_NO_MODIFY)
+		return FALSE
+	return TRUE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -116,6 +116,11 @@
 	var/required = quantity*recipe.req_amount
 	var/produced = min(quantity*recipe.res_amount, recipe.max_res_amount)
 
+	var/area/A = get_area(user)
+	if (!A.can_modify_area())
+		visible_message("You can't seem to make anything with \the [src] here.")
+		return
+
 	if (!can_use(required))
 		if (produced>1)
 			to_chat(user, "<span class='warning'>You haven't got enough [src] to build \the [produced] [recipe.display_name()]\s!</span>")

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -217,7 +217,8 @@
 	return FALSE
 
 /decl/hierarchy/rcd_mode/proc/can_handle_work(var/obj/item/weapon/rcd/rcd, var/atom/target)
-	return istype(target, handles_type)
+	var/area/A = get_area(get_turf(target))
+	return istype(target, handles_type) && A.can_modify_area()
 
 /decl/hierarchy/rcd_mode/proc/do_handle_work(var/atom/target)
 	var/result = get_work_result(target)
@@ -268,7 +269,8 @@
 	work_type = /turf/simulated/floor/airless
 
 /decl/hierarchy/rcd_mode/floor_and_walls/base_turf/can_handle_work(var/rcd, var/turf/target)
-	return istype(target) && (isspaceturf(target) || isopenspace(target) || istype(target, get_base_turf_by_area(target)))
+	var/area/A = get_area(target)
+	return istype(target) && (isspaceturf(target) || isopenspace(target) || istype(target, get_base_turf_by_area(target))) && A.can_modify_area()
 
 /decl/hierarchy/rcd_mode/floor_and_walls/floor_turf
 	cost = 3
@@ -316,7 +318,8 @@
 	. = ..()
 	if (.)
 		var/turf/T = get_turf(target)
-		if ((locate(/obj/structure/window) in T) || (locate(/obj/structure/grille) in T))
+		var/area/A = get_area(T)
+		if ((locate(/obj/structure/window) in T) || (locate(/obj/structure/grille) in T) || !A.can_modify_area())
 			return FALSE
 
 /decl/hierarchy/rcd_mode/deconstruction/window

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -238,6 +238,11 @@
 
 	if(W.item_flags & ITEM_FLAG_NO_BLUDGEON) return
 
+	var/area/A = get_area(src)
+	if (!A.can_modify_area())
+		to_chat(user, SPAN_NOTICE("There appears to be no way to dismantle \the [src]!"))
+		return
+
 	if(isScrewdriver(W))
 		if(reinf_material && construction_state >= 1)
 			construction_state = 3 - construction_state

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -1,5 +1,10 @@
 /turf/simulated/floor/attackby(var/obj/item/C, var/mob/user)
 
+	var/area/A = get_area(src)
+	if (!A.can_modify_area())
+		visible_message("\The [src] cannot be dismantled or modified in any way!")
+		return
+
 	if(!C || !user)
 		return 0
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -150,6 +150,11 @@
 
 /turf/simulated/wall/attackby(var/obj/item/weapon/W, var/mob/user)
 
+	var/area/A = get_area(src)
+	if (!A.can_modify_area())
+		to_chat(user, SPAN_NOTICE("\The [src] deflects all attempts to interact with it!"))
+		return
+
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 	if(!construction_stage && try_graffiti(user, W))
@@ -283,6 +288,7 @@
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)
 
 				else if(isWirecutter(W))
+
 					playsound(src, 'sound/items/Wirecutter.ogg', 100, 1)
 					construction_stage = 5
 					new /obj/item/stack/material/rods( src )

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -159,7 +159,8 @@
 	return
 
 /turf/simulated/wall/proc/take_damage(dam)
-	if(dam)
+	var/area/A = get_area(src)
+	if(dam && A.can_modify_area())
 		damage = max(0, damage + dam)
 		update_damage()
 	return

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1362,6 +1362,7 @@
 	icon_state = "Holodeck"
 	dynamic_lighting = 0
 	sound_env = LARGE_ENCLOSED
+	area_flags = AREA_FLAG_NO_MODIFY
 
 /area/holodeck/alphadeck
 	name = "\improper Holodeck Alpha"


### PR DESCRIPTION
:cl: Mucker
bugfix: Fix walls being able to be dismantled in holodeck areas.
/:cl:

Adds a new area flag (AREA_FLAG_NO_MODIFY) to identify areas with turfs that should not be dismantled. Current setup stops walls, windows, and floors from being dismantled/changed.

I probably missed some places where there should be checks, so I'll add them wherever I may have missed them should they be pointed out.

Closes #29669
Closes #29667