### PR TITLE
removes ability of voxship thruster APC to keep its secrets from Shoal Technicians

### DIFF
--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -411,10 +411,9 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	icon_state = "apc0";
 	name = "east bump";
 	pixel_x = 24;
-	pixel_y = 0
+	req_access = newlist()
 	},
 /obj/structure/cable{
 	d2 = 8;


### PR DESCRIPTION
:cl: SDTheCyanWyan
maptweak: Allows Shoal Technicians and Shoal Biotechnicians to access Voxship Thruster APC
/:cl:

While this is to mostly fix the fact that Shoal Technicians don't have access to the Thruster APCs. This also gives Shoal Biotechnicians access to the same APC due to same access flags, but considering they already have access to all the other APCs, this seems like a non-issue.
fixes #30091 