### PR TITLE
Restrict borg access to their departments

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -130,7 +130,7 @@ var/const/NO_EMAG_ACT = -50
 /obj/item/card/emag/Initialize()
 	. = ..()
 	set_extension(src,/datum/extension/chameleon/emag)
-	
+
 /obj/item/card/emag/get_antag_info()
 	. = ..()
 	. += "You can use this cryptographic sequencer in order to subvert electronics or forcefully open doors you don't have access to. These actions are irreversible and the card only has a limited number of charges!"
@@ -337,7 +337,7 @@ var/const/NO_EMAG_ACT = -50
 				id.military_branch = new_branch
 				id.military_rank = null
 			return
-	
+
 	to_chat(client, SPAN_WARNING("Input, must be an existing branch - [var_value] is invalid"))
 
 /decl/vv_set_handler/id_card_military_rank
@@ -366,7 +366,7 @@ var/const/NO_EMAG_ACT = -50
 		if(new_rank)
 			id.military_rank = new_rank
 			return
-	
+
 	to_chat(client, SPAN_WARNING("Input must be an existing rank belonging to military_branch - [var_value] is invalid"))
 
 /obj/item/card/id/silver
@@ -411,7 +411,7 @@ var/const/NO_EMAG_ACT = -50
 	detail_color = COLOR_AMBER
 
 /obj/item/card/id/synthetic/New()
-	access = get_all_station_access() + access_synth
+	access = GLOB.using_map.synth_access.Copy()
 	..()
 
 /obj/item/card/id/centcom

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_ascent.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_ascent.dm
@@ -6,14 +6,14 @@
 	sprites = list(
 		"Drone" = "drone-ascent"
 	)
-	// The duplicate clustertools in this list are so that they can set up to 
+	// The duplicate clustertools in this list are so that they can set up to
 	// hack doors, windows etc. without having to constantly cycle through tools.
 	equipment = list(
 		/obj/item/device/flash,
 		/obj/item/gun/energy/particle/small,
 		/obj/item/device/multitool/mantid,
 		/obj/item/clustertool,
-		/obj/item/clustertool, 
+		/obj/item/clustertool,
 		/obj/item/clustertool,
 		/obj/item/soap,
 		/obj/item/mop/advanced,
@@ -57,7 +57,7 @@
 		LANGUAGE_SKRELLIAN        = TRUE,
 		LANGUAGE_NABBER           = TRUE
 	)
-	
+
 	skills = list(
 		SKILL_BUREAUCRACY	= SKILL_ADEPT,
 		SKILL_FINANCE		= SKILL_EXPERT,
@@ -81,6 +81,10 @@
 		SKILL_ANATOMY		= SKILL_EXPERT,
 		SKILL_CHEMISTRY		= SKILL_EXPERT
 	)
+	access = list(
+		access_ascent
+	)
+	use_map_synth_access = FALSE
 
 // Copypasted from repair bot - todo generalize this step.
 /obj/item/robot_module/flying/ascent/finalize_synths()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
@@ -27,3 +27,10 @@
 		SKILL_CHEMISTRY = SKILL_EXPERT,
 		SKILL_SCIENCE   = SKILL_EXPERT,
 	)
+	access = list(
+		access_hydroponics,
+		access_kitchen,
+		access_research,
+		access_radio_sci,
+		access_radio_serv
+	)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -37,6 +37,21 @@
 		SKILL_CONSTRUCTION = SKILL_EXPERT,
 		SKILL_ELECTRICAL   = SKILL_EXPERT
 	)
+	access = list(
+		access_chemistry,
+		access_crematorium,
+		access_emergency_storage,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_medical,
+		access_medical_equip,
+		access_morgue,
+		access_senmed,
+		access_surgery,
+		access_virology,
+		access_radio_med
+	)
 
 /obj/item/robot_module/flying/emergency/finalize_emag()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -28,6 +28,16 @@
 		SKILL_SCIENCE             = SKILL_EXPERT,
 		SKILL_DEVICES             = SKILL_EXPERT
 	)
+	access = list(
+		access_emergency_storage,
+		access_cargo,
+		access_cargo_bot,
+		access_commissary,
+		access_hangar,
+		access_mailsorting,
+		access_radio_serv,
+		access_radio_sup
+	)
 
 /obj/item/robot_module/flying/filing/finalize_synths()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -37,6 +37,15 @@
 		SKILL_CONSTRUCTION        = SKILL_ADEPT,
 		SKILL_ANATOMY             = SKILL_ADEPT
 	)
+	access = list(
+		access_brig,
+		access_emergency_storage,
+		access_forensics_lockers,
+		access_morgue,
+		access_sec_doors,
+		access_security,
+		access_radio_sec
+	)
 
 /obj/item/robot_module/flying/forensics/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/reagent_containers/spray/luminol/luminol = locate() in equipment

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
@@ -56,6 +56,22 @@
 		SKILL_CONSTRUCTION = SKILL_PROF,
 		SKILL_ELECTRICAL   = SKILL_PROF
 	)
+	access = list(
+		access_atmospherics,
+		access_construction,
+		access_emergency_storage,
+		access_engine,
+		access_engine_equip,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_network,
+		access_robotics,
+		access_seneng,
+		access_tcomsat,
+		access_tech_storage,
+		access_radio_eng
+	)
 
 /obj/item/robot_module/flying/repair/finalize_synths()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -49,6 +49,13 @@
 	var/list/synths = list()
 	var/list/skills = list() // Skills that this module grants. Other skills will remain at minimum levels.
 
+	/// Access flags that this module grants. Overwrites all existing access flags.
+	var/list/access = list()
+	/// Whether or not to include the map's defined `synth_access` list.
+	var/use_map_synth_access = TRUE
+	/// Whether or not to apply get_all_station_access() to the access flags.
+	var/use_all_station_access = FALSE
+
 /obj/item/robot_module/Initialize()
 
 	. = ..()
@@ -63,6 +70,7 @@
 	add_camera_networks(R)
 	add_languages(R)
 	add_subsystems(R)
+	set_access(R)
 	apply_status_flags(R)
 
 	if(R.silicon_radio)
@@ -230,3 +238,12 @@
 /obj/item/robot_module/proc/reset_skills(var/mob/living/silicon/robot/R)
 	for(var/datum/skill_buff/buff in R.fetch_buffs_of_type(/datum/skill_buff/robot))
 		buff.remove()
+
+/// Updates the robot's access flags with the module's access
+/obj/item/robot_module/proc/set_access(mob/living/silicon/robot/R)
+	R.idcard.access.Cut()
+	R.idcard.access = access.Copy()
+	if (use_map_synth_access)
+		R.idcard.access |= GLOB.using_map.synth_access.Copy()
+	if (use_all_station_access)
+		R.idcard.access |= get_all_station_access()

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -47,6 +47,13 @@
 		SKILL_MEDICAL             = SKILL_BASIC,
 		SKILL_CHEMISTRY           = SKILL_ADEPT
 	)
+	access = list(
+		access_bar,
+		access_commissary,
+		access_hydroponics,
+		access_kitchen,
+		access_radio_serv
+	)
 
 /obj/item/robot_module/clerical/butler/finalize_equipment()
 	. = ..()
@@ -99,6 +106,16 @@
 	emag = /obj/item/stamp/chameleon
 	synths = list(
 		/datum/matter_synth/package_wrap
+	)
+	access = list(
+		access_emergency_storage,
+		access_cargo,
+		access_cargo_bot,
+		access_commissary,
+		access_hangar,
+		access_mailsorting,
+		access_radio_serv,
+		access_radio_sup
 	)
 
 /obj/item/robot_module/clerical/general/finalize_synths()

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -72,6 +72,22 @@
 		SKILL_ELECTRICAL   = SKILL_PROF,
 		SKILL_COMPUTER     = SKILL_EXPERT
 	)
+	access = list(
+		access_atmospherics,
+		access_construction,
+		access_emergency_storage,
+		access_engine,
+		access_engine_equip,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_network,
+		access_robotics,
+		access_seneng,
+		access_tcomsat,
+		access_tech_storage,
+		access_radio_eng
+	)
 
 /obj/item/robot_module/engineering/finalize_synths()
 

--- a/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
@@ -15,6 +15,10 @@
 		/obj/item/tank/jetpack/carbondioxide
 	)
 	var/id
+	access = list(
+		access_syndicate
+	)
+	use_map_synth_access = FALSE
 
 /obj/item/robot_module/syndicate/Initialize()
 	for(var/decl/hierarchy/skill/skill in GLOB.skills)

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -22,6 +22,11 @@
 		/obj/item/weldingtool
 	)
 	emag = /obj/item/reagent_containers/spray
+	access = list(
+		access_emergency_storage,
+		access_janitor,
+		access_radio_serv
+	)
 
 /obj/item/robot_module/janitor/finalize_emag()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -53,6 +53,7 @@
 		SKILL_CONSTRUCTION = SKILL_EXPERT,
 		SKILL_ELECTRICAL   = SKILL_EXPERT
 	)
+	use_all_station_access = TRUE
 
 /obj/item/robot_module/drone/finalize_equipment(var/mob/living/silicon/robot/R)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -10,6 +10,21 @@
 		/datum/nano_module/crew_monitor
 	)
 	can_be_pushed = 0
+	access = list(
+		access_chemistry,
+		access_crematorium,
+		access_emergency_storage,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_medical,
+		access_medical_equip,
+		access_morgue,
+		access_senmed,
+		access_surgery,
+		access_virology,
+		access_radio_med
+	)
 
 /obj/item/robot_module/medical/build_equipment()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_miner.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_miner.dm
@@ -38,6 +38,17 @@
 		SKILL_CONSTRUCTION = SKILL_EXPERT
 	)
 	no_slip = 1
+	access = list(
+		access_eva,
+		access_expedition_shuttle,
+		access_guppy,
+		access_hangar,
+		access_mining,
+		access_mining_office,
+		access_mining_station,
+		access_radio_exp,
+		access_radio_sup
+	)
 
 /obj/item/robot_module/miner/handle_emagged()
 	var/obj/item/pickaxe/D = locate(/obj/item/pickaxe/borgdrill) in equipment

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -44,6 +44,26 @@
 		SKILL_BOTANY              = SKILL_EXPERT,
 		SKILL_ELECTRICAL          = SKILL_EXPERT
 	)
+	access = list(
+		access_expedition_shuttle,
+		access_hangar,
+		access_mining_office,
+		access_mining_station,
+		access_petrov,
+		access_petrov_analysis,
+		access_petrov_chemistry,
+		access_petrov_maint,
+		access_petrov_phoron,
+		access_petrov_toxins,
+		access_research,
+		access_tox,
+		access_tox_storage,
+		access_xenoarch,
+		access_xenobiology,
+		access_radio_exp,
+		access_radio_sci
+	)
+
 /obj/item/robot_module/research/finalize_equipment()
 	. = ..()
 	var/obj/item/stack/nanopaste/N = locate() in equipment

--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -19,6 +19,15 @@
 		SKILL_FORENSICS   = SKILL_EXPERT,
 		SKILL_BUREAUCRACY = SKILL_ADEPT
 	)
+	access = list(
+		access_brig,
+		access_emergency_storage,
+		access_eva,
+		access_external_airlocks,
+		access_sec_doors,
+		access_security,
+		access_radio_sec
+	)
 
 /obj/item/robot_module/security/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
@@ -58,6 +67,8 @@
 		/obj/item/device/hailer
 	)
 	emag = /obj/item/gun/energy/laser/mounted
+	use_map_synth_access = FALSE
+	use_all_station_access = TRUE
 
 /obj/item/robot_module/security/combat
 	name = "combat robot module"

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -9,6 +9,13 @@
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
 
+	synth_access = list(
+		access_synth,
+		access_maint_tunnels,
+		access_teleporter,
+		access_solgov_crew
+	)
+
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd
 	species_to_job_blacklist = list(
 		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden), //Other jobs unavailable via branch restrictions,

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -46,6 +46,18 @@
 	)
 
 	emag = /obj/item/melee/energy/machete
+	access = list(
+		access_emergency_storage,
+		access_eva,
+		access_expedition_shuttle,
+		access_explorer,
+		access_guppy,
+		access_hangar,
+		access_petrov,
+		access_research,
+		access_radio_exp,
+		access_radio_sci
+	)
 
 /obj/item/robot_module/flying/surveyor/finalize_synths()
 	. = ..()
@@ -68,4 +80,3 @@
 		if(flag.amount < flag.max_amount)
 			flag.add(1)
 	..()
-

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1456,7 +1456,10 @@
 	name = "\improper Engineering Drone Fabrication"
 	icon_state = "drone_fab"
 	sound_env = SMALL_ENCLOSED
-	req_access = list(access_robotics)
+	req_access = list(
+		access_robotics,
+		access_synth
+	)
 
 /area/engineering/engine_monitoring
 	name = "\improper Engine Monitoring Room"

--- a/maps/~mapsystem/maps_jobs.dm
+++ b/maps/~mapsystem/maps_jobs.dm
@@ -7,6 +7,13 @@
 
 	var/default_assistant_title = "Assistant"
 
+	/// List of default access flags provided to all robots on top of their module's flags
+	var/list/synth_access = list(
+		access_synth,
+		access_maint_tunnels,
+		access_teleporter
+	)
+
 // The white, and blacklist are type specific, any subtypes (of both species and jobs) have to be added explicitly
 /datum/map/proc/is_species_job_restricted(var/datum/species/S, var/datum/job/J)
 	if(!istype(S) || !istype(J))


### PR DESCRIPTION
This should reduce borgs getting into things they shouldn't be involved in, and remove the mentality of the 'all-access key' that borgs tend to be treated as.

Also, borg accesses cannot be changed except by changing the module. This is intentional.

:cl: SierraKomodo
tweak: Robots no longer have full unlimited ship access, and instead receive access based on their module. All robots have solgov crew, maintenance, and teleporter access. See PR for a full list of accesses.
/:cl:

### Robot access flags:
- Clerical: Equivalent to Deck Technician, minus shuttle access
- Combat: Equivalent to ERT
- Engineering: Equivalent to Senior Engineer
- Forensics: Equivalent to Forensics Technician
- Janitor: Equivalent to Janitor
- Medical: Equivalent to EMT + Physician
- Miner: Equivalent to Prospector
- Research: Equivalent to Scientist
- Security: Equivalent to MAA
- Service: Equivalent to Bartender and Chef
- Surveyor: Equivalent to Explorer
- Syndicate: access_syndicate only
- Maintenance Drone: Retains full ship access