### PR TITLE
add gitblame workspace config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
 	"files.eol": "\r\n",
 	"files.insertFinalNewline": true,
 	"files.trimFinalNewlines": true,
-	"files.trimTrailingWhitespace": true
+	"files.trimTrailingWhitespace": true,
+	"gitblame.commitUrl": "https://github.com/baystation12/baystation12/commit/${hash}"
 }


### PR DESCRIPTION
Adds vscode workspace config for the [gitblame](https://marketplace.visualstudio.com/items?itemName=waderyan.gitblame) extension so that it opens to the repo correctly.