### PR TITLE
Halves the time it takes shuttlevators to move

### DIFF
--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -13,7 +13,7 @@
 	var/datum/computer/file/embedded_program/docking/active_docking_controller
 
 	var/obj/effect/shuttle_landmark/landmark_transition  //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
-	var/move_time = 240		//the time spent in the transition area
+	var/move_time = 120		//the time spent in the transition area
 
 	category = /datum/shuttle/autodock
 	flags = SHUTTLE_FLAGS_PROCESS | SHUTTLE_FLAGS_ZERO_G


### PR DESCRIPTION
🆑 
tweak: Shuttle-elevators like the Skipjack and ERT shuttle now have a base move time of 120 instead of 240.
/ 🆑 

Because nobody likes waiting around for roughly four minutes. Might encourage more use of the ERT and Raider shuttles too, making them each slightly more dynamic. I wanted to go even lower, but I figured I shouldn't go from 240 to, say, 30.