### PR TITLE
Allow hacking helms to remove speed limits

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -22,6 +22,32 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	. = ..()
 	get_known_sectors()
 
+/obj/machinery/computer/ship/helm/attackby(obj/item/I, mob/user)
+	if (panel_open && ismultitool(I) && user.a_intent != I_HURT)
+		if (user.skill_check(SKILL_ELECTRICAL, SKILL_ADEPT))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts reconfiguring \the [src]'s circuitry with \the [I]."),
+				SPAN_NOTICE("You start toggling \the [src]'s speed limiters [linked.speedlimit_hacked ? "on" : "off"] with \the [I].")
+			)
+			if (!do_after(user, 3 SECONDS, src, DO_DEFAULT | DO_PUBLIC_PROGRESS | DO_BOTH_UNIQUE_ACT))
+				return
+			user.visible_message(
+				SPAN_NOTICE("\The [user] reconfigures \the [src]'s circuitry with \the [I]."),
+				SPAN_NOTICE("You [linked.speedlimit_hacked ? "reset" : "increase"] \the [src]'s acceleration and speed limiters.")
+			)
+			linked.hack_speedlimit()
+		else
+			to_chat(user, SPAN_WARNING("You don't know what to do with \the [src] using \the [I]."))
+		return
+
+	..()
+
+
+/obj/machinery/computer/ship/helm/get_mechanics_info()
+	. = ..()
+	. += "You can increase or reset the helm's acceleration limiter and autopilot speed limiter's maximum values by using a multitool on the console while the panel is open. This requires TRAINED electrical engineering skill."
+
+
 /obj/machinery/computer/ship/helm/proc/get_known_sectors()
 	var/area/overmap/map = locate() in world
 	for(var/obj/effect/overmap/visitable/sector/S in map)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -22,6 +22,8 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	var/max_speed = 1/(1 SECOND)        // "speed of light" for the ship, in turfs/tick.
 	var/min_speed = 1/(2 MINUTES)       // Below this, we round speed to 0 to avoid math errors.
 	var/max_autopilot = 1 / (20 SECONDS) // The maximum speed any attached helm can try to autopilot at.
+	/// Whether or not the speed limiter has been hacked
+	var/speedlimit_hacked = FALSE
 
 	var/list/speed = list(0,0)          // speed in x,y direction
 	var/list/position = list(0,0)       // position within a tile.
@@ -35,6 +37,13 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	var/halted = 0        //admin halt or other stop.
 	var/skill_needed = SKILL_ADEPT  //piloting skill needed to steer it without going in random dir
 	var/operator_skill
+
+/obj/effect/overmap/visitable/ship/proc/hack_speedlimit()
+	speedlimit_hacked = !speedlimit_hacked
+	if (speedlimit_hacked)
+		max_autopilot = initial(max_autopilot) * 5
+	else
+		max_autopilot = initial(max_autopilot)
 
 /obj/effect/overmap/visitable/ship/Initialize()
 	. = ..()


### PR DESCRIPTION
Compromise between the useless limit of 5 and a removal of the limiter, that should prevent new pilots from committing Initial.D suicide via 100Gm/h autopilot. Trained electrical engineering and a multitool is required. This raises the autopilot cap by 5* the normal cap - For the Torch, this is 25.

:cl: SierraKomodo
feature: Helm control consoles can now be hacked with a multitool while the panel's open to massively increase the autopilot's speed limiter and the acceleration limiter's maximum values.
/:cl: