### PR TITLE
removes the nar'sie skybox and summoned mobs when nar'sie is removed

### DIFF
--- a/code/game/gamemodes/cult/cultify/de-cultify.dm
+++ b/code/game/gamemodes/cult/cultify/de-cultify.dm
@@ -4,3 +4,39 @@
 		ChangeTurf(/turf/unsimulated/wall)
 		return
 	..()
+
+/turf/simulated/wall/cult/attackby(obj/item/I, mob/user)
+	if (istype(I, /obj/item/weapon/nullrod))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] touches \the [src] with \the [I], and it shifts."),
+			SPAN_NOTICE("You touch \the [src] with \the [I], and it shifts.")
+		)
+		decultify_wall()
+		return
+	..()
+
+/turf/simulated/floor/cult/attackby(obj/item/I, mob/user)
+	if (istype(I, /obj/item/weapon/nullrod))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] touches \the [src] with \the [I], and it shifts."),
+			SPAN_NOTICE("You touch \the [src] with \the [I], and it shifts.")
+		)
+		decultify_floor()
+		return
+	..()
+
+/turf/proc/decultify_wall()
+	var/turf/simulated/wall/cult/wall = src
+	if (!istype(wall))
+		return
+	if (wall.reinf_material)
+		ChangeTurf(/turf/simulated/wall/r_wall/prepainted)
+	else
+		ChangeTurf(/turf/simulated/wall/prepainted)
+
+/turf/proc/decultify_floor()
+	var/turf/simulated/floor/cult/floor = src
+	if (!istype(floor))
+		return
+	else
+		ChangeTurf(/turf/simulated/floor/plating)

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -31,6 +31,20 @@ In short:
 	KillMobs()
 	SSskybox.change_skybox("narsie", new_use_stars = FALSE, new_use_overmap_details = FALSE)
 
+/datum/universal_state/hell/OnExit()
+	SSskybox.change_skybox("dyable", new_use_stars = TRUE, new_use_overmap_details = TRUE)
+	for (var/mob/living/simple_animal/S in GLOB.living_mob_list_)
+		if (S.faction == "cult")
+			to_chat(S, SPAN_OCCULT("You hear a terrible scream from a place beyond reality, as a life's sacrifice banishes your master. The dark power animating your form wavers, and withdraws, leaving it an unliving shell of meat. Your mind puffs away, like mist under a hot sun."))
+			S.set_stat(DEAD)
+	for (var/turf/simulated/wall/cult/wall)
+		wall.decultify_wall()
+	for (var/turf/simulated/floor/cult/floor)
+		floor.decultify_floor()
+	for (var/obj/effect/gateway/active/cult/G)
+		qdel(G)
+	return
+
 /datum/universal_state/hell/proc/MiscSet()
 	for(var/turf/simulated/floor/T)
 		if(!T.holy && prob(1))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -822,16 +822,18 @@
 		speak_incantation(user, "Uhrast ka'hfa heldsagen ver[pick("'","`")]lot!")
 		to_chat(user, "<span class='warning'>In the last moment of your humble life, you feel an immense pain as fabric of reality mends... with your blood.</span>")
 		for(var/mob/M in GLOB.living_mob_list_)
-			if(iscultist(M))
-				to_chat(M, "You see a vision of \the [user] keeling over dead, his blood glowing blue as it escapes \his body and dissipates into thin air; you hear an otherwordly scream and feel that a great disaster has just been averted.")
+			if (!iscultist(M))
+				to_chat(M, SPAN_OCCULT("You see a vision of \the [user] keeling over dead, their blood glowing blue as it escapes their body and dissipates into thin air; you hear an otherwordly scream and feel that a great disaster has just been averted."))
 			else
-				to_chat(M, "You see a vision of [name] keeling over dead, his blood glowing blue as it escapes his body and dissipates into thin air; you hear an otherwordly scream and feel very weak for a moment.")
+				to_chat(M, SPAN_OCCULT("You see a vision of [name] keeling over dead, their blood glowing blue as it escapes their body and dissipates into thin air; you hear an otherwordly scream and feel very weak for a moment."))
 		log_and_message_admins("mended reality with the greatest sacrifice", user)
 		user.dust()
 		GLOB.cult.powerless = 1
 		qdel(HECOMES)
 		qdel(src)
-		return
+
+		if (GLOB.universe.type == /datum/universal_state/hell)
+			SetUniversalState(/datum/universal_state)
 
 /obj/effect/rune/tearreality/attackby()
 	if(the_end_comes)


### PR DESCRIPTION
🆑 RustingWithYou
tweak: banishing nar'sie now deletes all simplemobs in the cult faction - constructs, creatures, faithless, etc.
tweak: banishing nar'sie now resets the skybox to its normal state
tweak: banishing nar'sie now properly checks for cultists when doing the global message
tweak: cult walls and floors can now be deconverted through nullrod application. banishing nar'sie will also deconvert those turfs
/🆑

Ran some tests on this on a private server, it seemed strange that sealing the HELL RIFT OF DOOM didn't get rid of the various cult mobs, and that it left the sky as a gaping hellhole of the blood god. Now if you do manage to banish Nar'Sie, you can really feel like you did a good job. Well done, you.