### PR TITLE
Remove Ckey display from Round-end Purchaser List

### DIFF
--- a/code/datums/repositories/uplink_purchases.dm
+++ b/code/datums/repositories/uplink_purchases.dm
@@ -18,12 +18,12 @@ var/repository/uplink_purchases/uplink_purchase_repository = new()
 		to_world("<b>The following went shopping:</b>")
 
 	var/list/pur_log = list()
-	for(var/datum/mind/ply in purchases_by_mind)
+	for (var/datum/mind/ply in purchases_by_mind)
 		pur_log.Cut()
 		var/uplink_purchase_entry/upe = purchases_by_mind[ply]
-		to_world("<b>[ply.name]</b> (<b>[ply.key]</b>) (used [upe.total_cost] TC\s):")
+		to_world("<b>[ply.name]</b> (used [upe.total_cost] TC\s):")
 
-		for(var/datum/uplink_item/UI in upe.purchased_items)
+		for (var/datum/uplink_item/UI in upe.purchased_items)
 			pur_log += "[upe.purchased_items[UI]]x[UI.log_icon()][UI.name]"
 		to_world(english_list(pur_log, nothing_text = ""))
 


### PR DESCRIPTION
:cl: Ryan180602
tweak: Removes the displaying of ckeys in the end-round shoppers list.
/:cl:

Fixes #30800 

Easier fix and there's little reason to showcase the ckeys twice (once in the antag list, once in the shopper's list. The `Show Ckey at Round-End` preference seems to affect only the former, not the latter).