### PR TITLE
Removes inability of stacks to automatically merge on the same tile

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -33,10 +33,19 @@
 		src.amount = amount
 	..()
 
-/obj/item/stack/Initialize()
+/obj/item/stack/Initialize(mapload)
 	. = ..()
 	if(!plural_name)
 		plural_name = "[singular_name]s"
+	if (!mapload && isturf(loc))
+		addtimer(CALLBACK(src, .proc/stack_new), 0)
+
+/obj/item/stack/proc/stack_new()
+	for (var/obj/item/stack/S in loc)
+		if (S == src)
+			continue
+		if (S.stacktype == stacktype)
+			transfer_to(S)
 
 /obj/item/stack/Destroy()
 	if(uses_charge)
@@ -310,6 +319,15 @@
 	. = ..()
 	if (amount < max_amount)
 		. = ceil(. * amount / max_amount)
+
+/obj/item/stack/Crossed(obj/o)
+	addtimer(CALLBACK(src, .proc/stack_crossed, o), 0)
+	. = ..()
+
+/obj/item/stack/proc/stack_crossed(obj/o)
+	if (!o.throwing && loc == o.loc && isturf(loc) && istype(o, /obj/item/stack))
+		var/obj/item/stack/S = o
+		transfer_to(S)
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)


### PR DESCRIPTION
:cl:
rscadd: Stacks created on or moved into the same turf while not being thrown will merge automatically.
/:cl: