### PR TITLE
Removes absence of Boron fusion

### DIFF
--- a/code/datums/supplypacks/dispcarts.dm
+++ b/code/datums/supplypacks/dispcarts.dm
@@ -61,6 +61,10 @@ SEC_PACK(cognac,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/cogna
 SEC_PACK(ale,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,      "Reagent refill - Ale",      "ale reagent cartridge crate",      15, access_bar)
 SEC_PACK(mead,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/mead,     "Reagent refill - Mead",     "mead reagent cartridge crate",     15, access_bar)
 
+// Engineering-restricted
+//
+SEC_PACK(boron,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/boron,   "Reagent refill - Boron",    "boron reagent cartridge crate",    45, access_engine)
+
 // Unrestricted (water, sugar, non-alcoholic drinks)
 //  Datum path   Contents type                                                       Supply pack name                        Container name                                          Cost
 PACK(water,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/water,      "Reagent refill - Water",               "water reagent cartridge crate",                         15)

--- a/code/modules/power/fusion/_setup.dm
+++ b/code/modules/power/fusion/_setup.dm
@@ -1,6 +1,3 @@
-// temperature of the core of the sun
-#define FUSION_HEAT_CAP 1.57e7
-
 #define SETUP_OK 1			// All good
 #define SETUP_WARNING 2		// Something that shouldn't happen happened, but it's not critical so we will continue
 #define SETUP_ERROR 3		// Something bad happened, and it's important so we won't continue setup.

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -311,11 +311,11 @@
 /obj/effect/fusion_em_field/proc/change_size(var/newsize = 1)
 	var/changed = 0
 	var/static/list/size_to_icon = list(
-			"3" = 'icons/effects/96x96.dmi', 
-			"5" = 'icons/effects/160x160.dmi', 
-			"7" = 'icons/effects/224x224.dmi', 
-			"9" = 'icons/effects/288x288.dmi', 
-			"11" = 'icons/effects/352x352.dmi', 
+			"3" = 'icons/effects/96x96.dmi',
+			"5" = 'icons/effects/160x160.dmi',
+			"7" = 'icons/effects/224x224.dmi',
+			"9" = 'icons/effects/288x288.dmi',
+			"11" = 'icons/effects/352x352.dmi',
 			"13" = 'icons/effects/416x416.dmi'
 			)
 
@@ -464,7 +464,6 @@
 	update_icon()
 	return 0
 
-#undef FUSION_HEAT_CAP
 #undef FUSION_INSTABILITY_DIVISOR
 #undef FUSION_RUPTURE_THRESHOLD
 #undef FUSION_REACTANT_CAP

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -160,8 +160,8 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 /decl/fusion_reaction/boron_hydrogen
 	p_react = "boron"
 	s_react = GAS_HYDROGEN
-	minimum_energy_level = FUSION_HEAT_CAP * 0.5
+	minimum_energy_level = 15000
 	energy_consumption = 3
-	energy_production = 15
+	energy_production = 12
 	radiation = 3
-	instability = 3
+	instability = 2.5

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -928,3 +928,12 @@
 	heating_products = list(/datum/reagent/acetone, /datum/reagent/carbon, /datum/reagent/ethanol)
 	heating_point = 145 CELSIUS
 	heating_message = "separates."
+
+/datum/reagent/toxin/boron
+	name = "Boron"
+	description = "A chemical that is highly valued for its potential in fusion energy."
+	taste_description = "metal"
+	reagent_state = SOLID
+	color = "#837e79"
+	value = 4
+	strength = 7

--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -81,6 +81,9 @@
 	decaf_cof	spawn_reagent = /datum/reagent/drink/decafcoffee
 	espresso	spawn_reagent = /datum/reagent/drink/coffee/espresso
 
+// Engineering
+	boron		spawn_reagent = /datum/reagent/toxin/boron
+
 	// ERT
 	inaprov		spawn_reagent = /datum/reagent/inaprovaline
 	ryetalyn	spawn_reagent = /datum/reagent/ryetalyn


### PR DESCRIPTION
:cl:
rscadd: Boron fusion can be done at the R-UST, using Boron chemical cartridges purchasable from supply. Higher output than normal fusion, but with higher risk.
/:cl:

You can order Boron from supply now, which you can then make fuel rods out of, and use in the fusion reactor. Contrary to the default hydrogen-hydrogen and deuterium-helium reactions that are the norm, boron-hydrogen reaction gives a higher power output, but with risk of meltdown due to instability.
Here's the maximum output I could get from it, without accumulation of instability.
![image](https://user-images.githubusercontent.com/11510380/108518519-8c6a5c00-72c0-11eb-85dd-c5bb6465e8fb.png)
It hovers around 5.6MW maximum. Bear in mind that the gyrotron stays at full power permanently to sustain it, which needs 1.2MW per shot. Thus, effective max power output: 4.2MW. Normal fusion outputs about 2MW.