### PR TITLE
Bugfixes and changes to spiders

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -98,7 +98,7 @@
 	. = ..()
 
 /obj/effect/spider/eggcluster/Process()
-	if(prob(80))
+	if(prob(70))
 		amount_grown += rand(0,2)
 	if(amount_grown >= 100)
 		var/num = rand(3,9)


### PR DESCRIPTION
:cl: Mucker
rscadd: Nurse spiders can now 'feed' a small number of spiderlings to cause them to begin growing.
rscadd: Spiders can now use ladders. Cower in fear.
bugfix: Fixed guard/nurse spiders not pairing up, so guards will now go 'berserk' when their nurse is killed.
bugfix: Nurse spiders will no longer cocoon other spiders (or themselves).
tweak: Nurse spiders now have a chance to be able to spawn an egg cluster after spawning, instead of needing to feed first.
tweak: Egg clusters now take slightly more time to spawn spiderlings.
tweak: Nurse spiders will no longer cocoon items.
/:cl:

Most of the changes listed above are done so that more of the spiders feature set is actually relevant to the player. Nurse spiders were pretty underwhelming previously, unable to spawn more spiders unless able to feed on a mob first, which was a rare occurrence. By letting them spawn eggclusters after spawning, and increasing the time it takes clusters to spawn spiderlings, it should make them more of a threat to the ship, especially since the guards will now actually _guard_ them.

As for the spiderling event, I think pretty much everyone (until now) assumed that the spiders _could_ grow up, so now it just does what people expected it to do. Note: it will not allow nurse type spiderlings to mature, thus ensuring there won't be a full-blown infestation from a mundane-level event.
