### PR TITLE
Randomizes the space piano spawn

### DIFF
--- a/code/modules/synthesized_instruments/real_instruments/Piano/piano.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Piano/piano.dm
@@ -4,3 +4,7 @@
 	icon_state = "piano"
 	path = /datum/instrument/piano
 
+/obj/random_multi/single_item/piano
+	name = "piano spawnpoint"
+	id = "spacepiano"
+	item_path = /obj/structure/synthesized_instrument/synthesizer/piano

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11755,6 +11755,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"Ct" = (
+/obj/random_multi/single_item/piano,
+/turf/simulated/floor/plating,
+/area/vacant/bar)
 "Cy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39860,7 +39864,7 @@ aa
 aa
 Xi
 QL
-yI
+Ct
 Ne
 Lj
 zL

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -837,7 +837,7 @@
 /area/janitor)
 "cT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/synthesized_instrument/synthesizer/piano,
+/obj/random_multi/single_item/piano,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "cU" = (

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3243,6 +3243,7 @@
 /area/crew_quarters/mess)
 "gB" = (
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/random_multi/single_item/piano,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/forestarboard)
 "gC" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2789,6 +2789,7 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
+/obj/random_multi/single_item/piano,
 /turf/simulated/floor/plating,
 /area/vacant/chapel)
 "fg" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -20006,6 +20006,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"iOh" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random_multi/single_item/piano,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/firstdeck/centralport)
 "iPb" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -50454,7 +50459,7 @@ aHn
 aHn
 cQo
 cQo
-tzg
+iOh
 aJS
 aPU
 cQo

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -12678,6 +12678,7 @@
 /area/maintenance/bridge/foreport)
 "JT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/random_multi/single_item/piano,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
 "JV" = (


### PR DESCRIPTION
🆑 
maptweak: The commissary's space piano will now randomly spawn at a set location on one of the six decks. Find them all!
/🆑

Because this is much more interesting. If we must have a free second piano, work for it. 