### PR TITLE
removes secrecy from manual valve interactions

### DIFF
--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -98,6 +98,9 @@
 	else if(network_node2)
 		network_node2.update = 1
 
+	if (usr)
+		visible_message(SPAN_WARNING("\The [usr] opens \the [src]."), range = 5)
+
 	return 1
 
 /obj/machinery/atmospherics/valve/proc/close()
@@ -113,6 +116,9 @@
 		qdel(network_node2)
 
 	build_network()
+
+	if (usr)
+		visible_message(SPAN_WARNING("\The [usr] closes \the [src]."), range = 5)
 
 	return 1
 


### PR DESCRIPTION
:cl: SDTheCyanWyan
tweak: Print a message when a manual valve is opened/closed
/:cl:

Considering the sprites are small and in weird places at times, I feel its a good additional feedback indicator. 

(I'm looking at you, valve hidden under the chair on the GUP.)