### PR TITLE
Ensure awaysite overmap grids are clear of hazards.

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -40,6 +40,9 @@
 
 	forceMove(locate(start_x, start_y, GLOB.using_map.overmap_z))
 
+	for(var/obj/effect/overmap/event/E in loc)
+		qdel(E)
+
 	docking_codes = "[ascii2text(rand(65,90))][ascii2text(rand(65,90))][ascii2text(rand(65,90))][ascii2text(rand(65,90))]"
 
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")


### PR DESCRIPTION
🆑 Mucker
tweak: Visitable away sites will no longer sometimes spawn with hazards over top them.
/🆑

Deletes overmap hazards on the same grid as a visitable away site, if the site spawns on one. Doesn't prevent them from being surrounded, but it should allow access to sites more often for more parties, without negating the need of the OFD from time to time.