### PR TITLE
Rag tweaks

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -52,7 +52,7 @@
 				return
 
 			//check for an aggressive grab (or robutts)
-			if(can_place(C, user))
+			if(C.has_danger_grab(user))
 				place_handcuffs(C, user)
 			else
 				to_chat(user, "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>")
@@ -90,7 +90,7 @@
 	if(!do_after(user,30, target))
 		return 0
 
-	if(!can_place(target, user)) // victim may have resisted out of the grab in the meantime
+	if(!target.has_danger_grab(user)) // victim may have resisted out of the grab in the meantime
 		return 0
 
 	var/obj/item/weapon/handcuffs/cuffs = src

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -39,6 +39,19 @@
 /mob/living/carbon/human/isMonkey()
 	return istype(species, /datum/species/monkey)
 
+
+/**
+ * Checks if the target has a grab from the user
+ */
+/mob/proc/has_danger_grab(mob/user)
+	if (user == src || istype(user, /mob/living/silicon/robot) || istype(user, /mob/living/bot))
+		return TRUE
+
+	for (var/obj/item/grab/G in grabbed_by)
+		if (G.force_danger())
+			return TRUE
+
+
 proc/isdeaf(A)
 	if(isliving(A))
 		var/mob/living/M = A


### PR DESCRIPTION
:cl:
admin: Smothering people with a rag and hitting people with an ignited rag now generates attack logs.
tweak: You now require a grab to smother people with a rag.
tweak: Smothering people with a rag now has a timed progress bar - 3 seconds if your CQC skill is trained or above, 6 seconds for everyone else.
/:cl:

Also added a global `has_danger_grab()` proc to mobs that mimics the check handcuffs used.