### PR TITLE
Fixes proc chain ordering of virtual mob destroy()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -22,7 +22,6 @@
 	var/does_spin = TRUE // Does the atom spin when thrown (of course it does :P)
 
 /atom/movable/Destroy()
-	. = ..()
 	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
 		crash_with("Was deleted before initalization")
 
@@ -44,6 +43,8 @@
 	if(virtual_mob && !ispath(virtual_mob))
 		qdel(virtual_mob)
 		virtual_mob = null
+
+	. = ..()
 
 /atom/movable/Bump(var/atom/A, yes)
 	if(!QDELETED(throwing))


### PR DESCRIPTION
Fixes the debug log spam that occurs whenever a mob or virtual mob is deleted.