### PR TITLE
Fixes the admin log for turrets

### DIFF
--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -169,7 +169,7 @@
 			check_anomalies = value
 
 		if(!isnull(log_action))
-			log_and_message_admins("has [log_action]", 1)
+			log_and_message_admins("has [log_action]", usr, loc)
 
 		updateTurrets()
 		return 1


### PR DESCRIPTION
:cl:
admin: Turret admin logs now display the user instead of 'INVALID' and have working MOB and LOC links.
/:cl: