### PR TITLE
Better siemens calculations

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -37,7 +37,6 @@ meteor_act
 	stun_amount *= siemens_coeff
 	agony_amount *= siemens_coeff
 	agony_amount *= affected.get_agony_multiplier()
-
 	affected.stun_act(stun_amount, agony_amount)
 
 	radio_interrupt_cooldown = world.time + RADIO_INTERRUPT_DEFAULT
@@ -92,6 +91,9 @@ meteor_act
 
 	var/list/clothing_items = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes) // What all are we checking?
 	for(var/obj/item/clothing/C in clothing_items)
+		for(var/obj/item/clothing/accessories in C.accessories)
+			if (accessories.body_parts_covered & def_zone.body_part)
+				siemens_coefficient *= accessories.siemens_coefficient
 		if(istype(C) && (C.body_parts_covered & def_zone.body_part)) // Is that body part being targeted covered?
 			siemens_coefficient *= C.siemens_coefficient
 


### PR DESCRIPTION
Fixes accessories not being calculated in siemens calculations.

Prior to this, wearing a low-profile tactical plate wouldn't help at all if shot by stuns. This remedies the issue.

:cl: Yvesza
tweak: Accessories are now included in Siemens calculations
/:cl: