### PR TITLE
Halves adrenaline resuscitation damage

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -920,7 +920,7 @@
 		remove_self(5)
 		if(M.resuscitate())
 			var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
-			heart.take_internal_damage(heart.max_damage * 0.15)
+			heart.take_internal_damage(heart.max_damage * 0.075)
 
 /datum/reagent/lactate
 	name = "Lactate"


### PR DESCRIPTION
🆑 
tweak: Using adrenaline to start a stopped heart now does half as much damage.
/🆑 

On suggestion from some medical folks. Open to feedback, as usual.