### PR TITLE
material weapon force_divisor is actually a multiplier

### DIFF
--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -4,8 +4,8 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "ashtray"
 	max_force = 10
-	force_divisor = 0.1
-	thrown_force_divisor = 0.1
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.1
 	randpixel = 5
 	var/max_butts = 10
 

--- a/code/game/objects/items/weapons/material/bell.dm
+++ b/code/game/objects/items/weapons/material/bell.dm
@@ -6,8 +6,8 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "bell"
 	max_force = 5
-	force_divisor = 0.8
-	thrown_force_divisor = 0.3
+	force_multiplier = 0.8
+	thrown_force_multiplier = 0.3
 	hitsound = 'sound/items/oneding.ogg'
 	default_material = MATERIAL_ALUMINIUM
 

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -7,8 +7,8 @@
 	force = 1
 	throwforce = 1
 	max_force = 5
-	force_divisor = 0.1
-	thrown_force_divisor = 0.1
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.1
 	w_class = 1
 	slot_flags = SLOT_EARS
 	var/string_colour

--- a/code/game/objects/items/weapons/material/folding.dm
+++ b/code/game/objects/items/weapons/material/folding.dm
@@ -8,7 +8,7 @@
 	item_state = null
 	force = 0.2 //force of folded obj
 	max_force = 10
-	force_divisor = 0.2
+	force_multiplier = 0.2
 	applies_material_colour = FALSE
 	applies_material_name = FALSE
 	unbreakable = TRUE
@@ -96,8 +96,8 @@
 	name = "the concept of a fighting knife in which the blade can be stowed in its own handle"
 	desc = "This is a master item - berate the admin or mapper who spawned this!"
 	max_force = 15
-	force_divisor = 0.25
-	thrown_force_divisor = 0.25
+	force_multiplier = 0.25
+	thrown_force_multiplier = 0.25
 	takes_colour = FALSE
 	worth_multiplier = 8
 

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -7,12 +7,12 @@
  */
 /obj/item/weapon/material/kitchen/utensil
 	w_class = ITEM_SIZE_TINY
-	thrown_force_divisor = 1
+	thrown_force_multiplier = 1
 	origin_tech = list(TECH_MATERIAL = 1)
 	attack_verb = list("attacked", "stabbed", "poked")
 	max_force = 5
-	force_divisor = 0.1 // 6 when wielded with hardness 60 (steel)
-	thrown_force_divisor = 0.25 // 5 when thrown with weight 20 (steel)
+	force_multiplier = 0.1 // 6 when wielded with hardness 60 (steel)
+	thrown_force_multiplier = 0.25 // 5 when thrown with weight 20 (steel)
 	default_material = MATERIAL_ALUMINIUM
 
 	var/loaded      //Descriptive string for currently loaded food object.
@@ -83,7 +83,7 @@
 	desc = "It's a spoon. You can see your own upside-down face in it."
 	icon_state = "spoon"
 	attack_verb = list("attacked", "poked")
-	force_divisor = 0.1 //2 when wielded with weight 20 (steel)
+	force_multiplier = 0.1 //2 when wielded with weight 20 (steel)
 
 /obj/item/weapon/material/kitchen/utensil/spoon/plastic
 	default_material = MATERIAL_PLASTIC
@@ -115,8 +115,8 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	default_material = MATERIAL_WOOD
 	max_force = 15
-	force_divisor = 0.7 // 10 when wielded with weight 15 (wood)
-	thrown_force_divisor = 1 // as above
+	force_multiplier = 0.7 // 10 when wielded with weight 15 (wood)
+	thrown_force_multiplier = 1 // as above
 
 /obj/item/weapon/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50) && user.unEquip(src))

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -6,7 +6,7 @@
 	icon_state = "knife"
 	item_state = "knife"
 	max_force = 15
-	force_divisor = 0.3
+	force_multiplier = 0.3
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	matter = list(MATERIAL_STEEL = 12000)
 	origin_tech = list(TECH_MATERIAL = 1)
@@ -35,7 +35,7 @@
 	icon_state = "table"
 	default_material = MATERIAL_ALUMINIUM
 	max_force = 7
-	force_divisor = 0.1
+	force_multiplier = 0.1
 	sharp = FALSE
 	attack_verb = list("prodded")
 	applies_material_name = FALSE
@@ -64,21 +64,21 @@
 	desc = "A heavy blade used to process food, especially animal carcasses."
 	icon_state = "butch"
 	armor_penetration = 5
-	force_divisor = 0.18
+	force_multiplier = 0.18
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
 /obj/item/weapon/material/knife/kitchen/cleaver/bronze
 	name = "master chef's cleaver"
 	desc = "A heavy blade used to process food. This one is so fancy, it must be for a truly exceptional chef. There aren't any here, so what it's doing here is anyone's guess."
 	default_material = MATERIAL_BRONZE
-	force_divisor = 1 //25 with material bronze
+	force_multiplier = 1 //25 with material bronze
 
 //fighting knives
 /obj/item/weapon/material/knife/combat
 	name = "combat knife"
 	desc = "A blade with a saw-like pattern on the reverse edge and a heavy handle."
 	icon_state = "tacknife"
-	force_divisor = 0.2
+	force_multiplier = 0.2
 	w_class = ITEM_SIZE_SMALL
 
 //random stuff
@@ -103,7 +103,7 @@
 	desc = "An utility knife with a polymer handle, commonly used through human space."
 	icon_state = "utility"
 	max_force = 10
-	force_divisor = 0.2
+	force_multiplier = 0.2
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/weapon/material/knife/utility/lightweight

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -17,8 +17,8 @@
 	var/furniture_icon  //icon states for non-material colorable overlay, i.e. handles
 
 	var/max_force = 40	 //any damage above this is added to armor penetration value
-	var/force_divisor = 0.5	// multiplier (sic) to material's generic damage value for this specific type of weapon
-	var/thrown_force_divisor = 0.5
+	var/force_multiplier = 0.5	// multiplier to material's generic damage value for this specific type of weapon
+	var/thrown_force_multiplier = 0.5
 
 	var/attack_cooldown_modifier = 0
 	var/unbreakable
@@ -39,7 +39,7 @@
 	if(matter.len)
 		for(var/material_type in matter)
 			if(!isnull(matter[material_type]))
-				matter[material_type] *= force_divisor // May require a new var instead.
+				matter[material_type] *= force_multiplier // May require a new var instead.
 
 /obj/item/weapon/material/get_material()
 	return material
@@ -50,14 +50,14 @@
 		new_force = material.get_edge_damage()
 	else
 		new_force = material.get_blunt_damage()
-	new_force = round(new_force*force_divisor)
+	new_force = round(new_force*force_multiplier)
 	force = min(new_force, max_force)
 
 	if(new_force > max_force)
 		armor_penetration = initial(armor_penetration) + new_force - max_force
 	armor_penetration += 2*max(0, material.brute_armor - 2)
 
-	throwforce = round(material.get_blunt_damage()*thrown_force_divisor)
+	throwforce = round(material.get_blunt_damage()*thrown_force_multiplier)
 	attack_cooldown = material.get_attack_cooldown() + attack_cooldown_modifier
 	//spawn(1)
 //		log_debug("[src] has force [force] and throwforce [throwforce] when made from default material [material.name]")

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -7,8 +7,8 @@
 	icon_state = "harpoon"
 	item_state = "harpoon"
 	max_force = 20
-	force_divisor = 0.3 // 18 with hardness 60 (steel)
-	thrown_force_divisor = 1.8
+	force_multiplier = 0.3 // 18 with hardness 60 (steel)
+	thrown_force_multiplier = 1.8
 	attack_verb = list("jabbed","stabbed","ripped")
 	does_spin = FALSE
 	var/spent
@@ -40,8 +40,8 @@
 	SetName("broken harpoon")
 	desc = "A short spear with just a barb - if it once had a spearhead, it doesn't any more."
 	icon_state = "harpoon_bomb_spent"
-	force_divisor = 0.1
-	thrown_force_divisor = 0.3
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.3
 	sharp = FALSE
 	edge = FALSE
 	worth_multiplier = 6
@@ -52,8 +52,8 @@
 	icon = 'icons/obj/weapons/melee_physical.dmi'
 	icon_state = "hatchet"
 	max_force = 15
