### PR TITLE
Add language support to papers

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -2,6 +2,7 @@
 	icon_state = "paper_talisman"
 	var/imbue = null
 	info = "<center><img src='talisman.png'></center><br/><br/>"
+	language = LANGUAGE_CULT
 
 /obj/item/paper/talisman/attack_self(var/mob/living/user)
 	if(iscultist(user))

--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -59,6 +59,7 @@
 	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
 	machine_understands = 0
 	shorthand = "Vox"
+	has_written_form = TRUE
 
 /datum/language/vox/can_speak_special(var/mob/speaker)
 	if(!ishuman(speaker))
@@ -93,6 +94,7 @@
 	machine_understands = 0
 	shorthand = "CT"
 	hidden_from_codex = TRUE
+	has_written_form = TRUE
 
 /datum/language/cult
 	name = LANGUAGE_CULT_GLOBAL
@@ -118,6 +120,7 @@
 	machine_understands = 0
 	shorthand = "AL"
 	hidden_from_codex = TRUE
+	has_written_form = TRUE
 
 /datum/language/alium/New()
 	speech_verb = pick("hisses","growls","whistles","blubbers","chirps","skreeches","rumbles","clicks")

--- a/code/modules/mob/language/alien/mantid.dm
+++ b/code/modules/mob/language/alien/mantid.dm
@@ -18,6 +18,7 @@
 		SPECIES_MONARCH_QUEEN,
 		SPECIES_MONARCH_WORKER
 	)
+	has_written_form = TRUE
 
 /datum/language/mantid/can_be_spoken_properly_by(var/mob/speaker)
 	var/mob/living/S = speaker
@@ -57,6 +58,7 @@
 	exclaim_verb = "flares"
 	flags = RESTRICTED | NO_STUTTER | SIGNLANG
 	shorthand = "KNV"
+	has_written_form = FALSE
 
 #define MANTID_SCRAMBLE_CACHE_LEN 20
 /datum/language/mantid/nonvocal/scramble(var/input)
@@ -92,8 +94,9 @@
 	speech_verb = "flashes"
 	ask_verb = "gleams"
 	exclaim_verb = "flares"
-	flags = RESTRICTED | NO_STUTTER | NONVERBAL | HIVEMIND 
+	flags = RESTRICTED | NO_STUTTER | NONVERBAL | HIVEMIND
 	shorthand = "KB"
+	has_written_form = FALSE
 
 /datum/language/mantid/worldnet/check_special_condition(var/mob/living/carbon/other)
 	if(istype(other, /mob/living/silicon/robot/flying/ascent))

--- a/code/modules/mob/language/alien/skrell.dm
+++ b/code/modules/mob/language/alien/skrell.dm
@@ -9,3 +9,4 @@
 	flags = WHITELISTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
 	shorthand = "SK"
+	has_written_form = TRUE

--- a/code/modules/mob/language/alien/unathi.dm
+++ b/code/modules/mob/language/alien/unathi.dm
@@ -21,6 +21,7 @@
 		"a",  "a",  "e",  "e",  "i",  "i",  "o",  "o",  "u",  "u",  "s",  "s"
 	)
 	shorthand = "UT"
+	has_written_form = TRUE
 
 /datum/language/yeosa
 	name = LANGUAGE_UNATHI_YEOSA
@@ -46,3 +47,4 @@
 		"a",  "a",  "e",  "e",  "i",  "i",  "o",  "o",  "u",  "u",  "s",  "s"
 	)
 	shorthand = "YU"
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/arabic.dm
+++ b/code/modules/mob/language/human/arabic.dm
@@ -19,3 +19,4 @@
 		"iam", "mim", "al", "ja", "non", "ha", "waw", "ya", "hem", "zah", "hml", "ks", "ini",
 		"da", "ks", "iga", "ih", "la", "ulf", "xe", "ayw", "'", "-"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/chinese.dm
+++ b/code/modules/mob/language/human/chinese.dm
@@ -13,7 +13,7 @@
 	partial_understanding = list(
 		LANGUAGE_HUMAN_EURO = 5,
 		LANGUAGE_HUMAN_ARABIC = 5,
-		LANGUAGE_HUMAN_INDIAN = 5, 
+		LANGUAGE_HUMAN_INDIAN = 5,
 		LANGUAGE_HUMAN_SELENIAN = 10,
 		LANGUAGE_SPACER = 20
 	)
@@ -45,3 +45,4 @@
 		"zhe", "zhei", "zhen", "zheng", "zhi", "zhong", "zhou", "zhu", "zhua", "zhuai", "zhuan", "zhuang", "zhui", "zhun", "zhuo", "zi",
 		"zong", "zou", "zuan", "zui", "zun", "zuo", "zu"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/euro.dm
+++ b/code/modules/mob/language/human/euro.dm
@@ -32,3 +32,4 @@
 		"ait", "les", "lle", "men", "ais", "ans", "ait", "ave", "con", "com", "des", "tre", "eta", "eur", "est",
 		"ing", "the", "ver", "was", "ith", "hin"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/indian.dm
+++ b/code/modules/mob/language/human/indian.dm
@@ -25,3 +25,4 @@
 		"khaa", "kin", "kiy", "ky", "dei", "dekh", "nhi", "pne", "pr", "baar", "yon",
 		"men", "iyaa", "main", "apn"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/misc/gutter.dm
+++ b/code/modules/mob/language/human/misc/gutter.dm
@@ -19,3 +19,4 @@
 		"yayo", "aiya", "chiksa", "tikat", "bazar","oi", "yo", "meit", "grok", "ken", "berk", "cohon", "pendeo"
 	)
 	shorthand = "GT"
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/misc/spacer.dm
+++ b/code/modules/mob/language/human/misc/spacer.dm
@@ -18,3 +18,4 @@
 		"ada", "zir", "bian", "ach", "usk", "ado", "ich", "cuan", "iga", "qing", "le", "que", "ki", "qaf", "dei", "eta"
 	)
 	colour = "spacer"
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/russian.dm
+++ b/code/modules/mob/language/human/russian.dm
@@ -15,3 +15,4 @@
 		"ko", "ne", "en", "po", "ra", "li", "on", "byl", "cto", "eni", "ost", "ol", "ego",
 		"ver", "stv", "pro"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/selenian.dm
+++ b/code/modules/mob/language/human/selenian.dm
@@ -21,3 +21,4 @@
 		"hin", "deed", "accord", "caveat", "pledge", "rights", "et", "ex", "bono", "quo", "pro", "ad",
 		"ek", "aur", "ki", "ki", "ke", "de", "ki", "ne", "ek", "aar", "ain", "ki", "me", "dei", "dekh"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/human/spanish.dm
+++ b/code/modules/mob/language/human/spanish.dm
@@ -24,3 +24,4 @@
 		"sta", "una", "ion", "tra", "men", "ele", "nao", "uma", "ame", "dos", "uno", "mas",
 		"ndo", "nha", "ver", "voc", "uma"
 	)
+	has_written_form = TRUE

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -24,6 +24,7 @@
 	var/warning = ""
 	var/hidden_from_codex			  // If it should not show up in Codex
 	var/category = /datum/language    // Used to point at root language types that shouldn't be visible
+	var/has_written_form = FALSE
 
 /datum/language/proc/can_be_spoken_properly_by(var/mob/speaker)
 	return TRUE
@@ -116,7 +117,7 @@
 	scramble_cache[input] = scrambled_text
 	if(scramble_cache.len > SCRAMBLE_CACHE_LEN)
 		scramble_cache.Cut(1, scramble_cache.len-SCRAMBLE_CACHE_LEN-1)
-	
+
 	return scrambled_text
 
 /datum/language/proc/format_message(message, verb)

--- a/code/modules/paperwork/adminpaper.dm
+++ b/code/modules/paperwork/adminpaper.dm
@@ -37,6 +37,7 @@
 	interactions += "<A href='?src=\ref[src];cancel=1'>Cancel fax</A> "
 	interactions += "<BR>"
 	interactions += "<A href='?src=\ref[src];changelogo=1'>Change logo</A> "
+	interactions += "<A href='?src=\ref[src];changelanguage=1'>Change language ([language])</A> "
 	interactions += "<A href='?src=\ref[src];toggleheader=1'>Toggle Header</A> "
 	interactions += "<A href='?src=\ref[src];togglefooter=1'>Toggle Footer</A> "
 	interactions += "<A href='?src=\ref[src];clear=1'>Clear page</A> "
@@ -155,6 +156,11 @@ obj/item/paper/admin/proc/updateDisplay()
 	if(href_list["changelogo"])
 		logo = input(usr, "What logo?", "Choose a logo", "") as null|anything in (logo_list)
 		generateHeader()
+		updateDisplay()
+		return
+
+	if (href_list["changelanguage"])
+		choose_language(usr, TRUE)
 		updateDisplay()
 		return
 

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -34,6 +34,7 @@
 		var/obj/item/paper/carbon/c = src
 		var/copycontents = c.info
 		var/obj/item/paper/carbon/copy = new /obj/item/paper/carbon (usr.loc)
+		copy.language = language
 		// <font>
 		if(info)
 			copycontents = replacetext(copycontents, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -88,6 +88,8 @@
 
 
 //Flavorful reminders
+/obj/item/paper/merc
+	language = LANGUAGE_SPACER
 
 /obj/item/paper/merc/tutorial_1
 	name = "highlighted note"

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -580,7 +580,7 @@
 /area/constructionsite/bridge)
 "bP" = (
 /obj/structure/table/standard,
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "\\\[center]\\\[b]ATTN: Regarding Meteor Storms\\\[/b]\[/center]\\\[br]\\\[br]We've recently heard mutterings from the Atmospheric Technicians that the meteor showers in this sector are becoming too much. However, this should be disregarded.\\\[br]\\\[br] High Command has assured us that our shields can easily keep pace with any meteor storm and then some. Any uneasiness the crew may feel should be disspelled swiftly. Thank you.";
 	name = "ATTN: Regarding Meteor Storms"
 	},

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -66,7 +66,7 @@
 /area/slavers_base/mort)
 "aq" = (
 /obj/structure/table/standard,
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "If they'll keep having fun with cargo in such manner, we'll run out of freezers to keep what's left from it.";
 	name = "Note"
 	},
@@ -487,7 +487,7 @@
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/cells)
 "bw" = (
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "Tonight, when lights are out. Prepare shivs, pieces of glass, whatever you might find.";
 	name = "Note"
 	},
@@ -1118,7 +1118,7 @@
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/hangar)
 "cJ" = (
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "Doc who checked us told implants won't explode our heads. Gotta make guys know. Seems I see a silver lining.";
 	name = "Note"
 	},
@@ -1710,7 +1710,7 @@
 /obj/structure/table/steel,
 /obj/item/device/flash,
 /obj/item/device/radio,
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "If this fuck from A-3 keeps thinking he's better then piece of meat, throw him to hangar and show how little pressure turns diamonds into shit.";
 	name = "Note"
 	},
@@ -1975,7 +1975,7 @@
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/o2,
 /obj/item/folder/white,
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "Seems they don't really look over my shoulder anymore. We have now maybe a dozen of them with inactive implants. Hope they will pick right moment to flip the lid. I'll kill few bastards myself soon as I have a chance.";
 	name = "Note"
 	},
@@ -3419,7 +3419,7 @@
 /area/slavers_base/dorms)
 "iy" = (
 /obj/structure/table/woodentable,
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "<center><b> Contract </b></center> <br>This contract describes exchanging of monetary pieces for the right o? the ownership for following examples: <list><*> Human, age 17. Price - 1500 thalers. <*> Human, age 49. Price - 1100 thalers. <*> Unathi, age 28. Good fist fighter. Price - 2400 thalers. <*> Human, age 34. Expirienced medic. Price - 6800 thalers. </list> <b> Overall price: 11800 thalers</b><br><small>Place for signatures</small>";
 	name = "Contract"
 	},
