### PR TITLE
Examining is no longer visible, add eye contact

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -219,11 +219,6 @@ var/list/_client_preferences_by_type
 	key = "DEPT_GOALS"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
-/datum/client_preference/examine_messages
-	description ="Examining messages"
-	key = "EXAMINE_MESSAGES"
-	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
-
 /datum/client_preference/goonchat
 	description = "Use Goon Chat"
 	key = "USE_GOONCHAT"

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -112,3 +112,5 @@
 	var/list/descriptors
 
 	var/last_smelt = 0
+
+	var/list/recent_examines = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -319,16 +319,6 @@
 
 	face_atom(A)
 
-	if(!isghost(src))
-		if(A.loc != src || A == l_hand || A == r_hand)
-			for(var/mob/M in viewers(4, src))
-				if(M == src)
-					continue
-				if(M.client && M.client.get_preference_value(/datum/client_preference/examine_messages) == GLOB.PREF_SHOW)
-					if(M.is_blind() || is_invisible_to(M))
-						continue
-					to_chat(M, "<span class='subtle'><b>\The [src]</b> looks at \the [A].</span>")
-
 	var/distance = INFINITY
 	if(isghost(src) || stat == DEAD)
 		distance = 0

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -61,6 +61,7 @@
 	var/thirst_factor = DEFAULT_THIRST_FACTOR // Multiplier for thirst.
 	var/taste_sensitivity = TASTE_NORMAL      // How sensitive the species is to minute tastes.
 	var/silent_steps
+	var/can_make_eye_contact = TRUE			  // Whether or not we are able to make direct eye contact with other things.
 
 	var/min_age = 17
 	var/max_age = 70

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -9,7 +9,8 @@
 	new environment."
 	hidden_from_codex = FALSE
 	silent_steps = TRUE
-
+	can_make_eye_contact = FALSE
+	
 	antaghud_offset_y = 8
 
 	assisted_langs = list(LANGUAGE_GUTTER, LANGUAGE_UNATHI_SINTA, LANGUAGE_SKRELLIAN, LANGUAGE_HUMAN_EURO, LANGUAGE_EAL, LANGUAGE_HUMAN_RUSSIAN)

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -262,7 +262,8 @@
 	health_hud_intensity = 2
 	hunger_factor = 3
 	thirst_factor = 0.01
-
+	can_make_eye_contact = FALSE
+	
 	min_age = 1
 	max_age = 300
 


### PR DESCRIPTION
First, examining objects will now no longer show up for other people. It doesn't make too much sense that you, a bystander, would be acutely aware of exactly what someone is looking at just judging by, what, their eye movements? And you're constantly looking at their eyes?

Well, maybe you are. In which case, another attentive person will realize. When you examine someone, there is a 5-second window where if they examine you back, you will both get a notice that you've made eye contact. Otherwise, you'll have to look at their body position (i.e., how they rotate) to get an idea of what they're looking at.

Of course, not every species is capable of making eye contact. GAS would have trouble with their compound eyes, for example. So, GAS, adherents, and dionaea are incapable of making use of this feature. This is just my guess, so if the SMs have strong opinions let me know.

I also fully understand if people are attached to the current way examining works, so if you dissent with the PR please express it in the appropriate channels. (As an alternative, examining the current way can be kept, while making eye contact stands out to the user instead of using a subtle span.)

:cl:
rscdel: You will no longer see when someone examines another object or mob. Also removed the examining message preference.
rscadd: If two mobs examine each other within a 5-second window, they will make eye contact. GAS, adherents, and dionaea are exempted.
/:cl: