### PR TITLE
Adds more renegade guns

### DIFF
--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -43,7 +43,11 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 		/obj/item/gun/projectile/shotgun/doublebarrel/sawn,
 		/obj/item/gun/projectile/pistol/magnum_pistol,
 		/obj/item/gun/projectile/revolver/holdout,
-		/obj/item/gun/projectile/pistol/throwback
+		/obj/item/gun/projectile/pistol/throwback,
+		/obj/item/gun/energy/xray/pistol,
+		/obj/item/gun/energy/toxgun,
+		/obj/item/gun/energy/incendiary_laser,
+		/obj/item/gun/projectile/pistol/magnum_pistol
 		)
 
 /datum/antagonist/renegade/create_objectives(var/datum/mind/player)


### PR DESCRIPTION
🆑 Jux
tweak: Adds four more pistols to the renegade gunpool.
/🆑 

Adds the phoron pistol, xray pistol, incendiary laser and the magnum pistol to the pool.

Because variety is the spice of life. 