### PR TITLE
Disabling crew monitor alert for morgue stuffed bodies

### DIFF
--- a/code/datums/repositories/crew/crew.dm
+++ b/code/datums/repositories/crew/crew.dm
@@ -60,7 +60,7 @@ var/global/datum/repository/crew/crew_repository = new()
 				var/list/crewmemberData = list("sensor_type"=C.sensor_mode, "stat"=H.stat, "area"="", "x"=-1, "y"=-1, "z"=-1, "ref"="\ref[H]")
 				if(!(run_queues(H, C, pos, crewmemberData) & MOD_SUIT_SENSORS_REJECTED))
 					crewmembers[++crewmembers.len] = crewmemberData
-					if (crewmemberData["alert"])
+					if (crewmemberData["alert"] && !istype(istype(H.loc, /obj/structure/closet/body_bag) ? H.loc.loc : H.loc, /obj/structure/morgue))
 						cache_data_alert[num2text(z_level)] = TRUE
 
 	crewmembers = sortByKey(crewmembers, "name")


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: If body placed into morgue tray, crew monitoring will not count them for showing alert, but it still shows them as alert pacients
/:cl: