### PR TITLE
Chorus polishing pass

### DIFF
--- a/code/game/antagonist/outsider/chorus.dm
+++ b/code/game/antagonist/outsider/chorus.dm
@@ -4,7 +4,8 @@ GLOBAL_DATUM_INIT(chorus, /datum/antagonist/chorus, new)
 	id = MODE_DEITY
 	role_text = "Chorus"
 	role_text_plural = "Chorus"
-	welcome_text = "You are one of many"
+	welcome_text = "You are one of many! Use this vessel as a habitat. Grow the Chorus, and pave the way for new progeny. \
+	Speak with any other minds in your Chorus by using chat functions to talk normally."
 	landmark_id = "xeno_spawn"
 
 	flags = ANTAG_OVERRIDE_MOB | ANTAG_OVERRIDE_JOB
@@ -14,3 +15,4 @@ GLOBAL_DATUM_INIT(chorus, /datum/antagonist/chorus, new)
 	hard_cap_round = 10
 	initial_spawn_req = 1
 	initial_spawn_target = 3
+	skill_setter = null // we are a flesh beast and do not use skills

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/building_chorus.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/building_chorus.dm
@@ -6,8 +6,10 @@
 	var/click_cooldown = 10
 	var/activation_cost_resource
 	var/activation_cost_amount
-	density = 1
-	anchored = 1
+	density = TRUE
+	anchored = TRUE
+	var/death_message = "crumbles!"
+	var/death_sound = 'sound/effects/splat.ogg'
 
 /obj/structure/chorus/Initialize(var/maploading, var/o)
 	. = ..()
@@ -20,9 +22,23 @@
 		owner.remove_building(src)
 	. = ..()
 
+/obj/structure/chorus/examine(mob/user, distance)
+	. = ..()
+	if (distance < 4 || ischorus(user))
+		var/message
+		switch(PERCENT(health, initial(health), 0))
+			if (75 to INFINITY)
+				message = "It is intact."
+			if (50 to 75)
+				message = "It is damaged."
+			if (25 to 50)
+				message = "It is heavily damaged."
+			else
+				message = "It is nearly destroyed."
+		to_chat(user, SPAN_WARNING(message))
 /obj/structure/chorus/proc/chorus_click(var/mob/living/carbon/alien/chorus/C)
 	if(can_activate(C))
-		activate()
+		activate(C)
 		last_click = world.time
 
 /obj/structure/chorus/proc/has_resources(mob/living/carbon/alien/chorus/C, warning = TRUE)
@@ -42,18 +58,18 @@
 		if(activation_cost_resource && !owner.use_resource(activation_cost_resource, activation_cost_amount))
 			if(warning && C)
 				var/datum/chorus_resource/cr = activation_cost_resource
-				to_chat(C, SPAN_WARNING("You need more [initial(cr.name)] to activate \the [src]"))
+				to_chat(C, SPAN_WARNING("You need more [initial(cr.name)] to activate \the [src]."))
 			return FALSE
 		return TRUE
 	return FALSE
 
-/obj/structure/chorus/proc/activate()
+/obj/structure/chorus/proc/activate(mob/living/carbon/alien/chorus/C)
 	return
 
 /obj/structure/chorus/attackby(obj/item/W as obj, mob/user as mob)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
-	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 50, 1)
+	playsound(get_turf(src), "swing_hit", 50, 1)
 	user.visible_message(
 		SPAN_DANGER("[user] hits \the [src] with \the [W]!"),
 		SPAN_DANGER("You hit \the [src] with \the [W]!"),
@@ -67,7 +83,8 @@
 		crumble()
 
 /obj/structure/chorus/proc/crumble()
-	src.visible_message("\The [src] crumbles!")
+	visible_message(SPAN_WARNING("\The [src] [death_message]"))
+	playsound(loc, death_sound, 50, TRUE)
 	qdel(src)
 
 /obj/structure/chorus/bullet_act(var/obj/item/projectile/P)

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
@@ -13,7 +13,7 @@
 
 /obj/structure/chorus/processor/chorus_click(var/mob/living/carbon/alien/chorus/C)
 	if(warning && C)
-		to_chat(C, SPAN_WARNING("\The [src] is automatic; it does not need to be activated"))
+		to_chat(C, SPAN_WARNING("\The [src] is automatic; it can't be used manually, and instead activates on its own."))
 		warning = FALSE
 
 /obj/structure/chorus/processor/clicker

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_five.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_five.dm
@@ -17,3 +17,4 @@
 	activation_cost_resource = /datum/chorus_resource/growth_meat
 	activation_cost_amount = 100
 	health = 200
+	death_message = "ruptures and splits, spilling forth lumps of flesh and thick amniotic fluid."

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_four.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_four.dm
@@ -43,6 +43,7 @@
 	click_cooldown = 30 SECONDS
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 15
+	death_message = "ruptures, spilling its corrosive contents around itself."
 
 /obj/structure/chorus/gastric_emitter/activate()
 	flick("growth_gastric_emit", src)

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_one.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_one.dm
@@ -1,5 +1,5 @@
 /datum/chorus_building/set_to_turf/growth/nutrient_syphon
-	desc = "An organ whose purpose is to extract nutrients from the air. Can be placed anywhere with no range restriction."
+	desc = "An organ whose purpose is to extract nutrients from the air. Can be placed anywhere, regardless of distance from other structures."
 	building_type_to_build = /obj/structure/chorus/nutrient_syphon
 	build_time = 10
 	resource_cost = list(/datum/chorus_resource/growth_nutrients = 5)
@@ -7,9 +7,10 @@
 
 /obj/structure/chorus/nutrient_syphon
 	name = "nutrient syphon"
-	desc = "Extracts vitamins and minerals straight from the air."
+	desc = "Some sort of waist-high... plant? Animal? It splits like a V, with wet strands of mucus hanging between each half."
 	icon_state = "growth_syphon"
 	click_cooldown = 5 SECONDS
+	death_message = "splits and falls apart."
 
 /obj/structure/chorus/nutrient_syphon/activate()
 	owner.add_to_resource(/datum/chorus_resource/growth_nutrients, 1)
@@ -17,7 +18,7 @@
 	flick("growth_syphon_exert", src)
 
 /datum/chorus_building/set_to_turf/growth/bitter
-	desc = "A small teeth-filled hole, used to injure prey."
+	desc = "A small teeth-filled hole, used to injure prey. Fragile."
 	building_type_to_build = /obj/structure/chorus/biter
 	build_time = 20
 	build_level = 1
@@ -28,17 +29,18 @@
 
 /obj/structure/chorus/biter
 	name = "biter"
-	desc = "a pit filled with teeth, capable of biting at those who step on it."
+	desc = "A shallow pit the size of a dinner plate, lined with viciously sharp teeth."
 	icon_state = "growth_biter"
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 5
 	health = 1
-	density = 0
+	density = FALSE
+	death_message = "closes and folds into the ground."
 	var/damage = 45
 
 /obj/structure/chorus/biter/chorus_click(var/mob/living/carbon/alien/chorus/c)
 	if(c)
-		to_chat(c, SPAN_WARNING("\The [src] automatically bites those who walk on it"))
+		to_chat(c, SPAN_WARNING("\The [src] automatically bites those who walk on it."))
 
 /obj/structure/chorus/biter/Initialize(var/maploading, var/o)
 	. = ..()
@@ -53,7 +55,12 @@
 		if((owner && owner.is_follower(L)) || !can_activate(null, FALSE))
 			return
 		flick("growth_biter_attack", src)
-		visible_message(SPAN_DANGER("\The [src] bites at \the [L]'s feet!"))
+		L.visible_message(
+			SPAN_DANGER("\The [src] bites at \the [L]'s feet!"),
+			FONT_LARGE(SPAN_DANGER("You stumble over a hole and teeth bite down into your legs!")),
+			SPAN_WARNING("You hear a meaty thump, then a crunch.")
+		)
+		playsound(loc, 'sound/weapons/bladeslice.ogg', 100, FALSE, frequency = 0.5)
 		if(istype(L, /mob/living/carbon/human))
 			var/target_foot = pick(list(BP_L_FOOT, BP_R_FOOT))
 			var/mob/living/carbon/human/H = L

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_three.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_three.dm
@@ -9,19 +9,24 @@
 
 /obj/structure/chorus/processor/sentry/tendril
 	name = "tendril"
-	desc = "A large mucus covered tentacle."
+	desc = "A large, mucus-covered tentacle. It occasionally twitches."
 	icon_state = "growth_tendril"
 	health = 100
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 2
 	click_cooldown = 3 SECONDS
+	death_message = "flails aimlessly, then sinks into the ground."
 	var/damage = 15
 	var/penetration = 10
 
 /obj/structure/chorus/processor/sentry/tendril/trigger_effect(var/list/targets)
 	var/mob/living/L = pick(targets)
 	flick("[initial(icon_state)]_attack", src)
-	visible_message(SPAN_DANGER("\The [src] whips out at \the [L]!"))
+	L.visible_message(
+		SPAN_DANGER("\The [src] whips out at \the [L]!"),
+		SPAN_DANGER("\The [src] lunges out and bludgeons you!"),
+		SPAN_WARNING("You hear a whoosh, and then a muffled, heavy thump.")
+	)
 	playsound(src, 'sound/weapons/pierce.ogg', 50, 1)
 	if(istype(L, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = L

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_two.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/growth/tier_two.dm
@@ -8,12 +8,13 @@
 
 /obj/structure/chorus/gastrointestional_tract
 	name = "gastrointestional tract"
-	desc = "A gross lump of organ meat."
+	desc = "A gross lump of organ meat. The smell is indescribable."
 	icon_state = "growth_stomach"
 	health = 30
 	click_cooldown = 5 SECONDS
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 2
+	death_message = "shears apart in a mess of meat, bile, and rancid fluid."
 
 /obj/structure/chorus/gastrointestional_tract/activate()
 	owner.add_to_resource(/datum/chorus_resource/growth_meat, 1)
@@ -36,6 +37,8 @@
 	click_cooldown = 5 SECONDS
 	activation_cost_resource = /datum/chorus_resource/growth_nutrients
 	activation_cost_amount = 2
+	death_message = "cracks loudly and falls to pieces."
+	death_sound = "fracture"
 
 /obj/structure/chorus/ossifier/activate()
 	owner.add_to_resource(/datum/chorus_resource/growth_bones, 1)
@@ -54,6 +57,7 @@
 	desc = "A large fan of what appears to be some sort of organic wire."
 	icon_state = "growth_node"
 	health = 50
+	death_message = "severs at the base and splatters on the ground."
 
 /datum/chorus_building/muscular_coat
 	desc = "Every beast needs an outside."
@@ -88,6 +92,7 @@
 	click_cooldown = 3 SECONDS
 	health = 200
 	icon_state = "growth_maw_closed"
+	death_message = "sinks into the ground."
 
 /obj/structure/chorus/maw/activate()
 	if(density)
@@ -100,7 +105,7 @@
 		flick("growth_maw_close", src)
 
 /datum/chorus_building/set_to_turf/growth/spinal_column
-	desc = "For growths that must grow up and out."
+	desc = "For growths that must grow up and out. Each use extends another spinal column in either vertical direction."
 	building_type_to_build = /obj/structure/chorus/zleveler/spinal_column
 	build_time = 120
 	build_level = 2
@@ -118,6 +123,9 @@
 	activation_cost_amount = 50
 	density = TRUE
 	turf_type_to_add = /turf/simulated/floor/scales
+	growth_verb = "bursts"
+	death_message = "fractures loudly in half, its two ends dangling apart."
+	death_sound = "fracture"
 
 /datum/chorus_building/set_to_turf/growth/bone_shooter
 	desc = "Automatically shoots bone fragments at enemies."


### PR DESCRIPTION
🆑
spellcheck: Adjusted descriptions for several Chorus-related things.
rscadd: Added death sounds for Chorus structures.
rscadd: Added different death messages for each Chorus structure.
tweak: Chorus structures can be examined to show their rough health.
bugfix: Chorus spinal columns now work correctly.
/🆑

Chorus still desperately needs attention. Let's try and fix that.

Full changes:
* `/obj/structure/chorus`
  * Now has a `death_message` var that can be edited to change what displays when the structure dies.
  * Now has a `death_sound` var that plays when the structure dies.
  * Can now be examined to show its rough remaining health.
  * Takes a chorus mob argument in the `activate()` proc, defaulting to null. This fixes the spinal column and other zlevelers not working at all.
* Changed the sound played when hitting a chorus structure to be a standard hit sound instead of glass being hit.
* Adjusted several examine texts, descriptions, and other strings.
* Biters now throw a big message in your chat and play a sound for player feedback, given that it usually bites your foot off if you aren't wearing armor.

All comments and feedback welcome! This is just an attempt to make Chorus moderately more polished. No content changes or anything like thiat.