### PR TITLE
Fixes item_state for most uniformed suits

### DIFF
--- a/maps/torch/items/clothing/solgov-suit.dm
+++ b/maps/torch/items/clothing/solgov-suit.dm
@@ -36,12 +36,14 @@
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/medical/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/engineering
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/engineering/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/supply
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/service)
@@ -51,118 +53,141 @@
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/security/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/service
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/service/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/service/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/exploration
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/exploration/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/research
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/research/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/research/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
 	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/service)
 
 /obj/item/clothing/suit/storage/solgov/service/fleet
 	name = "fleet service jacket"
 	desc = "A navy blue SCG Fleet service jacket."
 	icon_state = "blueservice"
+	item_state = "blueservice"
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 	name = "fleet SNCO service jacket"
 	desc = "A navy blue SCG Fleet service jacket with silver cuffs."
 	icon_state = "blueservice_snco"
+	item_state = "blueservice_snco"
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 	name = "fleet officer's service jacket"
 	desc = "A navy blue SCG Fleet dress jacket with silver accents."
 	icon_state = "blueservice_off"
+	item_state = "blueservice_off"
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	name = "fleet senior officer's service jacket"
 	desc = "A navy blue SCG Fleet dress jacket with gold accents."
 	icon_state = "blueservice_comm"
+	item_state = "blueservice_comm"
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/flag
 	name = "fleet flag officer's service jacket"
 	desc = "A navy blue SCG Fleet dress jacket with red accents."
 	icon_state = "blueservice_flag"
+	item_state = "blueservice_flag"
 
 /obj/item/clothing/suit/storage/solgov/service/army
 	name = "army coat"
 	desc = "An SCG Army service coat. Green and undecorated."
+	icon_state = "greenservice"
 	item_state = "greenservice"
 
 /obj/item/clothing/suit/storage/solgov/service/army/medical
 	name = "army medical jacket"
 	desc = "An SCG Army service coat. This one has blue markings."
 	icon_state = "greenservice_med"
+	item_state = "greenservice_med"
 
 /obj/item/clothing/suit/storage/solgov/service/army/medical/command
 	name = "army medical command jacket"
 	desc = "An SCG Army service coat. This one has blue and gold markings."
 	icon_state = "greenservice_medcom"
+	item_state = "greenservice_medcom"
 
 /obj/item/clothing/suit/storage/solgov/service/army/engineering
 	name = "army engineering jacket"
 	desc = "An SCG Army service coat. This one has orange markings."
 	icon_state = "greenservice_eng"
+	item_state = "greenservice_eng"
 
 /obj/item/clothing/suit/storage/solgov/service/army/engineering/command
 	name = "army engineering command jacket"
 	desc = "An SCG Army service coat. This one has orange and gold markings."
 	icon_state = "greenservice_engcom"
+	item_state = "greenservice_engcom"
 
 /obj/item/clothing/suit/storage/solgov/service/army/supply
 	name = "army supply jacket"
 	desc = "An SCG Army service coat. This one has brown markings."
 	icon_state = "greenservice_sup"
+	item_state = "greenservice_sup"
 
 /obj/item/clothing/suit/storage/solgov/service/army/security
 	name = "army security jacket"
 	desc = "An SCG Army service coat. This one has red markings."
 	icon_state = "greenservice_sec"
+	item_state = "greenservice_sec"
 
 /obj/item/clothing/suit/storage/solgov/service/army/security/command
 	name = "army security command jacket"
 	desc = "An SCG Army service coat. This one has red and gold markings."
 	icon_state = "greenservice_seccom"
+	item_state = "greenservice_seccom"
 
 /obj/item/clothing/suit/storage/solgov/service/army/service
 	name = "army service jacket"
 	desc = "An SCG Army service coat. This one has green markings."
 	icon_state = "greenservice_srv"
+	item_state = "greenservice_srv"
 
 /obj/item/clothing/suit/storage/solgov/service/army/service/command
 	name = "army service command jacket"
 	desc = "An SCG Army service coat. This one has green and gold markings."
 	icon_state = "greenservice_srvcom"
+	item_state = "greenservice_srvcom"
 
 /obj/item/clothing/suit/storage/solgov/service/army/exploration
 	name = "army exploration jacket"
 	desc = "An SCG Army service coat. This one has purple markings."
 	icon_state = "greenservice_exp"
