### PR TITLE
Gun safety is now visible message and quieter

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -555,9 +555,9 @@
 	safety_state = !safety_state
 	update_icon()
 	if(user)
-		to_chat(user, "<span class='notice'>You switch the safety [safety_state ? "on" : "off"] on [src].</span>")
+		user.visible_message(SPAN_WARNING("[user] switches the safety of \the [src] [safety_state ? "on" : "off"]."), SPAN_NOTICE("You switch the safety of \the [src] [safety_state ? "on" : "off"]."), range = 3)
 		last_safety_check = world.time
-		playsound(src, 'sound/weapons/flipblade.ogg', 30, 1)
+		playsound(src, 'sound/weapons/flipblade.ogg', 15, 1)
 
 /obj/item/weapon/gun/verb/toggle_safety_verb()
 	set src in usr


### PR DESCRIPTION
The sound is already played so it helps to have some visual feedback as well. To make it a bit less obvious from longer distances, it's quieter as well.

:cl:
tweak: You can now see if someone else toggles the safety of their gun within 3 tiles of you.
tweak: The sound for toggling the safety of a gun is now quieter.
/:cl: