### PR TITLE
Bluespace Residue Electric Boogaloo

### DIFF
--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -124,3 +124,19 @@
 	name = "guppy control console"
 	shuttle_tag = "Guppy"
 	req_access = list(access_guppy_helm)
+
+/obj/effect/overmap/visitable/ship/torch/Initialize()
+	. = ..()
+
+	var/obj/effect/overmap/visitable/sector/residue/R = new()
+	R.forceMove(locate(src.x, src.y, GLOB.using_map.overmap_z))
+
+	for(var/obj/machinery/computer/ship/helm/H in SSmachines.machinery)
+		H.add_known_sector(R)
+
+/obj/effect/overmap/visitable/sector/residue
+	name = "Bluespace Residue"
+	desc = "Trace radiation emanating from this sector is consistent with the aftermath of a bluespace jump."
+	icon_state = "event"
+	known = TRUE
+	


### PR DESCRIPTION
🆑 
rscadd: The Torch now spawns "Bluespace Residue" on it's overmap location round start. The Residue is known and acts as a "Torch was here" beacon to offships.
/🆑 

As with my previous attempts, this is essentially a roundabout way of flagging the Torch as "known" for mercs and other overmap roles to be able to expedite any Torch interactions. This attempt, however, is _functional_.

After watching me scream at various things, @MuckerMayhem came in with a mostly-solution and we screamed together until it was a done solution. Conclusion? I make a good rubber duck.