### PR TITLE
Swaps emergency armory peacekeeper gear for sol medium

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -9435,8 +9435,8 @@
 /obj/item/clothing/shoes/dutyboots,
 /obj/item/clothing/accessory/storage/holster/thigh,
 /obj/item/clothing/glasses/tacgoggles,
-/obj/item/clothing/suit/armor/pcarrier/blue/sol,
-/obj/item/clothing/head/helmet/solgov,
+/obj/item/clothing/suit/armor/pcarrier/medium/sol,
+/obj/item/clothing/head/helmet,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "aEH" = (


### PR DESCRIPTION
:cl:
tweak: The peacekeeper armor and helmet sets in the emergency armory are black medium with sol tags instead.
/:cl:

Technically you lose the arm guards, but it's all for the best.