### PR TITLE
strip permissions opinions from channel ignore

### DIFF
--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -9,23 +9,16 @@
 	var/mute_setting
 	var/show_preference_setting
 
-/decl/communication_channel/proc/can_ignore(var/client/C)
+
+/decl/communication_channel/proc/can_ignore(client/C)
 	if (!C)
 		return TRUE
 	// Channels that cannot be toggled can never be ignored
-	if(!show_preference_setting)
+	if (!show_preference_setting)
 		return FALSE
 	// If you're trying to see the channel, you can't ignore it
-	if (C.get_preference_value(show_preference_setting) == GLOB.PREF_SHOW)
-		return FALSE
-	// I suppose the host is more equal than others
-	if (check_rights(R_HOST, 0, C))
-		return TRUE
-	// Admins without ban permissions may ignore communication channels
-	if (check_rights(R_ADMIN, 0, C) && (!check_rights(R_BAN, 0, C)))
-		return TRUE
-	// Anyone else with investigation status may not ignore communication channels
-	return !check_rights(R_INVESTIGATE, 0, C)
+	return C.get_preference_value(show_preference_setting) != GLOB.PREF_SHOW
+
 
 /*
 * Procs for handling sending communication messages


### PR DESCRIPTION
:cl:
admin: Staff with investigate but not host are no longer unable to set meaningful channel preferences.
/:cl: