### PR TITLE
Rebalances Flash

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -80,8 +80,8 @@
 				if(flash_strength > 0)
 					M.flash_eyes(FLASH_PROTECTION_MODERATE - safety)
 					M.Stun(flash_strength / 2)
-					M.eye_blurry += flash_strength
-					M.confused += (flash_strength + 2)
+					M.eye_blurry = max(M.eye_blurry, flash_strength)
+					M.confused = max(M.confused, (flash_strength + 2))
 					if(flash_strength > 3)
 						M.drop_l_hand()
 						M.drop_r_hand()
@@ -94,12 +94,11 @@
 		var/mob/living/simple_animal/SA = M
 		var/safety = SA.eyecheck()
 		if(safety < FLASH_PROTECTION_MAJOR)
-			SA.Weaken(2)
+			SA.confused = max(SA.confused, (flash_strength * 0.5))
 			if(safety < FLASH_PROTECTION_MODERATE)
-				SA.Stun(flash_strength - 2)
 				SA.flash_eyes(2)
-				SA.eye_blurry += flash_strength
-				SA.confused += flash_strength
+				SA.eye_blurry = max(SA.eye_blurry, flash_strength)
+				SA.confused = max(SA.confused, (flash_strength))
 		else
 			flashfail = 1
 


### PR DESCRIPTION
Flashes no longer allow the user to stun simple mobs and remove all risk involved in fighting them, instead they'll make them less accurate and stumble around confused for a few moments.

Flashes also can no longer confuse someone for literally forever (There was no cap on confusion duration before, allowing a few uses of a flash to give someone up to a minute of confusion)

:cl: Yvesza
balance: Flashes no longer stun simple mobs / animals, instead they'll be confused and stumble around.
tweak: Flashes no longer stack their confusion / stun effects infinitely. 
/:cl: