### PR TITLE
Remove redundant button for suit sensors

### DIFF
--- a/nano/templates/crew_monitor_map_header.tmpl
+++ b/nano/templates/crew_monitor_map_header.tmpl
@@ -3,7 +3,6 @@ Title: Crew Monitoring Console (Map header)
 Used In File(s): code\modules\modular_computers\file_system\programs\medical\suit_sensors.dm
  -->
 {{:helper.link('Show Detail List', 'script', {'showMap' : 0})}}
-{{:helper.link('Hide Map', 'close', {'showMap' : 0})}}
 <div style="float: right; width: 240px;">
 	<span style="float: left;">Z Level:&nbsp;</span>
 	{{for config.mapZLevels :zValue:zIndex}}


### PR DESCRIPTION
The "Show Detailed View" and "Hide Map" buttons on the suit sensors do the same thing, this gets rid of "Hide Map" to make it more streamlined.

:cl:
tweak: The redundant "Hide Map" button on the suit sensors program has been removed.
/:cl: