### PR TITLE
removes previous lack of HUD implants

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1401,6 +1401,7 @@
 #include "code\modules\augment\simple.dm"
 #include "code\modules\augment\active\armblades.dm"
 #include "code\modules\augment\active\circuit.dm"
+#include "code\modules\augment\active\hudimplants.dm"
 #include "code\modules\augment\active\polytool.dm"
 #include "code\modules\augment\active\tool\engineering.dm"
 #include "code\modules\augment\active\tool\surgical.dm"

--- a/code/modules/augment/active/hudimplants.dm
+++ b/code/modules/augment/active/hudimplants.dm
@@ -1,0 +1,48 @@
+/obj/item/organ/internal/augment/active/hud
+	name = "integrated HUD"
+	desc = "A small implantable heads-up display."
+	icon_state = "booster"
+	action_button_name = "Toggle HUD"
+	allowed_organs = list(BP_AUGMENT_HEAD)
+	var/list/hud_type = list(HUD_MEDICAL, HUD_SECURITY)
+	var/active = FALSE
+
+/obj/item/organ/internal/augment/active/hud/Process()
+	..()
+	if (!owner)
+		return
+
+	if (active)
+		if (hud_type == HUD_MEDICAL)
+			req_access = list(access_medical)
+			if (allowed(owner))
+				process_med_hud(owner, 1)
+		else if (hud_type == HUD_SECURITY)
+			req_access = list(access_security)
+			if (allowed(owner))
+				process_sec_hud(owner, 1)
+
+/obj/item/organ/internal/augment/active/hud/emp_act(severity)
+	if (istype(src.loc, /mob/living/carbon/human))
+		var/mob/living/carbon/human/M = src.loc
+		to_chat(M, SPAN_DANGER("Your [name] malfunctions, blinding you!"))
+		M.eye_blind = 4
+		M.eye_blurry = 8
+		take_general_damage(rand(5, 15))
+		if (active)
+			active = FALSE
+
+/obj/item/organ/internal/augment/active/hud/activate()
+	if (!can_activate())
+		return
+	active = !active
+
+/obj/item/organ/internal/augment/active/hud/health
+	name = "integrated health HUD"
+	desc = "The Vey-Med H-27 is an implantable HUD, designed to interface directly with the user's optic nerve and display information about patient vitals."
+	hud_type = HUD_MEDICAL
+
+/obj/item/organ/internal/augment/active/hud/security
+	name = "integrated security HUD"
+	desc = "The Hephaestus Industries C-VSR is an implantable HUD, designed to interface directly with the user's optic nerve and local databases to display security information."
+	hud_type = HUD_SECURITY

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -521,6 +521,20 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 750)
 	id = "augment_armor"
 
+/datum/design/item/mechfab/augment/hud/health
+	name = "Implantable health HUD"
+	build_path = /obj/item/organ/internal/augment/active/hud/health
+	materials = list(DEFAULT_WALL_MATERIAL = 250, "glass" = 250)
+	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 3)
+	id = "augment_med_hud"
+
+/datum/design/item/mechfab/augment/hud/security
+	name = "Implantable security HUD"
+	build_path = /obj/item/organ/internal/augment/active/hud/security
+	materials = list(DEFAULT_WALL_MATERIAL = 250, "glass" = 250)
+	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2)
+	id = "augment_sec_hud"
+
 /datum/design/item/mechfab/augment/nanounit
 	name = "Nanite MCU"
 	build_path = /obj/item/organ/internal/augment/active/nanounit


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
rscadd: Adds two new implants: a medHUD and a secHUD, toggleable with an action button. Both can be implanted into normal and prosthetic heads.
/:cl:
Everyone likes implants, right? With the addition of these two new implantable HUDs, now you have a new reason to head to the roboticist. Both require the same amount of research from science as normal HUDs and are printable from the robotics mechfab.
Now with an action button toggle, so you can stop seeing HUD icons even when you close your eyes.