### PR TITLE
Pickpocket gloves no longer work on ID slot

### DIFF
--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -81,4 +81,4 @@
 
 /datum/codex_entry/pickpocket_gloves
 	associated_paths = list(/obj/item/clothing/gloves/thick/duty/pickpocket)
-	antag_text = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others or adjust their suit sensors."
+	antag_text = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others pockets, hands, ears, or suit storage, or adjust their suit sensors."

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -110,7 +110,7 @@
 				return
 
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip_text))
-	var/pickpocketable_list = list(slot_l_ear, slot_r_ear, slot_l_hand, slot_r_hand, slot_wear_id, slot_s_store)
+	var/pickpocketable_list = list(slot_l_ear, slot_r_ear, slot_l_hand, slot_r_hand, slot_s_store)
 	var/pickpocketable_object = (text2num(slot_to_strip_text) in pickpocketable_list)
 	if (stripping)
 		if (!istype(target_slot))  // They aren't holding anything valid and there's nothing to remove, why are we even here?


### PR DESCRIPTION
After seeing this in use for several rounds, being able to just take someone's ID without anyone knowing is a bit too powerful.

:cl:
tweak: Pickpocket gloves can no longer be used to silently steal ID/PDA from the ID slot
/:cl: