### PR TITLE
Changes to the forensics locker

### DIFF
--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -145,7 +145,6 @@
 		/obj/item/clothing/suit/armor/pcarrier/medium/security,
 		/obj/item/gun/energy/gun/small/secure,
 		/obj/item/device/flash,
-		/obj/item/melee/baton/loaded,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/taperoll/police,
 		/obj/item/clothing/accessory/storage/black_vest,


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Removes the stun baton from the forensics locker.
/:cl:

This is a step back toward the inventory forensics used to have at the launch of Torch.
The intent behind this PR is to discourage forensics from playing the role like an MA with additional responsibilities.
The gun, flash and pepperspray remain for the purpose of self-defense.

When deemed necessary, forensics can be geared up by the Brig Chief or the CoS. In a pinch, they also retain the option of taking gear from an MA's locker themself.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->