### PR TITLE
Exo Awakening tweaks

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -7,7 +7,6 @@
 #define ASSIGNMENT_MEDICAL "Medical"
 #define ASSIGNMENT_SCIENTIST "Scientist"
 #define ASSIGNMENT_SECURITY "Security"
-#define ASSIGNMENT_EXPLORER "Explorer"
 
 var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major")
 
@@ -175,7 +174,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",					/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Exoplanet Awakening",					/datum/event/exo_awakening,             25,     list(ASSIGNMENT_EXPLORER = 100))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Exoplanet Awakening",					/datum/event/exo_awakening,             75)
 	)
 
 /datum/event_container/major
@@ -188,7 +187,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",						/datum/event/spacevine, 			0,	list(ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Electrical Storm",		/datum/event/electrical_storm, 		0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Drone Revolution",				/datum/event/rogue_maint_drones/,	0,	list(ASSIGNMENT_ENGINEER = 10,ASSIGNMENT_MEDICAL = 10,ASSIGNMENT_SECURITY = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,         0,  list(ASSIGNMENT_EXPLORER = 100))
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,         0,  list(ASSIGNMENT_ANY = 45))
 	)
 
 
@@ -201,4 +200,3 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 #undef ASSIGNMENT_MEDICAL
 #undef ASSIGNMENT_SCIENTIST
 #undef ASSIGNMENT_SECURITY
-#undef ASSIGNMENT_EXPLORER


### PR DESCRIPTION
Tweaks exo awakening to occur more, removes broken spiderling spawn type, adapts spawned mobs to the atmos they spawn in so they don't instant-die on the more harsh planets.

🆑 Mucker
tweak: Removes broken spiderling spawn type from exo awakening event, replace with big spiders.
tweak: Exo awakening is now more likely to happen (though still rare), and can be more dangerous.
tweak: Mobs spawned by the exo event are now adapted to the planet they spawn on.
/🆑

Feedback has been scarce, but from what I can tell the event hasn't occurred naturally yet, so this is an attempt to make it more likely while still keeping it to a moderate rarity.

Also allows the major version of the event to occur during a moderate roll, as explorers are rarely on a planet when major events trigger, thus creating more danger from time-to-time and actually allowing them to experience a major roll of the event during common exploration times.

And an explanation to the first tweak: Turns out spiderlings weren't actually working, so I've gone with spawning big spiders with low spawn chances for the more deadly variants on a moderate event roll.