### PR TITLE
Removes lack of MRE vendor in the Mess Hall

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -6235,6 +6235,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
+"mt" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/machinery/vending/mredispenser{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/mess)
 "mv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -38682,7 +38691,7 @@ jd
 jd
 nj
 Lx
-jc
+mt
 Nw
 Xn
 sj


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Vhbraz
maptweak: The MRE vendor has been re-added to the Mess Hall.
/:cl:

Because I feel like surviving on candy machines and protein bars when there is not a competent Chef awake is a ICCG covert op intent on malnourishing solarian crewmembers.