### PR TITLE
Fixes a pipe leak on oldlab2

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -3466,7 +3466,7 @@
 /area/map_template/oldlab2/bathroom)
 "sr" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /obj/machinery/door/blast/regular{


### PR DESCRIPTION
🆑 
maptweak: Oldlab2 has had a leaky pipe fixed.
/🆑

Scrubber pipes were trying to connect to normal coloured pipes without an adapter. Added an adapter.