### PR TITLE
Tries to untangle carbon damage

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -3,10 +3,6 @@
 	if(!effective_force)
 		return 0
 
-	//Hulk modifier
-	if(MUTATION_HULK in user.mutations)
-		effective_force *= 2
-
 	//Apply weapon damage
 	var/damage_flags = I.damage_flags()
 	var/datum/wound/created_wound = apply_damage(effective_force, I.damtype, hit_zone, damage_flags, used_weapon=I)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -176,10 +176,13 @@ meteor_act
 	if(!affecting)
 		return 0
 
-	var/blocked = get_blocked_ratio(hit_zone, I.damtype, I.damage_flags(), I.armor_penetration, I.force)
-	// Handle striking to cripple.
 	if(user.a_intent == I_DISARM)
 		effective_force *= 0.66 //reduced effective force...
+
+	var/blocked = get_blocked_ratio(hit_zone, I.damtype, I.damage_flags(), I.armor_penetration, effective_force)
+
+	// Handle striking to cripple.
+	if(user.a_intent == I_DISARM)
 		if(!..(I, user, effective_force, hit_zone))
 			return 0
 
@@ -189,21 +192,22 @@ meteor_act
 	else if(!..())
 		return 0
 
+	var/unimpeded_force = (1 - blocked) * effective_force
 	if(effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(GLOB.hit_appends)	//forcesay checks stat already
 		radio_interrupt_cooldown = world.time + (RADIO_INTERRUPT_DEFAULT * 0.8) //getting beat on can briefly prevent radio use
-	if((I.damtype == BRUTE || I.damtype == PAIN) && prob(25 + (effective_force * 2)))
+	if((I.damtype == BRUTE || I.damtype == PAIN) && prob(25 + (unimpeded_force * 2)))
 		if(!stat)
 			if(headcheck(hit_zone))
 				//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(effective_force))
-					apply_effect(20, PARALYZE, blocked)
+				if(prob(unimpeded_force))
+					apply_effect(20, PARALYZE, 100 * blocked)
 					if(lying)
 						visible_message("<span class='danger'>[src] [species.knockout_message]</span>")
 			else
 				//Easier to score a stun but lasts less time
-				if(prob(effective_force + 5))
-					apply_effect(3, WEAKEN, blocked)
+				if(prob(unimpeded_force + 5))
+					apply_effect(3, WEAKEN, 100 * blocked)
 					if(lying)
 						visible_message("<span class='danger'>[src] has been knocked down!</span>")
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -118,10 +118,6 @@
 	if(!effective_force)
 		return 0
 
-	//Hulk modifier
-	if(MUTATION_HULK in user.mutations)
-		effective_force *= 2
-
 	//Apply weapon damage
 	var/damage_flags = I.damage_flags()
 


### PR DESCRIPTION
Issue #30302 made me look into damage code and I noticed some things that may or may not be intentional. So opening this PR to get feedback

This is also a reason why high damage mobs and items will just permanently stunlock you. Since stuns are derived from base damage and ignore armour, high damage sources will invariably floor you. Some thoughts on this is that maybe stunning should be a property of the weapon, like spider poison. Or of the attack (mech roundhouse attack)