### PR TITLE
Adds the supermatter power surge event

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1737,6 +1737,7 @@
 #include "code\modules\events\meteors.dm"
 #include "code\modules\events\money_hacker.dm"
 #include "code\modules\events\money_lotto.dm"
+#include "code\modules\events\power_surge.dm"
 #include "code\modules\events\prison_break.dm"
 #include "code\modules\events\radiation_storm.dm"
 #include "code\modules\events\random_antagonist.dm"

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -174,6 +174,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",					/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Supermatter Power Surge",				/datum/event/power_surge,				100,	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Exoplanet Awakening",					/datum/event/exo_awakening,             75)
 	)
 

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -41,6 +41,7 @@ var/list/event_last_fired = list()
 	possibleEvents[/datum/event/communications_blackout] = 50 + 25 * active_with_role["AI"] + active_with_role["Scientist"] * 25
 	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 25 + active_with_role["Robot"] * 25 + active_with_role["Engineer"] * 10 + active_with_role["Scientist"] * 5
 	possibleEvents[/datum/event/grid_check] = 25 + 10 * active_with_role["Engineer"]
+	possibleEvents[/datum/event/power_surge] = active_with_role["Engineer"] >= 2 ? 15 + 10 * active_with_role["Engineer"] : 0
 	possibleEvents[/datum/event/electrical_storm] = 15 * active_with_role["Janitor"] + 5 * active_with_role["Engineer"]
 	possibleEvents[/datum/event/wallrot] = 30 * active_with_role["Engineer"] + 50 * active_with_role["Gardener"]
 

--- a/code/modules/events/power_surge.dm
+++ b/code/modules/events/power_surge.dm
@@ -1,0 +1,25 @@
+/datum/event/power_surge
+	announceWhen = 5
+
+/datum/event/power_surge/setup()
+	endWhen = rand(120, 300)
+
+/datum/event/power_surge/announce()
+	command_announcement.Announce("Energy readings indicate a minor shift in engine crystalline hyperstructure. Closer monitoring of crystal stability and power output is recommended.", "[location_name()] Supermatter Monitoring System", zlevels = affecting_z)
+
+/datum/event/power_surge/start()
+	for (var/obj/machinery/power/supermatter/S in SSmachines.machinery)
+		if (!(S.z in affecting_z))
+			return
+		S.reaction_power_modifier += 0.2
+		S.radiation_release_modifier += 0.2
+		S.thermal_release_modifier += 1500
+
+/datum/event/power_surge/end()
+	for (var/obj/machinery/power/supermatter/S in SSmachines.machinery)
+		if (!(S.z in affecting_z))
+			return
+		S.reaction_power_modifier = initial(S.reaction_power_modifier)
+		S.radiation_release_modifier = initial(S.radiation_release_modifier)
+		S.thermal_release_modifier = initial(S.thermal_release_modifier)
+		command_announcement.Announce("Engine crystalline hyperstructure shift has now dissipated. Thank you for your patience.", "[location_name()] Supermatter Monitoring System", zlevels = affecting_z)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Adds a new moderate severity event; the Supermatter Power Surge, with about half the chance to occur as the grid check event. This increases the reaction power of the supermatter, causing it to emit a moderately increased amount of heat, radiation and power for at most 5 minutes. I am by no means an engineer, but local testing showed no severe impact on normal supermatter setups. This is more just a flavour thing to give engineers a reason to keep an eye on the crystal now and again.

:cl: 
rscadd: Adds a new random event; the Supermatter Power Surge. Increases emitted heat, radiation and power for a short duration.
/:cl: