### PR TITLE
Apply languages to mind

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -318,6 +318,7 @@
 #include "code\datums\item_modifiers\space_suits.dm"
 #include "code\datums\item_modifiers\~defines.dm"
 #include "code\datums\licences\license.dm"
+#include "code\datums\mind\language.dm"
 #include "code\datums\mind\memory.dm"
 #include "code\datums\mind\mind.dm"
 #include "code\datums\move_intent\move_intent.dm"

--- a/code/datums/mind/language.dm
+++ b/code/datums/mind/language.dm
@@ -1,0 +1,62 @@
+/datum/mind
+	var/list/languages
+	var/datum/language/default_language
+
+
+/datum/mind/proc/add_language(datum/language/language)
+	if (!istype(language))
+		language = all_languages[language]
+	if(!istype(language) || (language in languages))
+		return FALSE
+
+	languages += language
+	return TRUE
+
+
+/datum/mind/proc/remove_language(datum/language/language)
+	if (!istype(language))
+		language = all_languages[language]
+	if (!istype(language) || !(language in languages))
+		return FALSE
+
+	languages -= language
+	if (language == default_language)
+		set_default_language()
+	return TRUE
+
+
+/datum/mind/proc/clear_languages()
+	languages.Cut()
+	default_language = null
+
+
+/datum/mind/proc/apply_languages_to_mob()
+	if (current)
+		current.languages = languages.Copy()
+		current.default_language = default_language
+
+
+/datum/mind/proc/apply_languages_from_mob()
+	if (current)
+		languages = current.languages.Copy()
+		default_language = current.default_language
+
+
+/datum/mind/proc/set_default_language(datum/language/language, force)
+	if (!language)
+		if (languages.len)
+			default_language = languages[1]
+		else
+			default_language = null
+		return
+
+	if (!istype(language))
+		language = all_languages[language]
+	if (!istype(language))
+		return
+
+	if (language in languages)
+		default_language = language
+	else if (force)
+		add_language(language)
+		default_language = language

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -71,7 +71,7 @@
 	SSticker.minds -= src
 	. = ..()
 
-/datum/mind/proc/transfer_to(mob/living/new_character)
+/datum/mind/proc/transfer_to(mob/living/new_character, transfer_languages)
 	if(!istype(new_character))
 		to_world_log("## DEBUG: transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob. Please inform Carn.")
 	if(current)					//remove ourself from our old body's mind variable
@@ -88,6 +88,11 @@
 
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
+
+	if (transfer_languages)
+		apply_languages_to_mob()
+	else
+		apply_languages_from_mob()
 
 	if(learned_spells && learned_spells.len)
 		restore_spells(new_character)
@@ -542,6 +547,7 @@
 	mind.current = src
 	if(player_is_antag(mind))
 		src.client.verbs += /client/proc/aooc
+	mind.apply_languages_from_mob()
 
 //HUMAN
 /mob/living/carbon/human/mind_initialize()

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -139,6 +139,9 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	//This isn't strictly necessary but just to be safe...
 	add_language(LANGUAGE_CHANGELING_GLOBAL)
 
+	if (mind)
+		mind.apply_languages_from_mob()
+
 	return
 
 //Absorbs the victim's DNA making them uncloneable. Requires a strong grip on the victim.

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -179,12 +179,19 @@
 		return 0
 
 	languages.Add(new_language)
+
+	if (mind)
+		mind.add_language(language)
+
 	return 1
 
 /mob/proc/remove_language(var/rem_language)
 	var/datum/language/L = all_languages[rem_language]
 	. = (L in languages)
 	languages.Remove(L)
+
+	if (mind)
+		mind.remove_language(rem_language)
 
 /mob/living/remove_language(rem_language)
 	var/datum/language/L = all_languages[rem_language]

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -25,7 +25,7 @@
 	brainmob.timeofhostdeath = H.timeofdeath
 	brainmob.set_stat(CONSCIOUS)
 	if(H.mind)
-		H.mind.transfer_to(brainmob)
+		H.mind.transfer_to(brainmob, TRUE)
 	return
 
 /obj/item/device/mmi

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -935,7 +935,7 @@
 			if(H.brainmob)
 				if(H.brainmob.real_name == src.real_name)
 					if(H.brainmob.mind)
-						H.brainmob.mind.transfer_to(src)
+						H.brainmob.mind.transfer_to(src, TRUE)
 						qdel(H)
 
 	losebreath = 0
@@ -1257,6 +1257,8 @@
 	if(update_lang)
 		languages.Cut()
 		default_language = null
+		if (mind)
+			mind.clear_languages()
 		update_languages()
 
 	//recheck species-restricted clothing
@@ -1304,6 +1306,8 @@
 
 	if(LAZYLEN(default_languages) && isnull(default_language))
 		default_language = default_languages[1]
+		if (mind)
+			mind.set_default_language(default_language)
 
 /mob/living/carbon/human/proc/bloody_doodle()
 	set category = "IC"

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -23,6 +23,8 @@
 		to_chat(src, "<span class='notice'>You will now speak whatever your standard default language is if you do not specify one when speaking.</span>")
 
 	default_language = language
+	if (mind)
+		mind.set_default_language(language)
 
 // Silicons can't neccessarily speak everything in their languages list
 /mob/living/silicon/set_default_language(language as null|anything in speech_synthesizer_langs)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -207,7 +207,7 @@
 		if(mind)
 			mmi.dropInto(loc)
 			if(mmi.brainmob)
-				mind.transfer_to(mmi.brainmob)
+				mind.transfer_to(mmi.brainmob, TRUE)
 			else
 				to_chat(src, "<span class='danger'>Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug.</span>")
 				ghostize()

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -72,7 +72,7 @@
 		brainmob.timeofhostdeath = H.timeofdeath
 
 	if(H.mind)
-		H.mind.transfer_to(brainmob)
+		H.mind.transfer_to(brainmob, TRUE)
 
 	to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just \a [initial(src.name)].</span>")
 	callHook("debrain", list(brainmob))
@@ -109,7 +109,7 @@
 
 	if(brainmob)
 		if(brainmob.mind)
-			brainmob.mind.transfer_to(target)
+			brainmob.mind.transfer_to(target, TRUE)
 		else
 			target.key = brainmob.key
 

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -40,7 +40,7 @@
 		return 0
 	return cell && cell.use(amount)
 
-/obj/item/organ/internal/cell/proc/get_power_drain()	
+/obj/item/organ/internal/cell/proc/get_power_drain()
 	var/damage_factor = 1 + 10 * damage/max_damage
 	return servo_cost * damage_factor
 
@@ -164,9 +164,9 @@
 		. = stored_mmi
 		stored_mmi.forceMove(src.loc)
 		if(persistantMind)
-			persistantMind.transfer_to(stored_mmi.brainmob)
+			persistantMind.transfer_to(stored_mmi.brainmob, TRUE)
 		else
 			var/response = input(find_dead_player(ownerckey, 1), "Your [initial(stored_mmi.name)] has been removed from your body. Do you wish to return to life?", "Robotic Rebirth") as anything in list("Yes", "No")
 			if(response == "Yes")
-				persistantMind.transfer_to(stored_mmi.brainmob)
+				persistantMind.transfer_to(stored_mmi.brainmob, TRUE)
 	qdel(src)

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -112,7 +112,7 @@
 			if (sneaky)
 				brainmob.real_name = sneaky
 				brainmob.SetName(brainmob.real_name)
-				UpdateNames() 
+				UpdateNames()
 		else
 			to_chat(brainmob, SPAN_NOTICE("You're safe! Your brain didn't manage to replace you. This time."))
 	else
@@ -216,7 +216,7 @@
 /obj/item/organ/internal/posibrain/proc/transfer_identity(var/mob/living/carbon/H)
 	if(H && H.mind)
 		brainmob.set_stat(CONSCIOUS)
-		H.mind.transfer_to(brainmob)
+		H.mind.transfer_to(brainmob, TRUE)
 		brainmob.SetName(H.real_name)
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
@@ -295,7 +295,7 @@
 
 	if(brainmob)
 		if(brainmob.mind)
-			brainmob.mind.transfer_to(target)
+			brainmob.mind.transfer_to(target, TRUE)
 		else
 			target.key = brainmob.key
 
@@ -330,4 +330,3 @@
 
 
 	brainmob.open_subsystem(/datum/nano_module/law_manager, usr)
-	

--- a/code/modules/organs/internal/species/vox.dm
+++ b/code/modules/organs/internal/species/vox.dm
@@ -141,7 +141,7 @@
 						mat_stack.set_amount(mat_stack.amount + taking_sheets)
 						sheets -= taking_sheets
 						updated_stacks = TRUE
-						
+
 				// Create new stacks if needed.
 				while(sheets > 0)
 					var/obj/item/stack/material/mat_stack = new M.stack_type(src)
@@ -251,6 +251,8 @@
 	if (default_language)
 		owner.default_language = default_language
 	owner.languages = languages.Copy()
+	if (owner.mind)
+		owner.mind.apply_languages_from_mob()
 	to_chat(owner, SPAN_NOTICE("Consciousness slowly creeps over you as your new body awakens."))
 
 /datum/species/vox/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -86,7 +86,7 @@
 
 			new_mob.a_intent = "hurt"
 			if(M.mind)
-				M.mind.transfer_to(new_mob)
+				M.mind.transfer_to(new_mob, TRUE)
 			else
 				new_mob.key = M.key
 

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -40,10 +40,10 @@
 	cold_level_1 = 80
 	cold_level_2 = 50
 	cold_level_3 = -1
-	
+
 	min_age = 1
 	max_age = 100
-	
+
 	gluttonous = GLUT_TINY|GLUT_ITEM_NORMAL
 	stomach_capacity = 12
 
@@ -136,7 +136,7 @@
 /datum/species/vox/disfigure_msg(var/mob/living/carbon/human/H)
 	var/datum/gender/T = gender_datums[H.get_gender()]
 	return "<span class='danger'>[T.His] beak-segments are cracked and chipped! [T.He] [T.is] not even recognizable.</span>\n"
-	
+
 /datum/species/vox/skills_from_age(age)
 	. = 8
 
@@ -197,7 +197,7 @@
 	if (isnull(data) || data == "No")
 		return
 	var/mob/living/carbon/human/vox/vox = new(get_turf(src), SPECIES_VOX)
-	user.mind.transfer_to(vox)
+	user.mind.transfer_to(vox, TRUE)
 	OnCreated(vox, user)
 	data = sanitizeSafe(input(vox, "Enter Name:", "Enter Name", "") as text, MAX_NAME_LEN)
 	if (!length(data))

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -105,8 +105,10 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	H.set_see_in_dark(8)
 	H.set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 
-	H.languages = list()
+	H.languages.Cut()
 	H.add_language(LANGUAGE_ZOMBIE)
+	if (H.mind)
+		H.mind.apply_languages_from_mob()
 
 	H.sleeping = 0
 	H.resting = 0

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -244,7 +244,7 @@
 	else if (effective_dose > 10)
 		M.vomit(4, 2, rand(3 SECONDS, 10 SECONDS))
 	else
-		M.vomit(1, 1, rand(5 SECONDS, 15 SECONDS))	
+		M.vomit(1, 1, rand(5 SECONDS, 15 SECONDS))
 
 /datum/species/skrell/get_sex(var/mob/living/carbon/human/H)
 	return istype(H) && (H.descriptors["headtail length"] == 1 ? MALE : FEMALE)
@@ -397,7 +397,7 @@
 		if(101 to 200)	. = 12 // age bracket before this is 46 to 100 . = 8 making this +4
 		if(201 to 300)	. = 16 // + 8
 		else			. = ..()
-		
+
 // Dionaea spawned by hand or by joining will not have any
 // nymphs passed to them. This should take care of that.
 /datum/species/diona/handle_post_spawn(var/mob/living/carbon/human/H)
@@ -424,7 +424,7 @@
 		var/mob/living/carbon/alien/diona/S = new(get_turf(H))
 
 		if(H.mind)
-			H.mind.transfer_to(S)
+			H.mind.transfer_to(S, TRUE)
 		H.visible_message("<span class='danger'>\The [H] collapses into parts, revealing a solitary diona nymph at the core.</span>")
 		return
 	else

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -47,7 +47,7 @@
 			for(var/obj/item/I in M.contents)
 				M.drop_from_inventory(I)
 		if(M.mind)
-			M.mind.transfer_to(trans)
+			M.mind.transfer_to(trans, TRUE)
 		else
 			trans.key = M.key
 		new /obj/effect/temporary(get_turf(M), 5, 'icons/effects/effects.dmi', "summoning")
@@ -78,7 +78,7 @@
 		for(var/i in 1 to ceil(damage/10))
 			transformer.adjustBruteLoss(10)
 	if(target.mind)
-		target.mind.transfer_to(transformer)
+		target.mind.transfer_to(transformer, TRUE)
 	else
 		transformer.key = target.key
 	playsound(get_turf(target), revert_sound, 50, 1)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -346,9 +346,9 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 
 /decl/surgery_step/robotics/fix_organ_robotic/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	if(target.isSynthetic())
-		return SURGERY_SKILLS_ROBOTIC 
+		return SURGERY_SKILLS_ROBOTIC
 	else
-		return SURGERY_SKILLS_ROBOTIC_ON_MEAT 
+		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 
 /decl/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -537,7 +537,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	holder.update_from_mmi()
 
 	if(M.brainmob && M.brainmob.mind)
-		M.brainmob.mind.transfer_to(target)
+		M.brainmob.mind.transfer_to(target, TRUE)
 
 /decl/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips.</span>", \


### PR DESCRIPTION
Applies a mob's languages to its mind and allows them to be transferred back and forth. Should fix issues with FBPs not getting languages, merc/raiders losing languages, etc.

Fixes #27203

:cl:
bugfix: Newly built FBPs and IPCs now remember the languages they had from before.
bugfix: Appearance/species editors no longer make you lose your language.
/:cl: