### PR TITLE
supermatter shards are now orderable from supply

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -181,6 +181,14 @@
 	containername = "\improper Supermatter crate (CAUTION)"
 	access = access_ce
 
+/decl/hierarchy/supply_pack/engineering/smsmall
+	name = "Power - Supermatter shard"
+	contains = list(/obj/machinery/power/supermatter/shard)
+	cost = 75
+	containertype = /obj/structure/closet/crate/secure/large/phoron
+	containername = "\improper Supermatter crate (CAUTION)"
+	access = access_ce
+
 /decl/hierarchy/supply_pack/engineering/fueltank
 	name = "Liquid - Fuel tank"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)


### PR DESCRIPTION
:cl: RustingWIthYou
tweak: supermatter shards can now be ordered from supply for a lower price than a full supermatter core
/:cl:

decided to make this for a few reasons. one, so engineers have the option of a cheaper, shittier supermatter replacement in the event of someone yeeting the core and supply having a total of jack shit in the way of money. two, so research can get in on that good good magic rock roleplay as well. these are both things that are unlikely to happen, but given that 90% of the engineering supply packs are never ordered anyway i figure it can't really hurt.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->