### PR TITLE
add bm overlays, convert areas mode to it

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1258,6 +1258,7 @@
 #include "code\modules\admin\buildmode\ladders.dm"
 #include "code\modules\admin\buildmode\light_maker.dm"
 #include "code\modules\admin\buildmode\move_into.dm"
+#include "code\modules\admin\buildmode\overlay.dm"
 #include "code\modules\admin\buildmode\relocate_to.dm"
 #include "code\modules\admin\buildmode\room_builder.dm"
 #include "code\modules\admin\buildmode\throw_at.dm"

--- a/code/modules/admin/buildmode/build_mode.dm
+++ b/code/modules/admin/buildmode/build_mode.dm
@@ -3,6 +3,7 @@
 	var/name
 	var/icon_state
 	var/datum/click_handler/build_mode/host
+	var/datum/buildmode_overlay/overlay
 	var/mob/user
 
 /datum/build_mode/New(var/host)
@@ -11,6 +12,7 @@
 	user = src.host.user
 
 /datum/build_mode/Destroy()
+	QDEL_NULL(overlay)
 	host = null
 	. = ..()
 
@@ -31,6 +33,12 @@
 
 /datum/build_mode/proc/TimerEvent()
 	return
+
+/datum/build_mode/proc/UpdateOverlay(image/I, turf/T)
+	return
+
+/datum/build_mode/proc/CreateOverlay(icon_state)
+	overlay = new(user, src, icon_state)
 
 /datum/build_mode/proc/Log(message)
 	log_admin("BUILD MODE - [name] - [key_name(usr)] - [message]")

--- a/code/modules/admin/buildmode/click_handler.dm
+++ b/code/modules/admin/buildmode/click_handler.dm
@@ -44,6 +44,8 @@
 /datum/click_handler/build_mode/proc/TimerEvent()
 	if (!QDELETED(current_build_mode))
 		current_build_mode.TimerEvent()
+		if (current_build_mode.overlay)
+			current_build_mode.overlay.TimerEvent()
 
 /datum/click_handler/build_mode/Enter()
 	user.client.show_popup_menus = FALSE

--- a/code/modules/admin/buildmode/overlay.dm
+++ b/code/modules/admin/buildmode/overlay.dm
@@ -1,0 +1,55 @@
+/datum/buildmode_overlay
+	var/list/images = list()
+	var/mob/user
+	var/datum/build_mode/buildmode
+	var/shown
+	var/size
+
+/datum/buildmode_overlay/New(mob/user, buildmode, icon_state)
+	src.user = user
+	src.buildmode = buildmode
+	size = user.client.view
+	if (!icon_state)
+		icon_state = ""
+	for (var/x = -size to size step 1)
+		for (var/y = -size to size step 1)
+			var/image/I = new('icons/turf/overlays.dmi', user, icon_state)
+			I.appearance_flags = KEEP_APART|RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM|NO_CLIENT_COLOR|KEEP_APART
+			I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+			I.pixel_x = x * 32
+			I.pixel_y = y * 32
+			images += I
+	. = ..()
+
+/datum/buildmode_overlay/Destroy()
+	Hide()
+	images = null
+	buildmode = null
+	user = null
+	. = ..()
+
+/datum/buildmode_overlay/proc/Show()
+	if (shown || QDELETED(user?.client))
+		return
+	user.client.images += images
+	shown = TRUE
+
+/datum/buildmode_overlay/proc/Hide()
+	if (!shown || QDELETED(user?.client))
+		return
+	user.client.images -= images
+	shown = FALSE
+
+/datum/buildmode_overlay/proc/TimerEvent()
+	if (!shown || QDELETED(buildmode) || QDELETED(user?.client))
+		return
+	var/i = 1
+	for (var/x = -size to size step 1)
+		for (var/y = -size to size step 1)
+			var/image/I = images[i++]
+			var/turf/T = locate(user.x + x, user.y + y, user.z)
+			if (T)
+				I.alpha = 255
+				ImmediateInvokeAsync(buildmode, /datum/build_mode/.proc/UpdateOverlay, I, T)
+			else
+				I.alpha = 0


### PR DESCRIPTION
Pulled this out of radiation mode since I haven't actually finished the radiation mode part:

Build mode has a datum that can be told to exist for a given mode. It creates and holds a set of images mapped to the screen that can be changed by the build mode in an update proc that is populated with images and their corresponding turfs. Once created, the datum persists until build mode is exited.

Swaps areas mode over to this model instead of building and discarding images on a repeating timer, providing a simple example of use.

No player facing changes.