### PR TITLE
Modernizes emitter code and updates messages, adds info on examine for trained personnel

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -120,6 +120,11 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 #define SUPERMATTER_DATA_PRESSURE    "Pressure"
 #define SUPERMATTER_DATA_EPR         "Chamber EPR"
 
+// Emitter states
+#define EMITTER_LOOSE 0 // the goose is loose
+#define EMITTER_WRENCHED 1
+#define EMITTER_WELDED 2
+
 // Scrubber modes
 #define SCRUBBER_SIPHON   "siphon"
 #define SCRUBBER_SCRUB    "scrub"

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -3,7 +3,7 @@
 /obj/machinery/power/emitter/gyrotron
 	name = "gyrotron"
 	icon = 'icons/obj/machines/power/fusion.dmi'
-	desc = "It is a heavy duty industrial gyrotron suited for powering fusion reactors."
+	desc = "A heavy-duty, highly configurable industrial gyrotron suited for powering fusion reactors."
 	icon_state = "emitter-off"
 	req_access = list(access_engine)
 	use_power = POWER_USE_IDLE
@@ -21,8 +21,8 @@
 	base_type = /obj/machinery/power/emitter/gyrotron
 
 /obj/machinery/power/emitter/gyrotron/anchored
-	anchored = 1
-	state = 2
+	anchored = TRUE
+	state = EMITTER_WELDED
 
 /obj/machinery/power/emitter/gyrotron/Initialize()
 	set_extension(src, /datum/extension/local_network_member)
@@ -37,10 +37,10 @@
 	. = ..()
 
 /obj/machinery/power/emitter/gyrotron/get_rand_burst_delay()
-	return rate*10
+	return rate * 10
 
 /obj/machinery/power/emitter/gyrotron/get_burst_delay()
-	return rate*10
+	return rate * 10
 
 /obj/machinery/power/emitter/gyrotron/get_emitter_beam()
 	var/obj/item/projectile/beam/emitter/E = ..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -2,25 +2,26 @@
 
 /obj/machinery/power/emitter
 	name = "emitter"
-	desc = "A massive heavy industrial laser. This design is a fixed installation, capable of shooting in only one direction."
+	desc = "A massive, heavy-duty industrial laser. This design is a fixed installation, capable of shooting in only one direction."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "emitter"
-	anchored = 0
-	density = 1
+	anchored = FALSE
+	density = TRUE
 	req_access = list(access_engine_equip)
 	active_power_usage = 100 KILOWATTS
+	obj_flags = OBJ_FLAG_ROTATABLE
 
 	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.
-	var/active = 0
-	var/powered = 0
-	var/fire_delay = 100
-	var/max_burst_delay = 100
-	var/min_burst_delay = 20
+	var/active = FALSE
+	var/powered = FALSE
+	var/fire_delay = 10 SECONDS
+	var/max_burst_delay = 10 SECONDS
+	var/min_burst_delay = 2 SECONDS
 	var/burst_shots = 3
 	var/last_shot = 0
 	var/shot_number = 0
-	var/state = 0
-	var/locked = 0
+	var/state = EMITTER_LOOSE
+	var/locked = FALSE
 	core_skill = SKILL_ENGINES
 
 	uncreated_component_parts = list(
@@ -37,22 +38,36 @@
 	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/emitter = 1)
 
 /obj/machinery/power/emitter/anchored
-	anchored = 1
-	state = 2
+	anchored = TRUE
+	state = EMITTER_WELDED
 
 /obj/machinery/power/emitter/anchored/on
-	active = 1
-	powered = 1
+	active = TRUE
+	powered = TRUE
 
 /obj/machinery/power/emitter/Initialize()
 	. = ..()
-	if(state == 2 && anchored)
+	if (state == EMITTER_WELDED && anchored)
 		connect_to_network()
 
 /obj/machinery/power/emitter/Destroy()
 	log_and_message_admins("deleted \the [src]")
 	investigate_log("<font color='red'>deleted</font> at ([x],[y],[z])","singulo")
 	return ..()
+
+/obj/machinery/power/emitter/examine(mob/user)
+	. = ..()
+	var/is_observer = isobserver(user)
+	if (user.Adjacent(src) || is_observer)
+		var/state_message = "It is unsecured."
+		switch (state)
+			if (EMITTER_WRENCHED)
+				state_message = "It is bolted to the floor, but lacks securing welds."
+			if (EMITTER_WELDED)
+				state_message = "It is firmly secured in place."
+		to_chat(user, SPAN_NOTICE(state_message))
+		if (emagged && (user.skill_check(core_skill, SKILL_ADEPT) || is_observer))
+			to_chat(user, SPAN_WARNING("Its control locks have been fried."))
 
 /obj/machinery/power/emitter/on_update_icon()
 	if (active && powernet && avail(active_power_usage))
@@ -61,46 +76,56 @@
 		icon_state = "emitter"
 
 /obj/machinery/power/emitter/interface_interact(mob/user)
-	if(!CanInteract(user, DefaultTopicState()))
+	if (!CanInteract(user, DefaultTopicState()))
 		return FALSE
 	activate(user)
 	return TRUE
 
 /obj/machinery/power/emitter/proc/activate(mob/user as mob)
-	if(!istype(user))
+	if (!istype(user))
 		user = null // safety, as the proc is publicly available.
 
-	if(state == 2)
-		if(!powernet)
-			to_chat(user, "\The [src] isn't connected to a wire.")
-			return 1
-		if(!src.locked)
+	if (state == EMITTER_WELDED)
+		if (!powernet)
+			to_chat(user, SPAN_WARNING("You try to turn on \the [src], but it doesn't seem to be receiving power."))
+			return TRUE
+		if (!locked)
 			var/area/A = get_area(src)
-			if(src.active==1)
-				src.active = 0
-				to_chat(user, "You turn off \the [src].")
+			if (active)
+				active = FALSE
+				user.visible_message(
+					SPAN_NOTICE("\The [user] turns off \the [src]."),
+					SPAN_NOTICE("You power down \the [src]."),
+					SPAN_ITALIC("You hear a switch being flicked.")
+				)
+				playsound(src, "switch", 50)
 				log_and_message_admins("turned off \the [src] in [A.name]", user, src)
 				investigate_log("turned <font color='red'>off</font> by [key_name_admin(user || usr)] in [A.name]","singulo")
 			else
-				src.active = 1
-				if(user)
+				active = TRUE
+				if (user)
 					operator_skill = user.get_skill_value(core_skill)
 				update_efficiency()
-				to_chat(user, "You turn on \the [src].")
-				src.shot_number = 0
-				src.fire_delay = get_initial_fire_delay()
+				user.visible_message(
+					SPAN_NOTICE("\The [user] turns on \the [src]."),
+					SPAN_NOTICE("You configure \the [src] and turn it on."), // Mention configuration to allude to operator skill playing into efficiency
+					SPAN_ITALIC("You hear a switch being flicked.")
+				)
+				playsound(src, "switch", 50)
+				shot_number = 0
+				fire_delay = get_initial_fire_delay()
 				log_and_message_admins("turned on \the [src] in [A.name]", user, src)
 				investigate_log("turned <font color='green'>on</font> by [key_name_admin(user || usr)] in [A.name]","singulo")
 			update_icon()
 		else
-			to_chat(user, "<span class='warning'>The controls are locked!</span>")
+			to_chat(user, SPAN_WARNING("The controls are locked!"))
 	else
-		to_chat(user, "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>")
-		return 1
+		to_chat(user, SPAN_WARNING("\The [src] needs to be firmly secured to the floor first."))
+		return TRUE
 
 /obj/machinery/power/emitter/proc/update_efficiency()
 	efficiency = initial(efficiency)
-	if(!operator_skill)
+	if (!operator_skill)
 		return
 	var/skill_modifier = 0.8 * (SKILL_MAX - operator_skill)/(SKILL_MAX - SKILL_MIN) //How much randomness is added
 	efficiency *= 1 + (rand() - 1) * skill_modifier //subtract off between 0.8 and 0, depending on skill and luck.
@@ -109,139 +134,165 @@
 	return 1
 
 /obj/machinery/power/emitter/Process()
-	if(stat & (BROKEN))
+	if (stat & (BROKEN))
 		return
-	if(src.state != 2 || (!powernet && active_power_usage))
-		src.active = 0
+	if (state != EMITTER_WELDED || (!powernet && active_power_usage))
+		active = FALSE
 		update_icon()
 		return
-	if(((src.last_shot + src.fire_delay) <= world.time) && (src.active == 1))
+	if (((last_shot + fire_delay) <= world.time) && active)
 
 		var/actual_load = draw_power(active_power_usage)
-		if(actual_load >= active_power_usage) //does the laser have enough power to shoot?
-			if(!powered)
-				powered = 1
+		if (actual_load >= active_power_usage) // does the laser have enough power to shoot?
+			if (!powered)
+				powered = TRUE
 				update_icon()
+				visible_message(SPAN_WARNING("\The [src] turns on!"))
 				investigate_log("regained power and turned <font color='green'>on</font>","singulo")
 		else
-			if(powered)
-				powered = 0
+			if (powered)
+				powered = FALSE
 				update_icon()
+				visible_message(SPAN_WARNING("\The [src] powers down!"))
 				investigate_log("lost power and turned <font color='red'>off</font>","singulo")
 			return
 
-		src.last_shot = world.time
-		if(src.shot_number < burst_shots)
-			src.fire_delay = get_burst_delay()
-			src.shot_number ++
+		last_shot = world.time
+		if (shot_number < burst_shots)
+			fire_delay = get_burst_delay()
+			shot_number++
 		else
-			src.fire_delay = get_rand_burst_delay()
-			src.shot_number = 0
+			fire_delay = get_rand_burst_delay()
+			shot_number = 0
 
 		//need to calculate the power per shot as the emitter doesn't fire continuously.
-		var/burst_time = (min_burst_delay + max_burst_delay)/2 + 2*(burst_shots-1)
-		var/power_per_shot = (active_power_usage * efficiency) * (burst_time/10) / burst_shots
+		var/burst_time = (min_burst_delay + max_burst_delay) / 2 + 2 * (burst_shots - 1)
+		var/power_per_shot = (active_power_usage * efficiency) * (burst_time / 10) / burst_shots
 
-		if(prob(35))
+		if (prob(35))
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(5, 1, src)
 			s.start()
 
 		var/obj/item/projectile/beam/emitter/A = get_emitter_beam()
-		playsound(src.loc, A.fire_sound, 25, 1)
-		A.damage = round(power_per_shot/EMITTER_DAMAGE_POWER_TRANSFER)
-		A.launch( get_step(src.loc, src.dir) )
+		playsound(loc, A.fire_sound, 25, TRUE)
+		A.damage = round (power_per_shot / EMITTER_DAMAGE_POWER_TRANSFER)
+		A.launch( get_step(loc, dir) )
 
 /obj/machinery/power/emitter/attackby(obj/item/W, mob/user)
 
-	if(isWrench(W))
-		if(active)
-			to_chat(user, "Turn off [src] first.")
+	if (isWrench(W))
+		if (active)
+			to_chat(user, SPAN_WARNING("Turn \the [src] off first."))
 			return
 		switch(state)
-			if(0)
-				state = 1
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user.visible_message("[user.name] secures [src] to the floor.", \
-					"You secure the external reinforcing bolts to the floor.", \
-					"You hear a ratchet")
-				src.anchored = 1
-			if(1)
-				state = 0
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user.visible_message("[user.name] unsecures [src] reinforcing bolts from the floor.", \
-					"You undo the external reinforcing bolts.", \
-					"You hear a ratchet")
-				src.anchored = 0
-			if(2)
-				to_chat(user, "<span class='warning'>\The [src] needs to be unwelded from the floor.</span>")
+			if (EMITTER_LOOSE)
+				state = EMITTER_WRENCHED
+				playsound(loc, 'sound/items/Ratchet.ogg', 75, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] secures \the [src] to the floor."),
+					SPAN_NOTICE("You drop the external reinforcing bolts and secure them to the floor."),
+					SPAN_ITALIC("You hear ratcheting.")
+				)
+				anchored = TRUE
+			if (EMITTER_WRENCHED)
+				state = EMITTER_LOOSE
+				playsound(loc, 'sound/items/Ratchet.ogg', 75, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] unsecures \the [src] from the floor."),
+					SPAN_NOTICE("You undo the external reinforcing bolts."),
+					SPAN_ITALIC("You hear ratcheting.")
+				)
+				anchored = FALSE
+			if (EMITTER_WELDED)
+				to_chat(user, SPAN_WARNING("\The [src] needs to be unwelded from the floor before you raise its bolts."))
 		return
 
-	if(isWelder(W))
+	if (isWelder(W))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(active)
-			to_chat(user, "Turn off [src] first.")
+		if (active)
+			to_chat(user, SPAN_WARNING("Turn \the [src] off first."))
 			return
 		switch(state)
-			if(0)
-				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
-			if(1)
-				if (WT.remove_fuel(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to weld [src] to the floor.", \
-						"You start to weld [src] to the floor.", \
-						"You hear welding")
-					if (do_after(user,20,src))
-						if(!src || !WT.isOn()) return
-						state = 2
-						to_chat(user, "You weld [src] to the floor.")
+			if (EMITTER_LOOSE)
+				to_chat(user, SPAN_WARNING("\The [src] needs to be wrenched to the floor."))
+			if (EMITTER_WRENCHED)
+				if (WT.remove_fuel(0, user))
+					playsound(loc, 'sound/items/Welder.ogg', 50, TRUE)
+					user.visible_message(
+						SPAN_NOTICE("\The [user] starts to weld \the [src] to the floor."),
+						SPAN_NOTICE("You start to weld \the [src] to the floor."),
+						SPAN_ITALIC("You hear welding.")
+					)
+					if (do_after(user, 20, src))
+						if (!WT.isOn())
+							return
+						state = EMITTER_WELDED
+						playsound(loc, 'sound/items/Welder2.ogg', 50, TRUE)
+						user.visible_message(
+							SPAN_NOTICE("\The [user] welds \the [src] to the floor."),
+							SPAN_NOTICE("You weld the base of \the [src] to the floor, securing it in place."),
+							SPAN_ITALIC("You hear welding.")
+						)
 						connect_to_network()
 				else
-					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
-			if(2)
-				if (WT.remove_fuel(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to cut [src] free from the floor.", \
-						"You start to cut [src] free from the floor.", \
-						"You hear welding")
-					if (do_after(user,20,src))
-						if(!src || !WT.isOn()) return
-						state = 1
-						to_chat(user, "You cut [src] free from the floor.")
+					to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
+			if (EMITTER_WELDED)
+				if (WT.remove_fuel(0, user))
+					playsound(loc, 'sound/items/Welder.ogg', 50, TRUE)
+					user.visible_message(
+						SPAN_NOTICE("\The [user] starts to cut \the [src] free from the floor."),
+						SPAN_NOTICE("You start to cut \the [src] free from the floor."),
+						SPAN_ITALIC("You hear welding.")
+					)
+					if (do_after(user, 20, src))
+						if (!WT.isOn())
+							return
+						state = EMITTER_WRENCHED
+						playsound(loc, 'sound/items/Welder2.ogg', 50, TRUE)
+						user.visible_message(
+							SPAN_NOTICE("\The [user] cuts \the [src] free from the floor."),
+							SPAN_NOTICE("You cut \the [src] free from the floor."),
+							SPAN_ITALIC("You hear welding.")
+						)
 						disconnect_from_network()
 				else
-					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+					to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
 		return
 
-	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/modular_computer))
-		if(emagged)
-			to_chat(user, "<span class='warning'>The lock seems to be broken.</span>")
+	if (istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/modular_computer))
+		if (emagged)
+			to_chat(user, SPAN_WARNING("The control lock seems to be broken."))
 			return
-		if(src.allowed(user))
-			src.locked = !src.locked
-			to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
+		if (allowed(user))
+			locked = !locked
+			user.visible_message(
+				SPAN_NOTICE("\The [user] [locked ? "locks" : "unlocks"] \the [src]'s controls."),
+				SPAN_NOTICE("You [locked ? "lock" : "unlock"] the controls.")
+			)
 		else
-			to_chat(user, "<span class='warning'>Access denied.</span>")
+			to_chat(user, SPAN_WARNING("\The [src]'s controls flash an 'Access denied' warning."))
 		return
 	..()
 	return
 
 /obj/machinery/power/emitter/emag_act(var/remaining_charges, var/mob/user)
-	if(!emagged)
-		locked = 0
-		emagged = 1
+	if (!emagged)
+		locked = FALSE
+		emagged = TRUE
 		req_access.Cut()
-		user.visible_message("[user.name] emags [src].","<span class='warning'>You short out the lock.</span>")
-		return 1
+		user.visible_message(SPAN_WARNING("\The [user] messes with \the [src]'s controls."), SPAN_WARNING("You short out the control lock."))
+		user.playsound_local(loc, "sparks", 50, TRUE)
+		return TRUE
 
 /obj/machinery/power/emitter/proc/get_initial_fire_delay()
-	return 100
+	return 10 SECONDS
 
 /obj/machinery/power/emitter/proc/get_rand_burst_delay()
 	return rand(min_burst_delay, max_burst_delay)
 
 /obj/machinery/power/emitter/proc/get_burst_delay()
-	return 2
+	return 0.2 SECONDS // This value doesn't really affect normal emitters, but *does* affect subtypes like the gyrotron that can have very long delays
 
 /obj/machinery/power/emitter/proc/get_emitter_beam()
 	return new /obj/item/projectile/beam/emitter(get_turf(src))


### PR DESCRIPTION
🆑
tweak: Emitters can be rotated with alt-click if they're unsecured from the floor.
tweak: Examining an emitter with Trained engines skill or higher will show you if it's emagged.
spellcheck: Emitters have received a grammar and message pass.
/🆑

Emitters are old code, ft. magic numbers, spanless messages, and `src.` instances. I was bored and so I decided to modernize them in the following ways.
* Wording touchups across all actions. Emagging no longer explicitly says "X emags the emitter", and instead describes them as messing with the controls.
* Ran a styling pass on the whole emitter file.
* 0 and 1 -> FALSE and TRUE
* Decisecond vars -> `SECONDS` macros
* `<span class="blah">` -> `SPAN_BLAH` macros
* Replaced magic numbers with file-specific defines.
* Alt-clicking now rotates the emitter if it isn't anchored.
* More sounds! Click click.
* Examining emitters while adjacent (or a ghost) shows info about them. Also includes whether or not it's emagged. *That last part isn't intended to be a balance change, so if it's a problem, I'll remove it!*

