### PR TITLE
Adds splashing with drinking glasses + shattering/spilling beakers

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -105,6 +105,19 @@
 	reagents.splash(target, reagents.total_volume)
 	return 1
 
+/obj/item/reagent_containers/proc/splashtarget(obj/target, mob/user)
+	if (user.a_intent == I_HURT)
+		if (standard_splash_mob(user,target))
+			return TRUE
+		if (reagents && reagents.total_volume)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] splashes \the [src] onto \the [target]."),
+				SPAN_NOTICE("You splash the contents of \the [src] onto \the [target]."),
+				SPAN_NOTICE("You hear the sound of liquid splashing.")
+			)
+			reagents.splash(target, reagents.total_volume)
+			return TRUE
+
 /obj/item/reagent_containers/proc/self_feed_message(var/mob/user)
 	to_chat(user, "<span class='notice'>You eat \the [src]</span>")
 
@@ -130,11 +143,13 @@
 		if(target == user)
 			if(istype(user, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = user
-				if(!H.check_has_mouth())
+				if (user.a_intent == I_HURT)
+					return
+				if (!H.check_has_mouth())
 					to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
 					return
 				var/obj/item/blocked = H.check_mouth_coverage()
-				if(blocked)
+				if (blocked)
 					to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
 					return
 
@@ -147,12 +162,14 @@
 
 
 		else
+			if (user.a_intent == I_HURT)
+				return
 			var/mob/living/carbon/H = target
-			if(!H.check_has_mouth())
+			if (!H.check_has_mouth())
 				to_chat(user, "Where do you intend to put \the [src]? \The [H] doesn't have a mouth!")
 				return
 			var/obj/item/blocked = H.check_mouth_coverage()
-			if(blocked)
+			if (blocked)
 				to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
 				return
 

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -99,19 +99,31 @@
 		return
 	if(prob(80))
 		if(reagents.reagent_list.len > 0)
-			visible_message(SPAN_DANGER("\The [src] shatters from the impact and spills all its contents!"), SPAN_DANGER("You hear the sound of glass shattering!"))
+			visible_message(
+				SPAN_DANGER("\The [src] shatters from the impact and spills all its contents!"),
+				SPAN_DANGER("You hear the sound of glass shattering!")
+			)
 			reagents.splash(hit_atom, reagents.total_volume)
-		else 
-			visible_message(SPAN_DANGER("\The [src] shatters from the impact!"), SPAN_DANGER("You hear the sound of glass shattering!"))
+		else
+			visible_message(
+				SPAN_DANGER("\The [src] shatters from the impact!"),
+				SPAN_DANGER("You hear the sound of glass shattering!")
+			)
 		playsound(src.loc, pick(GLOB.shatter_sound), 100)
 		new /obj/item/material/shard(src.loc)
 		qdel(src)
 	else
 		if (reagents.reagent_list.len > 0)
-			visible_message(SPAN_DANGER("\The [src] bounces and spills all its contents!"), SPAN_WARNING("You hear the sound of glass hitting something."))
+			visible_message(
+				SPAN_DANGER("\The [src] bounces and spills all its contents!"),
+				SPAN_WARNING("You hear the sound of glass hitting something.")
+			)
 			reagents.splash(hit_atom, reagents.total_volume)
 		else
-			visible_message(SPAN_WARNING("\The [src] bounces dangerously. Luckily it didn't break."), SPAN_WARNING("You hear the sound of glass hitting something."))
+			visible_message(
+				SPAN_WARNING("\The [src] bounces dangerously. Luckily it didn't break."),
+				SPAN_WARNING("You hear the sound of glass hitting something.")
+			)
 		playsound(src.loc, "sound/effects/Glasshit.ogg", 50)
 
 /obj/item/reagent_containers/food/drinks/glass2/proc/can_add_extra(obj/item/glass_extra/GE)
@@ -172,7 +184,7 @@
 			underlays += filling
 
 		overlays += over_liquid
-		
+
 	else
 		SetName(custom_name || initial(name))
 		desc = custom_desc || initial(desc)
@@ -199,6 +211,11 @@
 			underlays += I
 		else continue
 		side = "right"
+
+/obj/item/reagent_containers/food/drinks/glass2/afterattack(obj/target, mob/user, proximity)
+	if (!proximity || standard_dispenser_refill(user, target) || standard_pour_into(user, target))
+		return TRUE
+	splashtarget(target, user)
 
 /obj/item/reagent_containers/food/drinks/glass2/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/material/kitchen/utensil/spoon))


### PR DESCRIPTION
:cl: Ryan180602
rscadd: Drinking glasses can now be used to splash mobs
rscadd: Beakers can now break when thrown, spilling its contents
tweak: Add a harm-intent check when clicking on self with glasses/beakers
/:cl:

bad copy-paste work go brr

Repurposed code from `reagent_containers/drinkingglass` and `reagent_containers/glass` both in each other to make their behaviors more consistent with eachother. This can all likely be done in `reagent_containers` itself, but that is above my knowledge for DM.