### PR TITLE
Use  docker/build-push-action for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,29 @@ jobs:
       with:
         repository: Baystation12/custom-items
         path: custom-items
-    - name: Build and Publish Image to Registry
-      env:
-        BUILD_ARGS: -Icustom-items/inc.dm
-      uses: elgohr/Publish-Docker-Github-Action@master
+    - name: Setup Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Setup Cache
+      uses: actions/cache@v2
       with:
-        name: ${{ secrets.IMAGE_NAME }}
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx-
+    - name: Login to Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.REG_URL }}
         username: ${{ secrets.REG_USER }}
         password: ${{ secrets.REG_PASS }}
-        tags: "latest"
-        buildargs: BUILD_ARGS
-        registry: ${{ secrets.REG_URL }}
-        cache: true
+    - name: Build and Push to Registry
+      uses: docker/build-push-action@v2
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        context: .
+        file: ./Dockerfile
+        outputs: type=registry
+        tags: ${{ secrets.REG_URL }}/${{ secrets.IMAGE_NAME }}:latest
+        build-args: BUILD_ARGS=-Icustom-items/inc.dm
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Use [`docker/build-push-action`](https://github.com/docker/build-push-action) and associated actions to publish to registry.

Pros:
- Caching for image layers, resulting in faster builds
- Officially supported method for this by docker (Instead of a community supported action as previously)
- *slightly faster*

Cons:
- moby/buildkit#838 prevents this from using the native `--push` flag, and instead has to workaround with `outputs: type=registry` and specifying the registry in the tag
- More complex in the workflow file