### PR TITLE
removes the rifle calibres being the wrong way round

### DIFF
--- a/code/__defines/guns.dm
+++ b/code/__defines/guns.dm
@@ -4,8 +4,8 @@
 #define CALIBER_PISTOL_FLECHETTE "4mm"
 #define CALIBER_PISTOL_ANTIQUE	"~10mm"
 
-#define CALIBER_RIFLE			"7mmR"
-#define CALIBER_RIFLE_MILITARY  "5mmR"
+#define CALIBER_RIFLE			"5mmR"
+#define CALIBER_RIFLE_MILITARY  "7mmR"
 #define CALIBER_ANTIMATERIAL    "15mmR"
 
 #define CALIBER_SHOTGUN			"12g"


### PR DESCRIPTION
This is so the more powerful boolet has the higher calibre. I know this isn't always the case but it makes more sense to me.
Up to whoever reviews if they want to merge this, I won't complain if they don't since it's subjective.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->