### PR TITLE
Runtime fixes - 2021-07-22

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -617,6 +617,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			src.updateUsrDialog()
 
 		else if(href_list["cancel_wanted"])
+			if (!connected_group.wanted_issue)
+				alert("There is no wanted issue to cancel.", "Ok")
+				return
 			if(connected_group.wanted_issue.is_admin_message)
 				alert("The wanted issue has been distributed by a [GLOB.using_map.company_name] higherup. You cannot take it down.","Ok")
 				return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -97,13 +97,13 @@ var/list/slot_equipment_priority = list( \
 	// Try put it in their backpack
 	if(istype(src.back,/obj/item/storage))
 		var/obj/item/storage/backpack = src.back
-		if(backpack.can_be_inserted(newitem, null, 1))
+		if(backpack.can_be_inserted(newitem, src, 1))
 			newitem.forceMove(src.back)
 			return backpack
 
 	// Try to place it in any item that can store stuff, on the mob.
 	for(var/obj/item/storage/S in src.contents)
-		if(S.can_be_inserted(newitem, null, 1))
+		if(S.can_be_inserted(newitem, src, 1))
 			newitem.forceMove(S)
 			return S
 


### PR DESCRIPTION
Fixes #30966, #30856, and #28907 (Cannot read `null.a_intent` in `storage.dm`)
Fixes #30955 (Cannot read `null.is_admin_message` in `newscaster.dm`)