### PR TITLE
Removes pickpocket gloves

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -164,9 +164,3 @@
 	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
 			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
 			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."
-
-/datum/uplink_item/item/tools/pickpocket_gloves
-	name = "Pickpocket's Gloves"
-	item_cost = 15
-	path = /obj/item/clothing/gloves/thick/duty/pickpocket
-	desc = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others or adjust their suit sensors."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -279,7 +279,6 @@ BLIND     // can't see anything
 	var/clipped = 0
 	var/obj/item/clothing/ring/ring = null		//Covered ring
 	var/mob/living/carbon/human/wearer = null	//Used for covered rings when dropping
-	var/pickpocket = FALSE  //Indicates these gloves are pickpocketing gloves.
 	body_parts_covered = HANDS
 	slot_flags = SLOT_GLOVES
 	attack_verb = list("challenged")

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -66,11 +66,11 @@
 	item_state = "swat_gl"
 	force = 5
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_PISTOL,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR)
 
 /obj/item/clothing/gloves/thick/combat //Combined effect of SWAT gloves and insulated gloves
@@ -82,11 +82,11 @@
 	permeability_coefficient = 0.05
 	force = 5
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_PISTOL,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR)
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
@@ -130,8 +130,8 @@
 	icon_state = "work"
 	item_state = "wgloves"
 	armor = list(
-		melee = ARMOR_MELEE_MINOR, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
+		melee = ARMOR_MELEE_MINOR,
+		bullet = ARMOR_BALLISTIC_MINOR,
 		laser = ARMOR_LASER_MINOR
 		)
 
@@ -147,8 +147,8 @@
 	siemens_coefficient = 0.50
 	permeability_coefficient = 0.05
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
+		melee = ARMOR_MELEE_KNIVES,
+		bullet = ARMOR_BALLISTIC_MINOR,
 		laser = ARMOR_LASER_MINOR
 		)
 
@@ -162,10 +162,10 @@
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.03
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_SMALL, 
-		energy = ARMOR_ENERGY_SMALL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_SMALL,
+		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 		)
 
@@ -185,8 +185,3 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
-
-/obj/item/clothing/gloves/thick/duty/pickpocket
-	desc = "These brown duty gloves are made from a durable synthetic. The inside is lined with wiring."
-	pickpocket = TRUE
-

--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -78,7 +78,3 @@
 /obj/item/clothing/suit/armor/pcarrier/get_mechanics_info()
 	. = ..()
 	. += "<br>Its protection is provided by the plate inside, examine it for details on armor.<br>"
-
-/datum/codex_entry/pickpocket_gloves
-	associated_paths = list(/obj/item/clothing/gloves/thick/duty/pickpocket)
-	antag_text = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others pockets, hands, ears, or suit storage, or adjust their suit sensors."

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -19,41 +19,21 @@
 	if(!istype(held) || is_robot_module(held))
 		stripping = TRUE
 
-	// Is the user wearing pickpocketing gloves?
-	var/stealth = FALSE
-	var/obj/item/clothing/gloves/glove = user.get_equipped_item(slot_gloves)
-	if(istype(glove))
-		stealth = glove.pickpocket
-
-	if(stealth)
-		strip_delay = strip_delay-10
-
-	var/strip_flags = stealth ? DO_DEFAULT : (DO_DEFAULT | DO_PUBLIC_PROGRESS)
-
 	switch (slot_to_strip_text)
 		if ("pockets")
 			if (stripping)
-				if (!stealth)
-					visible_message(SPAN_DANGER("\The [user] is trying to empty [src]'s pockets!"))
-				else
-					to_chat(user, SPAN_NOTICE("You start picking \the [src]'s pockets."))
-				if (do_after(user, strip_delay, src, do_flags = strip_flags))
+				visible_message(SPAN_DANGER("\The [user] is trying to empty [src]'s pockets!"))
+				if (do_after(user, strip_delay, src, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS))
 					empty_pockets(user)
 			else
-				if (!stealth)
-					visible_message(SPAN_DANGER("\The [user] is trying to stuff \a [held] into \the [src]'s pocket!"))
-				else
-					to_chat(user, SPAN_NOTICE("You start planting \a [held] into \the [src]'s pocket."))
-				if (do_after(user, strip_delay, src, do_flags = strip_flags))
+				visible_message(SPAN_DANGER("\The [user] is trying to stuff \a [held] into \the [src]'s pocket!"))
+				if (do_after(user, strip_delay, src, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS))
 					place_in_pockets(held, user)
 			return
 
 		if ("sensors")
-			if (!stealth)
-				visible_message(SPAN_DANGER("\The [user] is trying to set \the [src]'s sensors!"))
-			else
-				to_chat(user, SPAN_NOTICE("You start stealthily adjusting \the [src]'s sensors."))
-			if (do_after(user, strip_delay, src, do_flags = strip_flags))
+			visible_message(SPAN_DANGER("\The [user] is trying to set \the [src]'s sensors!"))
+			if (do_after(user, strip_delay, src, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS))
 				toggle_sensors(user)
 			return
 
@@ -79,7 +59,7 @@
 
 		if ("internals")
 			visible_message(SPAN_DANGER("\The [usr] is trying to set \the [src]'s internals!"))
-			if (do_after(user, strip_delay, src, do_flags = strip_flags))
+			if (do_after(user, strip_delay, src, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS))
 				toggle_internals(user)
 			return
 
@@ -94,11 +74,8 @@
 				A = input("Select an accessory to remove from [holder]") as null | anything in holder.accessories
 			if (isnull(A))
 				return
-			if (!stealth)
-				visible_message(SPAN_DANGER("\The [user] starts trying to remove \the [src]'s [A.name]!"))
-			else
-				to_chat(user, SPAN_NOTICE("You start stealthily removing \the [src]'s [A.name]."))
-			if (!do_after(user, strip_delay, src, do_flags = strip_flags))
+			visible_message(SPAN_DANGER("\The [user] starts trying to remove \the [src]'s [A.name]!"))
+			if (!do_after(user, strip_delay, src, do_flags = DO_DEFAULT | DO_PUBLIC_PROGRESS))
 				return
 			if (!A || holder.loc != src || !(A in holder.accessories))
 				return
@@ -120,23 +97,15 @@
 				return
 
 	var/obj/item/target_slot = get_equipped_item(text2num(slot_to_strip_text))
-	var/pickpocketable_list = list(slot_l_ear, slot_r_ear, slot_l_hand, slot_r_hand, slot_s_store)
-	var/pickpocketable_object = (text2num(slot_to_strip_text) in pickpocketable_list)
 	if (stripping)
 		if (!istype(target_slot))  // They aren't holding anything valid and there's nothing to remove, why are we even here?
 			return
 		if (!target_slot.mob_can_unequip(src, text2num(slot_to_strip_text), disable_warning = TRUE))
 			to_chat(user, SPAN_WARNING("You cannot remove \the [src]'s [target_slot.name]."))
 			return
-		if (!(stealth && pickpocketable_object))
-			visible_message(SPAN_DANGER("\The [user] is trying to remove \the [src]'s [target_slot.name]!"))
-		else
-			to_chat(user, SPAN_NOTICE("You start stealthily removing \the [src]'s [target_slot.name]."))
+		visible_message(SPAN_DANGER("\The [user] is trying to remove \the [src]'s [target_slot.name]!"))
 	else
-		if (!(stealth && pickpocketable_object))
-			visible_message(SPAN_DANGER("\The [user] is trying to put \a [held] on \the [src]!"))
-		else
-			to_chat(user, SPAN_NOTICE("You start stealthily planting \a [held] on \the [src]."))
+		visible_message(SPAN_DANGER("\The [user] is trying to put \a [held] on \the [src]!"))
 
 	if (!do_after(user, strip_delay, src))
 		return
@@ -155,24 +124,14 @@
 			user.put_in_active_hand(held)
 
 /mob/living/carbon/human/proc/empty_pockets(mob/living/user)
-	var/obj/item/clothing/gloves/glove = user.get_equipped_item(slot_gloves)
-	var/stealth = istype(glove, /obj/item/clothing/gloves) ? glove.pickpocket : FALSE
 	if (!r_store && !l_store)
 		to_chat(user, SPAN_WARNING("\The [src] has nothing in their pockets."))
 		return
-	var/target_slot = null
 	if (r_store)
-		target_slot = r_store
-		if (unEquip(r_store) && stealth)
-			user.put_in_active_hand(target_slot)
+		unEquip(r_store)
 	if (l_store)
-		target_slot = l_store
-		if (unEquip(l_store) && stealth)
-			user.put_in_inactive_hand(target_slot)
-	if (!stealth)
-		visible_message(SPAN_DANGER("\The [user] empties [src]'s pockets!"))
-	else
-		to_chat(user, SPAN_NOTICE("You stealthily pick [src]'s pockets."))
+		unEquip(l_store)
+	visible_message(SPAN_DANGER("\The [user] empties [src]'s pockets!"))
 
 /mob/living/carbon/human/proc/place_in_pockets(obj/item/I, var/mob/living/user)
 	if(!user.unEquip(I))


### PR DESCRIPTION
The concept was interesting, but the implementation proved to be more problematic than anything else. After the nerf to removing radios and IDs they're basically unused and useless now.

:cl: SierraKomodo
rscdel: Pickpocket gloves have been removed.
/:cl: