### PR TITLE
Add flash protection borg module

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -77,6 +77,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 			R.SetLockdown(0)
 			R.emagged = TRUE // Provides a traitor robot with its module's emag item
 			R.verbs |= /mob/living/silicon/robot/proc/ResetSecurityCodes
+			R.status_flags &= ~CANWEAKEN // Apply optical matrix protection (Flash resistance)
 		return 1
 
 	if(!..())
@@ -84,6 +85,15 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 
 	spawn_uplink(traitor_mob)
 	give_intel(traitor_mob)
+
+/datum/antagonist/traitor/unequip(mob/living/carbon/human/player)
+	if (istype(player, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/R = player
+		if (!R.flash_protected)
+			R.status_flags &= ~CANWEAKEN
+		return TRUE
+
+	return ..()
 
 /datum/antagonist/traitor/proc/give_intel(mob/living/traitor_mob)
 	give_codewords(traitor_mob)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -100,11 +100,14 @@
 				SA.flash_eyes(2)
 				SA.eye_blurry += flash_strength
 				SA.confused += flash_strength
-		else 
+		else
 			flashfail = 1
 
 	else if(issilicon(M))
-		M.Weaken(rand(str_min,6))
+		if (M.status_flags & CANWEAKEN)
+			M.Weaken(rand(str_min,6))
+		else
+			flashfail = TRUE
 
 	else
 		flashfail = 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -214,3 +214,19 @@
 
 	R.emagged = TRUE
 	return 1
+
+/obj/item/borg/upgrade/flash_protection
+	name = "optical matrix shielding"
+	desc = "Provides shielding for the optical matrix, rendering the robot immune to flashes."
+
+/obj/item/borg/upgrade/flash_protection/action(mob/living/silicon/robot/R)
+	if (..())
+		return FALSE
+
+	if (R.flash_protected)
+		to_chat(usr, SPAN_WARNING("\The [R]'s optical matrix is already shielded."))
+		return FALSE
+
+	R.status_flags &= ~CANWEAKEN
+	R.flash_protected = TRUE
+	return TRUE

--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -6,7 +6,7 @@
 		NETWORK_SECURITY
 	)
 	subsystems = list(
-		/datum/nano_module/crew_monitor, 
+		/datum/nano_module/crew_monitor,
 		/datum/nano_module/program/digitalwarrant
 	)
 	can_be_pushed = FALSE
@@ -77,3 +77,10 @@
 		/obj/item/crowbar
 	)
 	emag = /obj/item/gun/energy/lasercannon/mounted
+
+/obj/item/robot_module/security/combat/Initialize()
+	. = ..()
+	var/mob/living/silicon/robot/R = loc
+	if (istype(R))
+		R.status_flags &= ~CANWEAKEN // Pre-install the optical matrix shielding
+		R.flash_protected = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -88,6 +88,7 @@
 	var/braintype = "Cyborg"
 	var/intenselight = FALSE	// Whether cyborg's integrated light was upgraded
 	var/vtec = FALSE
+	var/flash_protected = FALSE
 
 	var/list/robot_verbs_default = list(
 		/mob/living/silicon/robot/proc/sensor_mode,

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -360,6 +360,13 @@
 	materials = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 15000, MATERIAL_DIAMOND = 10000)
 	build_path = /obj/item/borg/upgrade/syndicate
 
+/datum/design/item/robot_upgrade/flash_protection
+	name = "Optical Matrix Shielding"
+	desc = "Provides shielding for the optical matrix, rendering the robot immune to flashes."
+	id = "borg_flash_protection_module"
+	materials = list(MATERIAL_STEEL = 80000, MATERIAL_GLASS = 6000, MATERIAL_GOLD = 5000)
+	build_path = /obj/item/borg/upgrade/flash_protection
+
 /datum/design/item/exosuit
 	build_type = MECHFAB
 	category = "Exosuit Equipment"


### PR DESCRIPTION
:cl:
rscadd: Borgs can now have a new upgrade module installed, available from robotics fabricators, called "optical matrix shielding". This upgrade makes the borg immune to flashes when installed.
rscadd: Traitor borgs now have flash immunity when antagged. De-antagged traitor borgs will lose this immunity.
rscadd: Combat borgs now have flash immunity by default.
/:cl:

Current meta is to flash-spam and beat antag borgs to death, which leaves traitor borgs in an unpleasant position of not being able to actually do anything antagonistic without being immediately removed from the round - Something other traitors don't generally have to deal with. This helps give traitor borgs a chance to defend themselves.