### PR TITLE
Weapon parry baselines

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -166,6 +166,7 @@
 	icon_state = "maglight"
 	item_state = "maglight"
 	force = 10
+	base_parry_chance = 15
 	attack_verb = list ("smacked", "thwacked", "thunked")
 	matter = list(MATERIAL_ALUMINIUM = 200, MATERIAL_GLASS = 50)
 	hitsound = "swing_hit"

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -12,6 +12,7 @@
 	throw_speed = 5
 	throw_range = 20
 	max_amount = 100
+	base_parry_chance = 15
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	lock_picking_level = 3
 	matter_multiplier = 0.5

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -11,6 +11,7 @@
 	throw_speed = 2
 	throw_range = 10
 	force = 10.0
+	base_parry_chance = 15
 	matter = list(MATERIAL_STEEL = 90)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 

--- a/code/game/objects/items/weapons/material/folding.dm
+++ b/code/game/objects/items/weapons/material/folding.dm
@@ -53,6 +53,7 @@
 		w_class = ITEM_SIZE_NORMAL
 		attack_verb = list("slashed", "stabbed")
 		attack_cooldown_modifier = -1
+		base_parry_chance = 15
 		..()
 	else
 		force = initial(force)
@@ -62,6 +63,7 @@
 		w_class = initial(w_class)
 		attack_verb = closed_attack_verbs
 		attack_cooldown_modifier = initial(attack_cooldown_modifier)
+		base_parry_chance = initial(base_parry_chance)
 
 /obj/item/material/knife/folding/on_update_icon()
 	if(open)
@@ -100,6 +102,7 @@
 	thrown_force_multiplier = 0.25
 	takes_colour = FALSE
 	worth_multiplier = 8
+	base_parry_chance = 30
 
 /obj/item/material/knife/folding/combat/balisong
 	name = "butterfly knife"

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -7,6 +7,7 @@
 	item_state = "knife"
 	max_force = 15
 	force_multiplier = 0.3
+	base_parry_chance = 15
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	matter = list(MATERIAL_STEEL = 12000)
 	origin_tech = list(TECH_MATERIAL = 1)
@@ -79,6 +80,7 @@
 	desc = "A blade with a saw-like pattern on the reverse edge and a heavy handle."
 	icon_state = "tacknife"
 	force_multiplier = 0.2
+	base_parry_chance = 30
 	w_class = ITEM_SIZE_SMALL
 
 //random stuff
@@ -94,6 +96,7 @@
 	desc = "The unearthly energies that once powered this blade are now dormant."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
+	base_parry_chance = 30
 	applies_material_colour = FALSE
 	applies_material_name = FALSE
 

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -27,7 +27,7 @@
 	var/base_icon
 	var/base_name
 	var/unwielded_force_divisor = 0.25
-	var/wielded_parry_bonus = 15
+	var/wielded_parry_bonus = 20
 
 /obj/item/material/twohanded/update_twohanding()
 	var/mob/living/M = loc
@@ -83,6 +83,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	applies_material_colour = 0
 	worth_multiplier = 31
+	base_parry_chance = 15
 
 /obj/item/material/twohanded/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user as mob, proximity)
 	if(!proximity) return
@@ -119,6 +120,7 @@
 	default_material = MATERIAL_GLASS
 	does_spin = FALSE
 	worth_multiplier = 7
+	base_parry_chance = 30
 
 /obj/item/material/twohanded/spear/shatter(var/consumed)
 	if(!consumed)
@@ -143,6 +145,7 @@
 	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = -10
+	base_parry_chance = 30
 
 //Predefined materials go here.
 /obj/item/material/twohanded/baseballbat/metal/New(var/newloc)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -148,6 +148,7 @@
 	item_state = "sec-case"
 	desc = "A large briefcase with a digital locking system."
 	force = 8.0
+	base_parry_chance = 15
 	throw_speed = 1
 	throw_range = 4
 	w_class = ITEM_SIZE_HUGE

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -11,6 +11,7 @@
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 7
+	base_parry_chance = 15
 	w_class = ITEM_SIZE_LARGE
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE //enough to hold all starting contents
@@ -66,4 +67,5 @@
 	item_state = "toolbox_syndi"
 	origin_tech = list(TECH_COMBAT = 1, TECH_ESOTERIC = 1)
 	attack_cooldown = 10
+	base_parry_chance = 30
 	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters, /obj/item/device/multitool)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -13,6 +13,7 @@
 	icon = 'icons/obj/weapons/melee_physical.dmi'
 	icon_state = "baton"
 	item_state = "classic_baton"
+	base_parry_chance = 30
 	slot_flags = SLOT_BELT
 	force = 10
 
@@ -35,6 +36,7 @@
 	icon = 'icons/obj/weapons/melee_physical.dmi'
 	icon_state = "telebaton_0"
 	item_state = "telebaton_0"
+	base_parry_chance = 30
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL
 	force = 3

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -11,6 +11,7 @@
 	throwforce = 7
 	throw_range = 3
 	item_state = "crowbar"
+	base_parry_chance = 15
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 1)
 	matter = list(MATERIAL_STEEL = 140)
@@ -29,6 +30,7 @@
 	force = 4
 	throwforce = 6
 	throw_range = 5
+	base_parry_chance = 0
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_STEEL = 80)
 


### PR DESCRIPTION
Sets the base parry for most common weapons, this is part of a two-part PR to rebalance the way that CQC is handled in game. 

Prior to this any weapon could have a parry value, this lead to situations in which characters could parry fireaxes by grabbing their foot or using rolled up news paper to fend off attackers effectively. 

If I've missed out on any common weapon that didn't have a base parry value please let me know and I'll update them to this list.

:cl: Yvesza
balance: Set the base parry of most common weapons to a baseline of 15 / 30 
balance: improved the wielded bonus of two-handed weapons to 20, from 15.
/:cl:

