### PR TITLE
Add NOOP and NOOP test

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -1,5 +1,8 @@
 #define any2ref(x) "\ref[x]"
 
+//Do (almost) nothing - indev placeholder for switch case implementations etc
+#define NOOP (.=.);
+
 #define list_find(L, needle, LIMITS...) L.Find(needle, LIMITS)
 
 #define PUBLIC_GAME_MODE SSticker.master_mode

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -39,6 +39,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto use" 'goto '
+exactly 1 "NOOP match" 'NOOP'
 exactly 469 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P


### PR DESCRIPTION
NOOPs have many purposes, but a useful one is to act as an action placeholder/TODO.

Switch cases cause compilation failures when empty and using implicit scope. That can be annoying while doing test compiles on unfinished branches. Standardizing a placeholder macro and adding a test to make sure it can't make it to live seems like a good thing.
