### PR TITLE
Fixes cremation attack log

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -308,7 +308,7 @@
 		update()
 
 		for(var/mob/living/M in contents)
-			admin_attack_log(M, A, "Began cremating their victim.", "Has begun being cremated.", "began cremating")
+			admin_attack_log(A, M, "Began cremating their victim.", "Has begun being cremated.", "began cremating")
 			if(iscarbon(M))
 				var/mob/living/carbon/C = M
 				for(var/I, I < 60, I++)


### PR DESCRIPTION
:cl:
admin: Fixes the cremation attack log reversing the order of attacker/victim and claiming the crematee was the one creating the cremator.
/:cl: