### PR TITLE
Brings mercenary numbers down

### DIFF
--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -13,8 +13,8 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 
 	hard_cap = 4
 	hard_cap_round = 8
-	initial_spawn_req = 4
-	initial_spawn_target = 6
+	initial_spawn_req = 3
+	initial_spawn_target = 5
 	min_player_age = 14
 
 	faction = "mercenary"


### PR DESCRIPTION
🆑 
tweak: The number of mercs that can spawn is now 3 to 5, down from 4 to 6.
/🆑