### PR TITLE
Fixes icon cache caching icon layers when it should not

### DIFF
--- a/code/modules/mechs/mech_icon.dm
+++ b/code/modules/mechs/mech_icon.dm
@@ -1,5 +1,5 @@
 proc/get_mech_image(var/decal, var/cache_key, var/cache_icon, var/image_colour, var/overlay_layer = FLOAT_LAYER)
-	var/use_key = "[cache_key]-[cache_icon]-[decal ? decal : "none"]-[image_colour ? image_colour : "none"]"
+	var/use_key = "[cache_key]-[cache_icon]-[overlay_layer]-[decal ? decal : "none"]-[image_colour ? image_colour : "none"]"
 	if(!GLOB.mech_image_cache[use_key])
 		var/image/I = image(icon = cache_icon, icon_state = cache_key)
 		if(image_colour)


### PR DESCRIPTION
So exosuit icons were stuck with layer first retrieved...which seems wrong as construction step requests some layers and mech itself requests others. Now you get the layer you ask for.

Someone smarter in byond than me tell if this defeats purpose of cache somehow.