### PR TITLE
Items no longer attack on help intent

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -69,6 +69,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		return 0
 	if(M == user && user.a_intent != I_HURT)
 		return 0
+	if (user.a_intent == I_HELP)
+		return FALSE
 
 	/////////////////////////
 
@@ -101,4 +103,3 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(MUTATION_HULK in user.mutations)
 		power *= 2
 	return target.hit_with_weapon(src, user, power, hit_zone)
-

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -378,7 +378,7 @@ var/list/global/slot_flags_enumeration = list(
 		if(!H.slot_is_accessible(slot, src, _user))
 			return 0
 
-	
+
 	if (!force && istype(src, /obj/item/clothing))
 		var/obj/item/clothing/SC = src
 		var/bulky = SC.get_bulky_coverage() //disallow bulky things from covering one another
@@ -549,6 +549,8 @@ var/list/global/slot_flags_enumeration = list(
 	return loc
 
 /obj/item/proc/eyestab(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if (user.a_intent == I_HELP)
+		return FALSE
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -15,6 +15,9 @@
 	return src
 
 /obj/item/weapon/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
+	if (user.a_intent == I_HELP)
+		return FALSE
+
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -111,6 +111,8 @@
 	if(isliving(target))
 		var/mob/living/M = target
 		if(on_fire)
+			if (user.a_intent == I_HELP)
+				return FALSE
 			user.visible_message(
 				SPAN_DANGER("\The [user] hits \the [target] with \the [src]!"),
 				SPAN_DANGER("You hit \the [target] with \the [src]!")

--- a/html/changelogs/sierrakomodo-help-intent-no-hit.yml
+++ b/html/changelogs/sierrakomodo-help-intent-no-hit.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Clicking people with melee weapons or random objects while on help intent will no longer attack or cause harm."


### PR DESCRIPTION
``` yml
changes:
  - tweak: "Clicking people with melee weapons or random objects while on help intent will no longer attack or cause harm."
```