### PR TITLE
Fixes fleet department heads not getting department officer coveralls

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -69,7 +69,7 @@
 	name = "Fleet engineering CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/engineering,
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/beret/solgov/fleet/engineering,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
@@ -140,7 +140,7 @@
 	name = "Fleet security CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/security,
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/beret/solgov/fleet/security,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,
@@ -211,7 +211,7 @@
 	name = "Fleet medical CO"
 	min_rank = 11
 
-	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/command,
+	utility_extra = list(/obj/item/clothing/under/solgov/utility/fleet/officer/medical,
 						 /obj/item/clothing/head/beret/solgov/fleet/command,
 						 /obj/item/clothing/head/beret/solgov/fleet/medical,
 						 /obj/item/clothing/head/ushanka/solgov/fleet,


### PR DESCRIPTION
🆑 
bugfix: Fleet department heads now have the right officer coveralls in the vendor.
/ 🆑 

One of two solutions to issue #29834 , corrects fleet department heads getting gold cuffed officer coveralls when their department-specific varieties are coded in.

Other solution would be making department head uniforms all use command variants instead of department variants, but seeing as someone went out of the way to make engineering officer's coveralls, I believe this way was intended. 

Fixes #29834 