### PR TITLE
add pref option for showing chosen job in lobby

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -205,6 +205,11 @@ var/list/_client_preferences_by_type
 	key = "SHOW_CKEY_DEADCHAT"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/show_job
+	description = "Show Job in Lobby"
+	key = "SHOW_HIGH_JOB"
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+
 /datum/client_preference/play_instruments
 	description ="Play instruments"
 	key = "SOUND_INSTRUMENTS"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -90,8 +90,10 @@
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in GLOB.player_list)
 				var/highjob
-				if(player.client && player.client.prefs && player.client.prefs.job_high)
-					highjob = " as [player.client.prefs.job_high]"
+				if (player.client)
+					var/show_job = player.client.get_preference_value(/datum/client_preference/show_job) == GLOB.PREF_SHOW
+					if(player.client.prefs?.job_high && show_job)
+						highjob = " as [player.client.prefs.job_high]"
 				stat("[player.key]", (player.ready)?("(Playing[highjob])"):(null))
 				totalPlayers++
 				if(player.ready)totalPlayersReady++


### PR DESCRIPTION
🆑 Mucker
rscadd: Adds the 'Show Job in Lobby' option to Preferences, allowing players to choose if their high-priority job is shown to everyone or not while readied.
/🆑