### PR TITLE
Fixes xenoarch tank size

### DIFF
--- a/code/modules/xenoarcheaology/tools/coolant_tank.dm
+++ b/code/modules/xenoarcheaology/tools/coolant_tank.dm
@@ -3,6 +3,7 @@
 	desc = "A tank of industrial coolant."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "coolanttank"
+	initial_capacity = 10000
 	amount_per_transfer_from_this = 10
 
 /obj/structure/reagent_dispensers/coolanttank/New()


### PR DESCRIPTION
When I made  #28258 months ago I did it wrong and didn't actually increase the size of the tank, so its higher capacity was never actually utilized.

🆑 
bugfix: The xenoarch coolant tank is now the correct size.
/🆑 