### PR TITLE
Add user message to tweak item failures

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -149,7 +149,8 @@
 		if(path)
 			new path(I)
 		else
-			log_debug("Failed to tweak item: Index [i] in [json_encode(metadata)] did not result in a valid path. Valid contents: [json_encode(valid_contents)]")
+			log_debug("Failed to tweak item: Index [i] in [json_encode(metadata)] did not result in a valid path.")
+			to_chat(owner, SPAN_WARNING("Your loadout selection for \the [I] that includes \the [metadata[i]] could not spawn properly. This likely means a saved configuration is no longer available or is invalid. Contact a dev for help. This is likely a bug."))
 
 /*
 * Ragent adjustment


### PR DESCRIPTION
Because no sane person has debug logs open to catch these things like I do when observing.

:cl:
tweak: Loadout items that fail to spawn selected contents properly now display a warning to the user indicating there was a problem. If you see this message that says 'contact a dev', contact a dev.
admin: Item tweak failure debug logs no longer include the massive text dump of all valid entries.
/:cl: