### PR TITLE
removes the other-other raider thermals

### DIFF
--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -876,7 +876,7 @@
 /obj/item/clothing/head/helmet/space/vox/stealth,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
-/obj/item/clothing/glasses/thermal/plain/monocle,
+/obj/item/clothing/glasses/night,
 /obj/item/clothing/under/vox/vox_robes,
 /obj/item/weapon/gun/projectile/dartgun/vox/medical,
 /turf/unsimulated/floor{


### PR DESCRIPTION
🆑 
maptweak: The forgotten raider thermonocle has been swapped for NVGs
/🆑 

Apparently https://github.com/Baystation12/Baystation12/pull/30095 missed a pair. Whoops! Thanks for making me aware of it.