### PR TITLE
Slightly increases the threshold for adminwarnings about the supermatter

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -178,7 +178,7 @@
 	if((get_integrity() < 100) || (air.temperature > critical_temperature))
 		return SUPERMATTER_WARNING
 
-	if(air.temperature > (critical_temperature * 0.8))
+	if(air.temperature > (critical_temperature * 0.9))
 		return SUPERMATTER_NOTIFY
 
 	if(power > 5)


### PR DESCRIPTION
🆑 
admin: Slightly increases the threshold for the initial SM temperature admin warning to account for current meta spamming staff with logs.
/🆑 

because SOMEONE spams me with 
ADMIN LOG: EVENT INFO: Supermatter crystal is approaching unsafe operating temperature in Engine Room (LOC) x 19
and i hate. i hate all of it.