### PR TITLE
Makes lightbulb overlay above lighting

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -254,6 +254,9 @@
 	if(istype(lightbulb, /obj/item/weapon/light/))
 		var/image/I = image(icon, src, _state)
 		I.color = lightbulb.b_colour
+		if (on)
+			I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+			I.layer = ABOVE_LIGHTING_LAYER
 		overlays += I
 
 	if(on)


### PR DESCRIPTION
Ported from Nebula - https://github.com/NebulaSS13/Nebula/pull/1046

:cl: eckff (Ported by SierraKomodo)
tweak: Lightbulb sprites are now drawn above the lighting overlay to make them more 'bright light vibrant' looking
/:cl:

Before:
![dreamseeker_sQdGLjvvDx](https://user-images.githubusercontent.com/11140088/103836475-0b237680-503e-11eb-89ca-8b3049939fae.png)

After:
![dreamseeker_YcueSwkjsw](https://user-images.githubusercontent.com/11140088/103836456-fcd55a80-503d-11eb-8503-29e87437dd40.png)
