### PR TITLE
FBPs no longer cough in smoke

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -195,6 +195,8 @@ steam.start() -- spawns the effect
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
 	if (!istype(M))
 		return 0
+	if (M.isSynthetic())
+		return 0
 	if (M.internal != null)
 		if(M.wear_mask && (M.wear_mask.item_flags & ITEM_FLAG_AIRTIGHT))
 			return 0


### PR DESCRIPTION
:cl: Ryan180602
tweak: FBPs are no longer affected by the effects of smoke
/:cl:

Lazy PRs go!!!

In the same file that `smoke/bad` is handled, it seems to also have a definition for `smoke/mustard`. It does not seem to be used anywhere, and so I haven't made any changes to it, but if need be, another `isSynthetic()` check could easily be added.