### PR TITLE
remove gravity generator announcement spam

### DIFF
--- a/code/modules/events/gravity.dm
+++ b/code/modules/events/gravity.dm
@@ -18,5 +18,5 @@
 	for (var/area/A in gravity_status)
 		if (!A.has_gravity() && (A.z in affecting_z))
 			A.gravitychange(TRUE)
-		command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "[location_name()] Gravity Subsystem", zlevels = affecting_z)
 	gravity_status.Cut()
+	command_announcement.Announce("Gravity generators are again functioning within normal parameters. Sorry for any inconvenience.", "[location_name()] Gravity Subsystem", zlevels = affecting_z)


### PR DESCRIPTION
🆑 Mucker
bugfix: Fix the gravity event end announcement being spammed.
/🆑

So it appears our resident @Spookerton made a whoopsie in #30092 wherein he accidentally put the announcement line into the loop that re-enabled gravity in all areas, thus causing the announcement to spam for _every single_ area on the ship.