### PR TITLE
Fix dismantled grilles dropping default material

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -147,7 +147,7 @@
 	if(isWirecutter(W))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-			new /obj/item/stack/material/rods(get_turf(src), destroyed ? 1 : 2)
+			new /obj/item/stack/material/rods(get_turf(src), destroyed ? 1 : 2, material.name)
 			qdel(src)
 	else if((isScrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
 		if(!shock(user, 90))


### PR DESCRIPTION
Fixes #30484

:cl:
bugfix: Grilles of non-default materials now drop the correct material rod when dismantled with wirecutters.
/:cl: