### PR TITLE
Add player threshold for sites with slots & cost per site

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -59,7 +59,7 @@
 		. = B.qdels - A.qdels
 
 /proc/cmp_ruincost_priority(datum/map_template/ruin/A, datum/map_template/ruin/B)
-	return initial(A.cost) - initial(B.cost)
+	return initial(A.spawn_cost) - initial(B.spawn_cost)
 
 /proc/cmp_timer(datum/timedevent/a, datum/timedevent/b)
 	return a.timeToRun - b.timeToRun

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -6,7 +6,8 @@
 	It is clearly a mystery."
 
 	var/spawn_weight = 1
-	var/cost = null
+	var/spawn_cost = 0
+	var/player_cost = 0
 
 	var/prefix = null
 	var/suffixes = null

--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 
 	while (remaining > 0 && length(available))
 		var/datum/map_template/ruin/ruin = pickweight(available)
-		if (ruin.cost > budget)
+		if (ruin.spawn_cost > remaining)
 			available -= ruin
 			continue
 
@@ -54,8 +54,8 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 
 			load_ruin(choice, ruin)
 			selected += ruin
-			if (ruin.cost > 0)
-				remaining -= ruin.cost
+			if (ruin.spawn_cost > 0)
+				remaining -= ruin.spawn_cost
 			if (!(ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 				GLOB.banned_ruin_ids += ruin.id
 				available -= ruin

--- a/config/example/torch_config.txt
+++ b/config/example/torch_config.txt
@@ -19,6 +19,9 @@
 ## The number of away sites to pick for the overmap. Default 3
 #AWAY_SITE_BUDGET 3
 
+## The number of players subtracted from the player budget for away sites by the main map. Default 12
+#MIN_OFFMAP_PLAYERS 12
+
 ## The names of various entities to use for reports, listing, etc.
 #STATION_NAME Sev Torch
 #STATION_SHORT Torch

--- a/maps/away/ascent_caulship/_ascent_caulship.dm
+++ b/maps/away/ascent_caulship/_ascent_caulship.dm
@@ -12,7 +12,8 @@
 	area_usage_test_exempted_areas = list(
 		/area/ship/ascent_caulship
 	)
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 4
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/ascent)
 
 /obj/effect/overmap/visitable/sector/ascent_caulship_ring

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -35,7 +35,8 @@
 	id = "awaysite_bearcat_wreck"
 	description = "A wrecked light freighter."
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
-	cost = 1
+	spawn_cost = 1
+	player_cost = 4
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift)
 	area_usage_test_exempted_root_areas = list(/area/ship)
 	apc_test_exempt_areas = list(

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -20,7 +20,7 @@
 /datum/map_template/ruin/away_site/blueriver
 	name = "Bluespace River"
 	id = "awaysite_blue"
-	cost = 2
+	spawn_cost = 2
 	description = "Two z-level map with an arctic planet and an alien underground surface"
 	suffixes = list("blueriver/blueriver-1.dmm", "blueriver/blueriver-2.dmm")
 	generate_mining_by_z = 2

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -29,7 +29,7 @@
 	id = "awaysite_casino"
 	description = "A casino ship!"
 	suffixes = list("casino/casino.dmm")
-	cost = 1
+	spawn_cost = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/casino_cutter)
 	area_usage_test_exempted_root_areas = list(/area/casino)
 	apc_test_exempt_areas = list(

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -21,7 +21,7 @@
 	id = "awaysite_derelict"
 	description = "An abandoned construction project."
 	suffixes = list("derelict/derelict-station.dmm")
-	cost = 1
+	spawn_cost = 1
 	accessibility_weight = 10
 	area_usage_test_exempted_areas = list(/area/AIsattele)
 	area_usage_test_exempted_root_areas = list(/area/constructionsite, /area/derelict)

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -13,7 +13,7 @@
 	id = "awaysite_errant_pisces"
 	description = "Xynergy carp trawler"
 	suffixes = list("errant_pisces/errant_pisces.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/errant_pisces)
 
 /mob/living/simple_animal/hostile/carp/shark // generally stronger version of a carp that doesn't die from a mean look. Fance new sprites included, credits to F-Tang Steve

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -41,7 +41,7 @@
 	id = "awaysite_icarus"
 	description = "The crashlanding site of the SEV Icarus."
 	suffixes = list("icarus/icarus-1.dmm", "icarus/icarus-2.dmm")
-	cost = 2
+	spawn_cost = 2
 	generate_mining_by_z = list(1, 2)
 	area_usage_test_exempted_root_areas = list(/area/icarus)
 	area_coherency_test_exempt_areas = list(/area/icarus/vessel, /area/icarus/open)

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -11,7 +11,7 @@
 	id = "awaysite_lar_maria"
 	description = "An orbital virus research station."
 	suffixes = list("lar_maria/lar_maria-1.dmm", "lar_maria/lar_maria-2.dmm")
-	cost = 2
+	spawn_cost = 2
 	area_usage_test_exempted_root_areas = list(/area/lar_maria)
 
 ///////////////////////////////////crew and prisoners

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_lost_supply_base"
 	description = "An abandoned supply base."
 	suffixes = list("lost_supply_base/lost_supply_base.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/lost_supply_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_magshield"
 	description = "It's an orbital shield station."
 	suffixes = list("magshield/magshield.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/magshield)
 
 /obj/effect/shuttle_landmark/nav_magshield/nav1

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -18,7 +18,7 @@
 	id = "awaysite_meatstation"
 	description = "It's a research station full of baddies and some unique loot."
 	suffixes = list("meatstation/meatstation.dmm")
-	cost = 2
+	spawn_cost = 2
 	area_usage_test_exempted_root_areas = list(/area/meatstation)
 
 /obj/effect/shuttle_landmark/nav_meatstation/nav1

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -29,7 +29,7 @@
 	id = "awaysite_mining_asteroid"
 	description = "A medium-sized asteroid full of minerals."
 	suffixes = list("mining/mining-asteroid.dmm")
-	cost = 1
+	spawn_cost = 1
 	accessibility_weight = 10
 	generate_mining_by_z = 1
 	apc_test_exempt_areas = list(
@@ -100,7 +100,7 @@
 	id = "awaysite_mining_signal"
 	description = "A mineral-rich, formerly-volcanic site on a planetoid."
 	suffixes = list("mining/mining-signal.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	base_turf_for_zs = /turf/simulated/floor/asteroid
 	area_usage_test_exempted_root_areas = list(/area/mine, /area/outpost)
@@ -168,7 +168,7 @@
 	id = "awaysite_mining_orb"
 	description = "A sort of circular asteroid with a bird."
 	suffixes = list("mining/mining-orb.dmm")
-	cost = 1
+	spawn_cost = 1
 	accessibility_weight = 10
 	generate_mining_by_z = 1
 	base_turf_for_zs = /turf/simulated/floor/asteroid

--- a/maps/away/mininghome/mininghome.dm
+++ b/maps/away/mininghome/mininghome.dm
@@ -15,7 +15,7 @@
 	id = "awaysite_mininghome"
 	description = "A chill asteroid mining station."
 	suffixes = list("mininghome/mininghome.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 
 /obj/effect/shuttle_landmark/nav_mininghome_1
 	name = "Navpoint #1"

--- a/maps/away/miningstation/miningstation.dm
+++ b/maps/away/miningstation/miningstation.dm
@@ -16,7 +16,7 @@
 	id = "awaysite_miningstation"
 	description = "An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station."
 	suffixes = list("miningstation/miningstation.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/miningstation)
 
 /obj/effect/shuttle_landmark/nav_miningstation/hangar

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -11,7 +11,7 @@
 	id = "awaysite_mobius_rift"
 	description = "Non-euclidian mess."
 	suffixes = list("mobius_rift/mobius_rift.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/mobius_rift)
 	apc_test_exempt_areas = list(
 		/area/mobius_rift = NO_SCRUBBER|NO_VENT|NO_APC

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -7,7 +7,8 @@
 	id = "awaysite_gantry"
 	description = "Salvage Gantry turned Ship"
 	suffixes = list("scavver/scavver_gantry-1.dmm","scavver/scavver_gantry-2.dmm")
-	cost = 1
+	spawn_cost = 1
+	player_cost = 4
 	accessibility_weight = 10
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/scavver_gantry,

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -9,7 +9,8 @@
 	id = "awaysite_skrell_scout"
 	description = "A Skrellian SDTF scouting vessel."
 	suffixes = list("skrellscoutship/skrellscoutship_revamp.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 4
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/skrellscoutship, /datum/shuttle/autodock/overmap/skrellscoutshuttle)
 	apc_test_exempt_areas = list(
 		/area/ship/skrellscoutship/externalwing/port = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -22,7 +22,7 @@
 	id = "awaysite_slavers"
 	description = "Asteroid with slavers base inside."
 	suffixes = list("slavers/slavers_base.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/slavers_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -17,7 +17,7 @@
 	id = "awaysite_smugglers"
 	description = "Yarr."
 	suffixes = list("smugglers/smugglers.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/smugglers)
 	apc_test_exempt_areas = list(

--- a/maps/away/verne/verne.dm
+++ b/maps/away/verne/verne.dm
@@ -37,7 +37,8 @@
 	id = "awaysite_verne"
 	description = "Active CTI research ship"
 	suffixes = list("verne/verne-1.dmm", "verne/verne-2.dmm", "verne/verne-3.dmm")
-	cost = 2
+	spawn_cost = 2
+	player_cost = 4
 	spawn_weight = 0.33
 	area_usage_test_exempted_root_areas = list(/area/verne)
 	shuttles_to_initialise = list(

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -9,7 +9,8 @@
 	id = "awaysite_voxship2"
 	description = "Vox Scavenger Ship."
 	suffixes = list("voxship/voxship-2.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 4
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_ship, /datum/shuttle/autodock/overmap/vox_lander)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 	spawn_weight = 0.67

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -22,7 +22,7 @@
 	id = "awaysite_yach"
 	description = "Tiny movable ship with spiders."
 	suffixes = list("yacht/yacht.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 
 /obj/effect/shuttle_landmark/nav_yacht/nav1

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -5,7 +5,8 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
-	cost = 1.5
+	spawn_cost = 1.5
+	player_cost = 4
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	spawn_weight = 0.33

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -3,7 +3,7 @@
 	id = "datacapsule"
 	description = "A damaged capsule with some strange contents."
 	suffixes = list("datacapsule/datacapsule.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dm
@@ -3,6 +3,6 @@
 	id = "deserted_lab"
 	description = "A mid-sized abandoned lab with some enemies, traps, and loot."
 	suffixes = list("deserted_lab/deserted_lab.dmm")
-	cost = 1.5
+	spawn_cost = 1.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN

--- a/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dm
+++ b/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dm
@@ -3,6 +3,6 @@
 	id = "drill_site"
 	description = "A small, abandoned mining drill operation."
 	suffixes = list("drill_site/drill_site.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
@@ -3,7 +3,7 @@
 	id = "ec_old_wreck"
 	description = "An abandoned ancient STL exploration ship."
 	suffixes = list("ec_old_crash/ec_old_crash.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	apc_test_exempt_areas = list(
 		/area/map_template/ecship/engine = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/map_template/ecship/cockpit = NO_SCRUBBER|NO_APC

--- a/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
+++ b/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
@@ -3,6 +3,6 @@
 	id = "planetsite_fountain"
 	description = "The fountain of youth itself."
 	suffixes = list("fountain/fountain_ruin.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_CLEAR_CONTENTS
 	ruin_tags = RUIN_ALIEN

--- a/maps/random_ruins/exoplanet_ruins/hut/hut.dm
+++ b/maps/random_ruins/exoplanet_ruins/hut/hut.dm
@@ -3,6 +3,6 @@
 	id = "hut"
 	description = "A small and simple little research hut."
 	suffixes = list("hut/hut.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -3,7 +3,7 @@
 	id = "exoplanet_hydrobase"
 	description = "hydroponics base with random plants and a lot of enemies"
 	suffixes = list("hydrobase/hydrobase.dmm")
-	cost = 2
+	spawn_cost = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_ALIEN
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
@@ -3,6 +3,6 @@
 	id = "lodge"
 	description = "A wood cabin."
 	suffixes = list("lodge/lodge.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -3,7 +3,7 @@
 	id = "awaysite_marooned" 
 	description = "crashed dropship with marooned Magnitka officer" 
 	suffixes = list("marooned/marooned.dmm") 
-	cost = 1 
+	spawn_cost = 1 
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -3,7 +3,7 @@
 	id = "planetsite_monoliths"
 	description = "Bunch of monoliths surrounding an artifact."
 	suffixes = list("monoliths/monoliths.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_ALIEN
 

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis.dm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis.dm
@@ -3,7 +3,7 @@
 	id = "oasis1"
 	description = "A tiny patch of life in a vast desert."
 	suffixes = list("oasis/oasis.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_ALLOW_DUPLICATES
 	ruin_tags = RUIN_NATURAL|RUIN_WATER
 

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
@@ -4,7 +4,7 @@
 	id = "exoplanet_oldlab"
 	description = "an abandoned lab"
 	suffixes = list("oldlab/oldlab.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
 

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dm
@@ -4,7 +4,7 @@
 	id = "exoplanet_oldlab2"
 	description = "another abandoned lab"
 	suffixes = list("oldlab2/oldlab2.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
 

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
@@ -3,7 +3,7 @@
 	id = "oldpod"
 	description = "A now unused, crashed escape pod."
 	suffixes = list("oldpod/oldpod.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -5,7 +5,8 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony/colony.dmm")
-	cost = 3
+	spawn_cost = 3
+	player_cost = 4
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 	ban_ruins = list(/datum/map_template/ruin/exoplanet/playablecolony2)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
@@ -5,7 +5,8 @@
 	id = "playablecolony2"
 	description = "a recently landed colony ship"
 	suffixes = list("playablecolony2/colony2.dmm")
-	cost = 2
+	spawn_cost = 2
+	player_cost = 4
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 	ban_ruins = list(/datum/map_template/ruin/exoplanet/playablecolony)

--- a/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dm
+++ b/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dm
@@ -3,6 +3,6 @@
 	id = "radshrine"
 	description = "A small radioactive shrine dedicated to an anomaly."
 	suffixes = list("radshrine/radshrine.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dm
+++ b/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dm
@@ -3,6 +3,6 @@
 	id = "spider_nest"
 	description = "A small buidling with a spider infestation."
 	suffixes = list("spider_nest/spider_nest.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN

--- a/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dm
+++ b/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dm
@@ -3,6 +3,6 @@
 	id = "tar_anomaly"
 	description = "An anomaly in the center of a ring of tar."
 	suffixes = list("tar_anomaly/tar_anomaly.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_ALIEN

--- a/maps/random_ruins/space_ruins/space_ruins.dm
+++ b/maps/random_ruins/space_ruins/space_ruins.dm
@@ -2,11 +2,11 @@
 
 /datum/map_template/ruin/space
 	prefix = "maps/random_ruins/space_ruins/"
-	cost = 1
+	spawn_cost = 1
 
 /datum/map_template/ruin/space/multi_zas_test
 	name = "Multi-ZAS Test"
 	id = "multi_zas_test"
 	description = "if this has vacuum in it, that's not good!"
 	suffixes = list("multi_zas_test.dmm")
-	cost = 1
+	spawn_cost = 1

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -51,4 +51,6 @@
 	num_exoplanets = 1
 
 	away_site_budget = 3
+	min_offmap_players = 12
+
 	id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'


### PR DESCRIPTION
Initial values are that all sites with slots cost 4 players, and the map itself costs 12. This means at 16, 20, 24 players, etc, there can be (but are not guaranteed) 1, 2, 3, etc sites with slots.

nb: currently applies to space sites because planet ruins are selected separately. That's next.