### PR TITLE
Replaces supply leather chairs with office chairs

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -10154,7 +10154,7 @@
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
 "IF" = (
-/obj/structure/bed/chair/padded/brown{
+/obj/structure/bed/chair/office/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -12956,7 +12956,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "Rb" = (
-/obj/structure/bed/chair/padded/brown,
+/obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Re" = (


### PR DESCRIPTION
🆑
tweak: Indie-Sympathizing leather supply office chairs replaced with God-Intended SolGov Office Chairs.
/🆑

Back in my day, we didn't have any of these namby-pamby "leather" chairs in the supply office. We had office chairs in the office, because it was an office, and they destroyed our back, and we LIKED IT. Just like the Corps INTENDED. 

It's high time we un-sissyfy the Torch, and the ONLY way to do that is to replace these TWO CHAIRS in the supply office with their office variants. Which I've done, here, for you. You don't need to thank me. I know I'm beautiful already.