### PR TITLE
Removes reference to "escaped/transferred" people at the end of round.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -357,7 +357,7 @@ var/global/list/additional_antag_types = list()
 	var/text = "<br><br>"
 	if(surviving_total > 0)
 		text += "There [surviving_total>1 ? "were <b>[surviving_total] survivors</b>" : "was <b>one survivor</b>"]"
-		text += " (<b>[escaped_total>0 ? escaped_total : "none"] [evacuation_controller.emergency_evacuation ? "escaped" : "transferred"]</b>) and <b>[ghosts] ghosts</b>.<br>"
+		text += " and <b>[ghosts] ghosts</b>.<br>"
 	else
 		text += "There were <b>no survivors</b> (<b>[ghosts] ghosts</b>)."
 


### PR DESCRIPTION
:cl: Textor45
tweak: The end of round summary  no longer references the counter for escaped or transferred personnel.
/:cl:

At the end of the round, it always tells us we have x survivors (y escaped/transferred). The Y is always zero because the only way to be in that list is to be in centcom regions, which is rare at best and generally disallowed for non-ERT/adminbus activity. Additionally, we don't do transfers on the Torch, so there is never a situation in which any survivor would have an end-of-round crew transfer.

This removes the reference from the end of round summary. I did not change the webhook, as I do not know if that would break the webhook by removing it.