### PR TITLE
Exempts some items from phoron contamination

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -53,6 +53,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ITEM_FLAG_SILENT                 0x1000 // sneaky shoes
 #define ITEM_FLAG_NOCUFFS                0x2000 // Gloves that have this flag prevent cuffs being applied
 #define ITEM_FLAG_CAN_HIDE_IN_SHOES      0x4000 // Items that can be hidden in shoes that permit it
+#define ITEM_FLAG_WASHER_ALLOWED         0x8000 // Items that can be washed in washing machines
 
 // Flags for pass_flags.
 #define PASS_FLAG_TABLE  0x1

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -27,7 +27,7 @@
 	// Power
 	idle_power_usage = 10
 	active_power_usage = 150
-	
+
 	machine_name = "washing machine"
 	machine_desc = "Uses detergent and water to get your clothes minty fresh. Good for those pesky bloodstains! Also decontaminates clothing that has been exposed to toxic elements, as long as detergent is used in the washing process."
 
@@ -110,7 +110,7 @@
 		return
 	if(state & WASHER_STATE_CLOSED)
 		to_chat(usr, SPAN_WARNING("\The [src] is closed."))
-		return	
+		return
 	if(!do_after(usr, 2 SECONDS, src))
 		return
 	if(!(state & WASHER_STATE_CLOSED))
@@ -122,7 +122,7 @@
 /obj/machinery/washing_machine/clean_blood()
 	. = ..()
 	state &= ~WASHER_STATE_BLOODY
-	update_icon()	
+	update_icon()
 
 /obj/machinery/washing_machine/components_are_accessible(path)
 	return !(state & WASHER_STATE_RUNNING) && ..()
@@ -147,65 +147,29 @@
 		update_icon()
 		return TRUE
 
-	else if(istype(W,/obj/item/stack/hairlesshide) || \
-		istype(W,/obj/item/clothing/under)  || \
-		istype(W,/obj/item/clothing/mask)   || \
-		istype(W,/obj/item/clothing/head)   || \
-		istype(W,/obj/item/clothing/gloves) || \
-		istype(W,/obj/item/clothing/shoes)  || \
-		istype(W,/obj/item/clothing/suit)   || \
-		istype(W,/obj/item/bedsheet) || \
-		istype(W,/obj/item/underwear/))
+	if (state & WASHER_STATE_RUNNING)
+		to_chat(user, SPAN_WARNING("\The [src] is currently running."))
+		return TRUE
 
-		//YES, it's hardcoded... saves a var/can_be_washed for every single clothing item.
-		if ( istype(W,/obj/item/clothing/suit/space ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/suit/syndicatefake ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/suit/cyborg_suit ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/suit/bomb_suit ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/suit/armor ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/suit/armor ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/mask/gas ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/mask/smokable/cigarette ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/head/syndicatefake ) )
-			to_chat(user, "This item does not fit.")
-			return
-		if ( istype(W,/obj/item/clothing/head/helmet ) )
-			to_chat(user, "This item does not fit.")
-			return
+	else if (!(W.item_flags & ITEM_FLAG_WASHER_ALLOWED))
+		if (isScrewdriver(W) || isCrowbar(W) || isWrench(W))
+			return ..()
 
-		if(contents.len < 5)
-			if(!(state & WASHER_STATE_CLOSED))
-				if(!user.unEquip(W, src))
+		to_chat(user, SPAN_WARNING("\The [W] can't be washed in \the [src]!"))
+		return
+
+	else
+		if (contents.len < 5)
+			if (!(state & WASHER_STATE_CLOSED))
+				if (!user.unEquip(W, src))
 					return
 				state |= WASHER_STATE_FULL
 				update_icon()
 			else
 				to_chat(user, SPAN_NOTICE("You can't put the item in right now."))
 		else
-			to_chat(user, SPAN_NOTICE("\The [src] is full"))
-		return TRUE
+			to_chat(user, SPAN_NOTICE("\The [src] is full."))
 
-	if(state & WASHER_STATE_RUNNING)
-		to_chat(user, SPAN_WARNING("\The [src] is currently running."))
-		return TRUE
-
-	return ..()
 
 /obj/machinery/washing_machine/physical_attack_hand(mob/user)
 	if(state & WASHER_STATE_RUNNING)

--- a/code/game/objects/items/plunger.dm
+++ b/code/game/objects/items/plunger.dm
@@ -7,6 +7,7 @@
 	attack_verb = list("plunged")
 	force = 1
 	w_class = 3
+	item_flags = null
 	slot_flags = SLOT_HEAD | SLOT_MASK
 	hitsound = 'sound/effects/plunger.ogg'
 	matter = list("steel" = 5000)

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -2,7 +2,7 @@
 	name = "towel"
 	icon = 'icons/obj/weapons/other.dmi'
 	icon_state = "towel"
-	item_flags = ITEM_FLAG_IS_BELT
+	item_flags = ITEM_FLAG_IS_BELT | ITEM_FLAG_WASHER_ALLOWED
 	slot_flags = SLOT_HEAD | SLOT_BELT | SLOT_OCLOTHING
 	force = 0.5
 	w_class = ITEM_SIZE_NORMAL

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -12,6 +12,7 @@ LINEN BINS
 	item_state = "bedsheet"
 	randpixel = 0
 	slot_flags = SLOT_BACK
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	layer = BASE_ABOVE_OBJ_LAYER
 	throwforce = 1
 	throw_speed = 1

--- a/code/modules/ZAS/Phoron.dm
+++ b/code/modules/ZAS/Phoron.dm
@@ -42,10 +42,17 @@ obj/var/contaminated = 0
 
 
 /obj/item/proc/can_contaminate()
-	//Clothing and backpacks can be contaminated.
-	if(obj_flags & ITEM_FLAG_PHORONGUARD) return 0
-	else if(istype(src,/obj/item/storage/backpack)) return 0 //Cannot be washed :(
-	else if(istype(src,/obj/item/clothing)) return 1
+	//Clothing can be contaminated, with exceptions for certain items which cannot be washed in washing_machine.dm
+	if (obj_flags & ITEM_FLAG_PHORONGUARD) return 0
+
+	else if (istype(src, /obj/item/clothing/mask/gas)	|| \
+			istype(src, /obj/item/clothing/accessory)	|| \
+			istype(src, /obj/item/clothing/ring)		|| \
+			istype(src, /obj/item/clothing/ears)		|| \
+			istype(src, /obj/item/clothing/glasses))
+		return 0
+
+	else if (istype(src,/obj/item/clothing)) return 1
 
 /obj/item/proc/contaminate()
 	//Do a contamination overlay? Temporary measure to keep contamination less deadly than it was.
@@ -152,9 +159,9 @@ obj/var/contaminated = 0
 
 /mob/living/carbon/human/proc/suit_contamination()
 	//Runs over the things that can be contaminated and does so.
-	if(w_uniform) w_uniform.contaminate()
-	if(shoes) shoes.contaminate()
-	if(gloves) gloves.contaminate()
+	if (w_uniform && w_uniform.can_contaminate()) w_uniform.contaminate()
+	if (shoes && shoes.can_contaminate()) shoes.contaminate()
+	if (gloves && gloves.can_contaminate()) gloves.contaminate()
 
 
 turf/Entered(obj/item/I)

--- a/code/modules/ZAS/Phoron.dm
+++ b/code/modules/ZAS/Phoron.dm
@@ -45,14 +45,7 @@ obj/var/contaminated = 0
 	//Clothing can be contaminated, with exceptions for certain items which cannot be washed in washing_machine.dm
 	if (obj_flags & ITEM_FLAG_PHORONGUARD) return 0
 
-	else if (istype(src, /obj/item/clothing/mask/gas)	|| \
-			istype(src, /obj/item/clothing/accessory)	|| \
-			istype(src, /obj/item/clothing/ring)		|| \
-			istype(src, /obj/item/clothing/ears)		|| \
-			istype(src, /obj/item/clothing/glasses))
-		return 0
-
-	else if (istype(src,/obj/item/clothing)) return 1
+	else if (item_flags & ITEM_FLAG_WASHER_ALLOWED) return 1
 
 /obj/item/proc/contaminate()
 	//Do a contamination overlay? Temporary measure to keep contamination less deadly than it was.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -282,6 +282,7 @@ BLIND     // can't see anything
 	var/mob/living/carbon/human/wearer = null	//Used for covered rings when dropping
 	body_parts_covered = HANDS
 	slot_flags = SLOT_GLOVES
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	attack_verb = list("challenged")
 	species_restricted = list("exclude",SPECIES_NABBER, SPECIES_MONARCH_QUEEN, SPECIES_UNATHI, SPECIES_VOX, SPECIES_VOX_ARMALIS)
 	sprite_sheets = list(
@@ -398,6 +399,7 @@ BLIND     // can't see anything
 	)
 	body_parts_covered = HEAD
 	slot_flags = SLOT_HEAD
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_SMALL
 	blood_overlay_type = "helmetblood"
 
