### PR TITLE
Newmerc and Admin Shuttle Fixes

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -51,7 +51,7 @@
 /obj/effect/shuttle_landmark/merc/start
 	landmark_tag = "nav_merc_start"
 	name = "Hidden Base"
-	docking_controller = "merc_base"
+	docking_controller = "merc_shuttle_base"
 
 /obj/effect/shuttle_landmark/merc/nav1
 	landmark_tag = "nav_merc_1"
@@ -66,9 +66,8 @@
 	landmark_tag = "nav_merc_4"
 
 /obj/effect/shuttle_landmark/merc/dock
-	name = "Docking Port"
+	name = "4th Deck, Fore Airlock"
 	landmark_tag = "nav_merc_dock"
-	docking_controller = "eva_airlock"
 
 /obj/effect/shuttle_landmark/transit/merc
 	name = "In transit"

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -638,7 +638,7 @@
 "gK" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	id_tag = "merc_base_hatch"
+	id_tag = "merc_shuttle_base_inner"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1176,9 +1176,14 @@
 /area/map_template/merc_spawn)
 "mn" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "merc_base_pump"
+	id_tag = "merc_shuttle_base_pump"
 	},
 /obj/structure/handrail,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "merc_shuttle_base_sensor";
+	pixel_y = 25
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_spawn)
 "mo" = (
@@ -1272,6 +1277,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/shuttle_landmark/merc/start,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "nu" = (
@@ -1345,8 +1351,6 @@
 	icon_state = "map"
 	},
 /obj/machinery/door/airlock/external{
-	density = 1;
-	dir = 2;
 	frequency = 1380;
 	id_tag = "merc_shuttle_outer";
 	name = "Ship External Access"
@@ -1368,7 +1372,7 @@
 "oC" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	id_tag = "merc_base_hatch"
+	id_tag = "merc_shuttle_base_outer"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1439,7 +1443,6 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/obj/effect/shuttle_landmark/merc/start,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "pc" = (
@@ -1512,9 +1515,9 @@
 	pixel_y = -25;
 	req_access = list("ACCESS_SYNDICATE");
 	tag_airpump = "merc_shuttle_pump";
-	tag_exterior_door = "merc_shuttle_exterior";
+	tag_exterior_door = "merc_shuttle_outer";
 	tag_exterior_sensor = "merc_shuttle_exterior_sensor";
-	tag_interior_door = "merc_shuttle_interior";
+	tag_interior_door = "merc_shuttle_inner";
 	tag_interior_sensor = "merc_shuttle_sensor"
 	},
 /obj/structure/handrail{
@@ -2038,7 +2041,7 @@
 "xd" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
-	id_tag = "merc_base_pump"
+	id_tag = "merc_shuttle_base_pump"
 	},
 /obj/structure/handrail{
 	dir = 1;
@@ -3045,6 +3048,21 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
+"TK" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "merc_shuttle_base_pump"
+	},
+/obj/structure/handrail,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	id_tag = "merc_shuttle_base";
+	pixel_y = 19;
+	tag_airpump = "merc_shuttle_base_pump";
+	tag_exterior_door = "merc_shuttle_base_outer";
+	tag_interior_door = "merc_shuttle_base_inner";
+	tag_interior_sensor = "merc_shuttle_base_sensor"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/merc_spawn)
 "TL" = (
 /obj/structure/table/rack{
 	pixel_x = -1
@@ -3173,11 +3191,6 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "Ya" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "merc_base";
-	pixel_y = 19
-	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
@@ -6919,7 +6932,7 @@ aa
 aa
 aa
 mo
-mn
+TK
 Eh
 xd
 mo

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2884,13 +2884,12 @@
 "ka" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
-	id_tag = "eva_pump"
+	id_tag = "eva_airlock_pump"
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
-	id_tag = "eva_sensor";
-	pixel_x = 0;
+	id_tag = "eva_airlock_sensor";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3078,8 +3077,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "kP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
+	id_tag = "eva_airlock_pump"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -3409,8 +3407,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
+	id_tag = "eva_airlock_pump"
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
@@ -4748,7 +4745,7 @@
 "qJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
-	id_tag = "eva_pump"
+	id_tag = "eva_airlock_pump"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -4757,7 +4754,7 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "closed";
-	id_tag = "eva_outer";
+	id_tag = "eva_airlock_outer";
 	locked = 1;
 	name = "EVA External Access"
 	},
@@ -7397,6 +7394,10 @@
 "yp" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
+"yr" = (
+/obj/effect/shuttle_landmark/merc/dock,
+/turf/space,
+/area/space)
 "yu" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
@@ -7903,23 +7904,20 @@
 /area/maintenance/fourthdeck/foreport)
 "Am" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 2;
-	id_tag = "eva_pump"
+	id_tag = "eva_airlock_pump"
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
 	icon_state = "techfloor_edges"
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1380;
 	id_tag = "eva_airlock";
-	name = "Fore Dock";
-	pixel_y = 21;
-	req_access = list("ACCESS_EVA");
-	tag_airpump = "eva_pump";
-	tag_chamber_sensor = "eva_sensor";
-	tag_exterior_door = "eva_outer";
-	tag_interior_door = "eva_inner"
+	pixel_y = 20;
+	tag_airpump = "eva_airlock_pump";
+	tag_chamber_sensor = "eva_airlock_sensor";
+	tag_exterior_door = "eva_airlock_outer";
+	tag_interior_door = "eva_airlock_inner"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
@@ -10268,7 +10266,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
-	id_tag = "eva_pump"
+	id_tag = "eva_airlock_pump"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -11035,7 +11033,7 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "closed";
-	id_tag = "eva_inner";
+	id_tag = "eva_airlock_inner";
 	locked = 1;
 	name = "EVA Internal Access"
 	},
