### PR TITLE
removes zombie juice from available reagents for xenobotany

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -471,7 +471,8 @@
 			/datum/reagent/nanites,
 			/datum/reagent/water/holywater,
 			/datum/reagent/toxin/plantbgone,
-			/datum/reagent/chloralhydrate/beer2
+			/datum/reagent/chloralhydrate/beer2,
+			/datum/reagent/zombie
 			)
 		banned_chems += subtypesof(/datum/reagent/ethanol)
 		banned_chems += subtypesof(/datum/reagent/tobacco)


### PR DESCRIPTION
:cl:
rscdel: Liquid Corruption can no longer appear as a random chemical in xenobotany seeds.
/:cl: