### PR TITLE
removes observer join message from non-admins if this new preference is toggled

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -214,6 +214,11 @@ var/list/_client_preferences_by_type
 	key = "SHOW_READY"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/announce_ghost_join
+	description = "Announce When Joining as Observer"
+	key = "ANNOUNCE_GHOST"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+
 /datum/client_preference/play_instruments
 	description = "Play instruments"
 	key = "SOUND_INSTRUMENTS"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -142,7 +142,9 @@
 				to_chat(src, "<span class='danger'>Could not locate an observer spawn point. Use the Teleport verb to jump to the map.</span>")
 			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
-			if(isnull(client.holder))
+			var/should_announce = client.get_preference_value(/datum/client_preference/announce_ghost_join) == GLOB.PREF_YES
+
+			if(isnull(client.holder) && should_announce)
 				announce_ghost_joinleave(src)
 
 			var/mob/living/carbon/human/dummy/mannequin = new()


### PR DESCRIPTION
🆑 Mucker
rscadd: Adds a preference option to toggle whether or not your presence is announced when joining as an observer, called 'Announce When Joining as Observer'.
/🆑