### PR TITLE
Make helmet cams independent of NT-Net

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -36,6 +36,8 @@
 
 	var/affected_by_emp_until = 0
 
+	var/is_helmet_cam = FALSE
+
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
 	if(stat & BROKEN)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -59,6 +59,7 @@
 	if(ispath(camera))
 		camera = new camera(src)
 		camera.set_status(0)
+		camera.is_helmet_cam = TRUE
 
 	if(camera)
 		camera.set_status(!camera.status)

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -35,7 +35,7 @@
 	extended_desc = "This program allows remote access to the camera system. Some camera networks may have additional access requirements."
 	size = 12
 	available_on_ntnet = 1
-	requires_ntnet = 1
+	requires_ntnet = FALSE
 	category = PROG_MONITOR
 
 /datum/nano_module/camera_monitor
@@ -93,11 +93,15 @@
 
 	if(href_list["switch_camera"])
 		var/obj/machinery/camera/C = locate(href_list["switch_camera"]) in cameranet.cameras
+		var/datum/extension/interactive/ntos/os = get_extension(nano_host(), /datum/extension/interactive/ntos)
 		if(!C)
 			return
 		if(!(current_network in C.network))
 			return
 		if(!AreConnectedZLevels(get_z(C), get_z(host)) && !(get_z(C) in GLOB.using_map.admin_levels))
+			to_chat(usr, "Unable to establish a connection.")
+			return
+		if (!os?.get_ntnet_status() && !C.is_helmet_cam)
 			to_chat(usr, "Unable to establish a connection.")
 			return
 


### PR DESCRIPTION
🆑 Mucker
tweak: Helmet cameras can now be accessed independent of NT-Net.
tweak: The Camera Monitoring program can now be accessed without NT-Net, but regular security cameras are inaccessible when NT-Net is down.
/🆑

So the purpose of this change is entirely aimed at allowing shuttle pilots to watch what Exploration is doing while out on missions. By allowing them the ability to view nearby helmet-cameras regardless of their proximity to the Torch, it should hopefully make the pilot role a little less boring and detached.

Regular wall-mounted cameras cannot be viewed without NT-Net, and will display the "Unable to establish connection" dialogue when attempting to access them while NT-Net is down, or when the computer is anywhere but the Torch.