### PR TITLE
Reinforcen't

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -41,9 +41,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/toxins)
-"ag" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/quartermaster/hangar)
 "ah" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 1;
@@ -1236,7 +1233,7 @@
 	icon_state = "direction_evac";
 	pixel_y = -4
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
 "cu" = (
 /obj/structure/bed/padded,
@@ -1306,7 +1303,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "cD" = (
 /obj/machinery/door/airlock/hatch{
@@ -3103,7 +3100,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/compressed_gas,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
 "gt" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -3240,7 +3237,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/expedition/atmos)
 "gO" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/quartermaster/shuttlefuel)
 "gP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3464,7 +3461,7 @@
 /area/quartermaster/exploration)
 "hy" = (
 /obj/machinery/status_display/supply_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
 "hz" = (
 /turf/simulated/floor/tiled,
@@ -4936,7 +4933,7 @@
 /area/quartermaster/exploration)
 "kR" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
 "kS" = (
 /obj/machinery/status_display,
@@ -7112,7 +7109,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
 "pq" = (
 /obj/structure/sign/directions/science{
@@ -7125,7 +7122,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
 "pr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8016,9 +8013,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
-"rd" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/pilot)
 "re" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -8838,7 +8832,7 @@
 /area/vacant/infirmary)
 "sW" = (
 /obj/structure/sign/warning/biohazard,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/canister)
 "sX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -11412,14 +11406,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/rnd)
-"Be" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/fifthdeck/aftport)
 "Bf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -13200,9 +13186,6 @@
 /obj/machinery/vitals_monitor,
 /turf/simulated/floor/tiled/white,
 /area/vacant/infirmary)
-"HG" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/quartermaster/storage)
 "HH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -16096,9 +16079,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Sd" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/fifthdeck/fore)
 "Sg" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -16708,9 +16688,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
-"Ut" = (
-/turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -17918,7 +17895,7 @@
 	icon_state = "direction_evac";
 	pixel_y = -4
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "Zc" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -18070,7 +18047,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
 "ZA" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/canister)
 "ZB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -18135,7 +18112,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
 "ZN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31009,11 +30986,11 @@ er
 su
 DF
 jk
-Sd
-Sd
+fl
+fl
 jM
-Sd
-rd
+fl
+wF
 hm
 iA
 iI
@@ -31215,7 +31192,7 @@ pp
 db
 mQ
 ip
-rd
+wF
 iv
 iB
 iK
@@ -31417,7 +31394,7 @@ pq
 hu
 na
 iE
-rd
+wF
 lt
 iC
 ac
@@ -31619,7 +31596,7 @@ ct
 ii
 pk
 ii
-rd
+wF
 iy
 iy
 wF
@@ -32218,12 +32195,12 @@ ce
 jr
 ce
 ce
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+fl
+fl
+fl
+fl
+fl
+fl
 kR
 oH
 rP
@@ -32420,7 +32397,7 @@ bq
 jI
 ix
 lx
-Sd
+fl
 kl
 kl
 kl
@@ -32622,7 +32599,7 @@ gp
 jJ
 jz
 jz
-Sd
+fl
 kl
 kl
 kl
@@ -32824,7 +32801,7 @@ hk
 jJ
 jA
 lq
-Sd
+fl
 kl
 kl
 kl
@@ -33026,7 +33003,7 @@ jq
 jJ
 lc
 lr
-Sd
+fl
 kl
 kl
 kl
@@ -33228,13 +33205,13 @@ gd
 jK
 jL
 ly
-Sd
+fl
 kl
 kl
 kl
 kl
 kl
-Sd
+fl
 qJ
 aF
 oX
@@ -33430,12 +33407,12 @@ js
 js
 ce
 ce
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+fl
+fl
+fl
+fl
+fl
+fl
 pp
 lv
 fY
@@ -33451,11 +33428,11 @@ kq
 kt
 kq
 eu
-OX
-OX
-ag
-ag
-ag
+eu
+eu
+aJ
+aJ
+aJ
 uZ
 mT
 an
@@ -33657,7 +33634,7 @@ lQ
 lM
 jZ
 lH
-ag
+aJ
 ny
 ob
 ws
@@ -33859,7 +33836,7 @@ lV
 lS
 pF
 lG
-ag
+aJ
 nz
 oc
 ws
@@ -34061,7 +34038,7 @@ UH
 lW
 pF
 lG
-ag
+aJ
 nz
 oc
 ws
@@ -34263,7 +34240,7 @@ UH
 kD
 lS
 lL
-ag
+aJ
 nz
 oc
 ws
@@ -34465,7 +34442,7 @@ UH
 kD
 pF
 lH
-ag
+aJ
 uD
 hb
 ws
@@ -34667,7 +34644,7 @@ lX
 pF
 lT
 lG
-ag
+aJ
 nz
 oc
 ws
@@ -34869,7 +34846,7 @@ lR
 lN
 lF
 lK
-ag
+aJ
 nW
 og
 ws
@@ -35072,7 +35049,7 @@ gO
 gO
 gO
 gO
-Be
+rj
 Xx
 ws
 ws
@@ -35274,7 +35251,7 @@ jT
 jR
 jY
 CY
-Be
+rj
 Xx
 ws
 ws
@@ -35880,7 +35857,7 @@ gO
 gO
 gO
 gO
-Be
+rj
 oa
 ws
 ws
@@ -38471,10 +38448,10 @@ ZG
 ZG
 sd
 Jf
-Ut
-Ut
-Ut
-ag
+aW
+aW
+aW
+aJ
 kd
 ee
 ba
@@ -38676,7 +38653,7 @@ Um
 Ea
 sw
 sw
-ag
+aJ
 oI
 eH
 eT
@@ -38878,7 +38855,7 @@ Um
 Ea
 sx
 sz
-ag
+aJ
 aX
 aX
 aX
@@ -39078,9 +39055,9 @@ ZG
 aH
 Um
 Ea
-Ut
-Ut
-ag
+aW
+aW
+aJ
 aJ
 Qn
 Qn
@@ -39096,12 +39073,12 @@ WU
 lv
 iS
 lw
-dR
-dR
-dR
-dR
-dR
-HG
+Fk
+Fk
+Fk
+Fk
+Fk
+Em
 Em
 Em
 Em
@@ -39505,7 +39482,7 @@ UO
 uu
 UO
 UO
-HG
+Em
 ja
 ov
 ow
@@ -39909,7 +39886,7 @@ UO
 xg
 UO
 aS
-HG
+Em
 os
 OG
 ox
@@ -40111,7 +40088,7 @@ lu
 oQ
 oR
 oS
-HG
+Em
 MW
 OG
 Oy
@@ -40308,15 +40285,15 @@ WU
 qB
 Sc
 tQ
-dR
-dR
-dR
-dR
-dR
-HG
+Fk
+Fk
+Fk
+Fk
+Fk
+Em
 MS
 MS
-HG
+Em
 hR
 iG
 mD
@@ -40515,10 +40492,10 @@ ul
 wj
 wj
 wc
-HG
+Em
 gq
 gq
-HG
+Em
 iH
 ht
 CL
@@ -40717,10 +40694,10 @@ tu
 tx
 uv
 tU
-HG
-HG
-HG
-HG
+Em
+Em
+Em
+Em
 oB
 iJ
 iZ

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -50,9 +50,6 @@
 	},
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/forestarboard)
-"am" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/fourthdeck/center)
 "an" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -77,9 +74,6 @@
 "ar" = (
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod6/station)
-"as" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/galley)
 "at" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -666,9 +660,6 @@
 	},
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
-"ct" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/fourthdeck/fore)
 "cu" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -934,8 +925,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "dg" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/storage/auxillary/starboard)
+/turf/simulated/wall/r_wall,
+/area/teleporter/fourthdeck)
 "dh" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
@@ -4024,7 +4015,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/fore)
 "nx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4214,10 +4205,10 @@
 /area/hallway/primary/fourthdeck/fore)
 "oz" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/r_wall,
 /area/teleporter/fourthdeck)
 "oA" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/teleporter/fourthdeck)
 "oB" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -4302,9 +4293,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/command/pathfinder)
-"oP" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/quartermaster/office)
 "oQ" = (
 /obj/structure/catwalk,
 /obj/machinery/light/spot{
@@ -4606,7 +4594,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/center)
 "qa" = (
 /obj/effect/floor_decal/corner/green{
@@ -4625,7 +4613,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/command/pathfinder)
 "qc" = (
 /obj/structure/sign/directions/evac{
@@ -4851,9 +4839,6 @@
 	icon_state = "laptop"
 	},
 /turf/simulated/floor/tiled,
-/area/storage/primary)
-"rd" = (
-/turf/simulated/wall/r_wall/prepainted,
 /area/storage/primary)
 "re" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6617,7 +6602,7 @@
 /area/hallway/primary/fourthdeck/fore)
 "vC" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/hangcheck)
 "vD" = (
 /turf/simulated/wall/prepainted,
@@ -6699,7 +6684,7 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "wb" = (
 /obj/structure/cable/green{
@@ -6746,7 +6731,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "wg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -8584,7 +8569,7 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/foreport)
 "Dd" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/eva)
 "Dk" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -12253,7 +12238,7 @@
 /turf/simulated/floor/shuttle_ceiling,
 /area/space)
 "OX" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/hangcheck)
 "OZ" = (
 /obj/structure/table/marble,
@@ -12448,9 +12433,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
-"Pw" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/command/pathfinder)
 "Px" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -13040,7 +13022,7 @@
 	dir = 4;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/hangcheck)
 "Rn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13773,7 +13755,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "SQ" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/quartermaster/flightcontrol)
 "SR" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -14061,7 +14043,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/storage/primary)
 "Tx" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -14529,9 +14511,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
-"UO" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/commissary)
 "UQ" = (
 /obj/structure/catwalk,
 /obj/structure/ladder,
@@ -14722,9 +14701,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
-"Vq" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/lounge)
 "Vr" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/aft)
@@ -15032,7 +15008,7 @@
 	dir = 4;
 	pixel_y = -4
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
 "Wp" = (
 /obj/structure/disposalpipe/segment{
@@ -25582,7 +25558,7 @@ aa
 zj
 zj
 zj
-Dd
+zj
 Kk
 tH
 kc
@@ -27406,11 +27382,11 @@ nm
 oA
 oz
 pL
-oA
-oA
-oA
+dg
+dg
+dg
 vo
-oA
+dg
 wq
 Pz
 AH
@@ -27606,13 +27582,13 @@ ej
 mh
 nn
 oA
-oA
+dg
 pM
 qW
 sr
 tV
 vp
-oA
+dg
 xT
 mh
 AH
@@ -27808,13 +27784,13 @@ lb
 mi
 Nu
 no
-oA
+dg
 pN
 qX
 qX
 tW
 vq
-oA
+dg
 xU
 zq
 AI
@@ -28010,13 +27986,13 @@ ej
 Uy
 mj
 np
-oA
+dg
 pO
 qY
 ss
 qY
 vr
-oA
+dg
 xV
 zr
 AH
@@ -28201,7 +28177,7 @@ aa
 aa
 aa
 RQ
-dg
+RQ
 ej
 ej
 ej
@@ -28212,13 +28188,13 @@ ej
 mk
 nm
 nq
-oA
+dg
 pP
 qZ
 st
 tX
 vs
-oA
+dg
 xW
 zs
 AH
@@ -28414,13 +28390,13 @@ le
 ml
 Rn
 nr
-oA
-oA
-oA
-oA
-oA
-oA
-oA
+dg
+dg
+dg
+dg
+dg
+dg
+dg
 xX
 zt
 AJ
@@ -28810,11 +28786,11 @@ WZ
 WZ
 XD
 vF
-UO
+vF
 mK
-UO
-UO
-UO
+vF
+vF
+vF
 NA
 Uv
 nt
@@ -28828,13 +28804,13 @@ wE
 xZ
 zv
 le
-ct
-ct
-ct
-ct
-ct
-ct
-ct
+le
+le
+le
+le
+le
+le
+le
 WZ
 WZ
 cv
@@ -29223,8 +29199,8 @@ hu
 nu
 nv
 Tv
-rd
-rd
+wF
+wF
 sx
 ub
 vw
@@ -30029,10 +30005,10 @@ vF
 vF
 Xz
 mr
-ct
-ct
-ct
-rd
+le
+le
+le
+wF
 hE
 uc
 wF
@@ -30631,13 +30607,13 @@ er
 er
 er
 er
-am
-am
-am
-am
-am
-am
-am
+rp
+rp
+rp
+rp
+rp
+rp
+rp
 rj
 sB
 rj
@@ -30833,7 +30809,7 @@ KF
 TS
 Qr
 KI
-am
+rp
 kl
 kl
 kl
@@ -31035,7 +31011,7 @@ KF
 TS
 Kt
 KI
-am
+rp
 kl
 kl
 kl
@@ -31237,7 +31213,7 @@ KF
 TS
 Kt
 KI
-am
+rp
 kl
 kl
 kl
@@ -31439,7 +31415,7 @@ RA
 uu
 ya
 KI
-am
+rp
 kl
 kl
 kl
@@ -31641,13 +31617,13 @@ OA
 Mh
 XC
 UQ
-am
+rp
 kl
 kl
 kl
 kl
 kl
-am
+rp
 PS
 XV
 Uq
@@ -31843,12 +31819,12 @@ er
 er
 er
 er
-Pw
-Pw
-Pw
-Pw
-Pw
-Pw
+fl
+fl
+fl
+fl
+fl
+fl
 qb
 NP
 sG
@@ -33453,9 +33429,9 @@ Mt
 XG
 af
 af
-as
-as
-as
+af
+af
+af
 UC
 Xh
 Pf
@@ -33657,7 +33633,7 @@ af
 ao
 ao
 at
-as
+af
 AD
 pW
 bo
@@ -33682,9 +33658,9 @@ Yd
 Wh
 TY
 Zk
-Vq
-Vq
-Vq
+Sd
+Sd
+Sd
 Sd
 uw
 iS
@@ -33857,9 +33833,9 @@ bu
 XG
 Mp
 ap
-MX
-MX
-MX
+Mp
+Mp
+Mp
 fd
 hl
 Mp
@@ -33884,7 +33860,7 @@ Yd
 ER
 FB
 Zk
-Vq
+Sd
 Hv
 PO
 jr
@@ -35076,7 +35052,7 @@ Wx
 hp
 Ol
 MX
-MX
+Mp
 Ga
 mG
 lr
@@ -35278,7 +35254,7 @@ gu
 hq
 LQ
 jq
-MX
+Mp
 Ga
 mG
 lr
@@ -35480,7 +35456,7 @@ XM
 uy
 QA
 Zd
-MX
+Mp
 kq
 lk
 lr
@@ -37510,11 +37486,11 @@ NY
 Mn
 Rx
 we
-YJ
-YJ
-YJ
-YJ
-oP
+Xn
+Xn
+Xn
+Xn
+vQ
 PX
 ax
 vQ
@@ -37716,7 +37692,7 @@ Ym
 kM
 VA
 RD
-YJ
+Xn
 Re
 Vf
 SS
@@ -38524,7 +38500,7 @@ kX
 yF
 zZ
 Kj
-YJ
+Xn
 Qk
 Qk
 Yf
@@ -38721,12 +38697,12 @@ bB
 xN
 ow
 uH
-YJ
-YJ
-YJ
-YJ
-YJ
-YJ
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
 ul
 PB
 Qe

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -336,7 +336,7 @@
 	pixel_y = 12;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/storage/tools)
 "bh" = (
 /obj/structure/bed/roller,
@@ -2174,8 +2174,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/thirddeck/foreport)
 "eI" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/substation/thirddeck)
+/turf/simulated/wall/prepainted,
+/area/engineering/hardstorage)
 "eJ" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -3345,9 +3345,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/foreport)
-"gN" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/holocontrol)
 "gO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5460,9 +5457,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
-"kK" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/thirddeck/center)
 "kL" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/bar)
@@ -6399,9 +6393,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
-"mX" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/thirddeck/fore)
 "mY" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -6415,7 +6406,7 @@
 	pixel_y = -5;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/fore)
 "mZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6629,9 +6620,6 @@
 "nC" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/mess)
-"nD" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/mess)
 "nE" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -7645,7 +7633,7 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/center)
 "pT" = (
 /turf/simulated/floor/tiled/steel_ridged,
@@ -7661,7 +7649,7 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/center)
 "pV" = (
 /obj/machinery/door/blast/shutters{
@@ -9506,7 +9494,7 @@
 /area/hallway/primary/thirddeck/fore)
 "uK" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/habcheck)
 "uL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9521,7 +9509,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/thirddeck/center)
 "uM" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/bunk)
 "uN" = (
 /obj/machinery/door/firedoor,
@@ -9545,9 +9533,6 @@
 	},
 /turf/space,
 /area/space)
-"uP" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/sleep/cryo)
 "uQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian{
@@ -9584,7 +9569,7 @@
 /area/crew_quarters/sleep/cryo)
 "uT" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/cryo)
 "uU" = (
 /turf/simulated/wall/prepainted,
@@ -10872,7 +10857,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/thirddeck)
 "yN" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/r_wall,
 /area/teleporter/thirddeck)
 "yO" = (
 /obj/machinery/door/blast/shutters{
@@ -11259,9 +11244,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
-"zX" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/storage/tools)
 "zY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -12460,9 +12442,6 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/command/disperser)
-"DH" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/recreation)
 "DI" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/coffeecup/SCG,
@@ -13267,9 +13246,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
-"FB" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/crew_quarters/cryolocker)
 "FC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/civilian{
@@ -16010,7 +15986,7 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/cryo)
 "LY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16213,7 +16189,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/fore)
 "ME" = (
 /obj/machinery/door/airlock/external{
@@ -16260,7 +16236,7 @@
 	pixel_y = 12;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/storage/tools)
 "MP" = (
 /obj/structure/table/woodentable,
@@ -17096,7 +17072,7 @@
 	pixel_y = 12;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/storage/tools)
 "PB" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -17110,9 +17086,6 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
-"PD" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/thirddeck/foreport)
 "PE" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9;
@@ -18455,9 +18428,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"TD" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/thirddeck/aft)
 "TE" = (
 /turf/simulated/wall/prepainted,
 /area/chapel/office)
@@ -19200,7 +19170,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "Vx" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/habcheck)
 "VA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -19482,7 +19452,7 @@
 /area/thruster/d3starboard)
 "Wp" = (
 /obj/structure/sign/warning/engineering_access,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/hardstorage)
 "Wq" = (
 /obj/structure/cable/green{
@@ -20529,7 +20499,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/fore)
 "Zp" = (
 /obj/effect/floor_decal/techfloor{
@@ -31829,9 +31799,9 @@ yN
 yN
 yN
 yN
-PD
-PD
-PD
+zS
+zS
+zS
 zS
 eH
 zS
@@ -33630,11 +33600,11 @@ dv
 dv
 dv
 cK
-DH
-DH
-DH
-DH
-DH
+CF
+CF
+CF
+CF
+CF
 CF
 QR
 CF
@@ -34240,7 +34210,7 @@ mY
 oc
 oU
 pP
-mX
+mj
 se
 tp
 VU
@@ -34839,13 +34809,13 @@ qh
 MY
 YM
 XZ
-kK
-kK
-kK
-kK
-kK
-kK
-kK
+wD
+wD
+wD
+wD
+wD
+wD
+wD
 tt
 sh
 tt
@@ -35041,7 +35011,7 @@ dy
 dy
 GE
 dy
-kK
+wD
 lu
 lu
 lu
@@ -35243,7 +35213,7 @@ qn
 wC
 Uq
 PI
-kK
+wD
 lu
 lu
 lu
@@ -35445,7 +35415,7 @@ Ol
 gs
 Uq
 ih
-kK
+wD
 lu
 lu
 lu
@@ -35461,7 +35431,7 @@ jQ
 XJ
 Vx
 Ou
-PD
+zS
 Br
 Yb
 uM
@@ -35647,7 +35617,7 @@ hm
 Zx
 ST
 eu
-kK
+wD
 lu
 lu
 lu
@@ -35849,13 +35819,13 @@ hn
 ij
 iW
 dy
-kK
+wD
 lu
 lu
 lu
 lu
 lu
-kK
+wD
 NA
 Us
 Nn
@@ -36051,12 +36021,12 @@ dy
 IR
 dy
 dy
-kK
-kK
-kK
-kK
-kK
-kK
+wD
+wD
+wD
+wD
+wD
+wD
 pU
 YP
 sl
@@ -36475,12 +36445,12 @@ uM
 Cq
 uM
 uM
-uP
-uP
-uP
-FB
-FB
-FB
+Fd
+Fd
+Fd
+FS
+FS
+FS
 Gx
 FS
 zG
@@ -36667,7 +36637,7 @@ pV
 Xn
 pr
 dP
-uP
+Fd
 vR
 wY
 xZ
@@ -36680,7 +36650,7 @@ CZ
 DN
 Et
 EV
-uP
+Fd
 Sj
 sM
 Gy
@@ -36869,7 +36839,7 @@ pV
 qQ
 sk
 tD
-uP
+Fd
 Gt
 vS
 ya
@@ -37071,7 +37041,7 @@ pW
 qP
 IY
 tE
-uP
+Fd
 vT
 vT
 yb
@@ -37084,7 +37054,7 @@ Db
 DP
 vT
 vT
-uP
+Fd
 FV
 GA
 GZ
@@ -37273,7 +37243,7 @@ kL
 xE
 IZ
 Jc
-uP
+Fd
 vU
 vU
 yb
@@ -37286,7 +37256,7 @@ Db
 DP
 vU
 EW
-uP
+Fd
 FS
 GB
 FS
@@ -37488,7 +37458,7 @@ Dc
 DQ
 vV
 EX
-uP
+Fd
 DL
 GD
 Ge
@@ -37890,10 +37860,10 @@ vS
 vS
 De
 za
-uP
+Fd
 LX
-uP
-uP
+Fd
+Fd
 Lk
 EL
 Hf
@@ -38095,7 +38065,7 @@ za
 NF
 Hc
 Hc
-uP
+Fd
 Lk
 EL
 Hf
@@ -38283,7 +38253,7 @@ fB
 le
 VM
 tH
-uP
+Fd
 vU
 vU
 yf
@@ -38294,10 +38264,10 @@ vU
 vU
 Df
 Ub
-uP
-uP
-uP
-uP
+Fd
+Fd
+Fd
+Fd
 Lk
 EL
 Hf
@@ -38485,7 +38455,7 @@ Nw
 qQ
 sk
 tI
-uP
+Fd
 vV
 vV
 yg
@@ -38687,7 +38657,7 @@ Nw
 Xn
 sj
 tJ
-uP
+Fd
 Cj
 yk
 fm
@@ -38889,18 +38859,18 @@ fB
 qV
 sj
 tC
-uP
-uP
-uP
-uP
+Fd
+Fd
+Fd
+Fd
 fS
-uP
-uP
-uP
-uP
-uP
+Fd
+Fd
+Fd
+Fd
+Fd
 DS
-uP
+Fd
 Fd
 Ez
 Ez
@@ -39282,9 +39252,9 @@ gC
 hy
 fB
 fB
-nD
+fB
 ct
-nD
+fB
 fB
 fB
 fB
@@ -39484,9 +39454,9 @@ gD
 hz
 WN
 kY
-nD
+fB
 ld
-nD
+fB
 Sx
 nm
 fU
@@ -39686,9 +39656,9 @@ pw
 Ot
 os
 VD
-nD
+fB
 ld
-nD
+fB
 QT
 dd
 aY
@@ -39888,9 +39858,9 @@ cl
 cl
 ZV
 Vv
-nD
-nD
-nD
+fB
+fB
+fB
 cl
 yQ
 aY
@@ -41717,12 +41687,12 @@ Wb
 rh
 sx
 tS
-TD
-TD
-TD
-TD
-TD
-zX
+wl
+wl
+wl
+wl
+wl
+AN
 zE
 Bz
 TV
@@ -41906,16 +41876,16 @@ cl
 da
 Wb
 Wb
-nA
-nA
-nA
-nA
-nA
-nA
-nA
-nA
-nA
-nA
+eI
+eI
+eI
+eI
+eI
+eI
+eI
+eI
+eI
+eI
 ri
 sy
 QF
@@ -42512,7 +42482,7 @@ df
 fN
 rH
 KI
-nA
+eI
 ZD
 sP
 ex
@@ -42521,7 +42491,7 @@ Vd
 no
 on
 MU
-nA
+eI
 rl
 Jb
 sW
@@ -42714,7 +42684,7 @@ nC
 nC
 nC
 nC
-nA
+eI
 XD
 PQ
 rC
@@ -42723,7 +42693,7 @@ Up
 Ar
 oo
 pm
-nA
+eI
 cg
 sz
 re
@@ -42732,7 +42702,7 @@ YQ
 xl
 yp
 YQ
-zX
+AN
 AM
 BL
 Cy
@@ -42916,7 +42886,7 @@ nC
 fO
 Eg
 hB
-nA
+eI
 QK
 jq
 hH
@@ -42925,16 +42895,16 @@ ZH
 ZH
 ZH
 Mh
-nA
+eI
 ra
 sB
 OY
-TD
-TD
-TD
-TD
-TD
-zX
+wl
+wl
+wl
+wl
+wl
+AN
 AN
 AN
 AN
@@ -43118,7 +43088,7 @@ PF
 fP
 gG
 hC
-nA
+eI
 gP
 xv
 XC
@@ -43127,7 +43097,7 @@ uh
 yD
 dM
 dM
-nA
+eI
 rk
 sC
 tW
@@ -43325,11 +43295,11 @@ rA
 xW
 FR
 nA
-gN
-gN
-gN
-gN
-gN
+qd
+qd
+qd
+qd
+qd
 sW
 sv
 sW
@@ -44528,9 +44498,9 @@ bN
 cp
 dl
 ea
-eI
-eI
-gN
+dl
+dl
+qd
 hA
 hA
 hA
@@ -44732,7 +44702,7 @@ dm
 eb
 eJ
 yL
-gN
+qd
 hA
 hA
 hA
@@ -44934,7 +44904,7 @@ dl
 ec
 eK
 nq
-gN
+qd
 hA
 hA
 hA
@@ -45136,7 +45106,7 @@ dl
 ed
 ab
 hk
-gN
+qd
 hA
 hA
 hA
@@ -45337,8 +45307,8 @@ IS
 dl
 dl
 eM
-eI
-gN
+dl
+qd
 hA
 hA
 hA

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -295,8 +295,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/prototype/engine)
 "az" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/seconddeck/forestarboard)
+/turf/simulated/wall/prepainted,
+/area/engineering/engine_smes)
 "aA" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -407,7 +407,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "aK" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/vacant/armory)
 "aL" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -5070,7 +5070,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/storage)
 "kD" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/center)
 "kE" = (
 /obj/structure/table/standard,
@@ -5386,7 +5386,7 @@
 	dir = 4;
 	pixel_z = 10
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/center)
 "lp" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -6093,7 +6093,7 @@
 	dir = 4;
 	pixel_z = 10
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/elevator)
 "nb" = (
 /obj/machinery/disposal/deliveryChute{
@@ -6439,7 +6439,7 @@
 	dir = 1;
 	pixel_z = 6
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/center)
 "nQ" = (
 /obj/structure/sign/directions/security{
@@ -6449,7 +6449,7 @@
 	dir = 1;
 	pixel_z = 6
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/elevator)
 "nS" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -6468,7 +6468,7 @@
 	dir = 2;
 	pixel_z = 6
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/elevator)
 "nW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7372,7 +7372,7 @@
 /turf/space,
 /area/space)
 "qv" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/drone_fabrication)
 "qw" = (
 /turf/simulated/wall/r_wall/hull,
@@ -7675,7 +7675,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_monitoring)
 "qV" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/engine_monitoring)
 "qW" = (
 /obj/structure/disposalpipe/segment{
@@ -8434,7 +8434,7 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/engineering_monitoring)
 "sW" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -10243,8 +10243,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/foreport)
 "yf" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/incinerator)
+/turf/simulated/wall/prepainted,
+/area/vacant/prototype/control)
 "yg" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/incinerator)
@@ -10866,7 +10866,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "zO" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/atmos/storage)
 "zP" = (
 /obj/structure/railing/mapped{
@@ -13890,6 +13890,9 @@
 "HQ" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/surgery)
+"HS" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/storage)
 "HU" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/solgov,
@@ -15363,6 +15366,9 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/vacant/prototype/engine)
+"Nc" = (
+/turf/simulated/wall/r_wall,
+/area/teleporter/seconddeck)
 "Nd" = (
 /obj/machinery/power/terminal{
 	dir = 1;
@@ -15475,7 +15481,7 @@
 	dir = 1;
 	pixel_z = 6
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/center)
 "Nl" = (
 /obj/structure/table/standard,
@@ -16019,7 +16025,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/atmos)
 "OV" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/seconddeck/elevator)
 "OW" = (
 /obj/structure/cable/green{
@@ -17565,7 +17571,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/forestarboard)
 "TJ" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/shieldbay)
 "TK" = (
 /obj/structure/grille,
@@ -18925,7 +18931,7 @@
 /area/engineering/atmos)
 "YI" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/engineering/engine_smes)
 "YL" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -19219,8 +19225,12 @@
 /turf/simulated/wall/prepainted,
 /area/assembly/robotics/surgery)
 "ZH" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/engineering/engineering_monitoring)
+/obj/structure/sign/warning/radioactive{
+	dir = 4;
+	icon_state = "radiation"
+	},
+/turf/simulated/wall/prepainted,
+/area/vacant/prototype/control)
 "ZI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30292,7 +30302,7 @@ ir
 fU
 JX
 Sx
-Qe
+yf
 mf
 Rf
 Pg
@@ -30494,7 +30504,7 @@ is
 fU
 JX
 xR
-Qe
+yf
 Mi
 Sf
 Qg
@@ -30696,7 +30706,7 @@ gK
 fU
 JX
 LT
-Qe
+yf
 Gf
 Jh
 ri
@@ -30704,7 +30714,7 @@ vk
 Ij
 Rj
 Wj
-Qe
+yf
 uf
 Wp
 vt
@@ -30898,15 +30908,15 @@ gL
 fU
 JX
 xR
-Qe
+yf
 Hf
 Vh
 Gi
-Qe
+yf
 bl
 Sj
 Xi
-Qe
+yf
 ZV
 Wp
 vt
@@ -31100,15 +31110,15 @@ JX
 JX
 JX
 SU
-Qe
+yf
 Ug
 Vf
 vi
-Qe
+yf
 Fi
 Oi
 Nl
-Qe
+yf
 Mz
 Wp
 Wp
@@ -31302,15 +31312,15 @@ bd
 bI
 tj
 xR
-Qe
-Qe
-Qe
+yf
+yf
+yf
 qk
-VL
-Qe
-Qe
-Qe
-Qe
+ZH
+yf
+yf
+yf
+yf
 ZV
 uM
 UQ
@@ -32730,8 +32740,8 @@ Lp
 dX
 aK
 aK
-yf
-yf
+yg
+yg
 yg
 yg
 yg
@@ -32918,7 +32928,7 @@ zw
 zw
 Uf
 NQ
-az
+bI
 JH
 JL
 pJ
@@ -35353,7 +35363,7 @@ nc
 NJ
 sK
 fS
-lr
+nc
 zO
 qB
 yl
@@ -38989,11 +38999,11 @@ Qp
 Ab
 QI
 jy
-fp
+HS
 Yy
 kj
-Yy
-Yy
+Nc
+Nc
 Is
 Fn
 AN
@@ -39191,11 +39201,11 @@ Sv
 Ol
 hr
 fc
-fp
+HS
 jX
 kk
 kE
-Yy
+Nc
 tX
 SM
 AO
@@ -39393,12 +39403,12 @@ Ad
 ZB
 hr
 yv
-fp
+HS
 jZ
 km
 nB
-Yy
-Yy
+Nc
+Nc
 Fn
 AN
 TV
@@ -39600,7 +39610,7 @@ vS
 WA
 xC
 kG
-Yy
+Nc
 Fn
 AN
 Cf
@@ -39802,7 +39812,7 @@ Qv
 kx
 xC
 kM
-Yy
+Nc
 Fn
 AN
 AN
@@ -39999,12 +40009,12 @@ kh
 kB
 Qz
 PA
-fp
+HS
 kf
 zZ
 xC
 FV
-Yy
+Nc
 wL
 NF
 Cg
@@ -40201,12 +40211,12 @@ jy
 jy
 jy
 jy
-fp
+HS
 vS
 FI
-Yy
-Yy
-Yy
+Nc
+Nc
+Nc
 KE
 Bw
 Cg
@@ -41408,7 +41418,7 @@ HN
 pH
 qP
 CC
-ZH
+Ia
 sZ
 sZ
 sZ
@@ -42406,11 +42416,11 @@ xI
 Lk
 MD
 gt
-hp
-hp
+az
+az
 hk
-hp
-hp
+az
+az
 hQ
 tg
 fa
@@ -42608,11 +42618,11 @@ VP
 Lk
 fH
 gu
-hp
+az
 NZ
 sw
 OI
-hp
+az
 qV
 lL
 qV
@@ -43012,7 +43022,7 @@ gQ
 yp
 ZJ
 oU
-hp
+az
 Gd
 Nd
 Td
@@ -43214,7 +43224,7 @@ Ul
 Lk
 hj
 ke
-hp
+az
 hh
 Od
 Ud
@@ -43416,7 +43426,7 @@ eQ
 Lk
 hq
 WK
-hp
+az
 Id
 Pd
 Wd
@@ -43820,7 +43830,7 @@ eS
 Lk
 fM
 WK
-hp
+az
 Kd
 hm
 hG
@@ -44022,7 +44032,7 @@ Lk
 Lk
 dA
 tx
-hp
+az
 hp
 iX
 jH

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1051,8 +1051,8 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "acf" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/medical/medicalhallway)
+/turf/simulated/wall/prepainted,
+/area/medical/chemistry)
 "acg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
@@ -4860,8 +4860,8 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/counselor/therapy)
 "aiu" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/medical/counselor/therapy)
+/turf/simulated/wall/prepainted,
+/area/security/evidence)
 "aiG" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -6847,7 +6847,7 @@
 	dir = 4;
 	pixel_z = 3
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/fore)
 "asD" = (
 /obj/structure/cable/green{
@@ -7178,8 +7178,8 @@
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/aft)
 "aul" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/aft)
+/turf/simulated/wall/r_wall,
+/area/teleporter/firstdeck)
 "auv" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -7612,7 +7612,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/center)
 "awa" = (
 /turf/simulated/floor/tiled/steel_ridged,
@@ -7630,7 +7630,7 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/center)
 "awc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7743,7 +7743,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "awX" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/opscheck)
 "awY" = (
 /obj/structure/cable/green{
@@ -8602,7 +8602,7 @@
 /area/crew_quarters/sleep/cryo/aux)
 "aAs" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/sleep/cryo/aux)
 "aAt" = (
 /obj/effect/wallframe_spawn/no_grille,
@@ -8656,8 +8656,8 @@
 /turf/simulated/floor/plating,
 /area/rnd/development)
 "aAK" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/rnd/development)
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/sleep/cryo/aux)
 "aAT" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/teleporter/firstdeck)
@@ -9043,7 +9043,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
 "aBP" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/entry)
 "aCf" = (
 /turf/simulated/wall/prepainted,
@@ -10099,8 +10099,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aHi" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/rnd/locker)
+/turf/simulated/wall/prepainted,
+/area/rnd/misc_lab)
 "aHn" = (
 /turf/simulated/wall/prepainted,
 /area/rnd/locker)
@@ -11801,7 +11801,7 @@
 /area/hallway/primary/firstdeck/fore)
 "aOK" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/wing)
 "aOL" = (
 /obj/structure/disposalpipe/segment,
@@ -13152,7 +13152,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aSK" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/xenobiology/xenoflora)
 "aSS" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -15759,9 +15759,6 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/security/brig)
-"cva" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/medical/counselor)
 "cvb" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
@@ -18521,9 +18518,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
-"gSb" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/medical/washroom)
 "gVR" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -18601,7 +18595,7 @@
 	dir = 1;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/development)
 "haV" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -19028,7 +19022,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/development)
 "hwx" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
@@ -19259,7 +19253,7 @@
 /obj/structure/sign/directions/engineering{
 	pixel_y = 3
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/development)
 "hIl" = (
 /obj/structure/bed/chair/padded/blue,
@@ -19429,9 +19423,6 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
-"hVG" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/center)
 "hWb" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -19749,7 +19740,7 @@
 /area/maintenance/firstdeck/foreport)
 "ivh" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/misc_lab)
 "ivT" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -20095,7 +20086,7 @@
 /area/rnd/entry)
 "iRb" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/development)
 "iSb" = (
 /obj/structure/table/standard,
@@ -20275,7 +20266,7 @@
 	dir = 1;
 	icon_state = "xenobio"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/research)
 "jeb" = (
 /obj/structure/disposalpipe/segment,
@@ -23383,7 +23374,7 @@
 /area/security/nuke_storage)
 "mUm" = (
 /obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/entry)
 "mVb" = (
 /obj/machinery/nuclearbomb/station{
@@ -25464,9 +25455,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/brig)
-"pzb" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/rnd/research)
 "pzH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -26475,11 +26463,11 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/fore)
 "qHx" = (
 /obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/r_wall,
 /area/teleporter/firstdeck)
 "qIb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -26752,9 +26740,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
-"qXb" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/rnd/office)
 "qYb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27738,7 +27723,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/fore)
 "sab" = (
 /obj/effect/floor_decal/corner/research/mono,
@@ -27811,7 +27796,7 @@
 /area/maintenance/firstdeck/forestarboard)
 "scb" = (
 /obj/structure/sign/warning/biohazard,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/research)
 "scd" = (
 /obj/structure/closet/crate/freezer,
@@ -28097,7 +28082,7 @@
 /area/hallway/primary/firstdeck/center)
 "snG" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/aft)
 "sob" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -28242,7 +28227,7 @@
 /area/command/armoury/tactical)
 "swb" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/rnd/xenobiology/xenoflora)
 "sww" = (
 /obj/structure/railing/mapped{
@@ -29037,9 +29022,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"tkr" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/wing)
 "tlb" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
@@ -30114,14 +30096,14 @@
 	dir = 4;
 	icon_state = "securearea"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/foreport)
 "vtY" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/aft)
 "vvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30674,7 +30656,7 @@
 	dir = 4;
 	icon_state = "securearea"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/r_wall,
 /area/teleporter/firstdeck)
 "wWr" = (
 /obj/effect/floor_decal/corner/green/half{
@@ -30991,7 +30973,7 @@
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d1port)
 "xRh" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/security/processing)
 "xRu" = (
 /obj/structure/table/rack,
@@ -40361,7 +40343,7 @@ aMD
 nJo
 aOI
 aPv
-tkr
+aNH
 vrM
 tAS
 tAS
@@ -40563,7 +40545,7 @@ aME
 oMb
 aNG
 dkV
-tkr
+aNH
 kSc
 tAS
 tAS
@@ -40741,9 +40723,9 @@ mCe
 iFb
 lJb
 uXW
-pjR
+qWE
 uGu
-tkr
+aNH
 cXj
 wyb
 sxG
@@ -40753,7 +40735,7 @@ nbb
 nmb
 xRh
 aCy
-aDE
+cHj
 aKE
 cHj
 cHj
@@ -40765,7 +40747,7 @@ jpt
 oby
 nkh
 mCi
-tkr
+aNH
 uKa
 tKE
 tAS
@@ -40939,13 +40921,13 @@ adK
 aiP
 ajP
 vMw
-vMw
-vMw
-vMw
+aiu
+aiu
+aiu
 lVb
-vMw
+aiu
 cfn
-tkr
+aNH
 vJO
 oIb
 avI
@@ -40955,7 +40937,7 @@ ayP
 aAb
 cDO
 aJr
-aDE
+cHj
 cwQ
 nFh
 hDp
@@ -40967,7 +40949,7 @@ aMF
 aNH
 aNH
 aNH
-tkr
+aNH
 bnG
 aSm
 tAS
@@ -41147,7 +41129,7 @@ lKb
 lWb
 qya
 mfb
-tkr
+aNH
 vJO
 auv
 jpt
@@ -41169,7 +41151,7 @@ jpt
 nJo
 aOI
 mwy
-tkr
+aNH
 aRo
 aSn
 tAS
@@ -41349,7 +41331,7 @@ alW
 alW
 tUl
 hCE
-tkr
+aNH
 mCk
 hnL
 dPA
@@ -41359,7 +41341,7 @@ eyY
 gxi
 aBd
 qkc
-aDE
+cHj
 aEK
 aFS
 qig
@@ -41371,7 +41353,7 @@ aME
 lcL
 aNG
 dkV
-tkr
+aNH
 aRo
 aSo
 tAS
@@ -41551,7 +41533,7 @@ dkG
 ape
 amb
 kUt
-tkr
+aNH
 xzK
 auv
 jpt
@@ -41573,7 +41555,7 @@ jpt
 oby
 whm
 wEb
-tkr
+aNH
 aRp
 aSp
 tAS
@@ -41747,13 +41729,13 @@ adK
 adK
 ajT
 vMw
-vMw
-vMw
-vMw
-vMw
-vMw
-vMw
-tkr
+aiu
+aiu
+aiu
+aiu
+aiu
+aiu
+aNH
 vJO
 oIb
 avI
@@ -41763,19 +41745,19 @@ xRh
 bdo
 mdv
 xRh
-aDE
+cHj
 aJa
 riC
-aDE
+cHj
 aIb
 aJs
 aDG
 aLG
 aMJ
 aNH
-tkr
-tkr
-tkr
+aNH
+aNH
+aNH
 aRq
 aIr
 aBb
@@ -43571,7 +43553,7 @@ asq
 imK
 qiL
 art
-asy
+afI
 asy
 asy
 asy
@@ -43773,17 +43755,17 @@ dzG
 njj
 aqg
 aru
-asy
+afI
 atA
 auE
 avS
-aAT
+aul
 brb
 ngb
 npb
 nub
 nEb
-aAT
+aul
 aEU
 aFV
 aGP
@@ -43975,11 +43957,11 @@ njj
 njj
 aqh
 gzM
-asy
+afI
 atB
 auF
 avT
-aAT
+aul
 mXb
 nhb
 nqb
@@ -44181,7 +44163,7 @@ qHq
 atC
 auG
 avU
-aAT
+aul
 atw
 atw
 gDm
@@ -44383,13 +44365,13 @@ rZf
 atD
 auH
 wMo
-aAT
+aul
 lYS
 nZB
 aCp
-aAT
-aAT
-aAT
+aul
+aul
+aul
 iAZ
 aGf
 aGP
@@ -44585,11 +44567,11 @@ asB
 jxG
 auI
 avV
-aAT
+aul
 wWc
-aAT
+aul
 uXr
-aAT
+aul
 eZQ
 fVw
 obZ
@@ -45184,13 +45166,13 @@ geb
 hQb
 lCb
 lNb
-hVG
-hVG
-hVG
-hVG
-hVG
-hVG
-hVG
+auN
+auN
+auN
+auN
+auN
+auN
+auN
 axa
 axZ
 axa
@@ -45386,7 +45368,7 @@ gHb
 hWb
 lCb
 lOb
-hVG
+auN
 aqn
 aqn
 aqn
@@ -45588,7 +45570,7 @@ bMb
 bMb
 bMb
 bMb
-hVG
+auN
 aqn
 aqn
 aqn
@@ -45790,7 +45772,7 @@ aeg
 amn
 anm
 anm
-hVG
+auN
 aqn
 aqn
 aqn
@@ -45992,7 +45974,7 @@ aeg
 amn
 ann
 anm
-hVG
+auN
 aqn
 aqn
 aqn
@@ -46194,13 +46176,13 @@ agN
 nXk
 ann
 anm
-hVG
+auN
 aqn
 aqn
 aqn
 aqn
 aqn
-hVG
+auN
 sNn
 nUp
 aai
@@ -46396,12 +46378,12 @@ agN
 ahQ
 anp
 aol
-hVG
-hVG
-hVG
-hVG
-hVG
-hVG
+auN
+auN
+auN
+auN
+auN
+auN
 awb
 rKo
 aye
@@ -47214,20 +47196,20 @@ uSl
 axe
 ayh
 axe
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
 aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
+aAK
 aIB
 jjh
 jjh
@@ -47429,7 +47411,7 @@ aKU
 aLU
 aNb
 aOa
-aAr
+aAK
 aPK
 jjh
 aRB
@@ -47618,7 +47600,7 @@ kUb
 cZS
 mvl
 azm
-aAr
+aAK
 aBz
 aCQ
 aCQ
@@ -47631,7 +47613,7 @@ aKV
 aLV
 aLV
 aOb
-aAr
+aAK
 aPL
 aQI
 aRC
@@ -47820,7 +47802,7 @@ mrX
 lfb
 ayi
 ggA
-aAr
+aAK
 aBA
 aCR
 aCR
@@ -47833,7 +47815,7 @@ aCR
 aCR
 aCR
 aOc
-aAr
+aAK
 aPM
 jjh
 aRB
@@ -48035,7 +48017,7 @@ aCS
 aCS
 aCS
 aCS
-aAr
+aAK
 aPN
 oAx
 jjh
@@ -48237,7 +48219,7 @@ aJO
 aJO
 aJO
 aJO
-aAr
+aAK
 aPO
 jjh
 aRD
@@ -48439,7 +48421,7 @@ aDY
 aDY
 aDY
 aOd
-aAr
+aAK
 aPP
 aQJ
 aRE
@@ -48641,7 +48623,7 @@ aKW
 aKW
 aKW
 aKW
-aAr
+aAK
 aPQ
 jjh
 aRD
@@ -48843,7 +48825,7 @@ aCR
 aCR
 aCR
 aCR
-aAr
+aAK
 aPN
 oAx
 jjh
@@ -49032,7 +49014,7 @@ acE
 axh
 ayi
 ghI
-aAr
+aAK
 aBG
 aCS
 aCS
@@ -49045,7 +49027,7 @@ aCS
 aCS
 aCS
 aOe
-aAr
+aAK
 aPO
 jjh
 aRF
@@ -49234,7 +49216,7 @@ oJb
 abf
 ayg
 azq
-aAr
+aAK
 aBH
 aCW
 aCW
@@ -49247,7 +49229,7 @@ aKX
 aLW
 aNc
 aOf
-aAr
+aAK
 aPR
 aQK
 aRG
@@ -49449,7 +49431,7 @@ aGu
 aLX
 aNd
 aOg
-aAr
+aAK
 aPQ
 jjh
 aRF
@@ -49638,20 +49620,20 @@ leb
 xKz
 aym
 jsk
-aAr
-aAr
-aAr
-aAr
+aAK
+aAK
+aAK
+aAK
 aFj
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
-aAr
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
+aAK
 cKh
 jjh
 jjh
@@ -50451,11 +50433,11 @@ aBM
 aBM
 aEb
 rKL
-aHi
-aHi
+aHn
+aHn
 jtb
-aHi
-aHi
+aHn
+aHn
 cQo
 cQo
 tzg
@@ -50653,11 +50635,11 @@ rKL
 rKL
 rKL
 rKL
-aHi
+aHn
 jGb
 sNb
 pqb
-qXb
+mav
 mav
 mav
 mav
@@ -50855,11 +50837,11 @@ rxK
 cQo
 eEE
 aFo
-aHi
+aHn
 jHb
 jub
 prb
-qXb
+mav
 mlX
 foP
 eGY
@@ -51057,11 +51039,11 @@ aBO
 wiT
 lsb
 wHE
-aHi
+aHn
 jIb
 oRb
 psb
-qXb
+mav
 oib
 lxs
 xxY
@@ -51259,11 +51241,11 @@ awX
 awX
 awX
 awX
-aHi
+aHn
 aHn
 aIG
 aHn
-qXb
+mav
 qsO
 cAO
 dfZ
@@ -51672,10 +51654,10 @@ xVt
 pOL
 rrI
 tEs
-qXb
-pzb
-pzb
-pzb
+mav
+pkb
+pkb
+pkb
 aSZ
 aTA
 jjh
@@ -51873,8 +51855,8 @@ mav
 qqb
 qqb
 qEb
-qXb
-qXb
+mav
+mav
 rAb
 rPb
 jcO
@@ -52248,11 +52230,11 @@ agg
 ayA
 dcb
 dDb
-dDb
-dDb
+acf
+acf
 aby
 abH
-dDb
+acf
 adO
 dZb
 afY
@@ -52454,7 +52436,7 @@ abl
 abr
 abA
 abK
-dDb
+acf
 adQ
 afb
 afZ
@@ -52651,7 +52633,7 @@ uXe
 uXe
 uXe
 kaS
-dDb
+acf
 abm
 abs
 abB
@@ -52853,7 +52835,7 @@ sde
 sde
 uXe
 scd
-dDb
+acf
 abn
 abt
 abC
@@ -53055,8 +53037,8 @@ sde
 uXe
 uXe
 sde
-dDb
-dDb
+acf
+acf
 abu
 abD
 abU
@@ -53258,11 +53240,11 @@ uXe
 uXe
 uXe
 cqb
-dDb
+acf
 abv
 abG
 ace
-dDb
+acf
 aen
 afh
 aqL
@@ -53460,11 +53442,11 @@ sde
 sde
 dEb
 dQb
-dDb
+acf
 mJY
 uUK
-dDb
-dDb
+acf
+acf
 aeo
 afi
 aqM
@@ -53662,10 +53644,10 @@ kZb
 bdL
 rAu
 rAu
-gSb
-gSb
-gSb
-acf
+rAu
+rAu
+rAu
+acz
 adj
 aep
 afh
@@ -54284,7 +54266,7 @@ nCb
 awM
 jAM
 jab
-aAK
+aCf
 lnb
 abJ
 abX
@@ -54486,12 +54468,12 @@ nCb
 jhb
 ayz
 jhb
-cva
-cva
-cva
-cva
-cva
-cva
+abk
+abk
+abk
+abk
+abk
+abk
 jUb
 oUb
 bmb
@@ -54693,7 +54675,7 @@ ahf
 ahq
 ahU
 aii
-cva
+abk
 rap
 mTb
 bmb
@@ -54895,7 +54877,7 @@ ahg
 ahr
 ahZ
 aij
-cva
+abk
 jWb
 oXb
 bmb
@@ -55097,14 +55079,14 @@ ahh
 ahs
 aib
 aik
-cva
+abk
 jWb
 pcb
-aHQ
-aHQ
-aHQ
-aHQ
-aHQ
+aHi
+aHi
+aHi
+aHi
+aHi
 aHQ
 aHQ
 aHQ
@@ -55299,7 +55281,7 @@ ahi
 aht
 aic
 ail
-cva
+abk
 jYb
 pdb
 jZb
@@ -55501,7 +55483,7 @@ ahj
 ahu
 aid
 aim
-cva
+abk
 jWb
 peb
 pBb
@@ -55703,10 +55685,10 @@ abk
 abk
 aie
 abk
-cva
+abk
 jZb
 pfb
-aHQ
+aHi
 pNb
 qmb
 qOb
@@ -55905,7 +55887,7 @@ ahk
 ahv
 aif
 ain
-aiu
+ahd
 kab
 pgb
 pCb
@@ -56107,7 +56089,7 @@ ahl
 ahw
 aig
 aio
-aiu
+ahd
 kbb
 phb
 pPb
@@ -56116,7 +56098,7 @@ aLo
 qQb
 qUb
 rlb
-aHQ
+aHi
 aRd
 aSd
 aSd
@@ -56309,7 +56291,7 @@ ahm
 ahz
 ahz
 aip
-aiu
+ahd
 hvY
 pib
 pDb
@@ -56318,7 +56300,7 @@ iSb
 qnb
 rvb
 rmb
-aHQ
+aHi
 aRe
 aSe
 tgu
@@ -56511,7 +56493,7 @@ ahn
 ahn
 ahn
 aiq
-aiu
+ahd
 kpb
 pjb
 pEb
@@ -56520,7 +56502,7 @@ jAb
 aLo
 ycp
 rnb
-aHQ
+aHi
 uHz
 aSf
 dIA
@@ -56713,7 +56695,7 @@ aho
 ahH
 ahn
 air
-aiu
+ahd
 eGb
 pbb
 pFb
@@ -56722,7 +56704,7 @@ khb
 aLo
 ycp
 rob
-aHQ
+aHi
 aRf
 tCu
 nPT
@@ -56915,8 +56897,8 @@ ahp
 ahJ
 aih
 ahn
-aiu
-aHQ
+ahd
+aHi
 pnb
 pGb
 xMP
@@ -56924,7 +56906,7 @@ gcY
 qDb
 qWb
 rpb
-aHQ
+aHi
 aNy
 aDB
 aDB
@@ -57117,16 +57099,16 @@ ahd
 ahd
 ahd
 ais
-aiu
-aHQ
-aHQ
-aHQ
-aHQ
+ahd
+aHi
+aHi
+aHi
+aHi
 ivh
-aHQ
-aHQ
-aHQ
-aHQ
+aHi
+aHi
+aHi
+aHi
 aNy
 bDK
 bDK
@@ -57712,7 +57694,7 @@ acL
 xtq
 sCu
 usV
-aul
+auk
 vtY
 awI
 awJ
@@ -57720,7 +57702,7 @@ awJ
 awJ
 aAW
 vtY
-aul
+auk
 aTK
 vBV
 aTK
@@ -57914,7 +57896,7 @@ mpy
 acL
 asl
 asl
-abL
+acL
 snG
 lkp
 puw
@@ -57922,7 +57904,7 @@ ayJ
 ayJ
 mwJ
 snG
-aDB
+aTK
 xxB
 aLu
 ldP

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -29,7 +29,7 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/bridge/forestarboard)
 "ag" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/maintenance/bridge/aftstarboard)
 "ah" = (
 /obj/structure/cable/yellow{
@@ -348,7 +348,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "aK" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/cobed)
 "aL" = (
 /obj/structure/table/rack,
@@ -387,7 +387,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "aO" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -510,7 +510,7 @@
 	dir = 4;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "bb" = (
 /obj/structure/closet/emcloset,
@@ -642,7 +642,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/forestarboard)
 "bq" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/co)
 "bs" = (
 /obj/structure/cable/green{
@@ -1109,8 +1109,8 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "ck" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/bridgecheck)
+/turf/simulated/wall/prepainted,
+/area/bridge)
 "cl" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/starboard)
@@ -1909,7 +1909,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "dk" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cl/backroom)
 "dl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3027,7 +3027,7 @@
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -7
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "fy" = (
 /obj/structure/cable/green{
@@ -3184,7 +3184,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/aux_eva)
 "fI" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/aft)
 "fJ" = (
 /obj/machinery/light{
@@ -3804,7 +3804,7 @@
 	dir = 1;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/ce)
 "hz" = (
 /obj/structure/cable/green{
@@ -4006,7 +4006,7 @@
 /turf/simulated/floor/plating,
 /area/bridge/meeting_room)
 "ie" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/ce)
 "ig" = (
 /obj/structure/filingcabinet/chestdrawer{
@@ -4113,7 +4113,7 @@
 	dir = 2;
 	pixel_z = -10
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "io" = (
 /obj/structure/cable/green{
@@ -4639,7 +4639,7 @@
 	pixel_y = -4;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/aft)
 "jV" = (
 /turf/simulated/floor/tiled,
@@ -4655,7 +4655,7 @@
 	pixel_y = 3;
 	pixel_z = 0
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/aft)
 "jX" = (
 /obj/structure/cable/green{
@@ -4871,7 +4871,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "kJ" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cmo)
 "kK" = (
 /obj/structure/cable/green{
@@ -5117,7 +5117,7 @@
 	dir = 8;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cmo)
 "lB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5486,7 +5486,7 @@
 /turf/simulated/floor/plating,
 /area/security/bridgecheck)
 "mE" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cos)
 "mG" = (
 /obj/machinery/papershredder,
@@ -6131,7 +6131,7 @@
 /turf/simulated/floor/plating,
 /area/aux_eva)
 "on" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/aux_eva)
 "ox" = (
 /obj/structure/cable/green,
@@ -6797,7 +6797,7 @@
 /area/aux_eva)
 "qm" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cos)
 "qn" = (
 /obj/structure/cable/green{
@@ -6976,8 +6976,8 @@
 /turf/simulated/floor/tiled,
 /area/aquila/storage)
 "qH" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/bridge/aftport)
+/turf/simulated/wall/prepainted,
+/area/crew_quarters/heads/office/sea)
 "qI" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -7711,17 +7711,17 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/office/sgr)
 "sJ" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cl)
 "sL" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/sgr)
 "sP" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 1;
 	icon_state = "shock"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/sgr)
 "sQ" = (
 /obj/structure/cable/green{
@@ -7750,7 +7750,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room)
 "sT" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/rd)
 "sU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8542,7 +8542,7 @@
 	dir = 8;
 	icon_state = "deck-b"
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/hallway/primary/bridge/fore)
 "uW" = (
 /obj/effect/floor_decal/corner/blue{
@@ -8559,9 +8559,6 @@
 /area/bridge/disciplinary_board_room)
 "uX" = (
 /turf/simulated/wall/prepainted,
-/area/maintenance/auxsolarbridge)
-"uY" = (
-/turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/auxsolarbridge)
 "uZ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -8711,7 +8708,7 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "vv" = (
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/bridge/disciplinary_board_room/deliberation)
 "vx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -9891,7 +9888,7 @@
 /area/bridge)
 "yg" = (
 /obj/machinery/status_display,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "yh" = (
 /obj/effect/floor_decal/scglogo{
@@ -11370,7 +11367,7 @@
 /area/crew_quarters/heads/cobed)
 "EM" = (
 /obj/structure/sign/warning/detailed,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/xo)
 "EN" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -12697,7 +12694,7 @@
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = -6
 	},
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/rd)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -12922,7 +12919,7 @@
 /area/bridge/disciplinary_board_room)
 "Le" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall/prepainted,
+/turf/simulated/wall/prepainted,
 /area/crew_quarters/heads/office/cl)
 "Lf" = (
 /obj/structure/cable/green{
@@ -13885,9 +13882,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/fore)
-"Pi" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/bridge/disciplinary_board_room)
 "Pl" = (
 /obj/structure/closet/secure_closet/liaison,
 /obj/machinery/camera/network/command{
@@ -15794,9 +15788,6 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
-"Xr" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/maintenance/bridge/forestarboard)
 "Xx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/door/airlock/medical{
@@ -24339,7 +24330,7 @@ hn
 hn
 SJ
 ev
-eP
+ck
 UY
 Fg
 Ig
@@ -24945,7 +24936,7 @@ Kt
 Lw
 fN
 HW
-eP
+ck
 qQ
 rJ
 Ii
@@ -25356,10 +25347,10 @@ RT
 vm
 tW
 Iq
-sB
-sB
-sB
-sB
+qH
+qH
+qH
+qH
 Rl
 jc
 bH
@@ -25561,7 +25552,7 @@ En
 vj
 vO
 ww
-sB
+qH
 Oi
 lT
 Ht
@@ -25763,7 +25754,7 @@ Is
 vk
 vP
 IE
-sB
+qH
 aK
 aK
 aK
@@ -25958,14 +25949,14 @@ eD
 fa
 fA
 fR
-sB
+qH
 ZR
 vZ
 uG
 Nn
 Ck
 mz
-sB
+qH
 xc
 xc
 xc
@@ -26160,7 +26151,7 @@ eE
 fc
 fC
 fS
-sB
+qH
 tm
 tZ
 hU
@@ -27145,7 +27136,7 @@ af
 af
 aj
 VB
-Xr
+al
 aO
 aO
 kA
@@ -27347,7 +27338,7 @@ af
 af
 VB
 VB
-Xr
+al
 bb
 AR
 bU
@@ -27561,17 +27552,17 @@ bF
 bK
 cg
 cs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
-hs
+hq
+hq
+hq
+hq
+hq
+hq
+hq
+hq
+hq
+hq
+hq
 rc
 cG
 XN
@@ -28985,7 +28976,7 @@ kX
 eF
 Wj
 Eq
-ck
+yW
 FS
 yb
 sL
@@ -29594,10 +29585,10 @@ pF
 mN
 rg
 yb
-Pi
-Pi
-Pi
-Pi
+TX
+TX
+TX
+TX
 vv
 nI
 vv
@@ -29787,8 +29778,8 @@ hC
 La
 iX
 Lk
-hC
-ck
+fB
+yW
 mO
 oK
 zM
@@ -30387,10 +30378,10 @@ fl
 Jj
 Rj
 sT
-hC
-hC
-hC
-hC
+fB
+fB
+fB
+fB
 uV
 in
 kL
@@ -31609,12 +31600,12 @@ SN
 nb
 mX
 Ey
-qH
-qH
-qH
-qH
-qH
-qH
+oh
+oh
+oh
+oh
+oh
+oh
 tH
 ut
 fO
@@ -32021,7 +32012,7 @@ on
 on
 on
 on
-uY
+uX
 Pc
 wn
 wT
@@ -32223,7 +32214,7 @@ yi
 Bp
 Ci
 on
-uY
+uX
 vI
 wo
 wU
@@ -32626,7 +32617,7 @@ pR
 yD
 Fi
 Dt
-on
+CO
 dV
 dV
 wq
@@ -32820,7 +32811,7 @@ DN
 kT
 lO
 nd
-on
+CO
 Sh
 pQ
 pQ
@@ -32828,7 +32819,7 @@ QE
 Ai
 Ai
 Zy
-on
+CO
 dV
 dV
 Tc
@@ -33022,7 +33013,7 @@ DN
 kU
 Sg
 ne
-on
+CO
 Th
 Dq
 Uh
@@ -33030,7 +33021,7 @@ fH
 bk
 zz
 IW
-on
+CO
 dV
 dV
 ws


### PR DESCRIPTION
🆑 
maptweak: Because of intense budget cuts, many of the Torch's reinforced walls have been replaced with normal walls.
/🆑 

Un-babyproofs a lot of the torch. Antagonize! Suffer from explosions! Marvel at the aesthetics!

Semi-dependent on #30326 for balance reasons.