### PR TITLE
increases voxship spawn chance

### DIFF
--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -12,7 +12,7 @@
 	cost = 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_ship, /datum/shuttle/autodock/overmap/vox_lander)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
-	spawn_weight = 0.33
+	spawn_weight = 0.67
 
 /obj/effect/overmap/visitable/sector/vox_scav_ship
 	name = "small asteroid cluster"


### PR DESCRIPTION
:cl: RustingWithYou
tweak: doubles voxship spawn chance to pre-scavship levels
/:cl:

vox spawn chance was halved when scavship was added. now that voxbase has been removed, scavship almost never spawns as a consequence, so i've upped its spawn chance back to the levels of other provocateur roles