### PR TITLE
Fix pressure tanks initializing with incorrect volume

### DIFF
--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -21,8 +21,10 @@
 
 /obj/machinery/atmospherics/unary/tank/Initialize()
 	. = ..()
+
+	air_contents.volume = volume
+
 	if(filling)
-		air_contents.volume = volume
 		air_contents.temperature = T20C
 
 		var/list/gases = list()


### PR DESCRIPTION
:cl:
bugfix: Constructed pressure tanks now have the correct 10,000L volume instead of 200L.
/:cl:

Non-mapped pressure tanks have nothing set to `var/filling`, which leads to the volume being inherited from `/obj/machinery/atmospherics/unary/Initialize()` where it is hardcoded to `200`. This change fixes that.

For your reference, the relevant snippet from `code\modules\atmospherics\components\unary\unary_base.dm`:
```
/obj/machinery/atmospherics/unary/Initialize()
	air_contents = new
	air_contents.volume = 200
	. = ..()
```

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->