### PR TITLE
Fix examine text for wet people

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -167,8 +167,10 @@
 		if((stat == DEAD || is_asystole() || src.losebreath) && distance <= 3)
 			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span>\n"
 
-	if(fire_stacks)
+	if (fire_stacks > 0)
 		msg += "[T.He] looks flammable.\n"
+	else if (fire_stacks < 0)
+		msg += "[T.He] looks wet.\n"
 	if(on_fire)
 		msg += "<span class='warning'>[T.He] [T.is] on fire!.</span>\n"
 


### PR DESCRIPTION
:cl:
bugfix: Wet people no longer show up as 'flammable' when examined, and instead show up as 'wet'.
/:cl: