### PR TITLE
Prevents lidded beakers from going into industrial grinders

### DIFF
--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -125,6 +125,13 @@
 	else if (is_type_in_list(I, allowed_containers) && !is_type_in_list(I, banned_containers))
 		if (container)
 			to_chat(user, SPAN_WARNING("\The [src] already has \a [container]."))
+			return
+
+		var/obj/item/weapon/reagent_containers/RC = I
+		
+		if(istype(RC) && !RC.is_open_container())
+			to_chat(user, SPAN_WARNING("You can't put a sealed beaker into \the [src]."))
+			return
 		else if (user.unEquip(I, src))
 			container = I
 			update_icon()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Currently industrial grinders allow you to insert beakers that have a lid placed on. When used, however, the reagents being ground aren't placed inside the beaker and instead vanish. This adds the same check to industrial grinders as already exists for reagent dispensers, preventing a lidded beaker from being placed inside and showing a message to the user.

:cl:
tweak: Beakers with a lid on can no longer be placed inside industrial grinders.
/:cl: