### PR TITLE
Moves soporific to the contraband list in the NanoMed Plus

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -926,7 +926,6 @@
 	products = list(
 		/obj/item/reagent_containers/glass/bottle/antitoxin = 4,
 		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
-		/obj/item/reagent_containers/glass/bottle/stoxin = 4,
 		/obj/item/reagent_containers/syringe/antiviral = 4,
 		/obj/item/reagent_containers/pill/antitox = 6,
 		/obj/item/reagent_containers/syringe = 12,
@@ -941,6 +940,7 @@
 
 	contraband = list(
 		/obj/item/clothing/mask/chewable/candy/lolli/meds = 8,
+		/obj/item/reagent_containers/glass/bottle/stoxin = 4,
 		/obj/item/reagent_containers/pill/tox = 3,
 		/obj/item/reagent_containers/pill/stox = 4,
 		/obj/item/reagent_containers/glass/bottle/toxin = 4,


### PR DESCRIPTION
Shifts soporific from the normal list to the contraband list inside of NanoMed Plus, it's availability inside of vendors often leads people to misuse it and there's little reason to use such a slow acting chemical for antagonists.

🆑 Yvesza
tweak: NanoMed's no longer stock soporific by default, instead it's moved to the contraband list
🆑 