### PR TITLE
Clarify example admins.txt a bit

### DIFF
--- a/config/example/admins.txt
+++ b/config/example/admins.txt
@@ -3,6 +3,7 @@
 # Case is not important for ckey.                                    #
 # Case IS important for the rank. However punctuation/spaces are not #
 # Ranks can be anything defined in admin_ranks.txt           ~Carn   #
+# ** Lines starting with a # are comments and will be ignored. **    #
+# Example:                                                           #
+# not_a_user - Admin                                                 #
 ######################################################################
-
-# not_a_user - Admin


### PR DESCRIPTION
Users with less or no programming background have quite frequently gotten confused by the `#` before the example config line and thought it was a required element of the syntax. Hopefully now it's a bit clearer that it's not.