### PR TITLE
Paper language tweaks

### DIFF
--- a/code/modules/ascent/ascent_machines.dm
+++ b/code/modules/ascent/ascent_machines.dm
@@ -177,6 +177,7 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	req_access = list(access_ascent)
 	construct_state = /decl/machine_construction/default/panel_closed/computer/no_deconstruct
 	base_type = /obj/machinery/computer/ship/sensors
+	print_language = LANGUAGE_MANTID_VOCAL
 
 // This is an absolutely stupid machine. Basically the same as the debug one with some alterations.
 // It is a placeholder for a proper reactor setup (probably a RUST descendant)

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -35,6 +35,10 @@
 		data["battery_rating"] = battery_module.battery.maxcharge
 		data["battery_percent"] = round(battery_module.battery.percent())
 
+	// Configurable stuff
+	var/obj/item/stock_parts/computer/nano_printer/nano_printer = program.computer.get_component(/obj/item/stock_parts/computer/nano_printer)
+	data["print_language"] = nano_printer ? nano_printer.print_language : null
+
 	var/list/all_entries[0]
 	var/list/hardware = program.computer.get_all_components()
 	for(var/obj/item/stock_parts/computer/H in hardware)
@@ -57,3 +61,23 @@
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
+
+/datum/nano_module/program/computer_configurator/Topic(href, href_list)
+	. = ..()
+	if (.)
+		return
+
+	if (href_list["edit_language"])
+		var/obj/item/stock_parts/computer/nano_printer/nano_printer = program.computer.get_component(/obj/item/stock_parts/computer/nano_printer)
+		if (!nano_printer)
+			to_chat(usr, SPAN_WARNING("No printer found, unable to update language."))
+			return TOPIC_REFRESH
+		var/list/selectable_languages = list()
+		for (var/datum/language/L in usr.languages)
+			if (L.has_written_form)
+				selectable_languages += L
+		var/new_language = input(usr, "What language do you want to print in?", "Change language", nano_printer.print_language) as null|anything in selectable_languages
+		if (!new_language)
+			return TOPIC_HANDLED
+		nano_printer.print_language = new_language
+		return TOPIC_REFRESH

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -9,10 +9,12 @@
 	var/stored_paper = 50
 	var/max_paper = 50
 	var/last_print
+	var/print_language = LANGUAGE_HUMAN_EURO
 
 /obj/item/stock_parts/computer/nano_printer/diagnostics()
 	. = ..()
 	. += "Paper buffer level: [stored_paper]/[max_paper]"
+	. += "Printer language: [print_language]"
 
 /obj/item/stock_parts/computer/nano_printer/proc/print_text(var/text_to_print, var/paper_title = null, var/paper_type = /obj/item/paper, var/list/md = null)
 	if(printer_ready())
@@ -21,7 +23,7 @@
 		if(damage > damage_malfunction)
 			text_to_print = stars(text_to_print, 100-malfunction_probability)
 		var/turf/T = get_turf(src)
-		new paper_type(T,text_to_print, paper_title, md)
+		new paper_type(T, text_to_print, paper_title, md, print_language)
 		stored_paper--
 		playsound(T, "sound/machines/dotprinter.ogg", 30)
 		T.visible_message("<span class='notice'>\The [src] prints out a paper.</span>")

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -8,6 +8,12 @@
 	machine_name = "sensors console"
 	machine_desc = "Used to activate, monitor, and configure a spaceship's sensors. Higher range means higher temperature; dangerously high temperatures may fry the delicate equipment."
 	var/obj/machinery/shipsensors/sensors
+	var/print_language = LANGUAGE_HUMAN_EURO
+
+/obj/machinery/computer/ship/sensors/spacer
+	construct_state = /decl/machine_construction/default/panel_closed/computer/no_deconstruct
+	base_type = /obj/machinery/computer/ship/sensors
+	print_language = LANGUAGE_SPACER
 
 /obj/machinery/computer/ship/sensors/attempt_hook_up(obj/effect/overmap/visitable/ship/sector)
 	if(!(. = ..()))
@@ -103,7 +109,7 @@
 		var/obj/effect/overmap/O = locate(href_list["scan"])
 		if(istype(O) && !QDELETED(O) && (O in view(7,linked)))
 			playsound(loc, "sound/machines/dotprinter.ogg", 30, 1)
-			new/obj/item/paper/(get_turf(src), O.get_scan_data(user), "paper (Sensor Scan - [O])")
+			new/obj/item/paper/(get_turf(src), O.get_scan_data(user), "paper (Sensor Scan - [O])", L = print_language)
 		return TOPIC_HANDLED
 
 /obj/machinery/computer/ship/sensors/Process()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -46,11 +46,13 @@
 
 	var/scan_file_type = /datum/computer_file/data/text
 
-/obj/item/paper/New(loc, text, title, list/md = null)
+/obj/item/paper/New(loc, text, title, list/md = null, datum/language/L = null)
 	..(loc)
 	set_content(text ? text : info, title)
 	metadata = md
 
+	if (L)
+		language = L
 	var/old_language = language
 	if (!set_language(language, TRUE))
 		log_debug("[src] ([type]) initialized with invalid or missing language `[old_language]` defined.")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -52,10 +52,9 @@
 	metadata = md
 
 	var/old_language = language
-	language = global.all_languages[language]
-	if (!language)
+	if (!set_language(language, TRUE))
 		log_debug("[src] ([type]) initialized with invalid or missing language `[old_language]` defined.")
-		language = global.all_languages[LANGUAGE_HUMAN_EURO]
+		set_language(LANGUAGE_HUMAN_EURO, TRUE)
 
 /obj/item/paper/proc/set_content(text,title)
 	if(title)
@@ -65,6 +64,18 @@
 	update_icon()
 	update_space(info)
 	updateinfolinks()
+
+/obj/item/paper/proc/set_language(datum/language/new_language, force = FALSE)
+	if (!new_language || (info && !force))
+		return FALSE
+
+	if (!istype(new_language))
+		new_language = global.all_languages[new_language]
+	if (!istype(new_language))
+		return FALSE
+
+	language = new_language
+	return TRUE
 
 /obj/item/paper/on_update_icon()
 	if(icon_state == "paper_talisman" || is_memo)
@@ -87,7 +98,7 @@
 	else
 		to_chat(user, "<span class='notice'>You have to go closer if you want to read it.</span>")
 
-/obj/item/paper/verb/set_language()
+/obj/item/paper/verb/user_set_language()
 	set name = "Set writing language"
 	set category = "Object"
 	set src in usr
@@ -120,7 +131,7 @@
 	if (!admin_force && !Adjacent(user) && !CanInteract(user, GLOB.deep_inventory_state))
 		to_chat(user, SPAN_WARNING("You must remain next to or continue holding \the [src] to do that."))
 		return
-	language = new_language
+	set_language(new_language)
 
 /obj/item/paper/proc/show_content(mob/user, forceshow, editable = FALSE)
 	var/can_read = (istype(user, /mob/living/carbon/human) || isghost(user) || istype(user, /mob/living/silicon)) || forceshow

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -2631,7 +2631,7 @@
 	dir = 4;
 	icon_state = "techfloor_edges"
 	},
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/spacer{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -99,7 +99,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/command/bridge)
 "ao" = (
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/spacer{
 	dir = 8;
 	icon_state = "computer"
 	},

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -1213,7 +1213,7 @@
 /turf/simulated/floor/plating,
 /area/scavver/calypso)
 "uB" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors/spacer,
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/calypso)

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -2095,7 +2095,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/spacer{
 	dir = 4
 	},
 /obj/item/device/radio/intercom/map_preset/scavver{
@@ -3939,7 +3939,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/yachtup)
 "FK" = (
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/spacer{
 	dir = 8
 	},
 /obj/structure/cable{

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -3,6 +3,7 @@
 #include "skrellscoutship_areas.dm"
 #include "skrellscoutship_shuttles.dm"
 #include "skrellscoutship_radio.dm"
+#include "skrellscoutship_machines.dm"
 
 /datum/map_template/ruin/away_site/skrellscoutship
 	name = "Skrellian Scout Ship"

--- a/maps/away/skrellscoutship/skrellscoutship_machines.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_machines.dm
@@ -1,0 +1,4 @@
+/obj/machinery/computer/ship/sensors/skrell
+	construct_state = /decl/machine_construction/default/panel_closed/computer/no_deconstruct
+	base_type = /obj/machinery/computer/ship/sensors
+	print_language = LANGUAGE_SKRELLIAN

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -1210,7 +1210,7 @@
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/quarters)
 "en" = (
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/skrell{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/skrell/red,
@@ -1825,7 +1825,7 @@
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/hangar)
 "ga" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors/skrell,
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutshuttle)
 "gc" = (
@@ -2199,7 +2199,7 @@
 /area/ship/skrellscoutship/crew/rec)
 "gX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/skrell{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -3253,10 +3253,6 @@
 "kj" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/skrell/green,
-/area/ship/skrellscoutship/robotics)
-"km" = (
-/obj/structure/table/rack,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
 "kn" = (
@@ -12256,7 +12252,7 @@ PT
 jP
 bC
 bC
-km
+fy
 PT
 Gw
 Gw

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -1536,7 +1536,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/voxship/thrusters)
 "dq" = (
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/vox{
 	dir = 1;
 	icon_state = "computer"
 	},
@@ -3089,7 +3089,7 @@
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/shuttle)
 "ha" = (
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/vox{
 	dir = 1;
 	icon_state = "computer"
 	},

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -3,6 +3,7 @@
 #include "voxship_areas.dm"
 #include "voxship_jobs.dm"
 #include "voxship_radio.dm"
+#include "voxship_machines.dm"
 
 /datum/map_template/ruin/away_site/scavship
 	name = "Vox Scavenger Ship"

--- a/maps/away/voxship/voxship_machines.dm
+++ b/maps/away/voxship/voxship_machines.dm
@@ -1,0 +1,4 @@
+/obj/machinery/computer/ship/sensors/vox
+	construct_state = /decl/machine_construction/default/panel_closed/computer/no_deconstruct
+	base_type = /obj/machinery/computer/ship/sensors
+	print_language = LANGUAGE_VOX

--- a/nano/templates/laptop_configuration.tmpl
+++ b/nano/templates/laptop_configuration.tmpl
@@ -1,20 +1,20 @@
 <i>Welcome to computer configuration utility. Please consult your system administrator if you have any questions about your device.</i><hr>
 <h2>Power Supply</h2>
 <div class="itemLabel">
-	Battery Status: 
+	Battery Status:
 </div>
 {{if data.battery_exists}}
 	<div class="itemContent">
 		Active
 	</div>
 	<div class="itemLabel">
-		Battery Rating: 
+		Battery Rating:
 	</div>
 	<div class="itemContent">
 		{{:data.battery_rating}}
 	</div>
 	<div class="itemLabel">
-		Battery Charge: 
+		Battery Charge:
 	</div>
 	<div class="itemContent">
 		{{:helper.displayBar(data.battery_percent, 0, 100, (data.battery_percent <= 25) ? 'bad' : (data.battery_percent <= 50) ? 'average' : 'good')}}
@@ -26,12 +26,12 @@
 	</div>
 {{/if}}
 <div class="itemLabel">
-	Power Usage: 
+	Power Usage:
 </div>
 <div class="itemContent">
 	{{:data.power_usage}}W
 </div>
-<h2>File System</h2>	
+<h2>File System</h2>
 <div class="itemLabel">
 	Used Capacity:
 </div>
@@ -39,43 +39,54 @@
 	{{:helper.displayBar(data.disk_used, 0, data.disk_size, 'good')}}
 	{{:data.disk_used}}GQ / {{:data.disk_size}}GQ
 </div>
+<h2>System Configuration</h2>
+<div class="itemLabel">
+	Print Language:
+</div>
+<div class="itemContent">
+	{{if data.print_language}}
+		{{:helper.link(data.print_language, null, {'edit_language' : 1}, null)}}
+	{{else}}
+		<span class="bad">No printer installed</span>
+	{{/if}}
+</div>
 <h2>Computer Components</h2>
 {{for data.hardware}}
 	<h3>{{:value.name}}</h3>
 	<i>{{:value.desc}}</i><br>
 	<div class="itemLabel">
-		State: 
+		State:
 	</div>
 	<div class="itemContent">
 		{{:value.enabled ? "Enabled" : "Disabled"}}
-	</div>	
+	</div>
 	<div class="itemLabel">
-		Power Usage: 
+		Power Usage:
 	</div>
 	<div class="itemContent">
 		{{:value.powerusage}}W
 	</div>
 	{{if !value.critical}}
 	<div class="itemLabel">
-		Toggle Component: 
+		Toggle Component:
 	</div>
 	<div class="itemContent">
 		{{:helper.link("ON", null, {'PC_enable_component' : value.ref}, value.enabled ? 'disabled' : null)}}
 		{{:helper.link("OFF", null, {'PC_disable_component' : value.ref}, value.enabled ? null : 'disabled')}}
-	</div>			
+	</div>
 	{{/if}}
 	<br><br>
 {{/for}}
 	<h3>Auto-Updater</h3>
 	<i>Automatically downloads and installs critical OS upgrades if NTNet is reachable. Disabling voids warranty.</i><br>
 	<div class="itemLabel">
-		State: 
+		State:
 	</div>
 	<div class="itemContent">
 		{{:data.receives_updates ? "Enabled" : "Disabled"}}
-	</div>	
+	</div>
 	<div class="itemLabel">
-		Toggle Updates: 
+		Toggle Updates:
 	</div>
 	<div class="itemContent">
 		{{:helper.link("ON", null, {'PC_enable_update' : 1}, data.receives_updates ? 'disabled' : null)}}


### PR DESCRIPTION
Fixes #30510

:cl:
bugfix: Sensor consoles will now print scans in the language that makes sense for their mapped areas.
rscadd: Modular console printers can now have their printing language configured in the 'Computer Configuration Tool' menu for the console. These languages are limited to what languages the user knows.
admin: A `set_language()` proc has been added to papers to allow for easier changing of a paper's language without dealing with VV, which likes to crash clients when editing the language var for some reason.
/:cl: