### PR TITLE
Adjusts settings on the sauna alarm

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -113,6 +113,11 @@
 	target_temperature = T0C+75
 	environment_type = /decl/environment_data/finnish
 
+/obj/machinery/alarm/warm/Initialize()
+	. = ..()
+	TLV["temperature"] = list(T0C-26, T0C, T0C+75, T0C+85) // K
+	TLV["pressure"] = list(ONE_ATMOSPHERE*0.80,ONE_ATMOSPHERE*0.90,ONE_ATMOSPHERE*1.30,ONE_ATMOSPHERE*1.50) /* kpa */
+
 /obj/machinery/alarm/nobreach
 	breach_pressure = -1
 


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Regular use of the sauna will no longer trigger the air alarm in it.
/:cl:

The machines in the Sauna, including the thermostat on the air alarm itself, aim for 75 °C.
However, because the alarm has default safety settings, this triggered an alarm due to both increased pressure and temperature.
This PR fixes this issue this by adjusting the initial safe pressure and temperature bounds on the alarm.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->