### PR TITLE
tweak send_to_department() to handle all handheld devices

### DIFF
--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -140,8 +140,8 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	var/reached = 0
 
 	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
-		var/obj/item/modular_computer/pda/pda = locate() in H
-		if(!pda || !(get_z(pda) in GLOB.using_map.station_levels))
+		var/obj/item/modular_computer/device = locate() in H
+		if(!device || !(get_z(device) in GLOB.using_map.station_levels))
 			continue
 
 		var/datum/job/J = SSjobs.get_by_title(H.get_authentification_rank())
@@ -149,7 +149,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 			continue
 
 		if(J.department_flag & department)
-			to_chat(H, "<span class='notice'>Your [pda.name] alerts you to the fact that somebody is requesting your presence at your department.</span>")
+			to_chat(H, "<span class='notice'>Your [device.name] alerts you to the fact that somebody is requesting your presence at your department.</span>")
 			reached++
 
 	return reached


### PR DESCRIPTION
:cl: 
tweak: Departmental pagers will now still alert you if you're using any handheld computer instead of just PDAs.
/:cl:

Exactly what it says on the tin. The code was already set up so that it only alerts one device even if you have multiple differing devices. Very useful if you don't want to carry both devices but still want to get pager alerts (works for anything else that alerts specific departments too).

Redone from #30285 cause of my git inadequacies.