### PR TITLE
Fix exo event runtime

### DIFF
--- a/code/modules/events/exo_awaken.dm
+++ b/code/modules/events/exo_awaken.dm
@@ -180,9 +180,9 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	if (no_show && prob(98))
 		return
 
-	spawn_mob(chosen_area)
+	spawn_mob()
 
-/datum/event/exo_awakening/proc/spawn_mob(area/chosen_area, list/category)
+/datum/event/exo_awakening/proc/spawn_mob()
 	if(!living_observers_present(affecting_z))
 		return
 
@@ -195,7 +195,11 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 			if (prob(chosen_mob_list.spawn_near_chance))
 				var/mob/M = pick(players_on_site)
-				T = pick(trange(10, M) - trange(7, M))
+				var/turf/MT = get_turf(M)
+				if(MT)
+					T = pick(trange(10, MT) - trange(7, MT))
+				else
+					T = pick(area_turfs)
 			else
 				T = pick(area_turfs)
 


### PR DESCRIPTION
Closes #29973

I'm not entirely certain why this happened, but my guess is it occurs when a player is in a stasis bag, mech, or something that causes them to not technically be located on a turf while they're inside whatever it is.