### PR TITLE
Lets MAs and Detectives be lings

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -6,7 +6,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
-	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/hos)
+	protected_jobs = list(/datum/job/warden, /datum/job/captain, /datum/job/hos)
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"


### PR DESCRIPTION
🆑 
tweak: MAs and F-Techs can now be your friendly neighborhood changelings.
/ 🆑 

Security currently has a guarantee of no roundstart lings in the department.

Now no department is safe.
Suffer.

Thought about making it so XO couldn't be ling, but they can be traitor so they can be horrifying fleshbeasts too.