### PR TITLE
Disables Roundstart FBPs

### DIFF
--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -14,7 +14,7 @@
 	hidden_from_codex = FALSE
 	bandages_icon = 'icons/mob/bandage.dmi'
 
-	spawn_flags = SPECIES_CAN_JOIN
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_FBP_CHARGEN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_NORMAL | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
 	sexybits_location = BP_GROIN
@@ -244,14 +244,14 @@
 	else if (effective_dose > 10)
 		M.vomit(4, 2, rand(3 SECONDS, 10 SECONDS))
 	else
-		M.vomit(1, 1, rand(5 SECONDS, 15 SECONDS))	
+		M.vomit(1, 1, rand(5 SECONDS, 15 SECONDS))
 
 /datum/species/skrell/get_sex(var/mob/living/carbon/human/H)
 	return istype(H) && (H.descriptors["headtail length"] == 1 ? MALE : FEMALE)
 
 /datum/species/skrell/check_background()
 	return TRUE
-	
+
 /datum/species/skrell/can_float(mob/living/carbon/human/H)
 	if(!H.is_physically_disabled())
 		if(H.encumbrance() < 2)
@@ -397,7 +397,7 @@
 		if(101 to 200)	. = 12 // age bracket before this is 46 to 100 . = 8 making this +4
 		if(201 to 300)	. = 16 // + 8
 		else			. = ..()
-		
+
 // Dionaea spawned by hand or by joining will not have any
 // nymphs passed to them. This should take care of that.
 /datum/species/diona/handle_post_spawn(var/mob/living/carbon/human/H)


### PR DESCRIPTION
Does what the title says.

Given that the wiki has little to no official lore on FBPs, and what's been stated by Spook is that they're essentially an emergency support system with a ten year life expectancy, it makes little sense for them to be aboard a government vessel. A brain wasting away in a jar without any of the natural support systems.

In addition, the vast majority of FBPs use the Vey-Med sprite, which is just the normal human sprites, but now enjoy radiation immunity, a lack of pain, and _situationally_ increased durability. While there are some drawbacks to being an FBP, one of the most notable (RP) ones - being a relatively alien and jarring appearance - can be completely ignored.

There's also some minor issues that crop up now and then where players treat/play them as robots - nothing major, and almost always handled by staff, but this does serve to highlight that FBPs existing so easily takes away from IPCs, which are whitelisted. 

I understand this change may be jarring, but I genuinely believe it's for the better.

🆑 Jux
tweak: Spawning as a human or human subspecies FBP has been disabled.
/🆑 

And @Tennessee116 , this won't effect Vox. Lol.