### PR TITLE
Change Skills

### DIFF
--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -228,7 +228,7 @@ The generic antag version.
 Similar, but for station antags that have jobs.
 */
 /datum/nano_module/skill_ui/antag/station
-	max_choices = list(0, 0, 3, 1, 0)
+	max_choices = list(0, 0, 2, 1, 1)
 /*
 Similar, but for off-station jobs (Bearcat, Verne, survivor etc.).
 */


### PR DESCRIPTION
:cl: Viim
tweak: Changes traitor skills from three trained, one experienced, to two trained, one experienced, and one master.
/:cl:

As it stands, a traitor can be out-CQCd by a master CC MaA 100% of the time. By switching it up, traitors have a chance to fight back, or, of course, pick other skills.