### PR TITLE
Quadruples Cyclopes fuel

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1951,7 +1951,8 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
-	start_pressure = 15000
+	maximum_pressure = 50000;
+	start_pressure = 50000
 	},
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/light{
@@ -2033,7 +2034,8 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
-	start_pressure = 15000
+	maximum_pressure = 50000;
+	start_pressure = 50000
 	},
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,


### PR DESCRIPTION
Because mercs have consistently had trouble with the 35,000 kPa and instructions note, I've given them 150,000kPa. If you run out now, it's even moreso your fault.

The pipes didn't explode in testing, which is good.

🆑 
tweak: Quadruples the merc shuttle's starting fuel.
/🆑 