### PR TITLE
Add 50 and 60 to chemical dispenser

### DIFF
--- a/nano/templates/chem_disp.tmpl
+++ b/nano/templates/chem_disp.tmpl
@@ -12,7 +12,9 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 		{{:helper.link('20', 'gear', {'amount' : 20}, (data.amount == 20) ? 'selected' : null)}}
 		{{:helper.link('30', 'gear', {'amount' : 30}, (data.amount == 30) ? 'selected' : null)}}
 		{{:helper.link('40', 'gear', {'amount' : 40}, (data.amount == 40) ? 'selected' : null)}}
-		<br/><br/>
+		{{:helper.link('50', 'gear', {'amount' : 50}, (data.amount == 50) ? 'selected' : null)}}
+		{{:helper.link('60', 'gear', {'amount' : 60}, (data.amount == 60) ? 'selected' : null)}}
+		<br/><br/><br/>
 		{{:helper.link('--', '', {'amount' : data.amount-10})}}
 		{{:helper.link('-', '', {'amount' : data.amount-1})}}
 		<div style="float: left; width: 80px; text-align: center;">{{:data.amount}}</div>


### PR DESCRIPTION
These amounts are used frequently (60, at least), and it would help many chemists if they had quick access to them instead of needing to do 30 twice or 10 five times.

:cl:
tweak: The chemical dispenser UI now has options for 50 and 60.
/:cl: