### PR TITLE
Change the 'show job' pref to instead toggle showing overall ready status or not

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -209,9 +209,9 @@ var/list/_client_preferences_by_type
 	key = "SHOW_CKEY_DEADCHAT"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
-/datum/client_preference/show_job
-	description = "Show Job in Lobby"
-	key = "SHOW_HIGH_JOB"
+/datum/client_preference/show_ready
+	description = "Show Ready Status in Lobby"
+	key = "SHOW_READY"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
 /datum/client_preference/play_instruments

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -91,11 +91,11 @@
 			for(var/mob/new_player/player in GLOB.player_list)
 				var/highjob
 				if (player.client)
-					var/show_job = player.client.get_preference_value(/datum/client_preference/show_job) == GLOB.PREF_SHOW
-					if (player.client.prefs?.job_high && show_job)
+					var/show_ready = player.client.get_preference_value(/datum/client_preference/show_ready) == GLOB.PREF_SHOW
+					if (player.client.prefs?.job_high)
 						highjob = " as [player.client.prefs.job_high]"
 					if (!player.is_stealthed())
-						stat("[player.key]", (player.ready)?("(Playing[highjob])"):(null))
+						stat("[player.key]", (player.ready && show_ready)?("(Playing[highjob])"):(null))
 				totalPlayers++
 				if(player.ready)totalPlayersReady++
 


### PR DESCRIPTION
🆑 Mucker
tweak: Replaces the 'Show Job in Lobby' preference with 'Show Ready Status in Lobby' to make it easier for players to keep characters anonymous.
/🆑

I found that it was still not that hard to pick out who plays what role, even with my last attempt to help players remain anonymous. This slightly reworks my last preferences addition that previously let people opt out of showing what job they readied for, and now instead lets them toggle whether they show as ready at all.