### PR TITLE
Opens up mutineer to department heads and brings back command loyalist

### DIFF
--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -13,12 +13,11 @@
 
 /datum/antagonist/loyalists
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap, /datum/job/merchant)
-	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
 	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/revolutionary
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap, /datum/job/merchant)
-	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hop)
 	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/traitor


### PR DESCRIPTION
🆑 
tweak: Department heads can be head mutineers.
tweak: All of command can be head loyalist.
/ 🆑 

We tried moving away from command loyalist, but all it really did was kill the gamemode. 

Since the change, the most notable mutiny rounds have had command loyalists made by admin intervention. However, since there's still a hell of a balance issue when all of command is dogpiled against you, why not have department heads try and snatch a little power for themselves?

I think it's worth trying.