### PR TITLE
Rearranged Chemistry Skills

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -125,7 +125,9 @@
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,
-	                    SKILL_SCIENCE     = SKILL_MAX)
+	                    SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX
+					)
 	skill_points = 30
 
 	access = list(
@@ -170,11 +172,12 @@
 	                    SKILL_MEDICAL     = SKILL_EXPERT,
 	                    SKILL_ANATOMY     = SKILL_EXPERT,
 	                    SKILL_CHEMISTRY   = SKILL_BASIC,
-						SKILL_DEVICES     = SKILL_ADEPT)
-
+						SKILL_DEVICES     = SKILL_ADEPT
+					)
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
 	                    SKILL_ANATOMY     = SKILL_MAX,
-	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	                    SKILL_CHEMISTRY   = SKILL_MAX
+					)
 	skill_points = 26
 
 	access = list(

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -28,11 +28,11 @@
 	                    SKILL_MEDICAL     = SKILL_EXPERT,
 	                    SKILL_ANATOMY     = SKILL_EXPERT,
 	                    SKILL_CHEMISTRY   = SKILL_BASIC,
-						SKILL_DEVICES     = SKILL_ADEPT)
-
+						SKILL_DEVICES     = SKILL_ADEPT
+	)
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
-	                    SKILL_ANATOMY     = SKILL_MAX,
-	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	                    SKILL_ANATOMY     = SKILL_MAX
+	)
 	skill_points = 20
 
 	access = list(
@@ -71,11 +71,11 @@
 	                    SKILL_MEDICAL     = SKILL_EXPERT,
 	                    SKILL_ANATOMY     = SKILL_EXPERT,
 	                    SKILL_CHEMISTRY   = SKILL_BASIC,
-						SKILL_DEVICES     = SKILL_ADEPT)
-
+						SKILL_DEVICES     = SKILL_ADEPT
+					)
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
-	                    SKILL_ANATOMY     = SKILL_MAX,
-	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	                    SKILL_ANATOMY     = SKILL_MAX
+					)
 	skill_points = 16
 
 	access = list(
@@ -116,10 +116,10 @@
 	)
 	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
 	                    SKILL_MEDICAL = SKILL_BASIC,
-	                    SKILL_ANATOMY = SKILL_BASIC)
-
-	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
-	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	                    SKILL_ANATOMY = SKILL_BASIC
+	)
+	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX
+	)
 
 	access = list(
 		access_medical, access_morgue, access_maint_tunnels,
@@ -163,12 +163,11 @@
 	min_skill = list(   SKILL_EVA     = SKILL_ADEPT,
 	                    SKILL_HAULING = SKILL_ADEPT,
 	                    SKILL_MEDICAL = SKILL_EXPERT,
-	                    SKILL_ANATOMY = SKILL_BASIC)
-
+	                    SKILL_ANATOMY = SKILL_BASIC
+						)
 	max_skill = list(   SKILL_MEDICAL     = SKILL_MAX,
-	                    SKILL_ANATOMY     = SKILL_MAX,
-	                    SKILL_CHEMISTRY   = SKILL_MAX)
-
+	                    SKILL_ANATOMY     = SKILL_MAX
+						)
 	access = list(
 		access_medical, access_morgue, access_maint_tunnels,
 		access_external_airlocks, access_emergency_storage,
@@ -198,11 +197,12 @@
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
 	min_skill = list(   SKILL_MEDICAL   = SKILL_BASIC,
-	                    SKILL_CHEMISTRY = SKILL_ADEPT)
-
-	max_skill = list(   SKILL_MEDICAL     = SKILL_BASIC,
-						SKILL_ANATOMY	  = SKILL_BASIC,
-	                    SKILL_CHEMISTRY   = SKILL_MAX)
+	                    SKILL_CHEMISTRY = SKILL_ADEPT
+	)
+	max_skill = list(   SKILL_CHEMISTRY   = SKILL_MAX,
+						SKILL_MEDICAL     = SKILL_BASIC,
+						SKILL_ANATOMY     = SKILL_BASIC
+	)
 	skill_points = 16
 
 	access = list(

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -39,7 +39,9 @@
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,
-	                    SKILL_SCIENCE     = SKILL_MAX)
+	                    SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX
+					)
 	skill_points = 20
 
 /datum/job/scientist
@@ -65,8 +67,9 @@
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,
-	                    SKILL_SCIENCE     = SKILL_MAX)
-
+	                    SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX
+					)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/scientist
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
@@ -122,8 +125,9 @@
 	)
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,
-	                    SKILL_SCIENCE     = SKILL_MAX)
-
+	                    SKILL_SCIENCE     = SKILL_MAX,
+						SKILL_CHEMISTRY   = SKILL_MAX
+					)
 	access = list(
 		access_tox, access_tox_storage, access_research, access_petrov,
 		access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,


### PR DESCRIPTION
:cl: GeneralCamo
balance: Rearranged Chemistry skills: Medical Personnel (except for Laboratory Technicians and the CMO) can now only have "Trained" Chemistry; Science Personnel can now have "Master" Chemistry.
/:cl:

I'm expecting this to be controversial, but I will explain my reasoning:

Currently, Laboratory Technicians are restricted to "Basic" in Medicine and Anatomy. This is understandable considering a history of abuse; however, right now a Doctor can completely replace a Lab Tech when the Lab Tech cannot do the same. This PR changes that and forces Doctors to have some penalties when creating medicines.

Outwardly, this changes two things: Purification, and Grinding. Purification is generally uncommon, and the only recipes commonly used for Medicine that require it are Phoron-based, which the Medical Chemistry room gets an excess of. Grinding on the other hand is common, and this will reduce yields from grinding medications; It may be worthwhile for doctors to start using pills more often if losses are unacceptable to them.

This PR also grants Science personnel Master Chemistry; They have their own grinders and chemistry equipment in both the Petrov and in their RnD lab. They can now use them effectively if they have the correct skills. Doctors could potentially ask them to grind medicines for them as a result of this.