### PR TITLE
Small change to orbital mining station desc

### DIFF
--- a/maps/away/miningstation/miningstation.dm
+++ b/maps/away/miningstation/miningstation.dm
@@ -3,7 +3,7 @@
 
 /obj/effect/overmap/visitable/sector/miningstation
 	name = "Orbital Mining Station"
-	desc = "An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station. It is emitting a active distress beacon."
+	desc = "An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station. It is emitting a weak signal on a public frequency, with no other discernible radio traffic."
 	icon_state = "object"
 	known = 0
 	initial_generic_waypoints = list(


### PR DESCRIPTION
A slight adjustment to the description of the Orbital Mining Station (the one with the Deadspace mobs) changing 
"active distress beacon." to a more ambiguous "weak signal on a public frequency, with no other discernible radio traffic."

"Distress beacon" sounds similar to the distress calls that come with the sensor report at round start and as such, it gives the impression that this away site is something important that demands immediate attention. This way the site reads as something potentially interesting to be investigated but not "Drop everything and focus every available resource on this."

:cl: 
tweak: Orbital mining station description changed to be less important sounding.
/:cl: 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->