### PR TITLE
tentative 513+ification

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -28,13 +28,12 @@
 	if(!input)
 		return
 
-	if(max_length)
-		//testing shows that just looking for > max_length alone will actually cut off the final character if message is precisely max_length, so >= instead
-		if(length(input) >= max_length)
-			var/overflow = ((length(input)+1) - max_length)
-			to_chat(usr, "<span class='warning'>Your message is too long by [overflow] character\s.</span>")
+	if (max_length)
+		var/len = length_char(input)
+		if (len > max_length)
+			to_chat(usr, SPAN_WARNING("Your message is too long by [len - max_length] char\s."))
 			return
-		input = copytext(input,1,max_length)
+		input = copytext_char(input, 1, max_length + 1)
 
 	if(extra)
 		input = replace_characters(input, list("\n"=" ","\t"=" "))
@@ -230,13 +229,13 @@
 // Adds the required amount of 'character' in front of 'text' to extend the lengh to 'desired_length', if it is shorter
 // No consideration are made for a multi-character 'character' input
 /proc/pad_left(text, desired_length, character)
-	var/padding = generate_padding(length(text), desired_length, character)
+	var/padding = generate_padding(length_char(text), desired_length, character)
 	return length(padding) ? "[padding][text]" : text
 
 // Adds the required amount of 'character' after 'text' to extend the lengh to 'desired_length', if it is shorter
 // No consideration are made for a multi-character 'character' input
 /proc/pad_right(text, desired_length, character)
-	var/padding = generate_padding(length(text), desired_length, character)
+	var/padding = generate_padding(length_char(text), desired_length, character)
 	return length(padding) ? "[text][padding]" : text
 
 /proc/generate_padding(current_length, desired_length, character)
@@ -256,7 +255,7 @@
 
 //Returns a string with reserved characters and spaces after the last letter removed
 /proc/trim_right(text)
-	for (var/i = length(text), i > 0, i--)
+	for (var/i = length(text) to 1 step -1)
 		if (text2ascii(text, i) > 32)
 			return copytext(text, 1, i + 1)
 	return ""
@@ -266,8 +265,8 @@
 	return trim_left(trim_right(text))
 
 //Returns a string with the first element of the string capitalized.
-/proc/capitalize(var/t as text)
-	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
+/proc/capitalize(text)
+	return uppertext(copytext_char(text, 1, 2)) + copytext_char(text, 2)
 
 //This proc strips html properly, remove < > and all text between
 //for complete text sanitizing should be used sanitize()
@@ -327,11 +326,10 @@
 			count++
 	return count
 
-/proc/reverse_text(var/text = "")
-	var/new_text = ""
-	for(var/i = length(text); i > 0; i--)
-		new_text += copytext(text, i, i+1)
-	return new_text
+/proc/reverse_text(text)
+	. = ""
+	for (var/i = length_char(text) to 1 step -1)
+		. += copytext_char(text, i, i + 1)
 
 //Used in preferences' SetFlavorText and human's set_flavor verb
 //Previews a string of len or less length
@@ -376,7 +374,8 @@ proc/TextPreview(var/string,var/len=40)
 		. += ascii2text(letter)
 	. = jointext(.,null)
 
-#define starts_with(string, substring) (copytext(string,1,1+length(substring)) == substring)
+#define text_starts_with(string, substring) !!findtext_char((string), (substring), 1, 1 + length_char(substring))
+#define text_ends_with(string, substring) !!findtext_char((string), (substring), -length_char(substring))
 
 #define gender2text(gender) capitalize(gender)
 
@@ -582,10 +581,10 @@ proc/TextPreview(var/string,var/len=40)
 	return "[result]" == text ? result : default
 
 /proc/text2regex(text)
-	var/end = findlasttext(text, "/")
-	if (end > 2 && length(text) > 2 && text[1] == "/")
-		var/flags = end == length(text) ? FALSE : copytext(text, end + 1)
-		var/matcher = copytext(text, 2, end)
+	var/end = findlasttext_char(text, "/")
+	if (end > 2 && length_char(text) > 2 && copytext_char(text, 1, 2) == "/")
+		var/flags = end == length_char(text) ? FALSE : copytext_char(text, end + 1)
+		var/matcher = copytext_char(text, 2, end)
 		try
 			return flags ? regex(matcher, flags) : regex(matcher)
 		catch()

--- a/code/datums/repositories/admin_pm.dm
+++ b/code/datums/repositories/admin_pm.dm
@@ -13,7 +13,7 @@ var/repository/admin_pm/admin_pm_repository = new()
 	if(receiver)
 		if(istype(receiver))
 			receiver = client_repository.get_lite_client(receiver)
-		else if(starts_with(receiver, "IRC-"))
+		else if(text_starts_with(receiver, "IRC-"))
 			receiver = get_irc_client(receiver)
 		else
 			CRASH("Invalid receiver: [log_info_line(receiver)]")
@@ -41,4 +41,3 @@ var/repository/admin_pm/admin_pm_repository = new()
 	src.message = message
 	src.sender = sender
 	src.receiver = receiver
-

--- a/code/modules/admin/verbs/SDQL.dm
+++ b/code/modules/admin/verbs/SDQL.dm
@@ -1,8 +1,6 @@
 
 //Structured Datum Query Language. Basically SQL meets BYOND objects.
 
-//Note: For use in BS12, need text_starts_with proc, and to modify the action on select to use BS12's object edit command(s).
-
 /client/proc/SDQL_query(query_text as message)
 	set category = "Admin"
 	if(!check_rights(R_DEBUG))  //Shouldn't happen... but just to be safe.
@@ -370,16 +368,6 @@
 				return object.vars[text]
 			else
 				return null
-
-
-/proc/text_starts_with(text, start)
-	if(copytext(text, 1, length(start) + 1) == start)
-		return 1
-	else
-		return 0
-
-
-
 
 
 /proc/SDQL_tokenize(query_text)

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -205,14 +205,14 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	for (var/path in common_dirs)
 		var/list/filenames = flist(path)
 		for(var/filename in filenames)
-			if(copytext(filename, length(filename)) != "/") // Ignore directories.
+			if(copytext(filename, -1) != "/") // Ignore directories.
 				if(fexists(path + filename))
 					common[filename] = fcopy_rsc(path + filename)
 					register_asset(filename, common[filename])
 	for (var/path in uncommon_dirs)
 		var/list/filenames = flist(path)
 		for(var/filename in filenames)
-			if(copytext(filename, length(filename)) != "/") // Ignore directories.
+			if(copytext(filename, -1) != "/") // Ignore directories.
 				if(fexists(path + filename))
 					register_asset(filename, fcopy_rsc(path + filename))
 
@@ -222,7 +222,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 	var/list/filenames = flist(MAP_IMAGE_PATH)
 	for(var/filename in filenames)
-		if(copytext(filename, length(filename)) != "/") // Ignore directories.
+		if(copytext(filename, -1) != "/") // Ignore directories.
 			var/file_path = MAP_IMAGE_PATH + filename
 			if((filename in mapnames) && fexists(file_path))
 				common[filename] = fcopy_rsc(file_path)

--- a/code/modules/client/preference_setup/global/prefixes.dm
+++ b/code/modules/client/preference_setup/global/prefixes.dm
@@ -26,4 +26,4 @@
 
 /decl/prefix/custom_emote
 	name = "Emote, custom"
-	default_key = "*"
+	default_key = "/"

--- a/code/modules/flufftext/TextFilters.dm
+++ b/code/modules/flufftext/TextFilters.dm
@@ -1,28 +1,3 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
-
-proc/Intoxicated(phrase)
-	phrase = html_decode(phrase)
-	var/leng=length(phrase)
-	var/counter=length(phrase)
-	var/newphrase=""
-	var/newletter=""
-	while(counter>=1)
-		newletter=copytext(phrase,(leng-counter)+1,(leng-counter)+2)
-		if(rand(1,3)==3)
-			if(lowertext(newletter)=="o")	newletter="u"
-			if(lowertext(newletter)=="s")	newletter="ch"
-			if(lowertext(newletter)=="a")	newletter="ah"
-			if(lowertext(newletter)=="c")	newletter="k"
-		switch(rand(1,7))
-			if(1,3,5,8)	newletter="[lowertext(newletter)]"
-			if(2,4,6,15)	newletter="[uppertext(newletter)]"
-			if(7)	newletter+="'"
-			//if(9,10)	newletter="<b>[newletter]</b>"
-			//if(11,12)	newletter="<big>[newletter]</big>"
-			//if(13)	newletter="<small>[newletter]</small>"
-		newphrase+="[newletter]";counter-=1
-	return newphrase
-
 proc/NewStutter(phrase,stunned)
 	phrase = html_decode(phrase)
 
@@ -40,8 +15,8 @@ proc/NewStutter(phrase,stunned)
 		var/index = list_find(split_phrase, word) //Find the word in the split phrase so we can replace it.
 
 		//Search for dipthongs (two letters that make one sound.)
-		var/first_sound = copytext(word,1,3)
-		var/first_letter = copytext(word,1,2)
+		var/first_sound = copytext_char(word,1,3)
+		var/first_letter = copytext_char(word,1,2)
 		if(lowertext(first_sound) in list("ch","th","sh"))
 			first_letter = first_sound
 
@@ -100,7 +75,7 @@ proc/RadioChat(mob/living/user, message, distortion_chance = 60, distortion_spee
 	if(input_size < 20) // Short messages get distorted too. Bit hacksy.
 		distortion += (20-input_size)/2
 	while(lentext <= input_size)
-		var/newletter=copytext(message, lentext, lentext+1)
+		var/newletter=copytext_char(message, lentext, lentext+1)
 		if(!prob(distortion_chance))
 			new_message += newletter
 			lentext += 1

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -17,7 +17,7 @@
 
 /datum/language/noise/get_talkinto_msg_range(message)
 	// if you make a loud noise (screams etc), you'll be heard from 4 tiles over instead of two
-	return (copytext(message, length(message)) == "!") ? 4 : 2
+	return (copytext(message, -1) == "!") ? 4 : 2
 
 /datum/language/sign
 	name = LANGUAGE_SIGN

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -65,7 +65,7 @@
 	var/new_sentence = 0
 	for(var/w in words)
 		var/nword = "[w] "
-		var/input_ending = copytext(w, length(w))
+		var/input_ending = copytext(w, -1)
 		var/ends_sentence = findtext(".?!",input_ending)
 		if(!prob(understand_chance))
 			nword = scramble_word(w)
@@ -131,7 +131,7 @@
 
 /datum/language/proc/get_talkinto_msg_range(message)
 	// if you yell, you'll be heard from two tiles over instead of one
-	return (copytext(message, length(message)) == "!") ? 2 : 1
+	return (copytext(message, -1) == "!") ? 2 : 1
 
 /datum/language/proc/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 	log_say("[key_name(speaker)] : ([name]) [message]")

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -44,7 +44,7 @@
 		var/min_index = 10000 // if the message is longer than this, the autohiss is the least of your problems
 		var/min_char = null
 		for(var/char in map)
-			var/i = findtext(message, char)
+			var/i = findtext_char(message, char)
 			if(!i) // no more of this character anywhere in the string, don't even bother searching next time
 				map -= char
 			else if(i < min_index)
@@ -53,8 +53,8 @@
 		if(!min_char) // we didn't find any of the mapping characters
 			. += message
 			break
-		. += copytext(message, 1, min_index)
-		if(copytext(message, min_index, min_index+1) == uppertext(min_char))
+		. += copytext_char(message, 1, min_index)
+		if(copytext_char(message, min_index, min_index+1) == uppertext(min_char))
 			switch(text2ascii(message, min_index+1))
 				if(65 to 90) // A-Z, uppercase; uppercase R/S followed by another uppercase letter, uppercase the entire replacement string
 					. += uppertext(pick(map[min_char]))
@@ -62,6 +62,6 @@
 					. += capitalize(pick(map[min_char]))
 		else
 			. += pick(map[min_char])
-		message = copytext(message, min_index + 1)
+		message = copytext_char(message, min_index + 1)
 
 	return jointext(., null)

--- a/code/modules/mob/living/carbon/alien/say.dm
+++ b/code/modules/mob/living/carbon/alien/say.dm
@@ -12,8 +12,8 @@
 	if(stat == 2)
 		return say_dead(message)
 
-	if(copytext(message,1,2) == get_prefix_key(/decl/prefix/custom_emote))
-		return emote(copytext(message,2))
+	if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/custom_emote))
+		return emote(copytext_char(message,2))
 
 	var/datum/language/speaking = parse_language(message)
 

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -12,7 +12,7 @@
 		if(speaking)
 			message = copytext(message, 2+length(speaking.key))
 		var/verb = "says"
-		var/ending = copytext(message, length(message))
+		var/ending = copytext(message, -1)
 		if (speaking)
 			verb = speaking.get_spoken_verb(ending)
 		else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -7,7 +7,7 @@
 	if(!speaking)
 		speaking = parse_language(message)
 		if (speaking)
-			message = copytext(message,2+length(speaking.key))
+			message = copytext_char(message,2+length_char(speaking.key))
 		else
 			speaking = get_any_good_language(set_default=TRUE)
 			if (!speaking)
@@ -133,7 +133,7 @@
 
 /mob/living/carbon/human/say_quote(var/message, var/datum/language/speaking = null)
 	var/verb = "says"
-	var/ending = copytext(message, length(message))
+	var/ending = copytext(message, -1)
 
 	if(speaking)
 		verb = speaking.get_spoken_verb(ending)
@@ -231,12 +231,12 @@
 	. = ..()
 
 /mob/living/carbon/human/parse_language(var/message)
-	var/prefix = copytext(message,1,2)
+	var/prefix = copytext_char(message,1,2)
 	if(length(message) >= 1 && prefix == get_prefix_key(/decl/prefix/audible_emote))
 		return all_languages["Noise"]
 
 	if(length(message) >= 2 && is_language_prefix(prefix))
-		var/language_prefix = lowertext(copytext(message, 2 ,3))
+		var/language_prefix = lowertext(copytext_char(message, 2 ,3))
 		var/datum/language/L = language_keys[language_prefix]
 		if (can_speak(L))
 			return L

--- a/code/modules/mob/living/carbon/xenobiological/say.dm
+++ b/code/modules/mob/living/carbon/xenobiological/say.dm
@@ -4,13 +4,13 @@
 
 	var/verb = say_quote(message)
 
-	if(copytext(message,1,2) == get_prefix_key(/decl/prefix/custom_emote))
-		return emote(copytext(message,2))
+	if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/custom_emote))
+		return emote(copytext_char(message,2))
 
 	return ..(message, null, verb)
 
 /mob/living/carbon/slime/say_quote(var/text)
-	var/ending = copytext(text, length(text))
+	var/ending = copytext(text, -1)
 
 	if (ending == "?")
 		return "asks";

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -150,7 +150,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 	message = html_decode(message)
 
-	var/end_char = copytext(message, length(message), length(message) + 1)
+	var/end_char = copytext_char(message, -1)
 	if(!(end_char in list(".", "?", "!", "-", "~", ":")))
 		message += "."
 
@@ -167,17 +167,17 @@ proc/get_radio_key_from_channel(var/channel)
 			return say_dead(message)
 		return
 
-	var/prefix = copytext(message,1,2)
+	var/prefix = copytext_char(message, 1, 2)
 	if(prefix == get_prefix_key(/decl/prefix/custom_emote))
-		return emote(copytext(message,2))
+		return emote(copytext_char(message, 2))
 	if(prefix == get_prefix_key(/decl/prefix/visible_emote))
-		return custom_emote(1, copytext(message,2))
+		return custom_emote(1, copytext_char(message, 2))
 
 	//parse the language code and consume it
 	if(!speaking)
 		speaking = parse_language(message)
 		if(speaking)
-			message = copytext(message,2+length(speaking.key))
+			message = copytext_char(message, 2 + length_char(speaking.key))
 		else
 			speaking = get_default_language()
 
@@ -185,9 +185,9 @@ proc/get_radio_key_from_channel(var/channel)
 	var/message_mode = parse_message_mode(message, "headset")
 	if (message_mode)
 		if (message_mode == "headset")
-			message = copytext(message,2)	//it would be really nice if the parse procs could do this for us.
+			message = copytext_char(message, 2)	//it would be really nice if the parse procs could do this for us.
 		else
-			message = copytext(message,3)
+			message = copytext_char(message, 3)
 
 	message = trim_left(message)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -10,10 +10,10 @@
 		if (stat == DEAD)
 			return say_dead(message)
 
-		if(copytext(message,1,2) == "*")
+		if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/custom_emote))
 			return emote(copytext(message,2))
 
-		if(copytext(message,1,2) == ";")
+		if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
 			var/datum/language/L = all_languages[LANGUAGE_DRONE_GLOBAL]
 			if(istype(L))
 				return L.broadcast(src,trim(copytext(message,2)))

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -39,7 +39,7 @@
 		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
 
 /mob/living/silicon/say_quote(var/text)
-	var/ending = copytext(text, length(text))
+	var/ending = copytext(text, -1)
 	if (ending == "?")
 		return speak_query
 	else if (ending == "!")

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -17,8 +17,8 @@
 			to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")
 			return
 
-	if (copytext(message, 1, 2) == "*")
-		return emote(copytext(message, 2))
+	if (copytext_char(message, 1, 2) == get_prefix_key(/decl/prefix/custom_emote))
+		return emote(copytext_char(message, 2))
 
 	var/datum/language/L = parse_language(message)
 	if(L && L.flags & HIVEMIND)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -713,7 +713,7 @@
 
 
 	var/message_mode=""
-	if(copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
+	if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
 		message_mode = "headset"
 		message = copytext(message,2)
 
@@ -721,7 +721,7 @@
 		var/channel_prefix = copytext(message, 1 ,3)
 		message_mode = department_radio_keys[channel_prefix]
 
-	if(copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_channel_selection))
+	if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/radio_channel_selection))
 		var/positioncut = 3
 		message = trim(copytext(message,positioncut))
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -188,11 +188,6 @@
 /atom/proc/drain_power(var/drain_check,var/surge, var/amount = 0)
 	return -1
 
-/mob/proc/findname(msg)
-	for(var/mob/M in SSmobs.mob_list)
-		if (M.real_name == msg)
-			return M
-	return 0
 
 /mob/proc/movement_delay()
 	. = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -194,8 +194,8 @@ var/list/global/organ_rel_size = list(
 	var/intag = 0
 	var/block = list()
 	. = list()
-	for(var/i = 1, i <= length(n), i++)
-		var/char = copytext(n, i, i+1)
+	for(var/i = 1, i <= length_char(n), i++)
+		var/char = copytext_char(n, i, i+1)
 		if(!intag && (char == "<"))
 			intag = 1
 			. += stars_no_html(JOINTEXT(block), pr, re_encode) //stars added here
@@ -212,8 +212,8 @@ var/list/global/organ_rel_size = list(
 /proc/stars_no_html(text, pr, re_encode)
 	text = html_decode(text) //We don't want to screw up escaped characters
 	. = list()
-	for(var/i = 1, i <= length(text), i++)
-		var/char = copytext(text, i, i+1)
+	for(var/i = 1, i <= length_char(text), i++)
+		var/char = copytext_char(text, i, i+1)
 		if(char == " " || prob(pr))
 			. += char
 		else
@@ -224,12 +224,12 @@ var/list/global/organ_rel_size = list(
 
 proc/slur(phrase)
 	phrase = html_decode(phrase)
-	var/leng=length(phrase)
-	var/counter=length(phrase)
+	var/leng = length_char(phrase)
+	var/counter = length_char(phrase)
 	var/newphrase=""
 	var/newletter=""
 	while(counter>=1)
-		newletter=copytext(phrase,(leng-counter)+1,(leng-counter)+2)
+		newletter=copytext_char(phrase,(leng-counter)+1,(leng-counter)+2)
 		if(rand(1,3)==3)
 			if(lowertext(newletter)=="o")	newletter="u"
 			if(lowertext(newletter)=="s")	newletter="ch"
@@ -248,11 +248,11 @@ proc/slur(phrase)
 /proc/stutter(n)
 	var/te = html_decode(n)
 	var/t = ""//placed before the message. Not really sure what it's for.
-	n = length(n)//length of the entire word
+	n = length_char(n)//length of the entire word
 	var/p = null
 	p = 1//1 is the start of any word
 	while(p <= n)//while P, which starts at 1 is less or equal to N which is the length.
-		var/n_letter = copytext(te, p, p + 1)//copies text from a certain distance. In this case, only one letter at a time.
+		var/n_letter = copytext_char(te, p, p + 1)//copies text from a certain distance. In this case, only one letter at a time.
 		if (prob(80) && (ckey(n_letter) in list("b","c","d","f","g","h","j","k","l","m","n","p","q","r","s","t","v","w","x","y","z")))
 			if (prob(10))
 				n_letter = text("[n_letter]-[n_letter]-[n_letter]-[n_letter]")//replaces the current letter with this instead.
@@ -272,9 +272,9 @@ proc/slur(phrase)
 proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added
 	/* Turn text into complete gibberish! */
 	var/returntext = ""
-	for(var/i = 1, i <= length(t), i++)
+	for(var/i = 1, i <= length_char(t), i++)
 
-		var/letter = copytext(t, i, i+1)
+		var/letter = copytext_char(t, i, i+1)
 		if(prob(50))
 			if(p >= 70)
 				letter = ""
@@ -285,35 +285,6 @@ proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 fo
 		returntext += letter
 
 	return returntext
-
-
-/proc/ninjaspeak(n)
-/*
-The difference with stutter is that this proc can stutter more than 1 letter
-The issue here is that anything that does not have a space is treated as one word (in many instances). For instance, "LOOKING," is a word, including the comma.
-It's fairly easy to fix if dealing with single letters but not so much with compounds of letters./N
-*/
-	var/te = html_decode(n)
-	var/t = ""
-	n = length(n)
-	var/p = 1
-	while(p <= n)
-		var/n_letter
-		var/n_mod = rand(1,4)
-		if(p+n_mod>n+1)
-			n_letter = copytext(te, p, n+1)
-		else
-			n_letter = copytext(te, p, p+n_mod)
-		if (prob(50))
-			if (prob(30))
-				n_letter = text("[n_letter]-[n_letter]-[n_letter]")
-			else
-				n_letter = text("[n_letter]-[n_letter]")
-		else
-			n_letter = text("[n_letter]")
-		t = text("[t][n_letter]")
-		p=p+n_mod
-	return sanitize(t)
 
 
 /proc/shake_camera(mob/M, duration, strength=1)
@@ -341,13 +312,6 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 		M.client.eye=oldeye
 		M.shakecamera = 0
-
-
-/proc/findname(msg)
-	for(var/mob/M in SSmobs.mob_list)
-		if (M.real_name == text("[msg]"))
-			return 1
-	return 0
 
 
 /mob/proc/abiotic(var/full_body = FALSE)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -59,7 +59,7 @@
 	return 0
 
 /mob/proc/say_quote(var/message, var/datum/language/speaking = null)
-	var/ending = copytext(message, length(message))
+	var/ending = copytext(message, -1)
 	if(speaking)
 		return speaking.get_spoken_verb(ending)
 
@@ -80,7 +80,7 @@
 	return get_turf(src)
 
 /mob/proc/say_test(var/text)
-	var/ending = copytext(text, length(text))
+	var/ending = copytext(text, -1)
 	if (ending == "?")
 		return "1"
 	else if (ending == "!")
@@ -91,11 +91,11 @@
 //returns the message mode string or null for no message mode.
 //standard mode is the mode returned for the special ';' radio code.
 /mob/proc/parse_message_mode(var/message, var/standard_mode="headset")
-	if(length(message) >= 1 && copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
+	if(length(message) >= 1 && copytext_char(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
 		return standard_mode
 
 	if(length(message) >= 2)
-		var/channel_prefix = copytext(message, 1 ,3)
+		var/channel_prefix = copytext_char(message, 1 ,3)
 		return department_radio_keys[channel_prefix]
 
 	return null
@@ -103,12 +103,12 @@
 //parses the language code (e.g. :j) from text, such as that supplied to say.
 //returns the language object only if the code corresponds to a language that src can speak, otherwise null.
 /mob/proc/parse_language(var/message)
-	var/prefix = copytext(message,1,2)
+	var/prefix = copytext_char(message,1,2)
 	if(length(message) >= 1 && prefix == get_prefix_key(/decl/prefix/audible_emote))
 		return all_languages["Noise"]
 
 	if(length(message) >= 2 && is_language_prefix(prefix))
-		var/language_prefix = lowertext(copytext(message, 2 ,3))
+		var/language_prefix = lowertext(copytext_char(message, 2 ,3))
 		var/datum/language/L = language_keys[language_prefix]
 		if (can_speak(L))
 			return L

--- a/code/unit_tests/icon_tests.dm
+++ b/code/unit_tests/icon_tests.dm
@@ -17,7 +17,7 @@
 	for(var/icon_state in valid_states)
 		if(icon_state in excepted_icon_states_)
 			continue
-		if(starts_with(icon_state, "eyes-"))
+		if(text_starts_with(icon_state, "eyes-"))
 			continue
 		if(findtext(icon_state, "openpanel"))
 			continue


### PR DESCRIPTION
:cl:
tweak: The default builtin-emote key is / instead of * to prevent conflicts with italics.
/:cl:

Went through every copytext to see if it needed _char, these looked about right. The first commit is the important one, the rest just happened along the way. I don't think I can survive looking at every length but I handled a couple of relevant ones from other codebases' 513y stuff.

Users interested in the tweak CL will still need to use Setup -> Global -> Reset on `Emote, custom` to get that change (and can set it themselves there before merge anyway).