@@ -512,6 +514,7 @@ BLIND     // can't see anything
 	name = "mask"
 	icon = 'icons/obj/clothing/obj_mask.dmi'
 	slot_flags = SLOT_MASK
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	body_parts_covered = FACE|EYES
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/species/vox/onmob_mask_vox.dmi',
@@ -593,6 +596,7 @@ BLIND     // can't see anything
 	siemens_coefficient = 0.9
 	body_parts_covered = FEET
 	slot_flags = SLOT_FEET
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	permeability_coefficient = 0.50
 	force = 2
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_UNATHI, SPECIES_VOX, SPECIES_VOX_ARMALIS)
@@ -751,6 +755,7 @@ BLIND     // can't see anything
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	allowed = list(/obj/item/tank/emergency)
 	slot_flags = SLOT_OCLOTHING
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	blood_overlay_type = "suit"
 	siemens_coefficient = 0.9
 	w_class = ITEM_SIZE_NORMAL
@@ -800,6 +805,7 @@ BLIND     // can't see anything
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	permeability_coefficient = 0.90
 	slot_flags = SLOT_ICLOTHING
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_NORMAL
 	force = 0
 	var/has_sensor = SUIT_HAS_SENSORS //For the crew computer 2 = unable to change mode

--- a/code/modules/clothing/ears/skrell.dm
+++ b/code/modules/clothing/ears/skrell.dm
@@ -77,6 +77,7 @@
 	name = "headtail cloth"
 	desc = "A cloth shawl worn by female skrell draped around their head tails."
 	icon_state = "skrell_cloth_female"
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 
 //spawnable presets
 /obj/item/clothing/ears/skrell/cloth_female/red
@@ -101,6 +102,7 @@
 	name = "headtail cloth"
 	desc = "A cloth band worn by male skrell around their head tails."
 	icon_state = "skrell_cloth_male"
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 
 //spawnable presets
 /obj/item/clothing/ears/skrell/cloth_male/red

--- a/code/modules/clothing/glasses/blindfolds.dm
+++ b/code/modules/clothing/glasses/blindfolds.dm
@@ -7,6 +7,7 @@
 	off_state = "blindfoldup"
 	tint = TINT_BLIND
 	flash_protection = FLASH_PROTECTION_MAJOR
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	darkness_view = -1
 	toggleable = TRUE
 	activation_sound = null
@@ -23,7 +24,7 @@
 	if(active)
 		flags_inv &= ~HIDEEYES
 		body_parts_covered &= ~EYES
-	else 
+	else
 		flags_inv |= HIDEEYES
 		body_parts_covered |= EYES
 
@@ -34,5 +35,6 @@
 	action_button_name = null
 	icon_state = "tape_cross"
 	item_state = null
+	item_flags = null
 	w_class = ITEM_SIZE_TINY
 	toggleable = FALSE

--- a/code/modules/clothing/glasses/eyepatch.dm
+++ b/code/modules/clothing/glasses/eyepatch.dm
@@ -4,6 +4,7 @@
 	icon_state = "eyepatch"
 	item_state = "eyepatch"
 	body_parts_covered = 0
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	var/flipped = FALSE // Indicates left or right eye; 0 = on the right
 
 /obj/item/clothing/glasses/eyepatch/verb/flip_patch()
@@ -31,6 +32,7 @@
 	item_state = "hudpatch"
 	off_state = "hudpatch"
 	action_button_name = "Toggle iPatch"
+	item_flags = null
 	toggleable = TRUE
 	var/eye_color = COLOR_WHITE
 	electric = TRUE

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -4,7 +4,7 @@
 	icon_state = "white"
 
 /obj/item/clothing/gloves/color/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/color/white
 	color = COLOR_WHITE
@@ -13,7 +13,7 @@
 	color = COLOR_BLACK
 
 /obj/item/clothing/gloves/color/white/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/color/evening
 	desc = "A pair of gloves that reach past the elbow. Fancy!"
@@ -24,7 +24,7 @@
 	body_parts_covered = ARMS|HANDS //evening gloves don't quite cover the entire arm, but might as well differentiate the item a bit
 
 /obj/item/clothing/gloves/color/evening/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/rainbow
 	name = "rainbow gloves"
@@ -33,4 +33,4 @@
 	item_state = "rainbowgloves"
 
 /obj/item/clothing/gloves/rainbow/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -50,7 +50,7 @@
 	item_state = "bgloves"
 	siemens_coefficient = 0.50
 	permeability_coefficient = 0.05
-	item_flags = ITEM_FLAG_THICKMATERIAL
+	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
@@ -58,7 +58,7 @@
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/gloves/thick/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/thick/swat
 	desc = "These tactical gloves are somewhat fire and impact-resistant."
@@ -100,7 +100,7 @@
 	item_state = "ggloves"
 
 /obj/item/clothing/gloves/thick/botany/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/latex
 	name = "latex gloves"
@@ -113,7 +113,7 @@
 	germ_level = 0
 
 /obj/item/clothing/gloves/latex/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/latex/nitrile
 	name = "nitrile gloves"
@@ -122,7 +122,7 @@
 	item_state = "ngloves"
 
 /obj/item/clothing/gloves/latex/nitrile/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/thick/duty
 	desc = "These brown duty gloves are made from a durable synthetic."
@@ -136,7 +136,7 @@
 		)
 
 /obj/item/clothing/gloves/thick/duty/modified
-	item_flags = ITEM_FLAG_PREMODIFIED
+	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
 
 /obj/item/clothing/gloves/tactical
 	desc = "These brown tactical gloves are made from a durable synthetic, and have hardened knuckles."
@@ -177,7 +177,7 @@
 	siemens_coefficient = 0.50
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
-	item_flags = ITEM_FLAG_THICKMATERIAL
+	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	body_parts_covered = HANDS
 	cold_protection = HANDS
 	heat_protection = HANDS

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -6,6 +6,7 @@
 	brightness_on = 0.5 //luminosity when on
 	light_overlay = "hardhat_light"
 	w_class = ITEM_SIZE_NORMAL
+	item_flags = null
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_MINOR,

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -91,6 +91,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	siemens_coefficient = 2.0
 	body_parts_covered = HEAD|FACE|EYES
+	item_flags = null
 
 /obj/item/clothing/head/cueball
 	name = "cueball helmet"
@@ -99,6 +100,7 @@
 	item_state = "cueball"
 	flags_inv = BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
+	item_flags = null
 
 /obj/item/clothing/head/cardborg
 	name = "cardborg helmet"
@@ -107,6 +109,7 @@
 	item_state = "cardborg_h"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	body_parts_covered = HEAD|FACE|EYES
+	item_flags = null
 
 /obj/item/clothing/head/cardborg/Initialize()
 	. = ..()
@@ -287,6 +290,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	siemens_coefficient = 2.0
 	body_parts_covered = HEAD|FACE|EYES
