### PR TITLE
Modular computer power tweaks

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -3,6 +3,8 @@
 		last_power_usage = 0
 		return 0
 
+	handle_power() // Handles all power interaction
+
 	if(damage > broken_damage)
 		shutdown_computer()
 		return 0

--- a/code/modules/modular_computers/computers/modular_computer/power.dm
+++ b/code/modules/modular_computers/computers/modular_computer/power.dm
@@ -1,4 +1,4 @@
-/obj/item/modular_computer/proc/power_failure(var/malfunction = 0)
+/obj/item/modular_computer/proc/power_failure(malfunction = 0)
 	if(enabled) // Shut down the computer
 		visible_message("<span class='danger'>\The [src]'s screen flickers briefly and then goes dark.</span>", range = 1)
 		var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
@@ -6,8 +6,8 @@
 			os.event_powerfailure()
 		shutdown_computer(0)
 
-// Tries to use power from battery. Passing 0 as parameter results in this proc returning whether battery is functional or not.
-/obj/item/modular_computer/proc/battery_power(var/power_usage = 0)
+/// Tries to use power from battery. Passing false as a parameter results in this proc returning whether battery is functional or not.
+/obj/item/modular_computer/proc/battery_power(power_usage = FALSE)
 	apc_powered = FALSE
 	if(!battery_module || !battery_module.check_functionality() || battery_module.battery.charge <= 0)
 		return FALSE
@@ -15,8 +15,8 @@
 		return TRUE
 	return FALSE
 
-// Tries to use power from APC, if present.
-/obj/item/modular_computer/proc/apc_power(var/power_usage = 0)
+/// Tries to use power from APC, if present.
+/obj/item/modular_computer/proc/apc_power(power_usage = 0)
 	apc_powered = TRUE
 	// Tesla link was originally limited to machinery only, but this probably works too, and the benefit of being able to power all devices from an APC outweights
 	// the possible minor performance loss.
@@ -27,26 +27,31 @@
 		return FALSE
 
 	// At this point, we know that APC can power us for this tick. Check if we also need to charge our battery, and then actually use the power.
-	if(battery_module && (battery_module.battery.charge < battery_module.battery.maxcharge) && (power_usage > 0))
+	if(battery_module && (battery_module.battery.charge < battery_module.battery.maxcharge))
 		power_usage += tesla_link.passive_charging_rate
 		battery_module.battery.give(tesla_link.passive_charging_rate * CELLRATE)
 
 	A.use_power_oneoff(power_usage, EQUIP)
 	return TRUE
 
-// Handles power-related things, such as battery interaction, recharging, shutdown when it's discharged
-/obj/item/modular_computer/proc/calculate_power_usage()
-	var/power_usage = screen_on ? base_active_power_usage : base_idle_power_usage
-	for(var/obj/item/stock_parts/computer/H in get_all_components())
-		if(H.enabled)
-			power_usage += H.power_usage
-
-/obj/item/modular_computer/proc/handle_power()
-	last_power_usage = calculate_power_usage()
-
+/// Tries to use power in general (Abstraction)
+/obj/item/modular_computer/proc/computer_use_power(power_usage = 0)
 	// First tries to charge from an APC, if APC is unavailable switches to battery power. If neither works the computer fails.
-	if(apc_power(last_power_usage))
-		return
-	if(battery_power(last_power_usage))
+	if(apc_power(power_usage))
+		return TRUE
+	if(battery_power(power_usage))
+		return TRUE
+	return FALSE
+
+/// Handles power-related things, such as battery interaction, recharging, shutdown when it's discharged
+/obj/item/modular_computer/proc/handle_power()
+	var/power_usage = screen_on ? base_active_power_usage : base_idle_power_usage
+	if(enabled)
+		for(var/obj/item/stock_parts/computer/H in get_all_components())
+			if(H.enabled)
+				power_usage += H.power_usage
+		last_power_usage = power_usage
+
+	if(computer_use_power(power_usage))
 		return
 	power_failure()

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -2,51 +2,51 @@
 // have tremendeous capacity in comparsion. Higher tier cells would provide your device with nearly infinite battery life, which is something i want to avoid.
 /obj/item/stock_parts/computer/battery_module
 	name = "standard battery"
-	desc = "A standard power cell, commonly seen in high-end portable microcomputers or low-end laptops. It's rating is 75 Wh."
+	desc = "A standard power cell, commonly seen in high-end portable microcomputers or low-end laptops. It's rating is 120 Wh."
 	icon_state = "battery_normal"
 	critical = 1
 	malfunction_probability = 1
 	origin_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
-	var/battery_rating = 75
+	var/battery_rating = 120
 	var/obj/item/cell/battery = null
 
 /obj/item/stock_parts/computer/battery_module/advanced
 	name = "advanced battery"
-	desc = "An advanced power cell, often used in most laptops. It is too large to be fitted into smaller devices. It's rating is 110 Wh."
+	desc = "An advanced power cell, often used in most laptops. It is too large to be fitted into smaller devices. It's rating is 650 Wh."
 	icon_state = "battery_advanced"
 	origin_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	hardware_size = 2
-	battery_rating = 110
+	battery_rating = 650
 
 /obj/item/stock_parts/computer/battery_module/super
 	name = "super battery"
-	desc = "A very advanced power cell, often used in high-end devices, or as uninterruptable power supply for important consoles or servers. It's rating is 150 Wh."
+	desc = "A very advanced power cell, often used in high-end devices, or as uninterruptable power supply for important consoles or servers. It's rating is 820 Wh."
 	icon_state = "battery_super"
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
 	hardware_size = 2
-	battery_rating = 150
+	battery_rating = 820
 
 /obj/item/stock_parts/computer/battery_module/ultra
 	name = "ultra battery"
-	desc = "A very advanced large power cell. It's often used as uninterruptable power supply for critical consoles or servers. It's rating is 200 Wh."
+	desc = "A very advanced large power cell. It's often used as uninterruptable power supply for critical consoles or servers. It's rating is 1100 Wh."
 	icon_state = "battery_ultra"
 	origin_tech = list(TECH_POWER = 5, TECH_ENGINEERING = 4)
 	hardware_size = 3
-	battery_rating = 200
+	battery_rating = 1100
 
 /obj/item/stock_parts/computer/battery_module/micro
 	name = "micro battery"
-	desc = "A small power cell, commonly seen in most portable microcomputers. It's rating is 50 Wh."
+	desc = "A small power cell, commonly seen in most portable microcomputers. It's rating is 80 Wh."
 	icon_state = "battery_micro"
 	origin_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
-	battery_rating = 50
+	battery_rating = 80
 
 /obj/item/stock_parts/computer/battery_module/nano
 	name = "nano battery"
-	desc = "A tiny power cell, commonly seen in low-end portable microcomputers. It's rating is 30 Wh."
+	desc = "A tiny power cell, commonly seen in low-end portable microcomputers. It's rating is 60 Wh."
 	icon_state = "battery_nano"
 	origin_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
-	battery_rating = 30
+	battery_rating = 60
 
 // This is not intended to be obtainable in-game. Intended for adminbus and debugging purposes.
 /obj/item/stock_parts/computer/battery_module/lambda
@@ -54,7 +54,7 @@
 	desc = "A very complex power source compatible with various computers. It is capable of providing power for nearly unlimited duration."
 	icon_state = "battery_lambda"
 	hardware_size = 1
-	battery_rating = 3000
+	battery_rating = 9000
 
 /obj/item/stock_parts/computer/battery_module/lambda/New()
 	..()

--- a/code/modules/modular_computers/ntos/subtypes/device.dm
+++ b/code/modules/modular_computers/ntos/subtypes/device.dm
@@ -15,7 +15,7 @@
 
 /datum/extension/interactive/ntos/device/recalc_power_usage()
 	var/obj/item/modular_computer/C = holder
-	C.calculate_power_usage()
+	C.handle_power()
 	
 /datum/extension/interactive/ntos/device/emagged()
 	var/obj/item/modular_computer/C = holder


### PR DESCRIPTION
:cl: Paprikue
bugfix: Computer modules will now consume power as originally intended.
bugfix: Computers now die when you remove their batteries (as long as they don't have a tesla link to directly power them)
tweak: Tweaked battery depletion rates so that they don't discharge almost immediately.
/:cl: