### PR TITLE
Fixes airlock/door placements in away sites

### DIFF
--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1467,25 +1467,18 @@
 "eH" = (
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "constructionsite_airlock";
-	pixel_x = 20;
-	pixel_y = 0;
+	pixel_x = 23;
+	pixel_y = -10;
 	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/constructionsite/hallway/fore)
 "eI" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
 /obj/machinery/access_button/airlock_interior{
 	master_tag = "constructionsite_airlock";
-	pixel_x = -20;
-	pixel_y = 0;
+	pixel_x = -25;
+	pixel_y = -10;
 	req_access = newlist()
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/constructionsite/teleporter)
@@ -1520,42 +1513,36 @@
 /obj/machinery/door/airlock/glass/science{
 	name = "Research"
 	},
-/obj/machinery/door/blast/shutters,
+/obj/machinery/door/blast/shutters{
+	dir = 8
+	},
 /turf/simulated/floor/airless,
 /area/constructionsite/storage)
 "eQ" = (
-/obj/machinery/door/airlock/glass/science{
-	name = "Research"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/door/blast/shutters,
 /turf/simulated/floor/airless,
 /area/constructionsite/hallway/fore)
 "eR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "door_locked";
-	id_tag = "constructionsite_outer";
+	id_tag = "constructionsite_inner";
 	locked = 1
 	},
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
 "eS" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
-	id_tag = "constructionsite_vent"
-	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 9;
+	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
-/area/constructionsite/teleporter)
+/turf/simulated/floor/tiled/dark/airless,
+/area/constructionsite/hallway/fore)
 "eU" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "constructionsite_inner";
-	locked = 1
-	},
+/obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
 "eV" = (
@@ -1584,34 +1571,24 @@
 /obj/machinery/door/airlock/glass/science{
 	name = "Research"
 	},
-/obj/machinery/door/blast/shutters/open,
+/obj/machinery/door/blast/shutters/open{
+	dir = 8
+	},
 /turf/simulated/floor/airless,
 /area/constructionsite/hallway/fore)
 "fa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 5;
-	icon_state = "intact"
-	},
 /obj/machinery/light/small,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
-	id_tag = "constructionsite_airlock";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_access = newlist();
-	tag_airpump = "constructionsite_vent";
-	tag_chamber_sensor = "constructionsite_sensor";
-	tag_exterior_door = "constructionsite_outer";
-	tag_interior_door = "constructionsite_inner"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10;
 	icon_state = "warning"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 5;
+	icon_state = "intact"
+	},
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
 "fb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/blue,
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "constructionsite_sensor";
@@ -1622,6 +1599,7 @@
 	dir = 6;
 	icon_state = "warning"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/blue,
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
 "fc" = (
@@ -1722,6 +1700,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/constructionsite/teleporter)
@@ -2654,7 +2635,8 @@
 /turf/simulated/floor/reinforced/airmix,
 /area/constructionsite/atmospherics)
 "iJ" = (
-/obj/machinery/door/airlock/glass/medical{
+/obj/machinery/door/airlock/multi_tile/glass/medical{
+	dir = 4;
 	name = "Medbay"
 	},
 /turf/simulated/floor/airless,
@@ -3635,15 +3617,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/constructionsite/teleporter)
 "ob" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
-	id_tag = "constructionsite_vent"
+/obj/machinery/camera/motion{
+	c_tag = "Construction Site Teleporter Airlock"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/obj/machinery/camera/motion{
-	c_tag = "Construction Site Teleporter Airlock"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+	id_tag = "constructionsite_vent"
 	},
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
@@ -3661,6 +3643,32 @@
 "DP" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
+/turf/simulated/floor/airless,
+/area/constructionsite/hallway/aft)
+"HP" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "constructionsite_airlock";
+	pixel_y = 19;
+	req_access = newlist();
+	tag_airpump = "constructionsite_vent";
+	tag_chamber_sensor = "constructionsite_sensor";
+	tag_exterior_door = "constructionsite_outer";
+	tag_interior_door = "constructionsite_inner"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+	id_tag = "constructionsite_vent"
+	},
+/turf/simulated/floor,
+/area/constructionsite/teleporter)
+"Jz" = (
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	dir = 4;
+	name = "Atmospherics"
+	},
 /turf/simulated/floor/airless,
 /area/constructionsite/hallway/aft)
 "Lk" = (
@@ -22298,7 +22306,7 @@ dY
 dY
 dY
 dY
-eP
+dY
 eP
 dY
 dY
@@ -22362,10 +22370,10 @@ hn
 gO
 gO
 iE
-iJ
-iJ
+gQ
 iJ
 iE
+gO
 gO
 gO
 jg
@@ -22500,7 +22508,7 @@ bo
 bo
 bo
 dY
-eh
+dY
 eh
 dY
 bo
@@ -22702,7 +22710,7 @@ bo
 bu
 ev
 dY
-eh
+dY
 es
 dY
 bo
@@ -22903,8 +22911,8 @@ dz
 dz
 dz
 dz
+dz
 eG
-eQ
 eZ
 eG
 dA
@@ -23510,8 +23518,8 @@ ea
 cN
 cw
 eH
-cw
-cN
+eQ
+eS
 cw
 cw
 dR
@@ -23712,7 +23720,7 @@ dz
 dz
 dz
 eb
-eR
+eU
 eR
 eb
 dA
@@ -23914,7 +23922,7 @@ bo
 bo
 bo
 eb
-eS
+HP
 fa
 eb
 bo
@@ -24382,10 +24390,10 @@ hr
 gO
 gO
 iF
-ij
-ij
-ij
+gQ
+Jz
 iF
+gO
 gO
 gO
 aR
@@ -24586,7 +24594,7 @@ hr
 hr
 iK
 iN
-iN
+hr
 hr
 hr
 hP

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -5510,7 +5510,6 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nu" = (
-/obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5734,7 +5733,6 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nI" = (
-/obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5814,11 +5812,6 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nS" = (
-/turf/simulated/floor/tiled,
-/area/errant_pisces/aft_hallway)
-"nT" = (
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nU" = (
@@ -7023,6 +7016,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/head_m)
+"Ph" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile{
+	dir = 4;
+	name = "Airlock"
+	},
+/turf/simulated/floor/tiled,
+/area/errant_pisces/aft_hallway)
 "Ti" = (
 /obj/machinery/computer/modular{
 	dir = 4
@@ -25725,7 +25726,7 @@ jz
 jz
 jz
 nu
-nT
+Ph
 mz
 mz
 aa
@@ -33401,7 +33402,7 @@ hF
 hF
 hF
 nI
-nT
+Ph
 oi
 oi
 oi

--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -1716,29 +1716,22 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_ward)
 "eB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_ward)
 "eC" = (
-/obj/machinery/door/airlock/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/light,
+/obj/machinery/smartfridge/chemistry/virology,
 /turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_ward)
+/area/lar_maria/vir_aux)
 "eD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
 "eE" = (
@@ -1856,10 +1849,12 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_ward)
 "eT" = (
-/obj/machinery/door/airlock/virology,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1870,10 +1865,16 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/door/airlock/virology{
+	frequency = 1039;
+	id_tag = "ZHPvirology_access_airlock_outer"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_ward)
 "eU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -1887,6 +1888,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
 "eV" = (
@@ -1899,10 +1903,12 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
 "eX" = (
-/obj/machinery/smartfridge/chemistry/virology,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_aux)
+/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/biohazard{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/lar_maria/vir_hallway)
 "eY" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/freezer,
@@ -2028,12 +2034,20 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_ward)
 "fp" = (
-/obj/structure/sign/warning/biohazard{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/lar_maria/vir_hallway)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/lar_maria/vir_aux)
 "fq" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -2146,23 +2160,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
-"fB" = (
-/obj/machinery/door/airlock/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_aux)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2176,6 +2173,8 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_aux)
 "fD" = (
@@ -2573,10 +2572,11 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
 "gb" = (
-/obj/machinery/door/airlock/virology,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_aux)
+/obj/structure/sign/warning/biohazard{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/lar_maria/vir_hallway)
 "gc" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2714,18 +2714,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
-"gw" = (
-/obj/machinery/door/airlock/virology{
-	frequency = 1039;
-	id_tag = "ZHPvirology_access_airlock_inner"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "VirAccessBD"
-	},
-/turf/simulated/floor/tiled,
-/area/lar_maria/vir_access)
 "gx" = (
 /mob/living/simple_animal/hostile/lar_maria/guard/ranged,
 /turf/simulated/floor/tiled,
@@ -2862,10 +2850,6 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
 "gP" = (
-/obj/machinery/door/airlock/virology{
-	frequency = 1039;
-	id_tag = "ZHPvirology_access_airlock_inner"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2876,6 +2860,10 @@
 	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "VirAccessBD"
+	},
+/obj/machinery/door/airlock/virology{
+	frequency = 1039;
+	id_tag = "ZHPvirology_access_airlock_outer"
 	},
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_access)
@@ -27130,7 +27118,7 @@ do
 dJ
 dY
 dY
-eC
+dY
 eT
 dY
 cO
@@ -27536,10 +27524,10 @@ dL
 el
 dL
 eV
-fp
+eX
 fA
-dL
-fp
+gb
+el
 dL
 gO
 gz
@@ -27739,10 +27727,10 @@ dr
 dr
 dr
 dr
-fB
-gb
+fC
 dr
-gw
+dr
+gz
 gP
 gz
 hj
@@ -27941,8 +27929,8 @@ fG
 eE
 fG
 dr
-fC
-fG
+fp
+dr
 dr
 gx
 gQ
@@ -28141,10 +28129,10 @@ dM
 du
 fG
 fG
-eX
+eC
 dr
-fB
-gb
+fC
+dr
 dr
 gy
 gR

--- a/maps/away/lar_maria/lar_maria-2.dmm
+++ b/maps/away/lar_maria/lar_maria-2.dmm
@@ -2754,7 +2754,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled,
 /area/lar_maria/mess_hall)
 "hD" = (
@@ -2910,7 +2909,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/lar_maria/mess_hall)
 "hZ" = (

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -63,6 +63,14 @@
 /area/djstation)
 "ax" = (
 /obj/random/junk,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "lp_north_airlock";
+	pixel_x = 24;
+	tag_airpump = "lp_north_pump";
+	tag_chamber_sensor = "lp_north_sensor";
+	tag_exterior_door = "lp_north_outer";
+	tag_interior_door = "lp_north_inner"
+	},
 /turf/simulated/floor/airless,
 /area/djstation)
 "ay" = (
@@ -146,9 +154,8 @@
 /turf/simulated/floor/tiled/airless,
 /area/djstation)
 "aS" = (
-/obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled/airless,
-/area/djstation)
+/turf/unsimulated/mask,
+/area/mine/explored)
 "aT" = (
 /obj/random/loot,
 /turf/simulated/floor/tiled/airless,
@@ -256,27 +263,22 @@
 /turf/simulated/floor/airless,
 /area/djstation)
 "lb" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = "lp_north_airlock";
-	pixel_x = 24;
-	tag_airpump = "lp_north_pump";
-	tag_chamber_sensor = "lp_north_sensor";
-	tag_exterior_door = "lp_north_outer";
-	tag_interior_door = "lp_north_inner"
-	},
-/turf/simulated/floor/airless,
+/turf/unsimulated/mask,
 /area/djstation)
 "mb" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
 	id_tag = "lp_north_pump"
 	},
-/turf/simulated/floor/airless,
-/area/djstation)
-"nb" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "lp_north_sensor";
 	master_tag = "lp_north_airlock";
 	pixel_x = 24
+	},
+/turf/simulated/floor/airless,
+/area/djstation)
+"nb" = (
+/obj/machinery/door/airlock/multi_tile{
+	name = "Glass Airlock"
 	},
 /turf/simulated/floor/airless,
 /area/djstation)
@@ -288,15 +290,6 @@
 	locked = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/airless,
-/area/djstation)
-"pb" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "lp_north_inner";
-	locked = 1
-	},
 /turf/simulated/floor/airless,
 /area/djstation)
 "qb" = (
@@ -360,6 +353,10 @@
 	id_tag = "lp_east_inner";
 	locked = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/airless,
 /area/djstation)
 "xb" = (
@@ -369,6 +366,10 @@
 	id_tag = "lp_east_sensor";
 	pixel_x = 0;
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+	dir = 8;
+	id_tag = "lp_east_pump"
 	},
 /turf/simulated/floor/airless,
 /area/djstation)
@@ -399,27 +400,7 @@
 	dir = 6;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/airless,
-/area/djstation)
-"Bb" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "lp_east_inner";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/airless,
-/area/djstation)
-"Cb" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
-	dir = 8;
-	id_tag = "lp_east_pump"
-	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/tiled/airless,
 /area/djstation)
 "Db" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -24019,8 +24000,8 @@ ar
 aL
 aP
 aM
-aS
-aS
+aM
+aP
 aH
 aP
 aL
@@ -24208,11 +24189,11 @@ af
 af
 af
 ak
-af
-kb
-lb
-nb
-pb
+aS
+aj
+aj
+aj
+aj
 ar
 ar
 ar
@@ -24409,18 +24390,18 @@ af
 af
 af
 af
-af
-af
-aj
-aj
-aj
+aS
+aS
+lb
+lb
+lb
 aj
 aA
 aC
 aE
 ar
 al
-aM
+nb
 aQ
 at
 as
@@ -24431,8 +24412,8 @@ aj
 aj
 aj
 aj
-ar
 Ab
+Db
 Db
 Db
 Eb
@@ -24622,7 +24603,7 @@ at
 aF
 at
 ar
-aM
+at
 ar
 ar
 at
@@ -24634,7 +24615,7 @@ ab
 ab
 aj
 wb
-Bb
+aj
 aj
 aj
 aj
@@ -24836,8 +24817,8 @@ ab
 ab
 aj
 xb
-Cb
 aj
+lb
 ab
 ab
 ab
@@ -25038,8 +25019,8 @@ ab
 ab
 aj
 yb
-at
 aj
+lb
 ab
 ab
 ab
@@ -25240,8 +25221,8 @@ ab
 ab
 aj
 zb
-zb
 aj
+lb
 ab
 ab
 ab
@@ -25443,7 +25424,7 @@ ab
 vb
 af
 af
-af
+aS
 ab
 ab
 ab

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -1217,9 +1217,6 @@
 /area/outpost/abandoned)
 "dZ" = (
 /obj/effect/decal/cleanable/liquid_fuel,
-/obj/structure/sign/directions/medical{
-	dir = 8
-	},
 /turf/simulated/wall/titanium,
 /area/outpost/abandoned)
 "ea" = (
@@ -1351,17 +1348,10 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "ex" = (
-/obj/machinery/door/airlock/medical,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/airless,
-/area/outpost/abandoned)
-"ey" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9;
-	icon_state = "corner_white"
+/obj/structure/sign/directions/medical{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/wall/titanium,
 /area/outpost/abandoned)
 "ez" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1417,6 +1407,7 @@
 	dir = 1;
 	icon_state = "warningcee"
 	},
+/obj/effect/floor_decal/industrial/warning/cee,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "eI" = (
@@ -1593,19 +1584,6 @@
 "fe" = (
 /turf/simulated/floor/tiled/airless,
 /area/mine/explored)
-"ff" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4;
-	icon_state = "warning_dust"
-	},
-/turf/simulated/floor/asteroid,
-/area/mine/explored)
-"fg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/plating,
-/area/outpost/abandoned)
 "fh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13090,7 +13068,7 @@ af
 cG
 cG
 cG
-dD
+af
 eQ
 af
 af
@@ -13291,8 +13269,8 @@ aa
 aa
 aa
 aa
+av
 af
-ex
 eR
 af
 aa
@@ -13493,8 +13471,8 @@ aa
 aa
 aa
 aa
+av
 af
-ey
 eS
 af
 af
@@ -13695,8 +13673,8 @@ aa
 aa
 aa
 aa
+av
 af
-dH
 eT
 fr
 fI
@@ -13898,7 +13876,7 @@ aa
 af
 af
 dZ
-dH
+ex
 eU
 fs
 fJ
@@ -19151,7 +19129,7 @@ af
 af
 ek
 eF
-ff
+ej
 ek
 ab
 ab
@@ -19353,7 +19331,7 @@ aa
 af
 af
 eG
-eG
+af
 cy
 aa
 aa
@@ -19555,8 +19533,8 @@ aa
 af
 af
 eH
-fg
-af
+cG
+av
 aa
 aa
 aa
@@ -19757,7 +19735,7 @@ af
 af
 af
 eI
-eI
+cG
 cG
 af
 af


### PR DESCRIPTION
:cl: SDTheCyanWyan
maptweak: Replaced away site two-door mapping with double doors and double airlocks with singles.
/:cl:

Some rooms in Derelict Station, Errant Pisces, Lar Maria, Mining Asteroid and Mining Signal, usually had entrances using two single  doors instead of multi-tiled doors, causing misalignment upon generation. 
Airlocks with two internal and external doors have been trimmed down to one each.