### PR TITLE
Removes lack of a newscast program for modular computers/tablets/PDAs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2339,6 +2339,7 @@
 #include "code\modules\modular_computers\file_system\programs\generic\file_browser.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\game.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\library.dm"
+#include "code\modules\modular_computers\file_system\programs\generic\news.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\ntdownloader.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\ntnrc_client.dm"
 #include "code\modules\modular_computers\file_system\programs\generic\nttransfer.dm"

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -58,6 +58,7 @@
 	var/list/datum/feed_channel/network_channels = list()
 	var/datum/feed_message/wanted_issue
 	var/list/newscasters = list()
+	var/list/news_programs = list()
 	var/list/z_levels = list()
 
 /datum/feed_network/New()
@@ -103,6 +104,8 @@
 	for(var/obj/machinery/newscaster/NEWSCASTER in newscasters)
 		NEWSCASTER.newsAlert(annoncement)
 		NEWSCASTER.update_icon()
+	for(var/datum/nano_module/program/newscast/program in news_programs)
+		program.news_alert(annoncement)
 
 var/list/datum/feed_network/news_network = list()     //The global news-network, which is coincidentally a global list.
 

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -17,6 +17,7 @@
 	hard_drive.store_file(new /datum/computer_file/program/crew_manifest())
 	hard_drive.store_file(new /datum/computer_file/program/wordprocessor())
 	hard_drive.store_file(new /datum/computer_file/program/records())
+	hard_drive.store_file(new /datum/computer_file/program/newscast())
 	if(prob(50)) //harmless tax software
 		hard_drive.store_file(new /datum/computer_file/program/uplink())
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)

--- a/code/modules/modular_computers/file_system/programs/generic/news.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/news.dm
@@ -1,0 +1,137 @@
+#define NEWSCAST_HOME 1
+#define NEWSCAST_VIEW_CHANNEL 2
+
+/datum/computer_file/program/newscast
+	filename = "newscast"
+	filedesc = "Newscast"
+	program_icon_state = "generic"
+	program_menu_icon = "image"
+	extended_desc = "A newsfeed browser that connects to standard channels, including personalized recommendations that you can't turn off! Requires a connection to NTNet."
+	size = 4 // Cloud-based, but requires the software to actually fetch the data
+	requires_ntnet = TRUE
+	available_on_ntnet = TRUE
+	usage_flags = PROGRAM_ALL
+	nanomodule_path = /datum/nano_module/program/newscast
+
+/datum/nano_module/program/newscast
+	name = "Newscast"
+	var/prog_state = NEWSCAST_HOME
+	var/notifs_enabled = TRUE
+	var/datum/feed_channel/active_channel
+	var/datum/feed_network/connected_group
+
+/datum/nano_module/program/newscast/proc/news_alert(announcement)
+	if (!notifs_enabled || !announcement)
+		return
+	program.computer.visible_notification(announcement)
+	program.computer.audible_notification("sound/machines/twobeep.ogg")
+
+/datum/nano_module/program/newscast/Destroy()
+	if (connected_group)
+		LAZYREMOVE(connected_group.news_programs, src)
+	. = ..()
+
+/datum/nano_module/program/newscast/Topic(href, href_list)
+	if(..())
+		return TRUE
+
+	if (href_list["view_channel"])
+		// We cache a byond text ref of the selected channel, and use it here to get a proper DM pointer to that channel
+		var/datum/feed_channel/new_feed = locate(href_list["view_channel"]) in connected_group.network_channels
+		if (istype(new_feed))
+			active_channel = new_feed // and then if it's valid, it becomes our new active channel
+			prog_state = NEWSCAST_VIEW_CHANNEL
+		return TRUE
+	
+	else if (href_list["view_photo"])
+		var/datum/feed_message/story = locate(href_list["view_photo"]) in active_channel.messages
+		if (istype(story) && story.img)
+			send_rsc(usr, story.img, "tmp_photo.png")
+			var/output = "<html><head><title>photo - [story.author]</title></head>"
+			output += "<body style='overflow:hidden; margin:0; text-align:center'>"
+			output += "<img src='tmp_photo.png' width='192' style='-ms-interpolation-mode:nearest-neighbor' />"
+			output += "</body></html>"
+			show_browser(usr, output, "window=book; size=192x192]")
+		return TRUE
+	
+	else if (href_list["toggle_notifs"])
+		notifs_enabled = !notifs_enabled
+		return TRUE
+
+	else if (href_list["return_to_home"])
+		active_channel = null
+		prog_state = NEWSCAST_HOME
+		return TRUE 
+		
+	return FALSE
+
+/datum/nano_module/program/newscast/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
+	var/list/data = host.initial_data()
+
+	var/datum/computer_file/program/newscast/prog = program
+	var/turf/T = get_turf(prog.computer.get_physical_host())
+	if (!connected_group) // Look for a network connected to these z-levels
+		for (var/datum/feed_network/G in news_network)
+			if (T.z in G.z_levels)
+				connected_group = G
+				LAZYADD(G.news_programs, src)
+				break
+	else if (!(T.z in connected_group.z_levels)) // Lose our tracked group if we leave the network range but still have a connection
+		prog.computer.visible_error("Newscaster connection lost. Attempting to re-establish.")
+		LAZYREMOVE(connected_group.news_programs, src)
+		connected_group = null
+
+	if (!connected_group) // If we still fail to find a network, throw an error with no other data
+		data["has_network"] = FALSE
+	else // Otherwise, gather the data from the network
+		data["has_network"] = TRUE
+		data["notifs_enabled"] = notifs_enabled
+		data["prog_state"] = prog_state
+		data["time_blurb"] = "The date is <b>[stationdate2text()]</b> at <b>[stationtime2text()]</b>."
+		data["notifs_blurb"] = "New story notifications are <b>[notifs_enabled ? "enabled" : "disabled"]</b>."
+		data["dnotice_blurb"] = "<h2><font color='red'>CHANNEL LOCKED</h2><br>\
+		This channel has been deemed as threatening to the welfare of the [station_name()], and marked with a [GLOB.using_map.company_name] D-Notice.<br><br> \
+		Stories may not be published or viewed while the D-Notice is in effect. For further information, please contact the network administrator or a security representative.</font>"
+
+		data["channels"] = list()
+		data["active_channels"] = list() // There will only ever be one active channel, but we use this for unified handling in nanoUI
+		for(var/datum/feed_channel/channel in connected_group.network_channels)
+			var/list/channel_data = list()
+			channel_data["name"] = channel.channel_name
+			channel_data["admin"] = channel.is_admin_channel
+			channel_data["censored"] = channel.censored
+			channel_data["author"] = channel.author
+			channel_data["ref"] = "\ref[channel]"
+			
+			data["channels"] += list(channel_data)
+			if (channel == active_channel)
+				data["active_channels"] += list(channel_data)
+			
+		if (active_channel)
+			var/datum/feed_channel/feed = active_channel
+			data["active_channel"] = feed
+			data["active_stories"] = list()
+			for (var/i = 1 to length(feed.messages))
+				var/datum/feed_message/message = feed.messages[i]
+				var/list/story = list()
+				story["author"] = message.author
+				story["body"] = message.body
+				story["timestamp"] = message.time_stamp
+				story["has_photo"] = message.img != null
+				if (user && message.img) // user check here to avoid runtimes
+					var/resource_name = "newscaster_photo_[sanitize(feed.channel_name)]_[i].png"
+					send_asset(user.client, resource_name)
+					story["photo_dat"] = "<img src='[resource_name]' width='180'><br>"
+				story["story_ref"] = "\ref[message]"
+				data["active_stories"] += list(story)
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "newscast.tmpl", name, 450, 600, state = state)
+		ui.auto_update_layout = 1
+		ui.set_auto_update(1)
+		ui.set_initial_data(data)
+		ui.open()
+
+#undef NEWSCAST_HOME
+#undef NEWSCAST_VIEW_CHANNEL

--- a/nano/templates/newscast.tmpl
+++ b/nano/templates/newscast.tmpl
@@ -1,0 +1,54 @@
+{{if data.has_network}}
+	{{if data.prog_state == 1}} <!-- NEWSCAST_HOME - Display channels and date/time -->
+		<table style="width:100%">
+			<tr>
+			<td>Interface and networks operational.
+			<tr>
+			<td>{{:data.time_blurb}}
+			<tr>
+			<td>{{:data.notifs_blurb}}
+			<td>{{:helper.link(data.notifs_enabled ? "Disable" : "Enable", data.notifs_enabled ? 'volume-off' : 'volume-o', {'toggle_notifs' : 1})}}
+		</table>
+		<h3><u>Connected channels</u></h3>
+		<table style="width:100%">
+			{{for data.channels}}
+				<tr>
+				{{if value.censored}}
+					<td>{{:helper.link(value.name, null, {'view_channel' : value.ref})}} <font color='red'>***</font>
+				{{else}}
+					<td>{{:helper.link(value.name, null, {'view_channel' : value.ref})}}
+				{{/if}}
+			{{empty}}
+				<p><font color='red'><h2><b>NO CHANNELS FOUND</b></h2>Couldn't locate any channels on the local NTNet instance. Please try again in a few minutes.</font></p>
+			{{/for}}
+		</table>
+	{{else data.prog_state == 2}} <!-- NEWSCAST_VIEW_CHANNEL - Show the contents of the active channel -->
+		{{for data.active_channels}}
+			<h3><u>{{:value.name}}</u></h3>
+			<i><font size=1>Created by <font color="#cc9090">{{:value.author}}</font></font></i>
+			<hr>
+			{{if value.censored}}
+				{{:data.dnotice_blurb}}<br><br> <!-- no reading for you, pensive -->
+			{{else}}
+				{{for data.active_stories}}
+					<br>"{{:value.body}}"<br>
+					{{if value.has_photo}}
+						<br>
+						<table style="width:100%">
+							<tr>
+							<td>{{:value.photo_dat}}<br>
+							<!--<td>{{:helper.link("View photo", null, {'view_photo' : value.story_ref})}}-->
+						</table>
+					{{/if}}
+					<i><font size=1>Story by <font color="#cc9090">{{:value.author}}</font> at {{:value.timestamp}}</font></i>
+					<br><br><hr>
+				{{empty}}
+					<p><i>This network has submitted no stories during the current time slot. Please use network-specific sites, apps, and archives to access stories submitted outside of this time slot.</i></p>
+				{{/for}}
+			{{/if}}
+		{{/for}}
+		{{:helper.link("Return", 'arrowreturnthick-1-w', {'return_to_home' : 1})}}
+	{{/if}}
+{{else}}
+	<p><font color='red'><h2><b>NO NETWORK FOUND</b></h2>Couldn't fetch news data from a feed network. Ensure you have a connection to NTNet and there is a network broadcaster in your sector.</font></p>
+{{/if}}


### PR DESCRIPTION
🆑
rscadd: Added the Newscast program to computers. Acts like a read-only newscaster, but on your PDA, Tablet, or Console. Comes installed on PDAs by default.
/🆑

Will squash commits once it's been reviewed.

This MR does what it says on the tin. A news app is among the most basic things you'd expect to find on a device with a connection to a network, and here one is.
* Adds a new program, Newscast. It takes up 4 GQ. PDAs have it by default. All machines can download it.
* Newscast uses a NanoUI interface. You can browse news channels and see their submitted stories. Unlike a proper newscaster, you can't create new channels or submit stories. You also don't see "Wanted" notices - this is primarily because it'd be pretty messy with NanoUI, but it might be something to look into in the future.
* While the program is open or minimized, you'll get pings when a new story gets posted. You can enable or disable these notifications at your leisure.
* Unlike regular newscasters, message bodies are automatically encapsulated in quotes; this is because the NanoUI window has more visual noise to it, and coupled with the dark mode, makes it less smooth to read.
* Author and feed censorship are compatible. D-Notices on channels are compatible. Supports photos attached to stories.

This might pave the way for further revamps of the newscaster system, which is very old code and bad in a lot of ways. If people end up hating the missing hard drive space from pre-installed Newscast, I'm okay with removing it from the default.

Media:
<details>
<summary>Home screen (incl. default channels and user-made ones)</summary>

![tPgwQD2RDl](https://user-images.githubusercontent.com/47678781/107754695-d915cc00-6cef-11eb-9460-bfd3f2540a98.png)

</details>

<details>
<summary>Feed view 1</summary>

![lVs7qqiAmP](https://user-images.githubusercontent.com/47678781/107754754-edf25f80-6cef-11eb-9bce-1f288414f6e7.png)

</details>

<details>
<summary>Feed view 2</summary>

![duYpifDJ7S](https://user-images.githubusercontent.com/47678781/107754780-f5196d80-6cef-11eb-9816-907db8eca17f.png)

</details>

<details>
<summary>D-Notice on home screen</summary>

![EktVr9vSxq](https://user-images.githubusercontent.com/47678781/107754844-0c585b00-6cf0-11eb-99c2-c5e6f546074d.png)

</details>

<details>
<summary>D-Notice in channel</summary>

![Z9WAFheNT7](https://user-images.githubusercontent.com/47678781/107754869-1417ff80-6cf0-11eb-87f4-d8a7ff9df740.png)

</details>