### PR TITLE
Remove Gloves

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -164,9 +164,3 @@
 	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
 			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
 			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."
-
-/datum/uplink_item/item/tools/pickpocket_gloves
-	name = "Pickpocket's Gloves"
-	item_cost = 15
-	path = /obj/item/clothing/gloves/thick/duty/pickpocket
-	desc = "Through the use of synthetic fiber muscles, these gloves allow their wearer to easily and silently take small items from others or adjust their suit sensors."


### PR DESCRIPTION
:cl: Viim
rscdel: Removes the pickpocket's gloves from the traitor uplink.
/:cl:

Reason: the pickpocket's gloves have not held up to creative standards for traitor gear, and often do not promote fun gameplay.