### PR TITLE
Adds the notarget verb and status flag for mobs

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -12,6 +12,7 @@
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like changeling.changeling_fakedeath.
 #define NO_ANTAG    0x4000  // Players are restricted from gaining antag roles when occupying this mob
+#define NOTARGET    0x8000  // Player is invisible to all simple mobs
 
 // Grab Types
 #define GRAB_NORMAL			"normal"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -93,7 +93,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/add_trader,
 	/client/proc/remove_trader,
 	/datum/admins/proc/sendFax,
-	/client/proc/check_fax_history
+	/client/proc/check_fax_history,
+	/client/proc/cmd_admin_notarget
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -269,7 +270,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/roll_dices,
 	/proc/possess,
-	/proc/release
+	/proc/release,
+	/client/proc/cmd_admin_notarget
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	// right-click adminPM interface,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -287,6 +287,18 @@
 	message_admins("[key_name_admin(usr)] has toggled [key_name_admin(M)]'s nodamage to [(M.status_flags & GODMODE) ? "On" : "Off"]", 1)
 	SSstatistics.add_field_details("admin_verb","GOD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_admin_notarget(mob/living/M as mob in SSmobs.mob_list)
+	set category = "Special Verbs"
+	set name = "Notarget"
+	set desc = "Makes the target mob become invisible to all simple mobs."
+
+	if (!check_rights(R_ADMIN))
+		return
+
+	M.status_flags ^= NOTARGET
+	log_and_message_admins("has toggled [key_name(M)]'s notarget to [(M.status_flags & NOTARGET) ? "On" : "Off"]")
+	SSstatistics.add_field_details("admin_verb","NOTARGET") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 proc/cmd_admin_mute(mob/M as mob, mute_type)
 	if(!usr || !usr.client)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -61,10 +61,15 @@
 /mob/living/simple_animal/hostile/proc/ValidTarget(var/mob/M)
 	if(M == src)
 		return FALSE
+
+	if (M.status_flags & NOTARGET)
+		return FALSE
+
 	if(istype(M, /mob/living/simple_animal/hostile))
 		var/mob/living/simple_animal/hostile/H = M
 		if(H.faction == faction && !attack_same && !H.attack_same)
 			return FALSE
+
 	if(istype(M))
 		if(M.faction == faction)
 			return FALSE
@@ -76,6 +81,7 @@
 			var/mob/living/carbon/human/H = M
 			if(H.is_cloaked())
 				return FALSE
+
 	return TRUE
 
 /mob/living/simple_animal/hostile/proc/MoveToTarget()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -13,7 +13,7 @@
 	meat_amount = 3
 	bone_material = MATERIAL_BONE_GENERIC
 	bone_amount = 5
-	skin_material = MATERIAL_SKIN_GENERIC 
+	skin_material = MATERIAL_SKIN_GENERIC
 	skin_amount = 5
 
 	var/show_stat_health = 1	//does the percentage health show in the stat panel for the mob
@@ -66,7 +66,7 @@
 	//Null rod stuff
 	var/supernatural = 0
 	var/purge = 0
-	
+
 	var/bleed_ticks = 0
 	var/bleed_colour = COLOR_BLOOD_HUMAN
 	var/can_bleed = TRUE
@@ -122,7 +122,7 @@
 	handle_confused()
 	handle_supernatural()
 	handle_impaired_vision()
-	
+
 	if(can_bleed && bleed_ticks > 0)
 		handle_bleeding()
 
@@ -304,14 +304,14 @@
 					to_chat(user, SPAN_NOTICE("You botch harvesting \the [src], and ruin some of the meat in the process."))
 					subtract_meat(user)
 					return
-				else	
+				else
 					harvest(user, user.get_skill_value(SKILL_COOKING))
 					return
 			else
 				to_chat(user, SPAN_NOTICE("Your hand slips with your movement, and some of the meat is ruined."))
 				subtract_meat(user)
 				return
-				
+
 	else
 		if(!O.force)
 			visible_message("<span class='notice'>[user] gently taps [src] with \the [O].</span>")
@@ -401,9 +401,14 @@
 /mob/living/simple_animal/proc/SA_attackable(target_mob)
 	if (isliving(target_mob))
 		var/mob/living/L = target_mob
+
+		if (L.status_flags & NOTARGET)
+			return TRUE
+
 		if(!L.stat && L.health >= 0)
-			return (0)
-	return 1
+			return FALSE
+
+	return TRUE
 
 /mob/living/simple_animal/say(var/message)
 	var/verb = "says"
@@ -475,13 +480,13 @@
 		bleed_ticks = max(bleed_ticks, amount)
 	else
 		bleed_ticks = max(bleed_ticks + amount, 0)
-		
+
 	bleed_ticks = round(bleed_ticks)
-	
+
 /mob/living/simple_animal/proc/handle_bleeding()
 	bleed_ticks--
 	adjustBruteLoss(1)
-	
+
 	var/obj/effect/decal/cleanable/blood/drip/drip = new(get_turf(src))
 	drip.basecolor = bleed_colour
 	drip.update_icon()
@@ -497,7 +502,7 @@
 			return FLASH_PROTECTION_NONE
 		if(0)
 			return FLASH_PROTECTION_MAJOR
-		else 
+		else
 			return FLASH_PROTECTION_MAJOR
 
 /mob/living/simple_animal/proc/reflect_unarmed_damage(var/mob/living/carbon/human/attacker, var/damage_type, var/description)
@@ -514,4 +519,4 @@
 /mob/living/simple_animal/proc/get_natural_weapon()
 	if(ispath(natural_weapon))
 		natural_weapon = new natural_weapon(src)
-	return natural_weapon 
+	return natural_weapon


### PR DESCRIPTION
:cl: Mucker
admin: Adds the 'Notarget' verb to 'Special Verbs', toggling a mobs visibility to simple mobs.
/:cl:

Notarget causes mobs with it on to not be targetable by simple mobs. Works even if you were to attack a simple mob.