### PR TITLE
Torch and Skrell scoutship no longer have access to thermals

### DIFF
--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -157,14 +157,6 @@
 	time = 15
 	materials = list(MATERIAL_STEEL = 5000)
 
-/datum/design/item/mechfab/exosuit/combat_head
-	name = "combat exosuit sensors"
-	id = "combat_head"
-	time = 30
-	materials = list(MATERIAL_STEEL = 10000)
-	build_path = /obj/item/mech_component/sensors/combat
-	req_tech = list(TECH_COMBAT = 2)
-
 /datum/design/item/mechfab/exosuit/combat_torso
 	name = "combat exosuit chassis"
 	id = "combat_body"

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -1347,10 +1347,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/command/armory)
 "eE" = (
@@ -3261,12 +3257,6 @@
 /area/ship/skrellscoutship/robotics)
 "km" = (
 /obj/structure/table/rack,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
 "kn" = (


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Rebased version of https://github.com/Baystation12/Baystation12/pull/30293

:cl: Imienny
rscdel: Its no longer possible to make combat mech sensors(thermal mech sensors)
rscdel: Skrell scout ship no longer spawns with thermal goggles
/:cl:

I reverted changes to hacker rig in case if https://github.com/Baystation12/Baystation12/pull/30358 gets merged.