### PR TITLE
Add Holopad to Voxship + Rename Vox Fore

### DIFF
--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -1316,9 +1316,6 @@
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/fore)
 "cW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1327,10 +1324,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/fore)
 "cX" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1339,6 +1339,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/effect/shuttle_landmark/vox_base/hangar/vox_ship,
+/obj/machinery/hologram/holopad/longrange,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/techmaint/vox,
 /area/voxship/fore)
 "cY" = (
@@ -1351,7 +1353,6 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1360,6 +1361,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/vox,
 /area/voxship/fore)
 "cZ" = (
@@ -1582,10 +1584,10 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/vox,
 /area/voxship/fore)
 "du" = (
@@ -3168,6 +3170,22 @@
 /obj/machinery/telecomms/broadcaster/map_preset/voxship,
 /turf/simulated/floor/plating/vox,
 /area/voxship/thrusters)
+"Gf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/vox,
+/area/voxship/fore)
 "Lj" = (
 /turf/simulated/wall/r_titanium,
 /area/space)
@@ -7098,7 +7116,7 @@ ar
 ar
 ar
 cw
-cZ
+Gf
 ar
 dS
 ar

--- a/maps/away/voxship/voxship_areas.dm
+++ b/maps/away/voxship/voxship_areas.dm
@@ -8,7 +8,7 @@
 	req_access = list(access_voxship)
 
 /area/voxship/fore
-	name = "Vox Fore"
+	name = "Unknown Vessel Cockpit"
 	icon_state = "fore"
 	req_access = list(access_voxship)
 


### PR DESCRIPTION
:cl: Ryan180602
maptweak: Add Long Range Holopad to Vox Ship
maptweak: Rename Vox Fore to Unknown Vessel Cockpit
/:cl:

Vox not being able to call other ships seems like an oversight in of itself.
Vox Fore to Unknown Vessel Cockpit is to make it more ambiguous on the holopad contacts list.