### PR TITLE
Tweaks the armor, slowdown and siemens of various rigs

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -37,6 +37,7 @@
 
 /obj/item/clothing/gloves/rig/merc
 	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_NOCUFFS
+	siemens_coefficient = 0
 
 //Has most of the modules removed
 /obj/item/weapon/rig/merc/empty

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -35,22 +35,21 @@
 /obj/item/weapon/rig/industrial
 	name = "industrial suit control module"
 	suit_type = "industrial hardsuit"
-	desc = "A heavy, powerful rig used by construction crews and mining corporations."
+	desc = "An industrial hardsuit used by construction crews and mining corporations."
 	icon_state = "engineering_rig"
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR,
+		melee = ARMOR_MELEE_KNIVES,
 		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_HANDGUNS,
+		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	online_slowdown = 3
+	online_slowdown = 4
 	offline_slowdown = 10
 	vision_restriction = TINT_MODERATE
 	offline_vision_restriction = TINT_BLIND
-	emp_protection = -20
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 	min_pressure_protection = 0
 
@@ -263,7 +262,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 		)
-	online_slowdown = 1
+	online_slowdown = 0
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/medical


### PR DESCRIPTION
🆑 
tweak: The industrial hardsuit is no longer esword and egun proof and has slightly more slowdown, but is no longer as weak to EMPs.
tweak: Mercenary hardsuit gloves are now insulated.
tweak: The medical hardsuit no longer has slowdown when powered.
/ 🆑 

Tweaks were made according to my own experiences with the suits in ways I felt should be changed. 
The medical hardsuit is a thin, lightweight suit and it having slowdown while the EVA rig did not felt odd. 
The mercenary hardsuits not having insulated gloves made shuffling gloves awkward and made EVA hacking with a hardsuit a hassle. 
The industrial hardsuit's armor values are absurdly high, and I've survived several esword hits to the head with nothing more than some light bruising. It's also remarkably fast for a suit that's got extensive armor and is so visibly bulky, hence the slight slowdown increase.