### PR TITLE
removes  vars pathed as obj/item/weapon instead of obj/item

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -91,7 +91,7 @@
 	w_class = ITEM_SIZE_TINY
 	layer = ABOVE_OBJ_LAYER
 
-	var/obj/item/weapon/stuck = null
+	var/obj/item/stuck = null
 
 /obj/item/weapon/ducttape/attack_hand(var/mob/user)
 	anchored = FALSE // Unattach it from whereever it's on, if anything.

--- a/code/modules/admin/secrets/admin_secrets/prison_warp.dm
+++ b/code/modules/admin/secrets/admin_secrets/prison_warp.dm
@@ -25,7 +25,7 @@
 					security++
 		if(!security)
 			//strip their stuff before they teleport into a cell :downs:
-			for(var/obj/item/weapon/W in H)
+			for(var/obj/item/W in H)
 				if(istype(W, /obj/item/organ/external))
 					continue
 					//don't strip organs

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -32,7 +32,7 @@ var/list/mining_floors = list()
 	var/next_rock = 0
 	var/archaeo_overlay = ""
 	var/excav_overlay = ""
-	var/obj/item/weapon/last_find
+	var/obj/item/last_find
 	var/datum/artifact_find/artifact_find
 	var/image/ore_overlay
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -982,7 +982,7 @@
 
 	var/list/visible_implants = list()
 	for(var/obj/item/organ/external/organ in src.organs)
-		for(var/obj/item/weapon/O in organ.implants)
+		for(var/obj/item/O in organ.implants)
 			if(!istype(O,/obj/item/weapon/implant) && (O.w_class > class) && !istype(O,/obj/item/weapon/material/shard/shrapnel))
 				visible_implants += O
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -10,7 +10,7 @@
 	var/datum/research/techonly/files 	//The device uses the same datum structure as the R&D computer/server.
 										//This analyzer can only store tech levels, however.
 
-	var/obj/item/weapon/loaded_item	//What is currently inside the analyzer.
+	var/obj/item/loaded_item	//What is currently inside the analyzer.
 
 /obj/item/weapon/portable_destructive_analyzer/New()
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -867,7 +867,7 @@
 /mob/proc/remove_implant(var/obj/item/implant, var/surgical_removal = FALSE)
 	if(!LAZYLEN(get_visible_implants(0))) //Yanking out last object - removing verb.
 		verbs -= /mob/proc/yank_out_object
-	for(var/obj/item/weapon/O in pinned)
+	for(var/obj/item/O in pinned)
 		if(O == implant)
 			pinned -= O
 		if(!pinned.len)
@@ -937,7 +937,7 @@
 		else
 			to_chat(U, "[src] has nothing stuck in their wounds that is large enough to remove.")
 		return
-	var/obj/item/weapon/selection = input("What do you want to yank out?", "Embedded objects") in valid_objects
+	var/obj/item/selection = input("What do you want to yank out?", "Embedded objects") in valid_objects
 	if(self)
 		to_chat(src, "<span class='warning'>You attempt to get a good grip on [selection] in your body.</span>")
 	else

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -125,7 +125,7 @@
 	var/obj/buckled = null//Living
 	var/obj/item/l_hand = null//Living
 	var/obj/item/r_hand = null//Living
-	var/obj/item/weapon/back = null//Human/Monkey
+	var/obj/item/back = null//Human/Monkey
 	var/obj/item/weapon/storage/s_active = null//Carbon
 	var/obj/item/clothing/mask/wear_mask = null//Carbon
 

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -53,7 +53,7 @@
 		if(stored_paper >= max_paper)
 			to_chat(user, "You try to add \the [W] into \the [src], but its paper bin is full.")
 			return
-		for(var/obj/item/weapon/bundleitem in B) //loop through items in bundle
+		for(var/obj/item/bundleitem in B) //loop through items in bundle
 			if(istype(bundleitem, /obj/item/weapon/paper)) //if item is paper (and not photo), add into the bin
 				B.pages.Remove(bundleitem)
 				qdel(bundleitem)

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -60,7 +60,7 @@
 			var/list/bits = list()
 			for(var/obj/item/organ/internal/organ in internal_organs)
 				bits += organ.get_visible_state()
-			for(var/obj/item/weapon/implant in implants)
+			for(var/obj/item/implant in implants)
 				bits += implant.name
 			if(bits.len)
 				wound_descriptors["[english_list(bits)] visible in the wounds"] = 1

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -9,7 +9,7 @@
 	throw_speed = 3
 	throw_range = 10
 	var/obj/item/weapon/pen/haspen		//The stored pen.
-	var/obj/item/weapon/toppaper	//The topmost piece of paper.
+	var/obj/item/toppaper	//The topmost piece of paper.
 	slot_flags = SLOT_BELT
 	default_material = MATERIAL_WOOD
 	applies_material_name = FALSE
@@ -112,7 +112,7 @@
 					to_chat(usr, "<span class='notice'>You slot the pen into \the [src].</span>")
 
 		else if(href_list["write"])
-			var/obj/item/weapon/P = locate(href_list["write"])
+			var/obj/item/P = locate(href_list["write"])
 
 			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) && (P == toppaper) )
 
@@ -136,7 +136,7 @@
 						toppaper = null
 
 		else if(href_list["rename"])
-			var/obj/item/weapon/O = locate(href_list["rename"])
+			var/obj/item/O = locate(href_list["rename"])
 
 			if(O && (O.loc == src))
 				if(istype(O, /obj/item/weapon/paper))

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -87,7 +87,7 @@
 				P.attack_self(usr)
 				onclose(usr, "[P.name]")
 		else if(href_list["rename"])
-			var/obj/item/weapon/O = locate(href_list["rename"])
+			var/obj/item/O = locate(href_list["rename"])
 
 			if(O && (O.loc == src))
 				if(istype(O, /obj/item/weapon/paper))

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -104,7 +104,7 @@
 
 /obj/item/weapon/paper_bundle/proc/show_content(mob/user as mob)
 	var/dat
-	var/obj/item/weapon/W = pages[page]
+	var/obj/item/W = pages[page]
 
 	// first
 	if(page == 1)
@@ -144,7 +144,7 @@
 		return 1
 	if((src in usr.contents) || (istype(src.loc, /obj/item/weapon/folder) && (src.loc in usr.contents)))
 		usr.set_machine(src)
-		var/obj/item/weapon/in_hand = usr.get_active_hand()
+		var/obj/item/in_hand = usr.get_active_hand()
 		if(href_list["next_page"])
 			if(in_hand && (istype(in_hand, /obj/item/weapon/paper) || istype(in_hand, /obj/item/weapon/photo)))
 				insert_sheet_at(usr, page+1, in_hand)
@@ -158,7 +158,7 @@
 				page--
 				playsound(src.loc, "pageturn", 50, 1)
 		if(href_list["remove"])
-			var/obj/item/weapon/W = pages[page]
+			var/obj/item/W = pages[page]
 			usr.put_in_hands(W)
 			pages.Remove(pages[page])
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -80,7 +80,7 @@
 	else if(istype(i, /obj/item/weapon/paper_bundle))
 		to_chat(user, "<span class='notice'>You loosen \the [i] and add its papers into \the [src].</span>")
 		var/was_there_a_photo = 0
-		for(var/obj/item/weapon/bundleitem in i) //loop through items in bundle
+		for(var/obj/item/bundleitem in i) //loop through items in bundle
 			if(istype(bundleitem, /obj/item/weapon/paper)) //if item is paper, add into the bin
 				papers.Add(bundleitem)
 				update_icon()

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -78,7 +78,7 @@
 		// Move papers one by one as they fit; stop when we are empty or can't fit any more
 		while(paperamount > 0)
 
