### PR TITLE
Make antagonist addition failures more verbose

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -206,10 +206,20 @@
 	if(href_list["add_antagonist"])
 		var/datum/antagonist/antag = GLOB.all_antag_types_[href_list["add_antagonist"]]
 		if(antag)
+			if(!current)
+				to_chat(usr, SPAN_WARNING("\The [src] could not be made into a [antag.role_text]! They do not have a mob."))
+				return
+			if(src in antag.current_antagonists)
+				to_chat(usr, SPAN_WARNING("\The [src] is already a [antag.role_text]!"))
+				return
+			var/result = antag.can_become_antag_detailed(src, TRUE)
+			if(result)
+				to_chat(usr, SPAN_WARNING("\The [src] could not be made into a [antag.role_text]! [result]."))
+				return
 			if(antag.add_antagonist(src, 1, 1, 0, 1, 1)) // Ignore equipment and role type for this.
 				log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
 			else
-				to_chat(usr, "<span class='warning'>[src] could not be made into a [antag.role_text]!</span>")
+				to_chat(usr, SPAN_WARNING("\The [src] could not be made into a [antag.role_text]!"))
 
 	else if(href_list["remove_antagonist"])
 		var/datum/antagonist/antag = GLOB.all_antag_types_[href_list["remove_antagonist"]]

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -114,27 +114,30 @@
 /datum/antagonist/proc/tick()
 	return 1
 
-// Get the raw list of potential players.
+/// Get the raw list of potential players.
 /datum/antagonist/proc/build_candidate_list(datum/game_mode/mode, ghosts_only)
 	candidates = list() // Clear.
 
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in mode.get_players_for_role(id))
-		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
+		if (ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
-		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")
-		else if(player.special_role)
+			continue
+		if (player.special_role)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!")
-		else if (player in pending_antagonists)
+			continue
+		if (player in pending_antagonists)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They have already been selected for this role!")
-		else if(!can_become_antag(player))
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
-		else if(player_is_antag(player))
+			continue
+		if (player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
-		else
-			candidates |= player
+			continue
+		var/result = can_become_antag_detailed(player)
+		if (result)
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: [result]")
+			continue
+		candidates |= player
 
 	return candidates
 
@@ -213,20 +216,21 @@
 
 	return 1
 
-/datum/antagonist/proc/draft_antagonist(var/datum/mind/player)
+/datum/antagonist/proc/draft_antagonist(datum/mind/player)
 	//Check if the player can join in this antag role, or if the player has already been given an antag role.
-	if(!can_become_antag(player))
-		log_debug("[player.key] was selected for [role_text] by lottery, but is not allowed to be that role.")
-		return 0
 	if(player.special_role)
 		log_debug("[player.key] was selected for [role_text] by lottery, but they already have a special role.")
-		return 0
+		return FALSE
 	if(!(flags & ANTAG_OVERRIDE_JOB) && (!player.current || istype(player.current, /mob/new_player)))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
-		return 0
+		return FALSE
 	if(GAME_STATE >= RUNLEVEL_GAME && (isghostmind(player) || isnewplayer(player.current)) && !(player in SSticker.antag_pool))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they are a ghost not in the antag pool.")
-		return 0
+		return FALSE
+	var/result = can_become_antag_detailed(player)
+	if (result)
+		log_debug("[player.key] was selected for [role_text] by lottery, but is not allowed: [result].")
+		return FALSE
 
 	pending_antagonists |= player
 	log_debug("[player.key] has been selected for [role_text] by lottery.")
@@ -239,7 +243,7 @@
 	//Ensure that a player cannot be drafted for multiple antag roles, taking up slots for antag roles that they will not fill.
 	player.special_role = role_text
 
-	return 1
+	return TRUE
 
 //Spawns all pending_antagonists. This is done separately from attempt_spawn in case the game mode setup fails.
 /datum/antagonist/proc/finalize_spawn()

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -15,10 +15,13 @@
 
 	if(player_is_antag(player))
 		to_chat(src, "<span class='warning'>\The [player.current]'s loyalties seem to be elsewhere...</span>")
+		log_debug("\The [src] attempted to convert \the [player.current] to [faction], but failed: Player is already an antagonist.")
 		return
 
-	if(!faction.can_become_antag(player, 1))
+	var/result = faction.can_become_antag_detailed(player, TRUE)
+	if(result)
 		to_chat(src, "<span class='warning'>\The [player.current] cannot be \a [faction.faction_role_text]!</span>")
+		log_debug("\The [src] attempted to convert \the [player.current] to [faction], but failed: [result]")
 		return
 
 	if(world.time < player.rev_cooldown)
@@ -34,10 +37,12 @@
 		var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!")
 		if(choice == "Yes!" && faction.add_antagonist_mind(player, 0, faction.faction_role_text, faction.faction_welcome))
 			to_chat(src, "<span class='notice'>\The [player.current] joins the [faction.faction_descriptor]!</span>")
+			log_debug("\The [src] has successfully converted \the [player.current] to [faction].")
 			return
 		else
 			to_chat(player, "<span class='danger'>You reject this traitorous cause!</span>")
 	to_chat(src, "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>")
+	log_debug("\The [src] attempted to convert \the [player.current] to [faction], but failed: The player refused to join or the faction failed to add them.")
 
 /mob/living/proc/convert_to_loyalist(mob/M as mob in able_mobs_in_oview(src))
 	set name = "Convert"

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -1,25 +1,33 @@
-/datum/antagonist/proc/can_become_antag(var/datum/mind/player, var/ignore_role)
-
+/** Checks if the given player is able to become an antagonist or not.
+ * Will return 'FALSE' if they can become an antagonist, or a string value describing why they cannot become one.
+ * Use strict type comparisons for truthiness values.
+ * `ignore_role` will skip restriced job, player age, and player status flag checks.
+ */
+/datum/antagonist/proc/can_become_antag_detailed(datum/mind/player, ignore_role)
 	if(player.current)
 		if(jobban_isbanned(player.current, id))
-			return 0
+			return "Player is banned from this antagonist role."
 		if(player.current.faction != MOB_FACTION_NEUTRAL)
-			return 0
+			return "Player is already assigned to a non-neutral faction ([player.current.faction])."
 
 	if(is_type_in_list(player.assigned_job, blacklisted_jobs))
-		return 0
+		return "Player's assigned job ([player.assigned_job]) is blacklisted from this antagonist role."
 
 	if(!ignore_role)
 		if(player.current && player.current.client)
 			var/client/C = player.current.client
 			// Limits antag status to clients above player age, if the age system is being used.
 			if(C && config.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(min_player_age) && (C.player_age < min_player_age))
-				return 0
+				return "Player's server age ([C.player_age]) is below the minimum player age ([min_player_age])."
 		if(is_type_in_list(player.assigned_job, restricted_jobs))
-			return 0
+			return "Player's assigned job ([player.assigned_job]) is restricted from this antagonist role."
 		if(player.current && (player.current.status_flags & NO_ANTAG))
-			return 0
-	return 1
+			return "Player's mob has the NO_ANTAG flag set."
+	return FALSE
+
+/// Checks if the given player is able to become an antagonist or not. Simplified version of `can_become_antag_detailed()`.
+/datum/antagonist/proc/can_become_antag(datum/mind/player, ignore_role)
+	return !can_become_antag_detailed(player, ignore_role)
 
 /datum/antagonist/proc/antags_are_dead()
 	for(var/datum/mind/antag in current_antagonists)


### PR DESCRIPTION
'Blacklisted for this role!' it turns out meant a lot more than just a blacklisted job. Also adds some additional debug logs for faction recruitment failures, because people complain about those not working alot (Ala mutiny/loyalist).

:cl: SierraKomodo
admin: Debug logs for antagonist selection failures are now better at describing why someone isn't actually eligible for being an antagonist, instead of using a generic message for several different cases.
admin: Debug logs for antagonist faction (mutiny/loyalist) recruitment failures have been added to help debug why some people seem unable to be recruited randomly.
admin: Traitor panel failure messages now give more information on why someone could not be antagged.
/:cl: