### PR TITLE
Roundstart hour can now be any hour

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -140,7 +140,7 @@ var/round_start_time = 0
 	return last_round_duration
 
 /hook/startup/proc/set_roundstart_hour()
-	roundstart_hour = pick(2,7,12,17)
+	roundstart_hour = rand(0, 23)
 	return 1
 
 GLOBAL_VAR_INIT(midnight_rollovers, 0)


### PR DESCRIPTION
Rounds always start at either 02:00, 07:00, 12:00, or 17:00. This allows for much more diversity in when the shifts start which can make the time a bit less dull.

:cl:
tweak: The time at the start of the round can now be any hour of the day.
:cl: