### PR TITLE
Removes the Aquila's mass for maximum vroomage.

### DIFF
--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -89,7 +89,7 @@
 	name = "Aquila"
 	desc = "A PM-24 modular transport, broadcasting SCGEC codes and the callsign \"Torch-1 Aquila\"."
 	shuttle = "Aquila"
-	vessel_mass = 20000
+	vessel_mass = 10000
 	max_speed = 1/(1 SECONDS)
 	burn_delay = 0.5 SECONDS //spammable, but expensive
 	fore_dir = NORTH


### PR DESCRIPTION
🆑 
tweak: Halves the Aquila's shuttle mass to 10000, equivalent to two Charons.
/🆑 


Because previously, it was one fifth the Total mass of the Torch. Now, it still burns mad fuel, but in doesn't burn unreasonable amounts of fuel.