### PR TITLE
Adds a space piano

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -835,6 +835,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/janitor)
+"cT" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/synthesized_instrument/synthesizer/piano,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/commissary)
 "cU" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -29393,7 +29398,7 @@ PM
 LZ
 Ku
 RZ
-Wc
+cT
 Ct
 Oh
 vF


### PR DESCRIPTION
Adds: A space piano to the Commissary
Removes: A stool in the same tile
Removes: A spiderweb in the same tile
Why it's good: Because the space piano is cool and musicians can be very enjoyable in the bar

:cl: Cupax3
maptweak: The Deck Chief has dug up an old space piano from one of the Entertainers and put it up for grabs in the Commissary!
/:cl:

EDIT: Yeah uhhh I guess that area is not the Commissary. My bad.
EDIT 2: Now it's in the Commissary!
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->