### PR TITLE
Fixes antags not highlighting in certain staff logs

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -173,7 +173,7 @@
 			name = M.name
 
 
-		if(include_link && is_special_character(M) && highlight_special_characters)
+		if(is_special_character(M) && highlight_special_characters)
 			. += "/(<font color='#ffa500'>[name]</font>)" //Orange
 		else
 			. += "/([name])"


### PR DESCRIPTION
:cl:
admin: Attack logs and other admin logs that didn't highlight antags now highlight them in yellow, similarly to admin help logs.
/:cl: