### PR TITLE
Fixes few binoculars/scopes bugs

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -72,6 +72,9 @@
 
 /atom/proc/reveal_blood()
 	return
+	
+/atom/proc/MayZoom()
+	return TRUE
 
 /atom/proc/assume_air(datum/gas_mixture/giver)
 	return null

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -687,6 +687,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(zoom)
 		return
 
+	if(!user.loc?.MayZoom())
+		return
+
 	var/devicename = zoomdevicename || name
 
 	var/mob/living/carbon/human/H = user
@@ -703,6 +706,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(user.hud_used.hud_shown)
 		user.toggle_zoom_hud()	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
 	user.client.view = viewsize
+	if(istype(H))
+		H.handle_vision()
 	zoom = 1
 
 	var/viewoffset = WORLD_ICON_SIZE * tileoffset
@@ -757,6 +762,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	user.client.pixel_x = 0
 	user.client.pixel_y = 0
+	
+	var/mob/living/carbon/human/H = user
+	if(istype(H))
+		H.handle_vision()
 	user.visible_message("[zoomdevicename ? "\The [user] looks up from [src]" : "\The [user] lowers [src]"].")
 
 /obj/item/proc/pwr_drain()

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -70,6 +70,11 @@
 	var/obj/screen/exosuit/toggle/hatch_open/hud_open
 	var/obj/screen/exosuit/power/hud_power
 
+/mob/living/exosuit/MayZoom()
+	if(head?.vision_flags)
+		return FALSE
+	return TRUE
+
 /mob/living/exosuit/is_flooded(lying_mob, absolute)
 	. = (body && body.pilot_coverage >= 100 && hatch_closed) ? FALSE : ..()
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -51,7 +51,16 @@
 	equipment_darkness_modifier = 0
 	equipment_overlays.Cut()
 
-	if (!client || client.eye == src || client.eye == src.loc) // !client is so the unit tests function
+	if(istype(glasses, /obj/item/clothing/glasses))
+		process_prescription(glasses)
+	
+	var/binoc_check
+	if(client)
+		binoc_check = client.view == world.view
+	else
+		binoc_check = TRUE
+
+	if ((!client || client.eye == src || client.eye == loc || client.eye == bound_overlay) && binoc_check) // !client is so the unit tests function
 		if(istype(src.head, /obj/item/clothing/head))
 			add_clothing_protection(head)
 		if(istype(src.glasses, /obj/item/clothing/glasses))
@@ -61,24 +70,25 @@
 		if(istype(back,/obj/item/weapon/rig))
 			process_rig(back)
 
-/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
+/mob/living/carbon/human/proc/process_prescription(var/obj/item/clothing/glasses/G)
 	if(G)
-		// prescription applies regardless of if the glasses are active
 		equipment_prescription += G.prescription
-		if(G.active)
-			equipment_darkness_modifier += G.darkness_view
-			equipment_vision_flags |= G.vision_flags
-			equipment_light_protection += G.light_protection
-			if(G.overlay)
-				equipment_overlays |= G.overlay
-			if(G.see_invisible >= 0)
-				if(equipment_see_invis)
-					equipment_see_invis = min(equipment_see_invis, G.see_invisible)
-				else
-					equipment_see_invis = G.see_invisible
 
-			add_clothing_protection(G)
-			G.process_hud(src)
+/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
+	if(G?.active)
+		equipment_darkness_modifier += G.darkness_view
+		equipment_vision_flags |= G.vision_flags
+		equipment_light_protection += G.light_protection
+		if(G.overlay)
+			equipment_overlays |= G.overlay
+		if(G.see_invisible >= 0)
+			if(equipment_see_invis)
+				equipment_see_invis = min(equipment_see_invis, G.see_invisible)
+			else
+				equipment_see_invis = G.see_invisible
+
+		add_clothing_protection(G)
+		G.process_hud(src)
 
 /mob/living/carbon/human/proc/process_rig(var/obj/item/weapon/rig/O)
 	if(O.visor && O.visor.active && O.visor.vision && O.visor.vision.glasses && (!O.helmet || (head && O.helmet == head)))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Imienny
bugfix: Prescription glasses once again work while using camera.
bugfix: Goggles once again work when looking up.
tweak: Its no longer possible to use binoculars inside of mechs with sensors providing any vision flags.
tweak: Binoculars/scopes temporarily disable worn goggles when used.
/:cl: