### PR TITLE
fix areas overlay runtime

### DIFF
--- a/code/modules/admin/buildmode/areas.dm
+++ b/code/modules/admin/buildmode/areas.dm
@@ -33,7 +33,8 @@ Right Click       - List/Create Area
 	overlay.Show()
 
 /datum/build_mode/areas/Unselected()
-	overlay.Hide()
+	if (overlay)
+		overlay.Hide()
 
 /datum/build_mode/areas/UpdateOverlay(image/I, turf/T)
 	if (!overlay?.shown)


### PR DESCRIPTION
areas overlay only tries to hide its overlay if one has been created