### PR TITLE
Blood samples no longer fill syringes

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -129,7 +129,7 @@
 			if(istype(target, /mob/living/carbon/slime))
 				to_chat(user, "<span class='warning'>You are unable to locate any blood.</span>")
 				return
-			var/amount = reagents.get_free_space()
+			var/amount = min(reagents.get_free_space(), amount_per_transfer_from_this)
 			var/mob/living/carbon/T = target
 			if(!T.dna)
 				to_chat(user, "<span class='warning'>You are unable to locate any blood.</span>")


### PR DESCRIPTION
:cl: Paprikue
tweak: Syringes now use the current transfer amount for taking blood samples instead of filling the whole thing immediately.
/:cl:

It's a blood sample, not a blood letting.