### PR TITLE
Harpoon & Spear improvements

### DIFF
--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -11,6 +11,8 @@
 	thrown_force_multiplier = 1.8
 	attack_verb = list("jabbed","stabbed","ripped")
 	does_spin = FALSE
+	w_class = 5
+	throw_speed = 6
 	var/spent
 	worth_multiplier = 15
 

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -112,7 +112,7 @@
 	force_multiplier = 0.33 // 12/19 with hardness 60 (steel) or 10/16 with hardness 50 (glass)
 	unwielded_force_divisor = 0.20
 	thrown_force_multiplier = 1.5 // 20 when thrown with weight 15 (glass)
-	throw_speed = 3
+	throw_speed = 6
 	sharp = TRUE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")


### PR DESCRIPTION
Both weapons are largely overlooked in favor of more reliable alternatives, this seeks to give them a purpose by allowing them both to stagger and impale characters to walls provided that they're close enough. The damage of being impaled to a wall is quite significant, but as the speed of the thrown object remains just barely enough to impale they'll not cause any limbs to randomly explode.

This roughly equates one spear embed to be about equal to a single shot from a carbine, with the potentially added effect of impalement should there be a wall behind the victim which can cause it to deal about 1.5x the damage of a carbine, provided the spear is yanked out after impalement occurs. 

All of this assumes a plasteel spear, which is definitely towards the top end of weapon materials. Glass spears are vastly less effective, being more in line with a sidearm in terms of damage potential.

:cl: Yvesza
balance: Spears & Harpoons will cause their targets to stagger backwards and potentially be impaled to walls.
balance: Spears & Harpoons hurt more when they collide with their victims.
balance: Harpoons will no longer fit into bags
/:cl: