### PR TITLE
adjusts meatstation's inflatables

### DIFF
--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -925,7 +925,7 @@
 /turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "cl" = (
-/obj/random/single/meatstation/low/wormscientist,
+/obj/structure/inflatable/wall,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/swhallway)
 "cm" = (
@@ -1024,6 +1024,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/blood/drip,
+/obj/structure/inflatable/door,
 /turf/simulated/floor/tiled/dark/airless,
 /area/meatstation/cargo)
 "cu" = (
@@ -1683,7 +1684,6 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
-/obj/structure/inflatable/door,
 /obj/machinery/light/small/red{
 	dir = 8;
 	icon_state = "bulb_map"
@@ -1725,6 +1725,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/inflatable/door,
 /turf/simulated/floor/tiled/dark/airless,
 /area/meatstation/kitchen)
 "dZ" = (
@@ -1854,9 +1855,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/mine,
-/obj/random/trash,
-/obj/random/junk,
+/obj/structure/inflatable/door,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/swhallway)
 "ep" = (
@@ -2275,13 +2274,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/meatstation/hydroponics)
 "fb" = (
-/obj/structure/inflatable/wall,
-/obj/effect/floor_decal/corner/b_green/border{
-	dir = 8;
-	icon_state = "bordercolor"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/meatstation/storage)
+/obj/effect/floor_decal/corner/black/border,
+/obj/random/single/meatstation/meatworm,
+/turf/simulated/floor/tiled,
+/area/meatstation/centerhallway)
 "fc" = (
 /obj/effect/paint/meatstation,
 /turf/simulated/wall/r_wall,
@@ -3143,7 +3139,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/hygiene/sink/kitchen,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -3151,6 +3146,7 @@
 	dir = 1;
 	icon_state = "bordercolor"
 	},
+/obj/structure/inflatable/wall,
 /turf/simulated/floor/tiled/dark/airless,
 /area/meatstation/kitchen)
 "gR" = (
@@ -3780,6 +3776,7 @@
 	dir = 1;
 	icon_state = "bordercolor"
 	},
+/obj/structure/inflatable/wall,
 /turf/simulated/floor/tiled/dark/airless,
 /area/meatstation/kitchen)
 "io" = (
@@ -4086,6 +4083,7 @@
 "jg" = (
 /obj/item/stack/material/rods,
 /obj/item/weapon/material/shard,
+/obj/random/single/meatstation/low/wormscientist,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/swhallway)
 "jh" = (
@@ -7025,9 +7023,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled,
-/area/meatstation/centerhallway)
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1;
+	icon_state = "bordercolor"
+	},
+/obj/structure/inflatable/wall,
+/turf/simulated/floor/tiled/dark/airless,
+/area/meatstation/cargo)
 "qN" = (
 /obj/item/clothing/accessory/fire_overpants,
 /turf/simulated/floor/tiled/dark/airless,
@@ -7116,7 +7118,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/inflatable/door,
 /turf/simulated/floor/airless,
 /area/meatstation/centerhallway)
 "ra" = (
@@ -7131,6 +7132,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/inflatable/door,
 /turf/simulated/floor/airless,
 /area/meatstation/centerhallway)
 "rb" = (
@@ -8694,9 +8696,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
-/area/meatstation/nwhallway)
+/turf/simulated/floor/tiled/dark/airless,
+/area/meatstation/kitchen)
 "uz" = (
 /obj/structure/inflatable/wall,
 /turf/space,
@@ -9365,6 +9366,7 @@
 	dir = 10;
 	icon_state = "bordercolor"
 	},
+/obj/structure/inflatable/wall,
 /turf/simulated/floor/tiled/dark/airless,
 /area/meatstation/kitchen)
 "vT" = (
@@ -26059,10 +26061,10 @@ tH
 cd
 cd
 pe
-cJ
+cd
 cJ
 eh
-pw
+qM
 cv
 qE
 cv
@@ -26261,7 +26263,7 @@ ck
 ck
 ck
 ph
-uy
+sK
 oB
 cs
 ct
@@ -26285,7 +26287,7 @@ fC
 cz
 qS
 dv
-oG
+cz
 oG
 dA
 eo
@@ -32519,7 +32521,7 @@ we
 we
 yi
 bh
-yr
+fb
 ah
 aa
 aa
@@ -32922,7 +32924,7 @@ ah
 ah
 ah
 yb
-qM
+bh
 yr
 ah
 aa
@@ -34537,9 +34539,9 @@ bs
 aa
 lY
 rb
-qY
+ri
 ra
-qY
+ri
 ah
 aa
 jB
@@ -35755,7 +35757,7 @@ aa
 qY
 oF
 rm
-yx
+we
 yx
 we
 eL
@@ -35957,7 +35959,7 @@ rf
 bF
 rf
 rn
-rn
+bF
 rn
 es
 bF
@@ -36159,7 +36161,7 @@ tv
 rb
 tv
 bS
-bS
+tv
 eO
 bh
 rs
@@ -37403,7 +37405,7 @@ vR
 vS
 cX
 ed
-fb
+hD
 hD
 ht
 oh
@@ -37602,10 +37604,10 @@ fl
 tf
 fl
 iv
-fl
+uy
 ea
 er
-er
+hG
 iB
 hx
 oy
@@ -38195,7 +38197,7 @@ cD
 vH
 cD
 nA
-nB
+cD
 nB
 cX
 in


### PR DESCRIPTION
🆑 
maptweak: Shuffled meatstation's inflatables to be actually usable.
/🆑

Looks like they weren't adjusted post-inflatables nerf. They've been adjusted now.