### PR TITLE
remove & replace funky high power pump types

### DIFF
--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -23,12 +23,3 @@
 		icon_state = "off"
 	else
 		icon_state = "[use_power ? "on" : "off"]"
-
-// For mapping purposes
-/obj/machinery/atmospherics/binary/pump/high_power/on/max_pressure/
-	target_pressure = MAX_PUMP_PRESSURE
-
-// A possible variant for Atmospherics distribution feed.
-/obj/machinery/atmospherics/binary/pump/high_power/on/distribution/Initialize()
-	. = ..()
-	target_pressure = round(3 * ONE_ATMOSPHERE)

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -2420,7 +2420,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "BU" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on/max_pressure,
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	target_pressure = 10000
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)

--- a/maps/away/ascent_caulship/ascent-1.dmm
+++ b/maps/away/ascent_caulship/ascent-1.dmm
@@ -200,15 +200,17 @@
 	pixel_x = -24
 	},
 /obj/effect/catwalk_plated/ascent,
-/obj/machinery/atmospherics/binary/pump/high_power/on/distribution{
+/obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 1;
-	icon_state = "map_on"
+	target_pressure = 5000
 	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent_caulship)
 "aM" = (
 /obj/effect/catwalk_plated/ascent,
-/obj/machinery/atmospherics/binary/pump/high_power/on/distribution,
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	target_pressure = 150
+	},
 /turf/simulated/floor/ascent,
 /area/ship/ascent_caulship)
 "aN" = (

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -295,9 +295,9 @@
 /turf/simulated/floor/plating/vox,
 /area/voxship/engineering)
 "aR" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on/max_pressure{
+/obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4;
-	icon_state = "map_on"
+	target_pressure = 150
 	},
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/engineering)
@@ -2295,9 +2295,9 @@
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/engineering)
 "fa" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on/max_pressure{
+/obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4;
-	icon_state = "map_on"
+	target_pressure = 5000
 	},
 /obj/machinery/vending/engineering{
 	req_access = list()


### PR DESCRIPTION
removes the /max_pressure and /distribution subtypes of high power pump, replaces their uses in mapping with just tailored /on instances