### PR TITLE
Port Vorestation's sprite shifting, Take 2

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -507,6 +507,12 @@ default behaviour is:
 	if (buckled)
 		return
 
+	if(is_shifted)
+		is_shifted = FALSE
+		pixel_x = default_pixel_x
+		pixel_y = default_pixel_y
+
+
 	if(get_dist(src, pulling) > 1)
 		stop_pulling()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -588,11 +588,11 @@
 			else if(H.has_organ(BP_L_ARM) || H.has_organ(BP_R_ARM)) //If they only have one arm
 				grabtype = "arm"
 			else //If they have no arms
-				grabtype = "torso"	
+				grabtype = "torso"
 
 			visible_message(SPAN_WARNING("\The [src] leans down and grips \the [H]'s [grabtype]."), SPAN_NOTICE("You lean down and grip \the [H]'s [grabtype]."), exclude_mobs = list(H))
 			if(!H.stat)
-				to_chat(H, SPAN_WARNING("\The [src] leans down and grips your [grabtype]."))	
+				to_chat(H, SPAN_WARNING("\The [src] leans down and grips your [grabtype]."))
 
 		else //Otherwise we're probably just holding their arm to lead them somewhere
 			var/grabtype
@@ -1028,6 +1028,45 @@
 /mob/verb/westfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(WEST))
+
+/mob/proc/can_shift()
+	return !(incapacitated() || buckled || grabbed_by.len)
+
+/mob/verb/shiftnorth()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_y <= 16)
+		pixel_y++
+		is_shifted = TRUE
+		UPDATE_OO_IF_PRESENT
+
+/mob/verb/shiftsouth()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_y >= -8)
+		pixel_y--
+		is_shifted = TRUE
+		UPDATE_OO_IF_PRESENT
+
+/mob/verb/shiftwest()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_x >= -8)
+		pixel_x--
+		is_shifted = TRUE
+		UPDATE_OO_IF_PRESENT
+
+/mob/verb/shifteast()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_x <= 8)
+		pixel_x++
+		is_shifted = TRUE
+		UPDATE_OO_IF_PRESENT
 
 /mob/proc/adjustEarDamage()
 	return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -89,6 +89,7 @@
 	var/confused = 0		//Carbon
 	var/sleeping = 0		//Carbon
 	var/resting = FALSE			//Carbon
+	var/is_shifted = FALSE
 	var/lying = 0
 	var/lying_prev = 0
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -27,6 +27,9 @@ macro "borghotkeymode"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -35,6 +38,9 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -45,6 +51,9 @@ macro "borghotkeymode"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -53,6 +62,9 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -257,6 +269,9 @@ macro "macro"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -265,6 +280,9 @@ macro "macro"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -275,6 +293,9 @@ macro "macro"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -283,6 +304,9 @@ macro "macro"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -436,6 +460,9 @@ macro "hotkeymode"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -444,6 +471,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -454,6 +484,9 @@ macro "hotkeymode"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -462,6 +495,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -684,6 +720,9 @@ macro "borgmacro"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -692,6 +731,9 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -702,6 +744,9 @@ macro "borgmacro"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -710,6 +755,9 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"


### PR DESCRIPTION
Original PR is #29797. Nothing has been changed from it (yet) and credit goes to Jux/Mucker for the code changes.

This ports sprite shifting, where pressing CTRL+SHIFT+an arrow key will move your character a pixel to the left, right, up, or down. This can be done a maximum of 16 times in either direction to avoid shifting yourself to the next tile over.

If you are handcuffed, buckled, grabbed, or otherwise restrained in any way, any sprite shifting you had done previously will be reset and you will be unable to sprite shift until you are free again. Moving around will also reset it.

The following is a short video demonstration (it's hard to portray, but I was mashing the sprite shift keys while restrained and as you can see it did nothing):


https://user-images.githubusercontent.com/25853190/111406281-3b674100-868f-11eb-9bf3-a3b46d250617.mp4

The only things that may need changing are adding sprite shifting keys for hotkey mode (WASD), as right now it _only_ works for arrow keys. Other than that this seems good to go.

:cl: Shadowtail117 and juxtaposed
rscadd: Added sprite shifting. Press control + shift + an arrow key to move your character one pixel in any direction. You cannot do this if you are restrained or are moving.
/:cl: