### PR TITLE
Fix Voxship Igniter

### DIFF
--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -1244,7 +1244,9 @@
 /area/voxship/thrusters)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/igniter,
+/obj/machinery/igniter{
+	id_tag = "Voxship_igniter"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/voxship/thrusters)
 "cR" = (
@@ -2152,6 +2154,10 @@
 /obj/machinery/atmospherics/omni/mixer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/button/ignition{
+	id_tag = "Voxship_igniter";
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/thrusters)


### PR DESCRIPTION
Fixes: The Voxship now has an ignition switch for its burn chamber

:cl:
maptweak: The Vox Scavenger Ship now has a button to use its burn chamber igniter.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->