### PR TITLE
Fix changelog update workflow

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Commit And Push
         run: |
           git config --local user.email "${{ secrets.BOT_EMAIL }}"
-          git config --local user.name "$${{ secrets.BOT_NAME }}"
+          git config --local user.name "${{ secrets.BOT_NAME }}"
           git commit -m "Automatic changelog generation" -a
           git push https://${{ secrets.BOT_TOKEN }}:x-oauth-basic@github.com/Baystation12/Baystation12.git dev


### PR DESCRIPTION
Cannot currently push due to the following error: `Author identity unknown`

Correction based on the differences between Bay's version and the original at
https://github.com/NebulaSS13/Nebula/blob/dev/.github/workflows/changelog_generation.yml
as I cannot see what else might be wrong