### PR TITLE
Removes ability to remove specialty limbguards

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -191,6 +191,7 @@
 		bomb = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0.5
+	removable = FALSE
 
 /obj/item/clothing/accessory/armguards/ballistic
 	name = "ballistic arm guards"
@@ -204,6 +205,7 @@
 		bomb = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0.7
+	removable = FALSE
 
 /obj/item/clothing/accessory/armguards/ablative
 	name = "ablative arm guards"
@@ -217,6 +219,7 @@
 		bomb = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0
+	removable = FALSE
 
 //Leg guards
 /obj/item/clothing/accessory/legguards
@@ -280,6 +283,7 @@
 		)
 	siemens_coefficient = 0.5
 	slowdown = 1
+	removable = FALSE
 
 /obj/item/clothing/accessory/legguards/ballistic
 	name = "ballistic leg guards"
@@ -294,6 +298,7 @@
 		)
 	siemens_coefficient = 0.7
 	slowdown = 1
+	removable = FALSE
 
 /obj/item/clothing/accessory/legguards/ablative
 	name = "ablative leg guards"
@@ -308,6 +313,7 @@
 		)
 	siemens_coefficient = 0
 	slowdown = 1
+	removable = FALSE
 
 
 //Decorative attachments


### PR DESCRIPTION
:cl: theunlovedrock
tweak: you can no longer remove limbguards from the specialty armory armors.
/:cl:
I think these were never intended to be detachable. I can't think of a single good reason why you would detach them and attach them to another set of armor, except for the fact that the legguards give slowdown. That slowdown is important to balancing the armor sets, as they're generally on par with regular armor plates against damage types they aren't specialized for. The helmets do not share this effect, so they're fine on their own.


I know I did this on my dev branch, it was an accident.