### PR TITLE
Move crashed pod fuel tank to less exposed area

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -553,7 +553,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/orange,
-/obj/structure/reagent_dispensers/fueltank,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
@@ -562,6 +561,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/fabricator/hacked,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "fx" = (
@@ -799,7 +799,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/obj/machinery/fabricator/hacked,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "gi" = (


### PR DESCRIPTION
:cl:
map: The crashed survivor pod's fuel tank has been moved to a less exposed area so it stops being shot randomly by mobs, events, and security.
/:cl: