### PR TITLE
Fixes the voice changer mask being unable to change appearance

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -81,7 +81,7 @@
 
 /obj/item/clothing/mask/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src,/datum/extension/chameleon/clothing,/obj/item/clothing/mask)
 
 /obj/item/clothing/glasses/chameleon
 	name = "goggles"


### PR DESCRIPTION
🆑
bugfix: You can now properly change the appearance of the modified gas mask.
/🆑
The extension was looking for subtypes of the parent type, but since it was a single subtype of the existing chameleon mask, it was only finding itself. Passing an expected type as an argument solved the problem.

Fixes #30445.