### PR TITLE
Fix Backup Server Exploit

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -49,15 +49,21 @@
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "server"
 	desc = "Impact resistant server rack. You might be able to pry a disk out."
-	var/disk_looted
+	var/obj/item/weapon/stock_parts/computer/hard_drive/cluster/drive = new /obj/item/weapon/stock_parts/computer/hard_drive/cluster
 
 /obj/structure/backup_server/attackby(obj/item/W, mob/user, var/click_params)
 	if(isCrowbar(W))
+		if (!drive)
+			to_chat(user, SPAN_WARNING("There is nothing else to take from \the [src]."))
+			return
+
 		to_chat(user, SPAN_NOTICE("You pry out the data drive from \the [src]."))
 		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-		var/obj/item/weapon/stock_parts/computer/hard_drive/cluster/drive = new(get_turf(src))
 		drive.origin_tech = list(TECH_DATA = rand(4,5), TECH_ENGINEERING = rand(4,5), TECH_PHORON = rand(4,5), TECH_COMBAT = rand(2,5), TECH_ESOTERIC = rand(0,6))
-		
+		var/obj/item/weapon/stock_parts/computer/hard_drive/cluster/extracted_drive = drive
+		user.put_in_hands(extracted_drive)
+		drive = null
+
 /obj/effect/landmark/map_load_mark/ejected_datapod
 	name = "random datapod contents"
 	templates = list(/datum/map_template/ejected_datapod_contents, /datum/map_template/ejected_datapod_contents/type2, /datum/map_template/ejected_datapod_contents/type3)


### PR DESCRIPTION
Fixes being able to infinitely pull out data drives from the backup server.

🆑 Mucker
bugfix: Fixes the backup server exploit where an infinite number of data drives could be retrieved from them.
/🆑

Closes #29808 