### PR TITLE
add pp thing to easily clone prefs onto a mob

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -222,7 +222,8 @@ var/global/floorIsLava = 0
 	body += {"<br><br>
 			<b>Other actions:</b>
 			<br>
-			<A href='?src=\ref[src];forcespeech=\ref[M]'>Forcesay</A>
+			<A href='?src=\ref[src];forcespeech=\ref[M]'>Forcesay</A> |
+			<a href='?src=\ref[src];cloneother=\ref[M]'>Clone Other</a>
 			"}
 	if (M.client)
 		body += {" |

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1073,6 +1073,25 @@
 			return
 		P.copy_to(H)
 
+	else if (href_list["cloneother"])
+		if (!check_rights(R_DEBUG))
+			return
+		var/mob/living/carbon/human/H = locate(href_list["cloneother"])
+		if (!istype(H))
+			to_chat(usr, SPAN_WARNING("\The [H] is not a valid type to apply preferences to."))
+			return
+		var/client/C = select_client()
+		var/datum/preferences/P = C?.prefs
+		if (!P)
+			return
+		var/confirm = alert(usr, "This will replace \the [H] with the design of \"[P.real_name]\"!", "Clone Other", "Okay", "Cancel")
+		if (confirm != "Okay")
+			return
+		if (QDELETED(P) || QDELETED(H))
+			to_chat(usr, SPAN_WARNING("\The [H] or the preferences of [C] are no longer valid."))
+			return
+		P.copy_to(H)
+
 	else if(href_list["sendtoprison"])
 		if(!check_rights(R_ADMIN))	return
 


### PR DESCRIPTION
:cl:
admin: A new PP button, "Clone Other", allows you to select an online client and clone its current preferences onto the mob PP is open for.
/:cl:

technical limitations (ie, I am lazy) prevent selecting from the whole set of someone's characters but making a duplicate of an existing person is *most* of what this is about anyway
