### PR TITLE
Possibility of Cardiac Arrest on over-exertion/over-utilisation of pulse-heightening reagents

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -81,8 +81,11 @@
 			pulse = PULSE_NONE
 			return
 
-	// Pulse normally shouldn't go above PULSE_2FAST
-	pulse = Clamp(PULSE_NORM + pulse_mod, PULSE_SLOW, PULSE_2FAST)
+	// Pulse normally shouldn't go above PULSE_2FAST, unless extreme amounts of bad stuff in blood
+	if (pulse_mod < 6)
+		pulse = Clamp(PULSE_NORM + pulse_mod, PULSE_SLOW, PULSE_2FAST)
+	else
+		pulse = Clamp(PULSE_NORM + pulse_mod, PULSE_SLOW, PULSE_THREADY)
 
 	// If fibrillation, then it can be PULSE_THREADY
 	var/fibrillation = oxy <= BLOOD_VOLUME_SURVIVE || (prob(30) && owner.shock_stage > 120)


### PR DESCRIPTION
:cl: Ryan180602
tweak: Over-exertion and over-utilisation of pulse-heightening drugs like nicotine, caffeine and hyperzine can cause cardiac arrests
/:cl:

DeckTechs doing their job smoking and slowly drinking a cup of coffee would not drop dead on the floor.

Hyperzine doped personnel smoking and downing coffee cups and running all over the place will, but, standard uses of hyperzine, for example, in combat, should not be changed too much.

Pain is also a factor.