### PR TITLE
Rework admin narrates

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1299,6 +1299,7 @@
 #include "code\modules\admin\verbs\mapping.dm"
 #include "code\modules\admin\verbs\massmodvar.dm"
 #include "code\modules\admin\verbs\modifyvariables.dm"
+#include "code\modules\admin\verbs\narrate.dm"
 #include "code\modules\admin\verbs\playsound.dm"
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"

--- a/code/modules/admin/verbs/narrate.dm
+++ b/code/modules/admin/verbs/narrate.dm
@@ -1,0 +1,99 @@
+#define TARGET_ZONE_GLOBAL  "GLOBAL"
+#define TARGET_ZONE_INWORLD "INWORLD"
+#define TARGET_ZONE_ZLEVEL  "ZLEVEL"
+#define TARGET_ZONE_RANGE   "RANGE"
+#define TARGET_ZONE_VIEW    "VIEW"
+
+#define TARGET_ZONES list(TARGET_ZONE_GLOBAL, TARGET_ZONE_INWORLD, TARGET_ZONE_ZLEVEL, TARGET_ZONE_RANGE, TARGET_ZONE_VIEW)
+
+/**
+ * Narrates the provided text to mobs/clients based on the flags and vars provided. See `select_target_mobs()` for details on parameters.
+ */
+/proc/narrate(message, target_zone = TARGET_ZONE_GLOBAL, target_origin, target_range)
+	set waitfor = FALSE
+
+	var/list/recipients = select_narrate_targets(target_zone, target_origin, target_range)
+	if (!recipients)
+		return
+
+	for (var/recipient in recipients)
+		to_chat(recipient, message)
+
+
+/// Quick-use alias of `narrate` using the GLOBAL target zone.
+/proc/narrate_global(message)
+	narrate(message, TARGET_ZONE_GLOBAL)
+
+/// Quick-use alias of `narrate` using the INWORLD target zone.
+/proc/narrate_world(message)
+	narrate(message, TARGET_ZONE_INWORLD)
+
+
+/**
+ * Returns a list containing all mobs within the given target zone and matching the given parameters.
+ * Primarily used for `narrate()`.
+ *
+ * Target zones:
+ * - TARGET_ZONE_GLOBAL - Targets `world`, which essentially means "all connected players".
+ * - TARGET_ZONE_INWORLD - Targets all mobs that are actually in world. Effectively the same as GLOBAL, but skips players on the lobby screen.
+ * - TARGET_ZONE_ZLEVEL - Targets all mobs in the given z-level in `target_origin`.
+ * - TARGET_ZONE_RANGE - Targets all mobs within `target_range` tiles of `target_origin`.
+ * - TARGET_ZONE_VIEW - Targets all mobs within `oview()` of `target_origin` within `target_range` tiles.
+ */
+/proc/select_narrate_targets(target_zone = TARGET_ZONE_GLOBAL, target_origin, target_range)
+	log_debug("Targeting mobs in zone [target_zone].")
+	var/list/recipients = list()
+	switch (target_zone)
+		if (TARGET_ZONE_GLOBAL)
+			recipients += world
+
+		if (TARGET_ZONE_INWORLD)
+			for (var/mob/recipient in world)
+				if (!valid_narrate_target(recipient) || istype(recipient, /mob/new_player))
+					continue
+				recipients += recipient
+
+		if (TARGET_ZONE_ZLEVEL)
+			if (!isnum(target_origin))
+				to_chat(usr, SPAN_WARNING("Invalid z_level provided."))
+				return FALSE
+			for (var/mob/recipient in world)
+				if (!valid_narrate_target(recipient) || recipient.z != target_origin)
+					continue
+				recipients += recipient
+
+		if (TARGET_ZONE_RANGE)
+			if (!isatom(target_origin))
+				to_chat(usr, SPAN_WARNING("Invalid origin point."))
+				return FALSE
+			if (!isnum(target_range) || target_range <= 0)
+				to_chat(usr, SPAN_WARNING("Invalid broadcast range."))
+				return FALSE
+			for (var/mob/recipient in range(target_range, target_origin))
+				if (!valid_narrate_target(recipient))
+					continue
+				recipients += recipient
+
+		if (TARGET_ZONE_VIEW)
+			if (!isatom(target_origin))
+				to_chat(usr, SPAN_WARNING("Invalid origin point."))
+				return FALSE
+			if (!isnum(target_range) || target_range <= 0)
+				to_chat(usr, SPAN_WARNING("Invalid broadcast range."))
+				return FALSE
+			for (var/mob/recipient in orange(target_range, target_origin))
+				if (!valid_narrate_target(recipient))
+					continue
+				recipients += recipient
+
+	for (var/recipient in recipients)
+		log_debug(" - Targeted [recipient].")
+
+	return recipients
+
+/// Verifies the target matches any common requirements to be valid.
+/proc/valid_narrate_target(mob/target)
+	if (!target.client)
+		return FALSE
+
+	return TRUE

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -76,19 +76,43 @@
 
 /client/proc/cmd_admin_world_narrate() // Allows administrators to fluff events a little easier -- TLE
 	set category = "Special Verbs"
-	set name = "Global Narrate"
-	set desc = "Narrate to everyone."
+	set name = "Narrate"
+	set desc = "Narrate to players."
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/result = cmd_admin_narrate_helper(src)
-	if (!result)
+	var/target_zone = input(usr, "Narrate target zone", "Narrate target zone", null) as null|anything in TARGET_ZONES
+	if (isnull(target_zone))
 		return
+	var/message = input(usr, "Narrate message", "Narrate message", null) as null|text
+	if (isnull(message))
+		return
+	var/target_origin = null
+	var/target_range = null
+	switch (target_zone)
+		if (TARGET_ZONE_ZLEVEL)
+			target_origin = input(usr, "Target z-level", "Target z-level", get_z(usr)) as null|num
+			if (isnull(target_origin))
+				return
 
-	to_world(result[1])
+		if (TARGET_ZONE_RANGE || TARGET_ZONE_VIEW)
+			target_origin = get_turf(usr)
+			target_range = input(usr, "Range", "Range", 7) as null|num
+			if (isnull(target_range))
+				return
 
-	log_and_message_staff(" - GlobalNarrate [result[2]]/[result[3]]: [result[4]]")
+	narrate(message, target_zone, target_origin, target_range)
+
+	var/log_message_appendix = ""
+	if (target_origin && target_range)
+		log_message_appendix = " ([target_origin]/[target_range])"
+	else if (target_origin)
+		log_message_appendix = " ([target_origin])"
+	else if (target_range)
+		log_message_appendix = " ([target_range])"
+
+	log_and_message_staff(" - [target_zone] NARRATE[log_message_appendix] - \"[message]\"")
 	SSstatistics.add_field_details("admin_verb","GLN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 


### PR DESCRIPTION
Reworks admin narrates to allow for more options on the scope of the narrate - Z levels, range, visible range, multiple z levels, etc.

TODO:
- [X] Global narrate (Everyone on server)
- [X] 'World' narrate (Everyone not in the lobby)
- [X] z-level narrate (Everyone on a specific z-level
- [ ] Allow ranges of z-levels
- [X] Range narrates (Everyone within X tiles of an origin)
- [ ] Add direct-narrate replacement (Single mob target)