### PR TITLE
Minerborg magboots

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_miner.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_miner.dm
@@ -37,6 +37,7 @@
 		SKILL_EVA          = SKILL_PROF,
 		SKILL_CONSTRUCTION = SKILL_EXPERT
 	)
+	no_slip = 1
 
 /obj/item/weapon/robot_module/miner/handle_emagged()
 	var/obj/item/weapon/pickaxe/D = locate(/obj/item/weapon/pickaxe/borgdrill) in equipment


### PR DESCRIPTION
:cl:
tweak: The miner cyborg module now has built in magboots
/:cl:

Without this the mining borg is next to useless on asteroids. The engineering module already has mags, implying borgs intended to work in zero-g environments should have mags and the miner borg was an oversight.