### PR TITLE
Fix exo event being double announced

### DIFF
--- a/code/modules/events/exo_awaken.dm
+++ b/code/modules/events/exo_awaken.dm
@@ -143,9 +143,8 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	else
 		announcement = "Anomalous biological activity detected on [location_name()]."
 
-	for(var/obj/effect/overmap/visitable/OO in range(chosen_planet,2)) //announce the event to ships in range of the planet
-		if (istype(OO, /obj/effect/overmap/visitable/ship))
-			command_announcement.Announce(announcement, "[OO.name] Biological Sensor Array", zlevels = OO.find_z_levels())
+	for(var/obj/effect/overmap/visitable/ship/S in range(chosen_planet,2)) //announce the event to ships in range of the planet
+		command_announcement.Announce(announcement, "[S.name] Biological Sensor Array", zlevels = S.map_z)
 
 /datum/event/exo_awakening/tick()
 	count_mobs()


### PR DESCRIPTION
🆑 Mucker
bugfix: Fix the Exo event being announced multiple times on occasion.
/🆑

Should fix the case where the Charon either being on the planet or in open space also had its announcement sent to the Torch, as I believe my old method of announcing per z-levels was overlapping them.

Testing can be done by setting `required_players_count` to 0 or 1 and then debug-triggering the event while on the planet.