### PR TITLE
Add Exploration themed Storage Items and Cameras to Lockers

### DIFF
--- a/maps/torch/structures/closets/exploration.dm
+++ b/maps/torch/structures/closets/exploration.dm
@@ -77,8 +77,9 @@
 		/obj/item/clothing/accessory/buddytag,
 		/obj/item/storage/firstaid/light,
 		/obj/item/material/knife/folding/swiss/explorer,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger)),
+		/obj/item/device/camera,
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/explorer, /obj/item/storage/backpack/satchel/explorer)),
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger/explorer)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))
 	)
 


### PR DESCRIPTION
:cl: Ryan180602
maptweak: Exploration themed backpacks and cameras will now spawn in exploration lockers
/:cl:

Because one camera for an entire team doesn't usually cut it.