### PR TITLE
removes text/regex signature disparity between 512 and 513+

### DIFF
--- a/code/__datastructures/priority_queue.dm
+++ b/code/__datastructures/priority_queue.dm
@@ -38,7 +38,7 @@
 
 //return the position of an element or 0 if not found
 /PriorityQueue/proc/Seek(atom/A)
-	. = L.Find(A)
+	. = list_find(L, A)
 
 //return the element at the i_th position
 /PriorityQueue/proc/Get(i)

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -568,7 +568,7 @@ proc/TextPreview(var/string,var/len=40)
 // If char isn't part of the text the entire text is returned
 /proc/copytext_after_last(var/text, var/char)
 	var/regex/R = regex("(\[^[char]\]*)$")
-	R.Find(text)
+	regex_find(R, text)
 	return R.group[1]
 
 /proc/sql_sanitize_text(var/text)
@@ -595,5 +595,5 @@ proc/TextPreview(var/string,var/len=40)
 	if (message && length(config.chat_markup))
 		for (var/list/entry in config.chat_markup)
 			var/regex/matcher = entry[1]
-			message = matcher.Replace(message, entry[2])
+			message = replacetext_char(message, matcher, entry[2])
 	return message

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -183,7 +183,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 
 /proc/get_weekday_index()
 	var/list/weekdays = list("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
-	return weekdays.Find(time2text(world.timeofday, "DDD"))
+	return list_find(weekdays, time2text(world.timeofday, "DDD"))
 
 /proc/current_month_and_day()
 	var/time_string = time2text(world.realtime, "MM-DD")

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -603,8 +603,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 //Takes: Anything that could possibly have variables and a varname to check.
 //Returns: 1 if found, 0 if not.
 /proc/hasvar(var/datum/A, var/varname)
-	if(A.vars.Find(lowertext(varname))) return 1
-	else return 0
+	return !!list_find(A.vars, lowertext(varname))
 
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all areas of that type in the world.

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -2,11 +2,37 @@
 
 #if DM_VERSION < 513
 
-#define islist(A) istype(A, /list)
+	#define islist(A) istype(A, /list)
+	#define ismovable(A) istype(A, /atom/movable)
 
-#define ismovable(A) istype(A, /atom/movable)
+	#define copytext_char(ARGS...) copytext(##ARGS)
+	#define findlasttext_char(ARGS...) findlasttext(##ARGS)
+	#define findlasttextEx_char(ARGS...) findlasttextEx(##ARGS)
+	#define findtext_char(ARGS...) findtext(##ARGS)
+	#define findtextEx_char(ARGS...) findtextEx(##ARGS)
+	#define length_char(X) length(X)
+	#define nonspantext_char(ARGS...) nonspantext(##ARGS)
+	#define replacetext_char(ARGS...) replacetext(##ARGS)
+	#define replacetextEx_char(ARGS...) replacetextEx(##ARGS)
+	#define spantext_char(ARGS...) spantext(##ARGS)
+	#define splittext_char(ARGS...) splittext(##ARGS)
+	#define text2ascii_char(ARGS...) text2ascii(##ARGS)
+
+	#define regex_replace_char(RE, ARGS...) RE.Replace(##ARGS)
+	#define regex_replace(RE, ARGS...) RE.Replace(##ARGS)
+	#define regex_find_char(RE, ARGS...) RE.Find(##ARGS)
+	#define regex_find(RE, ARGS...) RE.Find(##ARGS)
+
+#else //513+
+
+	#define regex_replace_char(RE, ARGS...) RE.Replace_char(##ARGS)
+	#define regex_replace(RE, ARGS...) RE.Replace(##ARGS)
+	#define regex_find_char(RE, ARGS...) RE.Find_char(##ARGS)
+	#define regex_find(RE, ARGS...) RE.Find(##ARGS)
 
 #endif
+
+#define list_find(L, needle, LIMITS...) L.Find(needle, ##LIMITS)
 
 #define PUBLIC_GAME_MODE SSticker.master_mode
 

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -5,34 +5,34 @@
 	#define islist(A) istype(A, /list)
 	#define ismovable(A) istype(A, /atom/movable)
 
-	#define copytext_char(ARGS...) copytext(##ARGS)
-	#define findlasttext_char(ARGS...) findlasttext(##ARGS)
-	#define findlasttextEx_char(ARGS...) findlasttextEx(##ARGS)
-	#define findtext_char(ARGS...) findtext(##ARGS)
-	#define findtextEx_char(ARGS...) findtextEx(##ARGS)
+	#define copytext_char(ARGS...) copytext(ARGS)
+	#define findlasttext_char(ARGS...) findlasttext(ARGS)
+	#define findlasttextEx_char(ARGS...) findlasttextEx(ARGS)
+	#define findtext_char(ARGS...) findtext(ARGS)
+	#define findtextEx_char(ARGS...) findtextEx(ARGS)
 	#define length_char(X) length(X)
-	#define nonspantext_char(ARGS...) nonspantext(##ARGS)
-	#define replacetext_char(ARGS...) replacetext(##ARGS)
-	#define replacetextEx_char(ARGS...) replacetextEx(##ARGS)
-	#define spantext_char(ARGS...) spantext(##ARGS)
-	#define splittext_char(ARGS...) splittext(##ARGS)
-	#define text2ascii_char(ARGS...) text2ascii(##ARGS)
+	#define nonspantext_char(ARGS...) nonspantext(ARGS)
+	#define replacetext_char(ARGS...) replacetext(ARGS)
+	#define replacetextEx_char(ARGS...) replacetextEx(ARGS)
+	#define spantext_char(ARGS...) spantext(ARGS)
+	#define splittext_char(ARGS...) splittext(ARGS)
+	#define text2ascii_char(ARGS...) text2ascii(ARGS)
 
-	#define regex_replace_char(RE, ARGS...) RE.Replace(##ARGS)
-	#define regex_replace(RE, ARGS...) RE.Replace(##ARGS)
-	#define regex_find_char(RE, ARGS...) RE.Find(##ARGS)
-	#define regex_find(RE, ARGS...) RE.Find(##ARGS)
+	#define regex_replace_char(RE, ARGS...) RE.Replace(ARGS)
+	#define regex_replace(RE, ARGS...) RE.Replace(ARGS)
+	#define regex_find_char(RE, ARGS...) RE.Find(ARGS)
+	#define regex_find(RE, ARGS...) RE.Find(ARGS)
 
 #else //513+
 
-	#define regex_replace_char(RE, ARGS...) RE.Replace_char(##ARGS)
-	#define regex_replace(RE, ARGS...) RE.Replace(##ARGS)
-	#define regex_find_char(RE, ARGS...) RE.Find_char(##ARGS)
-	#define regex_find(RE, ARGS...) RE.Find(##ARGS)
+	#define regex_replace_char(RE, ARGS...) RE.Replace_char(ARGS)
+	#define regex_replace(RE, ARGS...) RE.Replace(ARGS)
+	#define regex_find_char(RE, ARGS...) RE.Find_char(ARGS)
+	#define regex_find(RE, ARGS...) RE.Find(ARGS)
 
 #endif
 
-#define list_find(L, needle, LIMITS...) L.Find(needle, ##LIMITS)
+#define list_find(L, needle, LIMITS...) L.Find(needle, LIMITS)
 
 #define PUBLIC_GAME_MODE SSticker.master_mode
 

--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -45,7 +45,7 @@ SUBSYSTEM_DEF(codex)
 	. = ..()
 
 /datum/controller/subsystem/codex/proc/parse_links(string, viewer)
-	while(linkRegex.Find(string))
+	while(regex_find(linkRegex, string))
 		var/key = linkRegex.group[4]
 		if(linkRegex.group[2])
 			key = linkRegex.group[3]

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -316,7 +316,7 @@ SUBSYSTEM_DEF(jobs)
 		for(var/mob/new_player/player in unassigned_roundstart)
 			// Loop through all jobs
 			for(var/datum/job/job in shuffledoccupations) // SHUFFLE ME BABY
-				if(job && !mode.disabled_jobs.Find(job.title) )
+				if(job && !list_find(mode.disabled_jobs, job.title))
 					if(job.defer_roundstart_spawn)
 						deferred_jobs[job] = TRUE
 					else if(attempt_role_assignment(player, job, level, mode))

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(mapping)
 		if (banned_maps)
 			var/is_banned = FALSE
 			for (var/mappath in MT.mappaths)
-				if(banned_maps.Find(mappath))
+				if(list_find(banned_maps, mappath))
 					is_banned = TRUE
 					break
 			if (is_banned)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -188,13 +188,13 @@
 	laws.internal_delete_law(laws.inherent_laws, laws.state_inherent, src)
 
 /datum/ai_law/supplied/delete_law(var/datum/ai_laws/laws)
-	var/index = laws.supplied_laws.Find(src)
+	var/index = list_find(laws.supplied_laws, src)
 	if(index)
 		laws.supplied_laws[index] = ""
 		laws.state_supplied[index] = 1
 
 /datum/ai_laws/proc/internal_delete_law(var/list/datum/ai_law/laws, var/list/state, var/list/datum/ai_law/law)
-	var/index = laws.Find(law)
+	var/index = list_find(laws, law)
 	if(index)
 		laws -= law
 		for(index, index < state.len, index++)
@@ -255,7 +255,7 @@
 	return laws.get_state_internal(laws.supplied_laws, laws.state_supplied, src)
 
 /datum/ai_laws/proc/get_state_internal(var/list/datum/ai_law/laws, var/list/state, var/list/datum/ai_law/law)
-	var/index = laws.Find(law)
+	var/index = list_find(laws, law)
 	if(index)
 		return state[index]
 	return 0
@@ -282,6 +282,6 @@
 	laws.set_state_law_internal(laws.supplied_laws, laws.state_supplied, src, state)
 
 /datum/ai_laws/proc/set_state_law_internal(var/list/datum/ai_law/laws, var/list/state, var/list/datum/ai_law/law, var/do_state)
-	var/index = laws.Find(law)
+	var/index = list_find(laws, law)
 	if(index)
 		state[index] = do_state

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -272,7 +272,7 @@
 		if (href_list["obj_edit"])
 			objective = locate(href_list["obj_edit"])
 			if (!objective) return
-			objective_pos = objectives.Find(objective)
+			objective_pos = list_find(objectives, objective)
 
 			//Text strings are easy to manipulate. Revised for simplicity.
 			var/temp_obj_type = "[objective.type]"//Convert path into a text string.

--- a/code/datums/security_state.dm
+++ b/code/datums/security_state.dm
@@ -64,8 +64,8 @@
 		comm_console_security_levels += security_level
 
 	// Now we ensure the high security level is not above the severe one (but we allow them to be equal)
-	var/severe_index = all_security_levels.Find(severe_security_level)
-	var/high_index = all_security_levels.Find(high_security_level)
+	var/severe_index = list_find(all_security_levels, severe_security_level)
+	var/high_index = list_find(all_security_levels, high_security_level)
 	if(high_index > severe_index)
 		high_security_level = severe_security_level
 
@@ -83,20 +83,20 @@
 	return given_security_level in standard_security_levels
 
 /decl/security_state/proc/current_security_level_is_lower_than(var/given_security_level)
-	var/current_index = all_security_levels.Find(current_security_level)
-	var/given_index   = all_security_levels.Find(given_security_level)
+	var/current_index = list_find(all_security_levels, current_security_level)
+	var/given_index   = list_find(all_security_levels, given_security_level)
 
 	return given_index && current_index < given_index
 
 /decl/security_state/proc/current_security_level_is_same_or_higher_than(var/given_security_level)
-	var/current_index = all_security_levels.Find(current_security_level)
-	var/given_index   = all_security_levels.Find(given_security_level)
+	var/current_index = list_find(all_security_levels, current_security_level)
+	var/given_index   = list_find(all_security_levels, given_security_level)
 
 	return given_index && current_index >= given_index
 
 /decl/security_state/proc/current_security_level_is_higher_than(var/given_security_level)
-	var/current_index = all_security_levels.Find(current_security_level)
-	var/given_index   = all_security_levels.Find(given_security_level)
+	var/current_index = list_find(all_security_levels, current_security_level)
+	var/given_index   = list_find(all_security_levels, given_security_level)
 
 	return given_index && current_index > given_index
 
@@ -111,8 +111,8 @@
 	var/decl/security_level/previous_security_level = current_security_level
 	current_security_level = new_security_level
 
-	var/previous_index = all_security_levels.Find(previous_security_level)
-	var/new_index      = all_security_levels.Find(new_security_level)
+	var/previous_index = list_find(all_security_levels, previous_security_level)
+	var/new_index      = list_find(all_security_levels, new_security_level)
 
 	if(new_index > previous_index)
 		previous_security_level.switching_up_from()
@@ -130,7 +130,7 @@
 
 // This proc decreases the current security level, if possible
 /decl/security_state/proc/decrease_security_level(var/force_change = FALSE)
-	var/current_index = all_security_levels.Find(current_security_level)
+	var/current_index = list_find(all_security_levels, current_security_level)
 	if(current_index == 1)
 		return FALSE
 	return set_security_level(all_security_levels[current_index - 1], force_change)

--- a/code/datums/vote/vote.dm
+++ b/code/datums/vote/vote.dm
@@ -87,7 +87,7 @@
 			
 // Remove candidate from choice_list and any votes for it from vote_list, transfering first choices to second
 /datum/vote/proc/remove_candidate(list/choice_list, list/vote_list, candidate)
-	var/candidate_index = choices.Find(candidate) // use choices instead of choice_list because we need the original indexing
+	var/candidate_index = list_find(choices, candidate) // use choices instead of choice_list because we need the original indexing
 	choice_list -= candidate
 	for(var/ckey in vote_list)
 		if(length(votes[ckey]) && vote_list[ckey][1] == candidate_index && length(vote_list[ckey]) > 1)
@@ -196,7 +196,7 @@
 		. += "<td style='text-align: center;'>"
 		if(voted_for)
 			var/list/vote = votes[user.ckey]
-			. += "[vote.Find(i)]"
+			. += "[list_find(vote, i)]"
 		. += "</td>"
 
 		if (additional_text[choice])

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -355,7 +355,7 @@ its easier to just keep the beam vertical.
 	var/list/y_arr = null
 	for(cur_x=1,cur_x<=GLOB.global_map.len,cur_x++)
 		y_arr = GLOB.global_map[cur_x]
-		cur_y = y_arr.Find(src.z)
+		cur_y = list_find(y_arr, src.z)
 		if(cur_y)
 			break
 //	log_debug("X = [cur_x]; Y = [cur_y]")

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -122,12 +122,12 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	// FIXME:  Species-specific defaults pls
 	if(!character.h_style)
 		character.h_style = "Skinhead"
-	var/hair = GLOB.hair_styles_list.Find(character.h_style)
+	var/hair = list_find(GLOB.hair_styles_list, character.h_style)
 
 	// Facial Hair
 	if(!character.f_style)
 		character.f_style = "Shaved"
-	var/beard	= GLOB.facial_hair_styles_list.Find(character.f_style)
+	var/beard	= list_find(GLOB.facial_hair_styles_list, character.f_style)
 
 	SetUIValueRange(DNA_UI_HAIR_R,    character.r_hair,    255,    1)
 	SetUIValueRange(DNA_UI_HAIR_G,    character.g_hair,    255,    1)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -74,7 +74,7 @@
 
 	//Actually enforce the air sharing
 	var/datum/pipe_network/network = connected_port.return_network(src)
-	if(network && !network.gases.Find(air_contents))
+	if(network && !list_find(network.gases, air_contents))
 		network.gases += air_contents
 		network.update = 1
 

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -69,7 +69,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+		if((list_find(usr.contents, src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 			usr.set_machine(src)
 
 			if(href_list["inject1"])

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -470,7 +470,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 /obj/machinery/newscaster/Topic(href, href_list)
 	if(..())
 		return
-	if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((list_find(usr.contents, src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 		if(href_list["set_channel_name"])
 			src.channel_name = sanitizeSafe(input(usr, "Provide a Feed Channel Name", "Network Channel Handler", ""), MAX_LNAME_LEN)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -154,7 +154,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/turf/T_position = get_turf(T)
 	if((position.z == T_position.z) || (src.long_range_link && T.long_range_link))
 		for(var/x in autolinkers)
-			if(T.autolinkers.Find(x))
+			if(list_find(T.autolinkers, x))
 				if(src != T)
 					links |= T
 

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -100,7 +100,7 @@ var/global/list/image/fluidtrack_cache=list()
 				stack.Remove(track)
 			track=new /datum/fluidtrack(b,bloodcolor,t)
 			stack.Add(track)
-			setdirs["[b]"]=stack.Find(track)
+			setdirs["[b]"]=list_find(stack, track)
 			updatedtracks |= b
 			updated=1
 
@@ -117,7 +117,7 @@ var/global/list/image/fluidtrack_cache=list()
 				stack.Remove(track)
 			track=new /datum/fluidtrack(b,bloodcolor,t)
 			stack.Add(track)
-			setdirs["[b]"]=stack.Find(track)
+			setdirs["[b]"]=list_find(stack, track)
 			updatedtracks |= b
 			updated=1
 

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -25,7 +25,7 @@
 
 /obj/item/weapon/contraband/poster/Initialize()
 	var/list/posters = subtypesof(/decl/poster)
-	var/serial_number = posters.Find(poster_type)
+	var/serial_number = list_find(posters, poster_type)
 	name += " - No. [serial_number]"
 
 	return ..()

--- a/code/game/objects/items/ascent.dm
+++ b/code/game/objects/items/ascent.dm
@@ -9,7 +9,7 @@
 	var/list/tool_modes = list("wrench", "wirecutters", "crowbar", "screwdriver")
 
 /obj/item/clustertool/attack_self(var/mob/user)
-	var/new_index = tool_modes.Find(tool_mode) + 1
+	var/new_index = list_find(tool_modes, tool_mode) + 1
 	if(new_index > tool_modes.len)
 		new_index = 1
 	tool_mode = tool_modes[new_index]

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -102,7 +102,7 @@
 
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	..()
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
+	if((over_object == usr && (in_range(src, usr) || list_find(usr.contents, src))))
 		fold(usr)
 
 /obj/item/robot_rack/body_bag

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -46,7 +46,7 @@
 	if(!is_type_in_list(target, supported_types))
 		to_chat(user, "[icon2html(src, user)] <span class='warning'>Unable to hack this target.</span>")
 		return 0
-	var/found = known_targets.Find(target)
+	var/found = list_find(known_targets, target)
 	if(found)
 		known_targets.Swap(1, found)	// Move the last hacked item first
 		return 1

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -43,7 +43,7 @@
 	//..()
 	if(usr.stat || usr.restrained())
 		return
-	if(((istype(usr, /mob/living/carbon/human) && (usr.IsAdvancedToolUser() && usr.contents.Find(src))) || (usr.contents.Find(master) || (in_range(src, usr) && istype(loc, /turf)))))
+	if(((istype(usr, /mob/living/carbon/human) && (usr.IsAdvancedToolUser() && list_find(usr.contents, src))) || (list_find(usr.contents, master) || (in_range(src, usr) && istype(loc, /turf)))))
 		usr.set_machine(src)
 		if(href_list["freq"])
 			var/new_frequency = sanitize_frequency(frequency + text2num(href_list["freq"]))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -388,7 +388,7 @@
 /obj/item/weapon/storage/attack_self(mob/user as mob)
 	//Clicking on itself will empty it, if it has the verb to do that.
 	if(user.get_active_hand() == src)
-		if(src.verbs.Find(/obj/item/weapon/storage/verb/quick_empty))
+		if(list_find(src.verbs, /obj/item/weapon/storage/verb/quick_empty))
 			src.quick_empty()
 			return 1
 

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -51,7 +51,7 @@ Frequency:
 	if(!current_location||current_location.z==2)//If turf was not found or they're on z level 2.
 		to_chat(usr, "The [src] is malfunctioning.")
 		return
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
+	if ((list_find(usr.contents, src) || (in_range(src, usr) && istype(src.loc, /turf))))
 		usr.set_machine(src)
 		if (href_list["refresh"])
 			src.temp = "<B>Persistent Signal Locator</B><HR>"

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -338,7 +338,7 @@
 		return
 	if(user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis)
 		return
-	if((!( istype(O, /atom/movable) ) || O.anchored || !Adjacent(user) || !Adjacent(O) || !user.Adjacent(O) || user.contents.Find(src)))
+	if((!( istype(O, /atom/movable) ) || O.anchored || !Adjacent(user) || !Adjacent(O) || !user.Adjacent(O) || list_find(user.contents, src)))
 		return
 	if(!isturf(user.loc)) // are you in a container/closet/pod/etc?
 		return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -73,7 +73,7 @@
 		src.connected = new /obj/structure/m_tray( src.loc )
 		step(src.connected, src.dir)
 		var/turf/T = get_step(src, src.dir)
-		if (T.contents.Find(src.connected))
+		if (list_find(T.contents, src.connected))
 			src.connected.connected = src
 			src.icon_state = "morgue0"
 			for(var/atom/movable/A as mob|obj in src)
@@ -113,7 +113,7 @@
 	src.connected = new /obj/structure/m_tray( src.loc )
 	step(src.connected, EAST)
 	var/turf/T = get_step(src, EAST)
-	if (T.contents.Find(src.connected))
+	if (list_find(T.contents, src.connected))
 		src.connected.connected = src
 		src.icon_state = "morgue0"
 		for(var/atom/movable/A as mob|obj in src)
@@ -159,7 +159,7 @@
 	return
 
 /obj/structure/m_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
+	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || list_find(user.contents, src) || list_find(user.contents, O)))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return
@@ -246,7 +246,7 @@
 		src.connected = new /obj/structure/c_tray(src.loc)
 		step(src.connected, dir)
 		var/turf/T = get_step(src, dir)
-		if (T.contents.Find(src.connected))
+		if (list_find(T.contents, src.connected))
 			src.connected.connected = src
 			src.icon_state = "crema0"
 			for(var/atom/movable/A as mob|obj in src)
@@ -279,7 +279,7 @@
 	src.connected = new /obj/structure/c_tray( src.loc )
 	step(src.connected, SOUTH)
 	var/turf/T = get_step(src, SOUTH)
-	if (T.contents.Find(src.connected))
+	if (list_find(T.contents, src.connected))
 		src.connected.connected = src
 		src.icon_state = "crema0"
 		for(var/atom/movable/A as mob|obj in src)
@@ -408,7 +408,7 @@
 	return
 
 /obj/structure/c_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
+	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || list_find(user.contents, src) || list_find(user.contents, O)))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -458,7 +458,7 @@ obj/structure/ex_act(severity)
 
 	tube_dirs = select_automatic_dirs(connected)
 
-	if(length(tube_dirs) == 2 && tube_dir_list.Find(tube_dirs[1]) > tube_dir_list.Find(tube_dirs[2]))
+	if(length(tube_dirs) == 2 && list_find(tube_dir_list, tube_dirs[1]) > list_find(tube_dir_list, tube_dirs[2]))
 		tube_dirs.Swap(1, 2)
 
 	generate_automatic_corners(tube_dirs)

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -98,7 +98,7 @@ proc/percentage_antagonists()
 proc/increment_ert_chance()
 	while(send_emergency_team == 0) // There is no ERT at the time.
 		var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-		var/index = security_state.all_security_levels.Find(security_state.current_security_level)
+		var/index = list_find(security_state.all_security_levels, security_state.current_security_level)
 		ert_base_chance += 2**index
 		sleep(600 * 3) // Minute * Number of Minutes
 

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -68,11 +68,11 @@ var/savefile/Banlist
 
 	if (!length(Banlist.dir)) log_admin("Banlist is empty.")
 
-	if (!Banlist.dir.Find("base"))
+	if (!list_find(Banlist.dir, "base"))
 		log_admin("Banlist missing base dir.")
 		Banlist.dir.Add("base")
 		Banlist.cd = "/base"
-	else if (Banlist.dir.Find("base"))
+	else if (list_find(Banlist.dir, "base"))
 		Banlist.cd = "/base"
 
 	ClearTempbans()
@@ -105,7 +105,7 @@ var/savefile/Banlist
 		bantimestamp = CMinutes + minutes
 
 	Banlist.cd = "/base"
-	if ( Banlist.dir.Find("[ckey][computerid]") )
+	if (list_find(Banlist.dir, "[ckey][computerid]"))
 		to_chat(usr, "<span class='warning'>Ban already exists.</span>")
 		return 0
 	else if (!ckey)

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -52,7 +52,7 @@
 	var/list/note_keys
 	from_save(note_list, note_keys)
 	if(!note_keys) note_keys = list()
-	if(!note_keys.Find(key)) note_keys += key
+	if(!list_find(note_keys, key)) note_keys += key
 	to_save(note_list, note_keys)
 	del(note_list) // savefile, so NOT qdel
 

--- a/code/modules/admin/secrets/admin_secrets/prison_warp.dm
+++ b/code/modules/admin/secrets/admin_secrets/prison_warp.dm
@@ -14,7 +14,7 @@
 	for(var/mob/living/carbon/human/H in SSmobs.mob_list)
 		var/turf/T = get_turf(H)
 		var/security = 0
-		if((T && (T in GLOB.using_map.admin_levels)) || GLOB.prisonwarped.Find(H))
+		if((T && (T in GLOB.using_map.admin_levels)) || list_find(GLOB.prisonwarped, H))
 		//don't warp them if they aren't ready or are already there
 			continue
 		H.Paralyse(5)

--- a/code/modules/admin/verbs/BrokenInhands.dm
+++ b/code/modules/admin/verbs/BrokenInhands.dm
@@ -11,19 +11,19 @@
 		if(!O) continue
 		var/icon/J = new(O.icon)
 		var/list/istates = J.IconStates()
-		if(!Lstates.Find(O.icon_state) && !Lstates.Find(O.item_state))
+		if(!list_find(Lstates, O.icon_state) && !list_find(Lstates, O.item_state))
 			if(O.icon_state)
 				text += "[O.type] is missing left hand icon called \"[O.icon_state]\".\n"
-		if(!Rstates.Find(O.icon_state) && !Rstates.Find(O.item_state))
+		if(!list_find(Rstates, O.icon_state) && !list_find(Rstates, O.item_state))
 			if(O.icon_state)
 				text += "[O.type] is missing right hand icon called \"[O.icon_state]\".\n"
 
 
 		if(O.icon_state)
-			if(!istates.Find(O.icon_state))
+			if(!list_find(istates, O.icon_state))
 				text += "[O.type] is missing normal icon called \"[O.icon_state]\" in \"[O.icon]\".\n"
 		//if(O.item_state)
-		//	if(!istates.Find(O.item_state))
+		//	if(!list_find(istates, O.item_state))
 		//		text += "[O.type] MISSING NORMAL ICON CALLED\n\"[O.item_state]\" IN \"[O.icon]\"\n"
 		//text+="\n"
 		qdel(O)

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -139,7 +139,7 @@
 										temp.SDQL_update(v, SDQL_expression(d, set_list[sets]))
 										break
 
-									if(temp.vars.Find(v) && (istype(temp.vars[v], /datum) || istype(temp.vars[v], /client)))
+									if(list_find(temp.vars, v) && (istype(temp.vars[v], /datum) || istype(temp.vars[v], /client)))
 										temp = temp.vars[v]
 
 									else

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
@@ -242,7 +242,7 @@
 		parse_error("Expected either FROM, IN or WHERE token, found [token(i)] instead.")
 		return i + 1
 
-	if (!node.Find("from"))
+	if (!list_find(node, "from"))
 		node["from"] = list("world")
 
 	return i

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_std.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_std.dm
@@ -166,7 +166,7 @@
 	L.Cut(Start, End)
 
 /proc/_list_find(var/list/L, var/Elem, var/Start = 1, var/End = 0)
-	return L.Find(Elem, Start, End)
+	return list_find(L, Elem, Start, End)
 
 /proc/_list_insert(var/list/L, var/Index, var/Item)
 	return L.Insert(Index, Item)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -235,7 +235,7 @@
 	if(assoc)
 		original_var = L[assoc_key]
 	else
-		original_var = L[L.Find(variable)]
+		original_var = L[list_find(L, variable)]
 
 	var/new_var
 	switch(class) //Spits a runtime error if you try to modify an entry in the contents list. Dunno how to fix it, yet.
@@ -248,7 +248,7 @@
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("edit referenced object")
 			modify_variables(variable)
@@ -265,49 +265,49 @@
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("num")
 			new_var = input("Enter new number:","Num") as num
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("type")
 			new_var = input("Enter type:","Type") in typesof(/obj,/mob,/area,/turf)
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("reference")
 			new_var = input("Select reference:","Reference") as mob|obj|turf|area in world
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("mob reference")
 			new_var = input("Select reference:","Reference") as mob in world
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("file")
 			new_var = input("Pick file:","File") as file
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("icon")
 			new_var = input("Pick icon:","Icon") as icon
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 		if("marked datum")
 			new_var = holder.marked_datum()
@@ -316,7 +316,7 @@
 			if(assoc)
 				L[assoc_key] = new_var
 			else
-				L[L.Find(variable)] = new_var
+				L[list_find(L, variable)] = new_var
 
 	to_world_log("### ListVarEdit by [src]: [O.type] [objectvar]: [original_var]=[new_var]")
 	log_admin("[key_name(src)] modified [original_name]'s [objectvar]: [original_var]=[new_var]")

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -28,7 +28,7 @@
 	else if(reference == node2)
 		network2 = new_network
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
+++ b/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
@@ -143,7 +143,7 @@
 		else if(reference == node2)
 			network2 = new_network
 
-		if(new_network.normal_members.Find(src))
+		if(list_find(new_network.normal_members, src))
 			return 0
 
 		new_network.normal_members += src

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -60,7 +60,7 @@
 		if(P.update)
 			if(output == P)
 				output = null
-			if(inputs.Find(P))
+			if(list_find(inputs, P))
 				inputs -= P
 
 			switch(P.mode)

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -218,7 +218,7 @@
 			P.network = new_network
 			break
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -54,7 +54,7 @@
 	if(reference == node)
 		network = new_network
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
@@ -37,7 +37,7 @@
 	else if (reference == node3)
 		network3 = new_network
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -66,7 +66,7 @@
 		if(!state)
 			network_node1 = new_network
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -22,7 +22,7 @@
 	if(reference == node)
 		network = new_network
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -55,7 +55,7 @@
 		if(open)
 			network_node1 = new_network
 
-	if(new_network.normal_members.Find(src))
+	if(list_find(new_network.normal_members, src))
 		return 0
 
 	new_network.normal_members += src

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -75,7 +75,7 @@
 				for(var/obj/machinery/atmospherics/pipe/item in result)
 					if(item.in_stasis)
 						continue
-					if(!members.Find(item))
+					if(!list_find(members, item))
 						members += item
 						possible_expansions += item
 
@@ -101,7 +101,7 @@
 
 /datum/pipeline/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 
-	if(new_network.line_members.Find(src))
+	if(list_find(new_network.line_members, src))
 		return 0
 
 	new_network.line_members += src

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -39,14 +39,14 @@
 	if(..())
 		return 1
 
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((list_find(usr.contents, src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		var/area/thearea = input("Area to jump bombard", "Open Fire") as null|anything in teleportlocs
 		thearea = thearea ? teleportlocs[thearea] : thearea
 		if (!thearea || CanUseTopic(usr, GLOB.physical_state) != STATUS_INTERACTIVE)
 			return
 		if (src.reload < 180)
 			return
-		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+		if ((list_find(usr.contents, src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 			command_announcement.Announce("Bluespace artillery fire detected. Brace for impact.")
 			log_and_message_admins("has launched an artillery strike.", 1)
 			var/list/L = list()

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -38,7 +38,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 		else
 			return 0
 
-	if(check_cache && (client.cache.Find(asset_name) || client.sending.Find(asset_name)))
+	if(check_cache && (list_find(client.cache, asset_name) || list_find(client.sending, asset_name)))
 		return 0
 
 	var/decl/asset_cache/asset_cache = decls_repository.get_decl(/decl/asset_cache)
@@ -57,7 +57,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 	var/t = 0
 	var/timeout_time = (ASSET_CACHE_SEND_TIMEOUT * client.sending.len) + ASSET_CACHE_SEND_TIMEOUT
-	while(client && !client.completed_asset_jobs.Find(job) && t < timeout_time) // Reception is handled in Topic()
+	while(client && !list_find(client.completed_asset_jobs, job) && t < timeout_time) // Reception is handled in Topic()
 		sleep(1) // Lock up the caller until this is received.
 		t++
 
@@ -105,7 +105,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 	var/t = 0
 	var/timeout_time = ASSET_CACHE_SEND_TIMEOUT * client.sending.len
-	while(client && !client.completed_asset_jobs.Find(job) && t < timeout_time) // Reception is handled in Topic()
+	while(client && !list_find(client.completed_asset_jobs, job) && t < timeout_time) // Reception is handled in Topic()
 		sleep(1) // Lock up the caller until this is received.
 		t++
 

--- a/code/modules/client/preference_setup/antagonism/02_setup.dm
+++ b/code/modules/client/preference_setup/antagonism/02_setup.dm
@@ -72,7 +72,7 @@
 		var/decl/uplink_source/US = locate(href_list["move_source_up"]) in pref.uplink_sources
 		if(!US)
 			return TOPIC_NOACTION
-		var/index = pref.uplink_sources.Find(US)
+		var/index = list_find(pref.uplink_sources, US)
 		if(index <= 1)
 			return TOPIC_NOACTION
 		pref.uplink_sources.Swap(index, index - 1)
@@ -82,7 +82,7 @@
 		var/decl/uplink_source/US = locate(href_list["move_source_down"]) in pref.uplink_sources
 		if(!US)
 			return TOPIC_NOACTION
-		var/index = pref.uplink_sources.Find(US)
+		var/index = list_find(pref.uplink_sources, US)
 		if(index >= pref.uplink_sources.len)
 			return TOPIC_NOACTION
 		pref.uplink_sources.Swap(index, index + 1)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -109,7 +109,7 @@ datum/preferences
 
 	S.cd = "/torch"
 	for(var/slot = 1 to 40)
-		if(!S.dir.Find("character[slot]"))
+		if(!list_find(S.dir, "character[slot]"))
 			continue
 		S.cd = "/torch/character[slot]"
 		default_slot = slot

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -302,7 +302,7 @@
 /stat_rig_module/Click()
 	if(CanUse())
 		var/list/href_list = list(
-							"interact_module" = module.holder.installed_modules.Find(module),
+							"interact_module" = list_find(module.holder.installed_modules, module),
 							"module_mode" = module_mode
 							)
 		AddHref(href_list)
@@ -360,7 +360,7 @@
 	module_mode = "select_charge_type"
 
 /stat_rig_module/charge/AddHref(var/list/href_list)
-	var/charge_index = module.charges.Find(module.charge_selected)
+	var/charge_index = list_find(module.charges, module.charge_selected)
 	if(!charge_index)
 		charge_index = 0
 	else

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -21,10 +21,10 @@ GLOBAL_VAR_INIT(actual_error_file_line, new/regex("^%% (.*?),(.*?) %% "))
 	var/eline = E.line
 
 	var/regex/actual_error_file_line = GLOB.actual_error_file_line
-	if(actual_error_file_line.Find(E.name))
+	if(regex_find(actual_error_file_line, E.name))
 		efile = actual_error_file_line.group[1]
 		eline = actual_error_file_line.group[2]
-		E.name = actual_error_file_line.Replace(E.name, "")
+		E.name = replacetext_char(E.name, actual_error_file_line, "")
 
 	var/erroruid = "[efile],[eline]"
 	var/last_seen = error_last_seen[erroruid]

--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -37,7 +37,7 @@ proc/NewStutter(phrase,stunned)
 			break
 		var/word = pick(unstuttered_words)
 		unstuttered_words -= word //Remove from unstuttered words so we don't stutter it again.
-		var/index = split_phrase.Find(word) //Find the word in the split phrase so we can replace it.
+		var/index = list_find(split_phrase, word) //Find the word in the split phrase so we can replace it.
 
 		//Search for dipthongs (two letters that make one sound.)
 		var/first_sound = copytext(word,1,3)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -233,7 +233,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/tmp/iconCache.sav")) //Cache o
 	//regex/Replace with a proc won't work here because icon2html takes target as an argument and there is no way to pass it to the replacement proc
 	//not even hacks with reassigning usr work
 	var/regex/i = new(@/<IMG CLASS=icon SRC=(\[[^]]+])(?: ICONSTATE='([^']+)')?>/, "g")
-	while(i.Find(message))
+	while(regex_find(i, message))
 		message = copytext(message,1,i.index)+icon2html(locate(i.group[1]), target, icon_state=i.group[2])+copytext(message,i.next)
 
 	if(trailing_newline)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -104,7 +104,7 @@
 /obj/machinery/computer/HolodeckControl/Topic(href, href_list)
 	if(..())
 		return 1
-	if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if((list_find(usr.contents, src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 
 		if(href_list["program"])

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -244,7 +244,7 @@
 
 			add_allowed_scanner(usr.ckey)
 
-			var/current_pos = assembly_components.Find(component)
+			var/current_pos = list_find(assembly_components, component)
 
 			if(href_list["remove"])
 				try_remove_component(component, usr)

--- a/code/modules/integrated_electronics/core/helpers.dm
+++ b/code/modules/integrated_electronics/core/helpers.dm
@@ -82,7 +82,7 @@
 			return
 		components = holder.assembly.assembly_components
 
-	var/component_number = components.Find(holder)
+	var/component_number = list_find(components, holder)
 
 	var/list/pin_holder_list
 	switch(pin_type)
@@ -95,7 +95,7 @@
 		else
 			return
 
-	var/pin_number = pin_holder_list.Find(src)
+	var/pin_number = list_find(pin_holder_list, src)
 
 	return list(component_number, pin_type, pin_number)
 

--- a/code/modules/integrated_electronics/core/special_pins/list_pin.dm
+++ b/code/modules/integrated_electronics/core/special_pins/list_pin.dm
@@ -68,7 +68,7 @@
 	if(holder.check_interactivity(user) && target_entry)
 		var/edited_entry = ask_for_data_type(user, target_entry)
 		if(edited_entry)
-			my_list[my_list.Find(target_entry)] = edited_entry
+			my_list[list_find(my_list, target_entry)] = edited_entry
 
 /datum/integrated_io/lists/proc/edit_in_list_by_position(mob/user, var/position)
 	var/list/my_list = data
@@ -96,8 +96,8 @@
 			second_target = input(user, "Which piece of data do you want to swap? (2)", "Swap") as null|anything in my_list - first_target
 
 		if(holder.check_interactivity(user) && second_target)
-			var/first_pos = my_list.Find(first_target)
-			var/second_pos = my_list.Find(second_target)
+			var/first_pos = list_find(my_list, first_target)
+			var/second_pos = list_find(my_list, second_target)
 			my_list.Swap(first_pos, second_pos)
 
 /datum/integrated_io/lists/proc/clear_list(mob/user)

--- a/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/code/modules/integrated_electronics/subtypes/lists.dm
@@ -90,7 +90,7 @@
 
 /obj/item/integrated_circuit/lists/search/do_work()
 	var/list/input_list = get_pin_data(IC_INPUT, 1)
-	var/output = input_list.Find(get_pin_data(IC_INPUT, 2))
+	var/output = list_find(input_list, get_pin_data(IC_INPUT, 2))
 
 	set_pin_data(IC_OUTPUT, 1, output)
 	push_data()

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -56,7 +56,7 @@
 			T.corners = list(null, null, null, null)
 
 		masters[T]   = diagonal
-		i            = LIGHTING_CORNER_DIAGONAL.Find(turn(diagonal, 180))
+		i            = list_find(LIGHTING_CORNER_DIAGONAL, turn(diagonal, 180))
 		T.corners[i] = src
 
 	// Now the horizontal one.
@@ -66,7 +66,7 @@
 			T.corners = list(null, null, null, null)
 
 		masters[T]   = ((T.x > x) ? EAST : WEST) | ((T.y > y) ? NORTH : SOUTH) // Get the dir based on coordinates.
-		i            = LIGHTING_CORNER_DIAGONAL.Find(turn(masters[T], 180))
+		i            = list_find(LIGHTING_CORNER_DIAGONAL, turn(masters[T], 180))
 		T.corners[i] = src
 
 	// And finally the vertical one.
@@ -76,7 +76,7 @@
 			T.corners = list(null, null, null, null)
 
 		masters[T]   = ((T.x > x) ? EAST : WEST) | ((T.y > y) ? NORTH : SOUTH) // Get the dir based on coordinates.
-		i            = LIGHTING_CORNER_DIAGONAL.Find(turn(masters[T], 180))
+		i            = list_find(LIGHTING_CORNER_DIAGONAL, turn(masters[T], 180))
 		T.corners[i] = src
 
 	update_active()

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -267,7 +267,7 @@
 	effect_str.Cut()
 
 /datum/light_source/proc/recalc_corner(var/datum/lighting_corner/C)
-	if(effect_str.Find(C)) // Already have one.
+	if(list_find(effect_str, C)) // Already have one.
 		REMOVE_CORNER(C)
 
 	APPLY_CORNER(C)

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -71,7 +71,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	var/list/atoms_to_initialise = list()
 	var/list/atoms_to_delete = list()
 
-	while(dmmRegex.Find(tfile, stored_index))
+	while(regex_find(dmmRegex, tfile, stored_index))
 		stored_index = dmmRegex.next
 
 		// "aa" = (/type{vars=blah})
@@ -419,12 +419,8 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 
 //text trimming (both directions) helper proc
 //optionally removes quotes before and after the text (for variable name)
-/dmm_suite/proc/trim_text(what as text,trim_quotes=0)
-	if(trim_quotes)
-		return trimQuotesRegex.Replace(what, "")
-	else
-		return trimRegex.Replace(what, "")
-
+/dmm_suite/proc/trim_text(text, trim_quotes)
+	return replacetext_char(text, trim_quotes ? trimQuotesRegex : trimRegex, "")
 
 //find the position of the next delimiter,skipping whatever is comprised between opening_escape and closing_escape
 //returns 0 if reached the last delimiter

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -38,7 +38,7 @@
 
 /mob/living/carbon/proc/get_breath_from_internal(var/volume_needed=STD_BREATH_VOLUME) //hopefully this will allow overrides to specify a different default volume without breaking any cases where volume is passed in.
 	if(internal)
-		if (!contents.Find(internal))
+		if (!list_find(contents, internal))
 			set_internals(null)
 		if (!(wear_mask && (wear_mask.item_flags & ITEM_FLAG_AIRTIGHT)))
 			set_internals(null)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -243,9 +243,9 @@
 				shown_objects += embedlist
 				var/parsedembed[0]
 				for(var/obj/embedded in embedlist)
-					if(!parsedembed.len || (!parsedembed.Find(embedded.name) && !parsedembed.Find("multiple [embedded.name]")))
+					if(!parsedembed.len || (!list_find(parsedembed, embedded.name) && !list_find(parsedembed, "multiple [embedded.name]")))
 						parsedembed.Add(embedded.name)
-					else if(!parsedembed.Find("multiple [embedded.name]"))
+					else if(!list_find(parsedembed, "multiple [embedded.name]"))
 						parsedembed.Remove(embedded.name)
 						parsedembed.Add("multiple "+embedded.name)
 				wound_flavor_text["[E.name]"] += "The [wound.desc] on [T.his] [E.name] has \a [english_list(parsedembed, and_text = " and \a ", comma_text = ", \a ")] sticking out of it!<br>"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -311,7 +311,7 @@
 			if(!rig.offline && (rig.air_supply && internal == rig.air_supply))
 				rig_supply = rig.air_supply
 
-		if (!rig_supply && (!contents.Find(internal) || !((wear_mask && (wear_mask.item_flags & ITEM_FLAG_AIRTIGHT)) || (head && (head.item_flags & ITEM_FLAG_AIRTIGHT)))))
+		if (!rig_supply && (!list_find(contents, internal) || !((wear_mask && (wear_mask.item_flags & ITEM_FLAG_AIRTIGHT)) || (head && (head.item_flags & ITEM_FLAG_AIRTIGHT)))))
 			set_internals(null)
 
 		if(internal)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -383,7 +383,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			continue
 		if(jobban_isbanned(O, "pAI"))
 			continue
-		if(asked.Find(O.key))
+		if(list_find(asked, O.key))
 			if(world.time < asked[O.key] + askDelay)
 				continue
 			else

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -45,7 +45,7 @@
 		to_chat(usr, "<span class='danger'>Access denied.</span>")
 		return
 
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if ((list_find(usr.contents, src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 
 	if (href_list["setarea"])

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -231,7 +231,7 @@
 		var/list/options = list(1,2,4,8,16,32,64,128,256,512)
 		for(var/i=0, i<num_boards, i++)
 			var/chosen = pick(options)
-			options.Remove(options.Find(chosen))
+			options.Remove(list_find(options, chosen))
 			spawnees |= chosen
 
 		if(spawnees & 1)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -59,7 +59,7 @@
 /mob/Login()
 
 	// Add to player list if missing
-	if (!GLOB.player_list.Find(src))
+	if (!list_find(GLOB.player_list, src))
 		ADD_SORTED(GLOB.player_list, src, /proc/cmp_mob_key)
 
 	update_Login_details()

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -15,7 +15,7 @@
 	set_sight(sight|SEE_TURFS)
 
 	// Add to player list if missing
-	if (!GLOB.player_list.Find(src))
+	if (!list_find(GLOB.player_list, src))
 		ADD_SORTED(GLOB.player_list, src, /proc/cmp_mob_key)
 
 	new_player_panel()

--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -121,7 +121,7 @@
 	if(href_list["PRG_downloadfile"])
 		if(!downloaded_file)
 			begin_file_download(href_list["PRG_downloadfile"], usr.get_skill_value(SKILL_COMPUTER))
-		else if(check_file_download(href_list["PRG_downloadfile"]) && !downloads_queue.Find(href_list["PRG_downloadfile"]) && downloaded_file.filename != href_list["PRG_downloadfile"])
+		else if(check_file_download(href_list["PRG_downloadfile"]) && !list_find(downloads_queue, href_list["PRG_downloadfile"]) && downloaded_file.filename != href_list["PRG_downloadfile"])
 			downloads_queue[href_list["PRG_downloadfile"]] = usr.get_skill_value(SKILL_COMPUTER)
 		return 1
 	if(href_list["PRG_removequeued"])

--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -20,7 +20,7 @@
 	if(.)
 
 		var/regex/name_regex = regex("\[A-Z\]{2}-\[A-Z\]{1} \[0-9\]{4}")
-		name_regex.Find(owner.real_name)
+		regex_find(name_regex, owner.real_name)
 
 		if(world.time < next_rename)
 			to_chat(owner, "<span class='warning'>[PROTOCOL_ARTICLE] forbids changing your ident again so soon.</span>")

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -14,7 +14,7 @@
 
 
 /obj/item/weapon/paper_bin/MouseDrop(mob/user as mob)
-	if((user == usr && (!( usr.restrained() ) && (!( usr.stat ) && (usr.contents.Find(src) || in_range(src, usr))))))
+	if((user == usr && (!( usr.restrained() ) && (!( usr.stat ) && (list_find(usr.contents, src) || in_range(src, usr))))))
 		if(!istype(usr, /mob/living/carbon/slime) && !istype(usr, /mob/living/simple_animal))
 			if( !usr.get_active_hand() )		//if active hand is empty
 				var/mob/living/carbon/human/H = user

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -128,7 +128,7 @@ var/global/photo_count = 0
 						M.put_in_l_hand(src)
 			add_fingerprint(usr)
 			return
-		if(over_object == usr && in_range(src, usr) || usr.contents.Find(src))
+		if(over_object == usr && in_range(src, usr) || list_find(usr.contents, src))
 			if(usr.s_active)
 				usr.s_active.close(usr)
 			show_to(usr)

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -27,9 +27,9 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 				fusion_reactions[cur_reaction.s_react] = list()
 			fusion_reactions[cur_reaction.s_react][cur_reaction.p_react] = cur_reaction
 
-	if(fusion_reactions.Find(p_react))
+	if(list_find(fusion_reactions, p_react))
 		var/list/secondary_reactions = fusion_reactions[p_react]
-		if(secondary_reactions.Find(s_react))
+		if(list_find(secondary_reactions, s_react))
 			return fusion_reactions[p_react][s_react]
 
 // Material fuels

--- a/code/modules/shuttles/shuttle_log.dm
+++ b/code/modules/shuttles/shuttle_log.dm
@@ -105,7 +105,7 @@
 	if(current_mission in queued_missions)
 		current_mission.stage = SHUTTLE_MISSION_QUEUED
 		current_mission = null //We'll reset this at the end.
-	var/index = queued_missions.Find(mission)
+	var/index = list_find(queued_missions, mission)
 	var/new_index = Clamp(index - relative_position, 1, length(queued_missions))
 	queued_missions -= mission
 	queued_missions.Insert(new_index, mission)

--- a/code/modules/synthesized_instruments/globals.dm
+++ b/code/modules/synthesized_instruments/globals.dm
@@ -216,7 +216,7 @@ Bit flags that modify the behavior of above properties
 
 /datum/musical_config/proc/environment_to_id(environment)
 	if (environment in src.all_environments)
-		return src.all_environments.Find(environment) - 2
+		return list_find(src.all_environments, environment) - 2
 	return -1
 
 

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -64,14 +64,14 @@
 /datum/turbolift/proc/do_move()
 	next_process = null
 
-	var/current_floor_index = floors.Find(current_floor)
+	var/current_floor_index = list_find(floors, current_floor)
 
 	if(!target_floor)
 		if(!queued_floors || !queued_floors.len)
 			return 0
 		target_floor = queued_floors[1]
 		queued_floors -= target_floor
-		if(current_floor_index < floors.Find(target_floor))
+		if(current_floor_index < list_find(floors, target_floor))
 			moving_upwards = 1
 		else
 			moving_upwards = 0

--- a/code/modules/xenoarcheaology/finds/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/fossils.dm
@@ -66,7 +66,7 @@
 				src.bstate = 1
 				src.set_density(1)
 				src.SetName("alien skeleton display")
-				if(src.contents.Find(/obj/item/weapon/fossil/skull/horned))
+				if(list_find(src.contents, /obj/item/weapon/fossil/skull/horned))
 					src.desc = "A creature made of [src.contents.len-1] assorted bones and a horned skull. The plaque reads \'[plaque_contents]\'."
 				else
 					src.desc = "A creature made of [src.contents.len-1] assorted bones and a skull. The plaque reads \'[plaque_contents]\'."
@@ -78,7 +78,7 @@
 	else if(istype(W,/obj/item/weapon/pen))
 		plaque_contents = sanitize(input("What would you like to write on the plaque:","Skeleton plaque",""))
 		user.visible_message("[user] writes something on the base of [icon2html(src, viewers(get_turf(src)))] [src].","You relabel the plaque on the base of [icon2html(src, user)] [src].")
-		if(src.contents.Find(/obj/item/weapon/fossil/skull/horned))
+		if(list_find(src.contents, /obj/item/weapon/fossil/skull/horned))
 			src.desc = "A creature made of [src.contents.len-1] assorted bones and a horned skull. The plaque reads \'[plaque_contents]\'."
 		else
 			src.desc = "A creature made of [src.contents.len-1] assorted bones and a skull. The plaque reads \'[plaque_contents]\'."

--- a/code/modules/xenoarcheaology/finds/talking.dm
+++ b/code/modules/xenoarcheaology/finds/talking.dm
@@ -94,7 +94,7 @@
 	text=lowertext(text)
 	for(var/ya,ya <= limit,ya++)
 
-		if(heard_words.Find("[text]"))
+		if(list_find(heard_words, "[text]"))
 			var/list/w = heard_words["[text]"]
 			text=pick(w)
 		else

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -293,7 +293,7 @@
 
 		var/anom_found = 0
 		if(G)
-			data = " - Spectometric analysis on mineral sample has determined type [finds_as_strings[responsive_carriers.Find(G.source_mineral)]]<br>"
+			data = " - Spectometric analysis on mineral sample has determined type [finds_as_strings[list_find(responsive_carriers, G.source_mineral)]]<br>"
 			if(G.age_billion > 0)
 				data += " - Radiometric dating shows age of [G.age_billion].[G.age_million] billion years<br>"
 			else if(G.age_million > 0)
@@ -303,7 +303,7 @@
 			data += " - Chromatographic analysis shows the following materials present:<br>"
 			for(var/carrier in G.find_presence)
 				if(G.find_presence[carrier])
-					var/index = responsive_carriers.Find(carrier)
+					var/index = list_find(responsive_carriers, carrier)
 					if(index > 0 && index <= finds_as_strings.len)
 						data += "	> [100 * G.find_presence[carrier]]% [finds_as_strings[index]]<br>"
 

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -201,7 +201,7 @@
 		dat += "Anomaly depth: [current.depth] cm<br>"
 		dat += "Anomaly size: [current.clearance] cm<br>"
 		dat += "Dissonance spread: [current.dissonance_spread]<br>"
-		var/index = responsive_carriers.Find(current.material)
+		var/index = list_find(responsive_carriers, current.material)
 		if(index > 0 && index <= finds_as_strings.len)
 			dat += "Anomaly material: [finds_as_strings[index]]<br>"
 		else

--- a/code/procs/dbcore.dm
+++ b/code/procs/dbcore.dm
@@ -140,7 +140,7 @@ DBQuery/proc/Quote(str)
 	return db_connection.Quote(str)
 
 DBQuery/proc/SetConversion(column,conversion)
-	if(istext(column)) column = columns.Find(column)
+	if(istext(column)) column = list_find(columns, column)
 	if(!conversions) conversions = new/list(column)
 	else if(conversions.len < column) conversions.len = column
 	conversions[column] = conversion

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -73,7 +73,7 @@
 		var/obj/effect/mobius_rift/chamber/chamber = rooms[chamber_tag]
 		for (var/dir_iter =1 to routes.len)
 			var/list/route = routes[routes[dir_iter]]
-			var/ch_pos = route.Find(chamber_tag) + 1
+			var/ch_pos = list_find(route, chamber_tag) + 1
 			if (ch_pos > (grid_number * grid_number))//if that's the last one
 				ch_pos = 1
 			var/obj/effect/mobius_rift/chamber/dest_chamber = route[route[ch_pos]]//getting destination chamber for direction

--- a/maps/torch/items/explo_shotgun.dm
+++ b/maps/torch/items/explo_shotgun.dm
@@ -34,7 +34,7 @@
 
 /obj/item/weapon/gun/projectile/shotgun/pump/exploration/free_fire()
 	var/my_z = get_z(src)
-	if(!GLOB.using_map.station_levels.Find(my_z))
+	if(!list_find(GLOB.using_map.station_levels, my_z))
 		return TRUE
 	return ..()
 

--- a/maps/~mapsystem/map_preferences.dm
+++ b/maps/~mapsystem/map_preferences.dm
@@ -18,7 +18,7 @@
 /datum/map/proc/private_use_legacy_saves(var/savefile/S, var/slot)
 	if(!load_legacy_saves) // Check if we're bothering with legacy saves at all
 		return FALSE
-	if(!S.dir.Find(path)) // If we cannot find the map path folder, load the legacy save
+	if(!list_find(S.dir, path)) // If we cannot find the map path folder, load the legacy save
 		return TRUE
 	S.cd = "/[path]" // Finally, if we cannot find the character slot in the map path folder, load the legacy save
-	return !S.dir.Find("character[slot]")
+	return !list_find(S.dir, "character[slot]")

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -42,6 +42,8 @@ exactly 1 "goto use" 'goto '
 exactly 484 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 233 "/global/ or /static/ vars defined" '/(global|static)/' -P
+exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
+exactly 5 ".Find( matches" '\.Find(_char)?\(' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
Not actually making ready for migration to 513 since user input handling is *not* changed, but this one makes it so that *_char functions are available in 512 and map to their byte versions via macros. The actual 513 change should be tiny after this.

Also updates regex uses to be major version agnostic with their macros / passing through text functions where appropriate. Less pleasantly, adds a related list_find macro and updates every `list.Find` to it to allow tests to enforce `.Replace` and `.Find` regex safety macro use.
