### PR TITLE
Make scanner modules repairable with nanopaste & cable coil

### DIFF
--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -52,6 +52,26 @@
 
 /obj/item/stock_parts/computer/scanner/attackby(obj/W, mob/living/user)
 	do_on_attackby(user, W)
+	// Nanopaste. Repair all damage if present for a single unit.
+	var/obj/item/stack/S = W
+	if (istype(S, /obj/item/stack/nanopaste))
+		if (!damage)
+			to_chat(user, "\The [src] doesn't seem to require repairs.")
+			return TRUE
+		if (S.use(1))
+			to_chat(user, "You apply a bit of \the [W] to \the [src]. It immediately repairs all damage.")
+			damage = 0
+		return TRUE
+	// Cable coil. Works as repair method, but will probably require multiple applications and more cable.
+	if (isCoil(S))
+		if (!damage)
+			to_chat(user, "\The [src] doesn't seem to require repairs.")
+			return TRUE
+		if (S.use(1))
+			to_chat(user, "You patch up \the [src] with a bit of \the [W].")
+			take_damage(-10)
+		return TRUE
+	return ..()
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_attackby(mob/user, atom/target)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This PR adds the ability to repair modular scanners (for medical, atmospheric, etc. PDAs) with nanopaste or cable coil, bringing them in line with other pieces of modular hardware. These changes were tested on a local server and appear to work - if they don't, please let me know.
:cl: NL208
tweak: Makes all modular scanners repairable with nanopaste or cable.
/:cl: