### PR TITLE
Send a message to players nearby a ship taking off/landing

### DIFF
--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -20,7 +20,7 @@
 	//Will also leave this type of turf behind if set.
 	var/turf/base_turf
 	//Name of the shuttle, null for generic waypoint
-	var/shuttle_restricted 
+	var/shuttle_restricted
 	var/flags = 0
 
 /obj/effect/shuttle_landmark/Initialize()
@@ -71,7 +71,7 @@
 	for(var/area/A in shuttle.shuttle_area)
 		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents)
 		if(check_collision(base_area, list_values(translation)))
-			return FALSE		
+			return FALSE
 	var/conn = GetConnectedZlevels(z)
 	for(var/w in (z - shuttle.multiz) to z)
 		if(!(w in conn))

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -102,6 +102,13 @@
 	moving_status = SHUTTLE_WARMUP
 	if(sound_takeoff)
 		playsound(current_location, sound_takeoff, 100, 20, 0.2)
+		if (!istype(start_location.base_area, /area/space))
+			var/area/A = get_area(start_location)
+
+			for (var/mob/M in GLOB.player_list)
+				if (M.client && M.z == A.z && !istype(get_turf(M), /turf/space) && !(get_area(M) in src.shuttle_area))
+					to_chat(M, SPAN_NOTICE("The rumble of engines are heard as a shuttle lifts off."))
+
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)
 			return	//someone cancelled the launch
@@ -120,6 +127,13 @@
 				if(!fwooshed && (arrive_time - world.time) < 100)
 					fwooshed = 1
 					playsound(destination, sound_landing, 100, 0, 7)
+					if (!istype(destination.base_area, /area/space))
+						var/area/A = get_area(destination)
+
+						for (var/mob/M in GLOB.player_list)
+							if (M.client && M.z == A.z && !istype(get_turf(M), /turf/space) && !(get_area(M) in src.shuttle_area))
+								to_chat(M, SPAN_NOTICE("The rumble of a shuttle's engines fill the area as a ship manuevers in for a landing."))
+
 				sleep(5)
 			if(!attempt_move(destination))
 				attempt_move(start_location) //try to go back to where we started. If that fails, I guess we're stuck in the interim location


### PR DESCRIPTION
:cl: Mucker
rscadd: Adds a message that is sent to players in the vicinity of a shuttle taking off or landing.
/:cl:

Send a message to players nearby a ship taking off/landing (aka, players that are on the same z-level as where the ship is landing too or taking off from). This is mostly intended for exoplanets, as given all landing/taking off occurs in small(ish) open area, it'd be pretty easy to see or at least hear ships taking off or landing around you, even if you weren't directly by where said ship is taking off or leaving from.

Cases where you won't get a message:

The ship is taking off from space.
The ship is leaving an area that is space.
The player is on a space turf.