### PR TITLE
removes raider thermals for NVGs

### DIFF
--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -39,9 +39,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 		)
 
 	var/list/raider_glasses = list(
-		/obj/item/clothing/glasses/thermal,
-		/obj/item/clothing/glasses/thermal/plain/eyepatch,
-		/obj/item/clothing/glasses/thermal/plain/monocle
+		/obj/item/clothing/glasses/night
 		)
 
 	var/list/raider_helmets = list(

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1280,9 +1280,9 @@
 "cT" = (
 /obj/structure/table/rack,
 /obj/random/raider/hardsuit,
-/obj/item/clothing/glasses/thermal/plain/monocle,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
+/obj/item/clothing/glasses/night,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cU" = (


### PR DESCRIPTION
Because of budget issues, Raiders have had to sell off their thermal monocles for night vision goggles.

🆑 
tweak: Raiders now spawn with NVGs instead of thermals.
maptweak: The skipjack now has a pair of NVGs instead of a thermonocle.
/🆑 