### PR TITLE
Prevent certain mob types from being buckled

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -30,7 +30,7 @@
 /obj/proc/buckle_mob(mob/living/M)
 	if(buckled_mob) //unless buckled_mob becomes a list this can cause problems
 		return 0
-	if(!istype(M) || (M.loc != loc) || M.buckled || M.pinned.len || (buckle_require_restraints && !M.restrained()))
+	if(!istype(M) || (M.loc != loc) || !M.can_be_buckled || M.buckled || M.pinned.len || (buckle_require_restraints && !M.restrained()))
 		return 0
 	if(ismob(src))
 		var/mob/living/carbon/C = src //Don't wanna forget the xenos.
@@ -74,9 +74,9 @@
 	if (M.grabbed_by.len)
 		to_chat(user, SPAN_WARNING("\The [M] is being grabbed and cannot be buckled."))
 		return FALSE
-	if(istype(M, /mob/living/carbon/slime))
-		to_chat(user, "<span class='warning'>\The [M] is too squishy to buckle in.</span>")
-		return 0
+	if (!M.can_be_buckled)
+		to_chat(user, SPAN_WARNING("\The [M] cannot be buckled."))
+		return FALSE
 
 	add_fingerprint(user)
 	unbuckle_mob()

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -20,6 +20,8 @@
 	bone_material = null
 	bone_amount = 0
 
+	can_be_buckled = FALSE
+
 	var/emp_damage = 0
 
 	var/obj/item/device/radio/exosuit/radio
@@ -230,5 +232,3 @@
 		hud_power_control?.queue_icon_update()
 	else
 		to_chat(user, SPAN_WARNING("Error: No power cell was detected."))
-
-

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -26,6 +26,8 @@
 	bone_material = null
 	bone_amount = 0
 
+	can_be_buckled = FALSE
+
 	var/toxloss = 0
 	var/is_adult = 0
 	var/number = 0 // Used to understand when someone is talking to it

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -2,6 +2,8 @@
 	see_in_dark = 2
 	see_invisible = SEE_INVISIBLE_LIVING
 	waterproof = FALSE
+	/// Whether or not the mob can be buckled to things.
+	var/can_be_buckled = TRUE
 
 	//Health and life related vars
 	var/maxHealth = 100 //Maximum health that should be possible.


### PR DESCRIPTION
Closes #30028 

:cl: SierraKomodo
bugfix: It is no longer possible to buckle mechs to chairs.
/:cl: