### PR TITLE
Remove helm debug log

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -267,8 +267,6 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	if (!autopilot && old_operator && viewing_overmap(old_operator))
 		unlook(old_operator)
 
-	log_debug("HELM CONTROL: [current_operator ? current_operator : "NO PILOT"] taking control of [src] from [old_operator ? old_operator : "NO PILOT"] in [get_area(src)]. [autopilot ? "(AUTOPILOT MODE)" : null]")
-
 	if (!silent)
 		display_operator_change_message(old_operator, current_operator, autopilot)
 


### PR DESCRIPTION
There's been no issues with the helm changes so there's no need for the verbose logging anymore.