### PR TITLE
Wallets can hold passports

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -40,7 +40,8 @@
 		/obj/item/clothing/accessory/badge,
 		/obj/item/clothing/accessory/medal,
 		/obj/item/clothing/accessory/armor/tag,
-		/obj/item/clothing/ring
+		/obj/item/clothing/ring,
+		/obj/item/weapon/passport
 	)
 	slot_flags = SLOT_ID
 


### PR DESCRIPTION
Wallets are already ethereal storage devices, capable of holding entire bundles of documents, what's a passport to boot?

🆑 
tweak: Wallets can now hold passports.
/ 🆑 
