### PR TITLE
fixes crates/closets being deleted when fired from the ofd

### DIFF
--- a/code/modules/overmap/disperser/disperser_fire.dm
+++ b/code/modules/overmap/disperser/disperser_fire.dm
@@ -67,7 +67,9 @@
 	playsound(start, 'sound/machines/disperser_fire.ogg', 100, 1)
 	handle_beam(start, direction)
 	handle_overbeam()
-	qdel(atomcharge)
+
+	if (chargetype != OVERMAP_WEAKNESS_DROPPOD)
+		qdel(atomcharge)
 
 	//Some moron disregarded the cooldown warning. Let's blow in their face.
 	if(prob(cool_failchance()))


### PR DESCRIPTION
🆑 Mucker
bugfix: Fix crates/closets being deleted when fired from the OFD instead of sent to their target.
/🆑