### PR TITLE
Utensil tweaks

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -40,16 +40,28 @@
 			return ..()
 
 	if (reagents.total_volume > 0)
-		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		if(M == user)
 			if(!M.can_eat(loaded))
 				return
-			M.visible_message("<span class='notice'>\The [user] eats some [loaded] from \the [src].</span>")
+			switch(M.get_fullness())
+				if (0 to 50)
+					to_chat(M, SPAN_DANGER("You ravenously stick \the [src] into your mouth and gobble the food!"))
+				if (50 to 150)
+					to_chat(M, SPAN_NOTICE("You hungrily chew the food on \the [src]."))
+				if (150 to 350)
+					to_chat(M, SPAN_NOTICE("You chew the food on \the [src]."))
+				if (350 to 550)
+					to_chat(M, SPAN_NOTICE("You unwillingly chew the food on \the [src]."))
+				if (550 to INFINITY)
+					to_chat(M, SPAN_WARNING("You cannot take one more bite from \the [src]!"))
+					return
+
 		else
 			user.visible_message("<span class='warning'>\The [user] begins to feed \the [M]!</span>")
 			if(!M.can_force_feed(user, loaded) || !do_after(user, 5 SECONDS, M))
 				return
 			M.visible_message("<span class='notice'>\The [user] feeds some [loaded] to \the [M] with \the [src].</span>")
+		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		playsound(M.loc,'sound/items/eatfood.ogg', rand(10,40), 1)
 		overlays.Cut()
 		return

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -138,10 +138,7 @@
 				to_chat(user, "<span class='warning'>You already have something on your [U].</span>")
 				return
 
-			user.visible_message( \
-				"\The [user] scoops up some [src] with \the [U]!", \
-				"<span class='notice'>You scoop up some [src] with \the [U]!</span>" \
-			)
+			to_chat(user, SPAN_NOTICE("You scoop up some [src] with \the [U]!"))
 
 			src.bitecount++
 			U.overlays.Cut()


### PR DESCRIPTION
Removes the chat bloat that utensils have. You don't get visible messages for eating food by hand, so you shouldn't for eating it with a utensil.

In addition, you can no longer eat past the point of fullness if you're feeding yourself. Feeding someone else uses separate logic so that was left untouched (as was the visible message as you're affecting someone else).

:cl:
tweak: Other people will no longer see when you use utensils, except when feeding others.
tweak: You will now get feedback on how full you are when eating from a utensil, and can no longer overstuff yourself.
/:cl: