### PR TITLE
Patches on voidsuits can now be removed

### DIFF
--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -49,7 +49,7 @@
 //Repair a certain amount of brute or burn damage to the suit.
 /obj/item/clothing/suit/space/proc/repair_breaches(var/damtype, var/amount, var/mob/user)
 
-	if(!can_breach || !breaches || !breaches.len || !damage)
+	if(!can_breach || !breaches || !breaches.len)
 		to_chat(user, "There are no breaches to repair on \the [src].")
 		return
 
@@ -76,7 +76,10 @@
 			amount_left = 0
 			B.update_descriptor()
 
-	user.visible_message("<b>[user]</b> patches some of the damage on \the [src].")
+	user.visible_message(
+		SPAN_NOTICE("\The [user] patches some of the damage on \the [src]."),
+		SPAN_NOTICE("You patch some of the damage on \the [src].")
+	)
 	calc_breach_damage()
 
 /obj/item/clothing/suit/space/proc/create_breaches(var/damtype, var/amount)
@@ -110,9 +113,11 @@
 				amount -= needs
 
 			if(existing.damtype == BRUTE)
-				visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] gapes wider[existing.patched ? ", tearing the patch" : ""]!</span>")
+				var/message = "\The [existing.descriptor] on \the [src] gapes wider[existing.patched ? ", tearing the patch" : ""]!"
+				visible_message(SPAN_WARNING(message))
 			else if(existing.damtype == BURN)
-				visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] widens[existing.patched ? ", ruining the patch" : ""]!</span>")
+				var/message = "\The [existing.descriptor] on \the [src] widens[existing.patched ? ", ruining the patch" : ""]!"
+				visible_message(SPAN_WARNING(message))
 
 			existing.patched = FALSE
 
@@ -128,9 +133,9 @@
 		B.holder = src
 
 		if(B.damtype == BRUTE)
-			visible_message("<span class = 'warning'>\A [B.descriptor] opens up on [src]!</span>")
+			visible_message(SPAN_WARNING("\A [B.descriptor] opens up on \the [src]!"))
 		else if(B.damtype == BURN)
-			visible_message("<span class = 'warning'>\A [B.descriptor] marks the surface of [src]!</span>")
+			visible_message(SPAN_WARNING("\A [B.descriptor] marks the surface of \the [src]!"))
 
 	calc_breach_damage()
 
@@ -188,10 +193,10 @@
 		if(!repair_power)
 			return
 
-		if(istype(src.loc,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = src.loc
+		if(istype(loc,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = loc
 			if(H.wear_suit == src)
-				to_chat(user, "<span class='warning'>You cannot repair \the [src] while it is being worn.</span>")
+				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
 				return
 
 		if(burn_damage <= 0)
@@ -206,10 +211,10 @@
 
 	else if(isWelder(W))
 
-		if(istype(src.loc,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = src.loc
+		if(istype(loc,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = loc
 			if(H.wear_suit == src)
-				to_chat(user, "<span class='warning'>You cannot repair \the [src] while it is being worn.</span>")
+				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
 				return
 
 		if (brute_damage <= 0)
@@ -218,7 +223,7 @@
 
 		var/obj/item/weapon/weldingtool/WT = W
 		if(!WT.remove_fuel(5))
-			to_chat(user, "<span class='warning'>You need more welding fuel to repair this suit.</span>")
+			to_chat(user, SPAN_WARNING("You need more welding fuel to repair this suit."))
 			return
 
 		repair_breaches(BRUTE, 3, user)
@@ -234,12 +239,15 @@
 
 		if(!target_breach)
 			to_chat(user, "There are no open breaches to seal with \the [W].")
-		else 
+		else
 			playsound(src, 'sound/effects/tape.ogg',25)
 			var/mob/living/carbon/human/H = user
 			if(!istype(H)) return
-			if(do_after(user, H.wear_suit == src? 60 : 30, istype(src.loc,/mob/living)? src.loc : null)) //Sealing a breach on your own suit is awkward and time consuming
-				user.visible_message("<b>[user]</b> uses \the [W] to seal \the [target_breach.descriptor] on \the [src].")
+			if(do_after(user, H.wear_suit == src? 60 : 30, istype(loc,/mob/living)? loc : null)) //Sealing a breach on your own suit is awkward and time consuming
+				user.visible_message(
+					SPAN_NOTICE("\The [user] uses \the [W] to seal \the [target_breach.descriptor] on \the [src]."),
+					SPAN_NOTICE("You use \the [W] to seal \the [target_breach.descriptor] on \the [src].")
+				)
 				target_breach.patched = TRUE
 				target_breach.update_descriptor()
 				calc_breach_damage()
@@ -251,7 +259,7 @@
 	. = ..()
 	if(can_breach && breaches && breaches.len)
 		for(var/datum/breach/B in breaches)
-			to_chat(user, "<span class='danger'>It has \a [B.descriptor].</span>")
+			to_chat(user, SPAN_DANGER("It has \a [B.descriptor]."))
 
 /obj/item/clothing/suit/space/get_pressure_weakness(pressure)
 	. = ..()


### PR DESCRIPTION
:cl:
bugfix: Voidsuit patches no longer prevent actual repairs
/:cl:

With this, those annoying patches can finally be removed from voidsuits, allowing a savvy repair person to restore a suit to factory new condition. Previously, the only way a patch could be removed was by attacking the suit's wearer.

I've checked to ensure there aren't any other wirecutter `attackby` interactions that would be broken as a result of this, and everything looks good.

I have not validated this in a local server (yet).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->