### PR TITLE
Mercs have lost chameleon clothing on spawn.

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -3003,7 +3003,6 @@
 /area/map_template/merc_spawn)
 "RT" = (
 /obj/structure/closet,
-/obj/item/weapon/storage/backpack/chameleon/sydie_kit,
 /obj/item/weapon/storage/belt/security,
 /obj/item/weapon/storage/belt/holster/security/tactical,
 /obj/item/clothing/accessory/storage/holster/thigh,


### PR DESCRIPTION
🆑 
tweak: Mercenary base no longer has mapped-in chameleon clothes.
/🆑 

You took too long playing dress-up and lost privileges. Buy it from the uplink or go without.