### PR TITLE
Changes to personal goals

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -131,11 +131,6 @@
 	out += "<b>Ambitions:</b> [ambition ? ambition.description : "None"] <a href='?src=\ref[src];amb_edit=\ref[src]'>\[edit\]</a></br>"
 	show_browser(usr, out, "window=edit_memory[src]")
 
-/datum/mind/proc/get_goal_from_href(var/href)
-	var/ind = isnum(href) ? href : text2num(href)
-	if(ind > 0 && ind <= LAZYLEN(goals))
-		return goals[ind]
-
 /datum/mind/Topic(href, href_list)
 
 	var/is_admin =   FALSE
@@ -146,14 +141,16 @@
 	if(href_list["add_goal"])
 
 		var/mob/caller = locate(href_list["add_goal_caller"])
-		if(caller && caller == current) can_modify = TRUE
+		if(!isghost(usr) && caller && caller == current) can_modify = TRUE
 
 		if(can_modify)
-			if(is_admin)
-				log_admin("[key_name_admin(usr)] added a random goal to [key_name(current)].")
-			var/did_generate_goal = generate_goals(assigned_job, TRUE, 1)
-			if(did_generate_goal)
-				to_chat(current, SPAN_NOTICE("You have received a new goal. Use <b>Show Goals</b> to view it."))
+			var/did_generate_goal = generate_goals(assigned_job, TRUE, 1, bypass_goal_checks = is_admin)
+			if(did_generate_goal && goals)
+				var/datum/goal/goal = goals[LAZYLEN(goals)]
+				to_chat(current, SPAN_NOTICE("<b>You have received a new goal:</b> '[goal.summarize(FALSE, FALSE)]'."))
+				if(usr != current)
+					to_chat(usr, SPAN_NOTICE("<b>You have added a new goal to \the [current]:</b> '[goal.summarize(FALSE, FALSE)]'."))
+					log_admin("[key_name_admin(usr)] added a random goal to [key_name(current)].")
 		return TRUE // To avoid 'you are not an admin' spam.
 
 	if(href_list["remove_memory"])
@@ -162,36 +159,38 @@
 		return TRUE
 
 	if(href_list["abandon_goal"])
-		var/datum/goal/goal = get_goal_from_href(href_list["abandon_goal"])
+		var/datum/goal/goal = locate(href_list["abandon_goal"])
 
 		var/mob/caller = locate(href_list["abandon_goal_caller"])
-		if(caller && caller == current) can_modify = TRUE
+		if(!isghost(usr) && caller && caller == current) can_modify = TRUE
 
-		if(goal && can_modify)
-			if(usr == current)
-				to_chat(current, SPAN_NOTICE("<b>You have abandoned your goal:</b> '[goal.summarize(FALSE, FALSE)]'."))
-			else
-				to_chat(usr, SPAN_NOTICE("<b>You have removed a goal from \the [current]:</b> '[goal.summarize(FALSE, FALSE)]'."))
-				to_chat(current, SPAN_NOTICE("<b>A goal has been removed:</b> '[goal.summarize(FALSE, FALSE)]'."))
-			qdel(goal)
+		if(can_modify && goal && (goal in goals))
+			if(delete_goal(assigned_job, goal, is_admin))
+				if(usr == current)
+					to_chat(current, SPAN_NOTICE("<b>You have abandoned your goal:</b> '[goal.summarize(FALSE, FALSE)]'."))
+				else
+					to_chat(usr, SPAN_NOTICE("<b>You have removed a goal from \the [current]:</b> '[goal.summarize(FALSE, FALSE)]'."))
+					to_chat(current, SPAN_NOTICE("<b>A goal has been removed:</b> '[goal.summarize(FALSE, FALSE)]'."))
+					log_admin("[key_name_admin(usr)] removed a goal from [key_name(current)].")
 		return TRUE
 
 	if(href_list["reroll_goal"])
-		var/datum/goal/goal = get_goal_from_href(href_list["reroll_goal"])
+		var/datum/goal/goal = locate(href_list["reroll_goal"])
 
 		var/mob/caller = locate(href_list["reroll_goal_caller"])
-		if(caller && caller == current) can_modify = TRUE
+		if(!isghost(usr) && caller && caller == current) can_modify = TRUE
 
