### PR TITLE
Fix the double comma in gear contents list

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -115,7 +115,7 @@
 	..()
 
 /datum/gear_tweak/contents/get_contents(var/metadata)
-	return "Contents: [english_list(metadata, and_text = ", ")]"
+	return "Contents: [english_list(metadata, and_text = ", ", final_comma_text = "")]"
 
 /datum/gear_tweak/contents/get_default()
 	. = list()


### PR DESCRIPTION
🆑 Mucker
bugfix: Fix lunchboxes having a double comma in the listing of its contents in the loadout menu.
/🆑

Closes #29708 