### PR TITLE
Add selected target zone to attack logs

### DIFF
--- a/code/datums/repositories/attack_logs.dm
+++ b/code/datums/repositories/attack_logs.dm
@@ -14,6 +14,7 @@ var/repository/attack_logs/attack_log_repository = new()
 /datum/attack_log
 	var/station_time
 	var/intent
+	var/zone_sel
 	var/datum/mob_lite/attacker      // We don't store the proper mob in case it gets deleted
 	var/datum/mob_lite/victim
 	var/turf/location                // Turfs are forever
@@ -33,6 +34,7 @@ var/repository/attack_logs/attack_log_repository = new()
 		message = "[victim.name] [action_message]"
 
 	intent = mob_attacker ? uppertext(mob_attacker.a_intent) : "N/A"
+	zone_sel = mob_attacker.zone_sel?.selecting ? uppertext(mob_attacker.zone_sel.selecting) : "N/A"
 
 	if(mob_attacker)
 		location = get_turf(mob_attacker)

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -48,17 +48,20 @@
 
 	var/turf/attack_location
 	var/intent = "(INTENT: N/A)"
+	var/zone_sel = "(ZONE_SEL: N/A)"
 	if(attacker)
 		intent = "(INTENT: [uppertext(attacker.a_intent)])"
+		if (attacker.zone_sel?.selecting)
+			zone_sel = "(ZONE_SEL: [uppertext(attacker.zone_sel.selecting)])"
 		if(victim)
-			attacker.attack_logs_ += text("\[[time_stamp()]\] <font color='red'>[key_name(victim)] - [attacker_message] [intent]</font>")
+			attacker.attack_logs_ += text("\[[time_stamp()]\] <font color='red'>[key_name(victim)] - [attacker_message] [intent] [zone_sel]</font>")
 		else
-			attacker.attack_logs_ += text("\[[time_stamp()]\] <font color='red'>[attacker_message] [intent]</font>")
+			attacker.attack_logs_ += text("\[[time_stamp()]\] <font color='red'>[attacker_message] [intent] [zone_sel]</font>")
 		attacker.last_attacked_ = mob_repository.get_lite_mob(victim)
 		attack_location = get_turf(attacker)
 	if(victim)
 		if(attacker)
-			victim.attack_logs_ += text("\[[time_stamp()]\] <font color='orange'>[key_name(attacker)] - [victim_message] [intent]</font>")
+			victim.attack_logs_ += text("\[[time_stamp()]\] <font color='orange'>[key_name(attacker)] - [victim_message] [intent] [zone_sel]</font>")
 		else
 			victim.attack_logs_ += text("\[[time_stamp()]\] <font color='orange'>[victim_message]</font>")
 		victim.last_attacker_ = mob_repository.get_lite_mob(attacker)
@@ -72,9 +75,9 @@
 
 	var/full_admin_message
 	if(attacker && victim)
-		full_admin_message = "[key_name(attacker)] [admin_message] [key_name(victim)] (INTENT: [attacker? uppertext(attacker.a_intent) : "N/A"])"
+		full_admin_message = "[key_name(attacker)] [admin_message] [key_name(victim)] [intent] [zone_sel]"
 	else if(attacker)
-		full_admin_message = "[key_name(attacker)] [admin_message] (INTENT: [attacker? uppertext(attacker.a_intent) : "N/A"])"
+		full_admin_message = "[key_name(attacker)] [admin_message] [intent] [zone_sel]"
 	else
 		full_admin_message = "[key_name(victim)] [admin_message]"
 	full_admin_message = append_admin_tools(full_admin_message, attacker||victim, attack_location)

--- a/code/modules/admin/secrets/investigation/attack_logs.dm
+++ b/code/modules/admin/secrets/investigation/attack_logs.dm
@@ -16,7 +16,7 @@
 	dat += " | <a href='?src=\ref[src];reset=1'>Reset</a>"
 	dat += "<HR>"
 	dat += "<table border='1' style='width:100%;border-collapse:collapse;'>"
-	dat += "<tr><th style='text-align:left;'>Time</th><th style='text-align:left;'>Attacker</th><th style='text-align:left;'>Intent</th><th style='text-align:left;'>Victim</th></tr>"
+	dat += "<tr><th style='text-align:left;'>Time</th><th style='text-align:left;'>Attacker</th><th style='text-align:left;'>Intent</th><th style='text-align:left;'>Zone Sel</th><th style='text-align:left;'>Victim</th></tr>"
 
 	for(var/log in attack_log_repository.attack_logs_)
 		var/datum/attack_log/al = log
@@ -32,13 +32,15 @@
 
 		dat += "<td>[al.intent]</td>"
 
+		dat += "<td>[al.zone_sel]</td>"
+
 		if(al.victim)
 			dat += "<td>[al.victim.key_name(check_if_offline = FALSE)] <a HREF='?_src_=holder;adminplayeropts=[al.victim.ref]'>PP</a></td>"
 		else
 			dat += "<td></td>"
 
 		dat += "</tr>"
-		dat += "<tr><td colspan=4>[al.message]"
+		dat += "<tr><td colspan=5>[al.message]"
 		if(al.location)
 			dat += " <a HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[al.location.x];Y=[al.location.y];Z=[al.location.z]'>JMP</a>"
 		dat += "</td></tr>"


### PR DESCRIPTION
Intended to tell when someone's been aiming for specific power gamey targets.

:cl:
admin: Attack logs now show the attacker's selected target zone.
/:cl:

![dreamseeker_CBqoIsXGpB](https://user-images.githubusercontent.com/11140088/116188085-9d2db880-a6db-11eb-9b26-a02ed95ed213.png)
![len64dwjs2](https://user-images.githubusercontent.com/11140088/116188090-9e5ee580-a6db-11eb-98ad-5daec6e26a2e.png)