-			var/obj/item/weapon/shred_temp = get_shredded_paper()
+			var/obj/item/shred_temp = get_shredded_paper()
 
 			if(empty_into.can_be_inserted(shred_temp, user, 0))
 				empty_into.handle_item_insertion(shred_temp)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -208,7 +208,7 @@
 //If need_toner is 0, the copies will still be lightened when low on toner, however it will not be prevented from printing. TODO: Implement print queues for fax machines and get rid of need_toner
 /obj/machinery/photocopier/proc/bundlecopy(var/obj/item/weapon/paper_bundle/bundle, var/need_toner=1)
 	var/obj/item/weapon/paper_bundle/p = new /obj/item/weapon/paper_bundle (src)
-	for(var/obj/item/weapon/W in bundle.pages)
+	for(var/obj/item/W in bundle.pages)
 		if(toner <= 0 && need_toner)
 			toner = 0
 			visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -10,7 +10,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	name = "destructive analyzer"
 	desc = "Accessed by a connected core fabricator console, it destroys and analyzes items and materials, recycling materials to any connected protolathe, and progressing the learning matrix of the connected core fabricator console."
 	icon_state = "d_analyzer"
-	var/obj/item/weapon/loaded_item = null
+	var/obj/item/loaded_item = null
 	var/decon_mod = 0
 
 	idle_power_usage = 30

--- a/code/modules/spells/targeted/equip/dyrnwyn.dm
+++ b/code/modules/spells/targeted/equip/dyrnwyn.dm
@@ -21,7 +21,7 @@
 
 
 /spell/targeted/equip_item/dyrnwyn/summon_item(var/new_type)
-	var/obj/item/weapon/W = new new_type(null,material)
+	var/obj/item/W = new new_type (null, material)
 	W.SetName("\improper Dyrnwyn")
 	W.damtype = BURN
 	W.hitsound = 'sound/items/welder2.ogg'

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -260,7 +260,7 @@
 	find_type = ARCHAEO_TOOL
 
 /obj/item/weapon/archaeological_find/tool/spawn_item()
-	var/obj/item/weapon/new_item
+	var/obj/item/new_item
 	if(prob(25))
 		new_item = new /obj/item/weapon/wrench(loc)
 	else if(prob(25))

--- a/code/modules/xenoarcheaology/finds/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/fossils.dm
@@ -9,14 +9,20 @@
 	desc = "It's a fossil."
 	var/animal = 1
 
-/obj/item/weapon/fossil/base/New()
-	var/list/l = list(/obj/item/weapon/fossil/bone=9,/obj/item/weapon/fossil/skull=3,
-	/obj/item/weapon/fossil/skull/horned=2)
-	var/t = pickweight(l)
-	var/obj/item/weapon/W = new t(src.loc)
-	var/turf/T = get_turf(src)
-	if(istype(T, /turf/simulated/mineral))
-		T:last_find = W
+/obj/item/weapon/fossil/base/Initialize()
+	. = ..()
+	if (. == INITIALIZE_HINT_QDEL)
+		return
+	var/list/fossil_weights = list(
+		/obj/item/weapon/fossil/bone = 9,
+		/obj/item/weapon/fossil/skull = 3,
+		/obj/item/weapon/fossil/skull/horned = 2
+	)
+	var/fossil_type = pickweight(fossil_weights)
+	var/obj/item/I = new fossil_type (loc)
+	var/turf/simulated/mineral/T = get_turf(src)
+	if (istype(T))
+		T.last_find = I
 	qdel(src)
 
 /obj/item/weapon/fossil/bone


### PR DESCRIPTION
clean up use of var/obj/item/weapon with sets
matches on /var/obj/item/weapon/\w*\s*=/i

clean up use of var/obj/item/weapon without sets
matches on /var/obj/item/weapon/\w+(\s*((//.*)|(/\*.*))?\n)/i

clean up use of var/obj/item/weapon/X in loops
matches on /for\s*\(var/obj/item/weapon/\w+\s/i
