### PR TITLE
Adds pre-loaded coilguns and codex entries

### DIFF
--- a/code/modules/codex/entries/guns.dm
+++ b/code/modules/codex/entries/guns.dm
@@ -7,6 +7,9 @@
 /obj/item/weapon/gun/energy
 	general_codex_key = "energy weapons"
 
+/obj/item/weapon/gun/magnetic
+	general_codex_key = "magnetic weapons"
+
 /obj/item/weapon/gun/get_antag_info()
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
@@ -40,11 +43,11 @@
 	if(scope_zoom)
 		traits += "It has a magnifying optical scope. It can be toggled with Use Scope verb."
 
-	if(LAZYLEN(firemodes) > 1) 
+	if(LAZYLEN(firemodes) > 1)
 		traits += "It has multiple firemodes. Click it in hand to cycle them."
-	
+
 	return jointext(traits, "<br>")
-	
+
 /obj/item/weapon/gun/projectile/get_mechanics_info()
 	. = ..()
 	var/list/traits = list()
@@ -62,7 +65,7 @@
 
 	if(load_method & (SINGLE_CASING|SPEEDLOADER))
 		traits += "It can hold [max_shells] rounds."
-	
+
 	if(jam_chance)
 		traits += "It's prone to jamming."
 
@@ -87,12 +90,23 @@
 	. = ..()
 	. += "This is a stealthy weapon which fires poisoned bolts at your target. When it hits someone, they will suffer a stun effect, in \
 	addition to toxins. The energy crossbow recharges itself slowly, and can be concealed in your pocket or bag.<br>"
-	
+
 /obj/item/weapon/gun/energy/chameleon/get_antag_info()
 	. = ..()
 	. += "This gun is actually a hologram projector that can alter its appearance to mimick other weapons. To change the appearance, use \
 	the appropriate verb in the object tab. Any beams or projectiles fired from this gun are actually holograms and useless for actual combat. \
 	Projecting these holograms over distance uses a little bit of charge.<br>"
+
+
+/obj/item/weapon/gun/magnetic/get_mechanics_info()
+	. = ..()
+	if (removable_components)
+		. += "<p>Its cell and capacitor can be removed and replaced. You can remove the components by clicking the gun with an empty hand while it's unloaded.</p>"
+	if (load_type)
+		var/load_item = new load_type()
+		. += "<p>It accepts [load_item] as ammunition, with a maximum capacity of [load_sheet_max].</p>"
+	if (gun_unreliable)
+		. += "<p>This weapon is unreliable and has a chance of exploding in your hands when you fire it.</p>"
 
 /datum/codex_entry/energy_weapons
 	display_name = "energy weapons"
@@ -112,3 +126,12 @@
 		weapons, difficulties in maintaining them, and the sheer stopping and wounding power of solid slugs or \
 		composite shot. Using a ballistic weapon on a spacebound habitat is usually considered a serious undertaking, \
 		as a missed shot or careless use of automatic fire could rip open the hull or injure bystanders with ease."
+
+/datum/codex_entry/magnetic_weapons
+	display_name = "magnetic weapons"
+	mechanics_text = "<p>This weapon is a magnetic weapon; it fires solid projectiles using a capacitive charge and magnets.</p>\
+		<p>You can unload it by holding it and clicking it with an empty hand, and reload it by clicking it with any items the weapon accepts as ammunition.</p>\
+		<p>Each shot not only uses ammunition, but also drains the gun's capacitor. The capacitor recharges from the inserted power cell.</p>"
+	lore_text = "<p>Magnetic weapons, while uncommon, are seen throughout human space, firing physical projectiles using powerful magnets. \
+		Magnetic weapons tend to be very power inefficient. The most recognizable form is the railgun, though crafty engineers have been known to \
+		produce their own makeshift coilguns.</p>"

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -24,8 +24,21 @@
 	var/power_cost = 950                                       // Cost per fire, should consume almost an entire basic cell.
 	var/power_per_tick                                         // Capacitor charge per process(). Updated based on capacitor rating.
 
+/obj/item/weapon/gun/magnetic/preloaded
+	cell = /obj/item/weapon/cell/high
+	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
+
 /obj/item/weapon/gun/magnetic/Initialize()
 	START_PROCESSING(SSobj, src)
+
+	if (ispath(cell))
+		cell = new cell(src)
+	if (ispath(capacitor))
+		capacitor = new capacitor(src)
+		capacitor.charge = capacitor.max_charge
+	if (ispath(loaded))
+		loaded = new loaded (src, load_sheet_max)
+
 	if(capacitor)
 		power_per_tick = (power_cost*0.15) * capacitor.rating
 	update_icon()

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -16,20 +16,13 @@
 	combustion = 1
 	bulk = GUN_BULK_RIFLE + 3
 
-	var/initial_cell_type = /obj/item/weapon/cell/hyper
-	var/initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv // 6-8 shots
+	cell = /obj/item/weapon/cell/hyper
+	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
 	gun_unreliable = 0
 	var/slowdown_held = 3
 	var/slowdown_worn = 2
 
 /obj/item/weapon/gun/magnetic/railgun/Initialize()
-
-	capacitor = new initial_capacitor_type(src)
-	capacitor.charge = capacitor.max_charge
-
-	cell = new initial_cell_type(src)
-	if (ispath(loaded))
-		loaded = new loaded (src, load_sheet_max)
 	slowdown_per_slot[slot_l_hand] =  slowdown_held
 	slowdown_per_slot[slot_r_hand] =  slowdown_held
 	slowdown_per_slot[slot_back] =    slowdown_worn
@@ -76,8 +69,8 @@
 	icon_state = "railgun-tcc"
 	removable_components = TRUE // Railgunners are expected to be able to completely disassemble and reassemble their weapons in the field. But we don't have that mechanic, so the cell and capacitor will do.
 
-	initial_cell_type = /obj/item/weapon/cell/hyper // Standard power
-	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv // 6-8 shots
+	cell = /obj/item/weapon/cell/hyper // Standard power
+	capacitor = /obj/item/weapon/stock_parts/capacitor/adv // 6-8 shots
 	power_cost = 280 // Same number of shots, but it'll seem to recharge slightly faster
 
 	loaded = /obj/item/stack/material/rods
@@ -116,8 +109,8 @@
 	icon_state = "heavy_railgun"
 	removable_components = FALSE // Absolutely not. This has an infinity cell.
 
-	initial_cell_type = /obj/item/weapon/cell/infinite
-	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/super
+	cell = /obj/item/weapon/cell/infinite
+	capacitor = /obj/item/weapon/stock_parts/capacitor/super
 
 	fire_delay =  8
 	slowdown_held = 4
@@ -153,8 +146,8 @@
 	one_hand_penalty = 2
 	fire_delay = 8
 	removable_components = FALSE
-	initial_cell_type = /obj/item/weapon/cell/hyper
-	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv
+	cell = /obj/item/weapon/cell/hyper
+	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
 	slot_flags = SLOT_BACK
 	power_cost = 100
 	load_type = /obj/item/weapon/magnetic_ammo
@@ -169,7 +162,7 @@
 
 /obj/item/weapon/gun/magnetic/railgun/flechette/out_of_ammo()
 	visible_message("<span class='warning'>\The [src] beeps to indicate the magazine is empty.</span>")
-	
+
 
 /obj/item/weapon/gun/magnetic/railgun/flechette/skrell
 	name = "skrellian rifle"
@@ -182,8 +175,8 @@
 	slowdown_held = 1
 	slowdown_worn = 1
 	removable_components = FALSE
-	initial_cell_type = /obj/item/weapon/cell/hyper
-	initial_capacitor_type = /obj/item/weapon/stock_parts/capacitor/adv
+	cell = /obj/item/weapon/cell/hyper
+	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
 	load_type = /obj/item/weapon/magnetic_ammo/skrell
 	loaded = /obj/item/weapon/magnetic_ammo/skrell/slug
 	projectile_type = /obj/item/projectile/bullet/magnetic/slug

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -4374,9 +4374,7 @@
 	pixel_x = 23;
 	pixel_y = -3
 	},
-/obj/item/weapon/gun/magnetic,
-/obj/item/weapon/stock_parts/capacitor/adv,
-/obj/item/weapon/cell/high,
+/obj/item/weapon/gun/magnetic/preloaded,
 /obj/item/weapon/cell/high,
 /obj/item/weapon/cell/high,
 /turf/simulated/floor/tiled/dark/monotile,


### PR DESCRIPTION
:cl:
tweak: The scavver gantry coilgun now comes pre-loaded with a fully-charged power cell and advanced capacitor, instead of having to load it yourself.
tweak: Magnetic weapons (Coilguns and railguns) now have proper codex entries, including mechanics tips on how to use them.
/:cl:

closes #30198