### PR TITLE
Survival Pod now spawns with plastic and the correct engineering tape.

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -482,7 +482,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/obj/item/tape/engineering,
+/obj/item/taperoll/engineering,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "fj" = (
@@ -665,6 +665,7 @@
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/plasteel/fifty,
+/obj/item/stack/material/plastic/fifty,
 /obj/item/device/flashlight/lantern,
 /obj/item/device/flashlight/lantern,
 /obj/item/storage/box/glowsticks,


### PR DESCRIPTION
:cl: GeneralCamo
maptweak: The crashed survival pod now spawns with plastic.
bugfix: The crashed survival pod now spawns the correct engineering tape roll (rather than pre-placed engineering tape)
/:cl:

The crashed survival pod currently spawns with solar panels, and everything needed to get a small solar system operational, except for plastic. The plastic is required for input controllers, and therefore it has now been included in the wreck.

In addition, there's some tape in the Pod. Currently it is treated as if it was placed however, rather than an item as intended. This PR fixes that as well.