### PR TITLE
fix holsters

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -68,7 +68,7 @@
 		return 0
 	if(user.get_active_hand() && user.get_inactive_hand())
 		to_chat(user, "<span class='warning'>You need an empty hand to draw \the [holstered]!</span>")
-		return 1
+		return 0
 	var/using_intent_preference = user.client ? user.client.get_preference_value(/datum/client_preference/holster_on_intent) == GLOB.PREF_YES : FALSE
 	if(avoid_intent || (using_intent_preference && user.a_intent != I_HELP))
 		var/sound_vol = 25

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -22,6 +22,9 @@
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
 
+	///If true, will not permit use of the storage UI
+	var/virtual
+
 	//initializes the contents of the storage with some items based on an assoc list. The assoc key must be an item path,
 	//the assoc value can either be the quantity, or a list whose first value is the quantity and the rest are args.
 	var/list/startswith
@@ -91,6 +94,8 @@
 		storage_ui.hide_from(user)
 
 /obj/item/storage/proc/open(mob/user as mob)
+	if (virtual)
+		return
 	if(!opened)
 		playsound(src.loc, src.open_sound, 50, 0, -5)
 		opened = 1
@@ -155,7 +160,7 @@
 	//Bypassing storage procedures when not using help intent for labeler/forensic tools.
 	if((istype(W, /obj/item/hand_labeler) || istype(W, /obj/item/forensics)) && user.a_intent != I_HELP)
 		return FALSE
-	
+
 	// Don't allow insertion of unsafed compressed matter implants
 	// Since they are sucking something up now, their afterattack will delete the storage
 	if(istype(W, /obj/item/implanter/compressed))

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -84,7 +84,7 @@
 			to_chat(user, "<span class='notice'>It smells clean!</span>")
 		if(SMELL_STINKY)
 			to_chat(user, "<span class='bad'>It's quite stinky!</span>")
-	
+
 
 /obj/item/clothing/proc/update_accessory_slowdown()
 	slowdown_accessory = 0
@@ -132,25 +132,32 @@
 	return container?.can_be_inserted(I, user, silent)
 
 
-/obj/item/clothing/accessory/storage/proc/handle_item_insertion(obj/item/I, silent, partial)
-	return container?.handle_item_insertion(I, silent, partial)
+/obj/item/clothing/accessory/storage/proc/handle_item_insertion(obj/item/I, silent, no_update)
+	return container?.handle_item_insertion(I, silent, no_update)
 
 
 /obj/item/clothing/proc/attempt_store_item(obj/item/I, mob/user, silent)
 	for (var/obj/item/clothing/accessory/storage/S in accessories)
-		if (S.can_be_inserted(I, user, TRUE) && S.handle_item_insertion(I, user))
-			if (!silent)
-				to_chat(user, SPAN_ITALIC("You store \the [I] in \the [S]."))
+		if (S.can_be_inserted(I, user, TRUE) && S.handle_item_insertion(I, silent))
 			return TRUE
 	return FALSE
 
 
-/obj/item/clothing/suit/storage/attempt_store_item(obj/item/I, mob/user, silent = TRUE)
-	if (pockets?.can_be_inserted(I, user, TRUE) && pockets.handle_item_insertion(I, user))
-		if (!silent)
-			to_chat(user, SPAN_ITALIC("You store \the [I] in \the [src]."))
+/obj/item/clothing/suit/storage/attempt_store_item(obj/item/I, mob/user, silent)
+	if (pockets?.can_be_inserted(I, user, TRUE) && pockets.handle_item_insertion(I, silent))
 		return TRUE
 	return ..()
+
+
+/obj/item/clothing/accessory/storage/holster/can_be_inserted(obj/item/I, mob/user, silent)
+	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
+	return H?.can_holster(I)
+
+
+/obj/item/clothing/accessory/storage/holster/handle_item_insertion(obj/item/I, silent, no_update)
+	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
+	return H.holster(I, usr)
+
 
 /obj/item/clothing/proc/removetie_verb()
 	set name = "Remove Accessory"

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -12,6 +12,7 @@
 /obj/item/clothing/accessory/storage/holster/Initialize()
 	. = ..()
 	INIT_SKIP_QDELETED
+	container.virtual = TRUE
 	set_extension(src, /datum/extension/holster, container, sound_in, sound_out, can_holster)
 
 /obj/item/clothing/accessory/storage/holster/attackby(obj/item/W as obj, mob/user as mob)
@@ -25,8 +26,7 @@
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.unholster(user))
 		return
-	else
-		. = ..(user)
+	. = ..(user)
 
 /obj/item/clothing/accessory/storage/holster/examine(mob/user)
 	. = ..(user)


### PR DESCRIPTION
:cl:
bugfix: Holsters behave correctly again.
tweak: You can no longer open holsters like storage.
/:cl:

\+ Added a `virtual` var to storage items that prevents their UIs being shown. Holsters set this on theirs.
\+ Cleaned up my drunk attach/insert code a bit.
\+ Fixed an incorrect success return in holsters.

Openable holsters was a cause of the holster/unholster state of the holster not being updated - the holster extension was a horrible mistake. Clicking a holster (or a uniform with a holster) that is occupied on help now does nothing, and on other intents removes the holstered thing; the storage ui will not be shown ever.

