### PR TITLE
Up required players for changeling

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -11,8 +11,8 @@
 		No one knows where it came from. No one knows who it is or what it wants. One thing is for \
 		certain though... there is never just one of them. Good luck."
 	config_tag = "changeling"
-	required_players = 2
-	required_enemies = 1
+	required_players = 15
+	required_enemies = 2
 	end_on_antag_death = FALSE
 	antag_scaling_coeff = 10
 	antag_tags = list(MODE_CHANGELING)


### PR DESCRIPTION
:cl: Mucker
tweak: Upped the required player count for changeling from 2 to 15, and the required enemy count from 1 to 2.
/:cl:

Seems weird that the game can start with only *two* people readied. Numbers are subject to change after proper discussion, but this should get the ball rolling on that.