### PR TITLE
Adds roller beds to flying medic drones

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -25,7 +25,8 @@
 		/obj/item/device/multitool,
 		/obj/item/stack/medical/ointment,
 		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/splint
+		/obj/item/stack/medical/splint,
+		/obj/item/robot_rack/roller
 	)
 	synths = list(/datum/matter_synth/medicine = 15000)
 	emag = /obj/item/reagent_containers/spray


### PR DESCRIPTION
It's kind of vital for emergency response, otherwise there's no point being a responder if you can't transport the wounded.

:cl:
tweak: Flying medic drones now have rollerbeds.
/:cl: