### PR TITLE
Stripping underwear makes logs

### DIFF
--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -105,7 +105,12 @@
 			var/obj/item/located_item = locate(slot_to_strip_text) in src
 			if (isunderwear(located_item))
 				var/obj/item/underwear/UW = located_item
+				visible_message(
+					SPAN_DANGER("\The [user] starts trying to remove \the [src]'s [UW.name]!"),
+					SPAN_WARNING("You start trying to remove \the [src]'s [UW.name]!")
+				)
 				if (UW.DelayedRemoveUnderwear(user, src))
+					admin_attack_log(user, src, "Stripped \an [UW] from \the [holder].", "Was stripped of \an [UW] from \the [holder].", "stripped \an [UW] from \the [holder] of")
 					user.put_in_active_hand(UW)
 				return
 


### PR DESCRIPTION
The fact I even had to PR this is just stupid.

:cl:
tweak: Stripping someone else's underwear now creates a visible message and attack log, consistent with all other strip actions.
/:cl: