### PR TITLE
Admin faxes no longer open the fax editing menu after being written on

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -146,8 +146,12 @@
 					toner = 0
 	return
 
-/obj/machinery/photocopier/proc/copy(var/obj/item/paper/copy, var/need_toner=1)
-	var/obj/item/paper/c = new copy.type(loc, copy.text, copy.name, copy.metadata )
+/obj/machinery/photocopier/proc/copy(obj/item/paper/copy, need_toner = TRUE, copy_admin = FALSE)
+	var/copy_type = copy.type
+	if (istype(copy, /obj/item/paper/admin) && !copy_admin) // Edge case for admin faxes so that they don't show the editing form
+		copy_type = /obj/item/paper
+	
+	var/obj/item/paper/c = new copy_type(loc, copy.text, copy.name, copy.metadata )
 
 	c.color = COLOR_WHITE
 


### PR DESCRIPTION
🆑
bugfix: Admin-sent faxes no longer open the fax editing menu when you finish writing on them.
/🆑

This is accomplished by forcing fax machines to send create paper types instead of admin papers (which seem to be intended for write-only in faxes, and never to actually be read) whenever a fax is sent by checking if the type is equal to `/obj/item/paper/admin`. If it is, then it'll spawn the base paper type instead.

Is this a hacky solution? This may be a hacky solution. I'm open to ideas. It worked on a local server, at least.

Fixes #29839.