### PR TITLE
Fixes nabbers joining with hostile stance by default

### DIFF
--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -326,8 +326,7 @@
 
 /datum/species/nabber/handle_post_spawn(var/mob/living/carbon/human/H)
 	..()
-	if(H.species.get_bodytype() == !SPECIES_MONARCH_QUEEN)
-		return H.pulling_punches = TRUE
+	return H.pulling_punches = TRUE
 
 /datum/species/nabber/has_fine_manipulation(var/mob/living/carbon/human/H)
 	if(H.species.get_bodytype() == SPECIES_MONARCH_QUEEN)


### PR DESCRIPTION
:cl:
bugfix: Fixed nabbers (GAS) joining with hostile stance by default
/:cl:

Nabbers were joining in their hostile stance by default. MSQ were excluded from joining in passive stance, but it for some reason had the same effect on nabbers. Either way, both should be spawning in passive stance.