### PR TITLE
Groins are now more pain resistant

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -296,7 +296,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 
 		else if(agony_amount > 0.5 * max_damage)
 			owner.visible_message("<span class='warning'>[owner] reels in pain!</span>")
-			if(has_genitals() || agony_amount > max_damage)
+			if(agony_amount > max_damage)
 				owner.Weaken(4)
 			else
 				owner.Stun(4)


### PR DESCRIPTION
:cl:
bugfix: Groins are now more pain resistant.
/:cl:
Fixes groin agony effect being 3x instead of 1.5x.
Presumably this was meant to replace `sexybits` agony multipliers instead of compounding with them, but it made most armor useless against pain guns by halving effective groin health at the same time as taking extra pain.
