### PR TITLE
Hotfix for some backgrounds breaking culture selection in the new system

### DIFF
--- a/code/modules/client/preference_setup/background/01_culture.dm
+++ b/code/modules/client/preference_setup/background/01_culture.dm
@@ -66,11 +66,15 @@
 				. += "<br>"
 			. += "<table width=100%><tr><td colspan=3>"
 			for (var/V in valid_values)
-				var/decl/cultural_info/CI = V
-				if (pref.cultural_info[token] == CI)
-					. += "<span class='linkOn'>[CI]</span> "
+				// this is yucky but we need to do it because, right now, the culture subsystem references decls by their string names
+				// html_encode() doesn't properly sanitize + symbols, otherwise we could just use that
+				// instead, we manually rip out the plus symbol and then replace it on OnTopic
+				var/sanitized_value = html_encode(replacetext(V, "+", "PLUS"))
+				
+				if (pref.cultural_info[token] == V)
+					. += "<span class='linkOn'>[V]</span> "
 				else
-					. += "<a href='?src=\ref[src];set_token_entry_[token]=[CI]'>[CI]</a> "
+					. += "<a href='?src=\ref[src];set_token_entry_[token]=[sanitized_value]'>[V]</a> "
 			. += "</table>"
 		. += "<hr>"
 	. = jointext(.,null)
@@ -89,7 +93,7 @@
 
 		var/new_token = href_list["set_token_entry_[token]"]
 		if (!isnull(new_token))
-			pref.cultural_info[token] = new_token
+			pref.cultural_info[token] = html_decode(replacetext(new_token, "PLUS", "+"))
 			return TOPIC_REFRESH
 			
 	. = ..()


### PR DESCRIPTION
A bunch of culture names - specifically those from Skrell and Unathi due to the absurd amount of apostrophes - are currently breaking the new culture selection system introduced in #30204 since I didn't test as much as I should.

Because the way cultures are stored would need a minor refactor to use direct refs instead of strings (like it does now) and peoples' prefs are breaking right now, this is a band-aid fix that runs `html_encode` on the values and replaces every plus sign with `PLUS`, then decodes that value when saving.

This appears to work with saving and loading slots, assigns the correct values in the cultural datums, and so on. I cycled through every available cultural option to ensure no more runtimes were being thrown (although obviously not every combination, since each token is stored discretely.)

The alternative to this is to revert the new selection system instead until the culture system can be adjusted to work correctly with it. In either case, it will necessitate a cleanup later if we want the new system (which I do, at least!) If a revert is preferred, I can update this MR to serve that purpose instead.