### PR TITLE
Updates the Bearcat not to be Weightless

### DIFF
--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -18,7 +18,7 @@
 /obj/effect/overmap/visitable/ship/bearcat
 	name = "light freighter"
 	color = "#00ffff"
-	vessel_mass = 60
+	vessel_mass = 20000
 	max_speed = 1/(10 SECONDS)
 	burn_delay = 10 SECONDS
 


### PR DESCRIPTION
🆑 PurplePineapple
tweak: "Increases the Bearcat's mass from 60 to 20,000."
/🆑 

A very minor bug I came across while working on the Bearcat for another server. This updates the weight to a more realistic value, so the acceleration is limited to about 1gm/h instead of unlimited power.