+	item_flags = null
 
 /obj/item/clothing/head/philosopher_wig
 	name = "natural philosopher's wig"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -25,6 +25,7 @@
 		melee = ARMOR_MELEE_SMALL
 		)
 	flags_inv = (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
+	item_flags = null
 	body_parts_covered = HEAD|FACE|EYES
 	action_button_name = "Flip Welding Mask"
 	siemens_coefficient = 0.9
@@ -118,6 +119,7 @@
 	item_state = "cake0"
 	var/onfire = 0
 	body_parts_covered = HEAD
+	item_flags = null
 
 /obj/item/clothing/head/cakehat/Process()
 	if(!onfire)
@@ -183,6 +185,7 @@
 	desc = "A jack o' lantern! Believed to ward off evil spirits."
 	icon_state = "hardhat0_pumpkin"//Could stand to be renamed
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
+	item_flags = null
 	body_parts_covered = HEAD|FACE|EYES
 	brightness_on = 0.2
 	light_overlay = "helmet_light"

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -9,6 +9,7 @@
 	var/chewtime = 0
 	var/brand
 	var/list/filling = list()
+	item_flags = null
 
 obj/item/clothing/mask/chewable/New()
 	..()

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -34,7 +34,7 @@
 	item_state = "sterile"
 	w_class = ITEM_SIZE_TINY
 	body_parts_covered = FACE
-	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL
+	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.01
 	armor = list(
@@ -59,6 +59,7 @@
 	desc = "For the Swimming Savant."
 	icon_state = "snorkel"
 	item_state = "snorkel"
+	item_flags = null
 	flags_inv = HIDEFACE
 	body_parts_covered = 0
 
@@ -70,7 +71,7 @@
 	icon_state = "blueneckscarf"
 	item_state = "blueneckscarf"
 	body_parts_covered = FACE
-	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL
+	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.90
 
@@ -80,7 +81,7 @@
 	icon_state = "redwhite_scarf"
 	item_state = "redwhite_scarf"
 	body_parts_covered = FACE
-	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL
+	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.90
 
@@ -90,7 +91,7 @@
 	icon_state = "green_scarf"
 	item_state = "green_scarf"
 	body_parts_covered = FACE
-	item_flags = ITEM_FLAG_THICKMATERIAL
+	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.90
 
@@ -100,7 +101,7 @@
 	icon_state = "ninja_scarf"
 	item_state = "ninja_scarf"
 	body_parts_covered = FACE
-	item_flags = ITEM_FLAG_THICKMATERIAL
+	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.90
 	siemens_coefficient = 0
@@ -138,6 +139,7 @@
 	icon_state = "s-ninja"
 	item_state = "s-ninja"
 	flags_inv = HIDEFACE
+	item_flags = null
 	body_parts_covered = FACE|EYES
 	action_button_name = "Toggle MUI"
 	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5)
@@ -271,7 +273,7 @@
 	body_parts_covered = FACE
 	icon_state = "bandblack"
 	item_state = "bandblack"
-	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL
+	item_flags = ITEM_FLAG_FLEXIBLEMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/bandana/equipped(var/mob/user, var/slot)
@@ -333,4 +335,3 @@
 	desc = "A fine black bandana with nanotech lining and a skull emblem. Can be worn on the head or face."
 	icon_state = "bandskull"
 	item_state = "bandskull"
-

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -11,6 +11,7 @@
 	icon_override = 'icons/mob/monitor_icons.dmi'
 	icon_state = "ipc_blank"
 	item_state = null
+	item_flags = null
 
 	var/monitor_state_index = "blank"
 	var/global/list/monitor_states = list(

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -3,6 +3,7 @@
 	desc = "You're not sure what this is. You should probably ahelp it."
 	body_parts_covered = 0
 	waterproof = FALSE
+	item_flags = null
 
 	var/lit = 0
 	var/icon_on

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -3,6 +3,7 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	name = "magboots"
 	icon_state = "magboots0"
+	item_flags = null
 	species_restricted = null
 	force = 3
 	overshoes = 1

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -21,14 +21,14 @@
 	icon_state = "swat"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH, 
-		bullet = ARMOR_BALLISTIC_RIFLE, 
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_RIFLE,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR
 		)
-	item_flags = ITEM_FLAG_NOSLIP
+	item_flags = ITEM_FLAG_NOSLIP | ITEM_FLAG_WASHER_ALLOWED
 	siemens_coefficient = 0.6
 
 /obj/item/clothing/shoes/combat //Basically SWAT shoes combined with galoshes.
@@ -37,14 +37,14 @@
 	icon_state = "jungle"
 	force = 5
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH, 
-		bullet = ARMOR_BALLISTIC_RIFLE, 
+		melee = ARMOR_MELEE_VERY_HIGH,
+		bullet = ARMOR_BALLISTIC_RIFLE,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR
 		)
-	item_flags = ITEM_FLAG_NOSLIP
+	item_flags = ITEM_FLAG_NOSLIP | ITEM_FLAG_WASHER_ALLOWED
 	siemens_coefficient = 0.6
 
 	cold_protection = FEET
