### PR TITLE
Fixes the Reclaimer's shuttle landmark on the Torch

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -21910,7 +21910,7 @@ aa
 aa
 aa
 aa
-aa
+Gt
 aa
 aa
 aa
@@ -22112,7 +22112,7 @@ aa
 aa
 aa
 aa
-Gt
+aa
 aa
 aa
 aa


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes the Reclaimer's shutte location at the Torch not being reachable.
/:cl:

Had to be shifted one turf left to give it enough space to move there.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->