### PR TITLE
Skrell are more resistant to space drugs

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -541,10 +541,11 @@
 		drug_strength = drug_strength * 0.8
 
 	M.druggy = max(M.druggy, drug_strength)
-	if(prob(10))
-		M.SelfMove(pick(GLOB.cardinal))
-	if(prob(7))
-		M.emote(pick("twitch", "drool", "moan", "giggle"))
+	if (alien != IS_SKRELL)
+		if (prob(10))
+			M.SelfMove(pick(GLOB.cardinal))
+		if(prob(7))
+			M.emote(pick("twitch", "drool", "moan", "giggle"))
 	M.add_chemical_effect(CE_PULSE, -1)
 
 /datum/reagent/serotrotium


### PR DESCRIPTION
Taken from the wiki:
> Despite an extremely low resistance to alcohol, Skrell have otherwise developed a high tolerance to a large amount of chemical substances, a result of their homeworld's flora being generally poisonous as a defence mechanism. Consequently, skrellian food is generally too harmful for human consumption.

Given that skrell regularly consume qokk'loa/qokk'hrona, which contains space drugs, it seems only natural for them to have developed a more pronounced tolerance to it. This exempts skrell from random giggling or moving.

Naturally this will need a pass by ekillz.

:cl:
tweak: Skrell are now more tolerant of space drugs (found in qokk'loa) and will no longer randomly giggle or move around when under its effects.
/:cl: