### PR TITLE
Rename autopsy scanner to injury scanner

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -238,7 +238,7 @@
 	contains = list(/obj/item/folder/white,
 					/obj/item/device/camera,
 					/obj/item/device/camera_film = 2,
-					/obj/item/autopsy_scanner,
+					/obj/item/injury_scanner,
 					/obj/item/scalpel,
 					/obj/item/storage/box/masks,
 					/obj/item/storage/box/gloves,

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -572,7 +572,7 @@ its easier to just keep the beam vertical.
 				to_chat(M, "<span class='danger'>You land heavily on your [affecting.name]!</span>")
 				affecting.take_external_damage(damage, 0)
 				if(affecting.parent)
-					affecting.parent.add_autopsy_data("Misadventure", damage)
+					affecting.parent.add_injury_data("Misadventure", damage)
 			else
 				to_chat(H, "<span class='danger'>You land heavily!</span>")
 				H.adjustBruteLoss(damage)

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -2,26 +2,26 @@
 //moved these here from code/defines/obj/weapon.dm
 //please preference put stuff where it's easy to find - C
 
-/obj/item/autopsy_scanner
-	name = "autopsy scanner"
+/obj/item/injury_scanner
+	name = "injury scanner"
 	desc = "Used to gather information on wounds."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "autopsy_scanner"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
-	var/list/datum/autopsy_data_scanner/wdata = list()
+	var/list/datum/injury_data_scanner/wdata = list()
 	var/list/chemtraces = list()
 	var/target_name = null
 	var/timeofdeath = null
 
-/datum/autopsy_data_scanner
+/datum/injury_data_scanner
 	var/weapon = null // this is the DEFINITE weapon type that was used
 	var/list/organs_scanned = list() // this maps a number of scanned organs to
 									 // the wounds to those organs with this data's weapon type
 	var/organ_names = ""
 
-/datum/autopsy_data
+/datum/injury_data
 	var/weapon = null
 	var/pretend_weapon = null
 	var/damage = 0
@@ -29,7 +29,7 @@
 	var/time_inflicted = 0
 
 	proc/copy()
-		var/datum/autopsy_data/W = new()
+		var/datum/injury_data/W = new()
 		W.weapon = weapon
 		W.pretend_weapon = pretend_weapon
 		W.damage = damage
@@ -37,17 +37,17 @@
 		W.time_inflicted = time_inflicted
 		return W
 
-/obj/item/autopsy_scanner/proc/add_data(var/obj/item/organ/external/O)
-	if(!O.autopsy_data.len) return
+/obj/item/injury_scanner/proc/add_data(var/obj/item/organ/external/O)
+	if(!O.injury_data.len) return
 
-	for(var/V in O.autopsy_data)
-		var/datum/autopsy_data/W = O.autopsy_data[V]
+	for(var/V in O.injury_data)
+		var/datum/injury_data/W = O.injury_data[V]
 
 		if(!W.pretend_weapon)
 			W.pretend_weapon = W.weapon
 
 
-		var/datum/autopsy_data_scanner/D = wdata[V]
+		var/datum/injury_data_scanner/D = wdata[V]
 		if(!D)
 			D = new()
 			D.weapon = W.weapon
@@ -62,7 +62,7 @@
 		qdel(D.organs_scanned[O.name])
 		D.organs_scanned[O.name] = W.copy()
 
-/obj/item/autopsy_scanner/verb/print_data()
+/obj/item/injury_scanner/verb/print_data()
 	set category = "Object"
 	set src in view(usr, 1)
 	set name = "Print Data"
@@ -77,14 +77,14 @@
 
 	var/n = 1
 	for(var/wdata_idx in wdata)
-		var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
+		var/datum/injury_data_scanner/D = wdata[wdata_idx]
 		var/total_hits = 0
 		var/total_score = 0
 		var/list/weapon_chances = list() // maps weapon names to a score
 		var/age = 0
 
 		for(var/wound_idx in D.organs_scanned)
-			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
+			var/datum/injury_data/W = D.organs_scanned[wound_idx]
 			total_hits += W.hits
 
 			var/wname = W.pretend_weapon
@@ -141,12 +141,12 @@
 
 	sleep(10)
 
-	var/obj/item/paper/P = new(usr.loc, "<tt>[scan_data]</tt>", "Autopsy Data ([target_name])")
+	var/obj/item/paper/P = new(usr.loc, "<tt>[scan_data]</tt>", "Injury Data ([target_name])")
 	if(istype(usr,/mob/living/carbon))
 		// place the item in the usr's hand if possible
 		usr.put_in_hands(P)
 
-/obj/item/autopsy_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
+/obj/item/injury_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
 	if(!istype(M))
 		return 0
 
@@ -170,7 +170,7 @@
 
 	return 1
 
-/obj/item/autopsy_scanner/proc/set_target(atom/new_target, user)
+/obj/item/injury_scanner/proc/set_target(atom/new_target, user)
 	if(target_name != new_target.name)
 		target_name = new_target.name
 		wdata.Cut()
@@ -178,7 +178,7 @@
 		timeofdeath = null
 		to_chat(user, "<span class='notice'>A new patient has been registered. Purging data for previous patient.</span>")
 
-/obj/item/autopsy_scanner/afterattack(obj/item/organ/external/target, mob/user, proximity_flag, click_parameters)
+/obj/item/injury_scanner/afterattack(obj/item/organ/external/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag)
 		return
 	if(!istype(target))
@@ -187,5 +187,5 @@
 	set_target(target, user)
 	add_data(target)
 
-/obj/item/autopsy_scanner/attack_self(mob/user)
+/obj/item/injury_scanner/attack_self(mob/user)
 	print_data(user)

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -198,7 +198,7 @@ var/list/worths = list(
 					/obj/item/airlock_electronics/secure = 600,
 					/obj/item/airlock_electronics = 300,
 					/obj/item/aiModule = 3000,
-					/obj/item/autopsy_scanner = 180,
+					/obj/item/injury_scanner = 180,
 //CARDS,
 					/obj/item/card/emag = 300,
 					/obj/item/card/id/silver = 200,

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -289,7 +289,7 @@
 			updatehealth()
 			if(!isSynthetic() && organs.len)
 				var/obj/item/organ/external/O = pick(organs)
-				if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage)
+				if(istype(O)) O.add_injury_data("Radiation Poisoning", damage)
 
 	/** breathing **/
 

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -22,7 +22,7 @@
 		/obj/item/borg/sight/hud/sec,
 		/obj/item/taperoll/police,
 		/obj/item/scalpel/laser1,
-		/obj/item/autopsy_scanner,
+		/obj/item/injury_scanner,
 		/obj/item/device/scanner/reagent,
 		/obj/item/reagent_containers/spray/luminol,
 		/obj/item/device/uv_light,

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -54,7 +54,7 @@
 	var/genetic_degradation = 0        // Amount of current genetic damage.
 
 	//Forensics stuff
-	var/list/autopsy_data = list()    // Trauma data for forensics.
+	var/list/injury_data = list()    // Trauma data for forensics.
 
 	// Joint/state stuff.
 	var/joint = "joint"                // Descriptive string used in dislocation.
@@ -135,7 +135,7 @@
 		while(null in owner.organs)
 			owner.organs -= null
 
-	if(autopsy_data)    autopsy_data.Cut()
+	if(injury_data)    injury_data.Cut()
 
 	return ..()
 
@@ -1349,13 +1349,13 @@ obj/item/organ/external/proc/remove_clamps()
 		var/max_halloss = round(owner.species.total_health * 0.8 * ((100 - armor) / 100)) //up to 80% of passing out, further reduced by armour
 		add_pain(Clamp(0, max_halloss - owner.getHalLoss(), 30))
 
-//Adds autopsy data for used_weapon.
-/obj/item/organ/external/proc/add_autopsy_data(var/used_weapon, var/damage)
-	var/datum/autopsy_data/W = autopsy_data[used_weapon]
+//Adds injury data for used_weapon.
+/obj/item/organ/external/proc/add_injury_data(var/used_weapon, var/damage)
+	var/datum/injury_data/W = injury_data[used_weapon]
 	if(!W)
 		W = new()
 		W.weapon = used_weapon
-		autopsy_data[used_weapon] = W
+		injury_data[used_weapon] = W
 
 	W.hits += 1
 	W.damage += damage

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -30,7 +30,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
 
 	if(used_weapon)
-		add_autopsy_data("[used_weapon]", brute + burn)
+		add_injury_data("[used_weapon]", brute + burn)
 
 	var/spillover = 0
 	var/pure_brute = brute

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -38,7 +38,7 @@
 	/obj/item/device/radio,
 	/obj/item/device/radio/headset,
 	/obj/item/device/radio/beacon,
-	/obj/item/autopsy_scanner,
+	/obj/item/injury_scanner,
 	/obj/item/bikehorn,
 	/obj/item/bonesetter,
 	/obj/item/material/knife/kitchen/cleaver,

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -4544,7 +4544,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
-/obj/item/autopsy_scanner,
+/obj/item/injury_scanner,
 /obj/item/stack/material/phoron/fifty,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -3684,7 +3684,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/item/autopsy_scanner,
+/obj/item/injury_scanner,
 /obj/item/scalpel,
 /obj/machinery/light/small{
 	dir = 4


### PR DESCRIPTION
Given that it works on living mobs too, it doesn't make sense for it to still be called an "autopsy" scanner. Alternative to #30627, and arguments for/against are mostly in #pr-feedback.

Many code references to it were also renamed for continuity's sake, though sprites and areas and a couple of other things were untouched.

:cl: Shadowtail117
tweak: The Autopsy Scanner has been renamed to the Injury Scanner.
/:cl: