### PR TITLE
The autopsy scanner can no longer be used on living mobs

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -149,6 +149,10 @@
 /obj/item/autopsy_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
 	if(!istype(M))
 		return 0
+	
+	if (M.stat != DEAD)
+		to_chat(user, SPAN_WARNING("\The [name] buzzes. 'Alert, vitals detected. Aborting scan.'"))
+		return FALSE
 
 	set_target(M, user)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
tweak: The autopsy scanner is now unable to scan living patients, only dead ones.
/:cl:
If you want to scan a live patient, there's many better ways of doing it than cutting them open. This corrects what seems to me like an oversight.