### PR TITLE
removes subjective sadness from robot surveyor module

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -12,6 +12,11 @@
 	if(can_buckle && buckled_mob)
 		user_unbuckle_mob(user)
 
+/obj/attack_robot(mob/user)
+	. = ..()
+	if (can_buckle && buckled_mob)
+		user_unbuckle_mob(user)
+
 /obj/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	if(can_buckle && istype(M))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -71,6 +71,10 @@
 	if(!Adjacent(victim))
 		return
 
+	if(victim.is_floating)
+		victim.visible_message("<span class='danger'>Tendrils lash out towards \the [victim] but \the [src] can't quite reach them as they float above!</span>", "<span class='danger'>Tendrils lash out from \the [src] below but can't quite reach you!</span>")
+		return
+
 	if(ishuman(victim))
 		var/mob/living/carbon/human/H = victim
 		if(H.species.species_flags & SPECIES_FLAG_NO_TANGLE)

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -39,27 +39,30 @@
 	if(!buckled_mob)
 		return
 	if(buckled_mob != user)
-		to_chat(user, "<span class='notice'>You try to free \the [buckled_mob] from \the [src].</span>")
+		to_chat(user, SPAN_NOTICE("You try to free \the [buckled_mob] from \the [src]."))
 		var/chance = round(100/(20*seed.get_trait(TRAIT_POTENCY)/100))
 		if(prob(chance))
-			buckled_mob.visible_message(\
-				"<span class='notice'>\The [user] frees \the [buckled_mob] from \the [src].</span>",\
-				"<span class='notice'>\The [user] frees you from \the [src].</span>",\
-				"<span class='warning'>You hear shredding and ripping.</span>")
+			buckled_mob.visible_message(
+				"\The [user] frees \the [buckled_mob] from \the [src].",
+				SPAN_NOTICE("\The [user] frees you from \the [src]."),
+				SPAN_WARNING("You hear shredding and ripping.")
+			)
 			unbuckle_mob()
 	else
 		user.setClickCooldown(100)
 		var/breakouttime = rand(600, 1200) //1 to 2 minutes.
 
 		user.visible_message(
-			"<span class='danger'>\The [user] attempts to get free from [src]!</span>",
-			"<span class='warning'>You attempt to get free from [src].</span>")
+			"\The [user] attempts to get free from [src]!",
+			SPAN_NOTICE("You attempt to get free from [src].")
+		)
 
 		if(do_after(user, breakouttime, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
 			if(unbuckle_mob())
 				user.visible_message(
-					"<span class='danger'>\The [user] manages to escape [src]!</span>",
-					"<span class='warning'>You successfully escape [src]!</span>")
+					"\The [user] manages to escape [src]!",
+					SPAN_NOTICE("You successfully escape [src]!")
+				)
 
 /obj/effect/vine/proc/entangle(mob/living/victim)
 	if(buckled_mob)
@@ -72,7 +75,10 @@
 		return
 
 	if(victim.is_floating)
-		victim.visible_message("<span class='danger'>Tendrils lash out towards \the [victim] but \the [src] can't quite reach them as they float above!</span>", "<span class='danger'>Tendrils lash out from \the [src] below but can't quite reach you!</span>")
+		victim.visible_message(
+			SPAN_WARNING("Tendrils lash out towards \the [victim] but \the [src] can't quite reach them as they float above!"),
+			SPAN_WARNING("Tendrils lash out from \the [src] below but can't quite reach you!")
+		)
 		return
 
 	if(ishuman(victim))
@@ -80,14 +86,19 @@
 		if(H.species.species_flags & SPECIES_FLAG_NO_TANGLE)
 			return
 		if(victim.loc != loc && istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & ITEM_FLAG_NOSLIP) || H.species.check_no_slip(H))
-			visible_message("<span class='danger'>Tendrils lash to drag \the [victim] but \the [src] can't pull them across the ground!</span>")
+			visible_message(
+				SPAN_WARNING("Tendrils lash to drag \the [victim] but \the [src] can't pull them across the ground!"),
+				SPAN_WARNING("Tendrils lash to drag you but \the [src] can't pull you across the ground!")
+			)
 			return
 	
-	victim.visible_message("<span class='danger'>Tendrils lash out from \the [src] and drag \the [victim] in!</span>", "<span class='danger'>Tendrils lash out from \the [src] and drag you in!</span>")
+	victim.visible_message(
+		SPAN_DANGER("Tendrils lash out from \the [src] and drag \the [victim] in!"),
+		SPAN_DANGER("Tendrils lash out from \the [src] and drag you in!"))
 	victim.forceMove(loc)
 	if(buckle_mob(victim))
 		victim.set_dir(pick(GLOB.cardinal))
