### PR TITLE
Makes Rescue hardsuit and CMO hardsuit gloves sterile

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -289,6 +289,7 @@
 		)
 
 /obj/item/clothing/shoes/magboots/rig/medical
+	germ_level = 0
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/generated/onmob_feet_unathi.dmi'

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -179,6 +179,7 @@
 	icon_state = "command_med_rig"
 /obj/item/clothing/shoes/magboots/rig/command/medical
 /obj/item/clothing/gloves/rig/command/medical
+	germ_level = 0
 
 
 /obj/item/weapon/rig/command/medical/equipped


### PR DESCRIPTION
:cl:
tweak: The Rescue hardsuit and CMO hardsuit gloves are now sterile.
/:cl:

It feels like medical hardsuit gloves could _probably_ be sterile, and it's kinda funky to retract your rig gloves just to put on regular sterile gloves for surgery, and physicians performing surgery while wearing the rig is not a difficult situation to imagine. IIRC you can even equip a surgical toolbox to the suit storage for the rescue hardsuit.
