### PR TITLE
Cult gamemode bugfixes, polish, and minor tweaks

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -143,7 +143,7 @@
 		return
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(istype(A,/mob/living))
-		if(!istype(natural_weapon) || a_intent == I_HELP)
+		if(!get_natural_weapon() || a_intent == I_HELP)
 			custom_emote(1,"[friendly] [A]!")
 			return
 		if(ckey)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -15,60 +15,54 @@
 	icon_state = "forge"
 
 /obj/structure/cult/pylon
-	name = "Pylon"
+	name = "pylon"
 	desc = "A floating crystal that hums with an unearthly energy."
 	icon = 'icons/obj/pylon.dmi'
 	icon_state = "pylon"
-	var/isbroken = 0
 	light_max_bright = 0.5
 	light_inner_range = 1
 	light_outer_range = 13
 	light_color = "#3e0000"
-	var/obj/item/wepon = null
+	var/health = 20
+	var/maxhealth = 20
 
-/obj/structure/cult/pylon/attack_hand(mob/M as mob)
-	attackpylon(M, 5)
-
-/obj/structure/cult/pylon/attack_generic(var/mob/user, var/damage)
-	attackpylon(user, damage)
-
-/obj/structure/cult/pylon/attackby(obj/item/W as obj, mob/user as mob)
-	attackpylon(user, W.force)
-
-/obj/structure/cult/pylon/proc/attackpylon(mob/user as mob, var/damage)
+/obj/structure/cult/pylon/attackby(obj/item/W, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if(!isbroken)
-		if(prob(1+ damage * 5))
+	if (istype(W, /obj/item/natural_weapon/cult_builder))
+		if (health >= maxhealth)
+			to_chat(user, SPAN_WARNING("\The [src] is fully repaired."))
+		else
 			user.visible_message(
-				"<span class='danger'>[user] smashed the pylon!</span>",
-				"<span class='warning'>You hit the pylon, and its crystal breaks apart!</span>",
-				"You hear a tinkle of crystal shards"
-				)
-			user.do_attack_animation(src)
-			playsound(get_turf(src), 'sound/effects/Glassbr3.ogg', 75, 1)
-			isbroken = 1
-			set_density(0)
-			icon_state = "pylon-broken"
-			set_light(0)
-		else
-			to_chat(user, "You hit the pylon!")
-			playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
+				SPAN_NOTICE("\The [user] mends some of the cracks on \the [src]."),
+				SPAN_NOTICE("You repair some of \the [src]'s damage.")
+			)
+			health = min(maxhealth, health + 5)
+		return
+	user.do_attack_animation(src)
+	if (W.force < 4)
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [src], but they bounce off!"),
+			SPAN_DANGER("You hit \the [src], but bounce off!"),
+			SPAN_WARNING("You hear thick glass being struck with something.")
+		)
+		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 50, TRUE)
+		return
+	health = max(0, health - W.force)
+	if(!health)
+		user.visible_message(
+			SPAN_DANGER("\The [user] smashes \the [src]!"),
+			SPAN_DANGER("You smash \the [src] into pieces!"),
+			SPAN_WARNING("You hear glass shattering, and a tinkle of shards.")
+		)
+		playsound(get_turf(src), 'sound/effects/Glassbr3.ogg', 75, TRUE)
+		qdel(src)
 	else
-		if(prob(damage * 2))
-			to_chat(user, "You pulverize what was left of the pylon!")
-			qdel(src)
-		else
-			to_chat(user, "You hit the pylon!")
-		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
-
-
-/obj/structure/cult/pylon/proc/repair(mob/user as mob)
-	if(isbroken)
-		to_chat(user, "You repair the pylon.")
-		isbroken = 0
-		set_density(1)
-		icon_state = "pylon"
-		set_light(0.5)
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [src]!"),
+			SPAN_DANGER("You hit \the [src]!"),
+			SPAN_WARNING("You hear thick glass being struck with something.")
+		)
+		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, TRUE)
 
 /obj/structure/cult/tome
 	name = "Desk"

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -8,9 +8,9 @@
 	unique = 1
 	carved = 2 // Don't carve it
 
-/obj/item/book/tome/attack_self(var/mob/user)
+/obj/item/book/tome/attack_self(mob/living/user)
 	if(!iscultist(user))
-		to_chat(user, "\The [src] seems full of illegible scribbles. Is this a joke?")
+		to_chat(user, SPAN_NOTICE("\The [src] seems full of illegible scribbles. Is this a joke?"))
 	else
 		to_chat(user, "Hold \the [src] in your hand while drawing a rune to use it.")
 
@@ -20,6 +20,21 @@
 		to_chat(user, "An old, dusty tome with frayed edges and a sinister looking cover.")
 	else
 		to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
+
+/obj/item/book/tome/attack(mob/living/M, mob/living/user)
+	if (user.a_intent != I_HELP || user.zone_sel.selecting != BP_EYES)
+		return ..()
+	user.visible_message(
+		SPAN_NOTICE("\The [user] shows \the [src] to \the [M]."),
+		SPAN_NOTICE("You open up \the [src] and show it to \the [M].")
+	)
+	if (iscultist(M))
+		if (user != M)
+			to_chat(user, SPAN_NOTICE("But they already know all there is to know."))
+		to_chat(M, SPAN_NOTICE("But you already know all there is to know."))
+	else
+		to_chat(M, SPAN_NOTICE("\The [src] seems full of illegible scribbles. Is this a joke?"))
+	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 
 /obj/item/book/tome/afterattack(var/atom/A, var/mob/user, var/proximity)
 	if(!proximity || !iscultist(user))

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -47,7 +47,7 @@
 	add_language(LANGUAGE_CULT)
 	add_language(LANGUAGE_CULT_GLOBAL)
 	for(var/spell in construct_spells)
-		src.add_spell(new spell, "const_spell_ready")
+		add_spell(new spell, "const_spell_ready")
 	update_icon()
 
 /mob/living/simple_animal/construct/death(gibbed, deathmessage, show_dead_message)
@@ -61,29 +61,13 @@
 	..()
 	add_glow()
 
-/mob/living/simple_animal/construct/attack_animal(var/mob/user)
-	if(istype(user, /mob/living/simple_animal/construct/builder))
-		if(health < maxHealth)
-			adjustBruteLoss(-5)
-			user.visible_message("<span class='notice'>\The [user] mends some of \the [src]'s wounds.</span>")
-		else
-			to_chat(user, "<span class='notice'>\The [src] is undamaged.</span>")
-		return
-	return ..()
-
 /mob/living/simple_animal/construct/examine(mob/user)
-	. = ..(user)
-	var/msg = "<span cass='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!\n"
-	if (src.health < src.maxHealth)
-		msg += "<span class='warning'>"
-		if (src.health >= src.maxHealth/2)
-			msg += "It looks slightly dented.\n"
+	. = ..()
+	if (health < maxHealth)
+		if (health >= maxHealth / 2)
+			to_chat(user, SPAN_WARNING("It looks slightly dented."))
 		else
-			msg += "<B>It looks severely dented!</B>\n"
-		msg += "</span>"
-	msg += "*---------*</span>"
-
-	to_chat(user, msg)
+			to_chat(user, SPAN_WARNING(SPAN_BOLD("It looks severely dented!")))
 
 /obj/item/ectoplasm
 	name = "ectoplasm"
@@ -159,7 +143,7 @@
 /mob/living/simple_animal/construct/wraith
 	name = "Wraith"
 	real_name = "Wraith"
-	desc = "A wicked bladed shell contraption piloted by a bound spirit."
+	desc = "A wicked contraption with a bladed shell, piloted by a bound spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "floating"
 	icon_living = "floating"
@@ -171,6 +155,12 @@
 	environment_smash = 1
 	see_in_dark = 7
 	construct_spells = list(/spell/targeted/ethereal_jaunt/shift)
+
+/mob/living/simple_animal/construct/wraith/can_fall(anchor_bypass, turf/location_override)
+	return FALSE
+
+/mob/living/simple_animal/construct/wraith/can_overcome_gravity()
+	return TRUE
 
 /obj/item/natural_weapon/wraith
 	name = "wicked blade"
@@ -209,6 +199,16 @@
 	name = "heavy arms"
 	attack_verb = list("rammed")
 	force = 5
+
+/obj/item/natural_weapon/cult_builder/attack(mob/living/M, mob/living/user)
+	if(istype(M, /mob/living/simple_animal/construct))
+		if(M.health < M.maxHealth)
+			M.adjustBruteLoss(-5)
+			user.visible_message(SPAN_NOTICE("\The [user] mends some of \the [M]'s wounds."))
+		else
+			to_chat(user, SPAN_NOTICE("\The [M] is undamaged."))
+		return
+	return ..()
 
 /////////////////////////////Behemoth/////////////////////////
 

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -11,6 +11,9 @@
 /obj/item/natural_weapon/attack_message_name()
 	return show_in_message ? ..() : null
 
+/obj/item/natural_weapon/can_embed()
+	return FALSE
+
 /obj/item/natural_weapon/bite
 	name = "teeth"
 	attack_verb = list("bitten")

--- a/code/modules/spells/aoe_turf/conjure/construct.dm
+++ b/code/modules/spells/aoe_turf/conjure/construct.dm
@@ -14,6 +14,7 @@
 	summon_type = list(/obj/structure/constructshell)
 
 	hud_state = "artificer"
+	cast_sound = 'sound/items/Deconstruct.ogg'
 
 /spell/aoe_turf/conjure/construct/lesser
 	charge_max = 1800
@@ -33,6 +34,7 @@
 	summon_type = list(/turf/simulated/floor/cult)
 
 	hud_state = "const_floor"
+	cast_sound = 'sound/items/Welder.ogg'
 
 /spell/aoe_turf/conjure/wall
 	name = "Lesser Construction"
@@ -46,6 +48,7 @@
 	summon_type = list(/turf/simulated/wall/cult)
 
 	hud_state = "const_wall"
+	cast_sound = 'sound/items/Welder.ogg'
 
 /spell/aoe_turf/conjure/wall/reinforced
 	name = "Greater Construction"
@@ -59,6 +62,7 @@
 	cast_delay = 50
 
 	summon_type = list(/turf/simulated/wall/r_wall)
+	cast_sound = 'sound/items/Welder.ogg'
 
 /spell/aoe_turf/conjure/soulstone
 	name = "Summon Soulstone"
@@ -74,6 +78,7 @@
 
 	hud_state = "const_stone"
 	override_base = "const"
+	cast_sound = 'sound/items/Welder.ogg'
 
 /spell/aoe_turf/conjure/pylon
 	name = "Red Pylon"
@@ -88,15 +93,7 @@
 	summon_type = list(/obj/structure/cult/pylon)
 
 	hud_state = "const_pylon"
-
-/spell/aoe_turf/conjure/pylon/cast(list/targets)
-	..()
-	var/turf/spawn_place = pick(targets)
-	for(var/obj/structure/cult/pylon/P in spawn_place.contents)
-		if(P.isbroken)
-			P.repair(usr)
-		continue
-	return
+	cast_sound = 'sound/items/Welder.ogg'
 
 /spell/aoe_turf/conjure/forcewall/lesser
 	name = "Shield"
@@ -111,11 +108,12 @@
 	duration = 200
 
 	hud_state = "const_juggwall"
+	cast_sound = 'sound/magic/forcewall.ogg'
 
 //Code for the Juggernaut construct's forcefield, that seemed like a good place to put it.
 /obj/effect/forcefield/cult
-	desc = "That eerie looking obstacle seems to have been pulled from another dimension through sheer force."
-	name = "Juggerwall"
+	name = "juggernaut shield"
+	desc = "An eerie-looking obstacle that seems to have been pulled from another dimension through sheer force."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "m_shield_cult"
 	light_color = "#b40000"

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -106,7 +106,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		holder = user //just in case
 	if(!cast_check(skipcharge, user))
 		return
-	to_chat(user, SPAN_NOTICE("You start casting [name]..."))
+	if (cast_delay > 1)
+		to_chat(user, SPAN_NOTICE("You start casting [name]..."))
 	if(cast_delay && !spell_do_after(user, cast_delay))
 		return
 	var/list/targets = choose_targets(user)

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -15,6 +15,19 @@
 
 	hud_state = "wiz_jaunt"
 
+	var/reappear_duration = 5
+	var/obj/effect/dummy/spell_jaunt/jaunt_holder
+	var/atom/movable/overlay/animation
+
+/spell/targeted/ethereal_jaunt/Destroy()
+	if (jaunt_holder) // eject our user in case something happens and we get deleted
+		var/turf/T = get_turf(jaunt_holder)
+		for(var/mob/living/L in jaunt_holder)
+			L.forceMove(T)
+	QDEL_NULL(jaunt_holder)
+	QDEL_NULL(animation)
+	return ..()
+
 /spell/targeted/ethereal_jaunt/cast(list/targets) //magnets, so mostly hardcoded
 	for(var/mob/living/target in targets)
 		if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(target))
@@ -24,10 +37,10 @@
 			target.buckled.unbuckle_mob()
 		spawn(0)
 			var/mobloc = get_turf(target.loc)
-			var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
-			var/atom/movable/overlay/animation = new /atom/movable/overlay(holder)
-			animation.SetName("water")
-			animation.set_density(0)
+			jaunt_holder = new/obj/effect/dummy/spell_jaunt(mobloc)
+			animation = new/atom/movable/overlay(mobloc)
+			animation.SetName("residue")
+			animation.set_density(FALSE)
 			animation.anchored = TRUE
 			animation.icon = 'icons/mob/mob.dmi'
 			animation.layer = FLY_LAYER 
@@ -35,25 +48,27 @@
 			if(target.buckled)
 				target.buckled = null
 			jaunt_disappear(animation, target)
-			target.forceMove(holder)
 			jaunt_steam(mobloc)
-			sleep(duration)
-			mobloc = holder.last_valid_turf
-			animation.forceMove(mobloc)
-			jaunt_steam(mobloc)
-			holder.reappearing = 1
-			sleep(20)
-			jaunt_reappear(animation, target)
-			sleep(5)
-			if(!target.forceMove(mobloc))
-				for(var/direction in list(1,2,4,8,5,6,9,10))
-					var/turf/T = get_step(mobloc, direction)
-					if(T)
-						if(target.forceMove(T))
-							break
-			target.client.eye = target
-			qdel(animation)
-			qdel(holder)
+			target.forceMove(jaunt_holder)
+			addtimer(CALLBACK(src, .proc/start_reappear, target), duration)
+
+/spell/targeted/ethereal_jaunt/proc/start_reappear(mob/living/user)
+	var/mob_loc = jaunt_holder.last_valid_turf
+	jaunt_holder.reappearing = TRUE
+	jaunt_steam(mob_loc)
+	jaunt_reappear(animation, user)
+	animation.forceMove(mob_loc)
+	addtimer(CALLBACK(src, .proc/reappear, mob_loc, user), reappear_duration)
+
+/spell/targeted/ethereal_jaunt/proc/reappear(var/mob_loc, mob/living/user)
+	if(!user.forceMove(mob_loc))
+		for(var/direction in list(1,2,4,8,5,6,9,10))
+			var/turf/T = get_step(mob_loc, direction)
+			if(T && user.forceMove(T))
+				break
+	user.client.eye = user
+	QDEL_NULL(animation)
+	QDEL_NULL(jaunt_holder)
 
 /spell/targeted/ethereal_jaunt/empower_spell()
 	if(!..())

--- a/code/modules/spells/targeted/shift.dm
+++ b/code/modules/spells/targeted/shift.dm
@@ -2,23 +2,25 @@
 	name = "Phase Shift"
 	desc = "This spell allows you to pass through walls."
 
-	charge_max = 200
+	charge_max = 20 SECONDS
 	spell_flags = Z2NOCAST | INCLUDEUSER | CONSTRUCT_CHECK
 	invocation_type = SpI_NONE
-	range = -1
-	duration = 50 //in deciseconds
+	duration = 5 SECONDS
+	reappear_duration = 1.2 SECONDS
 
 	hud_state = "const_shift"
 
 /spell/targeted/ethereal_jaunt/shift/jaunt_disappear(var/atom/movable/overlay/animation, var/mob/living/target)
+	to_chat(target, SPAN_DANGER("You silently phase out.")) // no visible message - phase shift is silent
 	animation.icon_state = "phase_shift"
 	animation.dir = target.dir
-	flick("phase_shift",animation)
+	flick("phase_shift", animation)
 
 /spell/targeted/ethereal_jaunt/shift/jaunt_reappear(var/atom/movable/overlay/animation, var/mob/living/target)
+	to_chat(target, SPAN_DANGER("You return from your jaunt."))
 	animation.icon_state = "phase_shift2"
 	animation.dir = target.dir
-	flick("phase_shift2",animation)
+	flick("phase_shift2", animation)
 
 /spell/targeted/ethereal_jaunt/shift/jaunt_steam(var/mobloc)
 	return


### PR DESCRIPTION
🆑
tweak: Cultist pylons are now destroyed permanently when they shatter, instead of being placed into a weird "broken" state where have the exact same sprite but can be passed over.
tweak: Cult pylons now have a proper health system, instead of using random chance to determine if they're damaged.
tweak: Wraiths now float, preventing them from falling down z-levels and letting them counteract gravity. They'll still drift in space, though.
tweak: Artificer abilities no longer use a super loud sound.
bugfix: Finally fixed wraiths being unable to use their Phase Shift.
bugfix: Fixed player-controlled simple animals (like constructs) being unable to hurt things.
bugfix: Natural weapons can no longer embed into wounds.
bugfix: Artificers now correctly repair constructs on an attack instead of bashing them.
/🆑

You can see the gist of this PR in the changelog, but there's also some stuff that isn't included in the changelog since it's backend. Here's some list-based content:
* Refactored the `ethereal_jaunt` spell type to use timers instead of sleep calls and allows for custom delays between when the reappear animation starts and when the player actually gains control again. This is used for wraiths to make them properly reappear visibly, instead of just instantly appearing.
* Pylons had a very weird "broken" state where it looked the exact same, but could be passed over and emitted no light. To me, this felt unfinished, and didn't feel intuitive. I nixed it, and made pylons delete instead on death of entering this weird limbo state.
* When casting a spell that's effectively instant (cast delay is no more than one decisecond), it doesn't give you a "you begin to cast" message.
* Some miscellaneous grammar tweaks here and there.

Because of the way the new natural weapons work, I ported artificers' repairing logic onto their natural weapons. The functionality itself is unchanged and remains the exact same.

Artificer construction sounds used a loud sound usually reserved for summoning objects or animals as a wizard (which is something that benefits from loud sounds) but was instead used for abilities used constantly every few seconds (which do not benefit from loud sounds.) The sounds now use welding and deconstruction noises, given how it fabricates stuff.

Turns out cult code is really bad, for the most part - at least the older parts. Maybe I'll try and fix some more stuff in the future.

Paging @CrimsonShrike since I figured they might want to know about the natural weapon changes.