### PR TITLE
Aim-firing now drops after the first reflexive shot.

### DIFF
--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -184,7 +184,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 	else
 		icon_state = "locking"
 
-/obj/aiming_overlay/proc/toggle_active(var/force_state = null)
+/obj/aiming_overlay/proc/toggle_active(var/force_state = null, var/no_message = FALSE)
 	if(!isnull(force_state))
 		if(active == force_state)
 			return
@@ -193,25 +193,27 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		active = !active
 
 	if(!active)
-		cancel_aiming()
+		cancel_aiming(no_message)
 
 	if(owner.client)
 		if(active)
-			to_chat(owner, "<span class='notice'>You will now aim rather than fire.</span>")
+			if(!no_message)
+				to_chat(owner, "<span class='notice'>You will now aim rather than fire.</span>")
 			owner.client.add_gun_icons()
 		else
-			to_chat(owner, "<span class='notice'>You will no longer aim rather than fire.</span>")
+			if(!no_message)
+				to_chat(owner, "<span class='notice'>You will no longer aim rather than fire.</span>")
 			owner.client.remove_gun_icons()
 		owner.gun_setting_icon.icon_state = "gun[active]"
 
 /obj/aiming_overlay/proc/cancel_aiming(var/no_message = 0)
 	if(!aiming_with || !aiming_at)
 		return
-	if(istype(aiming_with, /obj/item/weapon/gun))
-		sound_to(aiming_at, sound('sound/weapons/TargetOff.ogg'))
-		sound_to(owner, sound('sound/weapons/TargetOff.ogg'))
 	if(!no_message)
 		owner.visible_message("<span class='notice'>\The [owner] lowers \the [aiming_with].</span>")
+		if(istype(aiming_with, /obj/item/weapon/gun))
+			sound_to(aiming_at, sound('sound/weapons/TargetOff.ogg'))
+			sound_to(owner, sound('sound/weapons/TargetOff.ogg'))
 
 	GLOB.moved_event.unregister(owner, src)
 	if(aiming_at)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -28,3 +28,4 @@
 	var/obj/item/weapon/gun/G = aiming_with
 	if(istype(G))
 		G.Fire(aiming_at, owner)
+	toggle_active(FALSE, TRUE)

--- a/html/changelogs/mistakenot-aimfire.yml
+++ b/html/changelogs/mistakenot-aimfire.yml
@@ -1,0 +1,4 @@
+author: MistakeNot4892
+delete-after: True
+changes: 
+  - tweak: "Aim mode will now drop after the first reflexive shot."


### PR DESCRIPTION
Aim-firing is still very useful (an instant free shot with increased accuracy) but this prevents it being used as an essentially guaranteed kill when someone is aimed at in an open area with a hitscan weapon.