### PR TITLE
Use a more readable font for fancy pens

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -48,7 +48,7 @@
 	var/const/deffont = "Verdana"
 	var/const/signfont = "Times New Roman"
 	var/const/crayonfont = "Comic Sans MS"
-	var/const/fancyfont = "Segoe Script"
+	var/const/fancyfont = "Segoe Print"
 
 	var/scan_file_type = /datum/computer_file/data/text
 


### PR DESCRIPTION
:cl: SierraKomodo
tweak: The font used for fancy pens is now a more readable font, for people like me that may or may not be dyslexic.
/:cl:

Top font is the new one, bottom font is the old one.

![WINWORD_2021-08-10_15-33-28](https://user-images.githubusercontent.com/11140088/128943533-54d6955b-0dca-4ac1-990e-a47d9c7590f1.png)
