### PR TITLE
removes previous mob spawner qol in favor of better qol

### DIFF
--- a/code/modules/admin/buildmode/mob_spawning.dm
+++ b/code/modules/admin/buildmode/mob_spawning.dm
@@ -58,6 +58,7 @@ GLOBAL_LIST_INIT(mob_spawners, list())
 	data["interval"] = spawner.interval
 	data["variation"] = spawner.variation
 	data["radius"] = spawner.radius
+	data["atmos_immune"] = spawner.atmos_immune
 	data["spawn_count"] = spawner.spawn_count
 	data["paused"] = spawner.paused
 
@@ -83,7 +84,7 @@ GLOBAL_LIST_INIT(mob_spawners, list())
 
 	if (href_list["pick"])
 		var/type = input("Search for a mob", "Mob") as text
-		var/list/types = typesof(/mob)
+		var/list/types = typesof(/mob/living/simple_animal)
 		var/list/matches = new()
 
 		for (var/M in types)
@@ -93,7 +94,7 @@ GLOBAL_LIST_INIT(mob_spawners, list())
 		if (!matches.len)
 			return TOPIC_HANDLED
 
-		var/mob/living/chosen
+		var/mob/living/simple_animal/chosen
 		if(matches.len==1)
 			chosen = matches[1]
 		else
@@ -155,6 +156,11 @@ GLOBAL_LIST_INIT(mob_spawners, list())
 			return TOPIC_HANDLED
 
 		spawner.radius = radius
+
+		return TOPIC_HANDLED
+
+	if (href_list["atmos_immune"])
+		spawner.atmos_immune = !spawner.atmos_immune
 
 		return TOPIC_HANDLED
 

--- a/nano/templates/mob_mode.tmpl
+++ b/nano/templates/mob_mode.tmpl
@@ -41,6 +41,14 @@
 		</div>
 
 		<div class="itemLabel">
+			Atmos Immunity:
+		</div>
+
+		<div class="itemContent">
+			{{:helper.link(data.atmos_immune ? 'ON' : 'OFF', null, {'atmos_immune' : 1}, null, null)}}
+		</div>
+
+		<div class="itemLabel">
 			Mobs:
 		</div>
 		<div class="item">
@@ -65,9 +73,10 @@
 				"{{:value}}"<br>
 			{{/for}}
 		</div>
-			{{:helper.link(data.paused ? 'START' : 'STOP', null, {'pause' : 1}, null, null)}}
-		<div class="item">
 
+		<div class="item">
+			{{:helper.link(data.paused ? 'START' : 'STOP', null, {'pause' : 1}, null, null)}}
+		</div>
 
 		<div class="item">
 			{{:helper.link('Delete Spawner', 'alert', {'delete' : '1'}, null)}}


### PR DESCRIPTION
🆑 Mucker
admin: Changed the mob spawner expiration debug message to include a jump-to button and show its coordinates.
admin: Added the 'Atmos immune' toggle to the mob spawner, making spawned mobs immune to all atmospheric conditions.
/🆑

A consequence of the last change is that the spawner can now only spawn simple mobs, but I doubt it was ever or will ever be used for more than that.