### PR TITLE
Tweak voidsuits so they can only be unequipped by click-and-drag

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -307,6 +307,11 @@ else if(##equipment_var) {\
 
 	..()
 
+/obj/item/clothing/suit/space/void/attack_hand(mob/user as mob)
+	if (loc == user)
+		return
+	return ..()
+
 /obj/item/clothing/suit/space/void/attack_self() //sole purpose of existence is to toggle the helmet
 	toggle_helmet()
 


### PR DESCRIPTION
🆑 Mucker
tweak: Voidsuits can now only be dequipped by click-dragging them into an open hand.
/🆑

I think everyone's come across a time when they accidentally pulled off their voidsuit while in space, or a hazardous area, due to a very unfortunate miss-click. This aims to stop that from happening.  Voidsuits can now only be taken off by clicking and dragging them into an open hand.