### PR TITLE
integrated circuits - video camera circuit update

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -213,14 +213,15 @@
 
 /obj/item/integrated_circuit/output/video_camera
 	name = "video camera circuit"
-	desc = "Takes a string as a name and a boolean to determine whether it is on, and uses this to be a camera linked to the research network."
-	extended_desc = "The camera is linked to the Research camera network."
+	desc = "Takes a string as a name, a boolean to determine whether it is on, and a string to link the video camera to a network."
+	extended_desc = "Set the camera network string to any of the networks listed on the camera monitoring software, for example: First Deck, Engineering, Research, Thunderdome."
 	icon_state = "video_camera"
 	w_class = ITEM_SIZE_SMALL
 	complexity = 10
 	inputs = list(
 		"camera name" = IC_PINTYPE_STRING,
-		"camera active" = IC_PINTYPE_BOOLEAN
+		"camera active" = IC_PINTYPE_BOOLEAN,
+		"camera network" = IC_PINTYPE_STRING
 		)
 	inputs_default = list("1" = "video camera circuit")
 	outputs = list()
@@ -234,7 +235,7 @@
 /obj/item/integrated_circuit/output/video_camera/Initialize()
 	. = ..()
 	camera = new(src)
-	camera.replace_networks(list(NETWORK_THUNDER))
+	camera.replace_networks(list())
 	on_data_written()
 
 /obj/item/integrated_circuit/output/video_camera/Destroy()
@@ -253,8 +254,13 @@
 	if(camera)
 		var/cam_name = get_pin_data(IC_INPUT, 1)
 		var/cam_active = get_pin_data(IC_INPUT, 2)
+		var/cam_network = get_pin_data(IC_INPUT, 3)
 		if(!isnull(cam_name))
 			camera.c_tag = cam_name
+			invalidateCameraCache()
+		if(!isnull(cam_network))
+			camera.replace_networks(list(cam_network))
+			invalidateCameraCache()
 		set_camera_status(cam_active)
 
 /obj/item/integrated_circuit/output/video_camera/power_fail()


### PR DESCRIPTION
:cl: Taza
tweak: integrated circuits  - the video camera circuit now has a new camera network pin which can be configured to any listed camera monitoring network. 
/:cl:

The old camera code went to only one network and it was the wrong network (Thunderdome instead of Research) and always spawned a deactivated video camera circuit on roundstart under Thunderdome. 

This change fixes the roundstart issue and adds a camera network pin which allows you to enter any camera network listed on camera monitoring as a string to change the camera to that network. 