### PR TITLE
CQC Rebalancing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -519,8 +519,6 @@ var/list/global/slot_flags_enumeration = list(
 //Otherwise should return 0 to indicate that the attack is not affected in any way.
 /obj/item/proc/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	var/parry_chance = get_parry_chance(user)
-	if(attacker)
-		parry_chance = max(0, parry_chance - 10 * attacker.get_skill_difference(SKILL_COMBAT, user))
 	if(parry_chance)
 		if(default_parry_check(user, attacker, damage_source) && prob(parry_chance))
 			user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
@@ -535,9 +533,10 @@ var/list/global/slot_flags_enumeration = list(
 
 /obj/item/proc/get_parry_chance(mob/user)
 	. = base_parry_chance
-	if(user)
-		if(base_parry_chance || user.skill_check(SKILL_COMBAT, SKILL_ADEPT))
-			. += 10 * (user.get_skill_value(SKILL_COMBAT) - SKILL_BASIC)
+	if (user.a_intent == I_HELP)
+		. = 0
+	if (.)
+		. += Clamp((user.get_skill_value(SKILL_COMBAT) * 10) - 20, 0, 75)
 
 /obj/item/proc/on_disarm_attempt(mob/target, mob/living/attacker)
 	if(force < 1)

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -20,7 +20,7 @@
 
 	icon_state = "reinforce1"
 
-	break_chance_table = list(5, 20, 40, 80, 100)
+	break_chance_table = list(30, 35, 40, 45, 50)
 /datum/grab/normal/aggressive/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -20,7 +20,7 @@
 
 	icon_state = "kill1"
 
-	break_chance_table = list(5, 20, 40, 80, 100)
+	break_chance_table = list(3, 4, 5, 6, 7)
 
 /datum/grab/normal/kill/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -22,7 +22,7 @@
 
 	icon_state = "kill"
 
-	break_chance_table = list(3, 18, 45, 100)
+	break_chance_table = list(3, 5, 7, 9)
 
 /datum/grab/normal/neck/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -21,7 +21,7 @@
 
 	icon_state = "reinforce"
 
-	break_chance_table = list(5, 20, 30, 80, 100)
+	break_chance_table = list(40, 45, 50, 55, 60)
 
 
 /datum/grab/normal/struggle/process_effect(var/obj/item/grab/G)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -162,7 +162,7 @@ meteor_act
 		return target_zone
 
 	var/accuracy_penalty = user.melee_accuracy_mods()
-	accuracy_penalty += 10*get_skill_difference(SKILL_COMBAT, user)
+	accuracy_penalty += 5*get_skill_difference(SKILL_COMBAT, user)
 	accuracy_penalty += 10*(I.w_class - ITEM_SIZE_NORMAL)
 	accuracy_penalty -= I.melee_accuracy_bonus
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -631,22 +631,24 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 	var/list/holding = list(target.get_active_hand() = 60, target.get_inactive_hand() = 30)
 
-	var/skill_mod = 10 * attacker.get_skill_difference(SKILL_COMBAT, target)
+	var/skill_mod = attacker.get_skill_difference(SKILL_COMBAT, target)
 	var/state_mod = attacker.melee_accuracy_mods() - target.melee_accuracy_mods()
 	var/stim_mod = target.chem_effects[CE_STIMULANT]
-	var/push_mod = min(max(1 + attacker.get_skill_difference(SKILL_COMBAT, target), 1), 3)
+	var/push_threshold = 12 + (skill_mod - stim_mod)
+	var/disarm_threshold = 36 + ((skill_mod - stim_mod) * 3)
+
 	if(target.a_intent == I_HELP)
 		state_mod -= 30
 	//Handle unintended consequences
 	for(var/obj/item/I in holding)
-		var/hurt_prob = max(holding[I] - 2*skill_mod + state_mod, 0)
+		var/hurt_prob = max(holding[I] - 3*skill_mod, 0)
 		if(prob(hurt_prob) && I.on_disarm_attempt(target, attacker))
 			return
 
-	var/randn = rand(1, 100) - skill_mod + state_mod - stim_mod
-	if(!(check_no_slip(target)) && randn <= 20)
+	var/randn = rand(1, 100) + state_mod
+	if(!(check_no_slip(target)) && randn <= push_threshold)
 		var/armor_check = 100 * target.get_blocked_ratio(affecting, BRUTE, damage = 20)
-		target.apply_effect(push_mod, WEAKEN, armor_check)
+		target.apply_effect(2, WEAKEN, armor_check)
 		playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		if(armor_check < 100)
 			target.visible_message("<span class='danger'>[attacker] has pushed [target]!</span>")
@@ -654,7 +656,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			target.visible_message("<span class='warning'>[attacker] attempted to push [target]!</span>")
 		return
 
-	if(randn <= 50)
+	if(randn <= disarm_threshold)
 		//See about breaking grips or pulls
 		if(target.break_all_grabs(attacker))
 			playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)


### PR DESCRIPTION
A few tweaks to the way that CQC works to reduce the absolutely absurd effect that the skill has on the outcome of everything that involves touching people.

To go into the exact changes, expect the following.
Accuracy penalties (And increases) per level difference have been decreased to 5% from 10%

Parry is set to the baseline of the weapon (15 / 30 / 50 in most cases) and then increases by 10 / 20% for experienced / master, down from 20% bonus parry per level of difference (This worked both ways, so one level of difference meant you gained a 20% chance to parry and a 20% decreased chance to be parried, which was absurd)

Parry is now capped at 75% down from being theoretically capable of hitting 140% or higher in some cases.

Disarm chances have been decreased and the effect that skills have on disarm has been reduced, there's now at least always a chance you can disarm / shove someone even if the chance gets extremely low in the absolute worst case scenario. 

Stimulants now actually have relevance in the disarm calculations

The chance to hurt your hand on your opponents weapon scales a little more with skill

Grab chances are more sane, the odds of being able to escape a grab will never hit 100% but they'll also scale down in much less dramatic fashion. In order to make a grab inescapable you'll need to have 3+ levels over your opponent, or 2+ and also have them disoriented via flash / pepper spray / flashbang / concussions / pain

I think that about covers everything, the grab chances definitely need to see some live playtesting before I am happy with the numbers but this should be a way more reasonable baseline. 

I genuinely think these changes are needed, the last time we saw master CQC traitors life became hellish for security and the same really does go both ways. Bringing the effectiveness of CQC down to a more reasonable level will allow for more freedom in skill choices going forwards, in order to participate in any kind of melee combat you'll only really need trained instead of being required to take at least experienced.

It's worth noting that the changes in this PR are reliant on the changes in #31035 in order to allow many of the common weapons to parry

:cl: Yvesza
balance: Reduces the effectiveness of CQC
tweak: You can no longer parry attacks with unsuitable weapons
/:cl: