### PR TITLE
Bump supermatter thermal release

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -36,7 +36,7 @@
 	layer = ABOVE_HUMAN_LAYER
 
 	var/nitrogen_retardation_factor = 0.15	//Higher == N2 slows reaction more
-	var/thermal_release_modifier = 10000		//Higher == more heat released during reaction
+	var/thermal_release_modifier = 15000		//Higher == more heat released during reaction
 	var/phoron_release_modifier = 1500		//Higher == less phoron released by reaction
 	var/oxygen_release_modifier = 15000		//Higher == less oxygen released at high temperature/power
 	var/radiation_release_modifier = 2      //Higher == more radiation released with more power.
@@ -70,7 +70,7 @@
 
 	var/grav_pulling = 0
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
-	var/pull_time = 300
+	var/pull_time = 30 SECONDS
 	var/explosion_power = 9
 
 	var/emergency_issued = 0


### PR DESCRIPTION
:cl: SierraKomodo
tweak: The supermatter's thermal output has been bumped, which should result in higher EER (1,000+) setups being more dangerous and require more monitoring/micromanagement to maintain stability. These are the same settings that have been used in the test rounds.
/:cl: