### PR TITLE
CQC Grab & Accuracy changes

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -281,10 +281,21 @@
 		to_chat(G.affecting, "<span class='warning'>You can't resist in your current state!</span>")
 	var/skill_mod = Clamp(affecting.get_skill_difference(SKILL_COMBAT, assailant), -1, 1)
 	var/break_strength = breakability + size_difference(affecting, assailant) + skill_mod
+	var/shock = affecting.get_shock()
 
 	if(affecting.incapacitated(INCAPACITATION_ALL))
 		break_strength--
 	if(affecting.confused)
+		break_strength--
+	if(affecting.eye_blind)
+		break_strength--
+	if(affecting.eye_blurry)
+		break_strength--
+	if(shock >= 10)
+		break_strength--
+	if(shock >= 30)
+		break_strength--
+	if(shock >= 50)
 		break_strength--
 
 	if(break_strength < 1)

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -16,11 +16,12 @@
 	same_tile = 0
 	can_throw = 1
 	force_danger = 1
-	breakability = 3
+	breakability = 4
 
 	icon_state = "reinforce1"
 
-	break_chance_table = list(30, 35, 40, 45, 50)
+	break_chance_table = list(25, 30, 35, 40, 45, 50, 55)
+
 /datum/grab/normal/aggressive/process_effect(var/obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -12,7 +12,7 @@
 	can_absorb = 0
 	point_blank_mult = 1
 	same_tile = 0
-	breakability = 3
+	breakability = 4
 
 	grab_slowdown = 10
 	upgrade_cooldown = 20
@@ -21,7 +21,7 @@
 
 	icon_state = "reinforce"
 
-	break_chance_table = list(40, 45, 50, 55, 60)
+	break_chance_table = list(35, 40, 45, 50, 55, 60, 65)
 
 
 /datum/grab/normal/struggle/process_effect(var/obj/item/grab/G)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1750,6 +1750,14 @@
 		. += 15
 	if(shock_stage > 30)
 		. += 15
+	if(confused)
+		. += 15
+	if(weakened)
+		. += 15
+	if(eye_blurry)
+		. += 15
+	if(eye_blind)
+		. += 60
 
 /mob/living/carbon/human/ranged_accuracy_mods()
 	. = ..()

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -635,7 +635,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	var/state_mod = attacker.melee_accuracy_mods() - target.melee_accuracy_mods()
 	var/stim_mod = target.chem_effects[CE_STIMULANT]
 	var/push_threshold = 12 + (skill_mod - stim_mod)
-	var/disarm_threshold = 36 + ((skill_mod - stim_mod) * 3)
+	var/disarm_threshold = 24 + ((skill_mod - stim_mod) * 2)
 
 	if(target.a_intent == I_HELP)
 		state_mod -= 30


### PR DESCRIPTION
After the last set of changes to CQC had a bit of time to see play and testing, a number of issues came to light after review.

Grappling
1) A character that was downed could spam disarm attempts to break grapples, it was far too likely to make non-lethal methods of takedown almost impossible without resorting to smashing all of their limbs.

This has been fixed by reducing the odds of breaking a grapple via disarm, in addition characters that are on the floor suffer an accuracy penalty to all of their attacks.

2) The chances to break free from a grab were very high and outside of incapacitating your target entirely it was nearly impossible to successfully cuff a target.

Pain is now factored into grapple escape chances, being in severe pain will reduce your odds of escaping a grapple dramatically. 
In addition confusion and blinding effects make it harder to escape from a grapple, a character that has been floored by pepperspray and shot several times with a taser will have essentially no chance to escape from a grab without chemical enhancements to mitigate the pain.
This also means that a raw grab is still very unlikely to succeed on another character, attempting to instantly take down an uncooperative target is still not very likely to occur so anyone attempting to deal with an uncooperative target should bear in mind that pain and effects that impair a character will be useful if not required.

Furthermore, melee accuracy is now effected by the following.
Weaken - 15% Penalty
Confusion - 15% Penalty
Blurred Vision - 15% Penalty
Blindness - 60% Penalty

Prior to this change melee accuracy solely cared about shock which often allowed characters to fight on far longer than they reasonably should have been able to. 

The melee accuracy changes also effect disarming characters, both offensive and defensively. 

A blind character that is pushed will be at a 60% flat penalty to his defenses and almost assuredly will fall over, this rewards characters for using their equipment properly and attempting to disable targets before taking them down.

I think that about covers everything!

🆑 Yvesza
balance: Melee accuracy now cares about Weaken, Confusion, Blurred Vision and Blindness
balance: The chance to break free from a grapple via disarm has been reduced
balance: The victim of a grapple will have a harder time escaping while in pain or while impaired
🆑 