### PR TITLE
Remove mercenary combo roundtypes

### DIFF
--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -1,3 +1,4 @@
+/*
 /datum/game_mode/crossfire
 	name = "Mercenary & Heist"
 	round_description = "Mercenaries and raiders are preparing for a nice visit..."
@@ -8,3 +9,4 @@
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)
 	require_all_templates = TRUE
+*/

--- a/code/game/gamemodes/mixed/siege.dm
+++ b/code/game/gamemodes/mixed/siege.dm
@@ -1,3 +1,4 @@
+/*
 /datum/game_mode/siege
 	name = "Mercenary & Revolution"
 	config_tag = "siege"
@@ -10,3 +11,4 @@
 	shuttle_delay = 2
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_MERCENARY)
 	require_all_templates = TRUE
+*/

--- a/maps/torch/datums/game_modes/torch_siege.dm
+++ b/maps/torch/datums/game_modes/torch_siege.dm
@@ -1,4 +1,6 @@
+/*
 /datum/game_mode/siege
 	name = "Mercenary & Mutiny"
 	round_description = "Getting stuck between a rock and a hard place, maybe the nice visitors can help with your internal security problem?"
 	extended_round_description = "GENERAL QUARTERS! OH GOD WE GAVE THE MUTINEERS GUNS!"
+*/


### PR DESCRIPTION
I'd remove mercenary itself too but that's connected to a lot of other stuff and I can't be bothered. Will probably need a config change(?). The code is only commented out in case it's needed in the future.

:cl:
rscdel: Removes Mercenary & Mutiny and Mercenary & Heist gamemodes.
/:cl: