### PR TITLE
removes static antag intro text

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -104,6 +104,15 @@
 		if(role_text) GLOB.hud_icon_reference[role_text] = antaghud_indicator
 		if(faction_role_text) GLOB.hud_icon_reference[faction_role_text] = antaghud_indicator
 
+/datum/antagonist/proc/get_antag_text(mob/recipient)
+	return antag_text
+
+/datum/antagonist/proc/get_welcome_text(mob/recipient)
+	return welcome_text
+
+/datum/antagonist/proc/get_leader_welcome_text(mob/recipient)
+	return leader_welcome_text
+
 /datum/antagonist/proc/tick()
 	return 1
 

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -98,11 +98,11 @@
 	// Basic intro text.
 	to_chat(player.current, "<span class='danger'><font size=3>You are a [role_text]!</font></span>")
 	if(leader_welcome_text && player == leader)
-		to_chat(player.current, "<span class='antagdesc'>[leader_welcome_text]</span>")
+		to_chat(player.current, "<span class='antagdesc'>[get_leader_welcome_text(player.current)]</span>")
 	else
-		to_chat(player.current, "<span class='antagdesc'>[welcome_text]</span>")
+		to_chat(player.current, "<span class='antagdesc'>[get_welcome_text(player.current)]</span>")
 	if (config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
-		to_chat(player.current, "[antag_text]")
+		to_chat(player.current, get_antag_text(player.current))
 
 	if((flags & ANTAG_HAS_NUKE) && !spawned_nuke)
 		create_nuke()

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -7,11 +7,14 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	feedback_tag = "changeling_objective"
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
 	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/hos)
-	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
+	welcome_text = "Use say \"%LANGUAGE_PREFIX%g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"
 
 	faction = "changeling"
+
+/datum/antagonist/changeling/get_welcome_text(mob/recipient)
+	return replacetext(welcome_text, "%LANGUAGE_PREFIX%", recipient?.get_prefix_key(/decl/prefix/language) || ",")
 
 /datum/antagonist/changeling/get_special_objective_text(var/datum/mind/player)
 	return "<br><b>Changeling ID:</b> [player.changeling.changelingID].<br><b>Genomes Absorbed:</b> [player.changeling.absorbedcount]"

--- a/code/game/antagonist/station/provocateur.dm
+++ b/code/game/antagonist/station/provocateur.dm
@@ -6,12 +6,16 @@ GLOBAL_DATUM_INIT(provocateurs, /datum/antagonist/provocateur, new)
 	role_text_plural = "Deuteragonists"
 	antaghud_indicator = "hud_traitor"
 	flags = ANTAG_RANDOM_EXCEPTED
-	antag_text = "This role means you should feel free to pursue your goals even if they conflict with the station, but you aren't an antagonist and shouldn't act like one. Try to be reasonable and avoid killing or blowing things up!"
+	antag_text = "This role means you should feel free to pursue your goals even if they conflict with %WORLD_NAME%, but you aren't an antagonist and shouldn't act like one. Try to be reasonable and avoid killing or blowing things up!"
 	welcome_text = "You are a character in a side story!"
 	blacklisted_jobs = list()
 	skill_setter = null
 	min_player_age = 0
 
-/datum/antagonist/provocateur/New()
-	antag_text = "This role means you should feel free to pursue your goals even if they conflict with the [station_name()], but you aren't an antagonist and shouldn't act like one. Try to be reasonable and avoid killing or blowing things up!"
-	..()
+	var/antag_text_updated
+
+/datum/antagonist/provocateur/get_antag_text(mob/recipient)
+	if (!antag_text_updated)
+		antag_text = replacetext(antag_text, "%WORLD_NAME%", station_name())
+		antag_text_updated = TRUE
+	return antag_text


### PR DESCRIPTION
by adding overridable getters for antag texts because they are created before the map is
uses one to one-off update the the deuteragonist antag text when it's first sent to someone
fixes #30100
