### PR TITLE
increases caulship spawn chance to be in-line with other provocs

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/ascent_caulship/_ascent_caulship.dm
+++ b/maps/random_ruins/exoplanet_ruins/ascent_caulship/_ascent_caulship.dm
@@ -11,7 +11,7 @@
 	suffixes = list("ascent_caulship/ascent-1.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/ascent)
 	cost = 0.5
-	spawn_weight = 0.33
+	spawn_weight = 0.67
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	area_usage_test_exempted_areas = list(/area/ship/ascent_caulship)
 	ruin_tags = RUIN_ALIEN|RUIN_HABITAT


### PR DESCRIPTION
:cl: RustingWithYou
maptweak: boosts caulship spawn chance
/:cl:

caulship had half the spawn chance of other provoc spawns. boosted to the same levels so it might actually spawn once in a while