### PR TITLE
Emergency lockers now have set contents

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -20,15 +20,15 @@
 	closet_appearance = /decl/closet_appearance/oxygen
 
 /obj/structure/closet/emcloset/WillContain()
-	//Guaranteed kit - two tanks and masks
-	. = list(/obj/item/weapon/tank/emergency/oxygen = 2,
-			/obj/item/clothing/mask/breath = 2)
-
-	. += new/datum/atom_creator/simple(list(/obj/item/weapon/storage/toolbox/emergency, /obj/item/inflatable/wall = 2), 75)
-	. += new/datum/atom_creator/simple(list(/obj/item/weapon/tank/emergency/oxygen/engi, /obj/item/clothing/mask/gas/half), 10)
-	. += new/datum/atom_creator/simple(/obj/item/device/oxycandle, 15)
-	. += new/datum/atom_creator/simple(/obj/item/weapon/storage/firstaid/o2, 25)
-	. += new/datum/atom_creator/simple(list(/obj/item/clothing/suit/space/emergency,/obj/item/clothing/head/helmet/space/emergency), 25)
+	return list(/obj/item/weapon/tank/emergency/oxygen = 2,
+				/obj/item/clothing/mask/breath = 2,
+				/obj/item/weapon/storage/toolbox/emergency,
+				/obj/item/inflatable/wall = 2,
+				/obj/item/device/oxycandle,
+				/obj/item/weapon/storage/med_pouch/oxyloss = 2,
+				/obj/item/clothing/suit/space/emergency,
+				/obj/item/clothing/head/helmet/space/emergency
+	)
 
 /*
  * Fire Closet


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Emergency lockers are currently only guaranteed to have breath masks and oxygen tanks in, with other useful equipment such as softsuits and oxyloss first-aid kits reliant on a random spawn chance. Emergency lockers now always contain:
- 2 breath masks
- 2 emergency oxygen tanks
- 1 emergency softsuit
- 1 emergency toolbox
- 1 oxygen candle
- 2 oxyloss pouches
- 2 inflatable walls

:cl:
tweak: Emergency lockers no longer have random contents, instead always containing the same items.
/:cl: