### PR TITLE
Changes torch mutiny text to remove extension

### DIFF
--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -40,7 +40,7 @@
 	to_chat(src, "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>")
 
 /mob/living/proc/convert_to_loyalist(mob/M as mob in able_mobs_in_oview(src))
-	set name = "Convince Recidivist"
+	set name = "Convert"
 	set category = "Abilities"
 	if(!M.mind || !M.client)
 		return

--- a/maps/torch/datums/game_modes/torch_revolution.dm
+++ b/maps/torch/datums/game_modes/torch_revolution.dm
@@ -1,11 +1,9 @@
 /datum/game_mode/revolution
 	name = "Mutiny"
 	round_description = "Morale is shattered, and a mutiny is brewing! Use the 'Check Round Info' verb for more information!"
-	extended_round_description = "Time in space, away from home and loved ones, takes its toll on even the most grizzled space travellers. To make matters worse, the planned return trip to Sol \
-								for refitting, repairs and relaxation has been cancelled by the brass; instead, the SEV Torch is to, for the first time, enter a hibernative state. All crew will enter cryogenic stasis, \
-								and the shipbound AI system will complete a series of jumps that will take the ship lightyears further away from home. Outrage from friends and family of crew back \
-								on Mars, Luna and other various worlds has spawned primetime scandals that dominate the 24/7 news cycle. Videolink interviews with Torch crew reveal morale is at an \
-								all time low. Rumors are spreading of an impending mutiny."
+	extended_round_description = "Time in space, away from home and loved ones, takes its toll on even the most grizzled space travelers. As time goes on, some crew find themselves \
+								stretched to their breaking points; friendly faces become harsh and hostile, and the most sensible of minds become filled with bitterness and petty ideas. \
+								As their peers find themselves surrounded by ever-angrier forces, the situation on the Torch is rapidly reaching its brutal climax."
 	config_tag = "mutiny"
 	required_enemies = 4
 	required_players = 10
@@ -14,13 +12,13 @@
 	role_text = "Head Mutineer"
 	role_text_plural = "Mutineers"
 
-	faction_welcome = "It's time to go home. Obey all instructions from the leaders of the mutiny, and ensure the mutiny succeeds."
-	welcome_text = "You've been out here for what feels like an eternity. Time passes awkwardly in space. You were getting ready to head back to Sol - everyone has - but now \
-					that's all changed, and tomorrow you're all getting canned up like sardines, and the AI is to pilot you even further away from home. Most everyone knows this isn't right, this wasn't \
-					in the deal, that this isn't fair. You and a few others have decided to do something about it, and get everyone back home, by any means neccessary."
+	faction_welcome = "That's it; you're done taking this crap. Obey all instructions from the leaders of the mutiny, and ensure the mutiny succeeds."
+	welcome_text = "You've been out here for what feels like an eternity. The time spent in space has worn away at your conscience, and \
+					you won't let yourself be canned up like a sardine for even one more jump. Take control of your situation and use the Torch for your own ends, or \
+					even just to return home."
 
-	victory_text = "The heads of staff were relieved of their posts. The Torch is finally heading home."
-	loss_text = "The heads of staff managed to quash the mutiny. The mission will continue as ordered."
+	victory_text = "The Torch has fallen to the mutiny, and its future is now in question."
+	loss_text = "The attempted mutiny has failed, but the crew questions what happens now."
 
 	//Inround revs.
 	faction_role_text = "Mutineer"
@@ -35,8 +33,8 @@
 /datum/antagonist/loyalists
 
 
-	victory_text = "The heads of staff remained at their posts; the mission will continue as ordered."
-	loss_text = "The heads of staff could not contain the mutiny, and the Torch is now heading home."
+	victory_text = "The Torch is free of the mutineers, although the cost has yet to be discovered in full."
+	loss_text = "The mutineers have won; the Torch will never be the same."
 
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
 	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
@@ -44,8 +42,9 @@
 
 /datum/antagonist/loyalists/Initialize()
 	..()
-	welcome_text = "The SEV Torch, the most ambitious and prestigious human research project ever established, is now under threat from her very crew as a result of the Expeditionary Corps' brass decision \
-					to enter 'hibernation mode' (with crew in cryosleep, and the AI piloting the ship) instead of making the scheduled return to Sol. Crew morale is dangerously low. What the Torch needs now \
-					is a steady hand to guide her through what will likely be the greatest trial she will face."
-	faction_welcome = "Obey all instructions, follow the chain of command, and ensure the mission continues as ordered."
+	welcome_text = "The SEV Torch has been on this mission for some time, and there is still much to accomplish. \
+					However, whispers abound about malcontents, saboteurs and mutineers - the very ship faces threats from within!\
+					To protect your way of life, those who would change it must be pacified or eliminated, and those that remain \
+					must know not to intrude on your status."
+	faction_welcome = "Defend your own authority and that of your leaders; eliminate any threats."
 	faction_descriptor = "[GLOB.using_map.company_name]"


### PR DESCRIPTION
🆑 
tweak: Torch loyalist and mutineer text no longer reference an extension, and instead try to provoke more extreme behavior on both sides.
tweak: The loyalist convert verb is now just "convert" instead of "convince recidivist".
/ 🆑 

We always talk about doing this. Now I'm doing it.