### PR TITLE
Makes nanoblood risky again

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -958,9 +958,9 @@
 	if(!M.should_have_organ(BP_HEART)) //We want the var for safety but we can do without the actual blood.
 		return
 	if(M.regenerate_blood(4 * removed))
-		M.immunity = max(M.immunity - 0.1, 0)
+		M.immunity = max(M.immunity - 0.75, 0)
 		if(M.chem_doses[type] > M.species.blood_volume/8) //half of blood was replaced with us, rip white bodies
-			M.immunity = max(M.immunity - 0.5, 0)
+			M.immunity = max(M.immunity - 3, 0)
 
 // Sleeping agent, produced by breathing N2O.
 /datum/reagent/nitrous_oxide


### PR DESCRIPTION
🆑 
tweak: Nanoblood now dents a mob's immunity more.
/🆑 

Because magic blood with no tangible downside is lame. Values chosen are 75% of the oregano ones from when it was introduced.