### PR TITLE
Moves torch loyalist/mutiny jobstuff

### DIFF
--- a/maps/torch/datums/game_modes/torch_revolution.dm
+++ b/maps/torch/datums/game_modes/torch_revolution.dm
@@ -26,9 +26,6 @@
 
 	faction = "mutiny"
 
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
-	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
-	protected_jobs = list(/datum/job/officer)
 
 /datum/antagonist/loyalists
 
@@ -36,9 +33,6 @@
 	victory_text = "The Torch is free of the mutineers, although the cost has yet to be discovered in full."
 	loss_text = "The mutineers have won; the Torch will never be the same."
 
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
-	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
-	protected_jobs = list(/datum/job/officer)
 
 /datum/antagonist/loyalists/Initialize()
 	..()

--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -12,12 +12,14 @@
 	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/loyalists
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/submap)
-	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap, /datum/job/merchant)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
+	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/revolutionary
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/submap)
-	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap, /datum/job/merchant)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
+	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/traitor
 	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos)


### PR DESCRIPTION
Moves the loyalist/mutineer to torch_antagonism so we don't have the job restrictions in two separate places for the antag type.

Shouldn't be any changes for the player, just cleans up stuff.