@@ -12798,7 +12796,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "QB" = (
-/obj/effect/shuttle_landmark/merc/dock,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "eva_airlock";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -22;
+	req_access = list("ACCESS_MAINT")
+	},
 /turf/space,
 /area/space)
 "QC" = (
@@ -14189,7 +14195,6 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/effect/shuttle_landmark/skrellscoutshuttle/altdock,
-/obj/effect/shuttle_landmark/admin/out,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "TY" = (
@@ -15113,6 +15118,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
+"WB" = (
+/obj/effect/shuttle_landmark/admin/out,
+/turf/space,
+/area/space)
 "WC" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5;
@@ -23333,7 +23342,7 @@ aa
 aa
 aa
 aa
-aa
+yr
 aa
 aa
 aa
@@ -23536,7 +23545,7 @@ aa
 aa
 aa
 aa
-QB
+aa
 aa
 aa
 aa
@@ -24744,7 +24753,7 @@ aa
 aa
 aa
 aa
-aa
+QB
 zj
 zj
 qQ
@@ -40883,7 +40892,7 @@ aa
 aa
 aa
 aa
-aa
+WB
 TX
 UT
 QM

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -18,6 +18,7 @@
 		"ITV Vulcan" = list("nav_hangar_gantry_torch_two"),
 		"ITV Spiritus" = list("nav_hangar_gantry_torch_three"),
 		"SRV Venerable Catfish" = list("nav_verne_5"), //docking location for verne shuttle
+		"Cyclopes" = list("nav_merc_dock")
 	)
 
 	initial_generic_waypoints = list(
@@ -134,4 +135,3 @@
 	desc = "Trace radiation emanating from this sector is consistent with the aftermath of a bluespace jump."
 	icon_state = "event"
 	known = TRUE
-


### PR DESCRIPTION
🆑 
bugfix: The admin shuttle can dock again.
bugfix: The new merc airlock doors work properly.
bugfix: The new merc shuttle can dock again.
/ 🆑 

Merc docking isn't true docking, but until I figure out why some navpoint stuff isn't working, which won't be for a few weeks at best, it's an acceptable alternative for the shuttle to just mate with the hull and have the doors line up.

I don't really know when the admin shuttle broke, but someone must've moved the navpoint at one point. Moving it a single tile lets it dock again.