### PR TITLE
Raider gamemode requirements

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -12,8 +12,8 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 
 	hard_cap = 6
 	hard_cap_round = 10
-	initial_spawn_req = 4
-	initial_spawn_target = 6
+	initial_spawn_req = 3
+	initial_spawn_target = 4
 	min_player_age = 14
 
 	id_type = /obj/item/weapon/card/id/syndicate


### PR DESCRIPTION
🆑 
tweak: Raider needs one less player rolling raider to start, from four to three.
tweak: Raider won't always try to fill the six slot team, the target is now four.
/ 🆑 

Intended to make raider slightly more common, but reduce the frequency of rounds where the raider team is greater than or equal to the Torch's manifest size.