### PR TITLE
Increase explosive power of plushbombs

### DIFF
--- a/code/game/objects/items/traitor_plush.dm
+++ b/code/game/objects/items/traitor_plush.dm
@@ -76,7 +76,7 @@
 	return replace_characters(phrase, replacechars)
 
 /obj/item/plushbomb/proc/activate()
-	explosion(src.loc, -1, -1, 2, 1)
+	explosion(src.loc, 0, 0, 3, 3)
 	qdel(src)
 
 /obj/item/plushbomb/get_antag_info()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: Increases the explosive power of the voice-activated plushbomb.
/:cl:
Seems that the explosive power of a frag grenade without the fragments is more of a firework than an actual explosive.
Closes #31020