### PR TITLE
Fix invisible hydroponics trays displaying their machine description

### DIFF
--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -31,6 +31,7 @@
 	desc = null
 	icon = 'icons/obj/seeds.dmi'
 	icon_state = "blank"
+	machine_desc = null
 	var/list/connected_zlevels //cached for checking if we someone is obseving us so we should process
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/is_burnable()


### PR DESCRIPTION
:cl: Mucker
tweak: Invisible hydroponics trays will no longer display their machine description on examine.
/:cl:
closes #30479