### PR TITLE
Fix spawners putting mobs in dense objects, fix copy/paste bug

### DIFF
--- a/code/modules/admin/buildmode/_datums/mob_spawner.dm
+++ b/code/modules/admin/buildmode/_datums/mob_spawner.dm
@@ -15,7 +15,7 @@
 /datum/mob_spawner/proc/copy()
 	var/list/contents = list()
 
-	contents["mobs"] = mobs
+	contents["mobs"] = mobs.Copy()
 	contents["interval"] = interval
 	contents["variation"] = variation
 	contents["message"] = messages
@@ -31,7 +31,8 @@
 	if(contents.len == 0)
 		return
 
-	mobs = contents["mobs"]
+	var/list/mob_list = contents["mobs"]
+	mobs = mob_list.Copy()
 	interval = contents["interval"]
 	variation = contents["variation"]
 	messages = contents["message"]
@@ -53,7 +54,10 @@
 		var/mob/living/M
 		for (var/i = 1; i <= 10; i++)
 			if (radius == -1)
-				T = pick_area_turf(area)
+				T = pick_area_turf(area, list(/proc/not_turf_contains_dense_objects))
+
+				if (!T) //no open spaces to spawn on
+					T = pick_area_turf(area)
 			else
 				var/list/turfs = trange(radius, center)
 				T = pick(turfs)

--- a/code/modules/admin/buildmode/mob_spawning.dm
+++ b/code/modules/admin/buildmode/mob_spawning.dm
@@ -272,10 +272,6 @@ GLOBAL_LIST_INIT(mob_spawners, list())
 
 	if (pa["ctrl"])
 		if (pa["left"])
-			if (!spawner)
-				to_chat(user, SPAN_WARNING("There is no spawner in this area to copy from!"))
-				return
-
 			copied_spawner = spawner.copy()
 			to_chat(user, "Spawner from area [current_area] copied.")
 


### PR DESCRIPTION
🆑 Mucker
bugfix: Fix mob spawner copying sometimes not copying the mob list.
bugfix: Fix spawners putting mobs in walls or on occupied turfs.
/🆑

Closes #29990

Makes copy-pasting more reliable for the spawner as I noticed there were cases where mob lists weren't being copied. This was because I didn't actually _copy_ the mob lists, and was only referencing back to the original.