### PR TITLE
Prevent unremoval items and natural weapons from embedding

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -275,6 +275,11 @@
 			else if(S.can_be_inserted(src, user))
 				S.handle_item_insertion(src)
 
+/obj/item/can_embed()
+	if (!canremove)
+		return FALSE
+	return ..()
+
 /obj/item/proc/talk_into(mob/M as mob, text)
 	return
 
@@ -764,7 +769,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	user.client.pixel_x = 0
 	user.client.pixel_y = 0
-	
+
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		H.handle_vision()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -175,7 +175,7 @@
 		return
 
 	set_dir(turn(dir, 90))
-	update_icon() 
+	update_icon()
 
 //For things to apply special effects after damaging an organ, called by organ's take_damage
 /obj/proc/after_wounding(obj/item/organ/external/organ, datum/wound)

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -11,6 +11,9 @@
 /obj/item/natural_weapon/attack_message_name()
 	return show_in_message ? ..() : null
 
+/obj/item/natural_weapon/can_embed()
+	return FALSE
+
 /obj/item/natural_weapon/bite
 	name = "teeth"
 	attack_verb = list("bitten")


### PR DESCRIPTION
:cl:
bugfix: Natural weapons (I.e. teeth) will no longer embed in people.
/:cl: