### PR TITLE
VSC config and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Thumbs.db
 *.backup
 *.before
 data/
+dmdoc/
 cfg/
 build_log.txt
 use_map
@@ -20,8 +21,10 @@ atupdate
 config/*
 sql/test_db
 
-# vscode
+# VisualStudioCode
 .vscode/*
+!.vscode/settings.json
+*.code-workspace
 .history
 
 # swap
@@ -39,7 +42,6 @@ Session.vim
 
 # auto-generated tag files
 tags
-baystation12.code-workspace
 
 # ignore built libs
 lib/*.dll

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+	"editor.detectIndentation": false,
+	"editor.insertSpaces": false,
+	"editor.tabSize": 4,
+	"files.eol": "\r\n",
+	"files.insertFinalNewline": true,
+	"files.trimFinalNewlines": true,
+	"files.trimTrailingWhitespace": true
+}


### PR DESCRIPTION
- Updates `.gitignore` to allow folder-specific visual studio code configuration files to be committed, and block the output of `dmdco` from being committed.
- Adds some basic VSC configs to the main folder to enforce some whitespace, EOL, and tab vs spaces styling.