### PR TITLE
Fix throttle check direction to throttle

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_EMPTY(world_topic_throttle)
 	var/list/throttle = GLOB.world_topic_throttle[addr]
 	if (!throttle)
 		GLOB.world_topic_throttle[addr] = throttle = list(0, null)
-	else if (throttle[1] && throttle[1] < world.timeofday)
+	else if (throttle[1] && throttle[1] > world.timeofday)
 		return throttle[2] ? "Throttled ([throttle[2]])" : "Throttled"
 	SET_THROTTLE(3 SECONDS, null)
 


### PR DESCRIPTION
Now checks if $unthrottleTime is still in the future, rather than if it's in the past.

There's probably still an issue with timeofday here; if the time wraps around (i.e. midnight) after you call, you won't be able to make any further calls until the server restarts.