### PR TITLE
Re-roll for a new event whenever one is force-killed

### DIFF
--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -131,7 +131,7 @@
 	activeFor++
 
 //Called when start(), announce() and end() has all been called.
-/datum/event/proc/kill()
+/datum/event/proc/kill(reroll = FALSE)
 	// If this event was forcefully killed run end() for individual cleanup
 	if(isRunning)
 		isRunning = 0
@@ -139,6 +139,9 @@
 
 	endedAt = world.time
 	SSevent.event_complete(src)
+	if (reroll)
+		SSevent.event_containers[severity].start_event()
+
 
 //Called during building of skybox to get overlays
 /datum/event/proc/get_skybox_image()

--- a/code/modules/events/exo_awaken.dm
+++ b/code/modules/events/exo_awaken.dm
@@ -15,6 +15,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	var/target_mob_count_major = 55 //the target mob counts to choose from, based on severity (Major or Moderate)
 	var/target_mob_count_moderate = 35
 	var/datum/mob_list/chosen_mob_list //the chosen list of mobs we will pick from when spawning, also based on severity
+	var/original_severity
 
 /datum/mob_list
 	var/list/mobs = list()
@@ -74,7 +75,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 /datum/event/exo_awakening/setup()
 	announceWhen = rand(15, 45)
 	affecting_z = list()
-
+	original_severity = severity //incase we need to re-roll a different event.
 	if (severity == EVENT_LEVEL_MAJOR || prob(25))
 		severity = EVENT_LEVEL_MAJOR //if original event was moderate, this will need updating
 
@@ -123,8 +124,8 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		torch_players_present = FALSE
 
 	if (!torch_players_present)
-		log_and_message_admins("Failed to start the Exoplanet Awakening event, not enough players present on planetary surface.")
-		kill()
+		severity = original_severity
+		kill(TRUE)
 		return
 
 	for (var/client/C in players_on_site)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -31,7 +31,7 @@
 
 	if(!vermin_turfs)
 		log_debug("Vermin infestation failed to find a viable spawn after 3 attempts. Aborting.")
-		kill()
+		kill(TRUE)
 
 	var/list/spawn_types = list()
 	var/max_number
@@ -72,7 +72,7 @@
 	location = pick_area(list(/proc/is_not_space_area, /proc/is_station_area))
 	if(!location)
 		log_debug("Vermin infestation failed to find a viable area. Aborting.")
-		kill()
+		kill(TRUE)
 		return
 
 	var/list/vermin_turfs = get_area_turfs(location, list(/proc/not_turf_contains_dense_objects, /proc/IsTurfAtmosSafe))

--- a/code/modules/events/mail.dm
+++ b/code/modules/events/mail.dm
@@ -39,7 +39,7 @@
 	// Nobody got any mail :(
 	if(!to_receive.len)
 		log_debug("Nobody got any mail. Aborting event.")
-		kill()
+		kill(TRUE)
 
 /datum/event/mail/announce()
 	command_announcement.Announce("A batch of mail adressed to the crew of \the [location_name()] has arrived at the sorting office and will arrive on the next available supply shuttle.", pick("Major Bill's Shipping", "Flefingbridge Transport", "SolX Freight", "QuiCo. Mailing Services"), zlevels = affecting_z)

--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -9,7 +9,7 @@
 		for(var/j = 0 to drons)
 			if(!LAZYLEN(spots))
 				continue
-			
+
 			var/turf/T = pick_n_take(spots)
 			new/mob/living/simple_animal/hostile/rogue_drone(T)
 
@@ -31,12 +31,12 @@
 	var/area/location = pick_area(list(/proc/is_not_space_area, /proc/is_station_area, /proc/is_maint_area))
 	if(!location)
 		log_debug("Drone infestation failed to find a viable area. Aborting.")
-		kill()
+		kill(TRUE)
 		return
 
 	var/list/dron_turfs = get_area_turfs(location, list(/proc/not_turf_contains_dense_objects, /proc/IsTurfAtmosSafe))
 	if(!dron_turfs.len)
 		log_debug("Drone infestation failed to find viable turfs in \the [location].")
-		kill()
+		kill(TRUE)
 		return
 	return dron_turfs


### PR DESCRIPTION
🆑 Mucker
tweak: Events that fail to run will have a new event run in its place.
/🆑

Re-rolls for a new event whenever one is force-killed because of some missed condition or a failed check.