### PR TITLE
Raider Tweaks

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -261,3 +261,59 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	player.set_internals(locate(/obj/item/weapon/tank) in player.contents)
 	return 1
 
+/obj/random/raider/hardsuit
+	name = "Random Raider Hardsuit"
+	desc = "This is a random hardsuit control module."
+	icon = 'icons/obj/rig_modules.dmi'
+	icon_state = "generic"
+
+/obj/random/raider/hardsuit/spawn_choices()
+	return list(/obj/item/weapon/rig/industrial,
+				/obj/item/weapon/rig/eva,
+				/obj/item/weapon/rig/light/hacker,
+				/obj/item/weapon/rig/light,
+				/obj/item/weapon/rig/unathi
+	)
+
+/obj/random/raider/lilgun
+	name = "Random Raider Light Weapon"
+	desc = "This is a random raider sidearm."
+	icon = 'icons/obj/guns/pistol.dmi'
+	icon_state = "secguncomp"
+
+/obj/random/raider/lilgun/spawn_choices()
+	return list(/obj/item/weapon/gun/projectile/pistol/sec,
+				/obj/item/weapon/gun/energy/gun,
+				/obj/item/weapon/gun/energy/stunrevolver,
+				/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn,
+				/obj/item/weapon/gun/energy/xray/pistol,
+				/obj/item/weapon/gun/projectile/automatic/machine_pistol,
+				/obj/item/weapon/gun/projectile/pistol/military/alt,
+				/obj/item/weapon/gun/projectile/pistol/holdout,
+				/obj/item/weapon/gun/projectile/revolver,
+				/obj/item/weapon/gun/projectile/revolver/medium,
+				/obj/item/weapon/gun/energy/retro,
+				/obj/item/weapon/gun/projectile/pistol/throwback,
+				/obj/item/weapon/gun/energy/ionrifle/small
+	)
+
+/obj/random/raider/biggun
+	name = "Random Raider Heavy Weapon"
+	desc = "This is a random raider rifle."
+	icon = 'icons/obj/guns/assault_rifle.dmi'
+	icon_state = "arifle"
+
+/obj/random/raider/biggun/spawn_choices()
+	return list(/obj/item/weapon/gun/energy/lasercannon,
+				/obj/item/weapon/gun/energy/laser,
+				/obj/item/weapon/gun/energy/sniperrifle,
+				/obj/item/weapon/gun/projectile/shotgun/doublebarrel,
+				/obj/item/weapon/gun/energy/xray,
+				/obj/item/weapon/gun/projectile/heavysniper/boltaction,
+				/obj/item/weapon/gun/projectile/automatic/assault_rifle,
+				/obj/item/weapon/gun/projectile/automatic/sec_smg,
+				/obj/item/weapon/gun/energy/crossbow/largecrossbow,
+				/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+				/obj/item/weapon/gun/energy/ionrifle,
+				/obj/item/weapon/gun/projectile/shotgun/pump
+	)

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -314,7 +314,7 @@
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aR" = (
-/obj/random/loot,
+/obj/random/ammo,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -430,26 +430,12 @@
 /area/map_template/syndicate_mothership/raider_base)
 "bd" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/fabricator/hacked,
 /turf/unsimulated/floor{
 	icon_state = "plating";
 	name = "plating"
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "be" = (
-/obj/structure/closet/crate,
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -929,7 +915,7 @@
 "cc" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/glass/rag,
-/obj/random/loot,
+/obj/random/ammo,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},
@@ -1301,7 +1287,7 @@
 /area/map_template/skipjack_station/start)
 "cT" = (
 /obj/structure/table/rack,
-/obj/random/hardsuit,
+/obj/random/raider/hardsuit,
 /obj/item/clothing/glasses/thermal/plain/monocle,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
@@ -1318,7 +1304,7 @@
 /area/map_template/skipjack_station/start)
 "cX" = (
 /obj/structure/table/rack,
-/obj/random/hardsuit,
+/obj/random/raider/hardsuit,
 /obj/item/clothing/head/pirate,
 /obj/item/weapon/gun/launcher/money,
 /turf/simulated/floor/shuttle/red,
@@ -1351,7 +1337,7 @@
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
 /obj/item/weapon/material/harpoon,
-/obj/random/energy,
+/obj/random/raider/lilgun,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "db" = (
@@ -1445,7 +1431,7 @@
 /obj/item/weapon/tank/oxygen,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/obj/random/energy,
+/obj/random/raider/biggun,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "dk" = (
@@ -1494,13 +1480,16 @@
 /obj/item/weapon/tank/oxygen,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/obj/random/projectile,
+/obj/random/raider/lilgun,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "dr" = (
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/map_template/skipjack_station/start)
+/obj/random/ammo,
+/turf/unsimulated/floor{
+	icon_state = "carpet";
+	name = "carpet"
+	},
+/area/map_template/syndicate_mothership/raider_base)
 "ds" = (
 /obj/item/robot_parts/head,
 /turf/simulated/floor/plating,
@@ -1578,7 +1567,7 @@
 /obj/item/weapon/grenade/empgrenade,
 /obj/item/weapon/grenade/flashbang,
 /obj/item/weapon/grenade/spawnergrenade/manhacks,
-/obj/random/energy,
+/obj/random/raider/biggun,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dD" = (
@@ -1623,7 +1612,6 @@
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "dJ" = (
-/obj/random/loot,
 /obj/vehicle/bike/thermal,
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
@@ -1684,7 +1672,19 @@
 /area/map_template/skipjack_station/start)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/item/weapon/crowbar,
+/obj/machinery/fabricator/hacked,
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "dS" = (
@@ -1724,7 +1724,7 @@
 "dY" = (
 /obj/item/weapon/deck/cards,
 /obj/structure/table/steel,
-/obj/random/projectile,
+/obj/random/raider/lilgun,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dZ" = (
@@ -1786,7 +1786,7 @@
 /area/map_template/skipjack_station/start)
 "ei" = (
 /obj/structure/table/steel,
-/obj/random/loot,
+/obj/random/raider/lilgun,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "ej" = (
@@ -1935,9 +1935,6 @@
 	},
 /obj/item/weapon/melee/baton/cattleprod,
 /turf/simulated/floor/shuttle/white,
-/area/map_template/skipjack_station/start)
-"eE" = (
-/turf/space,
 /area/map_template/skipjack_station/start)
 "eF" = (
 /obj/structure/bed,
@@ -2859,7 +2856,7 @@ ab
 ab
 ab
 ab
-aq
+aR
 aq
 bA
 bU
@@ -3074,10 +3071,10 @@ aq
 aq
 aB
 aC
+aq
+aq
+aq
 aR
-aq
-aq
-aq
 aq
 aq
 cf
@@ -4156,7 +4153,7 @@ aD
 aN
 aY
 aY
-aY
+dr
 bG
 bq
 af
@@ -4181,7 +4178,7 @@ cR
 cR
 cR
 cR
-eE
+aa
 aa
 aa
 aa
@@ -5107,7 +5104,7 @@ cw
 cw
 cR
 di
-dr
+dm
 dx
 dm
 dP


### PR DESCRIPTION
🆑 
tweak: Raiders now have dedicated random item lists for weapons and hardsuits.
maptweak: The hacked raider lathe is on the skipjack now.
maptweak: Skipjack now uses the raider-specific random item spawners.
/ 🆑 

The dedicated raider lists are for hardsuits, big guns, and little guns. Raiders get four "little" guns and two "big" instead of their random weapons drawing from the random energy and projectile lists. Current weapon list is open to changes; please give feedback.

Random hardsuit list is essentially the same as before, sans the stealth suit. Again, we have plenty of things that can be put here if people want them.