### PR TITLE
Add marooned players count to round-end summary, update escape count

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -79,6 +79,9 @@
 /proc/isContactLevel(var/level)
 	return level in GLOB.using_map.contact_levels
 
+/proc/isEscapeLevel(var/level)
+	return level in GLOB.using_map.escape_levels
+
 /proc/circlerange(center=usr,radius=3)
 
 	var/turf/centerturf = get_turf(center)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -381,14 +381,18 @@ Helpers
 			if(Player.stat != DEAD)
 				var/turf/playerTurf = get_turf(Player)
 				if(evacuation_controller.round_over() && evacuation_controller.emergency_evacuation)
-					if(isNotAdminLevel(playerTurf.z))
+					if(isStationLevel(playerTurf.z))
 						to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned on [station_name()] as [Player.real_name]...</b></span>")
-					else
+					else if (isEscapeLevel(playerTurf.z))
 						to_chat(Player, "<font color='green'><b>You managed to survive the events on [station_name()] as [Player.real_name].</b></font>")
+					else
+						to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned in the sector as [Player.real_name]...</b></span>")
 				else if(isAdminLevel(playerTurf.z))
 					to_chat(Player, "<font color='green'><b>You successfully underwent crew transfer after events on [station_name()] as [Player.real_name].</b></font>")
 				else if(issilicon(Player))
 					to_chat(Player, "<font color='green'><b>You remain operational after the events on [station_name()] as [Player.real_name].</b></font>")
+				else if (isNotStationLevel(playerTurf.z))
+					to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned in the sector as [Player.real_name]...</b></span>")
 				else
 					to_chat(Player, "<span class='info'><b>You got through just another workday on [station_name()] as [Player.real_name].</b></span>")
 			else

--- a/code/modules/webhooks/webhook_roundend.dm
+++ b/code/modules/webhooks/webhook_roundend.dm
@@ -11,16 +11,12 @@
 
 			var/s_was =      "was"
 			var/s_survivor = "survivor"
-			var/s_escaped =  "escaped"
 
 			if(data["survivors"] != 1)
 				s_was = "were"
 				s_survivor = "survivors"
 
-			if(!evacuation_controller.emergency_evacuation)
-				s_escaped = "transferred"
-
-			desc += "There [s_was] **[data["survivors"]] [s_survivor] ([data["escaped"]] [s_escaped])** and **[data["ghosts"]] ghosts.**"
+			desc += "There [s_was] **[data["survivors"]] [s_survivor] ([data["escaped"]] escaped,  [data["marooned"]] marooned)** and **[data["ghosts"]] ghosts.**"
 		else
 			desc += "There were **no survivors** ([data["ghosts"]] ghosts)."
 

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -5,8 +5,9 @@
 	flags = MAP_HAS_BRANCH | MAP_HAS_RANK
 	config_path = "config/torch_config.txt"
 
-	admin_levels = list(7)
-	empty_levels = list(9)
+	admin_levels  = list(7)
+	escape_levels = list(8)
+	empty_levels  = list(9)
 	accessible_z_levels = list("1"=1,"2"=3,"3"=1,"4"=1,"5"=1,"6"=1,"9"=30)
 	overmap_size = 35
 	overmap_event_areas = 34

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -31,6 +31,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/list/player_levels = list()  // Z-levels a character can typically reach
 	var/list/sealed_levels = list()  // Z-levels that don't allow random transit at edge
 	var/list/empty_levels = null     // Empty Z-levels that may be used for various things (currently used by bluespace jump)
+	var/list/escape_levels = list()  // Z-levels that when a player is in, are considered to have 'escaped' after evacuations.
 
 	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
 


### PR DESCRIPTION
🆑 Mucker
tweak: The "escaped" round-end total now refers to players who made it off the Torch after evacuation on an escape pod.
rscadd: Added a 'marooned' count to the round-end statistics, referring to players left behind on the Torch after evac, or who are offship after the jump.
/🆑

Non-player facing changes:
Adds the `isEscapeLevel()` proc, which currently is just z-level 8 (where the escape pods end up after launching).

Alternative to #29870 