### PR TITLE
Change life-seeded planets to have more optimal temperatures.

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -96,6 +96,12 @@
 /obj/effect/overmap/visitable/sector/exoplanet/grass/terraformed/generate_habitability()
 	habitability_class = HABITABILITY_IDEAL
 
+/obj/effect/overmap/visitable/sector/exoplanet/grass/terraformed/generate_atmosphere()
+	..()
+	if(atmosphere)
+		atmosphere.temperature = T0C + rand(0, 50)
+		atmosphere.update_values()
+
 /obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
 	lightlevel = rand(0.7,0.9)/10
 	..()


### PR DESCRIPTION
:cl: Mucker
tweak: Life-seeded planets can no longer be overheated.
/:cl:

Life-seeded planets could have temperatures ranging from 25C to 100C+, the upper of that being pretty uninhabitable, so now the temperature range is kept within optimal values as intended.