### PR TITLE
Add db.conf to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ lib/*.so
 # python
 *.pyc
 __pycache__
+db.conf


### PR DESCRIPTION
`db.conf` is the suggested filename for mysql migration configuration in `sql\README.md` - Obviously you don't want to ever commit this file.