### PR TITLE
Migrates travis tests to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,94 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - dev
+    pull_request:
+      branches:
+        - dev
+
+env:
+  BYOND_MAJOR: "512"
+  BYOND_MINOR: "1485"
+  SPACEMAN_DMM_VERSION: suite-1.5
+
+jobs:
+  DreamChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: $HOME/spaceman_dmm/$SPACEMAN_DMM_VERSION
+          key: ${{ runner.os }}-spacemandmm-${{ env.SPACEMAN_DMM_VERSION }}
+      - name: Install Dreamchecker
+        run:  scripts/install-spaceman-dmm.sh dreamchecker
+      - name: Run Dreamchecker
+        run: ~/dreamchecker
+      - name: Run Failure Webhook
+        env:
+          JOB_STATUS: ${{ job.status }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ failure() }}
+        run: |
+          wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
+          chmod +x send.sh
+          ./sendsh failure $WEBHOOK_URL
+  Code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
+          key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
+      - name: Install Dependencies
+        run: sudo apt-get install -y uchardet
+      - name: Run Tests
+        env:
+          TEST: CODE
+        run: test/run-test.sh
+      - name: Run Failure Webhook
+        env:
+          JOB_STATUS: ${{ job.status }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ failure() }}
+        run: |
+          wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
+          chmod +x send.sh
+          ./sendsh failure $WEBHOOK_URL
+  Maps:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        map_path: [example, torch, bearcat, away_sites_testing]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
+          key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
+      - name: Run Tests
+        env:
+          TEST: MAP
+          MAP_PATH: ${{ matrix.map_path }}
+        run: test/run-test.sh
+      - name: Run Failure Webhook
+        env:
+          JOB_STATUS: ${{ job.status }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ failure() }}
+        run: |
+          wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
+          chmod +x send.sh
+          ./sendsh failure $WEBHOOK_URL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
           chmod +x send.sh
-          ./sendsh failure $WEBHOOK_URL
+          ./send.sh failure $WEBHOOK_URL
   Code:
     runs-on: ubuntu-latest
     steps:
@@ -63,7 +63,7 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
           chmod +x send.sh
-          ./sendsh failure $WEBHOOK_URL
+          ./send.sh failure $WEBHOOK_URL
   Maps:
     runs-on: ubuntu-latest
     strategy:
@@ -91,4 +91,4 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
           chmod +x send.sh
-          ./sendsh failure $WEBHOOK_URL
+          ./send.sh failure $WEBHOOK_URL

--- a/scripts/install-spaceman-dmm.sh
+++ b/scripts/install-spaceman-dmm.sh
@@ -7,6 +7,7 @@ then
   cp "$HOME/spaceman_dmm/$SPACEMAN_DMM_VERSION/$1" ~/$1
 else
   wget -O ~/$1 "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$1"
+  mkdir $HOME/spaceman_dmm
   cp ~/$1 $HOME/spaceman_dmm/$SPACEMAN_DMM_VERSION
 fi
 


### PR DESCRIPTION
Creates `.github/workflows/test.yml` which defines a workflow to replace Travis CI. Ports failure webhook to use [DiscordHooks/github-actions-discord-webhook](https://github.com/DiscordHooks/github-actions-discord-webhook) as well

Also edits install-spaceman-dmm.sh to add `mkdir spaceman-dmm`, as gh does not make it automatically

Test run located [Here](https://github.com/Lorwp/Baystation12/actions/runs/350451538)

Does not remove travis.yml, or disable travis
