### PR TITLE
you can't table tables

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -67,6 +67,8 @@
 /obj/structure/table/MouseDrop_T(mob/target, mob/user)
 	if (isrobot(user))
 		return
+	if (!ismob(target))
+		return
 	if (target.loc != loc)
 		step(target, get_dir(target, loc))
 	..()


### PR DESCRIPTION
adds a mob filter back to table drag-drop so that you can't drop tables onto each other by accident.