-		to_chat(victim, "<span class='danger'>The tendrils [pick("wind", "tangle", "tighten", "coil", "knot", "snag", "twist", "constrict", "squeeze", "clench", "tense")] around you!</span>")
+		to_chat(victim, SPAN_DANGER("The tendrils [pick("wind", "tangle", "tighten", "coil", "knot", "snag", "twist", "constrict", "squeeze", "clench", "tense")] around you!"))
 
 /obj/effect/vine/buckle_mob()
 	. = ..()

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -18,11 +18,6 @@
 			ExtinguishMob()
 		return TRUE
 
-	if(istype(buckled, /obj/effect/vine))
-		var/obj/effect/vine/V = buckled
-		spawn() V.manual_unbuckle(src)
-		return TRUE
-
 	if(..())
 		return TRUE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -669,6 +669,9 @@ default behaviour is:
 	if(buckled)
 		if(buckled.can_buckle)
 			buckled.user_unbuckle_mob(src)
+		else if (istype(buckled, /obj/effect/vine))
+			var/obj/effect/vine/V = buckled
+			spawn() V.manual_unbuckle(src)
 		else
 			to_chat(usr, "<span class='warning'>You can't seem to escape from \the [buckled]!</span>")
 			return

--- a/code/modules/projectiles/guns/launcher/net.dm
+++ b/code/modules/projectiles/guns/launcher/net.dm
@@ -5,6 +5,7 @@
 	item_state = "netgun"
 	fire_sound = 'sound/weapons/empty.ogg'
 	fire_sound_text = "a metallic thunk"
+	release_force = 5
 	var/obj/item/weapon/net_shell/chambered
 
 /obj/item/weapon/net_shell
@@ -70,11 +71,18 @@
 		return new /obj/item/weapon/energy_net/safari(src)
 
 /obj/item/weapon/gun/launcher/net/borg
+	has_safety = FALSE // Selecting the module for activation makes a safety redundant
 	var/list/shells
-	var/list/max_shells = 3
+	var/max_shells = 3
+
+/obj/item/weapon/gun/launcher/net/borg/Initialize()
+	. = ..()
+	// Start fully loaded
+	for(var/i in 1 to (max_shells + 1))
+		load(new /obj/item/weapon/net_shell)
 
 /obj/item/weapon/gun/launcher/net/borg/can_load(var/obj/item/weapon/net_shell/S, var/mob/user)
-	if(LAZYLEN(shells) >= 3)
+	if(LAZYLEN(shells) >= max_shells)
 		to_chat(user, SPAN_WARNING("\The [src] already has the maximum number of shells loaded."))
 		return FALSE
 	return TRUE
@@ -93,8 +101,8 @@
 	update_chambered_shell()
 
 /obj/item/weapon/gun/launcher/net/borg/consume_next_projectile()
-	update_chambered_shell()
 	. = ..()
+	update_chambered_shell()
 
 /obj/item/weapon/gun/launcher/net/borg/examine(mob/user)
 	. = ..()

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -26,6 +26,13 @@
 		if(L)
 			stat("Coordinates:", "[L.get_coordinates()]")
 
+/mob/living/silicon/robot/Stat()
+	. = ..()
+	if(statpanel("Status") && (istype(module_state_1, /obj/item/device/gps) || istype(module_state_2, /obj/item/device/gps) || istype(module_state_3, /obj/item/device/gps)))
+		var/obj/item/device/gps/L = locate() in src
+		if(L)
+			stat("Coordinates:", "[L.get_coordinates()]")
+
 /obj/item/device/measuring_tape
 	name = "measuring tape"
 	desc = "A coiled metallic tape used to check dimensions and lengths."

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -41,7 +41,8 @@
 		/obj/item/weapon/wirecutters,
 		/obj/item/device/multitool,
 		/obj/item/bioreactor,
-		/obj/item/weapon/inflatable_dispenser/robot
+		/obj/item/weapon/inflatable_dispenser/robot,
+		/obj/item/weapon/robot_harvester
 	)
 
 	emag = /obj/item/weapon/melee/energy/machete
@@ -56,7 +57,7 @@
 	if(!gun)
 		gun = new(src)
 		equipment += gun
-	if(length(gun.shells) < gun.max_shells)
+	if(LAZYLEN(gun.shells) < gun.max_shells)
 		gun.load(new /obj/item/weapon/net_shell)
 
 	for(var/flagtype in flag_types)


### PR DESCRIPTION
The surveyor module for the flying robot chassis was broken or at least somewhat annoying to use in a number of ways. This should hopefully improve that.

🆑 Ninetailed
rscadd: Robots can now unbuckle themselves and others from things by clicking on them, just like a real boy!
rscadd: Robots with the GPS/RPD as an active module now get coordinates in the Status box the same as humans do
rscadd: Surveyor module now has a harvester to gather plants for the bioreactor
tweak: Robot net gun no longer has a safety, as selecting the module for use serves the same purpose
tweak: Vines can no longer grab you if you're flying
bugfix: Net gun now actually fires nets instead of dropping them
bugfix: Robot net gun now spawns with shells loaded
bugfix: All living mobs, including robots, can break free of vines using the Resist verb, rather than this being restricted to carbon life
/🆑

Fixes #25310