### PR TITLE
fix tinted helmets not tinting on mob

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -77,11 +77,13 @@
 /obj/item/clothing/head/helmet/space/proc/update_tint()
 	if(tinted)
 		icon_state = "[initial(icon_state)]_dark"
+		item_state = "[initial(item_state)]_dark"
 		flash_protection = FLASH_PROTECTION_MAJOR
 		flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 		tint = TINT_MODERATE
 	else
 		icon_state = initial(icon_state)
+		item_state = initial(item_state)
 		flash_protection = FLASH_PROTECTION_NONE
 		flags_inv = HIDEEARS|BLOCKHAIR
 		tint = TINT_NONE


### PR DESCRIPTION
:cl:
bugfix: Tintable helmets tint on the sprite as well.
/:cl: