### PR TITLE
Fix names with special characters not matching crew record name

### DIFF
--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -155,6 +155,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	return dat
 
 /proc/get_crewmember_record(var/name)
+	name = sanitize(name)
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
 		if(CR.get_name() == name)
 			return CR


### PR DESCRIPTION
:cl: Mucker
bugfix: Fix HUD items not being able to find records for characters with special symbols in their name.
/:cl:

`get_name()` in this scenario was returning a sanitized string that turned special characters into html entities, this ensures that the input to the proc is also sanitized in the same way.

Closes #29706 