### PR TITLE
Fix round-end webhook not displaying escaped count

### DIFF
--- a/code/modules/webhooks/webhook_roundend.dm
+++ b/code/modules/webhooks/webhook_roundend.dm
@@ -16,7 +16,7 @@
 				s_was = "were"
 				s_survivor = "survivors"
 
-			desc += "There [s_was] **[data["surviving_total"]] [s_survivor] ([data["escaped"]] escaped)** and **[data["ghosts"]] ghosts.**"
+			desc += "There [s_was] **[data["surviving_total"]] [s_survivor] ([data["escaped_total"]] escaped)** and **[data["ghosts"]] ghosts.**"
 		else
 			desc += "There were **no survivors** ([data["ghosts"]] ghosts)."
 


### PR DESCRIPTION
🆑 Mucker
bugfix: Fix the webhook not displaying the escaped count.
/🆑