### PR TITLE
Changes how mech rads are handled

### DIFF
--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -93,7 +93,8 @@
 		if(BURN)
 			adjustFireLoss(damage, target)
 		if(IRRADIATE)
-			radiation += damage
+			for(var/mob/living/pilot in pilots)
+				pilot.apply_damage(damage, IRRADIATE, def_zone, damage_flags, used_weapon)
 
 	if((damagetype == BRUTE || damagetype == BURN) && prob(25+(damage*2)))
 		sparks.set_up(3,0,src)
@@ -103,13 +104,14 @@
 	return 1
 
 /mob/living/exosuit/rad_act(var/severity)
-	if(severity)
-		apply_damage(severity, IRRADIATE, damage_flags = DAM_DISPERSED)
+	return FALSE // Pilots already query rads, modify this for radiation alerts and such
 
 /mob/living/exosuit/get_rads()
+	. = ..()
 	if(!hatch_closed || (body.pilot_coverage < 100)) //Open, environment is the source
-		return ..()
-	return radiation //Closed, what made it through our armour?
+		return .
+	var/list/after_armor = modify_damage_by_armor(null, ., IRRADIATE, DAM_DISPERSED, src, 0, TRUE)
+	return after_armor[1]	
 
 /mob/living/exosuit/getFireLoss()
 	var/total = 0

--- a/code/modules/mechs/mech_life.dm
+++ b/code/modules/mechs/mech_life.dm
@@ -46,12 +46,6 @@
 	lying = FALSE // Fuck off, carp.
 	handle_vision(powered)
 
-/mob/living/exosuit/handle_mutations_and_radiation()
-	radiation = Clamp(radiation,0,500) //Dont let exosuits accumulate radiation
-
-	if(radiation)
-		radiation--
-
 /mob/living/exosuit/get_cell(force)
 	RETURN_TYPE(/obj/item/cell)
 	if(power == MECH_POWER_ON || force) //For most intents we can assume that a powered off exosuit acts as if it lacked a cell


### PR DESCRIPTION
🆑CrimsonShrike
tweak: Exosuits no longer accumulate radiation. They will instead return radiation at current location reduced by armour directly.
/🆑

closes #30555

This makes mech simply return turf rads, or when hit by radioactive weaponry, said rads. 

Mechs no longer care about radiation and will not accumulate it.