### PR TITLE
removes two hour rounds

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -181,6 +181,10 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 	if(isLeap(text2num(time2text(world.realtime, "YYYY"))))
 		.[2] = 29
 
+/proc/get_weekday_index()
+	var/list/weekdays = list("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+	return weekdays.Find(time2text(world.timeofday, "DDD"))
+
 /proc/current_month_and_day()
 	var/time_string = time2text(world.realtime, "MM-DD")
 	var/time_list = splittext(time_string, "-")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -28,8 +28,8 @@ var/list/gamemode_cache = list()
 	var/allow_admin_rev = 1				// allows admin revives
 	var/vote_delay = 6000				// minimum time between voting sessions (deciseconds, 10 minute default)
 	var/vote_period = 600				// length of voting period (deciseconds, default 1 minute)
-	var/vote_autotransfer_initial = 108000 // Length of time before the first autotransfer vote is called
-	var/vote_autotransfer_interval = 18000 // length of time before next sequential autotransfer vote
+	var/vote_autotransfer_initial = 120 MINUTES // Length of time before the first autotransfer vote is called
+	var/vote_autotransfer_interval = 30 MINUTES // length of time before next sequential autotransfer vote
 	var/vote_autogamemode_timeleft = 100 //Length of time before round start when autogamemode vote is called (in seconds, default 100).
 	var/vote_no_default = 0				// vote does not default to nochange/norestart (tbi)
 	var/vote_no_dead = 0				// dead people can't vote (tbi)
@@ -361,10 +361,24 @@ var/list/gamemode_cache = list()
 					config.vote_period = text2num(value)
 
 				if ("vote_autotransfer_initial")
-					config.vote_autotransfer_initial = text2num(value)
+					var/list/values = splittext(value, ";")
+					var/len = length(values)
+					if (len == 7)
+						config.vote_autotransfer_initial = text2num(values[get_weekday_index()]) MINUTES
+					else if (len == 1)
+						config.vote_autotransfer_initial = text2num(value) MINUTES
+					else
+						log_misc("Invalid vote_autotransfer_initial: [value]")
 
 				if ("vote_autotransfer_interval")
-					config.vote_autotransfer_interval = text2num(value)
+					var/list/values = splittext(value, ";")
+					var/len = length(values)
+					if (len == 7)
+						config.vote_autotransfer_interval = text2num(values[get_weekday_index()]) MINUTES
+					else if (len == 1)
+						config.vote_autotransfer_interval = text2num(value) MINUTES
+					else
+						log_misc("Invalid vote_autotransfer_interval: [value]")
 
 				if ("vote_autogamemode_timeleft")
 					config.vote_autogamemode_timeleft = text2num(value)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -127,11 +127,13 @@ VOTE_DELAY 6000
 ## time period (deciseconds) which voting session will last (default 1 minute)
 VOTE_PERIOD 600
 
-## autovote initial delay (deciseconds) before first automatic transfer vote call (default 180 minutes)
-VOTE_AUTOTRANSFER_INITIAL 108000
+## autovote initial delay in minutes before first automatic transfer vote call (default 120)
+# using seven semicolon (;) separated values allows for different weekday-based values
+VOTE_AUTOTRANSFER_INITIAL 120
 
-##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
-VOTE_AUTOTRANSFER_INTERVAL 18000
+##autovote delay in minutes before sequential automatic transfer votes are called (default 30)
+# using seven semicolon (;) separated values allows for different weekday-based values
+VOTE_AUTOTRANSFER_INTERVAL 30
 
 ## Time left (seconds) before round start when automatic gamemote vote is called (default 160).
 VOTE_AUTOGAMEMODE_TIMELEFT 160


### PR DESCRIPTION
round lengths can be configured with a single value or seven, one for each day of the week
also changes round length configuration to minutes instead of deciseconds for sanity's sake
changes the default round length to two hours, from three
adds a disgusting ~macro~ proc to get the index of the day of the week

no player facing changes, no changelog because it's a host thing

requires a config update with merge so that rounds aren't 72000 minutes long
