### PR TITLE
Add scrubbing_gas procs to scrubbers

### DIFF
--- a/code/modules/ascent/ascent_machines.dm
+++ b/code/modules/ascent/ascent_machines.dm
@@ -34,9 +34,9 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	sampled = 0
 	. = ..()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/on/ascent/Initialize()
+/obj/machinery/atmospherics/unary/vent_scrubber/on/ascent/reset_scrubbing()
 	. = ..()
-	scrubbing_gas -= GAS_METHYL_BROMIDE
+	remove_from_scrubbing(GAS_METHYL_BROMIDE)
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on/ascent/shuttle
 	stock_part_presets = list(

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -102,16 +102,33 @@
 	if (!id_tag)
 		id_tag = num2text(sequential_id("obj/machinery"))
 	if(!scrubbing_gas)
-		scrubbing_gas = list()
-		for(var/g in gas_data.gases)
-			if(g != GAS_OXYGEN && g != GAS_NITROGEN)
-				scrubbing_gas += g
+		reset_scrubbing()
 	var/area/A = get_area(src)
 	if(A && !A.air_scrub_names[id_tag])
 		var/new_name = "[A.name] Vent Scrubber #[A.air_scrub_names.len+1]"
 		A.air_scrub_names[id_tag] = new_name
 		SetName(new_name)
 	. = ..()
+
+
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/reset_scrubbing()
+	if (initial(scrubbing_gas))
+		scrubbing_gas = initial(scrubbing_gas)
+	else
+		scrubbing_gas = list()
+		for(var/g in gas_data.gases)
+			if(g != GAS_OXYGEN && g != GAS_NITROGEN)
+				add_to_scrubbing(g)
+
+
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/add_to_scrubbing(new_gas)
+	scrubbing_gas |= new_gas
+
+
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/remove_from_scrubbing(old_gas)
+	if (old_gas in scrubbing_gas)
+		scrubbing_gas -= old_gas
+
 
 /obj/machinery/atmospherics/unary/vent_scrubber/RefreshParts()
 	. = ..()
@@ -236,9 +253,9 @@
 	hibernate = FALSE
 	toggle_input_toggle()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/on/sauna/Initialize()
-	. = ..()
-	scrubbing_gas -= GAS_STEAM
+/obj/machinery/atmospherics/unary/vent_scrubber/on/sauna/reset_scrubbing()
+	..()
+	remove_from_scrubbing(GAS_STEAM)
 
 /decl/public_access/public_variable/scrubbing
 	expected_type = /obj/machinery/atmospherics/unary/vent_scrubber


### PR DESCRIPTION
Adds new procs to scrubbers to make it possible to change what gasses a scrubber is filtering without need to mess with VVing lists, and being able to mass-update them using SDQL.

Intended as a method of countering a specific form of atmos grief.

Adds these three new proc calls:
 - `reset_scrubbing()` will reset the scrubber to it's initial values as if it was just spawned (This is probably what you want to use for grief fixing).
 - `add_to_scrubbing(new_gas)` will add the gas name to the scrubber's filtering list
 - `remove_from_scrubbing(old_gas)` will remove the gas name from the scrubber's filtering list