### PR TITLE
Moves the fleet wheel cover to SNCOs and up 

### DIFF
--- a/maps/torch/datums/uniforms.dm
+++ b/maps/torch/datums/uniforms.dm
@@ -78,7 +78,7 @@
 	dress_skirt = /obj/item/clothing/under/solgov/service/fleet/skirt
 	dress_over = /obj/item/clothing/suit/dress/solgov/fleet/sailor
 	dress_shoes = /obj/item/clothing/shoes/dress
-	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/garrison
 	dress_gloves = /obj/item/clothing/gloves/white
 
 /decl/hierarchy/mil_uniform/civilian

--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -69,6 +69,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(
 		/obj/item/material/sword/replica/officersword/pettyofficer,
 		/obj/item/clothing/head/beret/solgov/fleet/dress
@@ -152,6 +153,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(
 		/obj/item/material/sword/replica/officersword/pettyofficer,
 		/obj/item/clothing/head/beret/solgov/fleet/dress
@@ -228,6 +230,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/med/officer
@@ -301,6 +304,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/sup/officer
@@ -379,6 +383,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/srv/officer
@@ -435,6 +440,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/exp/officer
@@ -491,6 +497,7 @@
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
 
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
 	dress_extra = list(/obj/item/material/sword/replica/officersword/pettyofficer, /obj/item/clothing/head/beret/solgov/fleet/dress)
 
 /decl/hierarchy/mil_uniform/fleet/spt/officer


### PR DESCRIPTION
🆑 Jux
tweak: The fleet wheel cover is now exclusive to SNCOs and Officers. Tout your headgear over the lower enlisted and laugh.
/🆑 

Higher ranks should feel special in service and dress. Big, exclusive hats help.
