### PR TITLE
Dangerous chemical fixes, chemistry tweaks and improvements to game readability.

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -7,7 +7,7 @@
 	layer = ABOVE_PROJECTILE_LAYER
 	time_to_live = 300
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE | PASS_FLAG_GLASS //PASS_FLAG_GLASS is fine here, it's just so the visual effect can "flow" around glass
-	var/splash_amount = 10 //atoms moving through a smoke cloud get splashed with up to 10 units of reagent
+	var/splash_amount = 5 //atoms moving through a smoke cloud get splashed with up to 10 units of reagent
 	var/turf/destination
 
 /obj/effect/effect/smoke/chem/New(var/newloc, smoke_duration, turf/dest_turf = null, icon/cached_icon = null)
@@ -84,6 +84,7 @@
 	var/list/targetTurfs
 	var/list/wallList
 	var/density
+	var/smokeVolume
 	var/show_log = 1
 
 /datum/effect/effect/system/smoke_spread/chem/spores
@@ -110,6 +111,7 @@
 	range = n * 0.3
 	cardinals = c
 	carry.trans_to_obj(chemholder, carry.total_volume, copy = 1)
+	smokeVolume = n
 
 	if(istype(loca, /turf/))
 		location = loca
@@ -179,7 +181,7 @@
 		I = icon('icons/effects/96x96.dmi', "smoke")
 
 	//Calculate smoke duration
-	var/smoke_duration = 150
+	var/smoke_duration = smokeVolume * 1.5 SECONDS
 
 	var/pressure = 0
 	var/datum/gas_mixture/environment = location.return_air()
@@ -192,7 +194,7 @@
 		var/radius = i * 1.5
 		if(!radius)
 			spawn(0)
-				spawnSmoke(location, I, 1, 1)
+				spawnSmoke(location, I, smoke_duration, 1)
 			continue
 
 		var/offset = 0
@@ -211,7 +213,7 @@
 				continue
 			if(T in targetTurfs)
 				spawn(0)
-					spawnSmoke(T, I, range)
+					spawnSmoke(T, I, smoke_duration, range)
 
 //------------------------------------------
 // Randomizes and spawns the smoke effect.
@@ -223,7 +225,7 @@
 	if(passed_smoke)
 		smoke = passed_smoke
 	else
-		smoke = new /obj/effect/effect/smoke/chem(location, smoke_duration + rand(0, 20), T, I)
+		smoke = new /obj/effect/effect/smoke/chem(location, smoke_duration + rand(1.5 SECONDS, 3 SECONDS), T, I)
 
 	if(chemholder.reagents.reagent_list.len)
 		chemholder.reagents.trans_to_obj(smoke, chemholder.reagents.total_volume / dist, copy = 1) //copy reagents to the smoke so mob/breathe() can handle inhaling the reagents

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -315,15 +315,21 @@
 	M.take_organ_damage(0, removed * power)
 
 /datum/reagent/acid/affect_touch(var/mob/living/carbon/M, var/alien, var/removed) // This is the most interesting
+
+	M.visible_message(
+		SPAN_WARNING("\The [M]'s skin sizzles and burns on contact with the liquid!"),
+		SPAN_DANGER("Your skin sizzles and burns!.")
+		)
+
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.head)
 			if(H.head.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.head] protects you from the acid.</span>")
+				to_chat(H, SPAN_WARNING("Your [H.head] protects you from the liquid."))
 				remove_self(volume)
 				return
 			else if(removed > meltdose)
-				to_chat(H, "<span class='danger'>Your [H.head] melts away!</span>")
+				to_chat(H, SPAN_DANGER("Your [H.head] melts away!"))
 				qdel(H.head)
 				H.update_inv_head(1)
 				H.update_hair(1)
@@ -333,11 +339,11 @@
 
 		if(H.wear_mask)
 			if(H.wear_mask.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid.</span>")
+				to_chat(H, SPAN_WARNING("Your [H.wear_mask] protects you from the liquid."))
 				remove_self(volume)
 				return
 			else if(removed > meltdose)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
+				to_chat(H, SPAN_DANGER("Your [H.wear_mask] melts away!"))
 				qdel(H.wear_mask)
 				H.update_inv_wear_mask(1)
 				H.update_hair(1)
@@ -347,10 +353,10 @@
 
 		if(H.glasses)
 			if(H.glasses.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.glasses] partially protect you from the acid!</span>")
+				to_chat(H, SPAN_WARNING("Your [H.glasses] partially protect you from the liquid!"))
 				removed /= 2
 			else if(removed > meltdose)
-				to_chat(H, "<span class='danger'>Your [H.glasses] melt away!</span>")
+				to_chat(H, SPAN_DANGER("Your [H.glasses] melt away!"))
 				qdel(H.glasses)
 				H.update_inv_glasses(1)
 				removed -= meltdose / 2


### PR DESCRIPTION
Chemistry suffers from a lot of nonfunctional chemicals, most of which are of the dangerous variety. This PR seeks to rebalance and breathe some life into them, along with fixing and tweaking a few minor things along the way.

This is also my first PR, I am so super sorry if I did anything wrong. I'll try to correct as much as I can but bear with me, I'm not used to this stuff at all!

- Amatoxin is now a delayed activation toxin, incredibly lethal but very slow to activate. It works by creating a second chemical 'Amaspores' which remain dormant in the body, once the amatoxin has run it's course the amaspores violently begin to attack the body at a rapid rate. 
- Lexorin is now much faster to act and is skin permeable but remains easily mitigated by dexalin. While the chemical is very similar to it's previous incarnation it now directly absorbs oxygen from the blood making it a potent threat rather than a mild inconvenience. May require some minor tweaks to death sting to compensate for the massively increased lethality, but the effects of lexorin quickly pass once the chemical is removed from the blood. 
- Carpotoxin properly earns the title of neurotoxin, a few drops can cause massive brain damage via seizures. While it's exceptionally dangerous and liable to kill without help, it does little to prevent the victim from calling for help and it's also exceptionally difficult to obtain. There may be an argument from removing this from the random toxin vial in the uplink, given that it's also used in the creation of another drug but that's somewhat outside of the scope of this PR.
- Impedrezene is exceptionally debilitating and will have lasting consequences for ingesting but takes an overwhelming dosage to become lethal. An excellent drug for use in situations when you want to keep someone under control, doesn't require much to be effective but will still leave the victim with 70%~ of their brain activity in most cases. 

- The smoke chemical now scales with the amount of reagents used to create it, 60u of reagents will now create smoke for 12 seconds before adding in a random factor of 1.5 to 3 seconds. The amount splashed per cloud was potentially excessive given the new duration of smoke so a reduction by 50% (10u to 5u) to the maximum amount of chemicals splashed was in order.

- Lexorin and Acid now present obvious warning messages to both the victim and nearby characters to make it obvious that the chemical being sprayed is in fact, dangerous. It's only fair that chemicals that work on touch inform people, weapons and dangerous things of this caliber should be obvious once deployed. Lexorin no longer works on vox due to their unusual biology.

- The message for being sprayed with acid while wearing protective gear has been obfuscated, you no longer instantly know that the wet stuff was acid because your glasses are resistant.



All of the toxins mentioned above were exceptionally weak, if to the point of being non-functional. Amatoxin took the better part of an hour to kill someone, Carpotoxin and impedrezene were both out healed by natural regeneration and lexorin was largely neutered by natural healing and the oxygen deprivation was so small as to not matter except in dosages close to one hundred units.

Chemical smoke essentially did nothing, the cloud patterns were too unreliable for smoke that lasted for such a short duration that often the first clouds were vanishing before the last ones had even reached their positions. Increasing the timer to be in line with smoke grenades should massively increase the potential for usage.

Acid having no messages for the horrific damage it could cause could often mean several people would sit and watch confused as someone had all of their limbs turn to ash. No more confused staring!

:cl: Yvesza
balance: Improved the effects of Amatoxin, Lexorin, Carpotoxin and Impedrezene. 
balance: Vox are no longer effected by Lexorin.
balance: Chemical smoke duration now scales with the amount of reagents used to create it.
balance: Chemical smoke splashes less reagents on touch (10 -> 5)
tweak: Characters being coated with harmful chemicals will receive warning messages, along with anyone close enough to bear witness.
tweak: Being sprayed with acid while wearing protective gear no longer automatically identifies it as acid.
/:cl: