### PR TITLE
flip overmap known-ness

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -2,7 +2,7 @@
 	name = "exoplanet"
 	icon_state = "globe"
 	in_space = 0
-	known = 1
+	known = TRUE
 	var/area/planetary_area
 	var/list/seeds = list()
 	var/list/animals = list()

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -4,12 +4,17 @@
 	icon_state = "object"
 	color = "#fffffe"
 
-	var/known = 1		//shows up on nav computers automatically
+	var/known = FALSE //shows up on nav computers automatically
 	var/scannable       //if set to TRUE will show up on ship sensors for detailed scans
 
 //Overlay of how this object should look on other skyboxes
 /obj/effect/overmap/proc/get_skybox_representation()
 	return
+
+/obj/effect/overmap/Initialize()
+	. = ..()
+	if (known)
+		update_known_connections(TRUE)
 
 /obj/effect/overmap/proc/get_scan_data(mob/user)
 	return desc

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -108,13 +108,6 @@
 	anchored = 1
 
 
-/obj/effect/overmap/visitable/sector/Initialize()
-	. = ..()
-
-	if(known)
-		update_known_connections(TRUE)
-
-
 /obj/effect/overmap/visitable/sector/update_known_connections(notify = FALSE)
 	. = ..()
 

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -14,6 +14,7 @@
 	desc = "Space faring vessel."
 	icon_state = "ship"
 	var/moving_state = "ship_moving"
+	known = TRUE
 
 	var/vessel_mass = 10000             //tonnes, arbitrary number, affects acceleration provided by engines
 	var/vessel_size = SHIP_SIZE_LARGE	//arbitrary number, affects how likely are we to evade meteors

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -6,7 +6,6 @@ var/list/cached_space = list()
 /obj/effect/overmap/visitable/sector/temporary
 	name = "Deep Space"
 	invisibility = 101
-	known = 0
 
 /obj/effect/overmap/visitable/sector/temporary/New(var/nx, var/ny, var/nz)
 	map_z += nz

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -8,6 +8,7 @@
 	desc = "Sensor array detects a medium cargo vessel with high structural damage."
 	in_space = 1
 	icon_state = "ship"
+	known = FALSE
 	hide_from_reports = TRUE
 	initial_generic_waypoints = list(
 		"nav_merc_1",
@@ -24,6 +25,7 @@
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL
 	vessel_mass = 14000
+	known = FALSE
 
 /datum/shuttle/autodock/overmap/merc_shuttle
 	name = "Desperado"

--- a/maps/away/ascent/ascent_shuttles.dm
+++ b/maps/away/ascent/ascent_shuttles.dm
@@ -11,6 +11,7 @@
 	fore_dir = SOUTH
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_SMALL
+	known = FALSE
 
 /obj/effect/overmap/visitable/ship/landable/ascent/two
 	name = "Lepidoptera"

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -4,7 +4,7 @@
 	name = "arctic planetoid"
 	desc = "Sensor array detects an arctic planet with a small vessle on the planet's surface. Scans further indicate strange energy levels below the planet's surface."
 	in_space = 0
-	known = 1
+	known = TRUE
 	icon_state = "globe"
 	initial_generic_waypoints = list(
 		"nav_blueriv_1",

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -4,7 +4,6 @@
 	name = "debris field"
 	desc = "A large field of miscellanious debris."
 	icon_state = "object"
-	known = 0
 
 	initial_generic_waypoints = list(
 		"nav_derelict_1",

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -4,7 +4,7 @@
 	name = "forest planetoid"
 	desc = "Sensors detect anomalous radiation area with the presence of artificial structures."
 	icon_state = "globe"
-	known = 1
+	known = TRUE
 	in_space = 0
 	initial_generic_waypoints = list(
 		"nav_icarus_1",

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -4,7 +4,6 @@
 	name = "Lar Maria space station"
 	desc = "Sensors detect an orbital station with low energy profile and sporadic life signs."
 	icon_state = "object"
-	known = 0
 
 /datum/map_template/ruin/away_site/lar_maria
 	name = "Lar Maria"

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -5,7 +5,6 @@
 	name = "supply station"
 	desc = "This looks like abandoned and heavy damaged supply station."
 	icon_state = "object"
-	known = 0
 
 	initial_generic_waypoints = list(
 		"nav_lost_supply_base_1",

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -4,7 +4,6 @@
 	name = "orbital station"
 	desc = "Sensors detect an orbital station above the exoplanet. Sporadic magentic impulses are registred inside it. Planet landing is impossible due to lower orbits being cluttered with chaotically moving metal chunks."
 	icon_state = "object"
-	known = 0
 
 	initial_generic_waypoints = list(
 		"nav_magshield_1",

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -4,7 +4,6 @@
 	name = "Unpowered Research Station"
 	desc = "An unpowered research station. A large quantity of nearby debris blocks more detail."
 	icon_state = "object"
-	known = 0
 	initial_generic_waypoints = list(
 		"nav_meatstation_1",
 		"nav_meatstation_2",

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -14,7 +14,6 @@
 		"nav_cluster_6",
 		"nav_cluster_7"
 	)
-	known = 0
 
 /obj/effect/overmap/visitable/sector/cluster/generate_skybox()
 	return overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
@@ -85,7 +84,6 @@
 		"nav_away_6",
 		"nav_away_7"
 	)
-	known = 0
 
 /obj/effect/overmap/visitable/sector/away/generate_skybox()
 	return overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
@@ -155,7 +153,6 @@
 		"nav_orb_6",
 		"nav_orb_7"
 	)
-	known = 0
 
 /obj/effect/overmap/visitable/sector/orb/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/skybox_rock_128.dmi', "bigrock", COLOR_ASTEROID_ROCK, RESET_COLOR)

--- a/maps/away/miningstation/miningstation.dm
+++ b/maps/away/miningstation/miningstation.dm
@@ -5,7 +5,6 @@
 	name = "Orbital Mining Station"
 	desc = "An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station. It is emitting a active distress beacon."
 	icon_state = "object"
-	known = 0
 	initial_generic_waypoints = list(
 		"nav_miningstation_hangar",
 		"nav_miningstation_exterior",

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -4,7 +4,6 @@
 	name = "unusual asteroid"
 	desc = "Sensors error: ERROR #E0x003141592: recursive stack overflow for CALCULATE_APPROXIMATE_SIZE()."
 	icon_state = "object"
-	known = 0
 
 /datum/map_template/ruin/away_site/mobius_rift
 	name = "Mobius rift"

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -48,7 +48,6 @@
 	fore_dir = NORTH
 	burn_delay = 2 SECONDS
 	hide_from_reports = TRUE
-	known = 0
 	initial_generic_waypoints = list(
 		"nav_gantry_one",
 		"nav_gantry_two",
@@ -65,6 +64,7 @@
 		"Aquila" = list("nav_gantry_aquila"),
 		"Desperado" = list("nav_gantry_desperado")
 	)
+	known = FALSE
 
 /obj/item/mech_component/sensors/light/salvage/prebuild()
   ..()

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -21,6 +21,7 @@
 	initial_restricted_waypoints = list(
 		"Skrellian Shuttle" = list("nav_skrellscoutsh_dock")
 	)
+	known = FALSE
 
 
 /obj/effect/overmap/visitable/ship/landable/skrellscoutship/New()
@@ -34,6 +35,7 @@
 	color = "#880088"
 	vessel_mass = 750
 	vessel_size = SHIP_SIZE_TINY
+	known = FALSE
 
 /datum/shuttle/autodock/overmap/skrellscoutship
 	name = "Skrellian Scout"

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -5,7 +5,6 @@
 	name = "large asteroid"
 	desc = "Sensor array is reading an artificial structure inside the asteroid."
 	icon_state = "object"
-	known = 0
 
 	initial_generic_waypoints = list(
 		"nav_slavers_base_1",

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -5,7 +5,6 @@
 	name = "asteroid station"
 	desc = "A small station built into an asteroid. No radio traffic detected."
 	icon_state = "object"
-	known = 0
 
 	initial_generic_waypoints = list(
 		"nav_smugglers",

--- a/maps/away/verne/verne.dm
+++ b/maps/away/verne/verne.dm
@@ -31,6 +31,7 @@
 		"nav_verne_2",
 		"nav_verne_3",
 	)
+	known = FALSE
 
 /datum/map_template/ruin/away_site/verne
 	name = "Active University Ship"

--- a/maps/away/verne/verne_shuttles.dm
+++ b/maps/away/verne/verne_shuttles.dm
@@ -15,6 +15,7 @@
 	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	skill_needed = SKILL_BASIC
+	known = FALSE
 
 /datum/shuttle/autodock/overmap/verne
 	name = "SRV Venerable Catfish"

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -63,6 +63,7 @@
 	shuttle = "Vox Shuttle"
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL
+	known = FALSE
 
 /obj/effect/submap_landmark/joinable_submap/voxship
 	archetype = /decl/submap_archetype/derelict/voxship
@@ -149,6 +150,7 @@
 	moving_state = "ship_moving"
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_SMALL
+	known = FALSE
 
 //Ship's little lander defined here
 /datum/shuttle/autodock/overmap/vox_lander
@@ -181,6 +183,7 @@
 	desc = "Sensor array detects a small, unmarked vessel."
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_TINY
+	known = FALSE
 
 /obj/effect/submap_landmark/joinable_submap/voxship/scavship
 	archetype = /decl/submap_archetype/derelict/voxship/scavship

--- a/maps/bearcat/bearcat_overmap.dm
+++ b/maps/bearcat/bearcat_overmap.dm
@@ -7,6 +7,7 @@
 	vessel_mass = 5000
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 2 SECONDS
+	known = FALSE
 
 	initial_generic_waypoints = list("nav_bearcat_below_bow", "nav_bearcat_below_starboardastern", "nav_bearcat_port_dock_shuttle")
 	initial_restricted_waypoints = list(


### PR DESCRIPTION
flips overmap entity known-ness to default off, moves known-ness updating down to base overmap entity initialization, roughly flips known on stuff that had it set. Ships with slots (antags, provocateurs) except for the torch are not known, derelicts are.
