### PR TITLE
More feedback for unconscious players, updates message shown for ghosted players

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -88,6 +88,8 @@
 
 	suppressing = !suppressing
 	user.visible_message("<span class='notice'>\The [user] switches [suppressing ? "on" : "off"] \the [src]'s neural suppressor.</span>")
+	if (victim.stat == UNCONSCIOUS)
+		to_chat(victim, SPAN_NOTICE(SPAN_BOLD("... [pick("good feeling", "white light", "pain fades away", "safe now")] ...")))
 	return TRUE
 
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -73,6 +73,8 @@
 
 	if(iscarbon(occupant) && stasis > 1)
 		occupant.SetStasis(stasis)
+		if (occupant.stat == UNCONSCIOUS && prob(2))
+			to_chat(occupant, SPAN_NOTICE(SPAN_BOLD("... [pick("comfy", "feels slow", "warm")] ...")))
 
 /obj/machinery/sleeper/on_update_icon()
 	if(!occupant)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -249,6 +249,8 @@
 		var/has_cryo_medicine = occupant.reagents.has_any_reagent(list(/datum/reagent/cryoxadone, /datum/reagent/clonexadone, /datum/reagent/nanitefluid)) >= REM
 		if(beaker && !has_cryo_medicine)
 			beaker.reagents.trans_to_mob(occupant, REM, CHEM_BLOOD)
+		if (prob(2))
+			to_chat(occupant, SPAN_NOTICE(SPAN_BOLD("... [pick("floating", "cold")] ...")))
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
 	if(air_contents.total_moles < 1)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -110,6 +110,8 @@
 					user.visible_message(SPAN_NOTICE("\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name]."), \
 					                              SPAN_NOTICE("You place a bandaid over \a [W.desc] on [M]'s [affecting.name].") )
 				W.bandage()
+				if (M.stat == UNCONSCIOUS && prob(25))
+					to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels a little better", "hurts a little less")] ...")))
 				playsound(src, pick(apply_sounds), 25)
 				used++
 			affecting.update_damages()
@@ -203,6 +205,8 @@
 				W.disinfect()
 				W.heal_damage(heal_brute)
 				used++
+				if (M.stat == UNCONSCIOUS && prob(25))
+					to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 			affecting.update_damages()
 			if(used == amount)
 				if(affecting.is_bandaged())
@@ -247,6 +251,8 @@
 			use(1)
 			affecting.salve()
 			affecting.disinfect()
+			if (M.stat == UNCONSCIOUS && prob(25))
+				to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 
 /obj/item/stack/medical/splint
 	name = "medical splints"

--- a/code/modules/codex/entries/misc.dm
+++ b/code/modules/codex/entries/misc.dm
@@ -20,3 +20,11 @@
 /datum/codex_entry/moneygun/New(_display_name, list/_associated_paths, list/_associated_strings, _lore_text, _mechanics_text, _antag_text)
 	. = ..()
 	antag_text = "Sliding a cryptographic sequencer into the receptacle will short the motors and override their speed. If you set the cannon to dispense 100 [GLOB.using_map.local_currency_name] or more, this might make a handy weapon."
+
+/datum/codex_entry/ssd
+	display_name = "SSD/S.S.D."
+	mechanics_text = "When a player has disconnected or ghosted, they display a special message when they're examined, colored in purple. If the message indicates something like them staring blankly, being fast asleep, or displaying a SYSTEM OFFLINE message, it's likely that the player's closed their BYOND client or lost their connection. In such a case, it's possible they'll resume play soon or at a later time. These players are referred as \"going SSD\" or otherwise being SSD.<br><br>\
+	\
+	If the message displays something more severe, like being completely comatose or having a full system failure, the player has voluntarily ghosted while still alive - this means that the character won't return back to the round as a player, short of invervention from an admin. For clarity, these cases will also always mention that the player won't be recovering or waking up any time soon.<br><br>\
+	\
+	The server's rules likely have special clauses regarding SSD players. Check the rule list before you touch a player who's disconnected or take any actions on them."

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -175,7 +175,7 @@
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span>\n"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. [T.He] won't be recovering any time soon.</span>\n"
 		else if(!client)
 			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>\n"
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -54,6 +54,7 @@
 	var/mob_size	= MOB_MEDIUM
 	var/strength    = STR_MEDIUM
 	var/show_ssd = "fast asleep"
+	var/show_coma = "completely comatose"
 	var/short_sighted                         // Permanent weldervision.
 	var/light_sensitive                       // Ditto, but requires sunglasses to fix
 	var/blood_volume = SPECIES_BLOOD_DEFAULT  // Initial blood volume.

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -44,7 +44,10 @@
 	return ((H && H.isSynthetic()) ? "gives one shrill beep before falling lifeless." : death_message)
 
 /datum/species/proc/get_ssd(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
+	if (H.key)
+		return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
+	else
+		return ((H && H.isSynthetic()) ? "displaying a blue screen on their monitor indicating total system failure" : show_coma)
 
 /datum/species/proc/get_blood_colour(var/mob/living/carbon/human/H)
 	return ((H && H.isSynthetic()) ? SYNTH_BLOOD_COLOUR : blood_color)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -114,6 +114,8 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			H.bloody_body(target,0)
 	if(shock_level)
 		target.shock_stage = max(target.shock_stage, shock_level)
+	if (target.stat == UNCONSCIOUS && prob(20))
+		to_chat(target, SPAN_NOTICE(SPAN_BOLD("... [pick("bright light", "faraway pain", "something moving in you", "soft beeping")] ...")))
 	return
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes


### PR DESCRIPTION
🆑
rscadd: While unconscious or asleep, you may now get bolded message similar to dreams to indicate that you're being treated, floating in a cryo tube, sitting in a sleeper with stasis, or on an operating table - these are added with the goal of helping someone understand what's happening to them even though they can't see around them while unconscious.
rscadd: Added a codex entry describing how SSD messages are displayed from a mechanical perspective.
spellcheck: Ghosted mobs now have a distinct examine message from disconnected mobs.
/🆑

Marking this as WIP so I can get feedback from both maintainers and other folks.

#30291 isn't really a problem (in my opinion), but the discussion spurned from it did highlight some perceived issues about the Black Screen Experience:
* If you can't hear, it isn't obvious what's happening to you. Medical could be working hard to save you for ten minutes, but you'd be seeing nothing and hearing silence.
* It's hard to differentiate between players that have disconnected or lost connection, and players that have ghosted. The text is different, but it's an addendum to the base message instead of a completely different one. Closing your client when you get downed is very bad tact, while ghosting is now the accepted solution if you no longer want to play.

To that end, I made this after observing a long and slightly aggressive discussion, as well as general input that seems to have been tossed around before then. The list of changes are as follows:
1. Ghosted mobs now have a distinct message from disconnected mobs. A disconnected human is described as staring blankly, while a ghosted human is described as being completely comatose. (This also works for synthetics)
2. Added a codex entry for SSD. It might not ever get read, but hey, documentation.
3. Various medical actions performed on you while you're unconscious may now display dream-like messages in bold, including being bandaged, surgery, and floating in active cryo tubes. Messages are subject to change, though.

The goals of all this are to fix a few interconnected problems like listed above. With ghosting now being the norm instead of succumbing, I wanted to clarify the gap between players that might return to the round (aghosted, DCed, lost Internet) and players that won't. I'm hoping this also makes saving a ghosted player more gratifying, as it can be fluffed as "they went into a coma from trauma" instead of "they went SSD during treatment".

I'm also hopeful that the messages for being treated while unconscious will make it more obvious to other players about what's happening to them at the moment - are they being triaged? On the operating table? In stasis? It's impossible to account for all cases, but I like to think that accounting for the most obvious ones will help the problem.

Everything here is open to input. The messages and presentation themselves are meant to make it obvious that you're being treated, even if you don't know what they strictly mean, but I'm down for changing them. Page me here or in #pr-feedback if you like (my name is Ava on discord, same avi as here.)