### PR TITLE
Moves flash modules to antag borgs instead of default

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -21,7 +21,6 @@
 		"Default" = "Service2"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/gripper/service,
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/material/minihoe,
@@ -38,7 +37,12 @@
 		/obj/item/tray/robotray,
 		/obj/item/reagent_containers/borghypo/service
 	)
-	emag = /obj/item/reagent_containers/food/drinks/bottle/small/beer
+
+	emag =  list(
+		/obj/item/device/flash,
+		/obj/item/reagent_containers/food/drinks/bottle/small/beer
+	)
+
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_PROF,
 		SKILL_COMPUTER            = SKILL_EXPERT,
@@ -85,7 +89,6 @@
 		"Default" =  "Service2"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/pen/robopen,
 		/obj/item/form_printer,
 		/obj/item/gripper/clerical,
@@ -96,7 +99,12 @@
 		/obj/item/crowbar,
 		/obj/item/stack/package_wrap/cyborg
 	)
-	emag = /obj/item/stamp/chameleon
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/stamp/chameleon
+	)
+
 	synths = list(
 		/datum/matter_synth/package_wrap
 	)

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -22,7 +22,6 @@
 	)
 	no_slip = 1
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/meson,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/hugetank,
@@ -64,7 +63,12 @@
 		/datum/matter_synth/plasteel = 20000,
 		/datum/matter_synth/wire =     50
 	)
-	emag = /obj/item/melee/baton/robot/electrified_arm
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/melee/baton/robot/electrified_arm
+	)
+
 	skills = list(
 		SKILL_ATMOS        = SKILL_PROF,
 		SKILL_ENGINES      = SKILL_PROF,

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -10,7 +10,6 @@
 		"Mop Gear Rex" = "mopgearrex"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/soap,
 		/obj/item/storage/bag/trash,
 		/obj/item/mop/advanced,
@@ -21,7 +20,11 @@
 		/obj/item/crowbar,
 		/obj/item/weldingtool
 	)
-	emag = /obj/item/reagent_containers/spray
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/reagent_containers/spray
+	)
 
 /obj/item/robot_module/janitor/finalize_emag()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -25,7 +25,6 @@
 		"Needles" = "medicalrobot"
 		)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/reagent_containers/borghypo/surgeon,
@@ -46,10 +45,16 @@
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/reagent_containers/dropper
 	)
+
 	synths = list(
 		/datum/matter_synth/medicine = 10000,
 	)
-	emag = /obj/item/reagent_containers/spray
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/reagent_containers/spray
+	)
+
 	skills = list(
 		SKILL_ANATOMY     = SKILL_PROF,
 		SKILL_MEDICAL     = SKILL_EXPERT,
@@ -100,7 +105,6 @@
 	)
 	equipment = list(
 		/obj/item/crowbar,
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/device/scanner/reagent/adv,
@@ -120,7 +124,11 @@
 	synths = list(
 		/datum/matter_synth/medicine = 15000
 	)
-	emag = /obj/item/reagent_containers/spray
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/reagent_containers/spray
+	)
+
 	skills = list(
 		SKILL_ANATOMY     = SKILL_BASIC,
 		SKILL_MEDICAL     = SKILL_PROF,

--- a/code/modules/mob/living/silicon/robot/modules/module_miner.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_miner.dm
@@ -20,7 +20,6 @@
 		/obj/item/borg/upgrade/jetpack
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/meson,
 		/obj/item/wrench,
 		/obj/item/screwdriver,
@@ -31,7 +30,12 @@
 		/obj/item/device/scanner/mining,
 		/obj/item/crowbar
 	)
-	emag = /obj/item/gun/energy/plasmacutter
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/gun/energy/plasmacutter
+	)
+
 	skills = list(
 		SKILL_PILOT        = SKILL_EXPERT,
 		SKILL_EVA          = SKILL_PROF,

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -11,7 +11,6 @@
 		"Droid" = "droid-science"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/portable_destructive_analyzer,
 		/obj/item/gripper/research,
 		/obj/item/gripper/no_use/loader,
@@ -29,10 +28,16 @@
 		/obj/item/gripper/chemistry,
 		/obj/item/stack/nanopaste
 	)
+
 	synths = list(
 		/datum/matter_synth/nanite = 10000
 	)
-	emag = /obj/prefab/hand_teleporter
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/prefab/hand_teleporter
+	)
+
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_EXPERT,
 		SKILL_FINANCE             = SKILL_EXPERT,

--- a/code/modules/mob/living/silicon/robot/modules/module_standard.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_standard.dm
@@ -7,13 +7,17 @@
 		"Default" = "robot"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/extinguisher,
 		/obj/item/wrench,
 		/obj/item/crowbar,
 		/obj/item/device/scanner/health
 	)
-	emag = /obj/item/melee/energy/sword
+
+	emag = list(
+		/obj/item/device/flash,
+		/obj/item/melee/energy/sword
+	)
+
 	skills = list(
 		SKILL_COMBAT       = SKILL_ADEPT,
 		SKILL_MEDICAL      = SKILL_ADEPT,


### PR DESCRIPTION
🆑 
tweak: Non-sec robots now only get flashes on being emagged or becoming a traitor.
/🆑

Basically, if the fleshy job equivalent doesn't get a flash in their locker, the robot doesn't either.  