+	item_state = "greenservice_exp"
 
 /obj/item/clothing/suit/storage/solgov/service/army/exploration/command
 	name = "army exploration command jacket"
 	desc = "An SCG Army service coat. This one has purple and gold markings."
 	icon_state = "greenservice_expcom"
+	item_state = "greenservice_expcom"
 
 /obj/item/clothing/suit/storage/solgov/service/army/command
 	name = "army command jacket"
 	desc = "An SCG Marine Corps service coat. This one has gold markings."
 	icon_state = "greenservice_com"
+	item_state = "greenservice_com"
 
 //Dress - murder me with a gun why are these 3 different types
 
@@ -170,6 +195,7 @@
 	name = "dress jacket"
 	desc = "A uniform dress jacket, plain and undecorated."
 	icon_state = "ecdress_xpl"
+	item_state = "ecdress_xpl"
 	body_parts_covered = UPPER_TORSO|ARMS
 	siemens_coefficient = 0.9
 	valid_accessory_slots = list(ACCESSORY_SLOT_MEDAL,ACCESSORY_SLOT_RANK, ACCESSORY_SLOT_INSIGNIA)
@@ -179,6 +205,7 @@
 	name = "expeditionary dress coat"
 	desc = "A silver and black dress peacoat belonging to the SCG Expeditionary Corps. Fashionable, for the 25th century at least."
 	icon_state = "ecdress_xpl"
+	item_state = "ecdress_xpl"
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'
 		)
@@ -186,27 +213,33 @@
 /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
 	name = "expeditionary senior's dress coat"
 	icon_state = "ecdress_sxpl"
+	item_state = "ecdress_sxpl"
 
 /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
 	name = "expeditionary chief's dress coat"
 	icon_state = "ecdress_cxpl"
+	item_state = "ecdress_cxpl"
 
 /obj/item/clothing/suit/storage/solgov/dress/expedition/command
 	name = "expeditionary officer's dress coat"
 	desc = "A gold and black dress peacoat belonging to the SCG Expeditionary Corps. The height of fashion."
 	icon_state = "ecdress_ofcr"
+	item_state = "ecdress_ofcr"
 
 /obj/item/clothing/suit/storage/solgov/dress/expedition/command/cdr
 	name = "expeditionary commander's dress coat"
 	icon_state = "ecdress_cdr"
+	item_state = "ecdress_cdr"
 
 /obj/item/clothing/suit/storage/solgov/dress/expedition/command/capt
 	name = "expeditionary captain's dress coat"
 	icon_state = "ecdress_capt"
+	item_state = "ecdress_capt"
 
 /obj/item/clothing/suit/storage/solgov/dress/expedition/command/adm
 	name = "expeditionary admiral's dress coat"
 	icon_state = "ecdress_adm"
+	item_state = "ecdress_adm"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet
 	name = "fleet dress jacket"
@@ -218,26 +251,31 @@
 	name = "fleet dress SNCO jacket"
 	desc = "A navy blue SCG Fleet dress jacket with silver cuffs. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_snco"
+	item_state = "whitedress_snco"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet/officer
 	name = "fleet officer's dress jacket"
 	desc = "A navy blue SCG Fleet dress jacket with silver accents. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_off"
+	item_state = "whitedress_off"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 	name = "fleet senior officer's dress jacket"
 	desc = "A navy blue SCG Fleet dress jacket with gold accents. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_comm"
+	item_state = "whitedress_comm"
 
 /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 	name = "fleet flag officer's dress jacket"
 	desc = "A navy blue SCG Fleet dress jacket with red accents. Don't get near pasta sauce or vox."
 	icon_state = "whitedress_flag"
+	item_state = "whitedress_flag"
 
 /obj/item/clothing/suit/dress/solgov
 	name = "dress jacket"
 	desc = "A uniform dress jacket, fancy."
 	icon_state = "blackdress"
+	item_state = "blackdress"
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	body_parts_covered = UPPER_TORSO|ARMS
@@ -249,22 +287,26 @@
 	name = "fleet dress overwear"
 	desc = "A navy blue SCG Fleet dress suit. Almost looks like a school-girl outfit."
 	icon_state = "sailordress"
+	item_state = "sailordress"
 
 /obj/item/clothing/suit/dress/solgov/army
 	name = "army dress jacket"
 	desc = "A tailored black SCG Army dress jacket with red trim. So sexy it hurts."
 	icon_state = "blackdress"
+	item_state = "blackdress"
 
 /obj/item/clothing/suit/dress/solgov/army/command
 	name = "army officer's dress jacket"
 	desc = "A tailored black SCG Army dress jacket with gold trim. Smells like ceremony."
 	icon_state = "blackdress_com"
+	item_state = "blackdress_com"
 
 //Misc
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov
 	name = "expeditionary winter coat"
 	icon_state = "coatec"
+	item_state = "coatec"
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA,ACCESSORY_SLOT_RANK)
@@ -272,17 +314,20 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army
 	name = "army winter coat"
 	icon_state = "coatar"
+	item_state = "coatar"
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA,ACCESSORY_SLOT_RANK)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet
 	name = "fleet winter coat"
 	icon_state = "coatfl"
+	item_state = "coatfl"
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
 /obj/item/clothing/suit/storage/jacket/solgov/fleet
 	name = "fleet engineering jacket"
 	desc = "A jacket commonly issued by the fleet to its engineers. It sports some yellow reflective stripes, and has elbow pads."
 	icon_state = "navyengjacket"
+	item_state = "navyengjacket"
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA,ACCESSORY_SLOT_RANK)
@@ -294,6 +339,7 @@
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its medical staff. It sports some discrete blue markings, and has thin elbow pads."
 	icon_state = "navymedjacket"
+	item_state = "navymedjacket"
 	allowed = list (/obj/item/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder,/obj/item/device/scanner/gas,/obj/item/device/radio,/obj/item/taperoll,/obj/item/stack/medical, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/syringe, \
 	/obj/item/device/scanner/health, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/clothing/head/hardhat, /obj/item/tank/emergency, /obj/item/reagent_containers/ivbag
 	)
@@ -302,6 +348,7 @@
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its security staff. It sports some discrete red markings, and has elbow pads."
 	icon_state = "navysecjacket"
+	item_state = "navysecjacket"
 	allowed = list (/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder,/obj/item/device/scanner/gas,/obj/item/device/radio,/obj/item/taperoll,/obj/item/gun/energy,/obj/item/device/radio,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/gun/magnetic,/obj/item/clothing/head/helmet
 	)
 
@@ -309,6 +356,7 @@
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its service staff. It sports some discrete green markings."
 	icon_state = "navysrvjacket"
+	item_state = "navysrvjacket"
 	allowed = list (/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder,/obj/item/device/scanner/gas,/obj/item/device/radio,/obj/item/taperoll
 	)
 
@@ -316,6 +364,7 @@
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its deck staff. It sports some discrete brown markings, and has elbow pads."
 	icon_state = "navysupjacket"
+	item_state = "navysupjacket"
 	allowed = list (/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder,/obj/item/device/scanner/gas,/obj/item/device/radio,/obj/item/taperoll
 	)
 
@@ -323,6 +372,7 @@
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its command staff. It sports some gold markings."
 	icon_state = "navycomjacket"
+	item_state = "navycomjacket"
 	allowed = list (/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder,/obj/item/device/scanner/gas,/obj/item/device/radio,/obj/item/taperoll
 	)
 
@@ -405,6 +455,7 @@
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	icon_state = "void_command"
+	item_state = "void_command"
 	name = "command voidsuit"
 	desc = "A light, radiation resistant voidsuit commonly used among SCG uniformed services. This one has an EC seal on its chest plate and command department markings."
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/briefcase/inflatable)
@@ -424,6 +475,7 @@
 	icon = 'maps/torch/icons/obj/obj_head_solgov.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/onmob_head_solgov.dmi')
 	icon_state = "helm_explorer"
+	item_state = "helm_explorer"
 	sprite_sheets = list(
 		SPECIES_SKRELL = 'maps/torch/icons/mob/skrell/onmob_head_solgov_skrell.dmi'
 		)
@@ -446,6 +498,7 @@
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	desc = "The bulky Exoplanet Exploration Unit is a standard voidsuit for Expeditionary Corps field operations. It features extra padding and respectable radiation-resistant lining."
 	icon_state = "void_explorer"
+	item_state = "void_explorer"
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'maps/torch/icons/mob/unathi/onmob_suit_solgov_unathi.dmi'
 		)


### PR DESCRIPTION
Fixes: item_state for most subobjects of /obj/item/clothing/suit/storage/solgov - only icon_state was set.
Fixes #30644

:cl:
bugfix: Most uniforms now correctly display, for example fleet dress.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->