### PR TITLE
Gives pathfinder teleporter access

### DIFF
--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -31,7 +31,7 @@
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
 		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
 		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
-		access_xenobiology, access_xenoarch, access_torch_fax
+		access_xenobiology, access_xenoarch, access_teleporter, access_torch_fax
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management,


### PR DESCRIPTION
🆑 
tweak: Pathfinders can access teleporters.
/ 🆑 
Because if the GUP or Charon is already away, this expedites things