### PR TITLE
Mapping tool for putting text files on modular computers + puts some on ahab's harpoon

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -165,3 +165,9 @@
 		/datum/computer_file/program/email_client,
 		/datum/computer_file/program/wordprocessor
 	)
+
+/obj/machinery/computer/modular/preset/filemanager
+	default_software = list(
+		/datum/computer_file/program/wordprocessor
+	)
+	autorun_program = /datum/computer_file/program/filemanager

--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -32,3 +32,33 @@
 
 /datum/computer_file/data/bodyscan/generate_file_data(var/mob/user)
 	return display_medical_data(metadata, user.get_skill_value(SKILL_MEDICAL), TRUE)
+
+/// Mapping tool - creates a named modular computer file in a computer's storage on late initialize.
+/// Use this to do things like automatic records and blackboxes. Alternative for paper records.
+/// Values can be in the editor for each map or as a subtype.
+/// This is an obj because raw atoms can't be placed in DM or third-party mapping tools.
+/obj/effect/computer_file_creator
+	name = "computer file creator"
+	desc = "This is a mapping tool used for installing text files onto a modular device when it's mapped on top of them. If you see it, it's bugged."
+	icon = 'icons/effects/landmarks.dmi'
+	icon_state = "x3"
+	anchored = TRUE
+	unacidable = TRUE
+	simulated = FALSE
+	invisibility = 101
+	var/file_name = "helloworld" // The name that the file will have once it's created
+	var/file_info = "Hello World!" // The contents of this file. Uses paper formatting.
+
+/obj/effect/computer_file_creator/Initialize()
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/computer_file_creator/LateInitialize()
+	var/turf/T = get_turf(src)
+	for (var/obj/O in T)
+		if (!istype(O, /obj/machinery/computer/modular) && !istype(O, /obj/item/modular_computer))
+			continue
+		var/datum/extension/interactive/ntos/os = get_extension(O, /datum/extension/interactive/ntos)
+		if (os)
+			os.save_file(file_name, file_info, /datum/computer_file/data/text)
+	qdel(src)

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -245,3 +245,58 @@ obj/structure/net/Initialize(var/mapload)
 	belt = /obj/item/weapon/material/knife/combat
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/hardhat/dblue
+
+/obj/effect/computer_file_creator/ahabs_harpoon01
+	name = "ahab's harpoon file spawner - sensor dump"
+
+/obj/effect/computer_file_creator/ahabs_harpoon01/Initialize()
+	var/i_month = max(text2num(time2text(world.timeofday, "MM")) - 1, 1) // Prevent month from going below 1
+	var/i_day = max(text2num(time2text(world.timeofday, "DD")) - 5, 1)
+	file_name = "NETMON_SENSORDUMP-BLACKBOX"
+	file_info = " \
+		<h2>XCV Ahab's Harpoon Sensor Log - <i>[GLOB.using_map.game_year]-[i_month]-[i_day]</i></h2> \
+		<hr> \
+		\<08:33:07\> Space carp migration detected within 1 Gm.<br>\
+		\<08:51:29\> Main net extended.<br>\
+		\<09:00:00\> Hourly report. Security level: GREEN. Crew status: NOMINAL. SMES charge: NOMINAL.<br>\
+		\<09:02:53\> Outflow cells opened.<br>\
+		\<09:04:12\> Exterior airlock cycling: Port Solar Control.<br>\
+		\<09:04:25\> <b>VITAL SIGNS ALERT:</b> C. BANCROFT, Retrieval Specialist, Port Solar Control<br>\
+		\<09:04:33\> <b>BRAIN ACTIVITY FLATLINE:</b> C. BANCROFT, Retrieval Specialist, Port Solar Control<br>\
+		\<09:04:39\> Unidentified lifesigns aboard.<br>\
+		\<09:04:45\> Multiple unidentified lifesigns aboard.<br>\
+		\<09:05:21\> <b>SECURITY LEVEL ALERT:</b> Elevated to RED.<br>\
+		\<09:33:07\> <b>SECURITY LEVEL ALERT:</b> Logging flight and sensor data to ship black box.<br>\
+		\<09:41:13\> <b>MULTIPLE VITAL SIGNS ALERTS</b><br>\
+		\<09:47:03\> All vital signs alerts cleared.<br>\
+		\<10:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: NOMINAL.<br>\
+		\<11:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: NOMINAL.<br>\
+		\<12:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: NOMINAL.<br>\
+		\<13:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: NOMINAL.<br>\
+		\<14:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: LOW.<br>\
+		\<15:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: LOW.<br>\
+		\<16:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: CRITICAL.<br>\
+		\<17:00:00\> Hourly report. Security level: RED. Crew status: CRITICAL. SMES charge: CRITICAL.<br>\
+		\<17:03:41\> Low power. Entering hibernation. Data dumped to local drive and stored in ship black box.<br>\
+		\<17:03:41\> Black box data pushed to access terminal.<br>\
+		\<17:03:42\> Shutting down.<br>\
+	"
+	. = ..()
+
+/obj/effect/computer_file_creator/ahabs_harpoon02
+	name = "ahab's harpoon file spawner - black box"
+	file_name = "NETMON_BLACKBOX"
+	file_info = "<p><i>This is the flight recorder data for the XCV Ahab's Harpoon. Its callsign and flight registration indicate that this is a medium size, long-haul commerical space carp fishing vessel, owned by Xynergy. The data recording here only includes hourly status reports, but they indicate that the ship went from nominal function at 09:00 to red alert and critical crew status by 10:00, before continuing at these levels for most of the day until SMES power failed.</i></p>\
+	\
+	<p><i>This data contains a wealth of information about the ship's records, manifest, and specifications, but nothing immediately useful about the events that happened on board. You may be able to glean further information if you could find more complete records.</i></p>"
+
+/obj/effect/computer_file_creator/ahabs_harpoon03
+	name = "ahab's harpoon file spawner - captain's log"
+	file_name = "captainslog"
+
+/obj/effect/computer_file_creator/ahabs_harpoon03/Initialize()
+	var/captain_name = "[capitalize(pick(GLOB.first_names_male + GLOB.first_names_female))] [capitalize(pick(GLOB.last_names))]"
+	file_info = "<p><i>This is the captain's log of the XCV Ahab's Harpoon, authored by Xynergy general manager [captain_name]. According to the log's contents, the ship embarked on its final voyage six months ago. All entries except the last one seem mundane - routine checks, inventory reports, flight path, and so on. The final entry seems to have been written in a hurry, with several typos that didn't get caught by the autocorrect:</i></p>\
+	\
+	<p>Had a major incident, have lost control f the ship. Hit a big shoal off Nine and scooped up a bunch but itr got the net tangled. Charlie went out to untangle it and a bunch got in. Big motherfuckers, got everywhere. Lkarger than pike. Got trhough doors. Gettim vital alerts for half the crew. Turning on distress but the emergency mode eats up a lot of powedr and it won't last forever. Solars might keep the lights on but it'll be brownouts/blackouts eventually. Going to make for engi where the blackbox comp is. Wish me luck. Please report to xyn/gov if you find this.</p>"
+	. = ..()

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -483,6 +483,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/computer/modular/preset/filemanager{
+	desc = "A brightly-colored terminal built from stress-resistant materials. Used to read data from a connected flight recorder.";
+	name = "black box terminal"
+	},
+/obj/effect/computer_file_creator/ahabs_harpoon02,
 /turf/simulated/floor/plating,
 /area/errant_pisces/enginering)
 "bq" = (
@@ -6242,9 +6247,12 @@
 /turf/simulated/floor/wood,
 /area/errant_pisces/bridge)
 "oY" = (
-/obj/machinery/computer/modular{
-	dir = 8
+/obj/machinery/computer/modular/preset/filemanager{
+	desc = "This console is stamped with the Xynergy logo and appears well-used. It sports an antenna on the back, poking above the screen.";
+	dir = 8;
+	name = "command terminal"
 	},
+/obj/effect/computer_file_creator/ahabs_harpoon01,
 /turf/simulated/floor/wood,
 /area/errant_pisces/bridge)
 "oZ" = (
@@ -6322,9 +6330,10 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "pj" = (
-/obj/machinery/computer/modular{
+/obj/machinery/computer/modular/preset/filemanager{
 	dir = 1
 	},
+/obj/effect/computer_file_creator/ahabs_harpoon01,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "pk" = (
@@ -6343,6 +6352,10 @@
 /area/errant_pisces/bridge)
 "pn" = (
 /obj/structure/table/woodentable,
+/obj/item/modular_computer/tablet/lease/preset/command{
+	desc = "A small, portable microcomputer. This one has a Xynergy logo in purple, and a serial number stamped into the case."
+	},
+/obj/effect/computer_file_creator/ahabs_harpoon03,
 /turf/simulated/floor/wood,
 /area/errant_pisces/bridge)
 "po" = (


### PR DESCRIPTION
🆑
tweak: Added some digital logs on modular computers on the Ahab's Harpoon away site that elucidates more about what happened. Keep an eye out for new digital logs going forward!
/🆑

I had a dream about this and I wanted to be helpful, so here we go. This adds a new atom, `/obj/effect/computer_file_creator`, that searches for a modular computer in its location on LateInitialize and adds a text file to it if it finds one, then deletes itself. This is, effectively, a way to add digital logs for fluff, info, black box data, and generally giving another way to create information that can be discovered IC, instead of only physical papers. I wanted to use `/atom` for this, but raw atoms can't be placed during mapping, which defeats the purpose.

As a proof-of-concept, I also placed several of these on the Errant Pisces away site (xcv ahab's harpoon) with some fluff about what happened and how it got there. All the terminals in the bridge have a sensor dump/timeline of events dated (arbitrarily) at one month and five days ago. A new console in the engineering room provides a fluffy black box readout, and a tablet in the captain's quarters has a log.

The Ahab's Harpoon stuff is fully just to demonstrate a usage in-game, and because the away site doesn't actually seem to currently have any information or logs to read. I'm fine with removing it, too.

Finally, this also adds a new modular computer preset, path `/obj/machinery/computer/modular/preset/filemanager`. This subtype auto-runs the file manager when turned on. Useful for getting explorers to see that there's a file there to read it. I replaced a bunch of existing, standard modular computer on the Harpoon with this new subtype.

Things I'm thinking about doing: admin click-drag or attackby to create files post-init. Would be used for things like build mode or events.

<details><summary>Harpoon black box data (on a console in engineering)</summary>

![image](https://user-images.githubusercontent.com/47678781/111041946-caaef300-8408-11eb-9d02-60df6536395d.png)

</details>

<details><summary>Harpoon sensor dump (on all consoles  in the ship bridge)</summary>

![image](https://user-images.githubusercontent.com/47678781/111041956-d4385b00-8408-11eb-91bb-843b62c96290.png)

</details>

<details><summary>Harpoon captain's log (on a command tablet in the captain's room. captain's name is randomly generated, it being Ava is purely coincidence. unintentional typo fixed in code)</summary>

![image](https://user-images.githubusercontent.com/47678781/111041967-e0bcb380-8408-11eb-92fa-eed4506ff88d.png)

</details>