### PR TITLE
Attempting to delete an owned mob in build mode now throws a confirmation prompt first

### DIFF
--- a/code/modules/admin/buildmode/build.dm
+++ b/code/modules/admin/buildmode/build.dm
@@ -33,6 +33,16 @@
 	if (parameters["right"])
 		if (isturf(target))
 			return
+		if (isobserver(target)) // don't delete ghosts because it causes very weird things to happen
+			return
+		if (ismob(target))
+			var/mob/M = target
+			if (M.ckey && !QDELETED(M))
+				var/alert_result = alert(user, "[M] is a player-controlled mob. Confirm?", "Build Mode", "Yes, Delete", "Cancel")
+				if (alert_result != "Yes, Delete" || QDELETED(M))
+					return
+			to_chat(M, SPAN_DEBUG(FONT_LARGE("OOC: You have been deleted by an admin using build mode. If this seems to be in error, please adminhelp and let them know.")))
+			M.ghostize()
 		qdel(target)
 	else if (parameters["left"])
 		if (!build_type)


### PR DESCRIPTION
🆑
bugfix: Being deleted in build mode should no longer crash your game.
tweak: For admins: build mode now has a confirmation prompt if you attempt to delete a player with an active ckey, and gives them a unique message informing them about what happened if you do.
/🆑

Requested by the admin that goes by `herbs#1075` on Discord. This just adds a basic "yes/no" prompt that shows up if you try to delete an owned mob (active ckey) in build mode.

Also calls `ghostize` on deleted mobs to prevent them from crashing, and prevents you from deleting observers because it causes very weird things to happen.

This was made by request; I'm not an admin (and probably won't ever be one!) so this doesn't affect me. Please let me know of any concerns about anything, or if any of these changes might impede normal use of build mode!

![dreamseeker_Gp4dXv9G4q](https://user-images.githubusercontent.com/47678781/120538745-e6e18100-c3b4-11eb-8297-6084833aa983.png)

![image](https://user-images.githubusercontent.com/47678781/120539621-bea65200-c3b5-11eb-9d4c-94477b851e63.png)

