### PR TITLE
Removes some grammar inconsistencies and rewrites some examine texts

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -159,7 +159,7 @@
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
 	singular_name = "advanced trauma kit"
-	desc = "An advanced trauma kit for severe injuries."
+	desc = "A packet filled antibacterial bio-adhesive, used to quickly seal and disinfect cuts, bruises, and other physical trauma. Can be used to treat both limbs and internal organs."
 	icon_state = "traumakit"
 	heal_brute = 0
 	origin_tech = list(TECH_BIO = 1)
@@ -215,7 +215,7 @@
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
 	singular_name = "advanced burn kit"
-	desc = "An advanced treatment kit for severe burns."
+	desc = "A packet containing a delicate membrane used to salve and disinfect burn wounds. Can be used to treat both limbs and internal organs."
 	icon_state = "burnkit"
 	heal_burn = 5
 	origin_tech = list(TECH_BIO = 1)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -13,7 +13,7 @@
  */
 /obj/item/weapon/retractor
 	name = "retractor"
-	desc = "Retracts stuff."
+	desc = "Used to separate the edges of a surgical incision to get to the juicy organs inside."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "retractor"
 	matter = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 5000)
@@ -26,7 +26,7 @@
  */
 /obj/item/weapon/hemostat
 	name = "hemostat"
-	desc = "You think you have seen this before."
+	desc = "A type of forceps used to prevent an incision from bleeding, or to extract objects from the inside of the body."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "hemostat"
 	matter = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 2500)
@@ -40,7 +40,7 @@
  */
 /obj/item/weapon/cautery
 	name = "cautery"
-	desc = "This stops bleeding."
+	desc = "Uses chemicals to quickly cauterize incisions and other small cuts without causing further damage."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "cautery"
 	matter = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 2500, MATERIAL_ALUMINIUM = 1000)
@@ -54,7 +54,7 @@
  */
 /obj/item/weapon/surgicaldrill
 	name = "surgical drill"
-	desc = "You can drill using this item. You dig?"
+	desc = "Effectively a very precise hand drill, used to bore holes through bone."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "drill"
 	hitsound = 'sound/weapons/circsawhit.ogg'
@@ -70,7 +70,7 @@
  */
 /obj/item/weapon/scalpel
 	name = "scalpel"
-	desc = "Cut, cut, and once more cut."
+	desc = "A tiny and extremely sharp steel cutting tool used for surgery, dissection, autopsy, and very precise cuts. The cornerstone of any surgical procedure."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
@@ -120,7 +120,7 @@
  */
 /obj/item/weapon/circular_saw
 	name = "circular saw"
-	desc = "For heavy duty cutting."
+	desc = "A small and nasty-looking hand saw used to cut through bone, or in an emergency, pizza."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw3"
 	hitsound = 'sound/weapons/circsawhit.ogg'
@@ -139,6 +139,7 @@
 //misc, formerly from code/defines/weapons.dm
 /obj/item/weapon/bonegel
 	name = "bone gel"
+	desc = "Sophisticated chemical gel used to mend fractures and broken bones before setting."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bone-gel"
 	force = 0
@@ -147,6 +148,7 @@
 
 /obj/item/weapon/FixOVein
 	name = "FixOVein"
+	desc = "Derived from a Vey-Med design, this is a very precise surgical tool used to mend cut tendons and severed arteries."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "fixovein"
 	force = 0
@@ -157,6 +159,7 @@
 
 /obj/item/weapon/bonesetter
 	name = "bone setter"
+	desc = "A large, heavy clamp for setting dislocated or fractured bones back in place."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bone setter"
 	force = 8.0

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -35,21 +35,21 @@
 	icon_closed = "labgreen"
 
 /obj/item/clothing/suit/storage/toggle/labcoat/genetics
-	name = "Geneticist labcoat"
+	name = "geneticist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a blue stripe on the shoulder."
 	icon_state = "labcoat_gen_open"
 	icon_open = "labcoat_gen_open"
 	icon_closed = "labcoat_gen"
 
 /obj/item/clothing/suit/storage/toggle/labcoat/chemist
-	name = "Pharmacist labcoat"
+	name = "pharmacist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has an orange stripe on the shoulder."
 	icon_state = "labcoat_chem_open"
 	icon_open = "labcoat_chem_open"
 	icon_closed = "labcoat_chem"
 
 /obj/item/clothing/suit/storage/toggle/labcoat/virologist
-	name = "Virologist labcoat"
+	name = "virologist labcoat"
 	desc = "A suit that protects against minor chemical spills. Offers slightly more protection against biohazards than the standard model. Has a green stripe on the shoulder."
 	icon_state = "labcoat_vir_open"
 	icon_open = "labcoat_vir_open"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -112,7 +112,7 @@
  * Radiation protection
  */
 /obj/item/clothing/head/radiation
-	name = "Radiation Hood"
+	name = "radiation hood"
 	icon_state = "rad"
 	desc = "A hood with radiation protective properties. Label: Made with lead, do not eat insulation."
 	flags_inv = BLOCKHAIR
@@ -124,7 +124,7 @@
 
 
 /obj/item/clothing/suit/radiation
-	name = "Radiation suit"
+	name = "radiation suit"
 	desc = "A suit that protects against radiation. Label: Made with lead, do not eat insulation."
 	icon_state = "rad"
 	item_state_slots = list(


### PR DESCRIPTION
:cl: Ilysen
spellcheck: Fixed some improper naming conventions on labcoats and the radiation suit.
spellcheck: Surgical tools and advanced kits now have more descriptive examine texts.
spellcheck: Added descriptions to bone gel, bone setters, and the FixOVein.
/:cl:

It's me again! I've had a hankering for SS13 again lately after taking an extended break (that I thought would go on forever, but hey, details) and I wanted to slake that itch for the time being by making a small-sized contribution to some inconsistencies that have been around for a while. This is a very small PR that does the following:
* Lowercases the names of various labcoats and the radiation suit. (i.e. `Pharmacist labcoat` -> `pharmacist labcoat`)
* Rewrote the descriptions for the suite of surgical tools, as well as the advanced trauma kit and advanced burn kit. These were done with a focus on actually highlighting what they do, with an occasional bit of humor.

As always, please let me know if you have any feedback on these or any concerns you want to bring up. There is a very minor lore adjustment made by describing the FixOVein as being derived from a Vey-Med design, but I don't know if this is important enough to discuss or not.