### PR TITLE
removes teleport beacon from inside misc research containment, and also vacuum

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -25547,6 +25547,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "pEr" = (
@@ -27723,8 +27724,7 @@
 	internal_pressure_bound_default = 4000;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
@@ -28127,7 +28127,6 @@
 /obj/effect/landmark{
 	name = "bluespacerift"
 	},
-/obj/item/device/radio/beacon,
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
 "srb" = (


### PR DESCRIPTION
:cl:
maptweak: The miscellaneous research lab's teleport beacon has been moved outside of the containment cell.
maptweak: The miscellaneous research lab's containment cell's siphon now starts off by default.
/:cl: