### PR TITLE
Restores Theatre Holodeck Chameleon Item Function

### DIFF
--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -15,7 +15,7 @@
 		chameleon_choices = LAZYACCESS(chameleon_choices_by_type, chameleon_type)
 		if(!chameleon_choices)
 			chameleon_choices = generate_chameleon_choices(chameleon_type)
-			LAZYSET(chameleon_choices_by_type, chameleon_type, chameleon_choices)	
+			LAZYSET(chameleon_choices_by_type, chameleon_type, chameleon_choices)
 	else
 		var/list/choices = list()
 		for(var/path in chameleon_choices)
@@ -103,6 +103,12 @@
 	if (!CanPhysicallyInteract(usr))
 		return
 	if (has_extension(src,/datum/extension/chameleon))
+		var/obj/item/I = src
+		if(I.holographic == TRUE)
+			if(istype(I, /obj/item/storage))
+				set_extension(I,/datum/extension/chameleon/backpack)
+			else
+				set_extension(I,/datum/extension/chameleon/clothing)
 		var/datum/extension/chameleon/C = get_extension(src, /datum/extension/chameleon)
 		C.change(usr)
 	else


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

🆑 RaveRadbury
bugfix: Chameleon items in the Holodeck Theatre work again
/🆑

Alternative to #30810

The holodeck uses `copy_contents_to` to duplicate the templates from the admin z-level to the Torch holodeck. Unfortunately the way in which it does this duplication does not respect extensions, causing the duplicated items to have extension `holder`s back on Centcom. This causes the Theatre chameleon items to fail their `!(holder in user)` checks, and even with that check disabled, the change is applied to the `holder` back on Centcom rather than the item in-hand.

This PR adds a check to see if a chameleon item is `holographic`, and if it is it will `set_extension`  to create a fresh extension for the holo-duplicate, allowing the chameleon function to return.

I think I need to add an equivalent to `!(holder in user)` to the check I'm adding here (otherwise it will `set_extension` every time the holo item is changed and that seems like bad practice), but when I try to use that specific line it's refused for being undefined within the `/atom/` scope (I think?). I'll keep tinkering with it, but any pointers or assistance would be appreciated.

Also `accessories` and `headsets` are not a part of the Theatre holodeck, but I can include them in the holo checking as well if needed.

Double also, `masks` have their own mask extension, if holodeck cham masks should have that extension I will add a `mask` check as well.

Closes #30810
Fixes #30435