### PR TITLE
Fixed Scrubbers not using the siphon sprites while siphoning

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -76,11 +76,12 @@
 	var/scrubber_icon = "scrubber"
 	if(welded)
 		scrubber_icon += "weld"
+	else if (!powered() || !use_power)
+		scrubber_icon += "off"
+	else if(scrubbing == SCRUBBER_SIPHON)
+		scrubber_icon += "in"
 	else
-		if(!powered())
-			scrubber_icon += "off"
-		else
-			scrubber_icon += "[use_power ? "[scrubbing ? "on" : "in"]" : "off"]"
+		scrubber_icon += "on"
 
 	overlays += icon_manager.get_atmos_icon("device", , , scrubber_icon)
 


### PR DESCRIPTION
:cl: GeneralCamo
bugfix: Scrubbers now use the correct sprites when siphoning.
/:cl:
This fixes scrubbers to use the proper sprites when siphoning; previously they used the standard sprites. As far as I could tell, this was an oversight from when exchange mode was introduced, as what was assumed to be a binary value no longer was. This fixes it by making it into a switch instead.

Commit that originally broke this: https://github.com/Baystation12/Baystation12/commit/8515dda39b4d49800308e96dd4c101081d69f666