### PR TITLE
iv stands and rollers can only take iv bags

### DIFF
--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -65,7 +65,7 @@
 		hook_up(over_object, usr)
 
 /obj/structure/iv_drip/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/reagent_containers))
+	if (istype(W, /obj/item/weapon/reagent_containers/ivbag))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
 			return

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -215,7 +215,7 @@
 /obj/structure/bed/roller/attackby(obj/item/I, mob/user)
 	if(isWrench(I) || istype(I, /obj/item/stack) || isWirecutter(I))
 		return 1
-	if(iv_stand && !beaker && istype(I, /obj/item/weapon/reagent_containers))
+	if(iv_stand && !beaker && istype(I, /obj/item/weapon/reagent_containers/ivbag))
 		if(!user.unEquip(I, src))
 			return
 		to_chat(user, "You attach \the [I] to \the [src].")


### PR DESCRIPTION
:cl:
bugfix: You can no longer drain donut souls directly from donuts into your own blood; IV stands and roller beds can only use IV bags as IV bags.
/:cl: