### PR TITLE
Exoplanet fixes

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -53,7 +53,7 @@
 /datum/random_map/noise/exoplanet/desert/get_additional_spawns(var/value, var/turf/T)
 	..()
 	var/v = noise2value(value)
-	if(v > 6 && prob(10))
+	if(v > 6 && prob(2))
 		new/obj/effect/quicksand(T)
 
 /area/exoplanet/desert

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_INIT(weighted_minerals_rich, \
 	return 1
 
 /datum/random_map/automata/cave_system/apply_to_map()
+	..()
 	if(!origin_x) origin_x = 1
 	if(!origin_y) origin_y = 1
 	if(!origin_z) origin_z = 1


### PR DESCRIPTION
:cl: Mucker
bugfix: Fix mined exoplanet mineral turfs not having gravity.
tweak: Lowered the amount of quicksand on desert planets.
/:cl:

There was _way_ too much quicksand being spawned before, and was a terrible thing to experience with it being invisible now.