### PR TITLE
fix renegade intro text, fix clothing wizard var

### DIFF
--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -101,8 +101,7 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 	for(var/spell/spell_to_remove in mind.learned_spells)
 		remove_spell(spell_to_remove)
 
-obj/item/clothing
-	var/wizard_garb = FALSE
+obj/item/clothing/var/wizard_garb = FALSE
 
 // Does this clothing slot count as wizard garb? (Combines a few checks)
 /proc/is_wiz_garb(var/obj/item/clothing/C)

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -6,14 +6,12 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/submap)
 	restricted_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
 	welcome_text = "Something's going to go wrong today, you can just feel it. You're paranoid, you've got a gun, and you're going to survive."
-	antag_text = "You are a <b>minor</b> antagonist! Within the rules, \
-		try to protect yourself and what's important to you. You aren't here to <i>cause</i> trouble, \
-		you're just willing (and equipped) to go to extremes to <b>stop</b> it. \
-		Your job is to oppose the other antagonists, should they threaten you, in ways that aren't quite legal. \
-		Try to make sure other players have <i>fun</i>! If you are confused or at a loss, always adminhelp, \
-		and before taking extreme actions, please try to also contact the administration! \
-		Think through your actions and make the roleplay immersive! <b>Please remember all \
-		rules aside from those without explicit exceptions apply to antagonists.</b>"
+	antag_text = {"\
+	<p>You are a <b>minor</b> antagonist! Make sure <b>you</b> survive the round at any cost.</p> \
+	<p>Betray friends, make deals with enemies, and keep your gun handy. \
+	You aren't here to go looking for trouble - but if <i>it</i> finds <i>you</i>, kill it.</p> \
+	<p>Remember that the rules still apply to antagonists - Chat with staff before taking extreme actions.</p>
+	"}
 
 	id = MODE_RENEGADE
 	flags = ANTAG_SUSPICIOUS | ANTAG_IMPLANT_IMMUNE | ANTAG_RANDSPAWN | ANTAG_VOTABLE


### PR DESCRIPTION
:cl:
tweak: Renegade intro text updated to better focus on role intent.
/:cl:

also one-lined wizard_garb so that the language server stops thinking that's where clothing is defined.