### PR TITLE
Mining beacons emit usable light

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -179,10 +179,10 @@
 
 /obj/item/stack/flag/green
 	light_color = COLOR_LIME
-	
+
 /obj/item/stack/flag/blue
 	light_color = COLOR_BLUE
-	
+
 /obj/item/stack/flag/teal
 	light_color = COLOR_TEAL
 
@@ -239,7 +239,7 @@
 		addon.layer = ABOVE_LIGHTING_LAYER
 		addon.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 		overlays += addon
-		set_light(0.2, 0.1, 1) // Very dim so the rest of the thingie is barely visible - if the turf is completely dark, you can't see anything on it, no matter what
+		set_light(0.5, 0.5, 3) 
 	else
 		pixel_x = rand(-randpixel, randpixel)
 		pixel_y = rand(-randpixel, randpixel)


### PR DESCRIPTION
🆑 
tweak: Mining beacons emit a more useful amount of light.
/🆑 

![newbeac](https://user-images.githubusercontent.com/68120725/104796457-6531e380-5784-11eb-8b92-004a64a2539d.PNG)

Because what good is a beacon you _can't see_?