### PR TITLE
Replaces Bridge Officer with Bridge Watchman

### DIFF
--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -137,8 +137,8 @@
 	detail_color = COLOR_COMMAND_BLUE
 	extra_details = list("onegoldstripe")
 
-/obj/item/weapon/card/id/torch/crew/bridgeofficer
-	job_access_type = /datum/job/bridgeofficer
+/obj/item/weapon/card/id/torch/crew/bridgewatchman
+	job_access_type = /datum/job/bridgewatchman
 	detail_color = COLOR_COMMAND_BLUE
 
 /obj/item/weapon/card/id/torch/crew/pathfinder

--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -28,8 +28,8 @@
 	icon_state = "qm_cypherkey"
 	channels = list("Supply" = 1, "Command" = 1, "Exploration" = 1, "Hailing" = 1)
 
-/obj/item/device/encryptionkey/bridgeofficer
-	name = "bridge officer's encryption key"
+/obj/item/device/encryptionkey/bridgewatchman
+	name = "bridge watchman's encryption key"
 	icon_state = "com_cypherkey"
 	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Supply" = 1, "Service" = 1, "Science" = 1, "Hailing" = 1)
 

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -95,15 +95,15 @@
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 
-/obj/item/device/radio/headset/bridgeofficer
-	name = "bridge officer's headset"
+/obj/item/device/radio/headset/bridgewatchman
+	name = "bridge watchman's headset"
 	desc = "A headset with access to the command, engineering and exploration channels."
 	icon_state = "com_headset"
 	item_state = "headset"
-	ks1type = /obj/item/device/encryptionkey/bridgeofficer
+	ks1type = /obj/item/device/encryptionkey/bridgewatchman
 
-/obj/item/device/radio/headset/bridgeofficer/alt
-	name = "bridge officer's bowman headset"
+/obj/item/device/radio/headset/bridgewatchman/alt
+	name = "bridge watchman's bowman headset"
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 	max_keys = 4

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -385,26 +385,24 @@
 /datum/job/sea/get_description_blurb()
 	return "You are the Senior Enlisted Advisor. You are the highest enlisted person on the ship. You are directly subordinate to the CO. You advise them on enlisted concerns and provide expertise and advice to officers. You are responsible for ensuring discipline and good conduct among enlisted, as well as notifying officers of any issues and \"advising\" them on mistakes they make. You also handle various duties on behalf of the CO and XO. You are an experienced enlisted person, very likely equal only in experience to the CO and XO. You know the regulations better than anyone."
 
-/datum/job/bridgeofficer
-	title = "Bridge Officer"
+/datum/job/bridgewatchman
+	title = "Bridge Watchman"
 	department = "Support"
 	department_flag = SPT
 	total_positions = 3
 	spawn_positions = 3
-	supervisors = "the Commanding Officer and heads of staff"
+	supervisors = "the CO, XO and heads of staff"
 	selection_color = "#2f2f7f"
 	minimal_player_age = 0
 	economic_power = 8
 	minimum_character_age = list(SPECIES_HUMAN = 22)
 	ideal_character_age = 24
-	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
+	outfit_type = /decl/hierarchy/outfit/job/torch/crew/command/bridgewatchman
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
-		/datum/mil_branch/fleet = /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/ec/o1,
-		/datum/mil_rank/fleet/o1
+		/datum/mil_rank/ec/e7,
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_PILOT       = SKILL_ADEPT)
@@ -432,4 +430,4 @@
 							 /datum/computer_file/program/deck_management)
 
 /datum/job/bridgeofficer/get_description_blurb()
-	return "You are a Bridge Officer. You are a very junior officer. You do not give orders of your own. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take the Torch's helm and pilot the Aquila if needed. You monitor bridge computer programs and communications and report relevant information to command."
+	return "You are a Bridge Watchman. You are Senior Enlisted personnel aboard the Torch. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take the Torch's helm and pilot the Aquila if needed. You monitor bridge computer programs and communications and report relevant information to command."

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -120,15 +120,10 @@
 	id_types = list(/obj/item/weapon/card/id/torch/crew/sea)
 	pda_type = /obj/item/modular_computer/pda/heads
 
-/decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
-	name = OUTFIT_JOB_NAME("Bridge Officer")
-	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
+/decl/hierarchy/outfit/job/torch/crew/command/bridgewatchman
+	name = OUTFIT_JOB_NAME("Bridge Watchman")
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/command
 	shoes = /obj/item/clothing/shoes/dutyboots
-	id_types = list(/obj/item/weapon/card/id/torch/crew/bridgeofficer)
+	id_types = list(/obj/item/weapon/card/id/torch/crew/bridgewatchman)
 	pda_type = /obj/item/modular_computer/pda/heads
-	l_ear = /obj/item/device/radio/headset/bridgeofficer
-
-/decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet
-	name = OUTFIT_JOB_NAME("Bridge Officer - Fleet")
-	uniform = /obj/item/clothing/under/solgov/utility/fleet/command
-	shoes = /obj/item/clothing/shoes/dutyboots
+	l_ear = /obj/item/device/radio/headset/bridgewatchman

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -21,7 +21,7 @@
 
 	allowed_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos,
 						/datum/job/liaison, /datum/job/bodyguard, /datum/job/representative, /datum/job/sea,
-						/datum/job/bridgeofficer, /datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
+						/datum/job/bridgewatchman, /datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
 						/datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee,
 						/datum/job/officer, /datum/job/warden, /datum/job/detective,
 						/datum/job/senior_doctor, /datum/job/doctor, /datum/job/junior_doctor, /datum/job/chemist, /datum/job/medical_trainee,

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -108,7 +108,7 @@
 	)
 
 /obj/structure/closet/secure_closet/bridgeofficer
-	name = "bridge officer's locker"
+	name = "bridge watchman's locker"
 	req_access = list(access_bridge, access_keycard_auth)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/command/bo
 
@@ -123,8 +123,8 @@
 		/obj/item/weapon/material/clipboard,
 		/obj/item/weapon/folder/blue,
 		/obj/item/modular_computer/tablet/lease/preset/command,
-		/obj/item/device/radio/headset/bridgeofficer,
-		/obj/item/device/radio/headset/bridgeofficer/alt,
+		/obj/item/device/radio/headset/bridgewatchman,
+		/obj/item/device/radio/headset/bridgewatchman/alt,
 		/obj/item/weapon/storage/belt/general,
 		/obj/item/weapon/material/knife/folding/swiss/officer,
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),


### PR DESCRIPTION
:cl:
rscdel: Removes Bridge Officer
rscadd: Adds Bridge Watchman, an E7 enlisted Command Support position to replace Bridge Officer
/:cl:

Notes: 
* In the current state of this PR, Bridge Watchman characters will find that the uniform vendor gives officer clothing (and a couple CXPL items). This will be resolved in a later PR, as Command characters using a uniform vendor may only access officer items as it is currently set up. Edit: To clarify, this affects the SEA role as well, and is a separate issue in its' entirety which will be resolved separately.
* A wiki update will be required in the unlikely circumstance this PR is approved.
* This is a role designed to replace Bridge Officer. It is exclusively Expeditionary Corps, currently open to E7 Chief Explorers. This is, of course, open to discussion. The roles and responsibilities of this role have not changed (torch helmsman, sensors lookout, small vessel operator if required, general command assistant, etc), nor has its' access.

There has been some discussion about this PR already in #ideas on the discord, and points were made to support both sides. Although I don't expect this PR to proceed past the drawing board, I would encourage a conversation around this to happen in the #pr-feedback channel, as feedback would be great on how to proceed forward with not only this PR, but on alternatives to this PR as well. Please feel free to reach out to me if you have anything else.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->