### PR TITLE
Adjusts landing spot generation

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -294,16 +294,16 @@
 //Tries to generate num landmarks, but avoids repeats.
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing(num = 1)
 	var/places = list()
-	var/attempts = 10*num
+	var/attempts = 30*num
 	var/new_type = landmark_type
 	while(num)
 		attempts--
-		var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])
+		var/turf/T = locate(rand(20, maxx - 30), rand(20, maxy - 30),map_z[map_z.len])
 		if(!T || (T in places)) // Two landmarks on one turf is forbidden as the landmark code doesn't work with it.
 			continue
 		if(attempts >= 0) // While we have the patience, try to find better spawn points. If out of patience, put them down wherever, so long as there are no repeats.
 			var/valid = 1
-			var/list/block_to_check = block(locate(T.x - 10, T.y - 10, T.z), locate(T.x + 10, T.y + 10, T.z))
+			var/list/block_to_check = block(locate(T.x - 15, T.y - 15, T.z), locate(T.x + 15, T.y + 15, T.z))
 			for(var/turf/check in block_to_check)
 				if(!istype(get_area(check), /area/exoplanet) || check.turf_flags & TURF_FLAG_NORUINS)
 					valid = 0

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -110,7 +110,7 @@
 
 //Subtype that calls explosion on init to clear space for shuttles
 /obj/effect/shuttle_landmark/automatic/clearing
-	var/radius = 10
+	var/radius = 15
 
 /obj/effect/shuttle_landmark/automatic/clearing/Initialize()
 	..()


### PR DESCRIPTION
This is being done for a couple of reasons, for one the Charon has been made larger (it still fit, but only by literally 1 tile) since the "safe" area around it was introduced. Second, I intend for something slightly larger to be landable soon and want to ensure that it has space. I have also bumped the distance the landing zones will be from the map boundary to account for the "Fading" edge so we no longer have situations where the Charon/OTHER THING is split in half.

Additionally, I increased the number of attempts the generator will use to find a suitable landing area without altering the terrain, so hopefully, this fallback will actually be used less.