@@ -58,11 +58,11 @@
 	icon_state = "jungle"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_MINOR, 
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_MINOR
 		)
 	siemens_coefficient = 0.7
@@ -73,11 +73,11 @@
 	icon_state = "desert"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_MINOR, 
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_MINOR
 		)
 	siemens_coefficient = 0.7
@@ -87,9 +87,9 @@
 	desc = "A pair of steel-toed synthleather boots with a mirror shine."
 	icon_state = "duty"
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		energy = ARMOR_ENERGY_MINOR, 
-		bomb = ARMOR_BOMB_PADDED, 
+		melee = ARMOR_MELEE_RESISTANT,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_PADDED,
 		rad = ARMOR_RAD_MINOR
 		)
 	siemens_coefficient = 0.7
@@ -106,10 +106,10 @@
 	icon_state = "desert"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_HANDGUNS, 
-		energy = ARMOR_ENERGY_SMALL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_PISTOL,
+		laser = ARMOR_LASER_HANDGUNS,
+		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_RESISTANT)
 	siemens_coefficient = 0.7
 
@@ -183,6 +183,7 @@
 	name = "cyborg boots"
 	desc = "Shoes for a cyborg costume."
 	icon_state = "boots"
+	item_flags = null
 
 /obj/item/clothing/shoes/slippers
 	name = "bunny slippers"

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -33,6 +33,7 @@
 	var/damage = 0                          // Current total damage. Does not count patched breaches.
 	var/brute_damage = 0                    // Specifically brute damage. Includes patched punctures.
 	var/burn_damage = 0                     // Specifically burn damage. Includes patched burns.
+	item_flags = null
 
 /datum/breach/proc/update_descriptor()
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -13,6 +13,7 @@
 	desc = "Blue Pride, Galaxy Wide."
 	icon_state = "bluetag"
 	blood_overlay_type = "armor"
+	item_flags = null
 	body_parts_covered = UPPER_TORSO
 	allowed = list (/obj/item/gun/energy/lasertag/blue)
 	siemens_coefficient = 3.0
@@ -22,6 +23,7 @@
 	desc = "Reputed to go faster."
 	icon_state = "redtag"
 	blood_overlay_type = "armor"
+	item_flags = null
 	body_parts_covered = UPPER_TORSO
 	allowed = list (/obj/item/gun/energy/lasertag/red)
 	siemens_coefficient = 3.0
@@ -108,6 +110,7 @@
 	icon_state = "syndicate"
 	desc = "A plastic replica of the syndicate space suit, you'll look just like a real murderous syndicate agent in this! This is a toy, it is not made for use in space!"
 	w_class = ITEM_SIZE_NORMAL
+	item_flags = null
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank/emergency,/obj/item/toy)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|HANDS|LEGS|FEET
@@ -158,6 +161,7 @@
 	name = "cardborg suit"
 	desc = "An ordinary cardboard box with holes cut in the sides."
 	icon_state = "cardborg"
+	item_flags = null
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	flags_inv = HIDEJUMPSUIT
 
@@ -261,6 +265,7 @@
 	name = "xenos suit"
 	desc = "A suit made out of chitinous alien hide."
 	icon_state = "xenos"
+	item_flags = null
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 2.0

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -73,6 +73,7 @@
 		)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
+	item_flags = null
 	siemens_coefficient = 0
 
 
@@ -92,6 +93,7 @@
 		)
 	flags_inv = HIDEJUMPSUIT|HIDETAIL
 	heat_protection = UPPER_TORSO|LOWER_TORSO
+	item_flags = null
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0
 

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -1,4 +1,5 @@
 /obj/item/underwear
+	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	w_class = ITEM_SIZE_TINY
 	var/required_slot_flags
 	var/required_free_body_parts


### PR DESCRIPTION
:cl: Fre3bie
tweak: Prevents certain unwashable clothing items from being contaminated by phoron gas.
/:cl:

Certain items which could be contaminated by phoron have no way of being cleaned, due to not being accepted by washing machines, preventing players from continuing to wear rings or other fluff items should they be exposed. The alternative to preventing the contamination in the first place would be to allow more items to be placed in the washing machine so they can be decontaminated, if that's preferred I'd be happy to make the change on that end.