### PR TITLE
fix skill panel losing focus on button presses

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -374,7 +374,6 @@
 		pref.ShowChoices(user) //Manual refresh to allow us to focus the panel, not the main window.
 		panel.set_content(generate_skill_content(J))
 		panel.open()
-		winset(user, panel.window_id, "focus=1") //Focuses the panel.
 
 	else if(href_list["skillinfo"])
 		var/decl/hierarchy/skill/S = locate(href_list["skillinfo"])


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the skill panel losing focus when editing skills.
/:cl:

ironic that the one line meant to fix this is what caused it in the first place.