### PR TITLE
Actually light ninja suit

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -17,7 +17,7 @@
 	disruptive = 0
 
 	use_power_cost = 250 KILOWATTS
-	active_power_cost = 6 KILOWATTS		// 30 min battery life /w best (3kWh) cell
+	active_power_cost = 30 KILOWATTS
 	passive_power_cost = 0
 	module_cooldown = 10 SECONDS
 	origin_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 6, TECH_ESOTERIC = 6, TECH_ENGINEERING = 7)
@@ -60,7 +60,7 @@
 	name = "teleportation module"
 	desc = "A complex, sleek-looking, hardsuit-integrated teleportation module."
 	icon_state = "teleporter"
-	use_power_cost = 25 KILOWATTS
+	use_power_cost = 400 KILOWATTS
 	redundant = 1
 	usable = 1
 	selectable = 1
@@ -143,7 +143,7 @@
 	engage_string = "Fabricate Net"
 
 	fabrication_type = /obj/item/weapon/energy_net
-	use_power_cost = 20 KILOWATTS
+	use_power_cost = 50 KILOWATTS
 	origin_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 5, TECH_ESOTERIC = 4, TECH_ENGINEERING = 6)
 
 /obj/item/rig_module/fabricator/energy_net/engage(atom/target)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -90,13 +90,13 @@
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_HANDGUNS,
+		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED
 		)
 	siemens_coefficient = 0.2 //heavy hardsuit level shock protection
-	emp_protection = 40 //change this to 30 if too high.
+	emp_protection = 20
 	online_slowdown = 0
 	aimove_power_usage = 50
 	chest_type = /obj/item/clothing/suit/space/rig/light/ninja
@@ -155,7 +155,6 @@
 /obj/item/clothing/gloves/rig/light/ninja
 	name = "insulated gloves"
 	siemens_coefficient = 0
-	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_NOCUFFS
 
 /obj/item/clothing/suit/space/rig/light/ninja
 	breach_threshold = 38 //comparable to regular hardsuits


### PR DESCRIPTION
🆑 
tweak: The hardsuit stealth module costs five times as much energy to maintain stealth.
tweak: The hardsuit teleporter module costs eight times as much energy to trigger. Teleportation is expensive.
tweak: The ninja hardsuit is small enough where cuffs can fit around it. Don't get caught.
tweak: The ninja hardsuit's laser armor has been lowered.
/ 🆑 

With the power changes, the ninja's cloak will no longer last sixty minutes on a full battery, and can "only" teleport **fifteen times** on a full battery. They keep their power sink, however, so getting that power back isn't a big problem if you aren't cloaked in a room desperately hoping your pursuers get bored before your formerly one-hour cloak ends.

The NOCUFFS flag makes sense for big, bulky hardsuits, but not the sleak pajama jumper the ninja has. Laser armor tweak is also to discourage just tanking security with your build in eswords, darts, and bomb - but we don't need to keep the armor change if there's enough outcry.


All of these changes are to prevent the killing of ninja as a game mode and the stealth module as a thing that exists.

All testing was done with the 3000 capacity battery the ninja hardsuit starts out with.