### PR TITLE
Gives Engineer Trainees access to Material Goggles

### DIFF
--- a/maps/torch/loadout/loadout_eyes.dm
+++ b/maps/torch/loadout/loadout_eyes.dm
@@ -21,4 +21,4 @@
 	allowed_roles = TECHNICAL_ROLES
 
 /datum/gear/eyes/material
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant)
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/engineer_trainee, /datum/job/mining, /datum/job/scientist_assistant)


### PR DESCRIPTION
:cl: Ryan180602
tweak: Engineer Trainees now get access to material goggles
/:cl:

Small tweak. If standard engineers can, doesn't make sense why trainees wouldn't be able to, either.