### PR TITLE
Remove the 'failed to find viable turf' debug message from exo awakening

### DIFF
--- a/code/modules/events/exo_awaken.dm
+++ b/code/modules/events/exo_awaken.dm
@@ -205,7 +205,6 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 			break
 
 		if (is_edge_turf(T) || T.is_wall() || T.density)
-			log_debug("Exoplanet Awakening: Failed to spawn mob on a viable turf.")
 			return
 
 


### PR DESCRIPTION
🆑 Mucker
rscdel: Removed an unused debug-message in exo awakening.
/🆑

Apparently this debug message flattened our resident dev @SierraKomodo pretty badly when the event occurred on bluespace river. Given the message doesn't really have much use, I'm just removing it.