### PR TITLE
Exoplanet ruins tweaks

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -42,7 +42,7 @@
 	//Flags deciding what features to pick
 	var/ruin_tags_whitelist
 	var/ruin_tags_blacklist
-	var/features_budget = 4
+	var/features_budget = 5
 	var/list/possible_features = list()
 	var/list/spawned_features
 

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -5,10 +5,10 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
-	cost = 2
+	cost = 1.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
-	spawn_weight = 0.67
+	spawn_weight = 0.33
 
 /area/map_template/crashed_pod
 	name = "\improper Crashed Survival Pod"

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -3,7 +3,7 @@
 	id = "datacapsule"
 	description = "A damaged capsule with some strange contents."
 	suffixes = list("datacapsule/datacapsule.dmm")
-	cost = 1
+	cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -5,14 +5,14 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony/colony.dmm")
-	cost = 2
+	cost = 3
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 	ban_ruins = list(/datum/map_template/ruin/exoplanet/playablecolony2)
 	apc_test_exempt_areas = list(
 		/area/map_template/colony/mineralprocessing = NO_SCRUBBER|NO_VENT
 	)
-	spawn_weight = 0.33
+	spawn_weight = 0.2
 
 /decl/submap_archetype/playablecolony
 	descriptor = "established colony"
@@ -21,7 +21,7 @@
 /datum/job/submap/colonist
 	title = "Colonist"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a reconstructed shelter made from the very ship that took you here."
-	total_positions = 6
+	total_positions = 4
 	outfit_type = /decl/hierarchy/outfit/job/colonist
 
 /decl/hierarchy/outfit/job/colonist

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
@@ -12,7 +12,7 @@
 	apc_test_exempt_areas = list(
 		/area/map_template/colony2/external = NO_SCRUBBER|NO_VENT
 	)
-	spawn_weight = 0.33
+	spawn_weight = 0.4
 
 /decl/submap_archetype/playablecolony2
 	descriptor = "landed colony ship"
@@ -22,7 +22,7 @@
 	title = "Ship Colonist"
 	supervisors = "the trust of your fellow Colonists"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a recently landed colony ship."
-	total_positions = 4
+	total_positions = 3
 	outfit_type = /decl/hierarchy/outfit/job/colonist2
 
 /decl/hierarchy/outfit/job/colonist2


### PR DESCRIPTION
🆑 
tweak: Exoplanets have more ruins spawning on them.
tweak: BigColony is slightly less common, takes more budget, and has two less jobslots, to four from six.
tweak: SmallColony has one less jobslot, from four to three, and is slightly more common.
tweak: The crashed pod is slightly less common, and takes up less of the exoplanet ruin budget.
/ 🆑 

Meant to give exoplanets more stuff to look at in a given round, and also make each colony and the survival pod less obstructive to explorer/other offship gameplay.