### PR TITLE
Open cockpit exosuits no longer move air

### DIFF
--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -186,7 +186,7 @@
 	to_chat(user, "It menaces with reinforcements of [material].")
 
 /mob/living/exosuit/return_air()
-	return (body && body.pilot_coverage >= 100 && hatch_closed) ? body.cockpit : loc.return_air()
+	return (body && body.pilot_coverage >= 100 && hatch_closed && body.cockpit) ? body.cockpit : loc.return_air()
 
 /mob/living/exosuit/GetIdCard()
 	return access_card


### PR DESCRIPTION
Open exosuit chassi no longer mantain a cockpit airmix. This will not affect players in any way ,but will prevent suits from moving air if teleported suddenly.