### PR TITLE
Autolandmarks radius defination

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -5,6 +5,7 @@
 
 #define TRANSITIONEDGE 7 // Distance from edge to move to another z-level.
 #define RUIN_MAP_EDGE_PAD 15
+#define LANDING_ZONE_RADIUS 15 // Used for autoplacing landmarks on exoplanets
 
 // Invisibility constants.
 #define INVISIBILITY_LIGHTING    20

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -241,12 +241,12 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	var/new_type = landmark_type
 	while(num)
 		attempts--
-		var/turf/T = locate(rand(20, maxx - 30), rand(20, maxy - 30),map_z[map_z.len])
+		var/turf/T = locate(rand(TRANSITIONEDGE + LANDING_ZONE_RADIUS, maxx - TRANSITIONEDGE - LANDING_ZONE_RADIUS), rand(TRANSITIONEDGE + LANDING_ZONE_RADIUS, maxy - TRANSITIONEDGE - LANDING_ZONE_RADIUS),map_z[map_z.len])
 		if (!T || (T in places)) // Two landmarks on one turf is forbidden as the landmark code doesn't work with it.
 			continue
 		if (attempts >= 0) // While we have the patience, try to find better spawn points. If out of patience, put them down wherever, so long as there are no repeats.
 			var/valid = TRUE
-			var/list/block_to_check = block(locate(T.x - 15, T.y - 15, T.z), locate(T.x + 15, T.y + 15, T.z))
+			var/list/block_to_check = block(locate(T.x - LANDING_ZONE_RADIUS, T.y - LANDING_ZONE_RADIUS, T.z), locate(T.x + LANDING_ZONE_RADIUS, T.y + LANDING_ZONE_RADIUS, T.z))
 			for (var/turf/check in block_to_check)
 				if (!istype(get_area(check), /area/exoplanet) || check.turf_flags & TURF_FLAG_NORUINS)
 					valid = FALSE

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -110,7 +110,7 @@
 
 //Subtype that calls explosion on init to clear space for shuttles
 /obj/effect/shuttle_landmark/automatic/clearing
-	var/radius = 15
+	var/radius = LANDING_ZONE_RADIUS
 
 /obj/effect/shuttle_landmark/automatic/clearing/Initialize()
 	..()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -109,13 +109,16 @@
 	SetName("[O.name] - [initial(name)] ([x],[y])")
 
 //Subtype that calls explosion on init to clear space for shuttles
+/obj/effect/shuttle_landmark/automatic/clearing
+	var/radius = LANDING_ZONE_RADIUS
+
 /obj/effect/shuttle_landmark/automatic/clearing/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/shuttle_landmark/automatic/clearing/LateInitialize()
 	..()
-	for(var/turf/T in range(LANDING_ZONE_RADIUS, src))
+	for(var/turf/T in range(radius, src))
 		if(T.density)
 			T.ChangeTurf(get_base_turf_by_area(T))
 

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -109,16 +109,13 @@
 	SetName("[O.name] - [initial(name)] ([x],[y])")
 
 //Subtype that calls explosion on init to clear space for shuttles
-/obj/effect/shuttle_landmark/automatic/clearing
-	var/radius = LANDING_ZONE_RADIUS
-
 /obj/effect/shuttle_landmark/automatic/clearing/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/shuttle_landmark/automatic/clearing/LateInitialize()
 	..()
-	for(var/turf/T in range(radius, src))
+	for(var/turf/T in range(LANDING_ZONE_RADIUS, src))
 		if(T.density)
 			T.ChangeTurf(get_base_turf_by_area(T))
 


### PR DESCRIPTION
Small rework of landmarks
Now landing zone radius is defined, not hardcoded
And now autolandmarks cheks to be placed not on the edge (or not to delete piece of world edge)

![image](https://user-images.githubusercontent.com/32466328/120918671-3ded9b80-c6be-11eb-9a89-2798d7e839a7.png)
