### PR TITLE
Thaler stacks now split the same way as material stacks

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -93,24 +93,27 @@
 	else
 		w_class = ITEM_SIZE_SMALL
 
-/obj/item/spacecash/bundle/attack_self()
-	var/amount = input(usr, "How many [GLOB.using_map.local_currency_name] do you want to take? (0 to [src.worth])", "Take Money", 20) as num
-	amount = round(Clamp(amount, 0, src.worth))
-	if(amount==0) return 0
+/obj/item/spacecash/bundle/attack_hand(mob/user as mob)
+	if (user.get_inactive_hand() == src)
+		var/amount = input(usr, "How many [GLOB.using_map.local_currency_name] do you want to take? (0 to [src.worth])", "Take Money", 20) as num
+		amount = round(Clamp(amount, 0, src.worth))
+		if (amount==0) return 0
 
-	src.worth -= amount
-	src.update_icon()
-	if(amount in list(1000,500,200,100,50,20,1))
-		var/cashtype = text2path("/obj/item/spacecash/bundle/c[amount]")
-		var/obj/cash = new cashtype (usr.loc)
-		usr.put_in_hands(cash)
+		src.worth -= amount
+		src.update_icon()
+		if (amount in list(1000,500,200,100,50,20,1))
+			var/cashtype = text2path("/obj/item/spacecash/bundle/c[amount]")
+			var/obj/cash = new cashtype (usr.loc)
+			usr.put_in_hands(cash)
+		else
+			var/obj/item/spacecash/bundle/bundle = new (usr.loc)
+			bundle.worth = amount
+			bundle.update_icon()
+			usr.put_in_hands(bundle)
+		if (!worth)
+			qdel(src)
 	else
-		var/obj/item/spacecash/bundle/bundle = new (usr.loc)
-		bundle.worth = amount
-		bundle.update_icon()
-		usr.put_in_hands(bundle)
-	if(!worth)
-		qdel(src)
+		..()
 
 /obj/item/spacecash/bundle/c1
 	name = "1 Thaler"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
tweak: You now split thaler stacks using your other hand, just as you do for material stacks.
/:cl:
Changes how thaler stacks are split. You now click on the stack with your other hand to split the bundle instead of using it in-hand, which is the same behaviour as material stacks and should be more familiar.