### PR TITLE
Creates *advanced* SMES coils

### DIFF
--- a/code/modules/ascent/ascent_machines.dm
+++ b/code/modules/ascent/ascent_machines.dm
@@ -237,12 +237,19 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	if(on)
 		add_avail(output_power)
 
-/obj/machinery/power/smes/buildable/power_shuttle/ascent
+/obj/machinery/power/smes/buildable/preset/ascent
 	name = "mantid battery"
 	desc = "Some kind of strange alien SMES technology."
-	icon = 'icons/obj/machines/power/mantid_smes.dmi'	
+	icon = 'icons/obj/machines/power/mantid_smes.dmi'
 	overlay_icon = 'icons/obj/machines/power/mantid_smes.dmi'
-	construct_state = /decl/machine_construction/default/no_deconstruct
+	uncreated_component_parts = list(
+		/obj/item/weapon/stock_parts/smes_coil/advanced = 2
+	)
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
+	_fully_charged = TRUE
 
 /obj/machinery/cryopod/ascent_spawn
 	name = "mantid cryotank"
@@ -271,7 +278,6 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	desc = "An interface between the gyne's brood and the cryotank oversight system."
 	color = COLOR_VIOLET
 	construct_state = null
-	
 	storage_type = "lifeforms"
 	storage_name = "Cryotank Oversight Control"
 
@@ -288,4 +294,3 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 /obj/machinery/computer/cryopod/ascent_spawn/Destroy()
 	qdel(announcer)
 	. = ..()
-	

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -39,6 +39,13 @@
 	ChargeCapacity = 20 KILOWATTS
 	IOCapacity = 1.25 MEGAWATTS
 
+// A superpowered coil to be used on event SMES units, away sites that run lots of power, and maybe as a rare merchant item.
+/obj/item/weapon/stock_parts/smes_coil/advanced
+	name = "advanced magnetic coil"
+	desc = " An advanced magnetic coil made from rare materials. Can store and transfer more power than any previous designs."
+	ChargeCapacity = 500 KILOWATTS
+	IOCapacity = 2.5 MEGAWATTS
+
 
 // DEPRECATED
 // These are used on individual outposts as backup should power line be cut, or engineering outpost lost power.

--- a/code/modules/power/smes_presets.dm
+++ b/code/modules/power/smes_presets.dm
@@ -22,3 +22,14 @@
 	output_attempt = _output_on
 	if(_fully_charged)
 		charge = capacity
+
+/obj/machinery/power/smes/buildable/preset/admin
+	uncreated_component_parts = list(
+		/obj/item/weapon/stock_parts/smes_coil/advanced = 4
+	)
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
+	_fully_charged = TRUE
+	

--- a/maps/away/ascent/ascent-1.dmm
+++ b/maps/away/ascent/ascent-1.dmm
@@ -1840,9 +1840,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/smes/buildable/power_shuttle/ascent{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/buildable/preset/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "ew" = (
@@ -2061,9 +2059,7 @@
 /turf/simulated/floor/tiled/ascent,
 /area/ship/ascent/shuttle_port)
 "eV" = (
-/obj/machinery/power/smes/buildable/power_shuttle/ascent{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/buildable/preset/ascent,
 /obj/structure/cable/cyan,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
@@ -2967,9 +2963,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/power/smes/buildable/power_shuttle/ascent{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/buildable/preset/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "gN" = (
@@ -2983,9 +2977,7 @@
 "gO" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/structure/cable/cyan,
-/obj/machinery/power/smes/buildable/power_shuttle/ascent{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/buildable/preset/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/engineering)
 "gP" = (
@@ -3577,9 +3569,7 @@
 /obj/machinery/light/ascent{
 	dir = 4
 	},
-/obj/machinery/power/smes/buildable/power_shuttle/ascent{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/buildable/preset/ascent,
 /obj/structure/cable/cyan{
 	d2 = 8;
 	icon_state = "0-8"

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -191,8 +191,8 @@
 
 /obj/machinery/power/smes/buildable/preset/skrell
 	uncreated_component_parts = list(
-		/obj/item/weapon/stock_parts/smes_coil/super_io = 2,
-		/obj/item/weapon/stock_parts/smes_coil/super_capacity = 2)
+		/obj/item/weapon/stock_parts/smes_coil/advanced = 2
+	)
 	_input_maxed = TRUE
 	_output_maxed = TRUE
 	_input_on = TRUE


### PR DESCRIPTION
🆑 
rscadd: Creates the "advanced" SMES coil for admin and away site use.
tweak: Skrell and Ascent SMES units now use advanced SMES coils.
/🆑

Power management is a pain, and there are also few tangible rewards from some away sites. Two birds with one stone here - the new coils will make mapping high-power sites require less SMES dumping, and could be mapped into away sites as a sort-of "reward" exploration could bring back for engineering. The new coil has double the I/O of transmission coils and double the storage of capacity coils. It's fairly meaty.

I've also added a SMES preset that uses the new coils, for your mapping pleasures.