### PR TITLE
Firedoor code improvements, firedoors now play sounds on open/close

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -1,4 +1,3 @@
-
 #define FIREDOOR_MAX_PRESSURE_DIFF 25 // kPa
 #define FIREDOOR_MAX_TEMP 50 // °C
 #define FIREDOOR_MIN_TEMP 0
@@ -6,19 +5,18 @@
 // Bitflags
 #define FIREDOOR_ALERT_HOT      1
 #define FIREDOOR_ALERT_COLD     2
-// Not used #define FIREDOOR_ALERT_LOWPRESS 4
 
 /obj/machinery/door/firedoor
-	name = "\improper Emergency Shutter"
-	desc = "Emergency air-tight shutter, capable of sealing off breached areas."
+	name = "emergency shutter"
+	desc = "An emergency air-tight shutter, capable of sealing off breached areas."
 	icon = 'icons/obj/doors/hazard/door.dmi'
 	var/panel_file = 'icons/obj/doors/hazard/panel.dmi'
 	var/welded_file = 'icons/obj/doors/hazard/welded.dmi'
 	icon_state = "open"
 	req_access = list(list(access_atmospherics, access_engine_equip))
 	autoset_access = FALSE
-	opacity = 0
-	density = 0
+	opacity = FALSE
+	density = FALSE
 	layer = BELOW_DOOR_LAYER
 	open_layer = BELOW_DOOR_LAYER
 	closed_layer = ABOVE_WINDOW_LAYER
@@ -26,21 +24,25 @@
 	pry_mod = 0.75
 	var/locked = FALSE //If the door is forced open, it will not close again until the next atmosphere alert in the area
 
-	//These are frequenly used with windows, so make sure zones can pass.
+	//These are frequently used with windows, so make sure zones can pass.
 	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
-	block_air_zones = 0
+	block_air_zones = FALSE
 
-	var/blocked = 0
-	var/lockdown = 0 // When the door has detected a problem, it locks.
-	var/pdiff_alert = 0
-	var/pdiff = 0
+	var/blocked = FALSE // Whether or not the door is welded shut.
+	var/lockdown = FALSE // When the door has detected a problem, it locks.
+	var/closing = FALSE
+	var/hatch_open = FALSE
+
+	var/pdiff = 0 // Pressure differential. Set to the difference between highest and lowest adjacent pressures in Process()
+	var/pdiff_alert = FALSE // If this firedoor has an active alert for pressure differential.
+	
 	var/nextstate = null
 	var/net_id
 	var/list/areas_added
 	var/list/users_to_open = new
 	var/next_process_time = 0
-	var/closing = 0
-	var/hatch_open = 0
+	var/open_sound = 'sound/machines/blastdoor_open.ogg'
+	var/close_sound = 'sound/machines/blastdoor_close.ogg'
 
 	power_channel = ENVIRON
 	idle_power_usage = 5
@@ -97,7 +99,7 @@
 		return
 
 	if(pdiff >= FIREDOOR_MAX_PRESSURE_DIFF)
-		to_chat(user, "<span class='warning'>WARNING: Current pressure differential is [pdiff]kPa! Opening door may result in injury!</span>")
+		to_chat(user, SPAN_WARNING("WARNING: Current pressure differential is [pdiff] kPa! Opening door may result in injury!"))
 	to_chat(user, "<b>Sensor readings:</b>")
 	for(var/index = 1; index <= tile_info.len; index++)
 		var/o = "&nbsp;&nbsp;"
@@ -111,7 +113,7 @@
 			if(4)
 				o += "WEST: "
 		if(tile_info[index] == null)
-			o += "<span class='warning'>DATA UNAVAILABLE</span>"
+			o += SPAN_WARNING("DATA UNAVAILABLE")
 			to_chat(user, o)
 			continue
 		var/celsius = convert_k2c(tile_info[index][1])
@@ -147,35 +149,38 @@
 		qdel(src)
 	..()
 
-/obj/machinery/door/firedoor/attack_hand(mob/user as mob)
+/obj/machinery/door/firedoor/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(operating)
 		return//Already doing something.
 
 	if(blocked)
-		to_chat(user, "<span class='warning'>\The [src] is welded solid!</span>")
+		to_chat(user, SPAN_WARNING("\The [src] is welded shut!"))
+		return
+	if(density && (stat & (BROKEN|NOPOWER))) //can still close without power
+		to_chat(user, "\The [src] is not functioning - you'll have to force it open manually.")
 		return
 
 	var/alarmed = lockdown
 	alarmed = get_alarm()
 
-	var/answer = alert(user, "Would you like to [density ? "open" : "close"] this [src.name]?[ alarmed && density ? "\nNote that by doing so, you acknowledge any damages from opening this\n[src.name] as being your own fault, and you will be held accountable under the law." : ""]",\
+	var/answer = alert(user, "Would you like to [density ? "open" : "close"] this [name]?[ alarmed && density ? "\nNote that by doing so, you acknowledge any damages from opening this\n[name] as being your own fault, and you will be held accountable under the law." : ""]",\
 	"\The [src]", "Yes, [density ? "open" : "close"]", "No")
 	if(answer == "No")
 		return
-	if(user.incapacitated() || (get_dist(src, user) > 1  && !issilicon(user)))
-		to_chat(user, "Sorry, you must remain able bodied and close to \the [src] in order to use it.")
-		return
-	if(density && (stat & (BROKEN|NOPOWER))) //can still close without power
-		to_chat(user, "\The [src] is not functioning, you'll have to force it open manually.")
+	if(user.incapacitated() || !user.Adjacent(src) && !issilicon(user))
+		to_chat(user, SPAN_WARNING("You must remain able-bodied and close to \the [src] in order to use it."))
 		return
 	if(alarmed && density && lockdown && !allowed(user))
-		to_chat(user, "<span class='warning'>Access denied. Please wait for authorities to arrive, or for the alert to clear.</span>")
+		to_chat(user, SPAN_WARNING("Access denied. Please wait for authorities to arrive, or for the alert to clear."))
 		return
 	else
-		user.visible_message("<span class='notice'>\The [src] [density ? "open" : "close"]s for \the [user].</span>",\
-		"\The [src] [density ? "open" : "close"]s.",\
-		"You hear a beep, and a door opening.")
+		user.visible_message(
+			SPAN_NOTICE("\The [src] [density ? "open" : "close"]s for \the [user]."),
+			SPAN_NOTICE("\The [src] [density ? "open" : "close"]s."),
+			SPAN_ITALIC("You hear a soft beep, and a door sliding [density ? "open" : "shut"].")
+		)
+		playsound(loc, 'sound/piano/A#6.ogg', 50)
 
 	var/needs_to_close = 0
 	if(density)
@@ -191,15 +196,9 @@
 			close()
 
 	if(needs_to_close)
-		sleep(100)
-		alarmed = 0
-		alarmed = get_alarm()	//Just in case a fire alarm is turned off while the firedoor is going through an autoclose cycle
+		addtimer(CALLBACK(src, .proc/attempt_autoclose), 10 SECONDS) //Just in case a fire alarm is turned off while the firedoor is going through an autoclose cycle
 
-		if(alarmed)
-			nextstate = FIREDOOR_CLOSED
-			close()
-
-/obj/machinery/door/firedoor/attackby(obj/item/weapon/C as obj, mob/user as mob)
+/obj/machinery/door/firedoor/attackby(obj/item/C, mob/user)
 	add_fingerprint(user, 0, C)
 	if(operating)
 		return //Already doing something.
@@ -207,14 +206,22 @@
 	if(isWelder(C) && !repairing)
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0, user))
-			playsound(src, 'sound/items/Welder.ogg', 100, 1)
+			user.visible_message(
+				SPAN_WARNING("\The [user] starts [!blocked ? "welding \the [src] shut" : "cutting open \the [src]"]."),
+				SPAN_DANGER("You start [!blocked ? "welding \the [src] closed" : "cutting open \the [src]"]."),
+				SPAN_ITALIC("You hear welding.")
+			)
+			playsound(loc, 'sound/items/Welder.ogg', 50, TRUE)
 			if(do_after(user, 2 SECONDS, src))
-				if(!W.isOn()) return
+				if(!W.isOn())
+					return
 				blocked = !blocked
-				user.visible_message("<span class='danger'>\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [W].</span>",\
-				"You [blocked ? "weld" : "unweld"] \the [src] with \the [W].",\
-				"You hear something being welded.")
-				playsound(src, 'sound/items/Welder.ogg', 100, 1)
+				user.visible_message(
+					SPAN_DANGER("\The [user] [blocked ? "welds \the [src] shut" : "cuts open \the [src]"]."),
+					SPAN_DANGER("You [blocked ? "weld shut" : "undo the welds on"] \the [src]."),
+					SPAN_ITALIC("You hear welding.")
+				)
+				playsound(loc, 'sound/items/Welder2.ogg', 50, TRUE)
 				update_icon()
 				return
 			else
@@ -223,30 +230,40 @@
 
 	if(density && isScrewdriver(C))
 		hatch_open = !hatch_open
-		user.visible_message("<span class='danger'>[user] has [hatch_open ? "opened" : "closed"] \the [src] maintenance hatch.</span>",
-									"You have [hatch_open ? "opened" : "closed"] the [src] maintenance hatch.")
-		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [hatch_open ? "opens" : "closes"] \the [src]'s maintenance hatch."),
+			SPAN_NOTICE("You [hatch_open ? "open" : "close"] \the [src]'s maintenance hatch."),
+			SPAN_ITALIC("You hear screws being adjusted.")
+		)
+		playsound(loc, 'sound/items/Screwdriver.ogg', 25, TRUE)
 		update_icon()
 		return
 
 	if(blocked && isCrowbar(C) && !repairing)
 		if(!hatch_open)
-			to_chat(user, "<span class='danger'>You must open the maintenance hatch first!</span>")
+			to_chat(user, SPAN_DANGER("You must open the maintenance hatch first!"))
 		else
-			user.visible_message("<span class='danger'>[user] is removing the electronics from \the [src].</span>",
-									"You start to remove the electronics from [src].")
-			if(do_after(user,30,src))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts removing \the [src]'s electronics."),
+				SPAN_NOTICE("You start levering out \the [src]'s electronics."),
+				SPAN_ITALIC("You hear metal bumping against metal.")
+			)
+			playsound(loc, 'sound/items/Crowbar.ogg', 100, TRUE)
+			if(do_after(user, 30, src))
 				if(blocked && density && hatch_open)
-					playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-					user.visible_message("<span class='danger'>[user] has removed the electronics from \the [src].</span>",
-										"You have removed the electronics from [src].")
+					playsound(loc, 'sound/items/Deconstruct.ogg', 100, TRUE)
+					user.visible_message(
+						SPAN_NOTICE("\The [user] removes the electronics from \the [src]!"),
+						SPAN_NOTICE("You pry out \the [src]'s circuit board."),
+						SPAN_ITALIC("You hear metal coming loose and clattering.")
+					)
 					deconstruct(user)
 			else
-				to_chat(user, "<span class='notice'>You must remain still to remove the electronics from \the [src].</span>")
+				to_chat(user, SPAN_NOTICE("You must remain still to remove the electronics from \the [src]."))
 		return
 
 	if(blocked)
-		to_chat(user, "<span class='danger'>\The [src] is welded shut!</span>")
+		to_chat(user, SPAN_DANGER("\The [src] is welded shut!"))
 		return
 
 	if(isCrowbar(C) || istype(C,/obj/item/weapon/material/twohanded/fireaxe))
@@ -254,9 +271,11 @@
 			return
 
 		if(blocked && isCrowbar(C))
-			user.visible_message("<span class='danger'>\The [user] pries at \the [src] with \a [C], but \the [src] is welded in place!</span>",\
-			"You try to pry \the [src] [density ? "open" : "closed"], but it is welded in place!",\
-			"You hear someone struggle and metal straining.")
+			user.visible_message(
+				SPAN_WARNING("\The [user] pries at \the [src], but it's stuck in place!"),
+				SPAN_WARNING("You try to pry \the [src] [density ? "open" : "closed"], but it's been welded in place!"),
+				SPAN_WARNING("You hear the unhappy sound of metal straining and groaning.")
+			)
 			return
 
 		if(istype(C,/obj/item/weapon/material/twohanded/fireaxe))
@@ -264,22 +283,29 @@
 			if(!F.wielded)
 				return
 
-		user.visible_message("<span class='danger'>\The [user] starts to force \the [src] [density ? "open" : "closed"] with \a [C]!</span>",\
-				"You start forcing \the [src] [density ? "open" : "closed"] with \the [C]!",\
-				"You hear metal strain.")
-		if(do_after(user,30,src))
+		user.visible_message(
+			SPAN_WARNING("\The [user] wedges \the [C] into \the [src] and starts forcing it [density ? "open" : "closed"]!"),
+			SPAN_DANGER("You start forcing \the [src] [density ? "open" : "shut"]."),
+			SPAN_WARNING("You hear metal groaning and grinding!")
+		)
+		playsound(loc, 'sound/machines/airlock_creaking.ogg', 100, TRUE)
+		if(do_after(user, 30, src))
 			if(isCrowbar(C))
 				if(stat & (BROKEN|NOPOWER) || !density)
-					user.visible_message("<span class='danger'>\The [user] forces \the [src] [density ? "open" : "closed"] with \a [C]!</span>",\
-					"You force \the [src] [density ? "open" : "closed"] with \the [C]!",\
-					"You hear metal strain, and a door [density ? "open" : "close"].")
+					user.visible_message(
+						SPAN_DANGER("\The [user] pries \the [src] [density ? "open" : "shut"]!"),
+						SPAN_DANGER("You force [density ? "open" : "shut"] \the [src]!"),
+						SPAN_WARNING("You hear metal groan as a door is forced [density ? "open" : "closed"]!")
+					)
 				else
-					user.visible_message("<span class='danger'>\The [user] forces \the [ blocked ? "welded" : "" ] [src] [density ? "open" : "closed"] with \a [C]!</span>",\
-						"You force \the [ blocked ? "welded" : "" ] [src] [density ? "open" : "closed"] with \the [C]!",\
-						"You hear metal strain and groan, and a door [density ? "opening" : "closing"].")
+					user.visible_message(
+						SPAN_DANGER("\The [user] forces \the [src] [density ? "open" : "shut"]!"),
+						SPAN_DANGER("You force [density ? "open" : "shut"] \the [src]!"),
+						SPAN_WARNING("You hear metal shrieking as a door is forced [density ? "open" : "closed"]!")
+					)
 			if(density)
 				spawn(0)
-					open(1)
+					open(TRUE)
 					if(lockdown || get_alarm())
 						locked = TRUE
 			else
@@ -288,19 +314,20 @@
 					close()
 			return
 		else
-			to_chat(user, "<span class='notice'>You must remain still to interact with \the [src].</span>")
+			to_chat(user, SPAN_WARNING("You must remain still to interact with \the [src]."))
+			return
 	return ..()
 
 /obj/machinery/door/firedoor/deconstruct(mob/user, var/moved = FALSE)
 	if (stat & BROKEN)
-		new /obj/item/weapon/stock_parts/circuitboard/broken(src.loc)
+		new /obj/item/weapon/stock_parts/circuitboard/broken(loc)
 	else
-		new/obj/item/weapon/airalarm_electronics(src.loc)
+		new/obj/item/weapon/airalarm_electronics(loc)
 
-	var/obj/structure/firedoor_assembly/FA = new/obj/structure/firedoor_assembly(src.loc)
+	var/obj/structure/firedoor_assembly/FA = new/obj/structure/firedoor_assembly(loc)
 	FA.anchored = !moved
-	FA.set_density(1)
-	FA.wired = 1
+	FA.set_density(TRUE)
+	FA.wired = TRUE
 	FA.update_icon()
 	qdel(src)
 
@@ -311,41 +338,42 @@
 	if(density && next_process_time <= world.time)
 		next_process_time = world.time + 100		// 10 second delays between process updates
 		var/changed = 0
-		lockdown=0
+		lockdown = FALSE
 		// Pressure alerts
-		pdiff = getOPressureDifferential(src.loc)
+
+		pdiff = getOPressureDifferential(loc)
 		if(pdiff >= FIREDOOR_MAX_PRESSURE_DIFF)
-			lockdown = 1
+			lockdown = TRUE
 			if(!pdiff_alert)
-				pdiff_alert = 1
-				changed = 1 // update_icon()
+				pdiff_alert = TRUE
+				changed = TRUE
 		else
 			if(pdiff_alert)
-				pdiff_alert = 0
-				changed = 1 // update_icon()
+				pdiff_alert = FALSE
+				changed = TRUE 
 
-		tile_info = getCardinalAirInfo(src.loc,list("temperature","pressure"))
+		tile_info = getCardinalAirInfo(loc,list("temperature", "pressure"))
 		var/old_alerts = dir_alerts
 		for(var/index = 1; index <= 4; index++)
-			var/list/tileinfo=tile_info[index]
-			if(tileinfo==null)
+			var/list/tileinfo = tile_info[index]
+			if(tileinfo == null)
 				continue // Bad data.
 			var/celsius = convert_k2c(tileinfo[1])
 
-			var/alerts=0
+			var/alerts = 0
 
 			// Temperatures
 			if(celsius >= FIREDOOR_MAX_TEMP)
 				alerts |= FIREDOOR_ALERT_HOT
-				lockdown = 1
+				lockdown = TRUE
 			else if(celsius <= FIREDOOR_MIN_TEMP)
 				alerts |= FIREDOOR_ALERT_COLD
-				lockdown = 1
+				lockdown = TRUE
 
 			dir_alerts[index]=alerts
 
 		if(dir_alerts != old_alerts)
-			changed = 1
+			changed = TRUE
 		if(changed)
 			update_icon()
 
@@ -355,7 +383,6 @@
 	switch(nextstate)
 		if(FIREDOOR_OPEN)
 			nextstate = null
-
 			open()
 		if(FIREDOOR_CLOSED)
 			nextstate = null
@@ -366,15 +393,19 @@
 	if(closing || locked)
 		return
 
-	closing = 1
+	closing = TRUE
 	latetoggle()
 	var/list/people = list()
 	for(var/turf/turf in locs)
 		for(var/mob/living/M in turf)
 			people += M
 	if(length(people))
-		visible_message(SPAN_DANGER("\The [src] beeps ominously, get out of the way!"), SPAN_DANGER("You hear some beeping coming from the ceiling."), 3)
-		playsound(src, "sound/machines/firedoor.ogg", 50)
+		visible_message(
+			SPAN_DANGER("\The [src] beeps ominously, get out of the way!"),
+			SPAN_DANGER("You hear buzzing coming from the ceiling."), 
+			range = 3
+		)
+		playsound(loc, "sound/machines/firedoor.ogg", 50)
 		sleep(2 SECONDS)
 		for(var/turf/turf in locs)
 			for(var/mob/living/M in turf)
@@ -401,17 +432,22 @@
 							if(istype(A) && !turf_contains_dense_objects(T))
 								direction = d
 
-				M.visible_message(SPAN_DANGER("\The [src] knocks [M.name] out of the way!"), SPAN_DANGER("\The [src] knocks you out of the way!"))
+				M.visible_message(
+					SPAN_DANGER("\The [src] knocks \the [M] out of the way!"),
+					SPAN_DANGER("\The [src] forcefully shoves you out of the way!"),
+					SPAN_WARNING("You hear metal smacking into something.")
+				)
 				M.apply_damage(10, BRUTE, used_weapon = src)
 				if(direction) 
 					M.Move(get_step(src, direction))
-	closing = 0
+	playsound(loc, close_sound, 25, TRUE)
+	closing = FALSE
 	return ..()
 
-/obj/machinery/door/firedoor/open(var/forced = 0)
+/obj/machinery/door/firedoor/open(var/forced = FALSE)
 	if(hatch_open)
-		hatch_open = 0
-		visible_message("The maintenance hatch of \the [src] closes.")
+		hatch_open = FALSE
+		visible_message(SPAN_NOTICE("\The [src]'s maintenance hatch falls shut as it moves."))
 		update_icon()
 
 	if(!forced)
@@ -422,16 +458,23 @@
 	else
 		log_and_message_admins("has forced open an emergency shutter.")
 	latetoggle()
+	playsound(loc, open_sound, 25, TRUE)
 	return ..()
+
+// Called ten seconds after a firedoor is opened manually during an active alert, to prevent it staying open for long.
+/obj/machinery/door/firedoor/proc/attempt_autoclose()
+	if(!density && get_alarm())
+		nextstate = FIREDOOR_CLOSED
+		close()
 
 // Only opens when all areas connecting with our turf have an air alarm and are cleared
 /obj/machinery/door/firedoor/proc/can_safely_open()
 	var/turf/neighbour
 	for(var/dir in GLOB.cardinal)
-		neighbour = get_step(src.loc, dir)
-		if(neighbour.c_airblock(src.loc) & AIR_BLOCKED)
+		neighbour = get_step(loc, dir)
+		if(neighbour.c_airblock(loc) & AIR_BLOCKED)
 			continue
-		for(var/obj/O in src.loc)
+		for(var/obj/O in loc)
 			if(istype(O, /obj/machinery/door))
 				continue
 			. |= O.c_airblock(neighbour)
@@ -479,11 +522,11 @@
 			lights_overlay += "palert"
 			do_set_light = TRUE
 		if(dir_alerts)
-			for(var/d=1;d<=4;d++)
+			for(var/d=1; d<=4; d++)
 				var/cdir = GLOB.cardinal[d]
-				for(var/i=1;i<=ALERT_STATES.len;i++)
-					if(dir_alerts[d] & (1<<(i-1)))
-						overlays += new/icon(icon,"alert_[ALERT_STATES[i]]", dir=cdir)
+				for(var/i=1; i<=ALERT_STATES.len; i++)
+					if(dir_alerts[d] & (1 << (i - 1)))
+						overlays += new/icon(icon, "alert_[ALERT_STATES[i]]", dir = cdir)
 						do_set_light = TRUE
 	else
 		icon_state = "open"


### PR DESCRIPTION
:cl:
rscadd: Emergency shutters now play sounds when they open and close.
spellcheck: Rewrote some emergency shutter messages from past tense to present tense (i.e. "has opened" -> "opens").
/:cl:

General touchup and modernization, similar to #30230.
* removal of `src.`
* `TRUE` and `FALSE`
* span wrapping
* code stylization
* documentation
* replaced a sleep() instance with a timer that calls a new proc that executes the same logic
* rewriting of visible messages (note: stuff like welding no longer explicitly names the used item - I felt like this info was superfluous, since I don't think it's something that most people are going to care about - just that the door is being welded or unwelded, and so on. as usual, if that's a problem, let me know so I can change it back!)
* firelocks now play sounds when opening and closing. these sounds are low in volume so as not to be overbearing. I used `blastdoor_open.ogg` and `blastdoor_close.ogg` for these.
* message for "not functioning, you'll have to open it manually" is now displayed before throwing the alert to manually open, not after

tested on a local server via manually pulling fire alarms, messing with the firelocks directly, a hull breach, a notably large phoron fire, and a massive hydrogen fire (ft. third deck starboard nacelle, a place with a special spot in my heart).