### PR TITLE
Windows & Wall damage update

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -63,7 +63,7 @@
 		fluid_update()
 
 /obj/structure/attackby(obj/item/O, mob/user)
-	if(user.a_intent != I_HELP)
+	if(user.a_intent != I_HELP && istype(O, /obj/item/natural_weapon))
 		//Bit dirty, but the entire attackby chain seems kinda wrong to begin with
 		//Things should probably be parent first and return true if something handled it already, not child first
 		src.add_fingerprint(user)

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -26,6 +26,7 @@
 	SSradiation.resistance_cache.Remove(src)
 	update_connections(1)
 	update_icon()
+	calculate_damage_data()
 
 
 /turf/simulated/wall/proc/set_material(var/material/newmaterial, var/material/newrmaterial)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -11,7 +11,11 @@
 	atom_flags = ATOM_FLAG_CAN_BE_PAINTED
 
 	var/damage = 0
+	var/max_damage = 0
 	var/damage_overlay = 0
+	var/force_damage_threshhold = 0 // Minimum amount of requried force to damage the wall
+	var/brute_armor = 0
+	var/burn_armor = 0
 	var/global/damage_overlays[16]
 	var/active
 	var/can_open = 0
@@ -28,7 +32,7 @@
 	var/global/list/wall_stripe_cache = list()
 	var/list/blend_turfs = list(/turf/simulated/wall/cult, /turf/simulated/wall/wood, /turf/simulated/wall/walnut, /turf/simulated/wall/maple, /turf/simulated/wall/mahogany, /turf/simulated/wall/ebony)
 	var/list/blend_objects = list(/obj/machinery/door, /obj/structure/wall_frame, /obj/structure/grille, /obj/structure/window/reinforced/full, /obj/structure/window/reinforced/polarized/full, /obj/structure/window/shuttle, ,/obj/structure/window/phoronbasic/full, /obj/structure/window/phoronreinforced/full) // Objects which to blend with
-	var/list/noblend_objects = list(/obj/machinery/door/window) //Objects to avoid blending with (such as children of listed blend objects.
+	var/list/noblend_objects = list(/obj/machinery/door/window) //Objects to avoid blending with (such as children of listed blend objects.)
 	var/dismantling = FALSE
 
 /turf/simulated/wall/New(var/newloc, var/materialtype, var/rmaterialtype)
@@ -70,6 +74,27 @@
 /turf/simulated/wall/proc/get_material()
 	return material
 
+/turf/simulated/wall/proc/calculate_damage_data()
+	// Max damage (Health)
+	max_damage = material.integrity
+	if (reinf_material)
+		max_damage += round(reinf_material.integrity / 2)
+
+	// Minimum force required to damage the wall
+	force_damage_threshhold = material.hardness * 2.5
+	if (reinf_material)
+		force_damage_threshhold += round(reinf_material.hardness * 1.25)
+	force_damage_threshhold = round(force_damage_threshhold / 10)
+
+	// Brute and burn armor
+	brute_armor = material.brute_armor * 0.5
+	burn_armor = material.burn_armor * 0.5
+	if (reinf_material)
+		brute_armor += reinf_material.brute_armor * 0.5
+		burn_armor += reinf_material.burn_armor * 0.5
+	brute_armor = round(brute_armor)
+	burn_armor = round(burn_armor)
+
 /turf/simulated/wall/bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj,/obj/item/projectile/beam))
 		burn(2500)
@@ -81,11 +106,11 @@
 	if(Proj.ricochet_sounds && prob(15))
 		playsound(src, pick(Proj.ricochet_sounds), 100, 1)
 
-	if(reinf_material)
-		if(Proj.damage_type == BURN)
-			proj_damage /= reinf_material.burn_armor
-		else if(Proj.damage_type == BRUTE)
-			proj_damage /= reinf_material.brute_armor
+	if(Proj.damage_type == BURN && burn_armor)
+		proj_damage /= burn_armor
+	else if(Proj.damage_type == BRUTE && brute_armor)
+		proj_damage /= brute_armor
+	proj_damage = round(proj_damage)
 
 	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
 	var/damage = min(proj_damage, 100)
@@ -98,7 +123,7 @@
 		var/obj/O = AM
 		var/tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
 		playsound(src, hitsound, tforce >= 15? 60 : 25, TRUE)
-		if (tforce >= 15)
+		if (tforce >= force_damage_threshhold)
 			take_damage(tforce)
 	..()
 
@@ -129,7 +154,7 @@
 	if(!damage)
 		to_chat(user, "<span class='notice'>It looks fully intact.</span>")
 	else
-		var/dam = damage / material.integrity
+		var/dam = damage / max_damage
 		if(dam <= 0.3)
 			to_chat(user, "<span class='warning'>It looks slightly damaged.</span>")
 		else if(dam <= 0.6)
@@ -166,21 +191,18 @@
 	return
 
 /turf/simulated/wall/proc/update_damage()
-	var/cap = material.integrity
-	if(reinf_material)
-		cap += reinf_material.integrity
-
+	var/cap = max_damage
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		cap = cap / 10
 
 	if(damage >= cap)
-		dismantle_wall()
+		dismantle_wall(TRUE)
 	else
 		update_icon()
 
 	return
 
-/turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air :(
+/turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air
 	burn(exposed_temperature)
 
 /turf/simulated/wall/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
@@ -294,7 +316,7 @@
 	update_icon()
 
 /turf/simulated/wall/proc/CheckPenetration(var/base_chance, var/damage)
-	return round(damage/material.integrity*180)
+	return round(damage / max_damage * 180)
 
 /turf/simulated/wall/can_engrave()
 	return (material && material.hardness >= 10 && material.hardness <= 100)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -162,11 +162,7 @@
 		to_chat(user, ("<span class='notice'>It's a holowindow, you can't dismantle it!</span>"))
 	else
 		if(W.damtype == BRUTE || W.damtype == BURN)
-			hit(W.force)
-			if(health <= 7)
-				anchored = FALSE
-				update_nearby_icons()
-				step(src, get_dir(user, src))
+			hit(W.force, user, W)
 		else
 			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		..()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -223,7 +223,12 @@
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.
 /material/proc/place_dismantled_product(var/turf/target,var/is_devastated)
-	place_sheet(target, is_devastated ? 1 : 2)
+	if (is_devastated)
+		var/return_count = rand(1, 2)
+		if (place_shard(target, return_count) == null)
+			place_sheet(target, return_count)
+	else
+		place_sheet(target, 2)
 
 // Debris product. Used ALL THE TIME.
 /material/proc/place_sheet(var/turf/target, var/amount = 1)


### PR DESCRIPTION
:cl:
tweak: Windows now have a minimum damage threshold based on the hardness of their material before they can actually be damaged by melee attacks, adjustments to their health calculation based on material integrity, and now have proper armor handling for melee attacks (Projectile processing for walls already had this). Walls are overall more robust when attacking them. See PR #30429 for specifics.
/:cl:

- Damage handling for walls has been tweaked to make better use of material values and reduce RNG. Overall, walls are more robust in general, depending on their material(s). Exact changes below:
- Minimum force to damage a wall with an object is now based on material hardness. New calculations result in the same force requirement (15) for hitting standard walls as before. - 2.5 * base material + 1.25 * reinforced material.
- Damage resistance calculation has been adjusted based on the materials *_armor stats - .5 * base material + .5 * reinforced material
- Destroyed walls now drop shards instead of sheets. For materials that don't have a defined shard, the walls continue to drop sheets. The number is a 50% chance of 1 or 2 being dropped.
- Damage resistance calculation is now applied to melee attacks as well as projectiles, dividing the damage taken by the armor value.
- Reinforced walls now gain half of their reinforcement material's integrity score as additional health.
- Wall destruction from melee attacks is now entirely based on health instead of random probabiltiies.
- Walls now play the correct hit sound effect when attacked, based on their material.