### PR TITLE
Only show attack logs for dangerous reagents in droppers

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -57,8 +57,9 @@
 						return
 
 				var/mob/living/M = target
-				var/contained = reagentlist()
-				admin_attack_log(user, M, "Squirted their victim with \a [src] (Reagents: [contained])", "Were squirted with \a [src] (Reagents: [contained])", "used \a [src] (Reagents: [contained]) to squirt at")
+				if (reagents.should_admin_log())
+					var/contained = reagentlist()
+					admin_attack_log(user, M, "Squirted their victim with \a [src] (Reagents: [contained])", "Were squirted with \a [src] (Reagents: [contained])", "used \a [src] (Reagents: [contained]) to squirt at")
 
 				var/spill_amt = M.incapacitated()? 0 : 30
 				trans += reagents.splash(target, reagents.total_volume/2, max_spill = spill_amt)


### PR DESCRIPTION
:cl: SierraKomodo
admin: Eyedroppers now only show attack logs for dangerous chemicals, matching the logging behavior of syringes.
/:cl: