### PR TITLE
Legalese Tweaks

### DIFF
--- a/code/modules/mob/language/human/misc/legalese.dm
+++ b/code/modules/mob/language/human/misc/legalese.dm
@@ -8,8 +8,8 @@
 	space_chance = 100
 	key = "u"
 	partial_understanding = list(
-		LANGUAGE_HUMAN_EURO = 10,
-		LANGUAGE_HUMAN_SELENIAN = 25,
+		LANGUAGE_HUMAN_EURO = 25,
+		LANGUAGE_HUMAN_SELENIAN = 20,
 		LANGUAGE_SKRELLIAN = 5
 	)
 	syllables = list(
@@ -17,4 +17,3 @@
 		"exonerated", "effecuate", "accord", "caveat", "stipulation", "pledgee", "covenant", "rights",
 		"lawful", "suit of law", "sequestrator", "et al", "et", "ex", "quid", "bono",	"quo", "pro", "ad"
 	)
-	

--- a/code/modules/species/mantid/mantid.dm
+++ b/code/modules/species/mantid/mantid.dm
@@ -121,6 +121,8 @@
 		/decl/emote/exertion/biological/pant
 	)
 
+	assisted_langs = LANGUAGE_LEGALESE
+
 /datum/species/mantid/handle_sleeping(var/mob/living/carbon/human/H)
 	return
 


### PR DESCRIPTION
:cl:
tweak: Ascent can't speak Legalese anymore.
tweak: Buffs ZAC-legalese cross-understanding slightly.
/:cl:

So this is an alternative to #29786.

Removes the possibility for Ascents to speak legalese (to prevent an exploit where a gyne could use it to dialogue with the Torch/any human). Also buffs the ZAC-legalese cross understanding slightly.

The original PR states that legalese is a meme that can be easily used to get rid of the language barrier by provocateurs. This PR is an attempt to avoid loss of game mechanics based on thin-to-non-existent argumentative.