### PR TITLE
Belts tweaks round 2

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -128,7 +128,9 @@
 		/obj/item/weapon/marshalling_wand,
 		/obj/item/weapon/hand_labeler,
 		/obj/item/clothing/gloves,
-		/obj/item/weapon/tape_roll
+		/obj/item/weapon/tape_roll,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 
@@ -183,7 +185,9 @@
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/storage/med_pouch,
 		/obj/item/bodybag,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 /obj/item/weapon/storage/belt/medical/emt
@@ -222,7 +226,9 @@
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/magnetic_ammo,
 		/obj/item/device/binoculars,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 /obj/item/weapon/storage/belt/security
@@ -254,7 +260,9 @@
 		/obj/item/device/holowarrant,
 		/obj/item/weapon/magnetic_ammo,
 		/obj/item/device/binoculars,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 /obj/item/weapon/storage/belt/general
@@ -294,7 +302,10 @@
 		/obj/item/weapon/crowbar/prybar,
 		/obj/item/weapon/tank/emergency,
 		/obj/item/clothing/mask/breath,
-		/obj/item/toy/bosunwhistle
+		/obj/item/toy/bosunwhistle,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/,
+		/obj/item/device/tape
 		)
 
 /obj/item/weapon/storage/belt/janitor
@@ -312,7 +323,9 @@
 		/obj/item/clothing/gloves,
 		/obj/item/device/assembly/mousetrap,
 		/obj/item/weapon/crowbar/prybar,
-		/obj/item/clothing/mask/plunger
+		/obj/item/clothing/mask/plunger,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 /obj/item/weapon/storage/belt/holster/general
@@ -353,7 +366,10 @@
 		/obj/item/weapon/crowbar/prybar,
 		/obj/item/weapon/tank/emergency,
 		/obj/item/clothing/mask/breath,
-		/obj/item/toy/bosunwhistle
+		/obj/item/toy/bosunwhistle,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/,
+		/obj/item/device/tape
 		)
 
 /obj/item/weapon/storage/belt/holster/forensic
@@ -381,7 +397,9 @@
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape,
 		/obj/item/weapon/storage/csi_markers,
-		/obj/item/device/scanner
+		/obj/item/device/scanner,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 /obj/item/weapon/storage/belt/forensic
@@ -408,7 +426,9 @@
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape,
 		/obj/item/weapon/storage/csi_markers,
-		/obj/item/device/scanner
+		/obj/item/device/scanner,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/
 		)
 
 /obj/item/weapon/storage/belt/holster/machete
@@ -439,7 +459,11 @@
 		/obj/item/device/tape,
 		/obj/item/device/scanner/gas,
 		/obj/item/clothing/gloves,
-		/obj/item/weapon/tape_roll
+		/obj/item/weapon/tape_roll,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/material/knife/folding/,
+		/obj/item/weapon/storage/firstaid/light,
+		/obj/item/device/flash
 		)
 	can_holster = list(/obj/item/weapon/material/hatchet/machete)
 	sound_in = 'sound/effects/holster/sheathin.ogg'


### PR DESCRIPTION
:cl:
tweak: Berets, folding knives, combi-knives and tapes now also fit in belts.
tweak: Explorers and pathfinders can now also fit their light first-aid kit and their flash in their 'chete belts.
/:cl:

I'm sure I'll headbust my desk after figuring out _yet more_ things that should probably fit in there, but whatever.