### PR TITLE
Fixes gen-less shield errors

### DIFF
--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -19,7 +19,9 @@
 	else
 		set_opacity(0)
 
-	if(gen && gen.check_flag(MODEFLAG_OVERCHARGE))
+	if (!gen)
+		color = COLOR_RED_LIGHT
+	else if (gen.check_flag(MODEFLAG_OVERCHARGE))
 		color = COLOR_VIOLET
 	else
 		color = COLOR_DEEP_SKY_BLUE
@@ -35,6 +37,15 @@
 /obj/effect/shield/New()
 	..()
 	update_nearby_tiles()
+
+
+/obj/effect/shield/Initialize(mapload, obj/machinery/power/shield_generator/new_gen)
+	. = ..(mapload)
+
+	if (QDELETED(new_gen))
+		log_debug(append_admin_tools("Shield effect ([name]) was created without a valid generator in [get_area(src)].", location = get_turf(src)))
+		return INITIALIZE_HINT_QDEL
+	gen = new_gen
 
 
 /obj/effect/shield/Destroy()
@@ -100,7 +111,7 @@
 
 /obj/effect/shield/attack_generic(var/source, var/damage, var/emote)
 	take_damage(damage, SHIELD_DAMTYPE_PHYSICAL)
-	if(gen.check_flag(MODEFLAG_OVERCHARGE) && istype(source, /mob/living/))
+	if(gen?.check_flag(MODEFLAG_OVERCHARGE) && istype(source, /mob/living/))
 		overcharge_shock(source)
 	..(source, damage, emote)
 
@@ -173,7 +184,7 @@
 
 
 /obj/effect/shield/c_airblock(turf/other)
-	return gen.check_flag(MODEFLAG_ATMOSPHERIC) ? BLOCKED : 0
+	return gen?.check_flag(MODEFLAG_ATMOSPHERIC) ? BLOCKED : 0
 
 
 // EMP. It may seem weak but keep in mind that multiple shield segments are likely to be affected.

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -123,8 +123,7 @@
 			vessel_reverse_dir = GLOB.reverse_dir[sector.fore_dir]
 
 	for(var/turf/T in shielded_turfs)
-		var/obj/effect/shield/S = new(T)
-		S.gen = src
+		var/obj/effect/shield/S = new(T, src)
 		S.flags_updated()
 		field_segments |= S
 		S.set_dir(vessel_reverse_dir)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Shield effects without a valid generator now appear red. If you see a red shield, ahelp it for a dev.
/:cl:

- Prevents shield effects from being spawned without a valid generator, due to code relying on a generator existing
- Adds a red color state to update_icon() for shield effects that lack a generator, just in case something bypasses the above somehow

Fixes #30997