### PR TITLE
Fix infinite recursion bug with unlinked consoles.

### DIFF
--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -62,7 +62,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	LAZYDISTINCTADD(viewers, weakref(user))
 
 /obj/machinery/computer/ship/proc/unlook(var/mob/user)
-	user.reset_view()
+	user.reset_view(null, FALSE)
 	if(user.client)
 		user.client.view = world.view
 	GLOB.moved_event.unregister(user, src, /obj/machinery/computer/ship/proc/unlook)


### PR DESCRIPTION
Fixes the infinite recursion bug that happens when clicking "Reconnect" on unlinked ship consoles.
Done by making sure `reset_view()` in the instance of ship computers can't call `handle_regular_hud_updates()`, which leads to a recursive loop.

🆑 Mucker
bugfix: Fix MC being crashed by clicking "Reconnect" on unlinked consoles.
/🆑

Closes #29689 