### PR TITLE
Cleaned up access permissions and renamed a few to make them more clear.

### DIFF
--- a/code/game/jobs/_access_defs.dm
+++ b/code/game/jobs/_access_defs.dm
@@ -7,7 +7,7 @@
 #define ACCESS_REGION_COMMAND 5
 #define ACCESS_REGION_GENERAL 6
 #define ACCESS_REGION_SUPPLY 7
-#define ACCESS_REGION_NT 8
+#define ACCESS_REGION_SERVICE 8
 
 // Keep those two up to date
 #define ACCESS_REGION_MIN 1

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -172,7 +172,7 @@
 		if(ACCESS_REGION_SECURITY) //security
 			return "Security"
 		if(ACCESS_REGION_MEDBAY) //medbay
-			return "Medbay"
+			return "Medical"
 		if(ACCESS_REGION_RESEARCH) //research
 			return "Research"
 		if(ACCESS_REGION_ENGINEERING) //engineering and maintenance
@@ -183,8 +183,8 @@
 			return "General"
 		if(ACCESS_REGION_SUPPLY) //supply
 			return "Supply"
-		if(ACCESS_REGION_NT) //nt
-			return "Corporate"
+		if(ACCESS_REGION_SERVICE) //nt
+			return "Service"
 
 /proc/get_access_desc(id)
 	var/list/AS = priv_all_access_datums_id || get_all_access_datums_by_id()

--- a/maps/torch/job/torch_access.dm
+++ b/maps/torch/job/torch_access.dm
@@ -41,7 +41,7 @@
 /datum/access/nanotrasen
 	id = access_nanotrasen
 	desc = "Corporate Personnel"
-	region = ACCESS_REGION_RESEARCH
+	region = ACCESS_REGION_SERVICE
 
 /var/const/access_emergency_armory = "ACCESS_TORCH_ARMORY" //83
 /datum/access/emergency_armory
@@ -66,8 +66,8 @@
 /var/const/access_sec_guard = "ACCESS_TORCH_SECURITY_GUARD" //86
 /datum/access/sec_guard
 	id = access_sec_guard
-	desc = "Security Guard"
-	region = ACCESS_REGION_RESEARCH
+	desc = "Corporate Security"
+	region = ACCESS_REGION_SERVICE
 
 /var/const/access_gun = "ACCESS_TORCH_CANNON" //87
 /datum/access/gun
@@ -152,6 +152,27 @@
 
 /datum/access/network
 	region = ACCESS_REGION_COMMAND
+	
+/datum/access/chapel_office
+	region = ACCESS_REGION_SERVICE
+	
+/datum/access/bar
+	region = ACCESS_REGION_SERVICE
+	
+/datum/access/kitchen
+	region = ACCESS_REGION_SERVICE
+	
+/datum/access/eva
+	region = ACCESS_REGION_GENERAL
+	
+/datum/access/crematorium
+	region = ACCESS_REGION_MEDBAY
+	
+/datum/access/janitor
+	region = ACCESS_REGION_SERVICE
+
+/datum/access/ai_upload
+	desc = "Cyborg Upload"
 
 /*************
 * NRV Petrov *
@@ -160,55 +181,55 @@
 /datum/access/petrov
 	id = access_petrov
 	desc = "Petrov"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_GENERAL
 
 /var/const/access_petrov_helm = "ACCESS_TORCH_PETROV_HELM" //201
 /datum/access/petrov_helm
 	id = access_petrov_helm
 	desc = "Petrov Helm"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_GENERAL
 
 /var/const/access_petrov_analysis = "ACCESS_TORCH_PETROV_ANALYSIS" //202
 /datum/access/petrov_analysis
 	id = access_petrov_analysis
 	desc = "Petrov Analysis Lab"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_RESEARCH
 
 /var/const/access_petrov_phoron = "ACCESS_TORCH_PETROV_PHORON" //203
 /datum/access/petrov_phoron
 	id = access_petrov_phoron
 	desc = "Petrov Phoron Sublimation Lab"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_RESEARCH
 
 /var/const/access_petrov_toxins = "ACCESS_TORCH_PETROV_TOXINS" //204
 /datum/access/petrov_toxins
 	id = access_petrov_toxins
 	desc = "Petrov Toxins Lab"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_RESEARCH
 
 /var/const/access_petrov_chemistry = "ACCESS_TORCH_PETROV_CHEMISTRY" //205
 /datum/access/petrov_chemistry
 	id = access_petrov_chemistry
 	desc = "Petrov Chemistry Lab"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_RESEARCH
 
 /var/const/access_petrov_rd = "ACCESS_TORCH_PETROV_RD" //206
 /datum/access/petrov_rd
 	id = access_petrov_rd
 	desc = "Petrov Chief Science Officer's Office"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_COMMAND
 
 /var/const/access_petrov_security = "ACCESS_TORCH_PETROV_SEC" //207
 /datum/access/petrov_security
 	id = access_petrov_security
 	desc = "Petrov Security Office"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_SECURITY
 
 /var/const/access_petrov_maint = "ACCESS_TORCH_PETROV_MAINT" //208
 /datum/access/petrov_maint
 	id = access_petrov_maint
 	desc = "Petrov Maintenance"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_GENERAL
 
 /var/const/access_torch_helm = "ACCESS_TORCH_HELM"
 /datum/access/torch_helm
@@ -246,19 +267,19 @@
 /datum/access/access_radio_sic
 	id = access_radio_sci
 	desc = "Science Radio"
-	region = ACCESS_REGION_NT
+	region = ACCESS_REGION_RESEARCH
 
 /var/const/access_radio_sup = "ACCESS_RADIO_SUP"
 /datum/access/access_radio_sup
 	id = access_radio_sup
 	desc = "Supply Radio"
-	region = ACCESS_REGION_GENERAL
+	region = ACCESS_REGION_SUPPLY
 
 /var/const/access_radio_serv = "ACCESS_RADIO_SERV"
 /datum/access/access_radio_serv
 	id = access_radio_serv
 	desc = "Service Radio"
-	region = ACCESS_REGION_GENERAL
+	region = ACCESS_REGION_SERVICE
 
 /var/const/access_radio_exp = "ACCESS_RADIO_EXP"
 /datum/access/access_radio_exp


### PR DESCRIPTION
:cl: GeneralCamo
tweak: Cleaned up access permissions and renamed a few to make them more clear.
/:cl:

This is something a bit overdue that I was working on a week ago, but I got distracted.

Player-wise, this mainly affects usage on the ID Card modification tool. I personally feel it's cleaner than before, and it's better for players to find a permission they are looking for, especially with the service permissions split out.