### PR TITLE
Expands intercomm talking to use exosuits too.

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -13,6 +13,7 @@
 	power_usage = 0
 	var/number = 0
 	var/last_tick //used to delay the powercheck
+	intercom_handling = TRUE
 
 /obj/item/device/radio/intercom/get_storage_cost()
 	return ITEM_SIZE_NO_CONTAINER

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -37,6 +37,8 @@
 
 	var/last_radio_sound = -INFINITY
 
+	var/intercom_handling = FALSE
+
 /obj/item/device/radio/hailing
 	name = "shortwave radio (Hailing)"
 	frequency = HAIL_FREQ
@@ -103,7 +105,7 @@
 
 	return ui_interact(user)
 
-/obj/item/device/radio/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+/obj/item/device/radio/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/data[0]
 
 	data["power"] = on
@@ -129,7 +131,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "radio_basic.tmpl", "[name]", 400, 430)
+		ui = new(user, src, ui_key, "radio_basic.tmpl", "[name]", 400, 430, state = state)
 		ui.set_initial_data(data)
 		ui.open()
 
@@ -897,6 +899,7 @@
 /obj/item/device/radio/exosuit
 	name = "exosuit radio"
 	cell = null
+	intercom_handling = TRUE
 
 /obj/item/device/radio/exosuit/get_cell()
 	. = ..()
@@ -926,5 +929,5 @@
 		if(istype(exosuit) && exosuit.head && exosuit.head.radio && exosuit.head.radio.is_functional())
 			return ..()
 
-/obj/item/device/radio/exosuit/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.mech_state)
+/obj/item/device/radio/exosuit/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, datum/nanoui/master_ui = null, var/datum/topic_state/state = GLOB.mech_state)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -164,10 +164,11 @@
 	switch(message_mode)
 		if("intercom")
 			if(!src.restrained())
-				for(var/obj/item/device/radio/intercom/I in view(1))
-					I.talk_into(src, message, null, verb, speaking)
-					I.add_fingerprint(src)
-					used_radios += I
+				for(var/obj/item/device/radio/I in view(1))
+					if(I.intercom_handling)
+						I.talk_into(src, message, null, verb, speaking)
+						I.add_fingerprint(src)
+						used_radios += I
 		if("headset")
 			if(l_ear && istype(l_ear,/obj/item/device/radio))
 				var/obj/item/device/radio/R = l_ear

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -31,6 +31,11 @@
 	if(message_mode)
 		if(message_mode == "general")
 			message_mode = null
+		if(message_mode == "intercom")
+			for(var/obj/item/device/radio/I in view(1))
+				if(I.intercom_handling)
+					I.talk_into(src, message, null, verb, speaking)
+					used_radios += I
 		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
 
 /mob/living/silicon/say_quote(var/text)

--- a/code/modules/nano/interaction/mech.dm
+++ b/code/modules/nano/interaction/mech.dm
@@ -1,8 +1,7 @@
-GLOBAL_DATUM_INIT(mech_state, /datum/topic_state/default/mech, new)
+GLOBAL_DATUM_INIT(mech_state, /datum/topic_state/physical/mech, new)
 
-/datum/topic_state/default/mech/can_use_topic(var/mob/living/exosuit/src_object, var/mob/user)
+/datum/topic_state/physical/mech/can_use_topic(var/mob/living/exosuit/src_object, var/mob/user)
 	if(istype(src_object))
-		if(user in src_object.pilots)
+		if((user in src_object.pilots) || (user == src_object))
 			return ..()
-	else return STATUS_CLOSE
-	return ..()
+	return STATUS_CLOSE


### PR DESCRIPTION
🆑CrimsonShrike
tweak: Intercomm quick access will now use exosuit radios if possible. (Use :i while in a mech to use the mech radio)
fix: Exosuit radios now will check distance correctly.
/🆑