### PR TITLE
Fixes gravity failure event so it doesn't give gravity to shuttles

### DIFF
--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -1,5 +1,6 @@
 /datum/event/gravity
 	announceWhen = 5
+	var/list/gravity_status = list()
 
 /datum/event/gravity/setup()
 	endWhen = rand(15, 60)
@@ -10,15 +11,16 @@
 /datum/event/gravity/start()
 	gravity_is_on = 0
 	for(var/area/A in world)
-		if(A.z in affecting_z)
+		if((A.z in affecting_z) && A.has_gravity())
+			gravity_status += A
 			A.gravitychange(gravity_is_on)
 
 /datum/event/gravity/end()
 	if(!gravity_is_on)
 		gravity_is_on = 1
-
-		for(var/area/A in world)
-			if((A.z in affecting_z) && initial(A.has_gravity))
+		for(var/area/A in gravity_status)
+			if((A.z in affecting_z) && !A.has_gravity())
 				A.gravitychange(gravity_is_on)
-
 		command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "[location_name()] Gravity Subsystem", zlevels = affecting_z)
+	gravity_status.Cut()
+


### PR DESCRIPTION
:cl:
bugfix: Gravity failure hazards will not give gravity to shuttles anymore.
/:cl:

fixes #29914 by ensuring the event only screws with gravity in areas that already had it enabled. The former check failed to account for shuttles, which start the game with gravity but very often lose it in transit. Thanks to MistakeNot for figuring out how to fix this.