### PR TITLE
Unlocked rig panels now won't check access

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -596,7 +596,7 @@
 	return ret
 
 /obj/item/rig/get_req_access()
-	if(!security_check_enabled)
+	if(!security_check_enabled || !locked)
 		return list()
 	return ..()
 


### PR DESCRIPTION
🆑CrimsonShrike
tweak: Rigs with unlocked panels require no access to use. Sharing rigs with department members no longer requires cutting wires.
/🆑