### PR TITLE
Sterile glove tweaks

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -2,6 +2,12 @@
 	name = "Medical"
 	containertype = /obj/structure/closet/crate/medical
 
+/decl/hierarchy/supply_pack/medical/gloves
+	name = "Refills - Sterile gloves"
+	contains = list(/obj/item/storage/box/gloves = 4)
+	cost = 20
+	containername = "medical crate"
+
 /decl/hierarchy/supply_pack/medical/medical
 	name = "Refills - Medical supplies"
 	contains = list(/obj/item/storage/firstaid/regular,

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -117,7 +117,7 @@
 	name = "box of sterile gloves"
 	desc = "Contains sterile gloves."
 	icon_state = "latex"
-	startswith = list(/obj/item/clothing/gloves/latex = 5,
+	startswith = list(/obj/item/clothing/gloves/latex = 6,
 					/obj/item/clothing/gloves/latex/nitrile = 2)
 
 /obj/item/storage/box/masks

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -5800,6 +5800,7 @@
 /obj/item/screwdriver,
 /obj/item/storage/box/masks,
 /obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/effect/floor_decal/corner/paleblue/mono,


### PR DESCRIPTION
🆑
tweak: Added an extra box of sterile gloves to the infirmary, and a supply crate for more.
/🆑

In my endless ambivalence, I have once again risen from my trapped, pallid state of quasi-ERP DMs with someone that definitely isn't Ozwell to grace you all with more minute tweaks. Real change and server direction is quite simply for sissies.

A full medical department of around nine or so people at the moment has one box of sterile gloves to share between all of them. There are only five pairs of latex gloves and two pairs of nitrile gloves. The math doesn't work, which is an issue when disposable gloves are necessary PPE. Two boxes is a more reasonable amount of gloves for an infirmary to have.

Tacking onto that, if those two boxes run out, which would not be surprising, you can now order more.

Additionally, sterile glove boxes hold six latex gloves instead of five now, because even numbers are better, and if I haven't attached more tweaks to this one pull request than a stimulus bill I'm not really doing my job as an American citizen.