### PR TITLE
Removes metroids from the random hostile mob spawner

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1077,8 +1077,7 @@ something, make sure it's not in one of the other lists.*/
 obj/random/hostile/spawn_choices()
 	return list(/mob/living/simple_animal/hostile/viscerator,
 				/mob/living/simple_animal/hostile/carp,
-				/mob/living/simple_animal/hostile/carp/pike,
-				/mob/living/simple_animal/hostile/vagrant/swarm)
+				/mob/living/simple_animal/hostile/carp/pike)
 
 /*
 	Selects one spawn point out of a group of points with the same ID and asks it to generate its items


### PR DESCRIPTION
🆑 
tweak: "Vagrant" (metroid) swarms will no longer be spawned from the random hostile mob spawner used on some away sites.
/🆑 

Because they're just broken.