### PR TITLE
Tweak VV so search results stay after refreshing (ported from Polaris)

### DIFF
--- a/code/js/view_variables.js
+++ b/code/js/view_variables.js
@@ -1,26 +1,52 @@
-function updateSearch() {
-	var filter_text = document.getElementById('filter');
-	var filter = filter_text.value.toLowerCase();
+// main search functionality
+var last_filter = "";
+function updateSearch(refid) {
+	var filter = document.getElementById('filter').value.toLowerCase();
+	var vars_ol = document.getElementById("vars");
 
-	var vars_ol = document.getElementById('vars');
-	var lis = vars_ol.children;
-	// the above line can be changed to vars_ol.getElementsByTagName("li") to filter child lists too
-	// potential todo: implement a per-admin toggle for this
+	if (filter === last_filter) {
+		// An event triggered an update but nothing has changed.
+		return;
+	} else if (filter.indexOf(last_filter) === 0) {
+		// The new filter starts with the old filter, fast path by removing only.
+		var children = vars_ol.childNodes;
+		for (var i = children.length - 1; i >= 0; --i) {
+			try {
+				var li = children[i];
+				if (li.innerText.toLowerCase().indexOf(filter) == -1) {
+					vars_ol.removeChild(li);
+				}
+			} catch(err) {}
+		}
+	} else {
+		// Remove everything and put back what matches.
+		while (vars_ol.hasChildNodes()) {
+			vars_ol.removeChild(vars_ol.lastChild);
+		}
 
-	for(var i = 0; i < lis.length; i++) {
-		var li = lis[i];
-		if(filter == "" || li.innerText.toLowerCase().indexOf(filter) != -1) {
-			li.style.display = "block";
-		} else {
-			li.style.display = "none";
+		for (var i = 0; i < complete_list.length; ++i) {
+			try {
+				var li = complete_list[i];
+				if (!filter || li.innerText.toLowerCase().indexOf(filter) != -1) {
+					vars_ol.appendChild(li);
+				}
+			} catch(err) {}
 		}
 	}
+
+	last_filter = filter;
+	document.cookie="[refid]][cookieoffset]search="+encodeURIComponent(filter);
 }
 
-function selectTextField() {
+function selectTextField(refid) {
 	var filter_text = document.getElementById('filter');
 	filter_text.focus();
 	filter_text.select();
+	var lastsearch = getCookie("[refid]][cookieoffset]search");
+	if (lastsearch) {
+		filter_text.value = lastsearch;
+		updateSearch(refid);
+	}
 }
 
 function loadPage(list) {
@@ -30,4 +56,15 @@ function loadPage(list) {
 
 	location.href=list.options[list.selectedIndex].value;
 	list.selectedIndex = 0;
+}
+
+function getCookie(cname) {
+	var name = cname + "=";
+	var ca = document.cookie.split(';');
+	for (var i=0; i<ca.length; i++) {
+		var c = ca[i];
+		while (c.charAt(0)==' ') c = c.substring(1,c.length);
+		if (c.indexOf(name)==0) return c.substring(name.length,c.length);
+	}
+	return "";
 }

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -14,6 +14,8 @@
 	if(!D)
 		return
 
+	var/static/cookieoffset = rand(1, 9999) //to force cookies to reset after the round.
+
 	var/icon/sprite
 	var/atom/A
 	if(istype(D, /atom))
@@ -34,7 +36,7 @@
 				.value { font-family: "Courier New", monospace; font-size: 8pt; }
 			</style>
 		</head>
-		<body onload='selectTextField(); updateSearch()'; onkeyup='updateSearch()'>
+		<body onload='selectTextField(\ref[D]); updateSearch(\ref[D])'; onkeyup='updateSearch(\ref[D])'>
 			<div align='center'>
 				<table width='100%'><tr>
 					<td width='50%'>
@@ -94,6 +96,11 @@
 			<ol id='vars'>
 				[make_view_variables_var_list(D)]
 			</ol>
+			<script type='text/javascript'>
+				var complete_list = \[\];
+				var lis = document.getElementById("vars").children;
+				for(var i = lis.length; i--;) complete_list\[i\] = lis\[i\];
+			</script>
 		</body>
 		</html>
 		"}


### PR DESCRIPTION
:cl: Mucker
admin: Search results in VV will remain in view after clicking 'refresh'.
/:cl:

Seems to have the minor consequence of making search results persistent through different VV windows if the user doesn't backspace it out, but I didn't find it to be much of an issue.