### PR TITLE
Brainborg removal

### DIFF
--- a/code/controllers/subsystems/initialization/robots.dm
+++ b/code/controllers/subsystems/initialization/robots.dm
@@ -10,18 +10,15 @@ SUBSYSTEM_DEF(robots)
 	var/list/robot_alt_titles            = list()
 
 	var/list/mob_types_by_title = list(
-		"robot, flying"  = /mob/living/silicon/robot/flying,
-		"drone, flying"  = /mob/living/silicon/robot/flying,
-		"cyborg, flying" = /mob/living/silicon/robot/flying
+		"robot, flying" = /mob/living/silicon/robot/flying,
+		"drone, flying" = /mob/living/silicon/robot/flying,
 	)
 
 	var/list/mmi_types_by_title = list(
-		"cyborg"         = /obj/item/device/mmi,
-		"robot"          = /obj/item/organ/internal/posibrain,
-		"drone"          = /obj/item/device/mmi/digital/robot,
-		"cyborg, flying" = /obj/item/device/mmi,
-		"robot, flying"  = /obj/item/organ/internal/posibrain,
-		"drone, flying"  = /obj/item/device/mmi/digital/robot
+		"robot"         = /obj/item/organ/internal/posibrain,
+		"drone"         = /obj/item/device/mmi/digital/robot,
+		"robot, flying" = /obj/item/organ/internal/posibrain,
+		"drone, flying" = /obj/item/device/mmi/digital/robot
 	)
 
 /datum/controller/subsystem/robots/Initialize()
@@ -61,7 +58,7 @@ SUBSYSTEM_DEF(robots)
 			.[include_override] = modules[include_override]
 
 /datum/controller/subsystem/robots/proc/get_mmi_type_by_title(var/check_title)
-	. = mmi_types_by_title[lowertext(trim(check_title))] || /obj/item/device/mmi
+	. = mmi_types_by_title[lowertext(trim(check_title))] || /obj/item/organ/internal/posibrain
 
 /datum/controller/subsystem/robots/proc/get_mob_type_by_title(var/check_title)
 	. = mob_types_by_title[lowertext(trim(check_title))] || /mob/living/silicon/robot

--- a/code/controllers/subsystems/initialization/robots.dm
+++ b/code/controllers/subsystems/initialization/robots.dm
@@ -10,15 +10,15 @@ SUBSYSTEM_DEF(robots)
 	var/list/robot_alt_titles            = list()
 
 	var/list/mob_types_by_title = list(
-		"robot, flying" = /mob/living/silicon/robot/flying,
-		"drone, flying" = /mob/living/silicon/robot/flying,
+		"android, flying" = /mob/living/silicon/robot/flying,
+		"drone, flying"   = /mob/living/silicon/robot/flying,
 	)
 
 	var/list/mmi_types_by_title = list(
-		"robot"         = /obj/item/organ/internal/posibrain,
-		"drone"         = /obj/item/device/mmi/digital/robot,
-		"robot, flying" = /obj/item/organ/internal/posibrain,
-		"drone, flying" = /obj/item/device/mmi/digital/robot
+		"android"         = /obj/item/organ/internal/posibrain,
+		"drone"           = /obj/item/device/mmi/digital/robot,
+		"android, flying" = /obj/item/organ/internal/posibrain,
+		"drone, flying"   = /obj/item/device/mmi/digital/robot
 	)
 
 /datum/controller/subsystem/robots/Initialize()

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -50,7 +50,7 @@
 	return H
 
 /datum/job/cyborg
-	title = "Robot"
+	title = "Android"
 	department_flag = MSC
 	total_positions = 2
 	spawn_positions = 2

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,8 +1,8 @@
 #define CYBORG_POWER_USAGE_MULTIPLIER 2.5 // Multiplier for amount of power cyborgs use.
 
 /mob/living/silicon/robot
-	name = "Robot"
-	real_name = "Robot"
+	name = "Android"
+	real_name = "Android"
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "robot"
 	maxHealth = 300
@@ -85,7 +85,7 @@
 	var/speed = 0
 	var/scrambledcodes = FALSE // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
-	var/braintype = "Robot"
+	var/braintype = "Android"
 	var/intenselight = FALSE	// Whether cyborg's integrated light was upgraded
 	var/vtec = FALSE
 
@@ -302,7 +302,7 @@
 		modtype = prefix
 
 	if(istype(mmi, /obj/item/organ/internal/posibrain))
-		braintype = "Robot"
+		braintype = "Android"
 	else if(istype(mmi, /obj/item/device/mmi/digital/robot))
 		braintype = "Drone"
 	else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,8 +1,8 @@
 #define CYBORG_POWER_USAGE_MULTIPLIER 2.5 // Multiplier for amount of power cyborgs use.
 
 /mob/living/silicon/robot
-	name = "Cyborg"
-	real_name = "Cyborg"
+	name = "Robot"
+	real_name = "Robot"
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "robot"
 	maxHealth = 300
@@ -85,7 +85,7 @@
 	var/speed = 0
 	var/scrambledcodes = FALSE // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
-	var/braintype = "Cyborg"
+	var/braintype = "Robot"
 	var/intenselight = FALSE	// Whether cyborg's integrated light was upgraded
 	var/vtec = FALSE
 


### PR DESCRIPTION
:cl:
tweak: The default braintype for station-bound robots is now positronic.
rscdel: Law-bound cyborgs (MMI/organic braintype) are not longer a spawnable option, but can still be created in-game using an MMI.
tweak: 'Robot' law-bound subtype has been renamed to 'Android'.
/:cl: