### PR TITLE
SkrellSnax are no longer improper

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3400,7 +3400,7 @@
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/skrellsnacks
-	name = "\improper SkrellSnax"
+	name = "SkrellSnax"
 	desc = "Cured fungus shipped all the way from Jargon 4, almost like jerky! Almost."
 	icon_state = "skrellsnacks"
 	filling_color = "#a66829"


### PR DESCRIPTION
Fixes an issue where they wouldn't be in lunchboxes/any other loadout items because of JSON fuckery.

:cl:
bugfix: SkrellSnax can now be put into lunchboxes in your loadout preferences and actually be in there.
/:cl: