### PR TITLE
Fixes some runtimes and diona gibbing

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -26,6 +26,10 @@
 //Dusting robots does not eject the MMI, so it's a bit more powerful than gib() /N
 /mob/proc/dust(anim="dust-m",remains=/obj/effect/decal/cleanable/ash)
 	death(1)
+
+	if(stat == DEAD)
+		ghostize(FALSE) //Ghosts the mob here so it keeps its sprite
+
 	var/atom/movable/overlay/animation = null
 	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
 	icon = null

--- a/code/modules/mob/living/carbon/alien/diona/_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/_nymph.dm
@@ -102,7 +102,7 @@
 	if(prob(emote_prob))
 		D.emote(pick("scratch","jump","chirp","tail"))
 
-/proc/split_into_nymphs(var/mob/living/carbon/human/donor)
+/proc/split_into_nymphs(var/mob/living/carbon/human/donor, dying)
 
 	if(!donor || donor.species.name != SPECIES_DIONA)
 		return
@@ -149,4 +149,5 @@
 		donor.drop_from_inventory(W)
 
 	donor.visible_message("<span class='warning'>\The [donor] quivers slightly, then splits apart with a wet slithering noise.</span>")
-	qdel(donor)
+	if (!dying)
+		qdel(donor)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -77,6 +77,8 @@
 
 /mob/living/carbon/gib()
 	for(var/mob/M in contents)
+		if(isspecies(src, SPECIES_DIONA) && istype(M, /mob/living/carbon/alien/diona) && (M.stat != DEAD))
+			continue
 		M.dropInto(loc)
 		visible_message(SPAN_DANGER("\The [M] bursts out of \the [src]!"))
 	..()

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -1,7 +1,7 @@
 /mob/living/silicon/robot/dust()
 	//Delete the MMI first so that it won't go popping out.
 	if(mmi)
-		qdel(mmi)
+		QDEL_NULL(mmi)
 	..()
 
 /mob/living/silicon/robot/death(gibbed,deathmessage, show_dead_message)

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -428,7 +428,7 @@
 		H.visible_message("<span class='danger'>\The [H] collapses into parts, revealing a solitary diona nymph at the core.</span>")
 		return
 	else
-		split_into_nymphs(H)
+		split_into_nymphs(H, TRUE)
 
 /datum/species/diona/get_blood_name()
 	return "sap"

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -262,9 +262,9 @@
 	give_psionic_implant_on_join = FALSE
 
 /datum/job/psychiatrist/equip(var/mob/living/carbon/human/H)
-	if(H.mind.role_alt_title == "Psionic Counselor")
+	if(H.mind?.role_alt_title == "Psionic Counselor")
 		psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT)
-	if(H.mind.role_alt_title == "Mentalist")
+	if(H.mind?.role_alt_title == "Mentalist")
 		psi_faculties = list("[PSI_COERCION]" = PSI_RANK_OPERANT)
 	return ..()
 


### PR DESCRIPTION
Fixes some runtimes that can happen during bluespace death
surprisingly haven't found any open issues about these

Also fixes dusted non-humans not having ghost sprites and ghosts being able to return to their dusted bodies (which _might_ have been the cause for #22876)

🆑 CSCMe, ChaosAlpha
bugfix: Gibbed Dionaea couldn't jump between their nymphs.
bugfix: Dusted non-humans didn't have ghost sprites
/🆑