### PR TITLE
Rebalances death sting

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -794,7 +794,7 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 	if(!T)	return 0
 	to_chat(T, "<span class='danger'>You feel a small prick and your chest becomes tight.</span>")
 	T.make_jittery(400)
-	if(T.reagents)	T.reagents.add_reagent(/datum/reagent/lexorin, 40)
+	if(T.reagents)	T.reagents.add_reagent(/datum/reagent/lexorin, 10)
 	SSstatistics.add_field_details("changeling_powers","DTHS")
 	return 1
 


### PR DESCRIPTION
Reduces the amount of lexorin pushed from 40u to 10u, a far more reasonable amount. 
In the wake of my recent changes to lexorin the death sting desperately needed to be retuned. 

:cl: Yvesza
balance: Reduces the amount of lexorin injected by death sting from 40u to 10u.
/:cl: