### PR TITLE
Revert thermal removals

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -102,6 +102,12 @@
 	item_cost = 28
 	path = /obj/item/storage/backpack/satchel/syndie_kit/space
 
+/datum/uplink_item/item/tools/thermal
+	name = "Thermal Imaging Glasses"
+	desc = "A pair of meson goggles that have been modified to instead show synthetics or living creatures, through thermal imaging."
+	item_cost = 24
+	path = /obj/item/clothing/glasses/thermal/syndi
+
 /datum/uplink_item/item/tools/flashdark
 	name = "Flashdark"
 	desc = "A device similar to a flash light that absorbs the surrounding light, casting a shadowy, black mass."

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -4,6 +4,12 @@
 /datum/uplink_item/item/hardsuit_modules
 	category = /datum/uplink_category/hardsuit_modules
 
+/datum/uplink_item/item/hardsuit_modules/thermal
+	name = "\improper Thermal Scanner"
+	desc = "A module capable of giving vision of synthetic or living creatures, through thermal imaging."
+	item_cost = 16
+	path = /obj/item/rig_module/vision/thermal
+
 /datum/uplink_item/item/hardsuit_modules/energy_net
 	name = "\improper Net Projector"
 	desc = "A module capable of creating an energy net device that can be thrown in order to capture targets like the prey they are."

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -39,7 +39,9 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 		)
 
 	var/list/raider_glasses = list(
-		/obj/item/clothing/glasses/night
+		/obj/item/clothing/glasses/thermal,
+		/obj/item/clothing/glasses/thermal/plain/eyepatch,
+		/obj/item/clothing/glasses/thermal/plain/monocle
 		)
 
 	var/list/raider_helmets = list(

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -70,6 +70,7 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/emag, 100, 50)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/clerical)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/space_suit, 50, 10)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/thermal)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/heavy_armor)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/powersink, 10, 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/ai_module, 25, 0)
@@ -83,12 +84,17 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/surgery, reselect_propbability = 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/combat, reselect_propbability = 10)
 
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/energy_net, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/ewar_voice, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/maneuvering_jets, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/egun, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/power_sink, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/laser_canon, reselect_propbability = 5)
+
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/suit_sensor_mobile)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/services/suit_sensor_shutdown, 75, 0)

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -876,7 +876,7 @@
 /obj/item/clothing/head/helmet/space/vox/stealth,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
-/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/thermal/plain/monocle,
 /obj/item/clothing/under/vox/vox_robes,
 /obj/item/gun/projectile/dartgun/vox/medical,
 /turf/unsimulated/floor{
@@ -1279,9 +1279,9 @@
 "cT" = (
 /obj/structure/table/rack,
 /obj/random/raider/hardsuit,
+/obj/item/clothing/glasses/thermal/plain/monocle,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
-/obj/item/clothing/glasses/night,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cU" = (


### PR DESCRIPTION
With the fixes to thermals+scopes made by #30256, my reasoning for having thermals removed is resolved.

:cl:
tweak: Thermals have been re-added to various antag sources that were previously removed.
/:cl: