### PR TITLE
Synthetics can't smell gunshot residue

### DIFF
--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -201,17 +201,21 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(get_skill_value(SKILL_FORENSICS) >= SKILL_EXPERT && get_dist(src, A) <= (get_skill_value(SKILL_FORENSICS) - SKILL_ADEPT))
 		var/clue
 		if(LAZYLEN(A.suit_fibers))
-			to_chat(src, "<span class='notice'>You notice some fibers embedded in \the [A].</span>")
+			to_chat(src, SPAN_NOTICE("You notice some fibers embedded in \the [A]."))
 			clue = 1
 		if(LAZYLEN(A.fingerprints))
-			to_chat(src, "<span class='notice'>You notice a partial print on \the [A].</span>")
+			to_chat(src, SPAN_NOTICE("You notice a partial print on \the [A]."))
 			clue = 1
 		if(LAZYLEN(A.gunshot_residue))
-			to_chat(src, "<span class='notice'>You notice a faint acrid smell coming from \the [A].</span>")
+			var/mob/living/carbon/human/M = src
+			if(M.isSynthetic())
+				to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))
+			else
+				to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))
 			clue = 1
 		//Noticing wiped blood is a bit harder
 		if((get_skill_value(SKILL_FORENSICS) >= SKILL_PROF) && LAZYLEN(A.blood_DNA))
-			to_chat(src, "<span class='warning'>You notice faint blood traces on \The [A].</span>")
+			to_chat(src, SPAN_WARNING("You notice faint blood traces on \The [A]."))
 			clue = 1
 		if(clue && has_client_color(/datum/client_color/noir))
 			playsound_local(null, pick('sound/effects/clue1.ogg','sound/effects/clue2.ogg'), 60, is_global = TRUE)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Changes a small message that appears when examining for gunshot residue so that synthetics are no longer told they can 'smell' something. Also touches up spans in the file to use macros.
🆑
tweak: Removes mention of smell for synthetics when examining gunshot residue.
/🆑