### PR TITLE
Fix shuttle movement knocking players over while buckled

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -283,7 +283,7 @@ var/list/mob/living/forced_ambiance_list = new
 
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
-		if(prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_PROF)))
+		if(!H.buckled && prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_PROF)))
 			if(!MOVING_DELIBERATELY(H))
 				H.AdjustStunned(6)
 				H.AdjustWeakened(6)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed shuttle movement into areas with gravity knocking players over while they were buckled.
/:cl:

Fixes #30233