-		if(goal && (goal in goals) && can_modify)
-			qdel(goal)
-			generate_goals(assigned_job, TRUE, 1)
-			if(goals)
-				goal = goals[LAZYLEN(goals)]
-				if(usr == current)
-					to_chat(usr, SPAN_NOTICE("<b>You have re-rolled a goal. Your new goal is:</b> '[goal.summarize(FALSE, FALSE)]'."))
-				else
-					to_chat(usr, SPAN_NOTICE("<b>You have re-rolled a goal for \the [current]. Their new goal is:</b> '[goal.summarize(FALSE, FALSE)]'."))
-					to_chat(current, SPAN_NOTICE("<b>A goal has been re-rolled. Your new goal is:</b> '[goal.summarize(FALSE, FALSE)]'."))
+		if(can_modify && goal && (goal in goals))
+			if(generate_goals(assigned_job, TRUE, 1, bypass_goal_checks = TRUE))
+				delete_goal(assigned_job, goal, TRUE)
+				if(goals)
+					goal = goals[LAZYLEN(goals)]
+					if(usr == current)
+						to_chat(usr, SPAN_NOTICE("<b>You have re-rolled a goal. Your new goal is:</b> '[goal.summarize(FALSE, FALSE)]'."))
+					else
+						to_chat(usr, SPAN_NOTICE("<b>You have re-rolled a goal for \the [current]. Their new goal is:</b> '[goal.summarize(FALSE, FALSE)]'."))
+						to_chat(current, SPAN_NOTICE("<b>A goal has been re-rolled. Your new goal is:</b> '[goal.summarize(FALSE, FALSE)]'."))
+						log_admin("[key_name_admin(usr)] rerolled a goal for [key_name(current)].")
 		return TRUE
 
 	if(!is_admin) return

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -44,8 +44,8 @@
 	var/available_by_default = TRUE
 
 	var/list/possible_goals
-	var/min_goals = 1
-	var/max_goals = 3
+	var/min_goals = 0
+	var/max_goals = 5
 
 	var/defer_roundstart_spawn = FALSE // If true, the job will be put off until all other jobs have been populated.
 	var/list/species_branch_rank_cache_ = list()

--- a/code/modules/goals/_goal.dm
+++ b/code/modules/goals/_goal.dm
@@ -23,13 +23,13 @@
 		owner = null
 	. = ..()
 
-/datum/goal/proc/summarize(var/show_success = FALSE, var/allow_modification = FALSE, var/mob/caller ,var/position = 1)
+/datum/goal/proc/summarize(var/show_success = FALSE, var/allow_modification = FALSE, var/mob/caller)
 	. = "[description][get_summary_value()]"
 	if(show_success)
 		. += get_success_string()
 	if(allow_modification)
-		if(can_abandon) . += " (<a href='?src=\ref[owner];abandon_goal=[position];abandon_goal_caller=\ref[caller]'>Abandon</a>)"
-		if(can_reroll)  . += " (<a href='?src=\ref[owner];reroll_goal=[position];reroll_goal_caller=\ref[caller]'>Reroll</a>)"
+		if(can_abandon) . += " (<a href='?src=\ref[owner];abandon_goal=\ref[src];abandon_goal_caller=\ref[caller]'>Abandon</a>)"
+		if(can_reroll)  . += " (<a href='?src=\ref[owner];reroll_goal=\ref[src];reroll_goal_caller=\ref[caller]'>Reroll</a>)"
 
 /datum/goal/proc/get_success_string()
 	return check_success() ? " <b><font color='green'>Success!</font></b>" : " <b><font color='red'>Failure.</font></b>"

--- a/code/modules/goals/goal_ambition.dm
+++ b/code/modules/goals/goal_ambition.dm
@@ -13,5 +13,5 @@
 /datum/goal/ambition/get_success_string()
 	return ""
 
-/datum/goal/ambition/summarize(var/show_success = FALSE, var/allow_modification = FALSE, var/mob/caller ,var/position = 1)
+/datum/goal/ambition/summarize(var/show_success = FALSE, var/allow_modification = FALSE, var/mob/caller)
 	. = SPAN_DANGER(..(show_success))

--- a/code/modules/goals/goal_department.dm
+++ b/code/modules/goals/goal_department.dm
@@ -24,7 +24,7 @@
 	. = list()
 	for(var/i = 1 to LAZYLEN(goals))
 		var/datum/goal/goal = goals[i]
-		. += "[i]. [goal.summarize(show_success, position = i)]"
+		. += "[i]. [goal.summarize(show_success)]"
 
 /datum/department/proc/update_progress(var/goal_type, var/progress)
 	var/datum/goal/goal = locate(goal_type) in goals

--- a/code/modules/goals/goal_mind.dm
+++ b/code/modules/goals/goal_mind.dm
@@ -13,23 +13,16 @@
 	if(LAZYLEN(goals))
 		for(var/i = 1 to LAZYLEN(goals))
 			var/datum/goal/goal = goals[i]
-			. += "[i]. [goal.summarize(show_success, allow_modification, caller, position = i)]"
+			. += "[i]. [goal.summarize(show_success, allow_modification, caller)]"
 
 // Create and display personal goals for this round.
-/datum/mind/proc/generate_goals(var/datum/job/job, var/adding_goals = FALSE, var/add_amount, var/is_spawning = FALSE)
+/datum/mind/proc/generate_goals(datum/job/job, adding_goals, add_amount, is_spawning, bypass_goal_checks)
 
 	if(!adding_goals)
 		goals = null
 
-	var/pref_val = current.get_preference_value(/datum/client_preference/give_personal_goals)
-	if(pref_val == GLOB.PREF_NEVER || (pref_val == GLOB.PREF_NON_ANTAG && player_is_antag(src)))
-		if(!is_spawning)
-			to_chat(src.current, "<span class='warning'>Your preferences do not allow you to add random goals.</span>")
-		return FALSE
-
 	var/list/available_goals = SSgoals.global_personal_goals ? SSgoals.global_personal_goals.Copy() : list()
-	if(job && LAZYLEN(job.possible_goals))
-		available_goals |= job.possible_goals
+		
 	if(ishuman(current))
 		var/mob/living/carbon/human/H = current
 		for(var/token in H.cultural_info)
@@ -37,15 +30,50 @@
 			var/list/new_goals = culture.get_possible_personal_goals(job ? job.department_flag : null)
 			if(LAZYLEN(new_goals))
 				available_goals |= new_goals
+
+	var/min_goals = 0
+	var/max_goals = 5
+	if(job)
+		min_goals = job.min_goals
+		max_goals = job.max_goals
+		if(LAZYLEN(job.possible_goals))
+			available_goals |= job.possible_goals
+	
 	if(isnull(add_amount))
-		var/min_goals = 1
-		var/max_goals = 3
-		if(job)
-			min_goals = job.min_goals
-			max_goals = job.max_goals
 		add_amount = rand(min_goals, max_goals)
+	
+	if (!bypass_goal_checks)
+		add_amount = min(max(0, max_goals - LAZYLEN(goals)), add_amount)
+		if(add_amount <= 0)
+			if(!is_spawning)
+				to_chat(src.current, SPAN_WARNING("Your job doesn't allow for any more distractions."))
+			return FALSE
+		
+		var/pref_val = current.get_preference_value(/datum/client_preference/give_personal_goals)
+		if (pref_val == GLOB.PREF_NEVER || (pref_val == GLOB.PREF_NON_ANTAG && player_is_antag(src)))
+			if(!is_spawning)
+				to_chat(src.current, SPAN_WARNING("Your preferences do not allow you to add random goals."))
+			return FALSE
+
+	if(LAZYLEN(goals))
+		for (var/datum/goal/mind_goal in goals)
+			LAZYREMOVE(available_goals, mind_goal.type)
+		if(!LAZYLEN(available_goals))
+			if(!is_spawning)
+				to_chat(src.current, SPAN_WARNING("There are no more goals available."))
+			return FALSE
 
 	for(var/i = 1 to min(LAZYLEN(available_goals), add_amount))
 		var/goal = pick_n_take(available_goals)
 		new goal(src)
 	return TRUE
+
+/datum/mind/proc/delete_goal(datum/job/job, datum/goal/goal, override_min_goals)
+	var/min_goals = job ? job.min_goals : 1
+
+	if(!override_min_goals && LAZYLEN(goals) == min_goals)
+		to_chat(src.current, SPAN_WARNING("Your job needs you to have at least [min_goals] distraction\s."))
+		return FALSE
+	else
+		qdel(goal)
+		return TRUE

--- a/code/modules/goals/goal_mob.dm
+++ b/code/modules/goals/goal_mob.dm
@@ -20,22 +20,29 @@
 		to_chat(src, SPAN_WARNING("You are mindless and cannot have goals."))
 		return
 
+	var/max_goals = 5
 	var/datum/department/dept
-	if(mind.assigned_job && mind.assigned_job.department_flag && SSgoals.departments["[mind.assigned_job.department_flag]"])
-		dept = SSgoals.departments["[mind.assigned_job.department_flag]"]
+	if(mind.assigned_job)
+		max_goals = mind.assigned_job.max_goals
+		if(mind.assigned_job.department_flag && SSgoals.departments["[mind.assigned_job.department_flag]"])
+			dept = SSgoals.departments["[mind.assigned_job.department_flag]"]
 
 	//No goals to display
 	if(!(allow_modification || LAZYLEN(mind.goals)) && !(dept && LAZYLEN(dept.goals)))
 		return
 
+	var/pref_val = get_preference_value(/datum/client_preference/give_personal_goals)
+	var/prefs_no_personal_goals = pref_val == GLOB.PREF_NEVER || (pref_val == GLOB.PREF_NON_ANTAG && player_is_antag(mind))
 	to_chat(src, "<hr>")
 	if(LAZYLEN(mind.goals))
 		to_chat(src, SPAN_NOTICE("<font size = 3><b>This round, you have the following personal goals:</b></font><br>[jointext(mind.summarize_goals(show_success, allow_modification, mind.current), "<br>")]"))
-	else
+	else if(prefs_no_personal_goals)
+		to_chat(src, SPAN_NOTICE("<font size = 3><b>Your preferences do not allow for personal goals.</b></font>"))
+	else 
 		to_chat(src, SPAN_NOTICE("<font size = 3><b>You have no personal goals this round.</b></font>"))
-	if(allow_modification && LAZYLEN(mind.goals) < 5)
+	if(allow_modification && !prefs_no_personal_goals && LAZYLEN(mind.goals) < max_goals)
 		to_chat(src, SPAN_NOTICE("<a href='?src=\ref[mind];add_goal=1;add_goal_caller=\ref[mind.current]'>Add Random Goal</a>"))
-	if(dept)
+	if(dept && get_preference_value(/datum/client_preference/show_department_goals) == GLOB.PREF_SHOW)
 		if(LAZYLEN(dept.goals))
 			to_chat(src, SPAN_NOTICE("<br><br><font size = 3><b>This round, [dept.name] has the following departmental goals:</b></font><br>[jointext(dept.summarize_goals(show_success), "<br>")]"))
 		else

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -48,6 +48,8 @@ Civilian
 		/datum/mil_rank/civ/civ,
 		/datum/mil_rank/civ/contractor
 	)
+	min_goals = 2
+	max_goals = 7
 
 /datum/job/merchant
 	title = "Merchant"


### PR DESCRIPTION
🆑 CSCMe
tweak: Clicking "Show Goals" tells you that they are disabled in preferences if they are.
tweak: Jobs allow 0 to 5 personal goals by default, instead of 1 to 3.
bugfix: Removing/re-rolling goals acts on the correct goals if used more than once.
bugfix: You cannot roll the same goal twice in the same set, or no goal if re-rolling one.
/🆑


Other changes:
You can now see the goal that was added to you when a new one is generated.
"Add random new goal" message now disappears when you have the maximum amount of goals your job allows instead of just 5
"Add random new goal" message also disappears if your preferences don't allow you to have personal goals
Ghosts can no longer remove their personal goals

Admin stuff:
Adding a goal to someone else now shows you the goal you generated
More admin logging for when someone adds/removes/re-rolls goals for someone else
Admins are exempt from any restrictions about preferences and min/max goal amounts when meddling with someone's goals