### PR TITLE
Fixes Splashing Liquid into Condimasters

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -19,6 +19,7 @@
 
 	var/list/can_be_placed_into = list(
 		/obj/machinery/chem_master/,
+		/obj/machinery/chem_master/condimaster,
 		/obj/machinery/chemical_dispenser,
 		/obj/machinery/reagentgrinder,
 		/obj/structure/table,


### PR DESCRIPTION
:cl: Ryan180602
bugfix: Fixes splashing liquids in beaker when transferring to Condimasters
/:cl:

Fixes #30512 

*Why doesn't `obj/machinery/chem_master` also include `/chem_master/condimaster`*