### PR TITLE
Should fix miningstation from not working

### DIFF
--- a/maps/away/miningstation/miningstation.dmm
+++ b/maps/away/miningstation/miningstation.dmm
@@ -2446,8 +2446,7 @@
 /obj/item/stack/material/gold/ten,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	)
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/miningstation/vault)
@@ -8491,6 +8490,11 @@
 /obj/effect/paint/black,
 /turf/simulated/wall/r_titanium,
 /area/miningstation/operationshall)
+"Qb" = (
+/obj/structure/lattice,
+/obj/effect/overmap/visitable/sector/miningstation,
+/turf/space,
+/area/space)
 "Qf" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -19149,7 +19153,7 @@ eE
 eR
 fn
 dY
-ao
+Qb
 gi
 dX
 mk


### PR DESCRIPTION
🆑 
maptweak: MiningStation now has the effect necessary to make it appear on the overmap.
/ 🆑 

Miningstation's map was missing 

/obj/effect/overmap/visitable/sector/miningstation

which prevented it from appearing on the overmap whenever it generated.

This _should_ fix that.