### PR TITLE
Removes Thermals from antags except traitors

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -107,6 +107,7 @@
 	desc = "A pair of meson goggles that have been modified to instead show synthetics or living creatures, through thermal imaging."
 	item_cost = 24
 	path = /obj/item/clothing/glasses/thermal/syndi
+	antag_roles = list(MODE_TRAITOR)
 
 /datum/uplink_item/item/tools/flashdark
 	name = "Flashdark"

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -4,12 +4,6 @@
 /datum/uplink_item/item/hardsuit_modules
 	category = /datum/uplink_category/hardsuit_modules
 
-/datum/uplink_item/item/hardsuit_modules/thermal
-	name = "\improper Thermal Scanner"
-	desc = "A module capable of giving vision of synthetic or living creatures, through thermal imaging."
-	item_cost = 16
-	path = /obj/item/rig_module/vision/thermal
-
 /datum/uplink_item/item/hardsuit_modules/energy_net
 	name = "\improper Net Projector"
 	desc = "A module capable of creating an energy net device that can be thrown in order to capture targets like the prey they are."

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -38,12 +38,6 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 		/obj/item/clothing/shoes/laceup
 		)
 
-	var/list/raider_glasses = list(
-		/obj/item/clothing/glasses/thermal,
-		/obj/item/clothing/glasses/thermal/plain/eyepatch,
-		/obj/item/clothing/glasses/thermal/plain/monocle
-		)
-
 	var/list/raider_helmets = list(
 		/obj/item/clothing/head/bearpelt,
 		/obj/item/clothing/head/ushanka,
@@ -156,7 +150,6 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	else
 		var/new_shoes =   pick(raider_shoes)
 		var/new_uniform = pick(raider_uniforms)
-		var/new_glasses = pick(raider_glasses)
 		var/new_helmet =  pick(raider_helmets)
 		var/new_suit =    pick(raider_suits)
 
@@ -167,7 +160,6 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 			player.equip_to_slot_or_del(new fallback_type(player), slot_shoes)
 
 		player.equip_to_slot_or_del(new new_uniform(player),slot_w_uniform)
-		player.equip_to_slot_or_del(new new_glasses(player),slot_glasses)
 		player.equip_to_slot_or_del(new new_helmet(player),slot_head)
 		player.equip_to_slot_or_del(new new_suit(player),slot_wear_suit)
 		equip_weapons(player)
@@ -239,7 +231,6 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 /datum/antagonist/raider/equip_vox(mob/living/carbon/human/vox, mob/living/carbon/human/old)
 
 	var/uniform_type = pick(list(/obj/item/clothing/under/vox/vox_robes,/obj/item/clothing/under/vox/vox_casual))
-	var/new_glasses = pick(raider_glasses)
 	var/new_holster = pick(raider_holster)
 
 	vox.equip_to_slot_or_del(new uniform_type(vox), slot_w_uniform)
@@ -248,7 +239,6 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	vox.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/swat/vox(vox), slot_wear_mask)
 	vox.equip_to_slot_or_del(new /obj/item/tank/nitrogen(vox), slot_back)
 	vox.equip_to_slot_or_del(new /obj/item/device/flashlight(vox), slot_r_store)
-	vox.equip_to_slot_or_del(new new_glasses(vox),slot_glasses)
 
 	var/obj/item/clothing/accessory/storage/holster/holster = new new_holster
 	if(holster)

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -84,17 +84,12 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/surgery, reselect_propbability = 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/combat, reselect_propbability = 10)
 
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/energy_net, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/ewar_voice, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/maneuvering_jets, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/egun, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/power_sink, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/laser_canon, reselect_propbability = 5)
-
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/thermal, reselect_propbability = 15)
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/suit_sensor_mobile)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/services/suit_sensor_shutdown, 75, 0)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -65,7 +65,7 @@
 		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/voice,
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/nvg,
 		/obj/item/rig_module/cooling_unit
 		)
 

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -876,7 +876,7 @@
 /obj/item/clothing/head/helmet/space/vox/stealth,
 /obj/item/clothing/shoes/magboots/vox,
 /obj/item/clothing/gloves/vox,
-/obj/item/clothing/glasses/thermal/plain/monocle,
+/obj/random/glasses,
 /obj/item/clothing/under/vox/vox_robes,
 /obj/item/gun/projectile/dartgun/vox/medical,
 /turf/unsimulated/floor{
@@ -1279,9 +1279,10 @@
 "cT" = (
 /obj/structure/table/rack,
 /obj/random/raider/hardsuit,
-/obj/item/clothing/glasses/thermal/plain/monocle,
+/obj/random/glasses,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
+/obj/random/glasses,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cU" = (
@@ -1634,6 +1635,7 @@
 "dN" = (
 /obj/structure/table/steel,
 /obj/random/maintenance,
+/obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dO" = (

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1077,6 +1077,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "lz" = (


### PR DESCRIPTION
🆑 Jux
tweak: Removes thermals from the merc uplink, and hardsuit thermals from all uplinks.
maptweak: The heist and merc ships now spawn with a single set of thermals each. First come, first serve.
tweak: Removes thermals from raider outfit.
tweak: Removes thermals from the cybersuit, replacing with NVG.
/🆑 

Good only in moderation.