### PR TITLE
Makes ascent Caulship a Torch-specific submap and disables it

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3138,7 +3138,6 @@
 #include "maps\antag_spawn\ninja\ninja.dm"
 #include "maps\antag_spawn\wizard\wizard.dm"
 #include "maps\away\away_sites.dm"
-#include "maps\away\ascent_caulship\_ascent_caulship.dm"
 #include "maps\away_sites_testing\away_sites_testing_define.dm"
 #include "maps\example\example_define.dm"
 #include "maps\random_ruins\exoplanet_ruins\exoplanet_ruins.dm"

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -171,6 +171,7 @@
 	#include "../away/mininghome/mininghome.dm"
 	#include "../away/scavver/scavver_gantry.dm"
 	#include "../away/verne/verne.dm"
+//	#include "../away/ascent_caulship/_ascent_caulship.dm"
 
 	#define using_map_DATUM /datum/map/torch
 

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -10990,10 +10990,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
-"Lv" = (
-/obj/effect/shuttle_landmark/ascent_caulship/torch,
-/turf/space,
-/area/space)
 "Lw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -40885,7 +40881,7 @@ aa
 aa
 aa
 aa
-Lv
+aa
 aa
 aa
 aa

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -56,3 +56,5 @@
 	)
 
 	var/list/area_purity_test_exempt_areas = list()
+
+/area/ship


### PR DESCRIPTION
🆑 
tweak: Disables the ascent caulship's spawn.
/🆑 

 Ascent Caulship's existence adds nothing and takes up space in the overmap. Leaves the map itself and the species untouched for future work.