### PR TITLE
Suicide Revamp

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -149,7 +149,11 @@
 /obj/screen/zone_sel/proc/set_selected_zone(bodypart)
 	var/old_selecting = selecting
 	selecting = bodypart
-	if(old_selecting != selecting)
+	var/mob/living/carbon/human/user = usr
+	if (istype(user) && (old_selecting == BP_MOUTH || selecting == BP_MOUTH) && user.aiming && user.aiming.active && user.aiming.aiming_at == user)
+		var/obj/aiming_overlay/AO = user.aiming
+		AO.aim_at(user, user.aiming.aiming_with, TRUE)
+	if (old_selecting != selecting)
 		update_icon()
 		return TRUE
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -99,13 +99,9 @@ meteor_act
 
 /mob/living/carbon/human/proc/check_head_coverage()
 
-	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform)
-	for(var/bp in body_parts)
-		if(!bp)	continue
-		if(bp && istype(bp ,/obj/item/clothing))
-			var/obj/item/clothing/C = bp
-			if(C.body_parts_covered & HEAD)
-				return 1
+	for(var/obj/item/clothing/bp in list(head, wear_mask, wear_suit, w_uniform))
+		if(bp.body_parts_covered & HEAD)
+			return 1
 	return 0
 
 //Used to check if they can be fed food/drinks/pills
@@ -114,6 +110,32 @@ meteor_act
 	for(var/obj/item/gear in protective_gear)
 		if(istype(gear) && (gear.body_parts_covered & FACE) && !(gear.item_flags & ITEM_FLAG_FLEXIBLEMATERIAL))
 			return gear
+
+///Returns null or the first equipped item covering the bodypart
+/mob/living/carbon/human/proc/get_clothing_coverage(bodypart)
+	switch(bodypart)
+		if (BP_HEAD)
+			bodypart = HEAD
+		if (BP_EYES)
+			bodypart = EYES
+		if (BP_MOUTH)
+			bodypart = FACE
+		if (BP_CHEST)
+			bodypart = UPPER_TORSO
+		if (BP_GROIN)
+			bodypart = LOWER_TORSO
+		if (BP_L_ARM, BP_R_ARM)
+			bodypart =  ARMS
+		if (BP_L_HAND,  BP_R_HAND)
+			bodypart =  HANDS
+		if (BP_L_LEG, BP_R_LEG)
+			bodypart = LEGS
+		if (BP_L_FOOT, BP_R_FOOT)
+			bodypart = FEET
+
+	for(var/obj/item/clothing/C in list(head, wear_mask, wear_suit, w_uniform, gloves, shoes, glasses))
+		if (C.body_parts_covered & bodypart)
+			return C
 	return null
 
 /mob/living/carbon/human/proc/check_shields(var/damage = 0, var/atom/damage_source = null, var/mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -129,15 +129,15 @@
 	healed_threshold = 0
 	to_chat(owner, "<span class = 'notice' font size='10'><B>Where am I...?</B></span>")
 	sleep(5 SECONDS)
-	if(!owner)
+	if (!owner || owner.stat == DEAD || (status & ORGAN_DEAD))
 		return
 	to_chat(owner, "<span class = 'notice' font size='10'><B>What's going on...?</B></span>")
 	sleep(10 SECONDS)
-	if(!owner)
+	if (!owner || owner.stat == DEAD || (status & ORGAN_DEAD))
 		return
 	to_chat(owner, "<span class = 'notice' font size='10'><B>What happened...?</B></span>")
 	alert(owner, "You have taken massive brain damage! You will not be able to remember the events leading up to your injury.", "Brain Damaged")
-	if(owner.psi)
+	if (owner.psi)
 		owner.psi.check_latency_trigger(20, "physical trauma")
 
 /obj/item/organ/internal/brain/Process()
@@ -207,16 +207,17 @@
 	..()
 	if(damage >= 20) //This probably won't be triggered by oxyloss or mercury. Probably.
 		var/damage_secondary = damage * 0.20
-		owner.flash_eyes()
-		owner.eye_blurry += damage_secondary
-		owner.confused += damage_secondary * 2
-		owner.Paralyse(damage_secondary)
-		owner.Weaken(round(damage, 1))
-		if(prob(30))
-			addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
+		if (owner)
+			owner.flash_eyes()
+			owner.eye_blurry += damage_secondary
+			owner.confused += damage_secondary * 2
+			owner.Paralyse(damage_secondary)
+			owner.Weaken(round(damage, 1))
+			if (prob(30))
+				addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
 
 /obj/item/organ/internal/brain/proc/brain_damage_callback(var/damage) //Confuse them as a somewhat uncommon aftershock. Side note: Only here so a spawn isn't used. Also, for the sake of a unique timer.
-	if (!owner)
+	if (!owner || owner.stat == DEAD || (status & ORGAN_DEAD))
 		return
 
 	to_chat(owner, "<span class = 'notice' font size='10'><B>I can't remember which way is forward...</B></span>")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -184,14 +184,27 @@
 	Fire(A,user,params) //Otherwise, fire normally.
 
 /obj/item/gun/attack(atom/A, mob/living/user, def_zone)
-	if (A == user && user.zone_sel.selecting == BP_MOUTH && !mouthshoot)
-		handle_suicide(user)
-	else if(user.aiming && user.aiming.active) //if aim mode, don't pistol whip - even on harm intent
+	var/suicide
+	if (user == A)
+		suicide = TRUE
+		if (user.zone_sel.selecting == BP_MOUTH && (!user.aiming || !user.aiming.active))
+			user.toggle_gun_mode()
+	if (user.aiming && user.aiming.active) //if aim mode, don't pistol whip - even on harm intent
 		if (user.aiming.aiming_at != A)
+			var/checkperm
+			if (suicide)
+				if (!(user.aiming.target_permissions & TARGET_CAN_CLICK))
+					user.aiming.toggle_permission(TARGET_CAN_CLICK, TRUE)
+					checkperm = TRUE
 			PreFire(A, user)
+			if (checkperm)
+				addtimer(CALLBACK(user.aiming, /obj/aiming_overlay/proc/toggle_permission, TARGET_CAN_CLICK, TRUE), 1)
 		else
-			Fire(A, user, pointblank=1)
-	else if(user.a_intent == I_HURT) //point blank shooting
+			if (suicide && user.zone_sel.selecting == BP_MOUTH && istype(user, /mob/living/carbon/human))
+				handle_suicide(user)
+			else
+				Fire(A, user, pointblank=1)
+	else if (user.a_intent == I_HURT) //point blank shooting
 		Fire(A, user, pointblank=1)
 	else
 		return ..() //Pistolwhippin'
@@ -439,47 +452,69 @@
 		playsound(user, shot_sound, 50, 1)
 
 //Suicide handling.
-/obj/item/gun/var/mouthshoot = 0 //To stop people from suiciding twice... >.>
 /obj/item/gun/proc/handle_suicide(mob/living/user)
-	if(!ishuman(user))
-		return
 	var/mob/living/carbon/human/M = user
-
-	mouthshoot = 1
-	admin_attacker_log(user, "is attempting to suicide with \a [src]")
-	M.visible_message("<span class='danger'>[user] sticks their gun in their mouth, ready to pull the trigger...</span>")
-	if(!do_after(user, 40, do_flags = DO_DEFAULT & ~DO_SHOW_PROGRESS))
-		M.visible_message("<span class='notice'>[user] decided life was worth living</span>")
-		mouthshoot = 0
+	if ((!waterproof && submerged()) || !special_check(M))
 		return
-	var/obj/item/projectile/in_chamber = consume_next_projectile()
-	if (istype(in_chamber))
-		user.visible_message("<span class = 'warning'>[user] pulls the trigger.</span>")
-		var/shot_sound = in_chamber.fire_sound? in_chamber.fire_sound : fire_sound
-		if(silenced)
-			playsound(user, shot_sound, 10, 1)
-		else
-			playsound(user, shot_sound, 50, 1)
-		if(istype(in_chamber, /obj/item/projectile/beam/lastertag))
-			user.show_message("<span class = 'warning'>You feel rather silly, trying to commit suicide with a toy.</span>")
-			mouthshoot = 0
-			return
+	if (world.time < next_fire_time)
+		if (world.time % 3)
+			to_chat(M, SPAN_WARNING("\The [src] is not ready to fire again!"))
+		return
+	M.setClickCooldown((burst - 1) * burst_delay)
+	next_fire_time = world.time + max(burst_delay + 1, fire_delay)
+	if (safety())
+		handle_click_safety(M)
+		return
 
-		in_chamber.on_hit(M)
+	last_safety_check = world.time
+	admin_attacker_log(M, "is trying to commit suicide with \a [src]")
+	user.visible_message(M, SPAN_WARNING("\The [M] pulls the trigger."))
+	to_chat(M, SPAN_NOTICE("You feel \the [src] go off..."))
+
+	var/obj/item/organ/brain = M.internal_organs_by_name[BP_BRAIN] || M.internal_organs_by_name[BP_POSIBRAIN]
+	var/bodypart = brain.parent_organ
+	if (brain.parent_organ == BP_HEAD)
+		bodypart = BP_MOUTH
+	var/obj/item/blocked = M.get_clothing_coverage(bodypart)
+
+	for (var/i = 1 to burst)
+		var/obj/item/projectile/in_chamber = consume_next_projectile()
+		if (!in_chamber)
+			handle_click_empty(M)
+			break
+		play_fire_sound(M, in_chamber)
+
 		if (in_chamber.damage_type != PAIN)
-			admin_attacker_log(user, "commited suicide using \a [src]")
-			user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, BP_HEAD, in_chamber.damage_flags(), used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
-			user.death()
+			in_chamber.on_hit(M, 0, brain.parent_organ)
+			if (istype(in_chamber, /obj/item/projectile/ion))
+				in_chamber.on_impact(M)
+			if (in_chamber.damage != 0)
+				M.apply_damage(in_chamber.damage * 2, in_chamber.damage_type, brain.parent_organ, in_chamber.damage_flags(), used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
+				var/dmgmultiplier
+				if (prob (95))
+					dmgmultiplier = rand(30, 50) / 10
+				else
+					dmgmultiplier = 0.5
+				if (blocked)
+					to_chat(M, SPAN_WARNING("A clear shot to your [bodypart] is blocked by the [blocked], significantly reducing damage to \the [brain.name]!"))
+					dmgmultiplier = dmgmultiplier/5
+				if (istype(brain, /obj/item/organ/internal/brain))
+					var/obj/item/organ/internal/brain/notposi = brain
+					notposi.take_internal_damage(in_chamber.damage*dmgmultiplier, 0)
+				else
+					brain.damage = brain.damage + (in_chamber.damage*dmgmultiplier)
 		else
-			to_chat(user, "<span class = 'notice'>Ow...</span>")
-			user.apply_effect(110,PAIN,0)
+			M.apply_effect(110,PAIN,0)
 		qdel(in_chamber)
-		mouthshoot = 0
-		return
-	else
-		handle_click_empty(user)
-		mouthshoot = 0
-		return
+		update_icon()
+		if (i < burst)
+			sleep(burst_delay)
+
+	var/delay = max(burst_delay+1, fire_delay)
+	M.setClickCooldown(min(delay, DEFAULT_QUICK_COOLDOWN))
+	next_fire_time = world.time + delay
+	if (brain.damage > brain.max_damage)
+		brain.die()
 
 /obj/item/gun/proc/scope()
 	set category = "Object"

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -24,32 +24,35 @@
 	loc = null
 	verbs.Cut()
 
-/obj/aiming_overlay/proc/toggle_permission(var/perm)
+/obj/aiming_overlay/proc/toggle_permission(perm, silent)
 
-	if(target_permissions & perm)
+	if (target_permissions & perm)
 		target_permissions &= ~perm
 	else
 		target_permissions |= perm
 
+	if (silent)
+		return
+
 	// Update HUD icons.
-	if(owner.gun_move_icon)
-		if(!(target_permissions & TARGET_CAN_MOVE))
+	if (owner.gun_move_icon)
+		if (!(target_permissions & TARGET_CAN_MOVE))
 			owner.gun_move_icon.icon_state = "no_walk0"
 			owner.gun_move_icon.SetName("Allow Movement")
 		else
 			owner.gun_move_icon.icon_state = "no_walk1"
 			owner.gun_move_icon.SetName("Disallow Movement")
 
-	if(owner.item_use_icon)
-		if(!(target_permissions & TARGET_CAN_CLICK))
+	if (owner.item_use_icon)
+		if (!(target_permissions & TARGET_CAN_CLICK))
 			owner.item_use_icon.icon_state = "no_item0"
 			owner.item_use_icon.SetName("Allow Item Use")
 		else
 			owner.item_use_icon.icon_state = "no_item1"
 			owner.item_use_icon.SetName("Disallow Item Use")
 
-	if(owner.radio_use_icon)
-		if(!(target_permissions & TARGET_CAN_RADIO))
+	if (owner.radio_use_icon)
+		if (!(target_permissions & TARGET_CAN_RADIO))
 			owner.radio_use_icon.icon_state = "no_radio0"
 			owner.radio_use_icon.SetName("Allow Radio Use")
 		else
@@ -58,24 +61,26 @@
 
 	var/message = "no longer permitted to "
 	var/use_span = "warning"
-	if(target_permissions & perm)
+	if (target_permissions & perm)
 		message = "now permitted to "
 		use_span = "notice"
 
 	switch(perm)
-		if(TARGET_CAN_MOVE)
+		if (TARGET_CAN_MOVE)
 			message += "move"
-		if(TARGET_CAN_CLICK)
+		if (TARGET_CAN_CLICK)
 			message += "use items"
-		if(TARGET_CAN_RADIO)
+		if (TARGET_CAN_RADIO)
 			message += "use a radio"
 		else
 			return
 
-	var/aim_message = "<span class='[use_span]'>[aiming_at ? "\The [aiming_at] is" : "Your targets are"] [message].</span>"
-	to_chat(owner, aim_message)
-	if(aiming_at)
+	if (aiming_at && aiming_at != owner)
+		to_chat(owner, "<span class='[use_span]'>\The [aiming_at] is [message].</span>")
 		to_chat(aiming_at, "<span class='[use_span]'>You are [message].</span>")
+	else
+		to_chat(owner, "<span class='[use_span]'>Your targets are [message].</span>")
+
 /obj/aiming_overlay/Process()
 	if(!owner)
 		qdel(src)
@@ -134,37 +139,62 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		spawn(0)
 			owner.set_dir(get_dir(get_turf(owner), get_turf(src)))
 
-/obj/aiming_overlay/proc/aim_at(var/mob/target, var/obj/thing)
+/obj/aiming_overlay/proc/aim_at(var/mob/target, var/obj/thing, var/no_target_change)
 
-	if(!owner || !isliving(target))
-		return
-
-	if(owner.incapacitated())
-		to_chat(owner, "<span class='warning'>You cannot aim a gun in your current state.</span>")
-		return
-	if(owner.lying)
-		to_chat(owner, "<span class='warning'>You cannot aim a gun while prone.</span>")
-		return
-	if(owner.restrained())
-		to_chat(owner, "<span class='warning'>You cannot aim a gun while handcuffed.</span>")
+	if (!owner || !isliving(target))
 		return
 
-	if(aiming_at)
-		if(aiming_at == target)
-			return
-		cancel_aiming(1)
-		owner.visible_message("<span class='danger'>\The [owner] turns \the [thing] on \the [target]!</span>")
+	if (owner.incapacitated())
+		to_chat(owner, SPAN_WARNING("You cannot aim a gun in your current state."))
+		return
+	if (owner.lying)
+		to_chat(owner, SPAN_WARNING("You cannot aim a gun while prone."))
+		return
+	if (owner.restrained())
+		to_chat(owner, SPAN_WARNING("You cannot aim a gun while handcuffed."))
+		return
+
+	var/gunpointedtarget = SPAN_DANGER("You now have \a [thing] pointed at you. No sudden moves!")
+	var/gunpointedself = ""
+	var/mob/living/carbon/human/user = owner
+
+	if (istype(user))
+		if (user.zone_sel.selecting == BP_MOUTH)
+			admin_attacker_log(user, "is getting ready to suicide with \a [src]")
+			if (user.check_has_mouth() && !(user.check_mouth_coverage()))
+				gunpointedself = SPAN_DANGER("\The [owner] puts the barrel of \the [thing] in their mouth, ready to pull the trigger...")
+			else
+				gunpointedself = SPAN_DANGER("\The [owner] aims \the [thing] at themselves, ready to pull the trigger...")
+		else
+			gunpointedself = SPAN_DANGER("\The [owner] aims \the [thing] at themselves!")
+
+	if (aiming_at)
+		if (!no_target_change)
+			if(aiming_at == target)
+				return
+			cancel_aiming(1)
+		if (owner != target)
+			owner.visible_message(SPAN_DANGER("\The [owner] turns \the [thing] on \the [target]!"))
+			to_chat(target, "[gunpointedtarget]")
+		else
+			owner.visible_message("[gunpointedself]")
+	else if (owner != target)
+		owner.visible_message(SPAN_DANGER("\The [owner] aims \the [thing] at \the [target]!"))
+		to_chat(target, "[gunpointedtarget]")
 	else
-		owner.visible_message("<span class='danger'>\The [owner] aims \the [thing] at \the [target]!</span>")
+		owner.visible_message("[gunpointedself]")
 
-	if(owner.client)
-		owner.client.add_gun_icons()
-	to_chat(target, "<span class='danger'>You now have a gun pointed at you. No sudden moves!</span>")
 	aiming_with = thing
-	aiming_at = target
-	if(istype(aiming_with, /obj/item/gun))
+	if (istype(aiming_with, /obj/item/gun))
 		sound_to(aiming_at, sound('sound/weapons/TargetOn.ogg'))
 		sound_to(owner, sound('sound/weapons/TargetOn.ogg'))
+
+	if (no_target_change)
+		return
+
+	if (owner.client)
+		owner.client.add_gun_icons()
+	aiming_at = target
 
 	forceMove(get_turf(target))
 	START_PROCESSING(SSobj, src)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -13,19 +13,23 @@
 				AO.update_aiming_deferred()
 
 /obj/aiming_overlay/proc/trigger(var/perm)
-	if(!owner || !aiming_with || !aiming_at || !locked)
+	if (!owner || !aiming_with || !aiming_at || !locked)
 		return
-	if(perm && (target_permissions & perm))
+	if (perm && (target_permissions & perm))
 		return
-	if(!owner.canClick())
+	if (!owner.canClick())
 		return
-	if(prob(owner.skill_fail_chance(SKILL_WEAPONS, 30, SKILL_ADEPT, 3)))
+	var/obj/item/gun/G = aiming_with
+	if (!istype(G))
+		return
+	if (owner == aiming_at)
+		addtimer(CALLBACK(G, /obj/item/gun/proc/handle_suicide, owner, 2))
+		return
+	if (prob(owner.skill_fail_chance(SKILL_WEAPONS, 30, SKILL_ADEPT, 3)))
 		to_chat(owner, "<span class='warning'>You fumble with the gun, throwing your aim off!</span>")
 		owner.stop_aiming(aiming_with)
 		return
 	owner.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
 	owner.visible_message("<span class='danger'>\The [owner] pulls the trigger reflexively!</span>")
-	var/obj/item/gun/G = aiming_with
-	if(istype(G))
-		G.Fire(aiming_at, owner)
+	G.Fire(aiming_at, owner)
 	toggle_active(FALSE, TRUE)


### PR DESCRIPTION
:cl: Domic
tweak: Suicide now accounts for damage, what you're wearing, where your brain actually is, utilizes aim mode, and is now triggered manually instead of being on a timer.
bugfix: People who suicide are no longer save-able via MMI.
bugfix: Suicide via less-than-lethal weapons is no longer easy to to.
/:cl:

In addition to what's stated in the changelog, I've added a proc which checks if a body part is covered with something, stopped the brain from giving brain damage messages after death, permitted suicide to use targeting triggers, and prevented suicide victims from being recoverable via MMI.

I'd just like to clarify that suicide is still (HEAVILY) discouraged on the server, the purpose of this PR is to make it less underwhelming and more realistic (no instant disorientator suicide, please) when used properly.

A side effect to making brain damage 'easier' to deal is psionic awakening potentially being easier to do.