### PR TITLE
GC failures are no longer a crash/runtime.

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -190,7 +190,7 @@ SUBSYSTEM_DEF(garbage)
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
 				if(!I.failures)
-					crash_with("GC: -- \ref[D] | [type] was unable to be GC'd --")
+					to_world_log("GC: -- \ref[D] | [type] was unable to be GC'd --")
 				I.failures++
 				fail_counts[level]++
 			if (GC_QUEUE_HARDDELETE)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 2 "/mob text paths" '"/mob'
 exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 118 "to_world uses" '\sto_world\('
-exactly 65 "to_world_log uses" '\sto_world_log\('
+exactly 66 "to_world_log uses" '\sto_world_log\('
 exactly 0 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 0 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 108 "<< uses" '(?<!<)<<(?!<)' -P


### PR DESCRIPTION
There is no reason to track these given that the traces don't tell you anything and the runtime tracker is massively crammed with automatic tickets that nobody is ever going to read.