### PR TITLE
Remove nuke spawning proc from antagonist datum

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -26,11 +26,10 @@
 #define ANTAG_IMPLANT_IMMUNE     0x10 // Cannot be loyalty implanted.
 #define ANTAG_SUSPICIOUS         0x20 // Shows up on roundstart report.
 #define ANTAG_HAS_LEADER         0x40 // Generates a leader antagonist.
-#define ANTAG_HAS_NUKE           0x80 // Will spawn a nuke at supplied location.
-#define ANTAG_RANDSPAWN         0x100 // Potentially randomly spawns due to events.
-#define ANTAG_VOTABLE           0x200 // Can be voted as an additional antagonist before roundstart.
-#define ANTAG_SET_APPEARANCE    0x400 // Causes antagonists to use an appearance modifier on spawn.
-#define ANTAG_RANDOM_EXCEPTED   0x800 // If a game mode randomly selects antag types, antag types with this flag should be excluded.
+#define ANTAG_RANDSPAWN          0x80 // Potentially randomly spawns due to events.
+#define ANTAG_VOTABLE           0x100 // Can be voted as an additional antagonist before roundstart.
+#define ANTAG_SET_APPEARANCE    0x200 // Causes antagonists to use an appearance modifier on spawn.
+#define ANTAG_RANDOM_EXCEPTED   0x400 // If a game mode randomly selects antag types, antag types with this flag should be excluded.
 
 // Mode/antag template macros.
 #define MODE_BORER         "borer"

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -60,8 +60,6 @@
 	// Runtime vars.
 	var/datum/mind/leader                   // Current leader, if any.
 	var/cur_max = 0                         // Autotraitor current effective maximum.
-	var/spawned_nuke                        // Has a bomb been spawned?
-	var/nuke_spawn_loc                      // If so, where should it be placed?
 	var/list/current_antagonists = list()   // All marked antagonists for this type.
 	var/list/pending_antagonists = list()   // Candidates that are awaiting finalized antag status.
 	var/list/starting_locations =  list()   // Spawn points.
@@ -79,7 +77,7 @@
 		and before taking extreme actions, please try to also contact the administration! \
 		Think through your actions and make the roleplay immersive! <b>Please remember all \
 		rules aside from those without explicit exceptions apply to antagonists.</b>"
-	
+
 	// Map template that antag needs to load before spawning. Nulled after it's loaded.
 	var/datum/map_template/base_to_load
 

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -54,45 +54,6 @@
 	player.equip_to_slot_or_del(R, slot_l_ear)
 	return R
 
-/datum/antagonist/proc/create_nuke(var/atom/paper_spawn_loc, var/datum/mind/code_owner)
-
-	// Decide on a code.
-	var/obj/effect/landmark/nuke_spawn = locate(nuke_spawn_loc ? nuke_spawn_loc : "landmark*Nuclear-Bomb")
-
-	var/code
-	if(nuke_spawn)
-		var/obj/machinery/nuclearbomb/nuke = new(get_turf(nuke_spawn))
-		code = "[rand(10000, 99999)]"
-		nuke.r_code = code
-
-	if(code)
-		if(!paper_spawn_loc)
-			if(leader && leader.current)
-				paper_spawn_loc = get_turf(leader.current)
-			else
-				paper_spawn_loc = get_turf(locate("landmark*Nuclear-Code"))
-
-		if(paper_spawn_loc)
-			// Create and pass on the bomb code paper.
-			var/obj/item/paper/P = new(paper_spawn_loc)
-			P.info = "The nuclear authorization code is: <b>[code]</b>"
-			P.SetName("nuclear bomb code")
-			if(leader && leader.current)
-				if(get_turf(P) == get_turf(leader.current) && !(leader.current.l_hand && leader.current.r_hand))
-					leader.current.put_in_hands(P)
-
-		if(!code_owner && leader)
-			code_owner = leader
-		if(code_owner)
-			code_owner.StoreMemory("<B>Nuclear Bomb Code</B>: [code]", /decl/memory_options/system)
-			to_chat(code_owner.current, "The nuclear authorization code is: <B>[code]</B>")
-	else
-		message_admins("<span class='danger'>Could not spawn nuclear bomb. Contact a developer.</span>")
-		return
-
-	spawned_nuke = code
-	return code
-
 /datum/antagonist/proc/greet(var/datum/mind/player)
 
 	// Basic intro text.
@@ -103,9 +64,6 @@
 		to_chat(player.current, "<span class='antagdesc'>[get_welcome_text(player.current)]</span>")
 	if (config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
 		to_chat(player.current, get_antag_text(player.current))
-
-	if((flags & ANTAG_HAS_NUKE) && !spawned_nuke)
-		create_nuke()
 
 	src.show_objectives_at_creation(player)
 	return 1

--- a/code/game/antagonist/antagonist_panel.dm
+++ b/code/game/antagonist/antagonist_panel.dm
@@ -37,21 +37,6 @@
 		dat += "</tr>"
 	dat += "</table>"
 
-	if(flags & ANTAG_HAS_NUKE)
-		dat += "<br><table><tr><td><B>Nuclear disk(s)</B></td></tr>"
-		for(var/obj/item/disk/nuclear/N in world)
-			dat += "<tr><td>[N.name], "
-			var/atom/disk_loc = N.loc
-			while(!istype(disk_loc, /turf))
-				if(istype(disk_loc, /mob))
-					var/mob/M = disk_loc
-					dat += "carried by <a href='?src=\ref[caller];adminplayeropts=\ref[M]'>[M.real_name]</a> "
-				if(istype(disk_loc, /obj))
-					var/obj/O = disk_loc
-					dat += "in \a [O.name] "
-				disk_loc = disk_loc.loc
-			dat += "in [disk_loc.loc] at ([disk_loc.x], [disk_loc.y], [disk_loc.z])</td></tr>"
-		dat += "</table>"
 	dat += get_additional_check_antag_output(caller)
 	dat += "<hr>"
 	return dat

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -6,7 +6,7 @@ GLOBAL_DATUM_INIT(deathsquad, /datum/antagonist/deathsquad, new)
 	role_text_plural = "Death Commandos"
 	welcome_text = "You work in the service of corporate Asset Protection, answering directly to the Board of Directors."
 	landmark_id = "Commando"
-	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_HAS_NUKE | ANTAG_HAS_LEADER | ANTAG_RANDOM_EXCEPTED
+	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_HAS_LEADER | ANTAG_RANDOM_EXCEPTED
 	default_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
 	antaghud_indicator = "huddeathsquad"
 

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -8,7 +8,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	landmark_id = "Syndicate-Spawn"
 	leader_welcome_text = "You are the leader of the mercenary strikeforce; hail to the chief. Use :t to speak to your underlings."
 	welcome_text = "To speak on the strike team's private channel use :t."
-	flags = ANTAG_VOTABLE | ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_NUKE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
+	flags = ANTAG_VOTABLE | ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	antaghud_indicator = "hudoperative"
 
 	hard_cap = 4


### PR DESCRIPTION
No player-facing changes.

The procs were just dumping errors anyway because there hasn't been a bomb spawn landmark in ages.