### PR TITLE
Fixes buckets and rags shattering when thrown

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -91,6 +91,9 @@
 /obj/item/reagent_containers/glass/throw_impact(atom/hit_atom)
 	if (QDELETED(src))
 		return
+	if (!LAZYISIN(matter, MATERIAL_GLASS))
+		return
+
 	if (prob(80))
 		if (reagents.reagent_list.len > 0)
 			visible_message(


### PR DESCRIPTION
Added an extra check if the material of the reagent container is glass before deciding to shatter it, to prevent buckets, rags, and potentially other items from shattering comically.

:cl: Fre3bie
bugfix: Checks if reagent containers are made of glass before shattering, so buckets and rags won't shatter comically.
/:cl: