### PR TITLE
Removes flashes from non-sec borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -9,7 +9,6 @@
 		"Eyebot" = "eyebot-medical"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/device/scanner/reagent/adv,

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -7,7 +7,6 @@
 		)
 	sprites = list("Drone" = "drone-service")
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/pen/robopen,
 		/obj/item/form_printer,
 		/obj/item/gripper/clerical,

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -21,7 +21,6 @@
 		"Default" = "Service2"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/gripper/service,
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/material/minihoe,
@@ -85,7 +84,6 @@
 		"Default" =  "Service2"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/pen/robopen,
 		/obj/item/form_printer,
 		/obj/item/gripper/clerical,

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -22,7 +22,6 @@
 	)
 	no_slip = 1
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/meson,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/hugetank,

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -10,7 +10,6 @@
 		"Mop Gear Rex" = "mopgearrex"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/soap,
 		/obj/item/storage/bag/trash,
 		/obj/item/mop/advanced,

--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -25,7 +25,6 @@
 		"Needles" = "medicalrobot"
 		)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/reagent_containers/borghypo/surgeon,
@@ -100,7 +99,6 @@
 	)
 	equipment = list(
 		/obj/item/crowbar,
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/device/scanner/reagent/adv,

--- a/code/modules/mob/living/silicon/robot/modules/module_miner.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_miner.dm
@@ -20,7 +20,6 @@
 		/obj/item/borg/upgrade/jetpack
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/meson,
 		/obj/item/wrench,
 		/obj/item/screwdriver,

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -11,7 +11,6 @@
 		"Droid" = "droid-science"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/portable_destructive_analyzer,
 		/obj/item/gripper/research,
 		/obj/item/gripper/no_use/loader,

--- a/code/modules/mob/living/silicon/robot/modules/module_standard.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_standard.dm
@@ -7,7 +7,6 @@
 		"Default" = "robot"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/extinguisher,
 		/obj/item/wrench,
 		/obj/item/crowbar,


### PR DESCRIPTION
🆑 
tweak: Removes flashes from non-security borg modules.
/🆑

You don't need them. 

Traitor borgs will get them once I scream enough at things to make #30589 work. 