### PR TITLE
Fixes NTNet Relay construction

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -116,12 +116,3 @@
 		D.target = null
 		D.error = "Connection to quantum relay severed"
 	..()
-
-/obj/machinery/ntnet_relay/attackby(obj/item/P, mob/user)
-	if (!istype(P,/obj/item/stock_parts/computer/hard_drive/portable))
-		return
-	else if (get_component_of_type(/obj/item/stock_parts/computer/hard_drive/portable))
-		to_chat(user, "This relay's portable drive slot is already occupied.")
-	else if(user.unEquip(P,src))
-		install_component(P)
-		to_chat(user, "You install \the [P] into \the [src]")


### PR DESCRIPTION
:cl:
fix: NTNet relays can be constructed and deconstructed properly.
/:cl:

Fixes #28386
Fixes #29165