-	force_divisor = 0.2 // 12 with hardness 60 (steel)
-	thrown_force_divisor = 0.75 // 15 with weight 20 (steel)
+	force_multiplier = 0.2 // 12 with hardness 60 (steel)
+	thrown_force_multiplier = 0.75 // 15 with weight 20 (steel)
 	w_class = ITEM_SIZE_SMALL
 	sharp = TRUE
 	edge = TRUE
@@ -76,7 +76,7 @@
 	base_parry_chance = 50
 	attack_cooldown_modifier = 1
 	max_force = 20
-	force_divisor = 0.20 //20 with hardness 80 (titanium) or 15 with hardness 60 (steel)
+	force_multiplier = 0.20 //20 with hardness 80 (titanium) or 15 with hardness 60 (steel)
 
 /obj/item/weapon/material/hatchet/machete/unbreakable
 	unbreakable = TRUE
@@ -107,8 +107,8 @@
 	icon_state = "hoe"
 	item_state = "hoe"
 	max_force = 5
-	force_divisor = 0.25 // 5 with weight 20 (steel)
-	thrown_force_divisor = 0.25 // as above
+	force_multiplier = 0.25 // 5 with weight 20 (steel)
+	thrown_force_multiplier = 0.25 // as above
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("slashed", "sliced", "cut", "clawed")
 
@@ -121,8 +121,8 @@
 	name = "scythe"
 	desc = "A sharp and curved blade on a long fibremetal handle, this tool makes it easy to reap what you sow."
 	max_force = 15
-	force_divisor = 0.275 // 16 with hardness 60 (steel)
-	thrown_force_divisor = 0.25 // 5 with weight 20 (steel)
+	force_multiplier = 0.275 // 16 with hardness 60 (steel)
+	thrown_force_multiplier = 0.25 // 5 with weight 20 (steel)
 	sharp = TRUE
 	edge = TRUE
 	throw_speed = 1
@@ -140,8 +140,8 @@
 	icon = 'icons/obj/weapons/other.dmi'
 	icon_state = "cross"
 	max_force = 5
-	force_divisor = 0.1
-	thrown_force_divisor = 0.1
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.1
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "bashed")
 

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -10,8 +10,8 @@
 	edge = TRUE
 	w_class = ITEM_SIZE_SMALL
 	max_force = 8
-	force_divisor = 0.12 // 6 with hardness 30 (glass)
-	thrown_force_divisor = 0.4 // 4 with weight 15 (glass)
+	force_multiplier = 0.12 // 6 with hardness 30 (glass)
+	thrown_force_multiplier = 0.4 // 4 with weight 15 (glass)
 	item_state = "shard-glass"
 	attack_verb = list("stabbed", "slashed", "sliced", "cut")
 	default_material = MATERIAL_GLASS

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -5,8 +5,8 @@
 	icon_state = "stick"
 	item_state = "stickmat"
 	max_force = 10
-	force_divisor = 0.1
-	thrown_force_divisor = 0.1
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.1
 	w_class = ITEM_SIZE_NORMAL
 	default_material = MATERIAL_WOOD
 	attack_verb = list("poked", "jabbed")

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -6,9 +6,9 @@
 	item_state = "claymore"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE
-	force_divisor = 0.5 // 30 when wielded with hardnes 60 (steel)
+	force_multiplier = 0.5 // 30 when wielded with hardnes 60 (steel)
 	armor_penetration = 10
-	thrown_force_divisor = 0.5 // 10 when thrown with weight 20 (steel)
+	thrown_force_multiplier = 0.5 // 10 when thrown with weight 20 (steel)
 	sharp = TRUE
 	edge = TRUE
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -21,8 +21,8 @@
 	max_force = 10
 	edge = FALSE
 	sharp = FALSE
-	force_divisor = 0.2
-	thrown_force_divisor = 0.2
+	force_multiplier = 0.2
+	thrown_force_multiplier = 0.2
 	worth_multiplier = 15
 
 /obj/item/weapon/material/sword/katana
@@ -38,8 +38,8 @@
 	max_force = 10
 	edge = FALSE
 	sharp = FALSE
-	force_divisor = 0.2
-	thrown_force_divisor = 0.2
+	force_multiplier = 0.2
+	thrown_force_multiplier = 0.2
 
 /obj/item/weapon/material/sword/katana/vibro
 	name = "vibrokatana"
@@ -50,4 +50,3 @@
 /obj/item/weapon/material/sword/katana/vibro/equipped(mob/user, slot)
 	if(slot == slot_l_hand || slot == slot_r_hand)
 		playsound(src, 'sound/weapons/katana_out.wav', 50, 1, -5)
-	

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -5,8 +5,8 @@
 	icon_state = "star"
 	randpixel = 12
 	max_force = 10
-	force_divisor = 0.1 // 6 with hardness 60 (steel)
-	thrown_force_divisor = 0.75 // 15 with weight 20 (steel)
+	force_multiplier = 0.1 // 6 with hardness 60 (steel)
+	thrown_force_multiplier = 0.75 // 15 with weight 20 (steel)
 	throw_speed = 10
 	throw_range = 15
 	sharp = TRUE

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -75,7 +75,7 @@
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 
 	max_force = 60	//for wielded
-	force_divisor = 0.6
+	force_multiplier = 0.6
 	unwielded_force_divisor = 0.3
 	sharp = TRUE
 	edge = TRUE
@@ -108,9 +108,9 @@
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
 	max_force = 20	//for wielded
 	applies_material_colour = 0
-	force_divisor = 0.33 // 12/19 with hardness 60 (steel) or 10/16 with hardness 50 (glass)
+	force_multiplier = 0.33 // 12/19 with hardness 60 (steel) or 10/16 with hardness 50 (glass)
 	unwielded_force_divisor = 0.20
-	thrown_force_divisor = 1.5 // 20 when thrown with weight 15 (glass)
+	thrown_force_multiplier = 1.5 // 20 when thrown with weight 15 (glass)
 	throw_speed = 3
 	sharp = TRUE
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -138,7 +138,7 @@
 	hitsound = 'sound/weapons/genhit3.ogg'
 	default_material = MATERIAL_MAPLE
 	max_force = 40	//for wielded
-	force_divisor = 1.1           // 22 when wielded with weight 20 (steel)
+	force_multiplier = 1.1           // 22 when wielded with weight 20 (steel)
 	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = -10

--- a/code/modules/augment/active/armblades.dm
+++ b/code/modules/augment/active/armblades.dm
@@ -7,7 +7,7 @@
 	desc = "A handy utility blade for the discerning augmentee. Warranty void if used for cutting."
 	base_parry_chance = 30
 	unbreakable = 1
-	force_divisor = 0.2
+	force_multiplier = 0.2
 	sharp = TRUE
 	edge = TRUE
 	attack_verb = list("stabbed", "sliced", "cut")
@@ -28,7 +28,7 @@
 	name = "combat claws"
 	desc = "These do not grow back."
 	base_parry_chance = 40
-	force_divisor = 0.3
+	force_multiplier = 0.3
 
 //Alternate look
 /obj/item/organ/internal/augment/active/simple/wolverine

--- a/code/modules/crafting/crafting_butterflyknife.dm
+++ b/code/modules/crafting/crafting_butterflyknife.dm
@@ -3,16 +3,16 @@
 	desc = "A knife blade. Unusable as a weapon without a grip."
 	icon = 'icons/obj/buildingobject.dmi'
 	icon_state = "butterfly2"
-	force_divisor = 0.1
-	thrown_force_divisor = 0.1
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.1
 
 /obj/item/weapon/material/butterflyhandle
 	name = "concealed knife grip"
 	desc = "A plasteel grip with screw fittings for a blade."
 	icon = 'icons/obj/buildingobject.dmi'
 	icon_state = "butterfly1"
-	force_divisor = 0.1
-	thrown_force_divisor = 0.1
+	force_multiplier = 0.1
+	thrown_force_multiplier = 0.1
 
 /decl/crafting_stage/balisong_blade
 	begins_with_object_type = /obj/item/weapon/material/butterflyhandle


### PR DESCRIPTION
renames `force_divisor` to `force_multiplier` in `/obj/item/weapon/material` to reflect what it actually does.

No functional changes, so no changelog.

I've reviewed the diff to make sure I didn't boop anything that shouldn't have been booped.
Then I reviewed it again, and now I see why Santa checks his list twice, as it turns out the pneumatic cannon is not naughty, but nice.