### PR TITLE
Refresh main menu on game start and character swap

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -99,6 +99,9 @@ SUBSYSTEM_DEF(ticker)
 		to_world("<span class='info'><B>Enjoy the game!</B></span>")
 		sound_to(world, sound(GLOB.using_map.welcome_sound))
 
+		for (var/mob/new_player/player in GLOB.player_list)
+			player.new_player_panel()
+
 	if(!length(GLOB.admins))
 		send2adminirc("Round has started with no admins online.")
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -190,6 +190,10 @@ datum/preferences
 		load_character(text2num(href_list["changeslot"]))
 		sanitize_preferences()
 		close_load_dialog(usr)
+
+		if (istype(client.mob, /mob/new_player))
+			var/mob/new_player/M = client.mob
+			M.new_player_panel()
 	else if(href_list["resetslot"])
 		if(real_name != input("This will reset the current slot. Enter the character's full name to confirm."))
 			return 0


### PR DESCRIPTION
🆑 Mucker
tweak: The main welcome menu now auto refreshes when swapping characters or when the game starts.
/🆑