### PR TITLE
Removes "custom event" text showing every round

### DIFF
--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -9,8 +9,6 @@
 
 	var/input = sanitize(input(usr, "Enter the description of the event. Be descriptive. To cancel the event, make this blank or hit cancel.", "Event", config.event) as message|null, MAX_BOOK_MESSAGE_LEN, extra = 0)
 	if(isnull(input))
-		return
-	if(input == "")
 		config.event = ""
 		log_admin("[usr.key] has cleared the event text.")
 		message_admins("[key_name_admin(usr)] has cleared the event text.")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -181,7 +181,7 @@
 
 	GLOB.using_map.map_info(src)
 
-	if (!config.event)
+	if (config.event)
 		to_chat(src, "<h1 class='alert'>Event</h1>")
 		to_chat(src, "<h2 class='alert'>An event is taking place. OOC Info:</h2>")
 		to_chat(src, "<span class='alert'>[config.event]</span>")


### PR DESCRIPTION
:cl: Ilysen
bugfix: The "custom event is taking place" popup no longer appears every round.
/:cl:

Missing conditional caused this to happen whenever the event was null, instead of when the event *wasn't* null (which also meant that the popup wouldn't show when an event was actually happening.) Also fixed it being impossible to clear the event text.