### PR TITLE
removes ascent control minds not being able to state laws on worldnet

### DIFF
--- a/code/modules/mob/living/silicon/robot/preset.dm
+++ b/code/modules/mob/living/silicon/robot/preset.dm
@@ -71,6 +71,23 @@
 	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
 	components["armour"] =         new/datum/robot_component/armour/light(src)
 
+/mob/living/silicon/robot/flying/ascent/law_channels()
+	var/list/channels = new()
+	channels += additional_law_channels
+	channels += LANGUAGE_MANTID_BROADCAST
+	return channels
+
+/mob/living/silicon/robot/flying/ascent/statelaws(datum/ai_laws/laws)
+	var/prefix = ""
+	if (lawchannel == LANGUAGE_MANTID_BROADCAST)
+		prefix = "[get_language_prefix()]\["
+
+	if (prefix)
+		dostatelaws(lawchannel, prefix, laws)
+	else
+		..()
+
+
 // Since they don't have binary, camera or radio to soak
 // damage, they get some hefty buffs to cell and actuator.
 /datum/robot_component/actuator/ascent


### PR DESCRIPTION
Fixes #29986 

Due to lack of a maintainer to clarify if this is a thing or if law stating should be deleted from ascent drones entirely, I'm taking the easier route.

:cl:
bugfix: Ascent drones can now state laws.
/:cl: