### PR TITLE
Added verb to dump storage contents

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -22,6 +22,7 @@
 	max_w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
 	open_sound = 'sound/effects/storage/unzip.ogg'
+	allow_slow_dump = TRUE
 
 /obj/item/storage/backpack/equipped()
 	if(!has_extension(src, /datum/extension/appearance))
@@ -496,4 +497,3 @@
 	name = "corporate security messenger bag"
 	desc = "A small, tactical backpack worn over one shoulder. This one is in EXO colors."
 	icon_state = "courierbagsec_exo"
-

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -27,6 +27,7 @@
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sound/effects/storage/box.ogg'
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
+	allow_slow_dump = TRUE
 
 /obj/item/storage/box/large
 	name = "large box"

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -10,3 +10,4 @@
 	w_class = ITEM_SIZE_HUGE
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	allow_slow_dump = TRUE

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -16,6 +16,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sound/effects/storage/box.ogg'
+	allow_slow_dump = TRUE
 
 /obj/item/storage/firstaid/empty
 	icon_state = "firstaid"

--- a/code/game/objects/items/weapons/storage/lunchbox.dm
+++ b/code/game/objects/items/weapons/storage/lunchbox.dm
@@ -8,6 +8,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	var/filled = FALSE
 	attack_verb = list("lunched")
+	allow_slow_dump = TRUE
 
 /obj/item/storage/lunchbox/New()
 	..()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -18,6 +18,7 @@
 	attack_verb = list("robusted")
 	use_sound = 'sound/effects/storage/toolbox.ogg'
 	matter = list(MATERIAL_STEEL = 5000)
+	allow_slow_dump = TRUE
 
 /obj/item/storage/toolbox/emergency
 	name = "emergency toolbox"


### PR DESCRIPTION
:cl: Fre3bie
rscadd: Added verb to dump contents from held bags, boxes, etc. Similar to mining/botany bags, however requires a short warm-up.
/:cl:

Originally I was looking to just fix the issue of paper bins getting stuck in storage containers forever and requiring admin intervention, however my small brain couldn't get a solution to work properly so instead I made a verb to just completely empty certain containers to prevent any items getting stuck, but also allowing security to dump search peoples belongings or whatever else the kids want to do.

The time to dump increases with amount of items, but takes at least three seconds so it's not too fast and someone can try to interrupt someone deciding to dump out their bag of illicit materials.

EDIT: While still looking into the mystery of the paper bins getting stuck in bags, I realized they're not actually broken at all, it's just not obvious how to get it back out. Rather than clicking on the bin, or dragging the bin into your hand, dragging the bin onto the mob sprite will get it out of the bag and into the active hand.