### PR TITLE
Maps in plastic doors in place of toilet curtains

### DIFF
--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -42,6 +42,9 @@
 		glass = 1
 		alpha = 180
 		set_opacity(0)
+	
+	if(!density)
+		set_opacity(0)
 	update_icon()
 
 /obj/machinery/door/unpowered/simple/c_airblock(turf/other)
@@ -246,6 +249,9 @@
 
 /obj/machinery/door/unpowered/simple/plastic/New(var/newloc,var/material_name,var/complexity)
 	..(newloc, MATERIAL_PLASTIC, complexity)
+
+/obj/machinery/door/unpowered/simple/plastic/open
+	density = FALSE
 
 /obj/machinery/door/unpowered/simple/glass/New(var/newloc,var/material_name,var/complexity)
 	..(newloc, MATERIAL_GLASS, complexity)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -2139,7 +2139,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "eE" = (
-/obj/structure/curtain/open/privacy,
+/obj/machinery/door/unpowered/simple/plastic/open,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "eF" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -22199,6 +22199,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/aux)
+"ltt" = (
+/obj/machinery/door/unpowered/simple/plastic/open,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/head/aux)
 "lvb" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -26162,7 +26166,7 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
 "qtQ" = (
-/obj/structure/curtain/open/shower,
+/obj/machinery/door/unpowered/simple/plastic/open,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
 "qvX" = (
@@ -45560,10 +45564,10 @@ rKo
 ayb
 ure
 aAm
-sYU
+ltt
 aAm
 aAm
-sYU
+ltt
 aAm
 aAm
 akZ
@@ -45767,7 +45771,7 @@ abR
 riD
 riD
 ado
-sYU
+ltt
 ala
 riD
 aAm


### PR DESCRIPTION
🆑 Hubblenaut
maptweak: Maps in plastic doors in place of toilet curtains.
/:cl:

Makes a new subtype `open` for plastic doors.
Affected areas are D3 Head, D1 Head and medbay.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->