### PR TITLE
Fixes simple doors not updating dir on spawn

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -371,14 +371,7 @@
 
 
 /obj/machinery/door/on_update_icon()
-	if(connections in list(NORTH, SOUTH, NORTH|SOUTH))
-		if(connections in list(WEST, EAST, EAST|WEST))
-			set_dir(SOUTH)
-		else
-			set_dir(EAST)
-	else
-		set_dir(SOUTH)
-
+	update_dir()
 	if(density)
 		icon_state = "door1"
 	else
@@ -386,6 +379,14 @@
 	SSradiation.resistance_cache.Remove(get_turf(src))
 	return
 
+/obj/machinery/door/proc/update_dir()
+	if(connections in list(NORTH, SOUTH, NORTH|SOUTH))
+		if(connections in list(WEST, EAST, EAST|WEST))
+			set_dir(SOUTH)
+		else
+			set_dir(EAST)
+	else
+		set_dir(SOUTH)
 
 /obj/machinery/door/proc/do_animate(animation)
 	switch(animation)

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -66,6 +66,7 @@
 		take_damage(min(damage, 100))
 
 /obj/machinery/door/unpowered/simple/on_update_icon()
+	update_dir()
 	if(density)
 		icon_state = "[icon_base]"
 	else


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes material doors spawning with the wrong direction.
/:cl:

This piece of code was actually supposed to be included in the original PR, curiously got rid of it somehow before the final commit.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->