### PR TITLE
Remove all sections requirement from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,6 @@ assignees: ''
 	Anything inside tags like these is a comment and will not be displayed in the final issue.
 	Be careful not to write inside them!
 
-	Every field other than 'specific information for locating' is required.
 	If you do not fill out the 'specific information' field, please delete the header.
 	/!\ Omitting or not answering a required field will result in your issue being closed. /!\
 	Repeated violation of this rule, or joke or spam issues, will result in punishment.


### PR DESCRIPTION
Because I was the only one still enforcing this anyway and I've just had all my permissions stripped, I don't really see the point.