### PR TITLE
removes brainwashing implants from merc uplinks

### DIFF
--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -40,3 +40,4 @@
 	set of law-like instructions to follow. This kit contains a dose of Mindbreaker Toxin."
 	item_cost = 20
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_imprinting
+	antag_roles = list(MODE_TRAITOR)


### PR DESCRIPTION
🆑 
tweak: Brainwashing implants are now restricted to traitor uplinks only.
/🆑 

Because we've just seen how that went.