### PR TITLE
Nerf CPR restarting the heart

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -101,7 +101,7 @@
 					if(heart)
 						heart.external_pump = list(world.time, 0.4 + 0.1*pumping_skill + rand(-0.1,0.1))
 
-					if(stat != DEAD && prob(10 + 5 * pumping_skill))
+					if(stat != DEAD && prob(2 * pumping_skill))
 						resuscitate()
 
 				if(!H.check_has_mouth())


### PR DESCRIPTION
Changes the logic behind chest compressions being able to restart the heart.

Having upwards of a 40% chance per compression with the old logic is absurd and frankly makes defibrillators worthless. The new chances to restart the heart per compression for each skill are:
- 2% for untrained
- 4% for basic
- 6% for trained
- 8% for experienced
- 10% for master

This should make defibrillators much more useful and needed to definitively restart a failing heart, while still giving a slight hope for people stuck without one.

For people who think these percents are too low, bear in mind the following:
- CPR will provide an oxygenation bonus for 20 seconds after the last time compressions were performed, meaning that spamming it only continues rolling the dice to restart the heart.
- Statistically, someone with trained medicine/anatomy will restart the heart an average of 1/17 compressions. Given that CPR is faster the higher your skill, and it only takes a couple of seconds per compression even at mid-tier levels, you will be able to resuscitate someone within 1-2 minutes. If these minutes are critical, then get a defibrillator in the 20-second grace period instead of wasting time spamming CPR.

:cl: 
tweak: CPR now is much less likely to restart a stopped heart.
/:cl: