### PR TITLE
Correct meat monster names and attack text

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/meat_horrors.dm
+++ b/code/modules/mob/living/simple_animal/hostile/meat_horrors.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/meat/
-	name = "Horror"
+	name = "horror"
 	desc = "A monstrously huge wall of flesh, it looks like you took who knows how many humans and put them together..."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "horror"
@@ -21,7 +21,7 @@
 	melee_damage_flags = DAM_SHARP | DAM_EDGE
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 0
-	attacktext = "mauls and slashes"
+	attacktext = "mauled and slashed"
 	faction = "meat"
 	pass_flags = PASS_FLAG_TABLE
 	move_to_delay = 3
@@ -38,7 +38,7 @@
 		)
 
 /mob/living/simple_animal/hostile/meat/abomination
-	name = "Abomination"
+	name = "abomination"
 	desc = "A monstrously huge wall of flesh, it looks like you took who knows how many humans and put them together..."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "abomination"
@@ -60,7 +60,7 @@
 	melee_damage_flags = DAM_SHARP | DAM_EDGE
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 0
-	attacktext = "mauls and slashes"
+	attacktext = "mauled and slashed"
 	faction = "meat"
 	pass_flags = PASS_FLAG_TABLE
 	move_to_delay = 3
@@ -77,7 +77,7 @@
 		)
 
 /mob/living/simple_animal/hostile/meat/horror
-	name = "Horror"
+	name = "horror"
 	desc = "A monstrously huge wall of flesh, it looks like you took two humans and put them together..."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "horror"
@@ -115,7 +115,7 @@
 		)
 
 /mob/living/simple_animal/hostile/meat/strippedhuman
-	name = "Turned Human"
+	name = "turned human"
 	desc = "What's left of a human. Their body's chest cavity is ripped open, their organs spilling out. It twitches, ready for it's next victim..."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "horror_alt"
@@ -137,7 +137,7 @@
 	melee_damage_flags = DAM_SHARP | DAM_EDGE
 	heat_damage_per_tick = 100
 	cold_damage_per_tick = 0
-	attacktext = "mauls"
+	attacktext = "mauled"
 	faction = "meat"
 	pass_flags = PASS_FLAG_TABLE
 	move_to_delay = 3
@@ -154,7 +154,7 @@
 		)
 
 /mob/living/simple_animal/hostile/meat/humansecurity
-	name = "Turned Security"
+	name = "turned security"
 	desc = "What's left of a SAARE security guard. The only way you can tell is by the tatters of their uniform. That armor they wore in life now gives them a bit of hardiness in death..."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "horror_security"
@@ -176,7 +176,7 @@
 	melee_damage_flags = DAM_SHARP | DAM_EDGE
 	heat_damage_per_tick = 100
 	cold_damage_per_tick = 0
-	attacktext = "slashes"
+	attacktext = "slashed"
 	faction = "meat"
 	pass_flags = PASS_FLAG_TABLE
 	move_to_delay = 3
@@ -193,7 +193,7 @@
 		)
 
 /mob/living/simple_animal/hostile/meat/horrorminer
-	name = "Turned Miner"
+	name = "turned miner"
 	desc = "What's left of a miner. Their head is hanging off the back by a few scraps of fabric."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "horror_miner"
@@ -232,7 +232,7 @@
 		)
 
 /mob/living/simple_animal/hostile/meat/horrorsmall
-	name = "Smaller Horror"
+	name = "smaller horror"
 	desc = "A creature with more legs than it could possibly need. It has multiple sets of eyes, though they're all human..."
 	icon = 'icons/mob/simple_animal/nightmaremonsters.dmi'
 	icon_state = "lesser_ling"
@@ -244,7 +244,7 @@
 	speak_chance = 5
 	turns_per_move = 5
 	see_in_dark = 10
-	attacktext = "slashes"
+	attacktext = "slashed"
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "pokes"


### PR DESCRIPTION
Grammar corrections to meat monster names and attack text.

🆑 Mucker
bugfix: Fixes meat monster names and attack texts to be grammatically correct.
/🆑