### PR TITLE
Fixes cyborg window repairing

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -346,7 +346,7 @@
 			construction_state = 0
 			set_anchored(0)
 
-	else if (istype(W, /obj/item/stack/material/glass))
+	else if (istype(W, /obj/item/stack/material))
 		if (health == maxhealth)
 			to_chat(user, SPAN_NOTICE("\The [src] does not need repair."))
 			return
@@ -355,7 +355,7 @@
 			to_chat(user, SPAN_NOTICE("\The [src] already has enough new [material] applied."))
 			return
 
-		var/obj/item/stack/material/glass/G = W
+		var/obj/item/stack/material/G = W
 		if (material != G.material || reinf_material != G.reinf_material)
 			to_chat(user, SPAN_WARNING("\The [src] must be repaired with the same type of [get_material_display_name()] it was made of."))
 			return


### PR DESCRIPTION
🆑
bugfix: Robots/synthetics can now repair windows with their sheet synthesizers.
/🆑

Fixes #30082.

Sierra's comment in the body about it probably being due to path was correct; it specifically checked for `/obj/item/stack/material/glass`, which made it not work because borg synthesizers don't use that path. This change makes it just check for `/obj/item/stack/material` instead. Tested on a local server with a repair borg on normal and reinforced windows. The logic for window repair has an explicit check to make sure the material types match up, so this doesn't make windows repairable with materials that they aren't made out of.

This doesn't affect window functionality at all other than letting them be repaired, although it does mean that if someone wanted to code wooden windows, they technically could.