### PR TITLE
Add suit sensors dead indicator

### DIFF
--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -20,36 +20,40 @@ Used In File(s): code\modules\modular_computers\file_system\programs\medical\sui
 		<tr class="candystripe">
 			<td>{{:value.name}} ({{:value.assignment}}): </td>
 
-			{{if value.sensor_type >= 2}}
-				{{if value.pulse != "N/A"}}
-					{{if value.true_pulse == -1}}
-						<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>
+			{{if value.sensor_type >= 1 && value.stat == 2}}
+				<td colspan="3"><span class="bad">DEAD</span></td>
+			{{else}}
+				{{if value.sensor_type >= 2}}
+					{{if value.pulse != "N/A"}}
+						{{if value.true_pulse == -1}}
+							<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>
+						{{else}}
+							<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span> bpm</td>
+						{{/if}}
+					{{else value.charge_span != "N/A"}}
+						<td><span class="white">Charge</span> <span class='{{:value.charge_span}}'>{{:value.charge}}%</span></td>
 					{{else}}
-						<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span> bpm</td>
+						<td><span class="white">Pulse</span> <span class="white">N/A</span></td>
 					{{/if}}
-				{{else value.charge_span != "N/A"}}
-					<td><span class="white">Charge</span> <span class='{{:value.charge_span}}'>{{:value.charge}}%</span></td>
 				{{else}}
-					<td><span class="white">Pulse</span> <span class="white">N/A</span></td>
+					{{if value.alert}}
+						<td><span class="bad">Medical issue detected</span></td>
+					{{else}}
+						<td>No issues detected</td>
+					{{/if}}
 				{{/if}}
-			{{else}}
-				{{if value.alert}}
-					<td><span class="bad">Medical issue detected</span></td>
+
+				{{if value.sensor_type >= 2}}
+					<td><span class="white">BP</span> {{:value.pressure}} {{if value.oxygenation}}(<span class='{{:value.oxygenation_span}}'>{{:value.oxygenation}}</span> oxygenation){{/if}}</td>
 				{{else}}
-					<td>No issues detected</td>
+					<td></td>
 				{{/if}}
-			{{/if}}
 
-			{{if value.sensor_type >= 2}}
-				<td><span class="white">BP</span> {{:value.pressure}} {{if value.oxygenation}}(<span class='{{:value.oxygenation_span}}'>{{:value.oxygenation}}</span> oxygenation){{/if}}</td>
-			{{else}}
-				<td></td>
-			{{/if}}
-
-			{{if value.sensor_type >= 2}}
-				<td><span class="white">Temp</span> {{:value.bodytemp}} C</td>
-			{{else}}
-				<td></td>
+				{{if value.sensor_type >= 2}}
+					<td><span class="white">Temp</span> {{:value.bodytemp}} C</td>
+				{{else}}
+					<td></td>
+				{{/if}}
 			{{/if}}
 
 			{{if value.sensor_type >= 3}}


### PR DESCRIPTION
:cl:
tweak: Braindead/deceased persons will now show as 'DEAD' on sensors.
/:cl:

![HtnpOliFXL](https://user-images.githubusercontent.com/11140088/114948030-19361f80-9e03-11eb-90e8-335016f62f3d.png)
