### PR TITLE
Lobby player list in alphabetical order

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -84,3 +84,15 @@
 
 /proc/cmp_planelayer(atom/A, atom/B)
 	return (B.plane - A.plane) || (B.layer - A.layer)
+
+/proc/cmp_mob_key(mob/A, mob/B)
+	if (!A && !B)
+		return 0
+
+	if (!A && B)
+		return -1
+
+	if (A && !B)
+		return 1
+
+	return sorttext(B.key, A.key)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -58,7 +58,10 @@
 
 /mob/Login()
 
-	GLOB.player_list |= src
+	// Add to player list if missing
+	if (!GLOB.player_list.Find(src))
+		ADD_SORTED(GLOB.player_list, src, /proc/cmp_mob_key)
+
 	update_Login_details()
 	world.update_status()
 

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -13,7 +13,10 @@
 	GLOB.using_map.show_titlescreen(client)
 	my_client = client
 	set_sight(sight|SEE_TURFS)
-	GLOB.player_list |= src
+
+	// Add to player list if missing
+	if (!GLOB.player_list.Find(src))
+		ADD_SORTED(GLOB.player_list, src, /proc/cmp_mob_key)
 
 	new_player_panel()
 


### PR DESCRIPTION
Changed the lobby player list to alphabetical order, rather than the unordered mess it was before. There's theoretically a performance hit for doing this but it wasn't enough that I noticed during testing with two users. I don't have a good way of testing with more, but it only happens before the round starts.

![alphabetical-lobby-list](https://user-images.githubusercontent.com/1348714/98827576-f015fb00-242e-11eb-9241-d17391deeed1.png)

🆑 Ninetailed
rscadd: Lobby player list in alphabetical order
/🆑

EDIT: New impementation
Sorts GLOB.player_list by client key

This is done by using ADD_SORTED to add newly logged in players to the global list. This results in a single O(n) performance hit on login. This is an infrequent enough event that this should be acceptable, but may manifest as a transient lag spike with large numbers of players.

This will result in the Lobby player list appearing in alphabetical order, and may also have the same effect on certain admin tools such as the debug player list.

As this is done on login, if a mob is transferred to a different client key, the list will not be updated. As this change primarily targets the pre-game lobby, before any such changes will be made, I consider this case to be out of scope.