### PR TITLE
Modularize roundend information stuff

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -79,6 +79,9 @@
 /proc/isContactLevel(var/level)
 	return level in GLOB.using_map.contact_levels
 
+/proc/isEscapeLevel(var/level)
+	return level in GLOB.using_map.escape_levels
+
 /proc/circlerange(center=usr,radius=3)
 
 	var/turf/centerturf = get_turf(center)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -376,28 +376,9 @@ Helpers
 	for(var/client/C)
 		if(!C.credits)
 			C.RollCredits()
-	for(var/mob/Player in GLOB.player_list)
-		if(Player.mind && !isnewplayer(Player))
-			if(Player.stat != DEAD)
-				var/turf/playerTurf = get_turf(Player)
-				if(evacuation_controller.round_over() && evacuation_controller.emergency_evacuation)
-					if(isNotAdminLevel(playerTurf.z))
-						to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned on [station_name()] as [Player.real_name]...</b></span>")
-					else
-						to_chat(Player, "<font color='green'><b>You managed to survive the events on [station_name()] as [Player.real_name].</b></font>")
-				else if(isAdminLevel(playerTurf.z))
-					to_chat(Player, "<font color='green'><b>You successfully underwent crew transfer after events on [station_name()] as [Player.real_name].</b></font>")
-				else if(issilicon(Player))
-					to_chat(Player, "<font color='green'><b>You remain operational after the events on [station_name()] as [Player.real_name].</b></font>")
-				else
-					to_chat(Player, "<span class='info'><b>You got through just another workday on [station_name()] as [Player.real_name].</b></span>")
-			else
-				if(isghost(Player))
-					var/mob/observer/ghost/O = Player
-					if(!O.started_as_observer)
-						to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></font>")
-				else
-					to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></font>")
+
+	GLOB.using_map.roundend_player_status()
+
 	to_world("<br>")
 
 	for(var/mob/living/silicon/ai/aiPlayer in SSmobs.mob_list)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -326,27 +326,10 @@ var/global/list/additional_antag_types = list()
 
 	sleep(2)
 
-	var/clients = 0
-	var/surviving_humans = 0
-	var/surviving_total = 0
-	var/ghosts = 0
-	var/escaped_humans = 0
-	var/escaped_total = 0
+	var/list/data = GLOB.using_map.roundend_statistics()
 
-	for(var/mob/M in GLOB.player_list)
-		if(M.client)
-			clients++
-			if(M.stat != DEAD)
-				surviving_total++
-				if(ishuman(M))
-					surviving_humans++
-				var/area/A = get_area(M)
-				if(A && is_type_in_list(A, GLOB.using_map.post_round_safe_areas))
-					escaped_total++
-					if(ishuman(M))
-						escaped_humans++
-			else if(isghost(M))
-				ghosts++
+	var/text = "<br><br>"
+	text += GLOB.using_map.roundend_summary(data)
 
 	var/departmental_goal_summary = SSgoals.get_roundend_summary()
 	for(var/thing in GLOB.clients)
@@ -354,30 +337,10 @@ var/global/list/additional_antag_types = list()
 		if(client.mob && client.mob.mind)
 			client.mob.mind.show_roundend_summary(departmental_goal_summary)
 
-	var/text = "<br><br>"
-	if(surviving_total > 0)
-		text += "There [surviving_total>1 ? "were <b>[surviving_total] survivors</b>" : "was <b>one survivor</b>"]"
-		text += " and <b>[ghosts] ghosts</b>.<br>"
-	else
-		text += "There were <b>no survivors</b> (<b>[ghosts] ghosts</b>)."
-
 	to_world(text)
 
-	if(clients > 0)
-		SSstatistics.set_field("round_end_clients",clients)
-	if(ghosts > 0)
-		SSstatistics.set_field("round_end_ghosts",ghosts)
-	if(surviving_humans > 0)
-		SSstatistics.set_field("survived_human",surviving_humans)
-	if(surviving_total > 0)
-		SSstatistics.set_field("survived_total",surviving_total)
-	if(escaped_humans > 0)
-		SSstatistics.set_field("escaped_human",escaped_humans)
-	if(escaped_total > 0)
-		SSstatistics.set_field("escaped_total",escaped_total)
-
-	send2mainirc("A round of [src.name] has ended - [surviving_total] survivor\s, [ghosts] ghost\s.")
-	SSwebhooks.send(WEBHOOK_ROUNDEND, list("survivors" = surviving_total, "escaped" = escaped_total, "ghosts" = ghosts))
+	send2mainirc("A round of [src.name] has ended - [data["surviving_total"]] survivor\s, [data["ghosts"]] ghost\s.")
+	SSwebhooks.send(WEBHOOK_ROUNDEND, data)
 
 	return 0
 

--- a/code/modules/webhooks/webhook_roundend.dm
+++ b/code/modules/webhooks/webhook_roundend.dm
@@ -7,20 +7,16 @@
 	var/desc = "A round of **[SSticker.mode ? SSticker.mode.name : "Unknown"]** has ended.\n"
 	if(data)
 
-		if(data["survivors"] > 0)
+		if(data["surviving_total"] > 0)
 
 			var/s_was =      "was"
 			var/s_survivor = "survivor"
-			var/s_escaped =  "escaped"
 
-			if(data["survivors"] != 1)
+			if(data["surviving_total"] != 1)
 				s_was = "were"
 				s_survivor = "survivors"
 
-			if(!evacuation_controller.emergency_evacuation)
-				s_escaped = "transferred"
-
-			desc += "There [s_was] **[data["survivors"]] [s_survivor] ([data["escaped"]] [s_escaped])** and **[data["ghosts"]] ghosts.**"
+			desc += "There [s_was] **[data["surviving_total"]] [s_survivor] ([data["escaped"]] escaped)** and **[data["ghosts"]] ghosts.**"
 		else
 			desc += "There were **no survivors** ([data["ghosts"]] ghosts)."
 

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -5,8 +5,9 @@
 	flags = MAP_HAS_BRANCH | MAP_HAS_RANK
 	config_path = "config/torch_config.txt"
 
-	admin_levels = list(7)
-	empty_levels = list(9)
+	admin_levels  = list(7)
+	escape_levels = list(8)
+	empty_levels  = list(9)
 	accessible_z_levels = list("1"=1,"2"=3,"3"=1,"4"=1,"5"=1,"6"=1,"9"=30)
 	overmap_size = 35
 	overmap_event_areas = 34

--- a/maps/torch/torch_procs.dm
+++ b/maps/torch/torch_procs.dm
@@ -29,3 +29,44 @@
 		GLOB.using_map.bolt_saferooms()
 	else
 		priority_announcement.Announce("The maintenance access requirement has been readded on all maintenance airlocks.", "Attention!")
+
+/datum/map/torch/roundend_player_status()
+	for(var/mob/Player in GLOB.player_list)
+		if(Player.mind && !isnewplayer(Player))
+			if(Player.stat != DEAD)
+				var/turf/playerTurf = get_turf(Player)
+				if(evacuation_controller.round_over() && evacuation_controller.emergency_evacuation)
+					if(isStationLevel(playerTurf.z))
+						to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned on [station_name()] as [Player.real_name]...</b></span>")
+					else if (isEscapeLevel(playerTurf.z))
+						to_chat(Player, "<font color='green'><b>You managed to survive the events on [station_name()] as [Player.real_name].</b></font>")
+					else
+						to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned in the sector as [Player.real_name]...</b></span>")
+				else if(issilicon(Player))
+					to_chat(Player, "<font color='green'><b>You remain operational after the events on [station_name()] as [Player.real_name].</b></font>")
+				else if (isNotStationLevel(playerTurf.z))
+					to_chat(Player, "<span class='info'><b>You managed to survive, but were marooned in the sector as [Player.real_name]...</b></span>")
+				else
+					to_chat(Player, "<span class='info'><b>You got through just another workday on [station_name()] as [Player.real_name].</b></span>")
+			else
+				if(isghost(Player))
+					var/mob/observer/ghost/O = Player
+					if(!O.started_as_observer)
+						to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></font>")
+				else
+					to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></font>")
+
+/datum/map/torch/roundend_summary(list/data)
+	var/desc
+	var/survivors = data["surviving_total"]
+	var/escaped_total = data["escaped_total"]
+	var/marooned_total = data["left_behind_total"]
+	var/ghosts = data["ghosts"]
+
+	if(survivors > 0)
+		desc += "There [survivors>1 ? "were <b>[survivors] survivors</b>" : "was <b>one survivor</b>"]"
+		desc += " (<b>[escaped_total>0 ? escaped_total : "none"] escaped, [marooned_total > 0 ? marooned_total : "none"] marooned</b>) and <b>[ghosts] ghosts</b>.<br>"
+	else
+		desc += "There were <b>no survivors</b>, (<b>[data["ghosts"]] ghosts</b>)."
+
+	return desc


### PR DESCRIPTION
🆑 Mucker
tweak: Tweaks round-end messages to include a 'marooned' count, aka people who were left behind.
/🆑

An attempt to make the round-end statistics and information more customizable. All of the round-end information displayed to the player has been separated and put into three procs attached to the map, making it easier for downstreams to edit them to their own scenarios.

This is (sort of) re-do of #29876, done how @Spookerton requested (hopefully).
