### PR TITLE
Raider coat fixes

### DIFF
--- a/code/datums/outfits/pirates.dm
+++ b/code/datums/outfits/pirates.dm
@@ -12,7 +12,7 @@
 
 /decl/hierarchy/outfit/pirate/space
 	name = "Pirate - Space"
-	head = /obj/item/clothing/suit/space/pirate
+	head = /obj/item/clothing/head/helmet/pirate
 	suit = /obj/item/clothing/suit/pirate
 	back = /obj/item/weapon/tank/jetpack/oxygen
 	flags = OUTFIT_HAS_JETPACK|OUTFIT_RESET_EQUIPMENT

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -219,3 +219,22 @@
 	desc = "A helmet built for use by a Skrell. This one appears to be fairly standard and reliable."
 	icon_state = "helmet_skrell"
 	valid_accessory_slots = null
+
+
+/obj/item/clothing/head/helmet/pirate
+	name = "pirate hat"
+	desc = "Yarr."
+	icon_state = "pirate"
+	item_state = "pirate"
+	armor = list(
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_PISTOL,
+		laser = ARMOR_LASER_SMALL,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
+		bio = ARMOR_BIO_SMALL,
+		rad = ARMOR_RAD_MINOR
+	)
+	flags_inv = BLOCKHAIR
+	body_parts_covered = 0
+	siemens_coefficient = 0.9

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -8,14 +8,14 @@
 		slot_r_hand_str = "syndicate-helm-black-red",
 		)
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH, 
-		bullet = ARMOR_BALLISTIC_RESISTANT, 
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_PADDED, 
-		bio = ARMOR_BIO_SHIELDED, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED,
+		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
-		)
+	)
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 	min_pressure_protection = 0
 	flags_inv = BLOCKHAIR
@@ -37,47 +37,6 @@
 	allowed = list(/obj/item) //for stuffing exta special presents
 
 /obj/item/clothing/suit/space/santa/New()
-	..()
-	slowdown_per_slot[slot_wear_suit] = 0
-
-//Space pirate outfit
-/obj/item/clothing/head/helmet/pirate
-	name = "pirate hat"
-	desc = "Yarr."
-	icon_state = "pirate"
-	item_state = "pirate"
-	armor = list(
-		melee = ARMOR_MELEE_MAJOR, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_SMALL,
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
-		bio = ARMOR_BIO_SMALL, 
-		rad = ARMOR_RAD_MINOR
-		)
-	flags_inv = BLOCKHAIR
-	body_parts_covered = 0
-	siemens_coefficient = 0.9
-
-/obj/item/clothing/suit/space/pirate
-	name = "pirate coat"
-	desc = "Yarr."
-	icon_state = "pirate"
-	w_class = ITEM_SIZE_NORMAL
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency)
-	armor = list(
-		melee = ARMOR_MELEE_MAJOR, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_SMALL,
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
-		bio = ARMOR_BIO_SMALL, 
-		rad = ARMOR_RAD_MINOR
-		)
-	siemens_coefficient = 0.9
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-
-/obj/item/clothing/suit/space/pirate/New()
 	..()
 	slowdown_per_slot[slot_wear_suit] = 0
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -33,7 +33,26 @@
 	name = "pirate coat"
 	desc = "Yarr."
 	icon_state = "pirate"
-	body_parts_covered = UPPER_TORSO|ARMS
+	w_class = ITEM_SIZE_NORMAL
+	allowed = list(
+		/obj/item/weapon/gun,
+		/obj/item/ammo_magazine,
+		/obj/item/ammo_casing,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/tank/emergency
+	)
+	armor = list(
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_PISTOL,
+		laser = ARMOR_LASER_SMALL,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
+		bio = ARMOR_BIO_SMALL,
+		rad = ARMOR_RAD_MINOR
+	)
+	siemens_coefficient = 0.9
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 
 /obj/item/clothing/suit/hgpirate

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1378,8 +1378,8 @@
 "de" = (
 /obj/structure/table/rack,
 /obj/item/weapon/melee/energy/sword/pirate,
-/obj/item/clothing/suit/space/pirate,
-/obj/item/clothing/suit/space/pirate,
+/obj/item/clothing/suit/pirate,
+/obj/item/clothing/suit/pirate,
 /obj/item/weapon/tank/oxygen,
 /obj/item/clothing/shoes/magboots,
 /obj/random/voidsuit,
@@ -1393,8 +1393,8 @@
 "df" = (
 /obj/structure/table/rack,
 /obj/item/weapon/melee/energy/sword/pirate,
-/obj/item/clothing/suit/space/pirate,
-/obj/item/clothing/suit/space/pirate,
+/obj/item/clothing/suit/pirate,
+/obj/item/clothing/suit/pirate,
 /obj/item/weapon/tank/oxygen,
 /obj/item/clothing/shoes/magboots,
 /obj/random/voidsuit,
@@ -1898,7 +1898,7 @@
 /area/map_template/skipjack_station/start)
 "eA" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/suit/space/pirate,
+/obj/item/clothing/suit/pirate,
 /obj/item/clothing/under/rank/medical/scrubs/black,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)


### PR DESCRIPTION
🆑 
tweak: The pirate coat suit that raiders get no longer lies about being space-proof.
/ 🆑 

We had two different coats using the same sprite with the same description. I've merged them into one under the path that doesn't try to pretend it's a spacesuit.