### PR TITLE
removes ability to use inflatables on space/open turfs

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -13,6 +13,9 @@
 	var/turf/T = get_turf(target)
 	if (!user.TurfAdjacent(T))
 		return
+	if (isspaceturf(T) || isopenspace(T))
+		to_chat(user, SPAN_WARNING("You cannot use \the [src] in open space."))
+		return
 	var/obstruction = T.get_obstruction()
 	if (obstruction)
 		to_chat(user, SPAN_WARNING("\The [english_list(obstruction)] is blocking that spot."))


### PR DESCRIPTION
:cl: SDTheCyanWyan
tweak: Prevents inflatables from being used in space
/:cl:

Not sure how inflatables can be used in space, realistically. Seems to only facilitate the cheesing of space maneuvering.