### PR TITLE
Increases Oxygenation Threshold of Brain Scarring

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -259,8 +259,8 @@
 
 /obj/item/organ/internal/brain/surgical_fix(mob/user)
 	var/blood_volume = owner.get_blood_oxygenation()
-	if(blood_volume < BLOOD_VOLUME_SURVIVE)
-		to_chat(user, "<span class='danger'>Parts of [src] didn't survive the procedure due to lack of air supply!</span>")
+	if(blood_volume < BLOOD_VOLUME_BAD)
+		to_chat(user, SPAN_DANGER("Parts of [src] didn't survive the procedure due to lack of air supply!"))
 		set_max_damage(Floor(max_damage - 0.25*damage))
 	heal_damage(damage)
 


### PR DESCRIPTION
:cl: Ryan180602
tweak: Increases oxygenation threshold of brain scarring from 30% to 60%
/:cl:

This will hopefully ensure the brain scars more often when surviving fatal situations, thus disallowing people from simply ATKing the brain constantly to keep someone alive and hopefully forcing them to actually fix the issue at hand, or risk losing the patient completely.
While this does make fully healing someone a bit more complicated, I think it's a positive change.