### PR TITLE
Hivebot beacon fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -74,8 +74,8 @@ Teleporter beacon, and its subtypes
 	anchored = TRUE
 
 	var/bot_type = /mob/living/simple_animal/hostile/hivebot
-	var/bot_amt = 10
-	var/spawn_delay = 100
+	var/bot_amt = 1
+	var/spawn_delay = 10 SECONDS
 	var/spawn_time = 0
 
 	ai_holder_type = /datum/ai_holder/simple_animal/hivebot/tele
@@ -88,6 +88,7 @@ Teleporter beacon, and its subtypes
 	visible_message("<span class='danger'>\The [src] warps in!</span>")
 	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
 	set_AI_busy(TRUE)
+	spawn_time = world.time + spawn_delay
 
 /mob/living/simple_animal/hostile/hivebot/tele/proc/warpbots()
 	while(bot_amt > 0 && bot_type)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Hivebot beacons now only spawn 1 bot per beacon, instead of a stack of 10.
fix: Hivebot beacons will now warp in their payload automatically without requiring admin intervention.
/:cl: