### PR TITLE
Remove Phlogiston

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -590,20 +590,6 @@
 	e.start()
 	holder.clear_reagents()
 
-/datum/chemical_reaction/phlogiston
-	name = "Phlogiston"
-	result = null
-	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/toxin/phoron = 1, /datum/reagent/acid = 1 )
-	result_amount = 1
-	mix_message = "The solution thickens and begins to bubble."
-
-/datum/chemical_reaction/phlogiston/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
-	..()
-	var/turf/location = get_turf(holder.my_atom.loc)
-	for(var/turf/simulated/floor/target_tile in range(0,location))
-		target_tile.assume_gas(/datum/reagent/toxin/phoron, created_volume, 400+T0C)
-		addtimer(CALLBACK(target_tile, /turf/proc/hotspot_expose, 700, 400), 0)
-
 /datum/chemical_reaction/napalm
 	name = "Napalm"
 	result = /datum/reagent/napalm


### PR DESCRIPTION
:cl: Ryan18062
rscdel: Removes Phlogiston
/:cl:

Phlogiston gives no reagent, it seems like it should be giving off phoron vapor/fire, but that is not what happens, and since the wiki lists this as napalm, people are misdirected into making this instead of actual napalm. As phlogiston itself doesn't exactly exist either, this seems like a useless and downright detrimental recipe.

The Chemistry page of the wiki will also need to be updated to reflect the actual recipe for Napalm, as the first recipe is for Phlogiston, and not Napalm.
I could've changed the recipe for Napalm to that of Phlogiston, but considering what it can be used for, making Napalm a bit more harder to acquire seems to be fine (current napalm recipe as compared to phlogiston's recipe).