### PR TITLE
Add trainee roles to blacklisted_jobs for traitor

### DIFF
--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -21,8 +21,7 @@
 	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/traitor
-	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos)
-	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee)
+	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos, /datum/job/medical_trainee, /datum/job/engineer_trainee)
 
 /datum/antagonist/ert
 	var/sic //Second-In-Command


### PR DESCRIPTION
:cl: lorwp
bugfix: trainees now can't be autotraitored
/:cl:

so they can't get autotraitored, like `protected_jobs` previously allowed