### PR TITLE
knife consistency tweaks

### DIFF
--- a/code/game/objects/items/weapons/material/folding.dm
+++ b/code/game/objects/items/weapons/material/folding.dm
@@ -52,6 +52,7 @@
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		w_class = ITEM_SIZE_NORMAL
 		attack_verb = list("slashed", "stabbed")
+		attack_cooldown_modifier = -1
 		..()
 	else
 		force = initial(force)
@@ -60,6 +61,7 @@
 		hitsound = initial(hitsound)
 		w_class = initial(w_class)
 		attack_verb = closed_attack_verbs
+		attack_cooldown_modifier = initial(attack_cooldown_modifier)
 
 /obj/item/weapon/material/knife/folding/on_update_icon()
 	if(open)
@@ -96,7 +98,6 @@
 	max_force = 15
 	force_divisor = 0.25
 	thrown_force_divisor = 0.25
-	attack_cooldown_modifier = -1
 	takes_colour = FALSE
 	worth_multiplier = 8
 

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -108,6 +108,5 @@
 
 /obj/item/weapon/material/knife/utility/lightweight
 	name = "lightweight utility knife"
-	desc = "A lightweight utility knife made out of a titanium alloy."
+	desc = "A lightweight utility knife made out of a steel alloy."
 	icon_state = "titanium"
-	matter = list(MATERIAL_TITANIUM = 12000)

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -15,12 +15,12 @@
 	var/applies_material_colour = 1
 	var/applies_material_name = 1 //if false, does not rename item to 'material item.name'
 	var/furniture_icon  //icon states for non-material colorable overlay, i.e. handles
-	
+
 	var/max_force = 40	 //any damage above this is added to armor penetration value
 	var/force_divisor = 0.5	// multiplier (sic) to material's generic damage value for this specific type of weapon
 	var/thrown_force_divisor = 0.5
 
-	var/attack_cooldown_modifier
+	var/attack_cooldown_modifier = 0
 	var/unbreakable
 	var/drops_debris = 1
 	var/worth_multiplier = 1


### PR DESCRIPTION
:cl:
tweak: Folding knives are no longer slightly worse than fixed-blade knives
tweak: The steel lightweight utility knife no longer pretends to be made of titanium
/:cl:

The primary result of this PR is all loadout-spawned knives (combi-knives included) will have equal damage output.

## Regarding the folding knife cooldown modifier
One of the examples given in the [PR creating the cooldown modifer](https://github.com/Baystation12/Baystation12/pull/21824) was making folding knives comparable to their fixed-blade variants. However, this was only applied for combat folding knives. This tweak makes *all* folding knives comparable to their fixed-blade variants in damage output. For example, the peasant knife becomes equal to the utility knife. Specifically, the -1 modifier counteracts the +1 w_class change when the knife is unfolded.

## Regarding the lightweight utility knife
It is obviously supposed to be made of titanium, but in game it appears as "steel lightweight utility knife" because codewise it is actually made of steel. It's just had its recycling material and description overridden. While I would very much like to, I cannot in good faith make it into a real titanium knife, as that would give it a significant damage boost unbefitting of a loadout-spawned item.

## Fun Fact
Combi-knives deal identical damage regardless of which of the sharp tools you use. Large knife, small knife, wood saw, glass cutter. All the same. It's just a really fancy folding knife... unless you want to kill a window or grille. Then definitely use the glass cutter. That thing does stupid bonus damage against windows.

## Why am I even looking at this code
...this whole thing started as a code dive that spiraled out of control when I wondered if diamond-tipped spears were comparable to plasteel spears. The answer is [yes, they are almost exactly identical](https://docs.google.com/spreadsheets/d/1QVYhJOuGpl4_D6PFUUii1R2T5JmelqypLEC4dK8uPcU/edit#gid=1144106056).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->