### PR TITLE
Fix some buildmode nanoui's not working if not ghosted

### DIFF
--- a/code/modules/admin/buildmode/_build_mode.dm
+++ b/code/modules/admin/buildmode/_build_mode.dm
@@ -66,3 +66,8 @@
 		return matches[1]
 	else
 		return (input("Select a type", "Select Type", matches[1]) as null|anything in matches)
+
+/datum/build_mode/CanUseTopic(mob/user)
+	if (check_rights(R_BUILDMODE, TRUE, user))
+		return STATUS_INTERACTIVE
+	return ..()


### PR DESCRIPTION
Fixes #30553

:cl: Mucker
admin: Fixed some buildmode nanoui's not working if you weren't ghosted. 
/:cl: