### PR TITLE
Allows Forensic Tools to Process Storage Containers

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -152,10 +152,10 @@
 				to_chat(user, "<span class='notice'>\The [src] has no more space specifically for \the [W].</span>")
 			return 0
 
-	//If attempting to lable the storage item, silently fail to allow it
-	if(istype(W, /obj/item/weapon/hand_labeler) && user.a_intent != I_HELP)
+	//Bypassing storage procedures when not using help intent for labeler/forensic tools.
+	if((istype(W, /obj/item/weapon/hand_labeler) || istype(W, /obj/item/weapon/forensics)) && user.a_intent != I_HELP)
 		return FALSE
-
+	
 	// Don't allow insertion of unsafed compressed matter implants
 	// Since they are sucking something up now, their afterattack will delete the storage
 	if(istype(W, /obj/item/weapon/implanter/compressed))


### PR DESCRIPTION
Dipping my toe back into things. This is a simple tweak to allow processing of storage containers by anyone using forensic tools by simply switching to an intent other than help. On help intent, the tool will be stored as usual.

:cl: Textor45
tweak: Switching off help intent will allow forensic tools to be used on storage containers without storing the tool.
/:cl: