### PR TITLE
Pressure tanks can now be colored in-game

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -154,6 +154,8 @@ Buildable meters
 	var/obj/machinery/atmospherics/P = new constructed_path(get_turf(src))
 
 	P.pipe_color = color
+	if (P.colorable)
+		P.color = color
 	P.set_dir(dir)
 	P.set_initial_level()
 

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -34,6 +34,7 @@ Pipelines + Other Objects -> Pipe network
 	var/atmos_initalized = FALSE
 	var/build_icon = 'icons/obj/pipe-item.dmi'
 	var/build_icon_state = "buildpipe"
+	var/colorable = FALSE
 
 	var/pipe_class = PIPE_CLASS_OTHER //If somehow something isn't set properly, handle it as something with zero connections. This will prevent runtimes.
 	var/rotate_class = PIPE_ROTATE_STANDARD

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -18,6 +18,8 @@
 
 	build_icon = 'icons/atmos/tank.dmi'
 	build_icon_state = "air"
+	colorable = TRUE
+	atom_flags = ATOM_FLAG_CAN_BE_PAINTED
 
 /obj/machinery/atmospherics/unary/tank/Initialize()
 	. = ..()
@@ -36,6 +38,11 @@
 
 /obj/machinery/atmospherics/unary/tank/set_initial_level()
 	level = 1 // Always on top, apparently.
+
+// required for paint sprayers to work due to an override in pipes.dm
+/obj/machinery/atmospherics/unary/tank/set_color(new_color)
+	color = new_color
+	icon_state = "air"
 
 /obj/machinery/atmospherics/unary/tank/update_underlays()
 	if(..())


### PR DESCRIPTION
:cl:
rscadd: Pressure tanks can now be colored
/:cl:

- Tested in a local server
- Building from a dispenser works
- Paint sprayer works

There's a lot of complexity in how pipes get colored and I'm not aware of a clean way to reuse that code here, so this implementation does not do any pipe_color overlay shenanigans, instead using a simple `color`-based approach.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->