### PR TITLE
Prevent zombies from being comatose

### DIFF
--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -61,6 +61,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	weaken_mod = 0.05
 	paralysis_mod = 0.2
 	show_ssd = null //No SSD message so NPC logic can take over
+	show_coma = null
 	warning_low_pressure = 0
 	hazard_low_pressure = 0
 	body_temperature = null


### PR DESCRIPTION
Fixes #30571 

:cl:
bugfix: AI-controlled zombies are no longer permanently comatose.
/:cl: