### PR TITLE
glowmasks for consoles, APCs, fire alarms

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -962,7 +962,7 @@ FIRE ALARM
 			var/decl/security_level/sl = security_state.current_security_level
 
 			set_light(sl.light_max_bright, sl.light_inner_range, sl.light_outer_range, 2, sl.light_color_alarm)
-			overlays += image(sl.icon, sl.overlay_alarm)
+			overlays += glowmasked_image(sl.icon, sl.overlay_alarm)
 		else
 			overlays += get_cached_overlay("fire0")
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -90,11 +90,12 @@
 	overlays += get_keyboard_overlay()
 
 /obj/machinery/computer/proc/get_screen_overlay()
-	return image(icon,icon_screen, overlay_layer)
+	if (icon_screen)
+		return glowmasked_image(icon, icon_screen)
 
 /obj/machinery/computer/proc/get_keyboard_overlay()
 	if(icon_keyboard)
-		overlays += image(icon, icon_keyboard, overlay_layer)
+		return glowmasked_image(icon, icon_keyboard)
 
 /obj/machinery/computer/proc/decode(text)
 	// Adds line breaks

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -12,8 +12,17 @@ GLOBAL_LIST_EMPTY(species_icon_template_cache)
 
 /proc/overlay_image(icon,icon_state,color,flags)
 	var/image/ret = image(icon,icon_state)
-	ret.color = color
-	ret.appearance_flags = flags
+	if (color)
+		ret.color = color
+	if (flags)
+		ret.appearance_flags = flags
+	return ret
+
+// Creates a standard overlay image, but adds a "glowmask" by placing it above lighting.
+/proc/glowmasked_image(icon, icon_state, color, flags)
+	var/image/ret = overlay_image(icon, icon_state, color, flags)
+	ret.layer = ABOVE_LIGHTING_LAYER
+	ret.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	return ret
 
 	///////////////////////

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -80,8 +80,8 @@
 	overlays.Cut()
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
-		overlays += os.get_screen_overlay()
-		overlays += os.get_keyboard_overlay()
+		overlays += os.get_screen_overlay(FALSE) // prevent glowmasking on PDAs/etc - unfortunately, it breaks inventory icons
+		overlays += os.get_keyboard_overlay(FALSE)
 
 	if(enabled)
 		set_light(0.2, 0.1, light_strength)

--- a/code/modules/modular_computers/ntos/visuals.dm
+++ b/code/modules/modular_computers/ntos/visuals.dm
@@ -4,7 +4,7 @@
 	if(istype(A))
 		A.update_icon()
 
-/datum/extension/interactive/ntos/proc/get_screen_overlay()
+/datum/extension/interactive/ntos/proc/get_screen_overlay(should_glowmask = TRUE)
 	if(!on)
 		return image(screen_icon_file, screensaver_icon)
 	if(!screen_icon_file)
@@ -12,11 +12,14 @@
 		if(istype(A))
 			screen_icon_file = A.icon
 	if(active_program)
-		return image(screen_icon_file, active_program.program_icon_state)
+		if (should_glowmask)
+			return glowmasked_image(screen_icon_file, active_program.program_icon_state)
+		else
+			return image(screen_icon_file, active_program.program_icon_state)
 	else
-		return image(screen_icon_file, menu_icon)
+		return glowmasked_image(screen_icon_file, menu_icon)
 
-/datum/extension/interactive/ntos/proc/get_keyboard_overlay()
+/datum/extension/interactive/ntos/proc/get_keyboard_overlay(should_glowmask = TRUE)
 	if(!on)
 		return
 	if(!screen_icon_file)
@@ -24,7 +27,10 @@
 		if(istype(A))
 			screen_icon_file = A.icon
 	if(active_program && active_program.program_key_state)
-		return image(screen_icon_file, active_program.program_key_state)
+		if (should_glowmask)
+			return glowmasked_image(screen_icon_file, active_program.program_key_state)
+		else
+			return image(screen_icon_file, active_program.program_key_state)
 	
 /datum/extension/interactive/ntos/proc/visible_error(message)
 	var/atom/A = holder

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -274,21 +274,21 @@
 		status_overlays_lighting.len = 5
 		status_overlays_environ.len = 5
 
-		status_overlays_lock[1] = image(icon, "apcox-0")    // 0=blue 1=red
-		status_overlays_lock[2] = image(icon, "apcox-1")
+		status_overlays_lock[1] = glowmasked_image(icon, "apcox-0")    // 0=blue 1=red
+		status_overlays_lock[2] = glowmasked_image(icon, "apcox-1")
 
-		status_overlays_charging[1] = image(icon, "apco3-0")
-		status_overlays_charging[2] = image(icon, "apco3-1")
-		status_overlays_charging[3] = image(icon, "apco3-2")
+		status_overlays_charging[1] = glowmasked_image(icon, "apco3-0")
+		status_overlays_charging[2] = glowmasked_image(icon, "apco3-1")
+		status_overlays_charging[3] = glowmasked_image(icon, "apco3-2")
 
 		var/list/channel_overlays = list(status_overlays_equipment, status_overlays_lighting, status_overlays_environ)
 		var/channel = 0
 		for(var/list/channel_leds in channel_overlays)
-			channel_leds[POWERCHAN_OFF + 1] = overlay_image(icon,"apco[channel]",COLOR_RED)
-			channel_leds[POWERCHAN_OFF_TEMP + 1] = overlay_image(icon,"apco[channel]",COLOR_ORANGE)
-			channel_leds[POWERCHAN_OFF_AUTO + 1] = overlay_image(icon,"apco[channel]",COLOR_ORANGE)
-			channel_leds[POWERCHAN_ON + 1] = overlay_image(icon,"apco[channel]",COLOR_LIME)
-			channel_leds[POWERCHAN_ON_AUTO + 1] = overlay_image(icon,"apco[channel]",COLOR_BLUE)
+			channel_leds[POWERCHAN_OFF + 1] = glowmasked_image(icon,"apco[channel]",COLOR_RED)
+			channel_leds[POWERCHAN_OFF_TEMP + 1] = glowmasked_image(icon,"apco[channel]",COLOR_ORANGE)
+			channel_leds[POWERCHAN_OFF_AUTO + 1] = glowmasked_image(icon,"apco[channel]",COLOR_ORANGE)
+			channel_leds[POWERCHAN_ON + 1] = glowmasked_image(icon,"apco[channel]",COLOR_LIME)
+			channel_leds[POWERCHAN_ON_AUTO + 1] = glowmasked_image(icon,"apco[channel]",COLOR_BLUE)
 			channel++
 
 	if(update_state < 0)


### PR DESCRIPTION
🆑
tweak: APCs, fire alarms, and most consoles now glow in the dark.
/🆑

sprites are pretty. also works with modular computers (but not PDAs, tablets, etc. because unfortunately it breaks.) not all consoles are glowmasked because some are old and use icon states instead of overlays.

added a global proc called `glowmasked_image` that functions like a wrapper for `overlay_image` but gives it glowmask properties by rendering it above lighting.

don't know the guidelines on what gets a glowmask and what doesn't so lmk if there's any special rules

<details><summary>bridge with all the consoles turned on</summary>

![image](https://user-images.githubusercontent.com/47678781/111391274-a6624900-868a-11eb-9e20-3ec1eb9f146f.png)

</details>

<details><summary>tcomms in darkness</summary>

![image](https://user-images.githubusercontent.com/47678781/111391283-ac582a00-868a-11eb-8879-54e7f60a5a55.png)

</details>


<details><summary>some discharging APCs in brig during code blue</summary>

![image](https://user-images.githubusercontent.com/47678781/111391249-9a768700-868a-11eb-8fcc-8fc009f43b9f.png)

</details>
