### PR TITLE
Adds new personal goal for scientists

### DIFF
--- a/code/modules/goals/_goal.dm
+++ b/code/modules/goals/_goal.dm
@@ -2,6 +2,7 @@
 	var/description
 	var/owner
 	var/completion_message
+	var/failure_message
 	var/can_reroll = TRUE
 	var/can_abandon = TRUE
 
@@ -53,6 +54,11 @@
 		if(istype(owner, /datum/mind))
 			var/datum/mind/mind = owner
 			to_chat(mind.current, "<font color='green'><b>[completion_message]</b></font>")
+
+/datum/goal/proc/on_failure()
+	if(failure_message && !check_success() && istype(owner, /datum/mind))
+		var/datum/mind/mind = owner
+		to_chat(mind.current, SPAN_DANGER(failure_message))
 
 /datum/goal/proc/is_valid()
 	return TRUE

--- a/code/modules/goals/definitions/department_science.dm
+++ b/code/modules/goals/definitions/department_science.dm
@@ -25,3 +25,9 @@
 // Personal:
 	// xenobio: finish a round without being attacked by a slime
 	// explorer: name an alien species, plant a flag on an undiscovered world
+
+/datum/goal/achievement/notslimefodder
+	success = TRUE
+	failable = TRUE
+	description = "You're feeling extra careful today. Don't let a slime snack on you."
+	failure_message = "You feel sticky and miserable."

--- a/code/modules/goals/definitions/personal_achievement.dm
+++ b/code/modules/goals/definitions/personal_achievement.dm
@@ -1,12 +1,16 @@
 // Simple toggles. Get an input from somewhere in the code, marked 
-// as successful for the rest of the round. Nothing very special.
+// as successful/unsuccessful for the rest of the round. Nothing very special.
 /datum/goal/achievement
+	var/failable = FALSE
 	var/success = FALSE
 
 /datum/goal/achievement/update_progress(var/progress)
-	if(!success)
+	if(!success && !failable)
 		success = progress
 		on_completion()
+	else if (success && failable)
+		success = progress
+		on_failure()
 
 /datum/goal/achievement/check_success()
 	return success

--- a/code/modules/goals/goal_mind.dm
+++ b/code/modules/goals/goal_mind.dm
@@ -28,6 +28,8 @@
 		return FALSE
 
 	var/list/available_goals = SSgoals.global_personal_goals ? SSgoals.global_personal_goals.Copy() : list()
+	if(job && LAZYLEN(job.possible_goals))
+		available_goals |= job.possible_goals
 	if(ishuman(current))
 		var/mob/living/carbon/human/H = current
 		for(var/token in H.cultural_info)
@@ -38,8 +40,7 @@
 	if(isnull(add_amount))
 		var/min_goals = 1
 		var/max_goals = 3
-		if(job && LAZYLEN(job.possible_goals))
-			available_goals |= job.possible_goals
+		if(job)
 			min_goals = job.min_goals
 			max_goals = job.max_goals
 		add_amount = rand(min_goals, max_goals)

--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -76,6 +76,7 @@
 					var/mob/living/carbon/C = M
 					if (C.can_feel_pain())
 						to_chat(M, "<span class='danger'>[painMes]</span>")
+				M.update_personal_goal(/datum/goal/achievement/notslimefodder, FALSE)
 
 			gain_nutrition(20 * hazmat)
 			totalDrained += 20 * hazmat

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -41,6 +41,7 @@
 	                    SKILL_DEVICES     = SKILL_MAX,
 	                    SKILL_SCIENCE     = SKILL_MAX)
 	skill_points = 20
+	possible_goals = list(/datum/goal/achievement/notslimefodder)
 
 /datum/job/scientist
 	title = "Scientist"
@@ -89,6 +90,7 @@
 
 	minimal_access = list()
 	skill_points = 20
+	possible_goals = list(/datum/goal/achievement/notslimefodder)
 
 /datum/job/scientist_assistant
 	title = "Research Assistant"
@@ -131,3 +133,4 @@
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry,
 		access_radio_sci, access_radio_exp
 	)
+	possible_goals = list(/datum/goal/achievement/notslimefodder)


### PR DESCRIPTION
Adds new "Don't let a slime attack you" personal goal for scientists
Also adds a framework for failable achievement-type personal goals
Fixes job-specific personal goals not generating after spawning (wasn't noticed because there were no job-specific goals before)

🆑 CSCMe
rscadd: Adds "Don't let a slime snack on you" personal goal for scientists.
/🆑