### PR TITLE
Remove SCGR office camera from security group

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -8506,7 +8506,7 @@
 /obj/machinery/camera/network/command{
 	c_tag = "Sol Government Representative - Office";
 	dir = 4;
-	network = list("Command","Security")
+	network = list("Command")
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)


### PR DESCRIPTION
:cl:
map: The SCGR office camera is no longer a part of the security camera network.
/:cl: