### PR TITLE
The CSO and SR can now actually take scihud implants

### DIFF
--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -10,5 +10,6 @@
 /datum/gear/augment/integrated_janitor_hud
 	allowed_roles = list(/datum/job/janitor)
 
-/datum/gear/augment/integrated_science_hud
-	allowed_roles = list(RESEARCH_ROLES, EXPLORATION_ROLES)
+/datum/gear/augment/integrated_science_hud/New()
+	allowed_roles = RESEARCH_ROLES | EXPLORATION_ROLES
+	..()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
bugfix: The CSO and Senior Researcher can now spawn with scihud implants as intended.
/:cl:
Even I forgot that the Senior Researcher actually existed.