### PR TITLE
Removes SEA's tac-arm access.

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -333,7 +333,7 @@
 	                    SKILL_COMBAT     = SKILL_BASIC,
 	                    SKILL_WEAPONS    = SKILL_ADEPT)
 
-	max_skill = list(	SKILL_PILOT        = SKILL_ADEPT, 
+	max_skill = list(	SKILL_PILOT        = SKILL_ADEPT,
 	                    SKILL_COMBAT       = SKILL_EXPERT,
 	                    SKILL_WEAPONS      = SKILL_EXPERT,
 	                    SKILL_CONSTRUCTION = SKILL_MAX,
@@ -346,8 +346,7 @@
 	access = list(access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 			            access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_janitor,
 			            access_kitchen, access_cargo, access_RC_announce, access_keycard_auth, access_aquila, access_guppy_helm,
-			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_emergency_armory,
-			            access_torch_fax)
+			            access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_torch_fax)
 
 	software_on_spawn = list(/datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/reports)


### PR DESCRIPTION
🆑 
tweak: SEA no longer has Tac-Arm access. They still have basic E-Arm Access.
/ 🆑 

Most department heads don't have Tac-Arm access, and giving it to the SEA unintentionally encourages poor SEA behavior where they'll act as another member of security. Furthermore, as was succinctly put in the discord, if a CO needs an SEA to hand out guns, they can _give_ them access. Otherwise, there's no reason for the command advisor to have access to an entire armory, especially when they don't have access to the _other_ armory that has less lethal weaponry.

If I could, I'd merge the items of tac-arm into sec-arm and make all the guns the brig chief's responsibility, but right now I'm not willing to take that project on.

If this is merged, the wiki will need an update removing the references to tac-arm from the SEA's page.
