### PR TITLE
removes uncolored pressure tank pipes

### DIFF
--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -42,6 +42,7 @@
 // required for paint sprayers to work due to an override in pipes.dm
 /obj/machinery/atmospherics/unary/tank/set_color(new_color)
 	color = new_color
+	pipe_color = new_color
 	icon_state = "air"
 
 /obj/machinery/atmospherics/unary/tank/update_underlays()


### PR DESCRIPTION
This fixes an edge case that could cause the pipe segment connected to a pressure tank to be the wrong color:
![image](https://user-images.githubusercontent.com/1807509/102004888-76498980-3cda-11eb-9b14-57a3dde70250.png)

Specifically, this happens if a paint sprayer is used to change the tank's color.

~~Skipping the changelog because the issue is so minor and so recent I don't believe it merits a bugfix tag, as I doubt anyone has noticed it aside from me.~~

:cl:
bugfix: Fix oversight causing pipes connected to pressure tanks to color incorrectly
/:cl:
