### PR TITLE
Renames caulship in join menu

### DIFF
--- a/maps/away/ascent_caulship/ascent_jobs.dm
+++ b/maps/away/ascent_caulship/ascent_jobs.dm
@@ -5,7 +5,7 @@
 	id = WEBHOOK_SUBMAP_LOADED_ASCENT
 
 /decl/submap_archetype/ascent_caulship
-	descriptor = "Ascent colony ship"
+	descriptor = "Ascent caulship"
 	map = "Ascent Caulship"
 	blacklisted_species = null
 	whitelisted_species = null


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
tweak: Ascent caulship is no longer referred to as 'colony ship' in the join menu.
/:cl:
The caulship is still referred to as the 'ascent colony ship' in the join menu. The caulship's more of a fleeing refugee ship these days.