### PR TITLE
runtimes fixes

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -78,16 +78,16 @@
 	Predicate Helpers
 */
 /proc/area_belongs_to_zlevels(var/area/A, var/list/z_levels)
-	. = (A.z in z_levels)
+	return A && (A.z in z_levels)
 
 /proc/is_station_area(var/area/A)
-	. = isStationLevel(A.z)
+	return A && (isStationLevel(A.z))
 
 /proc/is_contact_area(var/area/A)
-	. = isContactLevel(A.z)
+	return A && (isContactLevel(A.z))
 
 /proc/is_player_area(var/area/A)
-	. = isPlayerLevel(A.z)
+	return A && (isPlayerLevel(A.z))
 
 /proc/is_not_space_area(var/area/A)
 	. = !istype(A,/area/space)
@@ -96,7 +96,7 @@
 	. = !istype(A,/area/shuttle)
 
 /proc/is_area_with_turf(var/area/A)
-	. = isnum(A.x)
+	return A && (isnum(A.x))
 
 /proc/is_area_without_turf(var/area/A)
 	. = !is_area_with_turf(A)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -134,7 +134,6 @@ var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/check_custom_items,
 	/datum/admins/proc/spawn_plant,
 	/datum/admins/proc/spawn_atom,		// allows us to spawn instances,
-	/client/proc/respawn_character,
 	/client/proc/spawn_chemdisp_cartridge,
 	/datum/admins/proc/mass_debug_closet_icons
 	)
@@ -216,7 +215,6 @@ var/list/admin_verbs_permissions = list(
 	/client/proc/edit_admin_permissions
 	)
 var/list/admin_verbs_rejuv = list(
-	/client/proc/respawn_character
 	)
 
 //verbs which can be hidden - needs work

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -158,7 +158,7 @@
 
 	if(!check_rights(R_INVESTIGATE))
 		return
-	
+
 	var/options = list()
 
 	if(ismob(A))
@@ -166,7 +166,7 @@
 
 	if(check_rights(R_ADMIN, FALSE))
 		options += list("Visual Narrate", "Audible Narrate")
-	
+
 	var/result = input("What type of narrate?") as null | anything in options
 	switch(result)
 		if (null)
@@ -469,98 +469,6 @@ Ccomp's first proc.
 
 	log_admin("[key_name(usr)] has [action] on joining the round if they use AntagHUD")
 	message_admins("Admin [key_name_admin(usr)] has [action] on joining the round if they use AntagHUD", 1)
-
-/*
-If a guy was gibbed and you want to revive him, this is a good way to do so.
-Works kind of like entering the game with a new character. Character receives a new mind if they didn't have one.
-Traitors and the like can also be revived with the previous role mostly intact.
-/N */
-/client/proc/respawn_character()
-	set category = "Special Verbs"
-	set name = "Respawn Character"
-	set desc = "Respawn a person that has been gibbed/dusted/killed. They must be a ghost for this to work and preferably should not have a body to go back into."
-	if(!holder)
-		to_chat(src, "Only administrators may use this command.")
-		return
-	var/input = ckey(input(src, "Please specify which key will be respawned.", "Key", ""))
-	if(!input)
-		return
-
-	var/mob/observer/ghost/G_found
-	for(var/mob/observer/ghost/G in GLOB.player_list)
-		if(G.ckey == input)
-			G_found = G
-			break
-
-	if(!G_found)//If a ghost was not found.
-		to_chat(usr, "<font color='red'>There is no active key like that in the game or the person is not currently a ghost.</font>")
-		return
-
-	var/mob/living/carbon/human/new_character = new(pick(GLOB.latejoin))//The mob being spawned.
-
-	var/datum/computer_file/report/crew_record/record_found			//Referenced to later to either randomize or not randomize the character.
-	if(G_found.mind && !G_found.mind.active)
-		record_found = get_crewmember_record(G_found.real_name)
-
-	if(record_found)//If they have a record we can determine a few things.
-		new_character.real_name = record_found.get_name()
-		new_character.gender = record_found.get_sex()
-		new_character.age = record_found.get_age()
-		new_character.b_type = record_found.get_bloodtype()
-	else
-		new_character.gender = pick(MALE,FEMALE)
-		var/datum/preferences/A = new()
-		A.setup()
-		A.randomize_appearance_and_body_for(new_character)
-		new_character.real_name = G_found.real_name
-
-	if(!new_character.real_name)
-		if(new_character.gender == MALE)
-			new_character.real_name = capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
-		else
-			new_character.real_name = capitalize(pick(GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
-	new_character.SetName(new_character.real_name)
-
-	if(G_found.mind && !G_found.mind.active)
-		G_found.mind.transfer_to(new_character)	//be careful when doing stuff like this! I've already checked the mind isn't in use
-		new_character.mind.special_verbs = list()
-	else
-		new_character.mind_initialize()
-	if(!new_character.mind.assigned_role)	new_character.mind.assigned_role = GLOB.using_map.default_assistant_title//If they somehow got a null assigned role.
-
-	//DNA
-	new_character.dna.ready_dna(new_character)
-	if(record_found)//Pull up their name from database records if they did have a mind.
-		new_character.dna.unique_enzymes = record_found.get_dna()//Enzymes are based on real name but we'll use the record for conformity.
-	new_character.key = G_found.key
-
-	/*
-	The code below functions with the assumption that the mob is already a traitor if they have a special role.
-	So all it does is re-equip the mob with powers and/or items. Or not, if they have no special role.
-	If they don't have a mind, they obviously don't have a special role.
-	*/
-
-	var/player_key = G_found.key
-
-	//Now for special roles and equipment.
-	var/datum/antagonist/antag_data = get_antag_data(new_character.mind.special_role)
-	if(antag_data)
-		antag_data.add_antagonist(new_character.mind)
-		antag_data.place_mob(new_character)
-	else
-		SSjobs.equip_rank(new_character, new_character.mind.assigned_role, 1)
-
-	//Announces the character on all the systems, based on the record.
-	if(!issilicon(new_character))//If they are not a cyborg/AI.
-		if(!record_found && !player_is_antag(new_character.mind, only_offstation_roles = 1)) //If there are no records for them. If they have a record, this info is already in there. MODE people are not announced anyway.
-			if(alert(new_character,"Would you like an active AI to announce this character?",,"No","Yes")=="Yes")
-				call(/proc/AnnounceArrival)(new_character, new_character.mind.assigned_role)
-
-	log_and_message_admins("has respawned [player_key] as [new_character.real_name].")
-
-	to_chat(new_character, "You have been fully respawned. Enjoy the game.")
-	SSstatistics.add_field_details("admin_verb","RSPCH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	return new_character
 
 /client/proc/cmd_admin_add_freeform_ai_law()
 	set category = "Fun"

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -194,7 +194,7 @@
 
 // Returns the organ of the grabbed person that the grabber is targeting
 /obj/item/grab/proc/get_targeted_organ()
-	return (affecting.get_organ(target_zone))
+	return (affecting?.get_organ(target_zone))
 
 /obj/item/grab/proc/resolve_item_attack(var/mob/living/M, var/obj/item/I, var/target_zone)
 	if((M && ishuman(M)) && I)
@@ -273,6 +273,15 @@
 
 /obj/item/grab/proc/reset_position()
 	current_grab.reset_position(src)
+
+/obj/item/grab/proc/has_hold_on_organ(obj/item/organ/external/O)
+	if (!O)
+		return FALSE
+
+	if (get_targeted_organ() == O)
+		return TRUE
+
+	return FALSE
 
 /*
 	This section is for the simple procs used to return things from current_grab.

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -72,6 +72,10 @@
 	G.attacking = 1
 
 	if(do_after(assailant, action_cooldown - 1, affecting))
+		if (!G.has_hold_on_organ(O))
+			to_chat(assailant, SPAN_WARNING("You must keep a hold on your target to jointlock!"))
+			return
+
 
 		G.attacking = 0
 		G.action_used()
@@ -105,6 +109,10 @@
 		G.attacking = 1
 
 		if(do_after(assailant, action_cooldown - 1, affecting))
+
+			if (!G.has_hold_on_organ(O))
+				to_chat(assailant, SPAN_WARNING("You must keep a hold on your target to dislocate!"))
+				return
 
 			G.attacking = 0
 			G.action_used()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -714,9 +714,9 @@
 		if(stomach.ingested.total_volume)
 			stomach.ingested.trans_to_holder(D.reagents, 15)
 		return
-			
+
 	var/turf/location = loc
-	
+
 	visible_message(SPAN_DANGER("\The [src] throws up!"),SPAN_DANGER("You throw up!"))
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 	if(istype(location, /turf/simulated))

--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -28,7 +28,7 @@
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You are too exhausted to maneuver right now."))
 		return FALSE
-	if ((get_turf(user)).z != (get_turf(target)).z)
+	if (target && user.z != target.z)
 		if (!silent)
 			to_chat(user, SPAN_WARNING("You cannot manuever to a different z-level!"))
 		return FALSE

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -3,7 +3,7 @@
 	name = "Redaction"
 	associated_intent = I_HELP
 	armour_types = list("bio", "rad")
-	
+
 /decl/psionic_power/redaction
 	faculty = PSI_REDACTION
 	admin_log = FALSE
@@ -70,6 +70,10 @@
 			var/valid_objects = list()
 			for(var/thing in E.implants)
 				var/obj/imp = thing
+
+				if(!imp)
+					continue
+
 				if(imp.w_class >= removal_size && !istype(imp, /obj/item/weapon/implant))
 					valid_objects += imp
 			if(LAZYLEN(valid_objects))

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -384,6 +384,9 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	adjustBruteLoss(100)
 	sleep(150)
 
+	if (QDELETED(src))
+		return
+
 	if (isspecies(src, SPECIES_ZOMBIE)) //Check again otherwise Consume can run this twice at once
 		return
 

--- a/code/modules/species/species_attack.dm
+++ b/code/modules/species/species_attack.dm
@@ -38,6 +38,10 @@
 /datum/unarmed_attack/claws/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/obj/item/organ/external/affecting = target.get_organ(zone)
 
+	if (!affecting)
+		to_chat(user, SPAN_WARNING("\The [target] does not have that bodypart!"))
+		return
+
 	attack_damage = Clamp(attack_damage, 1, 5)
 
 	if(target == user)


### PR DESCRIPTION
runtime clobbering

:cl: Mucker
bugfix: Fixes some situations where non-existent bodyparts could be targeted and attacked.
bugfix: Fix being able to jointlock/dislocate even when the assailant's grip is lost.
admin: Removed unused 'Respawn Character' verb in 'Special Verbs'.
/:cl:

Closes #29687 
Closes #29686 
Closes #29684 
Closes #29681 (seems to stem from admins trying to remove respawn timers on themselves, or other admins?)
Closes #29680 
Closes #29660 
Closes #29679
Closes #29685 
Closes #29678 (you admins and your off-site building...)
Closes #29748 
