### PR TITLE
Fix Petrov's atmos laptop access

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -16084,7 +16084,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/computer/atmoscontrol/laptop{
 	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
-	req_access = list("ACCESS_TORCH_PETROV_MAINT")
+	req_access = list("ACCESS_TORCH_PETROV")
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;


### PR DESCRIPTION
:cl: Mucker
tweak: Tweak Petrov's atmos laptop access so all science personnel can use it.
/:cl:

For some reason only those with Petrov access _and_ maintenance access could use the laptop, so this fixes it for those in the research assistant role, and possibly others.