### PR TITLE
The fountain exoplanet ruin no longer ways more than a full lab

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
+++ b/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
@@ -3,6 +3,6 @@
 	id = "planetsite_fountain"
 	description = "The fountain of youth itself."
 	suffixes = list("fountain/fountain_ruin.dmm")
-	cost = 2
+	cost = 0.5
 	template_flags = TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_CLEAR_CONTENTS
 	ruin_tags = RUIN_ALIEN


### PR DESCRIPTION
🆑 
tweak: Drastically lowers the fountain exoplanet ruin's spawn cost.
/ 🆑 

The current cost is two. This is more than some big lab away sites. This is silly.

I cut it to .5, the same as the datacapsule, which is roughly the same size.