### PR TITLE
Fixes ghosts voting by entering their dead bodies

### DIFF
--- a/code/datums/vote/transfer.dm
+++ b/code/datums/vote/transfer.dm
@@ -59,7 +59,7 @@
 	if((. = ..()))
 		return
 	if(config.vote_no_dead_crew_transfer)
-		return !isliving(user) || ismouse(user) || is_drone(user)
+		return !isliving(user) || ismouse(user) || is_drone(user) || user.stat == DEAD
 
 /datum/vote/transfer/check_toggle()
 	return config.allow_vote_restart ? "Allowed" : "Disallowed"


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: You can no longer abuse voting restrictions by re-entering your dead body to vote.
/:cl: