### PR TITLE
Fixes additional teleporter beacons being unselectable when having the same area

### DIFF
--- a/code/game/machinery/teleporter/console.dm
+++ b/code/game/machinery/teleporter/console.dm
@@ -138,7 +138,7 @@
 		var/area/A = get_area(B)
 		if (!A)
 			continue
-		result["[A.name] \[[++ids[A]]\]"] = B
+		result["[A.name] \[[++ids[A.name]]\]"] = B
 	for (var/obj/item/implant/tracking/T)
 		if (QDELETED(T) || !T.implanted || !ismob(T.loc))
 			continue
@@ -147,7 +147,7 @@
 			continue
 		if (!isPlayerLevel(M.z))
 			continue
-		result["[M.name] \[[++ids[M]]\]"] = T
+		result["[M.name] \[[++ids[M.name]]\]"] = T
 	return result
 
 


### PR DESCRIPTION
Found this while refactoring my beacon overhaul.

:cl:
bugfix: Teleporters can now select additional beacons that have the same area names.
/:cl: