### PR TITLE
Fix zooming in being instantly reset

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -291,8 +291,6 @@
 
 /mob/proc/reset_view(atom/A)
 	if (client)
-		client.pixel_x = initial(client.pixel_x)
-		client.pixel_y = initial(client.pixel_y)
 		A = A ? A : eyeobj
 		if (istype(A, /atom/movable))
 			client.perspective = EYE_PERSPECTIVE


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed binoculars not being able to stay zoomed in.
/:cl:

Changes to the `/mob/proc/reset_view(atom/A)` proc caused the pixel orientation to be constantly reset.

Fix #30864