### PR TITLE
Fixes Emags

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -303,6 +303,7 @@
 		sleep(6)
 		open()
 		operating = -1
+		set_broken(TRUE)
 		return 1
 
 /obj/machinery/door/proc/check_force(obj/item/I, mob/user)


### PR DESCRIPTION
:cl:
bugfix: Cryptographic Sequencers correctly break open doors again.
/:cl:

Closes #30068.

Apparently emags stopped breaking doors at some point. Who knew? Instead of fussing over the weird logic with the operating variable, I've just made it call the break proc for lots of fancy sparks. Shiny.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->