### PR TITLE
Duct tape finally fits in toolbelts. Glove and duct tape finally fits in machete belts.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -127,7 +127,8 @@
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/marshalling_wand,
 		/obj/item/weapon/hand_labeler,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/weapon/tape_roll
 		)
 
 
@@ -436,7 +437,9 @@
 		/obj/item/weapon/pinpointer/radio,
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape,
-		/obj/item/device/scanner/gas
+		/obj/item/device/scanner/gas,
+		/obj/item/clothing/gloves,
+		/obj/item/weapon/tape_roll
 		)
 	can_holster = list(/obj/item/weapon/material/hatchet/machete)
 	sound_in = 'sound/effects/holster/sheathin.ogg'


### PR DESCRIPTION
:cl: Flying_loulou
tweak: Duct tape fits in tool belts. Duct tape and some gloves fit in machete belts.
/:cl:

I swear I've been wanting to do this for so long.
Don't see why duct tape wouldn't fit in a tool belt, while it's pmuch _the_ basic engineering tool.
Same for gloves in the machete sheath... and well, the duct tape too because while we're at it, why not.