### PR TITLE
Fix #30611

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -186,7 +186,7 @@
 /obj/item/gun/attack(atom/A, mob/living/user, def_zone)
 	if (A == user && user.zone_sel.selecting == BP_MOUTH && !mouthshoot)
 		handle_suicide(user)
-	else if(user.a_intent != I_HURT && user.aiming && user.aiming.active) //if aim mode, don't pistol whip
+	else if(user.aiming && user.aiming.active) //if aim mode, don't pistol whip - even on harm intent
 		if (user.aiming.aiming_at != A)
 			PreFire(A, user)
 		else


### PR DESCRIPTION
Fixes #30611: Point-blank no longer occurs when you are on harm intent and wanting to aim

:cl:
tweak: Attacking point blank with a gun on harm intent no longer attacks, and instead aims, if gun mode is aiming.
/:cl:
