### PR TITLE
Nymphs now leave a shard when engulfing glasses

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -14,6 +14,7 @@
 	filling_states = "20;40;60;80;100"
 	volume = 30
 	matter = list(MATERIAL_GLASS = 65)
+	trash = /obj/item/material/shard
 
 	var/list/extras = list() // List of extras. Two extras maximum
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Leaving _something_ upon engulfing a glass instead of deleting the container and its contents is probably nice. Let's just assume that the glasses aboard the Torch aren't rated to withstand being eaten by a living tree.
:cl: SealCure
tweak: Nymphs engulfing drinking glasses will now obtain a glass shard instead of deleting the container.
/:cl: