### PR TITLE
Removes construction skill requirement from barricade construction

### DIFF
--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -123,6 +123,7 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/barricade
 	title = "barricade"
 	result_type = /obj/structure/barricade
+	difficulty = 0
 	req_amount = 5
 	time = 50
 


### PR DESCRIPTION
:cl: theunlovedrock
tweak: barricades no longer require construction skill to construct
/:cl:

Barricades are ramshackle and really bad- they take forever to build and you're definitely better off building a wall, a window, a girder, even just a table you can flip is a better barricade. I don't see why they need so much construction skill, and reducing the requirement may create the rare circumstance that barricades are actually what you would use to build a barricade.