### PR TITLE
Allows Skrell to spawn as Verne Xenoscience Student

### DIFF
--- a/maps/away/verne/verne_jobs.dm
+++ b/maps/away/verne/verne_jobs.dm
@@ -55,7 +55,7 @@
 	info = "You are an undergraduate xenoscience researcher on the SRV Verne, alongside the rest of your class of the prestigious Ceti Technical Institute conducting research \
 	in the depths of space. A survey team will be accompanying you, on hand to assist your studies on the exoplanets in this system. Your team has awoken \
 	to find the Verne running at low capacity, under-staffed, with much of the automated life support systems doing the heavy lifting."
-	whitelisted_species = list(SPECIES_HUMAN,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_TRITONIAN)
+	whitelisted_species = list(SPECIES_HUMAN,SPECIES_SPACER,SPECIES_GRAVWORLDER,SPECIES_VATGROWN,SPECIES_TRITONIAN,SPECIES_SKRELL)
 	required_language = LANGUAGE_HUMAN_EURO
 	min_skill = list(
 		SKILL_BUREAUCRACY = SKILL_BASIC,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 
tweak: Skrell can now spawn as CTI Xenoscience Researchers.
/🆑 
Upon request. Skrell in a notable human university was marginally declined when first proposed, because it would be a major downgrade for them.

It's still a major downgrade from a lore perspective, but it's about as reasonable as Skrell in the EC.
And someone asked.