### PR TITLE
Fix expedition storage access

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -6136,7 +6136,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "uw" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Lounge Maintenance"
@@ -7290,7 +7290,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "yb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10633,7 +10633,7 @@
 "Kt" = (
 /obj/structure/railing/mapped,
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "Ku" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -10739,7 +10739,7 @@
 "KF" = (
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "KG" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -10770,7 +10770,7 @@
 /area/security/hangcheck)
 "KI" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "KK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11237,7 +11237,7 @@
 "Mh" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "Mi" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -12098,7 +12098,7 @@
 	name = "Expedition Storage"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "OB" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
@@ -12762,7 +12762,7 @@
 	dir = 8
 	},
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "Qs" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13151,6 +13151,9 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/storage/primary)
+"RA" = (
+/turf/simulated/wall/prepainted,
+/area/quartermaster/expedition/storage)
 "RC" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -14163,7 +14166,7 @@
 /area/maintenance/fourthdeck/aft)
 "TS" = (
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "TT" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
@@ -14511,7 +14514,7 @@
 /obj/structure/catwalk,
 /obj/structure/ladder,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "UR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15521,7 +15524,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/open,
-/area/maintenance/fourthdeck/forestarboard)
+/area/quartermaster/expedition/storage)
 "XD" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Commissary Counter"
@@ -31406,7 +31409,7 @@ aa
 ak
 ak
 kQ
-er
+RA
 uu
 ya
 KI


### PR DESCRIPTION
Expedition storage (the small area in deck 4 maintenance) was marked as being part of maintenance instead of having mining access, allowing anyone with maintenance access to enter it and go down into the storage area leading into the hangar, effectively bypassing the hangar access requirements. While this change will probably be seen as unpopular, it's a bug and it needs to be fixed. Discussion should be aimed at whether roles like MAAs/physicians/whatever should simply be given hangar access.

:cl:
bugfix: Fixed the access requirements on the upper level of expedition storage.
/:cl: