### PR TITLE
Nanomed content shuffling

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -12,7 +12,7 @@
 	uncreated_component_parts = null
 	stat_immune = 0
 	var/mob/living/carbon/human/occupant = null
-	var/list/base_chemicals = list("Inaprovaline" = /datum/reagent/inaprovaline, "Soporific" = /datum/reagent/soporific, "Paracetamol" = /datum/reagent/paracetamol, "Dylovene" = /datum/reagent/dylovene, "Dexalin" = /datum/reagent/dexalin)
+	var/list/base_chemicals = list("Inaprovaline" = /datum/reagent/inaprovaline, "Paracetamol" = /datum/reagent/paracetamol, "Dylovene" = /datum/reagent/dylovene, "Dexalin" = /datum/reagent/dexalin)
 	var/list/available_chemicals = list()
 	var/list/upgrade_chemicals = list("Kelotane" = /datum/reagent/kelotane)
 	var/list/upgrade2_chemicals = list("Hyronalin" = /datum/reagent/hyronalin)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -921,15 +921,29 @@
 	base_type = /obj/machinery/vending/medical
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
 	req_access = list(access_medical_equip)
-	products = list(/obj/item/weapon/reagent_containers/glass/bottle/antitoxin = 4,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline = 4,
-					/obj/item/weapon/reagent_containers/glass/bottle/stoxin = 4,/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,
-					/obj/item/weapon/reagent_containers/syringe/antiviral = 4,/obj/item/weapon/reagent_containers/syringe = 12,
-					/obj/item/device/scanner/health = 5,/obj/item/weapon/reagent_containers/glass/beaker = 4, /obj/item/weapon/reagent_containers/dropper = 2,
-					/obj/item/stack/medical/advanced/bruise_pack = 3, /obj/item/stack/medical/advanced/ointment = 3, /obj/item/stack/medical/splint = 2,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 4)
-	contraband = list(/obj/item/clothing/mask/chewable/candy/lolli/meds = 8,
-					/obj/item/weapon/reagent_containers/pill/tox = 3,/obj/item/weapon/reagent_containers/pill/stox = 4,/obj/item/weapon/reagent_containers/pill/antitox = 6,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/combatpain = 2)
+	products = list(
+		/obj/item/weapon/reagent_containers/glass/bottle/antitoxin = 4,
+		/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline = 4,
+		/obj/item/weapon/reagent_containers/glass/bottle/stoxin = 4,
+		/obj/item/weapon/reagent_containers/syringe/antiviral = 4,
+		/obj/item/weapon/reagent_containers/pill/antitox = 6,
+		/obj/item/weapon/reagent_containers/syringe = 12,
+		/obj/item/device/scanner/health = 5,
+		/obj/item/weapon/reagent_containers/glass/beaker = 4,
+		/obj/item/weapon/reagent_containers/dropper = 2,
+		/obj/item/stack/medical/advanced/bruise_pack = 3,
+		/obj/item/stack/medical/advanced/ointment = 3,
+		/obj/item/stack/medical/splint = 2,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 4
+	)
+
+	contraband = list(
+		/obj/item/clothing/mask/chewable/candy/lolli/meds = 8,
+		/obj/item/weapon/reagent_containers/pill/tox = 3,
+		/obj/item/weapon/reagent_containers/pill/stox = 4,
+		/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/combatpain = 2
+	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
 


### PR DESCRIPTION
🆑 
tweak: Nanomed+'s now lock generic toxin behind the contraband wire.
tweak: Nanomed+'s no longer lock dylovene pills behind the contraband wire.
tweak: Sleepers no longer have soporific.
/🆑 