### PR TITLE
Changes to age based skills

### DIFF
--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -806,11 +806,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	show_browser(src, species.get_description(), "window=species;size=700x400")
 
 /datum/species/proc/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
-	switch(age)
-		if(0 to 22) 	. = 0
-		if(23 to 30) 	. = 3
-		if(31 to 45)	. = 6
-		else			. = 8
+	. = 4
 
 /datum/species/proc/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
 	return

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -807,6 +807,8 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 /datum/species/proc/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
 	. = 4
+	if(alien == IS_SKRELL)
+	. = 8
 
 /datum/species/proc/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
 	return


### PR DESCRIPTION
Replaces the scaling 0 / 3 / 6 / 8 skill points from age to be a flat 4 instead.

🆑  Yvesza
balance: Age no longer effects skill scaling for shipside humanoid races. 
🆑 