### PR TITLE
Shift Medical's Cooler and O2 (Cryo) set-up near Autopsy

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -10110,14 +10110,13 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos)
 "xI" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/closet/secure_closet/medical_torch,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)
 "xJ" = (
@@ -11041,6 +11040,12 @@
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos)
+"Ar" = (
+/obj/item/device/radio/intercom/department/medbay{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/storage/medical)
 "As" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -17582,9 +17587,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "TW" = (
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)
@@ -42193,7 +42197,7 @@ aU
 Xr
 bW
 Lk
-eP
+Ar
 eP
 TW
 Lk

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -3520,14 +3520,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
-"age" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "agf" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -3599,6 +3591,10 @@
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -8259,8 +8255,7 @@
 /area/hallway/primary/firstdeck/aft)
 "ayD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
@@ -14641,6 +14636,9 @@
 	name = "Infirmary Maintenance Access"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/foyer/storeroom)
 "bhb" = (
@@ -15951,10 +15949,21 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/processing)
 "cEb" = (
-/obj/structure/closet/secure_closet/medical_torch,
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 1;
+	icon_state = "freezer";
+	set_temperature = 80;
+	use_power = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
@@ -16508,19 +16517,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "dmb" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 1;
-	icon_state = "freezer";
-	set_temperature = 80;
-	use_power = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/door/window/northleft{
-	autoset_access = 0;
-	name = "Cryogenic Maintenance";
-	req_access = list("ACCESS_MEDICAL_EQUIP")
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "dmz" = (
 /obj/machinery/firealarm{
@@ -16535,19 +16533,10 @@
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "dnb" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/window/northright{
-	autoset_access = 0;
-	name = "Cryogenic Maintenance";
-	req_access = list("ACCESS_MEDICAL_EQUIP")
-	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "dob" = (
@@ -17681,8 +17670,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "fmb" = (
-/obj/structure/closet/secure_closet/medical_torch,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "fnu" = (
@@ -17777,8 +17776,9 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "fxb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -18582,13 +18582,13 @@
 /turf/simulated/floor/plating,
 /area/medical/exam_room)
 "gZb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -19115,6 +19115,9 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 1;
 	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -24540,6 +24543,13 @@
 /obj/machinery/self_destruct,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
+"oty" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "ouI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -24654,6 +24664,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
+"ozN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "oAp" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -30634,6 +30651,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury/access)
+"wUg" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/foyer/storeroom)
 "wWc" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 4;
@@ -30765,6 +30792,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "xuW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "xvt" = (
@@ -52614,8 +52644,8 @@ acH
 adt
 uXe
 uXe
-age
-dmb
+ayD
+uXe
 dDb
 abm
 abs
@@ -52814,10 +52844,10 @@ mpy
 mpy
 uXe
 adw
-sde
+dmb
 sde
 ayD
-dnb
+sde
 dDb
 abn
 abt
@@ -53018,7 +53048,7 @@ acJ
 adw
 sde
 uXe
-sde
+ayD
 sde
 dDb
 dDb
@@ -53218,9 +53248,9 @@ mpy
 mpy
 acK
 adw
-sde
-sde
 uXe
+uXe
+dnb
 uXe
 cqb
 dDb
@@ -53422,7 +53452,7 @@ xTT
 adv
 sde
 sde
-sde
+ayD
 dEb
 dQb
 dDb
@@ -54432,7 +54462,7 @@ uXe
 adv
 kZb
 alo
-xuW
+ozN
 cEb
 fmb
 rAu
@@ -54635,7 +54665,7 @@ adw
 kZb
 afn
 agn
-xuW
+oty
 fxb
 dRb
 emb
@@ -54837,7 +54867,7 @@ adw
 kZb
 kYM
 cIb
-cGd
+wUg
 gZb
 uFk
 enb

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15990,12 +15990,6 @@
 	use_power = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "cFb" = (
@@ -17681,13 +17675,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
-	dir = 2;
-	health = 1e+007
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "fnu" = (
@@ -21120,6 +21107,14 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/misc_lab)
+"kaS" = (
+/obj/structure/closet/crate/freezer,
+/obj/random/medical,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/medical,
+/obj/random/medical,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/aftstarboard)
 "kbb" = (
 /obj/structure/table/standard,
 /obj/machinery/light_switch{
@@ -27816,6 +27811,14 @@
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/research)
+"scd" = (
+/obj/structure/closet/crate/freezer,
+/obj/random/medical,
+/obj/random/medical,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/medical,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/aftstarboard)
 "scr" = (
 /obj/machinery/door/airlock/medical{
 	name = "Equipment Storage"
@@ -52646,7 +52649,7 @@ adt
 uXe
 uXe
 uXe
-uXe
+kaS
 dDb
 abm
 abs
@@ -52848,7 +52851,7 @@ adw
 sde
 sde
 uXe
-sde
+scd
 dDb
 abn
 abt

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1937,6 +1937,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "adI" = (
@@ -1978,6 +1982,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "adM" = (
@@ -2011,6 +2018,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -2049,6 +2059,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
@@ -2160,6 +2173,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aee" = (
@@ -2241,6 +2257,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aek" = (
@@ -2289,6 +2308,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aen" = (
@@ -2311,6 +2333,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -2338,6 +2363,9 @@
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 23
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aep" = (
@@ -2358,6 +2386,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -2430,6 +2461,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aev" = (
@@ -2459,6 +2493,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
@@ -2544,6 +2581,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aeC" = (
@@ -2564,6 +2604,9 @@
 	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/foyer)
 "aeD" = (
@@ -2590,6 +2633,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -2828,6 +2874,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
@@ -3591,10 +3641,6 @@
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -6140,6 +6186,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "anM" = (
@@ -6519,7 +6566,6 @@
 	id_tag = "medsafe";
 	name = "Medical Safe Room"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8206,9 +8252,6 @@
 	dir = 4;
 	icon_state = "techfloororange_edges"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -8253,12 +8296,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
-"ayD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "ayF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14636,9 +14673,6 @@
 	name = "Infirmary Maintenance Access"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/foyer/storeroom)
 "bhb" = (
@@ -15904,9 +15938,6 @@
 /area/maintenance/firstdeck/centralstarboard)
 "cDb" = (
 /obj/effect/floor_decal/techfloor/orange,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -15953,7 +15984,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/freezer{
-	dir = 1;
+	dir = 4;
 	icon_state = "freezer";
 	set_temperature = 80;
 	use_power = 1
@@ -16125,9 +16156,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
 "cSb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault/bolted{
 	autoset_access = 0;
@@ -16315,10 +16343,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "dcb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
 /obj/machinery/suit_storage_unit/standard_unit{
 	req_access = newlist()
 	},
@@ -16395,15 +16419,9 @@
 /area/rnd/office)
 "dgb" = (
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "dhb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 6;
 	icon_state = "techfloor_edges"
@@ -16416,9 +16434,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "dib" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/weapon/storage/briefcase/inflatable,
@@ -16516,10 +16531,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"dmb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "dmz" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -16532,13 +16543,6 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
-"dnb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/aftstarboard)
 "dob" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/table/standard,
@@ -16963,8 +16967,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -17010,7 +17013,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "eaF" = (
@@ -17193,6 +17195,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "enM" = (
@@ -17334,6 +17337,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "exc" = (
@@ -17453,6 +17457,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "eJy" = (
@@ -17654,6 +17659,7 @@
 	name = "Medical Storeroom"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/foyer/storeroom)
 "fll" = (
@@ -17776,10 +17782,8 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "fxb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "fxe" = (
@@ -18590,6 +18594,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "gZT" = (
@@ -19115,9 +19123,6 @@
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 1;
 	pixel_y = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
@@ -19797,6 +19802,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "ixB" = (
@@ -24547,7 +24553,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "ouI" = (
@@ -24664,13 +24673,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
-"ozN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1;
-	icon_state = "map"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/foyer/storeroom)
 "oAp" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10;
@@ -29077,6 +29079,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "tnb" = (
@@ -29715,6 +29718,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "uGu" = (
@@ -30792,9 +30796,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "xuW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "xvt" = (
@@ -52644,7 +52645,7 @@ acH
 adt
 uXe
 uXe
-ayD
+uXe
 uXe
 dDb
 abm
@@ -52844,9 +52845,9 @@ mpy
 mpy
 uXe
 adw
-dmb
 sde
-ayD
+sde
+uXe
 sde
 dDb
 abn
@@ -53048,7 +53049,7 @@ acJ
 adw
 sde
 uXe
-ayD
+uXe
 sde
 dDb
 dDb
@@ -53250,7 +53251,7 @@ acK
 adw
 uXe
 uXe
-dnb
+uXe
 uXe
 cqb
 dDb
@@ -53452,7 +53453,7 @@ xTT
 adv
 sde
 sde
-ayD
+sde
 dEb
 dQb
 dDb
@@ -54462,7 +54463,7 @@ uXe
 adv
 kZb
 alo
-ozN
+xuW
 cEb
 fmb
 rAu


### PR DESCRIPTION
:cl: SDTheCyanWyan
maptweak: Replace two Medical Technician lockers near Autopsy with Cooler and O2 (Cryo) set-up
maptweak: Move one of the replaced Medical Technician locker to Deck Two Medical Storage
/:cl:

_Trying second time after accidentally deleting the previous branch_

This aims to do two things:

1. Fix the issue where you'd need to use the turf menu to interact with the cooler by removing the windoor altogether and placing the set-up in a more secure place.
2. Remove one of the two extra MT lockers, as two extra ones seem to be too much.