### PR TITLE
Typo fix, 'floot' to 'floor'.

### DIFF
--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -100,5 +100,5 @@
 	result_type = /obj/item/stack/tile/walnut
 
 /datum/stack_recipe/tile/metal/pool
-	title = "pool floot tile"
+	title = "pool floor tile"
 	result_type = /obj/item/stack/tile/pool


### PR DESCRIPTION
🆑 Xoxeyos
spellcheck: Simple typo fix for floor paneling in the crafting menu.
/🆑