### PR TITLE
removes build mode color code duplication

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1247,6 +1247,7 @@
 #include "code\modules\admin\spam_prevention.dm"
 #include "code\modules\admin\ticket.dm"
 #include "code\modules\admin\topic.dm"
+#include "code\modules\admin\buildmode\_color_pool.dm"
 #include "code\modules\admin\buildmode\advance.dm"
 #include "code\modules\admin\buildmode\areas.dm"
 #include "code\modules\admin\buildmode\basic.dm"

--- a/code/modules/admin/buildmode/_color_pool.dm
+++ b/code/modules/admin/buildmode/_color_pool.dm
@@ -1,0 +1,31 @@
+/**
+Temporary color pool using text/number/path/instance keys.
+Once fixed distinct colors are expended, md5(key) is used.
+Null key is always #000000.
+*/
+
+/color_pool
+	var/list/available = list( //source: https://sashamaps.net/docs/resources/20-colors
+		"#ffffff", "#a9a9a9", "#e6194b", "#3cb44b", "#ffe119", "#4363d8",
+		"#f58231", "#42d4f4", "#f032e6", "#fabebe", "#469990", "#e6beff",
+		"#9a6324", "#fffac8", "#800000", "#aaffc3", "#000075"
+	)
+	var/list/assigned = list()
+
+/color_pool/proc/get(key)
+	if (isnull(key))
+		return "#000000"
+	if (isnum(key) || ispath(key))
+		key = "[key]"
+	else if (!istext(key))
+		key = "\ref[key]"
+	var/result = assigned[key]
+	if (!result)
+		var/count = length(available)
+		if (!count)
+			result = "#[copytext(md5(key), 1, 7)]"
+		else
+			result = available[count]
+			available.Cut(count)
+		assigned[key] = result
+	return result

--- a/code/modules/admin/buildmode/areas.dm
+++ b/code/modules/admin/buildmode/areas.dm
@@ -9,13 +9,9 @@ Middle Click      - Copy Turf Area
 Right Click       - List/Create Area
 ************************************\
 "}
-	var/list/distinct_colors = list(
-		"#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231", "#42d4f4",
-		"#f032e6", "#fabebe", "#469990", "#e6beff", "#9a6324", "#fffac8",
-		"#800000", "#aaffc3", "#000075", "#a9a9a9", "#ffffff", "#000000"
-	)
-	var/list/area_colors = list()
+
 	var/area/selected_area
+	var/color_pool/colors
 
 /datum/build_mode/areas/Destroy()
 	UnselectArea()
@@ -28,27 +24,18 @@ Right Click       - List/Create Area
 /datum/build_mode/areas/Selected()
 	if (!overlay)
 		CreateOverlay("whiteOverlay")
-	distinct_colors = initial(distinct_colors)
-	area_colors = list()
+	colors = new
 	overlay.Show()
 
 /datum/build_mode/areas/Unselected()
 	if (overlay)
 		overlay.Hide()
+	QDEL_NULL(colors)
 
 /datum/build_mode/areas/UpdateOverlay(atom/movable/M, turf/T)
 	if (!overlay?.shown)
 		return
-	var/color = area_colors[T.loc]
-	if (!color)
-		var/len = length(distinct_colors)
-		if (len)
-			color = distinct_colors[len]
-			distinct_colors.Cut(len)
-		else
-			color = "#" + copytext(md5("\ref[T.loc]"), 1, 7)
-		area_colors[T.loc] = color
-	M.color = color
+	M.color = colors.get(T.loc)
 
 /datum/build_mode/areas/OnClick(var/atom/A, var/list/parameters)
 	if (parameters["right"])


### PR DESCRIPTION
Adds `/color_pool`, a datum you instantiate and feed a key into to get a color out of.
Uses it for areas mode and mob spawners mode.