### PR TITLE
Torch camera fixes and anchored drains

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -189,7 +189,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small{
 	dir = 4;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/starboard)
@@ -6936,9 +6935,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/hangcheck)
 "wK" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Fourth Deck - Security Checkpoint"
-	},
 /obj/effect/floor_decal/corner/red/half{
 	dir = 1;
 	icon_state = "bordercolorhalf"

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -241,7 +241,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Firing Range"
+	c_tag = "Third Deck Hallway - Head"
 	},
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -6667,7 +6667,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "nP" = (
@@ -13752,7 +13752,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/foreport)
 "GY" = (
-/obj/item/drain,
+/obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "GZ" = (


### PR DESCRIPTION
🆑 
maptweak: The D4 security checkpoint no longer has two cameras.
maptweak: The D3 "firing range" camera no longer calls the bathroom a firing range.
maptweak: The drains in hydroponics are now the proper type.
/ 🆑 