### PR TITLE
Removes Medical's starting Syringe Gun

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2668,9 +2668,6 @@
 /area/assembly/robotics)
 "eS" = (
 /obj/structure/table/rack,
-/obj/item/weapon/gun/launcher/syringe,
-/obj/item/weapon/storage/box/syringegun,
-/obj/item/weapon/storage/box/syringegun,
 /obj/item/weapon/defibrillator/compact,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -17896,6 +17896,12 @@
 /obj/item/stack/material/steel{
 	amount = 30
 	},
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/ocp{
+	amount = 10
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -18893,15 +18899,11 @@
 /obj/structure/table/rack{
 	dir = 4
 	},
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/weapon/gun/launcher/syringe,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/item/stack/material/ocp{
-	amount = 10
-	},
-/obj/item/stack/material/plasteel{
-	amount = 20
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -17896,12 +17896,6 @@
 /obj/item/stack/material/steel{
 	amount = 30
 	},
-/obj/item/stack/material/plasteel{
-	amount = 20
-	},
-/obj/item/stack/material/ocp{
-	amount = 10
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -18899,11 +18893,15 @@
 /obj/structure/table/rack{
 	dir = 4
 	},
-/obj/item/weapon/storage/box/syringegun,
-/obj/item/weapon/gun/launcher/syringe,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/stack/material/ocp{
+	amount = 10
+	},
+/obj/item/stack/material/plasteel{
+	amount = 20
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)


### PR DESCRIPTION
:cl: SDTheCyanWyan
maptweak: Removes the starting syringe gun from Medical Morgue Storage
/:cl:

It's a rarely used item, and from the times it has been used, its only purpose has been to be loaded with chloral hydrate.