### PR TITLE
Add firer to hostile simple mob projectiles

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -242,7 +242,7 @@
 	playsound(user, projectilesound, 100, 1)
 	if(!A)	return
 	var/def_zone = get_exposed_defense_zone(target)
-	A.launch(target, def_zone)
+	A.launch_from_mob(target, src, def_zone)
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings() //courtesy of Lohikar
 	if(!can_act())

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -155,6 +155,16 @@
 	addtimer(CALLBACK(src, .proc/finalize_launch, curloc, targloc, x_offset, y_offset, angle_offset),0)
 	return 0
 
+/obj/item/projectile/proc/launch_from_mob(atom/target, mob/user, target_zone, x_offset = 0, y_offset = 0, angle_offset = 0)
+	if(user == target) //Shooting yourself
+		user.bullet_act(src, target_zone)
+		qdel(src)
+		return 0
+
+	firer = user
+
+	return launch(target, target_zone, x_offset, y_offset)
+
 /obj/item/projectile/proc/finalize_launch(var/turf/curloc, var/turf/targloc, var/x_offset, var/y_offset, var/angle_offset)
 	setup_trajectory(curloc, targloc, x_offset, y_offset, angle_offset) //plot the initial trajectory
 	Process()


### PR DESCRIPTION
:cl:
admin: Attack logs generated by ranged simple mobs now properly display the source, and only appear in chat if both parties have a ckey (Like all other attack logs)
/:cl: