### PR TITLE
Cancel redundant jobs when pushing to dev

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,16 @@
+name: Cancel
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  cancel:
+    name: 'Cancel Redundant Builds'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          workflow_id: [27212, 3545321]
+          access_token: ${{ github.token }}


### PR DESCRIPTION
using <https://github.com/styfle/cancel-workflow-action>

At least until (if ever) this is provided natively in actions