### PR TITLE
fix simple mobs being able to open doors they shouldn't

### DIFF
--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -276,7 +276,7 @@
 				if (D.allowed(holder) && D.operable())
 					// First, try to open the door if possible without smashing it. We might have access.
 					ai_log("destroy_surroundings() : Opening closed door.", AI_LOG_INFO)
-					return D.open()
+					return D.Bumped(holder)
 
 				//Try to force the door if its broken/has no power
 				if (!prying && holder.can_pry && !D.operable())


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed simple mobs being able to open doors they shouldn't be able to.
/:cl:

Fixes #30980