### PR TITLE
Enables Dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
To keep track of dependencies in current (and future) workflows. More of a concern when tests get ported to actions.

Will create a PR when one of these dependencies gets outdated, updating it.

Full Docs:
<https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-dependabot-version-updates>
