### PR TITLE
Cigarette filters and rolling paper are no longer invisible

### DIFF
--- a/code/modules/clothing/masks/cig_crafting.dm
+++ b/code/modules/clothing/masks/cig_crafting.dm
@@ -27,6 +27,7 @@
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cig_paper"
 	w_class = ITEM_SIZE_TINY
+	is_memo = TRUE
 
 /obj/item/paper/cig/fancy
 	name = "\improper Trident rolling paper"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
fix: Cigarette rolling paper and filters have icons once more.
/:cl:
Free us from the curse of icons