### PR TITLE
Exosuits no longer need full reset for emp damage

### DIFF
--- a/code/modules/mechs/mech_life.dm
+++ b/code/modules/mechs/mech_life.dm
@@ -24,6 +24,9 @@
 	if(health <= 0 && stat != DEAD)
 		death()
 
+	if(emp_damage > 0)
+		emp_damage -= min(1, emp_damage) //Reduce emp accumulation over time
+
 	..() //Handles stuff like environment
 
 	handle_hud_icons()


### PR DESCRIPTION
Bit of an oversight. EMP damage (as in, the part where UI bugs out and such) will slowly reset to 0 over time.