### PR TITLE
Adds non-fire melting

### DIFF
--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -52,6 +52,7 @@ Class Procs:
 	var/list/graphic_add = list()
 	var/list/graphic_remove = list()
 	var/last_air_temperature = TCMB
+	var/melttemp = FALSE
 
 /zone/New()
 	SSair.add_zone(src)
@@ -144,6 +145,18 @@ Class Procs:
 	air.group_multiplier = contents.len+1
 
 /zone/proc/tick()
+
+	//Handle melting stuff
+	if (air.temperature >= PHORON_MINIMUM_BURN_TEMPERATURE)
+		melttemp = TRUE
+		for (var/turf/simulated/checkit in contents)
+			if (istype(checkit))
+				checkit.check_meltables(FALSE)
+	else if (melttemp)
+		melttemp = FALSE
+		for (var/turf/simulated/checkit in contents)
+			if (!istype(checkit))
+				checkit.check_meltables(TRUE)
 
 	// Update fires.
 	if(air.temperature >= PHORON_FLASHPOINT && !(src in SSair.active_fire_zones) && air.check_combustability() && contents.len)

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -147,7 +147,7 @@ Class Procs:
 /zone/proc/tick()
 
 	//Handle melting stuff
-	if (air.temperature >= PHORON_MINIMUM_BURN_TEMPERATURE)
+	if (air.temperature >= PHORON_MINIMUM_BURN_TEMPERATURE && contents.len < 10000)
 		melttemp = TRUE
 		for (var/turf/simulated/checkit in contents)
 			if (istype(checkit))


### PR DESCRIPTION
WIP, slapped-together testing version.

Works surprisingly well. We can bypass constant performance issues by only doing the necessary checks when a zone detects higher-than-usual temperatures. May start dying if there are too many turfs doing checks, although this doesn't seem to happen easily.

Some meltables not implemented, others are implemented badly and/or partially.

It seems like the Torch is extremely vulnerable to melting (lots of non-fireshutter windows and steel walls), mapping changes should be done alongside this, assuming it gets finished and is considered acceptable.

Would definitely like to hear feedback on this, I'm not really familiar with atmos code, and I'm not sure if the check should happen during tick(), or if it should be somewhere else.