### PR TITLE
Removes auto-notes from spam kick

### DIFF
--- a/code/modules/admin/spam_prevention.dm
+++ b/code/modules/admin/spam_prevention.dm
@@ -26,7 +26,6 @@ GLOBAL_LIST_EMPTY(ckey_punished_for_spam) // this round; to avoid redundant reco
 		qdel(C)
 		return
 	GLOB.ckey_punished_for_spam[ckey] = TRUE
-	notes_add(ckey, "\[AUTO\] Kicked for possible spam abuse.")
 	qdel(C)
 
 /client/Center()


### PR DESCRIPTION
They get ignored and just clutter the notes log.

:cl:
admin: Spam flood autokicks no longer generate automatic notes.
/:cl: