### PR TITLE
Improves low-profile plates

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -72,6 +72,7 @@
 /obj/item/clothing/accessory/armorplate/sneaky
 	name = "low-profile armor vest"
 	desc = "An armor vest made of layered polymer fibers. Can attach to your slacks and office shirt."
+	siemens_coefficient = 0.6
 	item_icons = list(slot_wear_suit_str = 'icons/mob/onmob/onmob_accessories.dmi')
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	slot_flags = SLOT_OCLOTHING //can wear in suit slot as well
@@ -83,7 +84,6 @@
 /obj/item/clothing/accessory/armorplate/sneaky/tactical
 	name = "low-profile tactical armor vest"
 	desc = "An armor vest made of layered smart polymers. Can attach to your slacks and office shirt."
-	slowdown = 0.5
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		bullet = ARMOR_BALLISTIC_PISTOL,


### PR DESCRIPTION
Low profile plates for antagonists do not fit their expected role and purpose, the lack of any notable Siemens coefficient made them vulnerable to stun shots which are the primary arms used aboard the ship. This is quite clearly represented in the fact that they are only really bought by mistake, they're an item with very cool potential that goes entirely unused because of their inability to perform.

This PR increases the siemens coefficient to 0.6 which matches plate carriers (Increasing the shots required to go down from three to five) and removes the slowdown from the tactical plate to make both options more appealing to characters wanting to use armor in stealthy settings while still retaining the opportunity cost of taking up often very useful webbing slot. 

:cl: Yvesza
balance: Low-profile plates now absorb stuns as well as plate carriers
balance: Low-profile tactical plates no longer slowdown their wearer
/:cl: