### PR TITLE
Monarch Serpentid namelists

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_ascent.dm
+++ b/code/modules/culture_descriptor/culture/cultures_ascent.dm
@@ -8,6 +8,11 @@ GLOBAL_LIST_INIT(gyne_names, list())
 	GLOB.gyne_names += gynename
 	return gynename
 
+/proc/create_queen_name()
+	return capitalize(pick(GLOB.queen_names))
+
+/proc/create_worker_name()
+	return capitalize(pick(GLOB.worker_names))
 //Thanks to:
 // - https://en.wikipedia.org/wiki/List_of_landforms
 // - https://en.wikipedia.org/wiki/Outline_of_classical_architecture
@@ -63,6 +68,22 @@ GLOBAL_LIST_INIT(gyne_architecture, list(
 	"ethical",       "micro",         "macro",       "genetic",      "intrinsic",     "extrinsic",     "academic",     "literary",
 	"artisan",       "absolute",      "absolutist",  "autonomous",   "collectivist",  "bicameral",     "colonialist",  "federal",
 	"imperial",      "independant",   "managed",     "multilateral", "neutral",       "nonaligned",    "parastatal"
+))
+
+GLOBAL_LIST_INIT(queen_names, list(
+	"ascension", 		"conquest", 	"majesty", 			"triumph",  		"glory",  		"highness", 		"victory", 		"sovereignty",
+	"regality", 		"supremacy",	"transcendence", 	"vengeance", 		"might", 		"purity", 			"prosperity",	"maximaility",
+	"benevolence", 		"generosity",	"magnanimity", 		"gracefulness", 	"eternity", 	"expansiveness",	"absoluteness",	"absolution",
+	"abundance",		"extravagance", "profusion",		"philanthropy",		"hospitality",	"largesse",			"benefaction",	"affluence",
+	"opulence",			"omnipresence",	"existence",		"substance",		"luxuriance",	"plenitude",		"fervor",		"transitivity",
+	"vigor",			"vibrancy",		"transiency",		"elation",			"energy",		"collaboration"
+))
+
+GLOBAL_LIST_INIT(worker_names, list(
+	"climber",		"leaper",		"leaf",		"tree",		"hider",	 "striker",		"breaker",		"river",	"waterfall",	"breaker",		"stone",
+	"dark",			"bright",		"hunter",	"killer",	"grass",	 "flame",		"fire",			"fighter",	"thinker",		"flier",		"rock",
+	"speaker",		"lake",			"devourer",	"mountain",	"soarer",	 "sleeper",		"bush",			"strong",	"clever",		"wasteful",		"cavern",
+	"ocean",		"swimmer",		"fixer"
 ))
 
 /decl/cultural_info/culture/ascent

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -85,15 +85,21 @@
 		var/datum/job/submap/ascent/ascent_job = mind.assigned_job
 		var/datum/submap/ascent/cutter = ascent_job.owner
 		if(istype(cutter))
-			var/new_name = sanitize(input("What is your name", "Choose name") as text|null, MAX_NAME_LEN)
-			if(!new_name)
-				return
-
 			if(!mind || mind.assigned_job != ascent_job)
 				return
 
 			// Rename ourselves.
-			fully_replace_character_name("[new_name]")
+			if(species.name == SPECIES_MONARCH_QUEEN)
+				var/new_name = sanitize(input("What is your name? Queen...", "Choose name") as text|null, MAX_NAME_LEN)
+				if(!new_name)
+					return
+				fully_replace_character_name("["Queen"] [new_name]")
+
+			else
+				var/new_name = sanitize(input("What is your name?", "Choose name") as text|null, MAX_NAME_LEN)
+				if(!new_name)
+					return
+				fully_replace_character_name("[new_name]")
 
 	verbs -= /mob/living/carbon/human/proc/serpentid_namepick
 
@@ -163,10 +169,10 @@
 			var/new_alate_number = is_species_whitelisted(H, SPECIES_MANTID_GYNE) ? random_id(/datum/species/mantid, 1000, 9999) : random_id(/datum/species/mantid, 10000, 99999)
 			H.real_name = "[new_alate_number] [cutter.gyne_name]"
 		if(SPECIES_MONARCH_WORKER)
-			H.real_name = "["monarch worker of "][cutter.gyne_name]"
+			H.real_name = "[create_worker_name()]"
 			H.verbs |= /mob/living/carbon/human/proc/serpentid_namepick
 		if(SPECIES_MONARCH_QUEEN)
-			H.real_name = "["monarch queen of "][cutter.gyne_name]"
+			H.real_name = "["Queen "][create_queen_name()]"
 			H.verbs |= /mob/living/carbon/human/proc/serpentid_namepick
 	H.name = H.real_name
 	if(H.mind)


### PR DESCRIPTION
:cl: RustingWithYou
tweak: adds new namelists for Monarch Serpentid Queens and Workers
tweak: the Serpentid Queen and Serpentid Adjunct jobs will now pick a name from their respective lists instead of just 'monarch of [cutter]'
/:cl: