### PR TITLE
Adds two spare headsets to robotics

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1116,6 +1116,8 @@
 /obj/item/aicard,
 /obj/item/clothing/gloves/insulated,
 /obj/item/clothing/gloves/insulated,
+/obj/item/device/radio/headset/headset_eng,
+/obj/item/device/radio/headset/headset_eng,
 /obj/item/device/multitool{
 	pixel_x = 3
 	},


### PR DESCRIPTION
:cl: Domic
maptweak: Adds spare headsets to robotics
/:cl:

So if you're wondering why there are 1224 deletions, while saving strongDMM had an episode and deleted everything it deemed useless (such as pixel_x = 0 and similar nonsense). I have no idea how to avoid this, but it doesn't seem like a "bad" thing to do, hopefully it won't cause any trouble. The additions are mostly just things github thinks I removed but I didn't so it adds them back right after.

The headsets have been added to a plastic crate on D2, the one with intellicards, insulateds, and other valuable equipment.