### PR TITLE
Adds plated catwalk to the Caulship

### DIFF
--- a/maps/away/ascent_caulship/ascent-1.dmm
+++ b/maps/away/ascent_caulship/ascent-1.dmm
@@ -1473,6 +1473,10 @@
 /obj/effect/catwalk_plated/ascent,
 /turf/simulated/floor/ascent,
 /area/ship/ascent_caulship)
+"Xe" = (
+/obj/effect/catwalk_plated/ascent,
+/turf/simulated/floor/ascent,
+/area/ship/ascent_caulship)
 
 (1,1,1) = {"
 aa
@@ -21171,7 +21175,7 @@ bl
 cu
 bq
 bu
-az
+Xe
 cO
 ab
 ax
@@ -21373,7 +21377,7 @@ bO
 bm
 br
 bv
-az
+Xe
 cR
 cS
 cT
@@ -21575,7 +21579,7 @@ bh
 bn
 bs
 bw
-az
+Xe
 cC
 ab
 ax


### PR DESCRIPTION
Adds: Ability for the Caulship to tinker with itself minimally
Adds: Ascent can now run the shield directly off the box at the risk of draining all their power

:cl:
maptweak: The Caulship now has three new cat walks beneath the shield generator and Ascent SMES, allowing for tinkering with the power net directly.
/:cl:

Lore maintainer (I guess) please approve

EDIT: More precise maptweak message, old one:
maptweak: The Ascent have re-learned the ability to tinker with their tiny little starship to make it more efficient, at the cost of making it potentially more volatile.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->