### PR TITLE
removes some of the huge energy from portable floodlamps

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -416,9 +416,9 @@
 	w_class = ITEM_SIZE_LARGE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_ROTATABLE
 
-	flashlight_max_bright = 1
-	flashlight_inner_range = 3
-	flashlight_outer_range = 7
+	flashlight_max_bright = 0.8
+	flashlight_inner_range = 1
+	flashlight_outer_range = 5
 
 /obj/item/device/flashlight/lamp/floodlamp/green
 	icon_state = "greenfloodlamp"


### PR DESCRIPTION
🆑 
tweak: Portable floodlamps are now appropriately weaker than industrial floodlights.
/🆑 
![reasonable flooding](https://user-images.githubusercontent.com/68120725/106530911-38d3d200-64bb-11eb-92a2-9fa1cb269e54.PNG)
