### PR TITLE
Buffs damage threshold for posibrain permadeath

### DIFF
--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -14,7 +14,7 @@
 	throw_range = 5
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2, TECH_DATA = 4)
 	attack_verb = list("attacked", "slapped", "whacked")
-	max_damage = 90
+	max_damage = 200
 	min_bruised_damage = 30
 	min_broken_damage = 60
 	relative_size = 60


### PR DESCRIPTION
:cl: Funguss
tweak: Posibrain permadeath threshold buffed from 90 to 200
/:cl:
Currently IPCs are prone to dying instantly to somewhat unavoidable damage sources. A good gun, any launcher hit that knocks one into a wall, or a particularly powerful or close EMP will instantly convert an IPC player into an observer.  This keeps the same crit threshold, so the outcome of combat will remain the same, but buffs posibrain health up to flesh brain parity and allows the roboticist a chance to do their job and actually fix a damaged IPC.