### PR TITLE
Wallet Storage Rework

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -25,17 +25,11 @@
 		/obj/item/implanter,
 		/obj/item/flame,
 		/obj/item/paper,
-		/obj/item/paper_bundle,
 		/obj/item/pen,
 		/obj/item/photo,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/pill,
-		/obj/item/reagent_containers/hypospray/autoinjector,
-		/obj/item/reagent_containers/glass/beaker/vial,
 		/obj/item/device/radio/headset,
-		/obj/item/device/paicard,
-		/obj/item/stamp,
+		/obj/item/device/encryptionkey,
 		/obj/item/key,
 		/obj/item/clothing/accessory/badge,
 		/obj/item/clothing/accessory/medal,
@@ -43,6 +37,7 @@
 		/obj/item/clothing/ring,
 		/obj/item/passport
 	)
+
 	slot_flags = SLOT_ID
 
 	var/obj/item/card/id/front_id = null


### PR DESCRIPTION
🆑
tweak: Wallets can hold less things they shouldn't be able to, and can hold more things they should.
/🆑

### I'm back, bitches.

And upon my awakening, as the lord (me) foretold, I bring change, glorious, glorious change. The ethereal storage compartment so long ago added to the wallet has been removed, and in exchange, things that should fit in wallets shall now actually fit in wallets. Your prayers, long gone unheard, have been answered, at last. Rejoice in the fields and in the streets, in the cities and towns. I shall allow it, **this once.**