### PR TITLE
Adds default skills (Roboticist)

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -195,6 +195,8 @@
 	                    SKILL_DEVICES		= SKILL_ADEPT,
 	                    SKILL_EVA           = SKILL_ADEPT,
 	                    SKILL_ANATOMY       = SKILL_ADEPT,
+						SKILL_CONSTRUCTION  = SKILL_BASIC,
+						SKILL_ELECTRICAL    = SKILL_BASIC,
 	                    SKILL_MECH          = HAS_PERK)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,


### PR DESCRIPTION
:cl: Ryan180602
tweak: Add Construction/Electrical BASIC as default for Roboticists
/:cl:

Considering without Construction you cannot outright make certain items as a Roboticist (like Drill Heads), and Electrical is a necessity for certain wire-based skill checks, it seems like they should be there for Roboticists by default