### PR TITLE
Shift Medical's Cooler and O2 (Cryo) set-up near Autopsy

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -10110,14 +10110,13 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos)
 "xI" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/closet/secure_closet/medical_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)
 "xJ" = (
@@ -17313,6 +17312,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/shieldbay)
+"SS" = (
+/obj/item/device/radio/intercom/department/medbay{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/storage/medical)
 "SU" = (
 /obj/structure/sign/warning/pods/east{
 	dir = 1;
@@ -17582,9 +17587,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "TW" = (
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)
@@ -42193,7 +42197,7 @@ aU
 Xr
 bW
 Lk
-eP
+SS
 eP
 TW
 Lk

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -3520,14 +3520,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
-"age" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "agf" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -3599,6 +3591,10 @@
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -8259,8 +8255,7 @@
 /area/hallway/primary/firstdeck/aft)
 "ayD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
@@ -14641,6 +14636,9 @@
 	name = "Infirmary Maintenance Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/foyer/storeroom)
 "bhb" = (
@@ -15951,10 +15949,22 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/processing)
 "cEb" = (
-/obj/structure/closet/secure_closet/medical_torch,
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 1;
+	icon_state = "freezer";
+	set_temperature = 80;
+	use_power = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
@@ -16508,17 +16518,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "dmb" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 1;
-	icon_state = "freezer";
-	set_temperature = 80;
-	use_power = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/door/window/northleft{
-	autoset_access = 0;
-	name = "Cryogenic Maintenance";
-	req_access = list("ACCESS_MEDICAL_EQUIP")
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/aftstarboard)
@@ -16535,21 +16536,13 @@
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "dnb" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	icon_state = "map"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	autoset_access = 0;
-	name = "Cryogenic Maintenance";
-	req_access = list("ACCESS_MEDICAL_EQUIP")
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "dob" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/table/standard,
@@ -16641,6 +16634,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"dzs" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "dzG" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
@@ -17681,8 +17681,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "fmb" = (
-/obj/structure/closet/secure_closet/medical_torch,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "fnu" = (
@@ -17777,8 +17788,9 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "fxb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -18582,13 +18594,13 @@
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
 "gZb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -19115,6 +19127,9 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 1;
 	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -30634,6 +30649,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/access)
+"wVO" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "wWc" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -30765,6 +30790,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "xuW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "xvt" = (
@@ -52614,8 +52642,8 @@ acH
 adt
 uXe
 uXe
-age
-dmb
+ayD
+uXe
 dDb
 abm
 abs
@@ -52817,7 +52845,7 @@ adw
 sde
 sde
 ayD
-dnb
+sde
 dDb
 abn
 abt
@@ -53018,7 +53046,7 @@ acJ
 adw
 sde
 uXe
-sde
+ayD
 sde
 dDb
 dDb
@@ -53220,7 +53248,7 @@ acK
 adw
 sde
 sde
-uXe
+dmb
 uXe
 cqb
 dDb
@@ -53422,7 +53450,7 @@ xTT
 adv
 sde
 sde
-sde
+ayD
 dEb
 dQb
 dDb
@@ -54432,7 +54460,7 @@ uXe
 adv
 kZb
 alo
-xuW
+dnb
 cEb
 fmb
 rAu
@@ -54635,7 +54663,7 @@ adw
 kZb
 afn
 agn
-xuW
+dzs
 fxb
 dRb
 emb
@@ -54837,7 +54865,7 @@ adw
 kZb
 kYM
 cIb
-cGd
+wVO
 gZb
 uFk
 enb

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15283,6 +15283,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod13/station)
+"bRO" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "bSz" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -16521,7 +16528,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "dmz" = (
 /obj/machinery/firealarm{
@@ -16536,7 +16544,6 @@
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "dnb" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1;
 	icon_state = "map"
@@ -16634,13 +16641,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"dzs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark,
-/area/medical/foyer/storeroom)
 "dzG" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
@@ -23581,6 +23581,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
+"njL" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "njQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30649,16 +30659,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/access)
-"wVO" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1;
-	icon_state = "techfloor_edges"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/foyer/storeroom)
 "wWc" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -53046,7 +53046,7 @@ acJ
 adw
 sde
 uXe
-ayD
+dmb
 sde
 dDb
 dDb
@@ -53248,7 +53248,7 @@ acK
 adw
 sde
 sde
-dmb
+ayD
 uXe
 cqb
 dDb
@@ -54663,7 +54663,7 @@ adw
 kZb
 afn
 agn
-dzs
+bRO
 fxb
 dRb
 emb
@@ -54865,7 +54865,7 @@ adw
 kZb
 kYM
 cIb
-wVO
+njL
 gZb
 uFk
 enb


### PR DESCRIPTION
:cl: SDTheCyanWyan
maptweak: Replace two Medical Technician lockers near Autopsy with Cooler and O2 (Cryo) set-up
maptweak: Move one of the replaced Medical Technician locker to Deck Two Medical Storage
/:cl:

This aims to do two things:
1. Fix the issue where you'd need to use the turf menu to interact with the cooler by removing the windoor altogether and placing the set-up in a more secure place.
2. Remove one of the two extra MT lockers, as two extra ones seem to be too much. 