### PR TITLE
The rogue drone swarm no longer claims laser fire was detected.

### DIFF
--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -20,14 +20,7 @@
 			D.disabled = rand(15, 60)
 
 /datum/event/rogue_drone/announce()
-	var/msg
-	if(prob(33))
-		msg = "Attention: unidentified patrol drones detected within proximity to the [location_name()]"
-	else if(prob(50))
-		msg = "Unidentified Unmanned Drones approaching the [location_name()]. All hands take notice."
-	else
-		msg = "Class II Laser Fire detected nearby the [location_name()]."
-	command_announcement.Announce(msg, "[location_name()] Sensor Array", zlevels = affecting_z)
+	command_announcement.Announce("Attention: unidentified patrol drones detected within proximity to the [location_name()]", "[location_name()] Sensor Array", zlevels = affecting_z)
 
 /datum/event/rogue_drone/end()
 	var/num_recovered = 0


### PR DESCRIPTION
🆑 
tweak: Rogue drone swarms will no longer occasionally announce as Class II laser fire.
/🆑

The rogue drone swarm had three potential announcement messages. Two that were functionally identical - there's a rogue drone swarm in space. 
Then there was a third potential message announcing class 2 laser fire. The drones that spawn have no laser weapons, nor do random lasers shoot at or near the hull.

I've removed the essentially duplicate drone swarm message and the lying laser fire message. If there's going to be a message about laser fire, there should _actually be laser fire_.