### PR TITLE
Fix for interacting with objects on window tiles

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ATOM_FLAG_INITIALIZED            0x0020 // Has this atom been initialized
 #define ATOM_FLAG_NO_TEMP_CHANGE         0x0040 // Reagents do not cool or heat to ambient temperature in this container.
 #define ATOM_FLAG_CAN_BE_PAINTED         0x0080 // Can be painted using a paint sprayer or similar.
+#define ATOM_FLAG_ADJACENT_EXCEPTION     0x0100 // Skips adjacent checks for atoms that should always be reachable in window tiles
 
 #define MOVABLE_FLAG_PROXMOVE            0x0001 // Does this object require proximity checking in Enter()?
 #define MOVABLE_FLAG_Z_INTERACT          0x0002 // Should attackby and attack_hand be relayed through ladders and open spaces?

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -130,7 +130,7 @@ turf/proc/Adjacent_free_dir(atom/destination, path_dir = 0)
 	This is defined as any dense ATOM_FLAG_CHECKS_BORDER object, or any dense object without throwpass.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
-/turf/proc/ClickCross(var/target_dir, var/border_only, var/target_atom = null)
+/turf/proc/ClickCross(target_dir, border_only, atom/target_atom = null)
 	for(var/obj/O in src)
 		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
 
@@ -139,7 +139,7 @@ turf/proc/Adjacent_free_dir(atom/destination, path_dir = 0)
 				var/obj/structure/window/W = target_atom
 				if(istype(W) && W.is_fulltile()) //exception for breaking full tile windows on top of single pane windows
 					return 1
-				if(istype(target_atom, /obj/structure/wall_frame)) // exception for low walls beneath windows
+				if(target_atom && (target_atom.atom_flags & ATOM_FLAG_ADJACENT_EXCEPTION)) // exception for atoms that should always be reachable
 					return 1
 				else
 					return 0

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -28,6 +28,7 @@
 	closed_layer = ABOVE_WINDOW_LAYER
 	dir = 1
 	explosion_resistance = 25
+	atom_flags = ATOM_FLAG_ADJACENT_EXCEPTION
 
 	//Most blast doors are infrequently toggled and sometimes used with regular doors anyways,
 	//turning this off prevents awkward zone geometry in places like medbay lobby, for example.

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,6 +22,7 @@
 	closed_layer = ABOVE_WINDOW_LAYER
 	movable_flags = MOVABLE_FLAG_Z_INTERACT
 	pry_mod = 0.75
+	atom_flags = ATOM_FLAG_ADJACENT_EXCEPTION
 	var/locked = FALSE //If the door is forced open, it will not close again until the next atmosphere alert in the area
 
 	//These are frequently used with windows, so make sure zones can pass.

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/wall_frame.dmi'
 	icon_state = "frame"
 
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_CAN_BE_PAINTED
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_CAN_BE_PAINTED | ATOM_FLAG_ADJACENT_EXCEPTION
 	anchored = TRUE
 	density = TRUE
 	throwpass = 1


### PR DESCRIPTION
🆑 Nirnael
bugfix: Shutters are again reachable on window tiles.
/:cl:
I've been discussing this with others and there just doesn't seem to be an easy way to take care of all this except for a generic framework which requires way too much work. So it will have to be an exception. The next best thing from a raw istype exception I think is with flags. This takes up one atom_flag slot, but is probably worth it until someone needs that slot. It is still possible to work on windows underneath the shutters, but I'll leave that for someone else to design/fix.