@@ -3882,7 +3882,7 @@
 /turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "jC" = (
-/obj/item/paper{
+/obj/item/paper/spacer{
 	info = "We made over 200 grands for two last weeks. We should stay low-key for month or so, or we'll get our base discovered by fucking marshalls so shut your whining and relax, I'l l get you three crates of booze and some cargo to play with.";
 	name = "Note"
 	},

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -1,42 +1,42 @@
-/datum/map_template/ruin/exoplanet/marooned 
-	name = "Marooned" 
-	id = "awaysite_marooned" 
-	description = "crashed dropship with marooned Magnitka officer" 
-	suffixes = list("marooned/marooned.dmm") 
-	spawn_cost = 1 
+/datum/map_template/ruin/exoplanet/marooned
+	name = "Marooned"
+	id = "awaysite_marooned"
+	description = "crashed dropship with marooned Magnitka officer"
+	suffixes = list("marooned/marooned.dmm")
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	apc_test_exempt_areas = list(
 		/area/map_template/marooned = NO_SCRUBBER|NO_VENT|NO_APC
 	)
 
-/obj/item/clothing/under/magintka_uniform 
-	name = "officer uniform" 
-	desc = "A dark uniform coat worn by Magnitka fleet officers." 
-	icon_state = "magnitka_officer" 
-	icon = 'maps/random_ruins/exoplanet_ruins/marooned/marooned_icons.dmi' 
-	item_icons = list(slot_w_uniform_str = 'maps/random_ruins/exoplanet_ruins/marooned/marooned_icons.dmi') 
- 
-/obj/item/clothing/accessory/medal/silver/marooned_medal 
-	name = "silver medal" 
-	desc = "An silver round medal of marooned officer. It has inscription \"For Distinguished Service\" in lower part. On medal's plank it's engraved \"H. Warda\"" 
-	icon_state = "marooned_medal" 
-	icon = 'maps/random_ruins/exoplanet_ruins/marooned/marooned_icons.dmi' 
- 
-/obj/effect/landmark/corpse/marooned_officer 
-	name = "Horazy Warda" 
-	corpse_outfits = list(/decl/hierarchy/outfit/marooned_officer) 
-	spawn_flags = ~CORPSE_SPAWNER_RANDOM_NAME 
- 
-/decl/hierarchy/outfit/marooned_officer 
-	name = "Dead Magnitka's fleet officer" 
-	uniform = /obj/item/clothing/under/magintka_uniform 
-	suit = /obj/item/clothing/suit/storage/hooded/wintercoat 
-	shoes = /obj/item/clothing/shoes/jungleboots 
-	gloves = /obj/item/clothing/gloves/thick 
-	head = /obj/item/clothing/head/beret 
-	l_pocket = /obj/item/material/knife/folding/combat/switchblade 
- 
+/obj/item/clothing/under/magintka_uniform
+	name = "officer uniform"
+	desc = "A dark uniform coat worn by Magnitka fleet officers."
+	icon_state = "magnitka_officer"
+	icon = 'maps/random_ruins/exoplanet_ruins/marooned/marooned_icons.dmi'
+	item_icons = list(slot_w_uniform_str = 'maps/random_ruins/exoplanet_ruins/marooned/marooned_icons.dmi')
+
+/obj/item/clothing/accessory/medal/silver/marooned_medal
+	name = "silver medal"
+	desc = "An silver round medal of marooned officer. It has inscription \"For Distinguished Service\" in lower part. On medal's plank it's engraved \"H. Warda\""
+	icon_state = "marooned_medal"
+	icon = 'maps/random_ruins/exoplanet_ruins/marooned/marooned_icons.dmi'
+
+/obj/effect/landmark/corpse/marooned_officer
+	name = "Horazy Warda"
+	corpse_outfits = list(/decl/hierarchy/outfit/marooned_officer)
+	spawn_flags = ~CORPSE_SPAWNER_RANDOM_NAME
+
+/decl/hierarchy/outfit/marooned_officer
+	name = "Dead Magnitka's fleet officer"
+	uniform = /obj/item/clothing/under/magintka_uniform
+	suit = /obj/item/clothing/suit/storage/hooded/wintercoat
+	shoes = /obj/item/clothing/shoes/jungleboots
+	gloves = /obj/item/clothing/gloves/thick
+	head = /obj/item/clothing/head/beret
+	l_pocket = /obj/item/material/knife/folding/combat/switchblade
+
 /obj/item/gun/projectile/revolver/medium/marooned
 	name = "worn-out revolver"
 
@@ -51,6 +51,7 @@
 
 /obj/item/paper/marooned/
 	name = "diary page"
+	language = LANGUAGE_HUMAN_RUSSIAN
 /obj/item/paper/marooned/note01
 	info = "Horacy Warda, Captain First Rank of Magnitka Defence Forces, Special Observation Flotilia. I have been betrayed by my crew and illegally marooned.<br>Main conspirators were Lieutenant Igor Pytlak, Lieutenant Hans Kovac and Captain Third Rank Dragomir Mladic.<br>If you find this, please make sure those dogs face justice."
 /obj/item/paper/marooned/note02


### PR DESCRIPTION
:cl:
rscadd: Papers are now written in languages. If you understand the language, you can read it. If not, it has the same effects as hearing people talking in a language you don't understand. You can set the language you're writing in when writing on a blank sheet by clicking the language name at the top of the paper's UI window. ZAC is used by default for each paper.
admin: The fax prompt now has a 'Change Language' button to set what language the fax is written in. ZAC is used by default.
/:cl:

Papers can only be written in languages that have a 'written form'. Generally that means no sign language, EAL, serpentid, or hivemind/global languages.