### PR TITLE
Disable Verne & Seedship, halves bearcat and voxship jobs

### DIFF
--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -12,10 +12,10 @@
 	suffixes = list("ascent/ascent-1.dmm")
 	cost = 0.5
 	shuttles_to_initialise = list(
-		/datum/shuttle/autodock/overmap/ascent, 
+		/datum/shuttle/autodock/overmap/ascent,
 		/datum/shuttle/autodock/overmap/ascent/two
 	)
-	spawn_weight = 0.67
+	spawn_weight = 0
 
 // Overmap objects.
 /obj/effect/overmap/visitable/ship/ascent_seedship

--- a/maps/away/bearcat/bearcat_jobs.dm
+++ b/maps/away/bearcat/bearcat_jobs.dm
@@ -1,6 +1,6 @@
 /datum/job/submap/bearcat_captain
 	title = "Independant Captain"
-	total_positions = 1
+	total_positions = 0
 	outfit_type = /decl/hierarchy/outfit/job/bearcat/captain
 	supervisors = "your bottom line"
 	info = "Your ship has suffered a catastrophic amount of damage, leaving it dark and crippled in the depths of \
@@ -10,7 +10,7 @@
 /datum/job/submap/bearcat_crewman
 	title = "Independant Crewman"
 	supervisors = "the Captain"
-	total_positions = 3
+	total_positions = 2
 	outfit_type = /decl/hierarchy/outfit/job/bearcat/crew
 	info = "Your ship has suffered a catastrophic amount of damage, leaving it dark and crippled in the depths of \
 	unexplored space. Work together with the Acting Captain and what's left of the crew, and maybe you'll be able \

--- a/maps/away/verne/verne.dm
+++ b/maps/away/verne/verne.dm
@@ -38,7 +38,7 @@
 	description = "Active CTI research ship"
 	suffixes = list("verne/verne-1.dmm", "verne/verne-2.dmm", "verne/verne-3.dmm")
 	cost = 2
-	spawn_weight = 0.33
+	spawn_weight = 0
 	area_usage_test_exempted_root_areas = list(/area/verne)
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/verne,

--- a/maps/away/voxship/voxship_jobs.dm
+++ b/maps/away/voxship/voxship_jobs.dm
@@ -1,6 +1,6 @@
 /datum/job/submap/voxship_vox
 	title = "Shoal Scavenger"
-	total_positions = 2
+	total_positions = 0
 	outfit_type = /decl/hierarchy/outfit/job/voxship/crew
 	supervisors = "quill, apex and the arkship"
 	info = "Scrap is thin. Not much food is left, but thankfully the sector is quite rich, and it's time to get some more supplies. \


### PR DESCRIPTION
🆑 
tweak: Drops bearcat jobs to two crewmen.
tweak: Drops VoxShip to three Vox.
tweak: Disables seedship from spawning.
tweak: Disables verne from spawning.
/ 🆑 

Changes intended to make bearcat less of a Torch alternative, make Vox less "Merc but you can't attack Torch" and remove the ships that sit dead and empty 9/10 times without making them completely unplayable.

Seedship and Verne can still be spawned by staff - they just have a zero chance of being generated when the world is made.

The jobs that had their slots killed still exist & can be freed up by staff intervention.