### PR TITLE
Make deceased mobs always have no pulse

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1557,6 +1557,8 @@
 // output for machines ^	 ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ output for people
 
 /mob/living/carbon/human/proc/pulse()
+	if (stat == DEAD)
+		return PULSE_NONE
 	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
 	return H ? H.pulse : PULSE_NONE
 


### PR DESCRIPTION
:cl:
bugfix: Deceased mobs will now always properly show as having no pulse.
/:cl:

Closes #22998