### PR TITLE
Revamps culture entry selection for character backgrounds

### DIFF
--- a/code/modules/client/preference_setup/background/01_culture.dm
+++ b/code/modules/client/preference_setup/background/01_culture.dm
@@ -18,12 +18,15 @@
 	name = "Culture"
 	sort_order = 1
 	var/list/hidden
+	var/list/expanded
 	var/list/tokens = ALL_CULTURAL_TAGS
 
 /datum/category_item/player_setup_item/background/culture/New()
 	hidden = list()
+	expanded = list()
 	for(var/token in tokens)
 		hidden[token] = TRUE
+		expanded[token] = FALSE
 	..()
 
 /datum/category_item/player_setup_item/background/culture/sanitize_character()
@@ -53,9 +56,23 @@
 	. = list()
 	for(var/token in tokens)
 		var/decl/cultural_info/culture = SSculture.get_culture(pref.cultural_info[token])
-		var/title = "<b>[tokens[token]]<a href='?src=\ref[src];set_[token]=1'><small>?</small></a>:</b><a href='?src=\ref[src];set_[token]=2'>[pref.cultural_info[token]]</a>"
+		var/title = "<a href='?src=\ref[src];expand_options_[token]=1'>[tokens[token]]</a><b>- </b>[pref.cultural_info[token]]"
 		var/append_text = "<a href='?src=\ref[src];toggle_verbose_[token]=1'>[hidden[token] ? "Expand" : "Collapse"]</a>"
 		. += culture.get_description(title, append_text, verbose = !hidden[token])
+		if (expanded[token])
+			var/list/valid_values
+			GET_ALLOWED_VALUES(valid_values, token)
+			if (!hidden[token])
+				. += "<br>"
+			. += "<table width=100%><tr><td colspan=3>"
+			for (var/V in valid_values)
+				var/decl/cultural_info/CI = V
+				if (pref.cultural_info[token] == CI)
+					. += "<span class='linkOn'>[CI]</span> "
+				else
+					. += "<a href='?src=\ref[src];set_token_entry_[token]=[CI]'>[CI]</a> "
+			. += "</table>"
+		. += "<hr>"
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/background/culture/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -65,33 +82,16 @@
 		if(href_list["toggle_verbose_[token]"])
 			hidden[token] = !hidden[token]
 			return TOPIC_REFRESH
+		
+		if(href_list["expand_options_[token]"])
+			expanded[token] = !expanded[token]
+			return TOPIC_REFRESH
 
-		var/check_href = text2num(href_list["set_[token]"])
-		if(check_href > 0)
-
-			var/list/valid_values
-			if(check_href == 1)
-				valid_values = SSculture.get_all_entries_tagged_with(token)
-			else
-				GET_ALLOWED_VALUES(valid_values, token)
-
-			var/choice = input("Please select an entry.") as null|anything in valid_values
-			if(!choice)
-				return
-
-			// Check if anything changed between now and then.
-			if(check_href == 1)
-				valid_values = SSculture.get_all_entries_tagged_with(token)
-			else
-				GET_ALLOWED_VALUES(valid_values, token)
-
-			if(valid_values[choice])
-				var/decl/cultural_info/culture = SSculture.get_culture(choice)
-				if(check_href == 1)
-					show_browser(user, culture.get_description(), "window=[token];size=700x400")
-				else
-					pref.cultural_info[token] = choice
-				return TOPIC_REFRESH
+		var/new_token = href_list["set_token_entry_[token]"]
+		if (!isnull(new_token))
+			pref.cultural_info[token] = new_token
+			return TOPIC_REFRESH
+			
 	. = ..()
 
 #undef GET_ALLOWED_VALUES

--- a/code/modules/culture_descriptor/_culture.dm
+++ b/code/modules/culture_descriptor/_culture.dm
@@ -72,7 +72,7 @@
 	dat += "</td>"
 	if(append)
 		dat += "<td width = '100px'>[append]</td>"
-	dat += "</tr></table><hr>"
+	dat += "</tr></table>"
 	return jointext(dat, null)
 #undef COLLAPSED_CULTURE_BLURB_LEN
 


### PR DESCRIPTION
🆑
tweak: The Background menu in character selection no longer puts the user through a popup to select an option. Instead, clicking the name of an entry expands a list that lets you select from all entries in realtime, which should hopefully make it a lot smoother to use and open the door for new ones to be added again.
/🆑

This is a big chunk of HTML change to the culture menu to change its functionality. Currently, selecting an option involves going through a Byond input proc, which doesn't tell you anything and is generally very unfriendly to actually knowing what you're messing with. This PR changes that to display a list of options that you can click to select in realtime, a lot like the loadout system uses.

This also removes the `?` button on the loadout menu that displayed a popup showing the description of whatever option you selected, since that's no longer necessary, given that you can switch in realtime and see detail changes instantly.

### ***Important note:*** All of the pictures below show the full list of options, but this list of options is *not* visible by default. You'll need to click the link labeled `Culture`, `Residence`, etc. to display or hide them. Having them show by default would be icky!

Pictures often speak better than words, so here's some pictures.

<details><summary>Culture options</summary>

![](https://media.discordapp.net/attachments/812491963185496094/813049891085221888/unknown.png)

</details>
<details><summary>Selecting in realtime</summary>

![](https://cdn.discordapp.com/attachments/812491963185496094/813050018822488074/unknown.png)

</details>
<details><summary>Works for Skrell and all other races</summary>

![](https://media.discordapp.net/attachments/812491963185496094/813050206407884810/unknown.png)

</details>
<details><summary>Also works for planets (and every other category)!</summary>

![](https://media.discordapp.net/attachments/812491963185496094/813050356454916186/unknown.png)

</details>
<details><summary>All together now (but don't open them all at once that's yucky)</summary>

![](https://cdn.discordapp.com/attachments/812491963185496094/813050475627806740/unknown.png)

</details>

Wishlist: Making the name for each category (i.e. "Culture", "Residence") change appearance depending on if the options are expanded or collapsed. This is probably easy to do but I don't know how. If it's not done here, it might be done in a later MR.