### PR TITLE
Makes supply net default for Prospectors

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -52,7 +52,7 @@
 /obj/item/device/encryptionkey/headset_mining
 	name = "prospector radio encryption key"
 	icon_state = "srv_cypherkey"
-	channels = list("Exploration" = 1, "Supply" = 1)
+	channels = list("Supply" = 1, "Exploration" = 1)
 
 /obj/item/weapon/storage/box/encryptionkey/exploration
 	name = "box of spare exploration radio keys"


### PR DESCRIPTION
:cl: Ryan180602
tweak: Makes Supply the default channel for Prospectors
/:cl:

Considering Prospectors work closer to supply than they do to Exploration, it only makes sense for Supply to be their default net. 
Prospectors also tend to communicate on supply either ways, but this is just a minor change for those who use `:H`, to prevent transmitting on a different channel accidentally.