### PR TITLE
cookers don't smoke on creation

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -281,3 +281,14 @@
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (isclient(I) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
 #define INCREMENT_WORLD_Z_SIZE world.maxz++; if (SSzcopy.zlev_maximums.len) { SSzcopy.calculate_zstack_limits() }
+
+//Semantic; usage intent of variable
+#define EMPTY_BITFIELD 0
+
+//-- Masks for /atom/var/init_flags --
+//- machinery
+#define INIT_MACHINERY_PROCESS_SELF 0x1
+#define INIT_MACHINERY_PROCESS_COMPONENTS 0x2
+#define INIT_MACHINERY_PROCESS_ALL 0x3
+//--
+

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -13,6 +13,7 @@
 	var/datum/reagents/reagents // chemical contents.
 	var/list/climbers
 	var/climb_speed_mult = 1
+	var/init_flags = EMPTY_BITFIELD
 
 /atom/New(loc, ...)
 	//atom creation method that preloads variables at creation

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -81,6 +81,7 @@ Class Procs:
 	icon = 'icons/obj/stationobjs.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER // Layer under items
+	init_flags = INIT_MACHINERY_PROCESS_SELF
 
 	var/stat = 0
 	var/reason_broken = 0
@@ -123,7 +124,8 @@ Class Procs:
 	. = ..()
 	if(d)
 		set_dir(d)
-	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF) // It's safe to remove machines from here, but only if base machinery/Process returned PROCESS_KILL.
+	if (init_flags & INIT_MACHINERY_PROCESS_ALL)
+		START_PROCESSING_MACHINE(src, init_flags & INIT_MACHINERY_PROCESS_ALL)
 	SSmachines.machinery += src // All machines should remain in this list, always.
 	if(ispath(wires))
 		wires = new wires(src)

--- a/code/game/machinery/kitchen/cookers.dm
+++ b/code/game/machinery/kitchen/cookers.dm
@@ -16,6 +16,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	init_flags = EMPTY_BITFIELD
 
 	var/capacity = 1 //how many things the cooker can hold at once
 	var/cook_time = 20 SECONDS //how many seconds the cooker takes to cook its contents
@@ -38,7 +39,6 @@
 	smoke.set_up(2, 0)
 
 /obj/machinery/cooker/Destroy()
-	STOP_PROCESSING(SSmachines, src)
 	QDEL_NULL_LIST(cooking)
 	. = ..()
 
@@ -63,14 +63,14 @@
 
 /obj/machinery/cooker/proc/enable()
 	update_use_power(active_power_usage)
-	START_PROCESSING(SSmachines, src)
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	icon_state = "[initial(icon_state)]_on"
 	started = world.time
 	threshold = 0
 
 /obj/machinery/cooker/proc/disable()
 	update_use_power(idle_power_usage)
-	STOP_PROCESSING(SSmachines, src)
+	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	icon_state = initial(icon_state)
 
 /obj/machinery/cooker/proc/empty()


### PR DESCRIPTION
Adds `EMPTY_BITFIELD => 0` define for variable usage hinting.
Adds `/atom/var/init_flags`, a general field for signalling to base Initialize behaviors.
Adds `INIT_MACHINERY_PROCESS_*` masks for `/atom/init_flags` inside `/obj/machinery` context.
`/obj/machinery` uses prior behavior with `INIT_MACHINERY_PROCESS_SELF`.
Cookers override behavior and do not start processing in Initialize, preventing spawn smoking.
Cookers use the correct machine stop/start macros.