### PR TITLE
Runtime fix for synthetic forensics

### DIFF
--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -207,8 +207,13 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 			to_chat(src, SPAN_NOTICE("You notice a partial print on \the [A]."))
 			clue = 1
 		if(LAZYLEN(A.gunshot_residue))
-			var/mob/living/carbon/human/M = src
-			if(M.isSynthetic())
+			if(isliving(src))
+				var/mob/living/M = src
+				if(M.isSynthetic())
+					to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))
+				else
+					to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))
+			else if(isrobot(src))
 				to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))
 			else
 				to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixes runtime introduced by #30271 that occurred when a mob other than /carbon/human examined gunshot ressidue.
Fixes #30277.