### PR TITLE
fixes nibbling ascent

### DIFF
--- a/code/modules/mob/living/silicon/robot/preset.dm
+++ b/code/modules/mob/living/silicon/robot/preset.dm
@@ -43,6 +43,7 @@
 	req_access = list(access_ascent)
 	silicon_radio = null
 	machine_restriction = FALSE
+	faction = "kharmaani"
 	var/global/ascent_drone_count = 0
 
 /mob/living/silicon/robot/flying/ascent/add_ion_law(law)


### PR DESCRIPTION
🆑 
bugfix: Ascent nymphs will no longer nibble ascent drones.
/ 🆑 

Gave the control mind module the kharmaani faction that the nymphs have, haven't been attacked on my own testing.

Closes #29936