### PR TITLE
Convert mech module admin logs to attack logs

### DIFF
--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -41,6 +41,9 @@
 /proc/admin_attack_log(var/mob/attacker, var/mob/victim, var/attacker_message, var/victim_message, var/admin_message)
 	if(!(attacker || victim))
 		EXCEPTION("Neither attacker or victim was supplied.")
+	if ((attacker && !istype(attacker)) || (victim && !istype(victim)))
+		log_debug("Attack log skipped due to invalid mobtype - ATTACKER '[attacker.name]' ([attacker.type]) - VICTIM '[victim.name]' ([victim.type]) - MESSAGE '[admin_message]'.")
+		return
 	if(!store_admin_attack_log(attacker, victim))
 		return
 

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -21,7 +21,7 @@
 	if(body)
 		if(!body.MouseDrop(over_object))
 			return ..()
-	
+
 /mob/living/exosuit/RelayMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, var/mob/user)
 	if(user && (user in pilots) && user.loc == src)
 		return OnMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, user)
@@ -61,8 +61,8 @@
 	. = ..()
 	if(!hatch_closed)
 		return max(shared_living_nano_distance(src_object), .) //Either visible to mech(outside) or visible to user (inside)
-	
-	
+
+
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)
 
 	if(!user || incapacitated() || user.incapacitated())
@@ -75,20 +75,20 @@
 	if(modifiers["shift"])
 		user.examinate(A)
 		return
-		
+
 	if(modifiers["ctrl"])
 		if(selected_system)
 			if(selected_system == A)
 				selected_system.CtrlClick(user)
 				setClickCooldown(3)
-			return	
+			return
 
 	if(!(user in pilots) && user != src)
 		return
 
 	if(!canClick())
 		return
-	
+
 	// Are we facing the target?
 	if(A.loc != src && !(get_dir(src, A) & dir))
 		return
@@ -175,7 +175,7 @@
 					ruser = user
 				temp_system.afterattack(A,ruser,adj,params)
 			if(system_moved) //We are using a proxy system that may not have logging like mech equipment does
-				log_and_message_admins("used [temp_system] targetting [A]", user, src.loc)
+				admin_attack_log(user, A, "Attacked using \a [temp_system] (MECH)", "Was attacked with \a [temp_system] (MECH)", "used \a [temp_system] (MECH) to attack")
 			//Mech equipment subtypes can add further click delays
 			var/extra_delay = 0
 			if(!isnull(selected_system))
@@ -421,7 +421,7 @@
 				if(!body || body.cell)
 					to_chat(user, SPAN_WARNING("There is already a cell in there!"))
 					return
-				
+
 				if(user.unEquip(thing))
 					thing.forceMove(body)
 					body.cell = thing


### PR DESCRIPTION
:cl:
admin: Mech weapons now generate proper attack logs instead of admin logs, and only appear when targeting mobs.
/:cl:

Save me from the mech log spam.