### PR TITLE
Fix exo awakening runtimes, do some housekeeping

### DIFF
--- a/code/modules/events/exo_awaken.dm
+++ b/code/modules/events/exo_awaken.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 /datum/event/exo_awakening
 	announceWhen	= 45
 	endWhen			= 75
-	var/no_show = FALSE //set to true once we hit the target mob count of spawned mobs so we stop spawning
+	var/stop_spawning = FALSE //set to true once we hit the target mob count of spawned mobs so we stop spawning
 	var/spawned_mobs //total count of all spawned mobs by the event
 	var/list/exoplanet_areas //all possible exoplanet areas the event can take place on
 	var/area/chosen_area
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 				list(/mob/living/simple_animal/hostile/giant_spider/spitter, 55),
 				list(/mob/living/simple_animal/hostile/giant_spider, 90)
 			)
-	arrival_message = "The planet rumbles as you begin to feel an uncountable number of eyes suddenly staring at you from all around."
+	arrival_message = "The ground beneath you shakes and rumbles, and is accompanied by an approaching skittering sound..."
 	arrival_sound   = 'sound/effects/wind/wind_3_1.ogg'
 	limit = 25
 	length = 45
@@ -111,6 +111,9 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	endWhen = chosen_mob_list.length
 	endWhen += severity*25
 
+	apply_spawn_delay()
+
+/datum/event/exo_awakening/proc/apply_spawn_delay()
 	delay_time = chosen_mob_list.delay_time
 	var/delay_mod = delay_time / 6
 	var/delay_max = (EVENT_LEVEL_MAJOR - severity) * delay_mod
@@ -124,13 +127,23 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	var/total_mobs
 	total_mobs = GLOB.exo_event_mob_count.len
 
-	if(total_mobs >= target_mob_count || SSmobs.ticks >= 10 || !living_observers_present(affecting_z))
-		no_show = TRUE
+	if (total_mobs >= target_mob_count || SSmobs.ticks >= 10 || !living_observers_present(affecting_z))
+		stop_spawning = TRUE
 	else
-		no_show = FALSE
+		stop_spawning = FALSE
 
 /datum/event/exo_awakening/start()
-	var/torch_players_present = FALSE
+
+	find_suitable_planet()
+	notify_players()
+	adjust_to_planet_size()
+
+	addtimer(CALLBACK(src, /datum/event/exo_awakening/proc/start_spawning), delay_time)
+
+//Locates a planet with players on it (prioritizes players from the station).
+//If no suitable planets are found, the event is killed and something else is run instead.
+/datum/event/exo_awakening/proc/find_suitable_planet()
+	var/station_players_present = FALSE
 	var/list/sites = list() //a list of sites that have players present
 	var/list/players = list()
 
@@ -138,11 +151,11 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		var/mob/M
 		for (var/i = length(GLOB.player_list) to 1 step -1)
 			M = GLOB.player_list[i]
-			if (M.stat != DEAD && (get_z(M) in GetConnectedZlevels(A.z)))
+			if (M && M.stat != DEAD && (get_z(M) in GetConnectedZlevels(A.z)))
 				players += M
 
 				if (get_crewmember_record(M.real_name || M.name))
-					torch_players_present = TRUE
+					station_players_present = TRUE
 					chosen_area = A
 					chosen_planet = map_sectors["[A.z]"]
 					affecting_z = GetConnectedZlevels(A.z)
@@ -151,12 +164,12 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 			sites += A
 			players_on_site[A] = players
 
-		if (torch_players_present && (length(players_on_site[A]) >= required_players_count))
+		if (station_players_present && (length(players_on_site[A]) >= required_players_count))
 			break
 
-		torch_players_present = FALSE
+		station_players_present = FALSE
 
-	if (!torch_players_present)
+	if (!station_players_present)
 
 		if (!length(sites))
 			log_debug("Exoplanet Awakening failed to run, not enough players on any planet. Aborting.")
@@ -168,6 +181,13 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 		chosen_planet = map_sectors["[chosen_area.z]"]
 		affecting_z = GetConnectedZlevels(chosen_area.z)
 
+	if (!length(affecting_z))
+		log_debug("Exoplanet Awakening failed critically! No z-levels found for chosen area '[chosen_area]'!")
+		severity = original_severity
+		kill(TRUE)
+
+//Notify all players on the planet that the event is beginning.
+/datum/event/exo_awakening/proc/notify_players()
 	for (var/mob/M in players_on_site[chosen_area])
 		if (severity > EVENT_LEVEL_MODERATE)
 			to_chat(M, SPAN_DANGER(chosen_mob_list.arrival_message))
@@ -176,11 +196,11 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 		sound_to(M, chosen_mob_list.arrival_sound)
 
+//Lowers the amount of spawned mobs if the planet is smaller than normal.
+/datum/event/exo_awakening/proc/adjust_to_planet_size()
 	var/list/dimensions = chosen_area.get_dimensions()
 	if (dimensions["x"] <= 100)
 		target_mob_count = round(target_mob_count / 3.5) //keep mob count lower in smaller areas.
-
-	addtimer(CALLBACK(src, /datum/event/exo_awakening/proc/start_spawning), delay_time)
 
 /datum/event/exo_awakening/announce()
 	var/announcement = ""
@@ -194,7 +214,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 /datum/event/exo_awakening/tick()
 	count_mobs()
-	if (!spawning || (no_show && prob(98)))
+	if (!spawning || (stop_spawning && prob(99)))
 		return
 
 	spawn_mob()
@@ -204,20 +224,20 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	log_debug("Exoplanet Awakening spawning initiated.")
 
 /datum/event/exo_awakening/proc/spawn_mob()
-	if(!living_observers_present(affecting_z))
+	if (!living_observers_present(affecting_z))
 		return
 
 	var/list/area_turfs = get_area_turfs(chosen_area)
 	var/n = rand(severity-1, severity*2)
 	var/I = 0
-	while(I < n)
+	while (I < n)
 		var/turf/T
 		for (var/i = 1 to 5)
 
 			if (prob(chosen_mob_list.spawn_near_chance))
 				var/mob/M = pick(players_on_site[chosen_area])
 				var/turf/MT = get_turf(M)
-				if(MT)
+				if (MT)
 					T = pick(trange(10, MT) - trange(7, MT))
 				else
 					T = pick(area_turfs)
@@ -253,19 +273,19 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 
 			spawned_mobs++
 		I++
-		if(no_show)
+		if (stop_spawning)
 			break
 
 /datum/event/exo_awakening/proc/reduce_mob_count(mob/M)
 	var/list/L = GLOB.exo_event_mob_count
-	if(M in L)
+	if (M in L)
 		LAZYREMOVE(L,M)
 
 	GLOB.death_event.unregister(M,src,/datum/event/exo_awakening/proc/reduce_mob_count)
 	GLOB.destroyed_event.unregister(M,src,/datum/event/exo_awakening/proc/reduce_mob_count)
 
 /datum/event/exo_awakening/end()
-	if(!chosen_area)
+	if (!chosen_area)
 		return
 
 	QDEL_NULL(chosen_mob_list)


### PR DESCRIPTION
Fixes #30513
Fixes #23633

Added appropriate null checks, and the event will kill itself if (somehow) it finds a planet, but can't get its z-level(s).
Did some minor housekeeping as well.