### PR TITLE
disables build width scaling for humans

### DIFF
--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_generic.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_generic.dm
@@ -47,5 +47,5 @@
 		"dwarfing you"
 		)
 	var/list/scale_effect = list(
-		SPECIES_HUMAN = list(-7.5, 0, 0, 0, 7.5)
+		//SPECIES_TAG_DEFINE = list(lowest, low, middle, high, highest)<,>
 	)


### PR DESCRIPTION
:cl:
tweak: Human sprites no longer width scale when rail thin or heavily built
/:cl:

In practice, it doesn't look great. I'd rather turn it off for now than try and pick better numbers.