### PR TITLE
Stop CLcompiler from throwing errors

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -31,5 +31,6 @@ jobs:
         run: |
           git config --global user.email "${{ secrets.BOT_EMAIL }}"
           git config --global user.name "${{ secrets.BOT_NAME }}"
+          git diff --quiet --exit-code && echo "No changes found, abort." && exit 0
           git commit -m "Automatic changelog generation" -a
           git push


### PR DESCRIPTION
That should stop CL compiler from throwing action's failure if there is no changelogs to compile
![image](https://user-images.githubusercontent.com/32466328/120066570-da40ee00-c07f-11eb-924e-9ad89a280849.png)
