### PR TITLE
Allow restricting jobs by species whitelists

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -53,6 +53,8 @@
 	var/psi_latency_chance = 0            // Chance of an additional psi latency, if any.
 	var/give_psionic_implant_on_join = TRUE // If psionic, will be implanted for control.
 
+	var/use_species_whitelist // If set, restricts the job to players with the given species whitelist. This does NOT restrict characters joining as the job to the species itself.
+
 	var/required_language
 
 /datum/job/New()
@@ -194,7 +196,12 @@
 	return (supplied_title == desired_title) || (H.mind && H.mind.role_alt_title == desired_title)
 
 /datum/job/proc/is_restricted(var/datum/preferences/prefs, var/feedback)
+	var/datum/species/S
 
+	if (!is_species_whitelist_allowed(prefs.client, use_species_whitelist))
+		S = all_species[use_species_whitelist]
+		to_chat(feedback, "<span class='boldannounce'>\An [S] species whitelist is required for [title].</span>")
+		return TRUE
 
 	if(!isnull(allowed_branches) && (!prefs.branches[title] || !is_branch_allowed(prefs.branches[title])))
 		to_chat(feedback, "<span class='boldannounce'>Wrong branch of service for [title]. Valid branches are: [get_branches()].</span>")
@@ -204,7 +211,7 @@
 		to_chat(feedback, "<span class='boldannounce'>Wrong rank for [title]. Valid ranks in [prefs.branches[title]] are: [get_ranks(prefs.branches[title])].</span>")
 		return TRUE
 
-	var/datum/species/S = all_species[prefs.species]
+	S = all_species[prefs.species]
 	if(!is_species_allowed(S))
 		to_chat(feedback, "<span class='boldannounce'>Restricted species, [S], for [title].</span>")
 		return TRUE
@@ -221,7 +228,7 @@
 
 /datum/job/proc/get_join_link(var/client/caller, var/href_string, var/show_invalid_jobs)
 	if(is_available(caller))
-		if(is_restricted(caller.prefs))
+		if(is_restricted(caller))
 			if(show_invalid_jobs)
 				return "<tr><td><a style='text-decoration: line-through' href='[href_string]'>[title]</a></td><td>[current_positions]</td><td>(Active: [get_active_count()])</td></tr>"
 		else
@@ -246,6 +253,14 @@
 	if(!allowed_branches || !GLOB.using_map || !(GLOB.using_map.flags & MAP_HAS_BRANCH))
 		return TRUE
 	return LAZYLEN(get_branch_rank(S))
+
+/datum/job/proc/is_species_whitelist_allowed(client/C)
+	if (isnull(use_species_whitelist))
+		return TRUE
+	if (!C?.mob)
+		log_debug("Failed to find a valid client/mob for whitelist checking - Job `[src]` - Client `[C]` - Mob `[C?.mob]`")
+		return FALSE
+	return is_species_whitelisted(C.mob, use_species_whitelist)
 
 // Don't use if the map doesn't use branches but jobs do.
 /datum/job/proc/get_branch_rank(var/datum/species/S)
@@ -364,6 +379,8 @@
 		reasons["Your branch of service does not allow it."] = TRUE
 	else if(!isnull(allowed_ranks) && (!caller.prefs.ranks[title] || !is_rank_allowed(caller.prefs.branches[title], caller.prefs.ranks[title])))
 		reasons["Your rank choice does not allow it."] = TRUE
+	if (!is_species_whitelist_allowed(caller))
+		reasons["You do not have the required [use_species_whitelist] species whitelist."] = TRUE
 	var/datum/species/S = all_species[caller.prefs.species]
 	if(S)
 		if(!is_species_allowed(S))

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -156,6 +156,8 @@
 					bad_message = "<b>\[UNAVAILABLE]</b>"
 				else if(jobban_isbanned(user, title))
 					bad_message = "<b>\[BANNED]</b>"
+				else if (!job.is_species_whitelist_allowed(user.client))
+					bad_message = "\[WHITELIST RESTRICTED ([job.use_species_whitelist])]"
 				else if(!job.player_old_enough(user.client))
 					var/available_in_days = job.available_in_days(user.client)
 					bad_message = "\[IN [(available_in_days)] DAYS]"

--- a/maps/away/ascent_caulship/ascent_jobs.dm
+++ b/maps/away/ascent_caulship/ascent_jobs.dm
@@ -120,6 +120,7 @@
 		SKILL_SCIENCE = SKILL_ADEPT,
 		SKILL_MEDICAL = SKILL_BASIC
 	)
+	use_species_whitelist = SPECIES_MANTID_GYNE
 	var/requires_supervisor = FALSE
 	var/set_species_on_join = SPECIES_MANTID_GYNE
 
@@ -133,15 +134,6 @@
 			if(istype(ascent_job) && ascent_job.owner == owner)
 				return TRUE
 		return FALSE
-
-/datum/job/submap/ascent/is_available(client/caller)
-	. = ..()
-	if(.)
-		switch(set_species_on_join)
-			if(SPECIES_MANTID_GYNE)
-				. = is_species_whitelisted(caller.mob, SPECIES_MANTID_GYNE)
-			if(SPECIES_MONARCH_QUEEN)
-				. = is_species_whitelisted(caller.mob, SPECIES_NABBER)
 
 /datum/job/submap/ascent/handle_variant_join(var/mob/living/carbon/human/H, var/alt_title)
 
@@ -193,6 +185,7 @@
 		SKILL_WEAPONS = SKILL_ADEPT,
 		SKILL_MEDICAL = SKILL_BASIC
 	)
+	use_species_whitelist = null
 
 /datum/job/submap/ascent/drone
 	title = "Ascent Drone"
@@ -201,6 +194,7 @@
 	info = "You are a Machine Intelligence of an independent Ascent vessel. The Gyne you assist has fled her sisters, ending up in this sector full of primitive bioforms. Try to keep her alive, and assist where you can."
 	set_species_on_join = /mob/living/silicon/robot/flying/ascent
 	requires_supervisor = "Ascent Gyne"
+	use_species_whitelist = null
 
 // Spawn points.
 /obj/effect/submap_landmark/spawnpoint/ascent_caulship


### PR DESCRIPTION
Cherry-picked from #30499. Allows for easier means of restricting a job slot based on species whitelists and applies it to the Ascent Gyne role in place of the snow-flake proc calls that previously existed. No player-facing changes.