### PR TITLE
Give surgeon borgs syringes

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -40,10 +40,11 @@
 		/obj/item/weapon/surgicaldrill,
 		/obj/item/weapon/gripper/organ,
 		/obj/item/weapon/shockpaddles/robot,
+		/obj/item/weapon/reagent_containers/syringe,
 		/obj/item/weapon/crowbar,
 		/obj/item/stack/nanopaste,
 		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/weapon/reagent_containers/dropper/
+		/obj/item/weapon/reagent_containers/dropper
 	)
 	synths = list(
 		/datum/matter_synth/medicine = 10000,


### PR DESCRIPTION
Because syringes are a vital part of being a surgeon as it turns out - Alkysine, peridaxon, oxycodone, spaceacillin, etc.

:cl:
tweak: Surgeon borgs now have syringes
/:cl: