### PR TITLE
Reverts #30756

### DIFF
--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -228,7 +228,7 @@ The generic antag version.
 Similar, but for station antags that have jobs.
 */
 /datum/nano_module/skill_ui/antag/station
-	max_choices = list(0, 0, 2, 1, 1)
+	max_choices = list(0, 0, 3, 1, 0)
 /*
 Similar, but for off-station jobs (Bearcat, Verne, survivor etc.).
 */


### PR DESCRIPTION
Reverts #30756, which allowed antags to pick a master skill

In theory, good idea for combat balance.

In practice, power creep gives traitors/renegades an overwhelming advantage due to how strong master CQC is. Let antags gain advantages in equipment and initiative, not raw skill picks.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->