### PR TITLE
Makes flash powder bang and fixes a horrible bug

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -529,7 +529,7 @@
 	name = "Flash powder"
 	result = null
 	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1 )
-	result_amount = null
+	result_amount = 3
 	mix_message = "The solution bubbles vigorously!"
 
 /datum/chemical_reaction/flash_powder/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
@@ -543,24 +543,25 @@
 			if(0 to 1)
 				if (M.eyecheck() < FLASH_PROTECTION_MODERATE)
 					M.flash_eyes(2)
-					M.weakened = max(10, created_volume / 20)
-					M.confused = max(20, (created_volume / 5))
-					M.eye_blurry = max(40, (created_volume / 5))
+					M.weakened = min(10, (created_volume / 20))
+					M.confused = min(20, (created_volume / 5))
+					M.eye_blurry = min(40, (created_volume / 5))
 				else
-					M.stunned = max(10, (created_volume / 30))
-					M.confused = max(20, (created_volume / 10))
-					M.eye_blurry = max(40, (created_volume / 10))
+					M.stunned = min(10, (created_volume / 30))
+					M.confused = min(20, (created_volume / 10))
+					M.eye_blurry = min(40, (created_volume / 10))
 
 			if(2 to 4)
 				if (M.eyecheck() < FLASH_PROTECTION_MODERATE)
 					M.flash_eyes(2)
-					M.stunned = max(5, (created_volume / 30))
-					M.confused = max(10, (created_volume / 10))
-					M.eye_blurry = max(20, (created_volume / 10))
+					M.stunned = min(5, (created_volume / 30))
+					M.confused = min(10, (created_volume / 10))
+					M.eye_blurry = min(20, (created_volume / 10))
 				else
-					M.stunned = max(5, (created_volume / 60))
-					M.confused = max(10, (created_volume / 10))
-					M.eye_blurry = max(20, (created_volume / 10))
+					M.stunned = min(5, (created_volume / 60))
+					M.confused = min(10, (created_volume / 20))
+					M.eye_blurry = min(20, (created_volume / 20))
+		playsound(location, 'sound/effects/bang.ogg', 50, 1, 30)
 
 /datum/chemical_reaction/emp_pulse
 	name = "EMP Pulse"


### PR DESCRIPTION
I may have accidentally set the values to max, instead of min. Also flash powder used a null value for the created volume which meant that it'd always use incorrect values.

Also this is entirely required for #31060 or else flashbangs will down people for absurd periods of time.

🆑 Yvesza
tweak: Flash powder now bangs.
tweak: Flash powder now creates appropriate volume and no longer uses maximum values always.
tweak: Protection now properly applies at ranges 2-4
🆑 
