### PR TITLE
removes inability to click through new bm overlays

### DIFF
--- a/code/modules/admin/buildmode/areas.dm
+++ b/code/modules/admin/buildmode/areas.dm
@@ -36,7 +36,7 @@ Right Click       - List/Create Area
 	if (overlay)
 		overlay.Hide()
 
-/datum/build_mode/areas/UpdateOverlay(image/I, turf/T)
+/datum/build_mode/areas/UpdateOverlay(atom/movable/M, turf/T)
 	if (!overlay?.shown)
 		return
 	var/color = area_colors[T.loc]
@@ -48,7 +48,7 @@ Right Click       - List/Create Area
 		else
 			color = "#" + copytext(md5("\ref[T.loc]"), 1, 7)
 		area_colors[T.loc] = color
-	I.color = color
+	M.color = color
 
 /datum/build_mode/areas/OnClick(var/atom/A, var/list/parameters)
 	if (parameters["right"])

--- a/code/modules/admin/buildmode/build_mode.dm
+++ b/code/modules/admin/buildmode/build_mode.dm
@@ -34,7 +34,7 @@
 /datum/build_mode/proc/TimerEvent()
 	return
 
-/datum/build_mode/proc/UpdateOverlay(image/I, turf/T)
+/datum/build_mode/proc/UpdateOverlay(atom/movable/M, turf/T)
 	return
 
 /datum/build_mode/proc/CreateOverlay(icon_state)

--- a/code/modules/admin/buildmode/overlay.dm
+++ b/code/modules/admin/buildmode/overlay.dm
@@ -1,5 +1,5 @@
 /datum/buildmode_overlay
-	var/list/images = list()
+	var/list/display_atoms = list()
 	var/mob/user
 	var/datum/build_mode/buildmode
 	var/shown
@@ -13,17 +13,18 @@
 		icon_state = ""
 	for (var/x = -size to size step 1)
 		for (var/y = -size to size step 1)
-			var/image/I = new('icons/turf/overlays.dmi', user, icon_state)
-			I.appearance_flags = KEEP_APART|RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM|NO_CLIENT_COLOR|KEEP_APART
-			I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-			I.pixel_x = x * 32
-			I.pixel_y = y * 32
-			images += I
+			var/atom/movable/M = new
+			M.mouse_opacity = 0
+			M.icon = 'icons/turf/overlays.dmi'
+			M.icon_state = icon_state
+			M.screen_loc = "CENTER[x < 0 ? "-" : "+"][abs(x)],CENTER[y < 0 ? "-" : "+"][abs(y)]"
+			M.appearance_flags = KEEP_APART|RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM|NO_CLIENT_COLOR|TILE_BOUND
+			display_atoms += M
 	. = ..()
 
 /datum/buildmode_overlay/Destroy()
 	Hide()
-	images = null
+	display_atoms = null
 	buildmode = null
 	user = null
 	. = ..()
@@ -31,13 +32,13 @@
 /datum/buildmode_overlay/proc/Show()
 	if (shown || QDELETED(user?.client))
 		return
-	user.client.images += images
+	user.client.screen += display_atoms
 	shown = TRUE
 
 /datum/buildmode_overlay/proc/Hide()
 	if (!shown || QDELETED(user?.client))
 		return
-	user.client.images -= images
+	user.client.screen -= display_atoms
 	shown = FALSE
 
 /datum/buildmode_overlay/proc/TimerEvent()
@@ -46,10 +47,10 @@
 	var/i = 1
 	for (var/x = -size to size step 1)
 		for (var/y = -size to size step 1)
-			var/image/I = images[i++]
+			var/atom/movable/M = display_atoms[i++]
 			var/turf/T = locate(user.x + x, user.y + y, user.z)
 			if (T)
-				I.alpha = 255
-				ImmediateInvokeAsync(buildmode, /datum/build_mode/.proc/UpdateOverlay, I, T)
+				M.alpha = 255
+				ImmediateInvokeAsync(buildmode, /datum/build_mode/.proc/UpdateOverlay, M, T)
 			else
-				I.alpha = 0
+				M.alpha = 0


### PR DESCRIPTION
:cl:
admin: Unbroke build mode overlay clickthrough - areas works as expected again.
/:cl:
