### PR TITLE
Document Everything: Machinery Edition

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -54,6 +54,9 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	holder = null
 	return ..()
 
+/datum/wires/proc/get_mechanics_info()
+	return
+
 /datum/wires/proc/GenerateWires()
 	var/list/colours_to_pick = wireColours.Copy() // Get a copy, not a reference.
 	var/list/indexes_to_pick = list()

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -4,20 +4,20 @@
 	if(. != MCS_CHANGE) return (. == MCS_BLOCK);\
 	. = TRUE
 
-/obj/machinery
-	var/decl/machine_construction/construct_state
+/// The construction state decl associated with this machine
+/obj/machinery/var/decl/machine_construction/construct_state
 
 /obj/machinery/Initialize()
 	if(construct_state)
 		construct_state = decls_repository.get_decl(construct_state)
 	. = ..()
 
-// Called on state transition; can intercept, but must call parent.
-/obj/machinery/proc/state_transition(var/decl/machine_construction/new_state)
+/// Called on state transition; can intercept, but must call parent.
+/obj/machinery/proc/state_transition(decl/machine_construction/new_state)
 	construct_state = new_state
 
-// Return a change state define or a fail message to block transition.
-/obj/machinery/proc/cannot_transition_to(var/state_path, var/mob/user)
+/// Return a change state define or a fail message to block transition.
+/obj/machinery/proc/cannot_transition_to(state_path, mob/user)
 	return MCS_CHANGE
 
 /decl/machine_construction

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -543,6 +543,10 @@ Class Procs:
 		var/decl/hierarchy/skill/core_skill_decl = core_skill
 		. += "<p>It utilizes the [initial(core_skill_decl.name)] skill.</p>"
 
+	var/wire_mechanics = wires?.get_mechanics_info()
+	if (wire_mechanics)
+		. += "<hr><h5>Wiring</h5>[wire_mechanics]"
+
 // This is really pretty crap and should be overridden for specific machines.
 /obj/machinery/water_act(depth)
 	..()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -496,6 +496,53 @@ Class Procs:
 	if (user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC) || isobserver(user))
 		to_chat(user, SPAN_NOTICE(machine_desc))
 
+/obj/machinery/get_mechanics_info()
+	. = ..()
+	if (maximum_component_parts)
+		var/component_parts_list
+		for (var/atom/item as anything in maximum_component_parts)
+			var/count = maximum_component_parts[item]
+			if (isnull(count))
+				component_parts_list += "<li>Infinite [initial(item.name)]</li>"
+			else
+				component_parts_list += "<li>[count] [initial(item.name)]\s</li>"
+		. += {"
+			<p>It can hold the following component types:</p>
+			<ul>
+				[component_parts_list]
+			</ul>
+		"}
+
+	if (silicon_restriction)
+		switch (silicon_restriction)
+			if (STATUS_UPDATE)
+				. += "<p>Silicons are blocked from controlling it.</p>"
+			if (STATUS_DISABLED || STATUS_CLOSE)
+				. += "<p>Silicons are blocked from viewing or controlling it.</p>"
+
+	var/power_channel_name
+	switch (initial(power_channel))
+		if (EQUIP)
+			power_channel_name = "Equipment"
+		if (LIGHT)
+			power_channel_name = "Lighting"
+		if (ENVIRON)
+			power_channel_name = "Environment"
+		if (LOCAL)
+			power_channel_name = "Local"
+	. += "<p>By default, it draws power from the [power_channel_name] channel.</p>"
+
+	if (idle_power_usage && active_power_usage)
+		. += "<p>It draws [idle_power_usage] watts while idle, and [active_power_usage] watts while active."
+	else if (idle_power_usage)
+		. += "<p>It draws [idle_power_usage] watts while idle.</p>"
+	else if (active_power_usage)
+		. += "<p>It draws [active_power_usage] watts while active.</p>"
+
+	if (core_skill)
+		var/decl/hierarchy/skill/core_skill_decl = core_skill
+		. += "<p>It utilizes the [initial(core_skill_decl.name)] skill.</p>"
+
 // This is really pretty crap and should be overridden for specific machines.
 /obj/machinery/water_act(depth)
 	..()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -83,42 +83,70 @@ Class Procs:
 	layer = STRUCTURE_LAYER // Layer under items
 	init_flags = INIT_MACHINERY_PROCESS_SELF
 
-	var/stat = 0
-	var/reason_broken = 0
-	var/stat_immune = NOSCREEN | NOINPUT // The machine will never set stat to these flags.
+	/// Bitflag. Machine's base status. Can include `BROKEN`, `NOPOWER`, etc.
+	var/stat = EMPTY_BITFIELD
+	/// Bitflag. Reason the machine is 'broken'. Can be any combination of `MACHINE_BROKEN_*`. Do not modify directly - Use `set_broken()` instead.
+	var/reason_broken = EMPTY_BITFIELD
+	/// Bitflag. The machine will never set stat to these flags.
+	var/stat_immune = NOSCREEN | NOINPUT
+	/// Boolean. Whether or not the machine has been emagged.
 	var/emagged = FALSE
-	var/malf_upgraded = 0
-	var/datum/wires/wires //wire datum, if any. If you place a type path, it will be autoinitialized.
+	/// Boolean. Whether or not the machine has been upgrade by a malfunctioning AI.
+	var/malf_upgraded = FALSE
+	/// Wire datum, if any. If you place a type path, it will be autoinitialized.
+	var/datum/wires/wires
+	/// One of `POWER_USE_*`. The power usage state of the machine. Use `update_use_power()` to modify this during runtime.
 	var/use_power = POWER_USE_IDLE
-		//0 = dont run the auto
-		//1 = run auto, use idle
-		//2 = run auto, use active
+	/// Power usage for idle machinery. Used if `use_power` is set to `POWER_USE_IDLE`. Use `change_power_consumption()` to modify this during runtime.
 	var/idle_power_usage = 0
+	/// Power usage for active machinery. Used if `use_power` is set to `POWER_USE_ACTIVE`. Use `change_power_consumption()` to modify this during runtime.
 	var/active_power_usage = 0
-	var/power_channel = EQUIP //EQUIP, ENVIRON or LIGHT
-	var/power_init_complete = FALSE // Helps with bookkeeping when initializing atoms. Don't modify.
-	var/list/component_parts           //List of component instances. Expected type: /obj/item/stock_parts
-	var/list/uncreated_component_parts = list(/obj/item/stock_parts/power/apc) //List of component paths which have delayed init. Indeces = number of components.
-	var/list/maximum_component_parts = list(/obj/item/stock_parts = 10)         //null - no max. list(type part = number max).
+	/// Power channel the machine draws from in APCs. `EQUIP`, `ENVIRON`, or `LIGHT`. Use `update_power_channel()` to modify this during runtime.
+	var/power_channel = EQUIP
+	/// Helps with bookkeeping when initializing atoms. Don't modify.
+	var/power_init_complete = FALSE
+	/// List of component instances. Expected type: `/obj/item/stock_parts.`
+	var/list/component_parts
+	/// List of component paths which have delayed init. Indeces = number of components.
+	var/list/uncreated_component_parts = list(/obj/item/stock_parts/power/apc)
+	/// List of componant paths and the maximum number of that specific path that can be inserted into the machine. `null` - no max. `list(type part = number max)`.
+	var/list/maximum_component_parts = list(/obj/item/stock_parts = 10)
+	/// Numeric unique ID number. Set to the value of `gl_uid++` when used.
 	var/uid
-	var/panel_open = 0
+	/// Boolean. Whether or not the maintenance panel is open.
+	var/panel_open = FALSE
+	/// Numeric unique ID number tracker. Used for ensuring `uid` is unique.
 	var/global/gl_uid = 1
-	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
-	var/clicksound			// sound played on succesful interface use by a carbon lifeform
-	var/clickvol = 40		// sound played on succesful interface use
-	var/next_clicksound = 0 // value to compare with world.time for whether to play clicksound according to CLICKSOUND_INTERVAL
-	var/core_skill = SKILL_DEVICES //The skill used for skill checks for this machine (mostly so subtypes can use different skills).
-	var/operator_skill      // Machines often do all operations on Process(). This caches the user's skill while the operations are running.
-	var/base_type           // For mapped buildable types, set this to be the base type actually buildable.
-	var/id_tag              // This generic variable is to be used by mappers to give related machines a string key. In principle used by radio stock parts.
-	var/frame_type = /obj/machinery/constructable_frame/machine_frame/deconstruct // what is created when the machine is dismantled.
+	/// Boolean. Can the machine be interacted with while de-powered.
+	var/interact_offline = FALSE
+	/// Sound played on succesful interface use by a carbon lifeform.
+	var/clicksound
+	/// Sound played on succesful interface use.
+	var/clickvol = 40
+	/// Value to compare with `world.time` for whether to play `clicksound` according to `CLICKSOUND_INTERVAL`.
+	var/next_clicksound = 0
+	/// The skill used for skill checks for this machine (mostly so subtypes can use different skills).
+	var/core_skill = SKILL_DEVICES
+	/// Machines often do all operations on `Process()`. This caches the user's skill while the operations are running.
+	var/operator_skill
+	/// For mapped buildable types, set this to be the base type actually buildable.
+	var/base_type
+	/// This generic variable is to be used by mappers to give related machines a string key. In principle used by radio stock parts.
+	var/id_tag
+	/// What is created when the machine is dismantled.
+	var/frame_type = /obj/machinery/constructable_frame/machine_frame/deconstruct
 
-	var/list/processing_parts // Component parts queued for processing by the machine. Expected type: /obj/item/stock_parts
-	var/processing_flags         // What is being processed
-	var/silicon_restriction = FALSE // FALSE or one of the STATUS_* flags. If set, will force the given status flag if a silicon tries to access the machine.
+	/// Component parts queued for processing by the machine. Expected type: `/obj/item/stock_parts`
+	var/list/processing_parts
+	/// Bitflag. What is being processed. One of `MACHINERY_PROCESS_*`.
+	var/processing_flags
+	/// One of the `STATUS_*` flags. If set, will force the given status flag if a silicon tries to access the machine.
+	var/silicon_restriction = null
 
-	var/machine_name = null // The human-readable name of this machine, shown when examining circuit boards.
-	var/machine_desc = null // A simple description of what this machine does, shown on examine for circuit boards.
+	/// The human-readable name of this machine, shown when examining circuit boards.
+	var/machine_name = null
+	/// A simple description of what this machine does, shown on examine for circuit boards.
+	var/machine_desc = null
 
 /obj/machinery/Initialize(mapload, d=0, populate_parts = TRUE)
 	. = ..()
@@ -141,7 +169,8 @@ Class Procs:
 	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_ALL)
 	. = ..()
 
-/obj/machinery/proc/ProcessAll(var/wait)
+/// Part of the machinery subsystem's process stack. Processes everything defined by `processing_flags`.
+/obj/machinery/proc/ProcessAll(wait)
 	if(processing_flags & MACHINERY_PROCESS_COMPONENTS)
 		for(var/thing in processing_parts)
 			var/obj/item/stock_parts/part = thing
@@ -155,7 +184,7 @@ Class Procs:
 	return PROCESS_KILL // Only process if you need to.
 
 /obj/machinery/emp_act(severity)
-	if(use_power && stat == 0)
+	if(use_power && stat == EMPTY_BITFIELD)
 		use_power_oneoff(7500/severity)
 
 		var/obj/effect/overlay/pulse2 = new /obj/effect/overlay(loc)
@@ -165,21 +194,21 @@ Class Procs:
 		pulse2.anchored = TRUE
 		pulse2.set_dir(pick(GLOB.cardinal))
 
-		spawn(10)
-			qdel(pulse2)
+		addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, pulse2), 1 SECOND)
 	..()
 
 /obj/machinery/ex_act(severity)
 	switch(severity)
-		if(1.0)
+		if(1)
 			qdel(src)
-		if(2.0)
+		if(2)
 			if (prob(50))
 				qdel(src)
-		if(3.0)
+		if(3)
 			if (prob(25))
 				qdel(src)
 
+/// Toggles the `BROKEN` flag on the machine's `stat` variable. Includes immunity and other checks. `cause` can be any of `MACHINE_BROKEN_*`.
 /obj/machinery/proc/set_broken(new_state, cause = MACHINE_BROKEN_GENERIC)
 	if(stat_immune & BROKEN)
 		return FALSE
@@ -192,6 +221,7 @@ Class Procs:
 		queue_icon_update()
 		return TRUE
 
+/// Toggles the `NOSCREEN` flag on the machine's `stat` variable. Includes immunity checks.
 /obj/machinery/proc/set_noscreen(new_state)
 	if(stat_immune & NOSCREEN)
 		return FALSE
@@ -199,6 +229,7 @@ Class Procs:
 		stat ^= NOSCREEN                // so flip it
 		return TRUE
 
+/// Toggles the `NOINPUT` flag on the machine's `stat` variable. Includes immunity checks.
 /obj/machinery/proc/set_noinput(new_state)
 	if(stat_immune & NOINPUT)
 		return FALSE
@@ -206,22 +237,27 @@ Class Procs:
 		stat ^= NOINPUT
 		return TRUE
 
-/proc/is_operable(var/obj/machinery/M, var/mob/user)
+/// Checks whether or not the machine `M` can be operated by `user`.
+/proc/is_operable(obj/machinery/M, mob/user)
 	return istype(M) && M.operable()
 
-/obj/machinery/proc/is_broken(var/additional_flags = 0)
+/// Checks whether or not the machine's stat variable has the `BROKEN` flag, or any of the provided `additional_flags`. Returns `TRUE` if any of the flags match.
+/obj/machinery/proc/is_broken(additional_flags = EMPTY_BITFIELD)
 	return (stat & (BROKEN|additional_flags))
 
-/obj/machinery/proc/is_powered(var/additional_flags = 0)
+/// Checks whether or not the machine's stat variable has the `NOPOWER` flag, or any of the provided `additional_flags`. Returns `FALSE` if any of the flags match.
+/obj/machinery/proc/is_powered(additional_flags = EMPTY_BITFIELD)
 	return !(stat & (NOPOWER|additional_flags))
 
-/obj/machinery/proc/operable(var/additional_flags = 0)
+/// Inverse of `inoperable()`.
+/obj/machinery/proc/operable(additional_flags = EMPTY_BITFIELD)
 	return !inoperable(additional_flags)
 
-/obj/machinery/proc/inoperable(var/additional_flags = 0)
+/// Checks whether or not the machine's state variable has the `BROKEN` or `NOPOWER` flags, or any of the provided `additional_flags`. Returns `TRUE` if any of the flags match.
+/obj/machinery/proc/inoperable(additional_flags = EMPTY_BITFIELD)
 	return (stat & (NOPOWER|BROKEN|additional_flags))
 
-/obj/machinery/CanUseTopic(var/mob/user)
+/obj/machinery/CanUseTopic(mob/user)
 	if(stat & BROKEN)
 		return STATUS_CLOSE
 
@@ -244,6 +280,7 @@ Class Procs:
 		return min(..(), STATUS_UPDATE)
 	return ..()
 
+/// Whether or not the mob can directly interact with the machine regardless of screen and input status. Checked in `CanUseTopic()`.
 /mob/proc/direct_machine_interface(obj/machinery/machine)
 	return FALSE
 
@@ -253,17 +290,17 @@ Class Procs:
 /mob/observer/ghost/direct_machine_interface(obj/machinery/machine)
 	return TRUE
 
-/obj/machinery/CanUseTopicPhysical(var/mob/user)
+/obj/machinery/CanUseTopicPhysical(mob/user)
 	if(stat & BROKEN)
 		return STATUS_CLOSE
 
 	return GLOB.physical_state.can_use_topic(nano_host(), user)
 
-/obj/machinery/CouldUseTopic(var/mob/user)
+/obj/machinery/CouldUseTopic(mob/user)
 	..()
 	user.set_machine(src)
 
-/obj/machinery/CouldNotUseTopic(var/mob/user)
+/obj/machinery/CouldNotUseTopic(mob/user)
 	user.unset_machine()
 
 /obj/machinery/Topic(href, href_list, datum/topic_state/state)
@@ -305,15 +342,15 @@ Class Procs:
 	if(!CanPhysicallyInteract(user))
 		return FALSE // The interactions below all assume physical access to the machine. If this is not the case, we let the machine take further action.
 	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
 		return TRUE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.getBrainLoss() >= 55)
-			visible_message("<span class='warning'>[H] stares cluelessly at \the [src].</span>")
+			visible_message(SPAN_WARNING("\The [H] stares cluelessly at \the [src]."))
 			return TRUE
 		else if(prob(H.getBrainLoss()))
-			to_chat(user, "<span class='warning'>You momentarily forget how to use \the [src].</span>")
+			to_chat(user, SPAN_WARNING("You momentarily forget how to use \the [src]."))
 			return TRUE
 	if((. = component_attack_hand(user)))
 		return
@@ -324,18 +361,23 @@ Class Procs:
 	if(CanUseTopic(user, DefaultTopicState()) > STATUS_CLOSE)
 		return interface_interact(user)
 
-// If you want to have interface interactions handled for you conveniently, use this.
-// Return TRUE for handled.
-// If you perform direct interactions in here, you are responsible for ensuring that full interactivity checks have been made (i.e CanInteract).
-// The checks leading in to here only guarantee that the user should be able to view a UI.
+/**
+ * If you want to have interface interactions handled for you conveniently, use this.
+ * Return `TRUE` for handled.
+ * If you perform direct interactions in here, you are responsible for ensuring that full interactivity checks have been made (i.e `CanInteract()`).
+ * The checks leading in to here only guarantee that the user should be able to view a UI.
+ */
 /obj/machinery/proc/interface_interact(user)
 	return FALSE
 
-// If you want a physical interaction which happens after all relevant checks but preempts the UI interactions, do it here.
-// Return TRUE for handled.
+/**
+ * If you want a physical interaction which happens after all relevant checks but preempts the UI interactions, do it here.
+ * Return `TRUE` for handled.
+ */
 /obj/machinery/proc/physical_attack_hand(user)
 	return FALSE
 
+/// Refreshes the machines parts-related `stat` flags, and calls `on_refresh()` on each component.
 /obj/machinery/proc/RefreshParts()
 	set_noinput(TRUE)
 	set_noscreen(TRUE)
@@ -345,22 +387,25 @@ Class Procs:
 	var/list/missing = missing_parts()
 	set_broken(!!missing, MACHINE_BROKEN_NO_PARTS)
 
-/obj/machinery/proc/state(var/msg)
+/// Displays a message for mobs in range.
+/obj/machinery/proc/state(msg)
 	for(var/mob/O in hearers(src, null))
-		O.show_message("[icon2html(src, O)] <span class = 'notice'>[msg]</span>", 2)
+		O.show_message("[icon2html(src, O)] " + SPAN_NOTICE(msg), AUDIBLE_MESSAGE)
 
-/obj/machinery/proc/ping(text=null)
+/// Displays a ping message and sound effect.
+/obj/machinery/proc/ping(text)
 	if (!text)
 		text = "\The [src] pings."
 
-	state(text, "blue")
-	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+	state(text)
+	playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 
+/// Electrocutes the mob `user` based on probability `prb`, if the machine is in a state capable of doing so. Returns `TRUE` if the user was shocked.
 /obj/machinery/proc/shock(mob/user, prb)
 	if(inoperable())
-		return 0
+		return FALSE
 	if(!prob(prb))
-		return 0
+		return FALSE
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(5, 1, src)
 	s.start()
@@ -373,9 +418,10 @@ Class Procs:
 			if(terminal && terminal.powernet)
 				terminal.powernet.trigger_warning()
 		if(user.stunned)
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
+/// Deconstructs the machine into its base frame and ejects all of its components. Returns boolean.
 /obj/machinery/proc/dismantle()
 	playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
 	var/obj/item/stock_parts/circuitboard/circuit = get_component_of_type(/obj/item/stock_parts/circuitboard)
@@ -394,60 +440,64 @@ Class Procs:
 		O.dropInto(loc)
 
 	qdel(src)
-	return 1
+	return TRUE
 
 /obj/machinery/InsertedContents()
 	return (contents - component_parts)
 
+/// Applies visual overlays relating to viewing through a specific datum, i.e. cameras.
 /datum/proc/apply_visual(mob/M)
 	return
 
+/// Removes visual overlays relating to viewing through a specific datum, i.e. cameras.
 /datum/proc/remove_visual(mob/M)
 	return
 
-/obj/machinery/proc/malf_upgrade(var/mob/living/silicon/ai/user)
-	return 0
+/// Handles updgrading the machine for a malfunctioning AI. Return `TRUE` if the machine was successfully upgraded.
+/obj/machinery/proc/malf_upgrade(mob/living/silicon/ai/user)
+	return FALSE
 
-/obj/machinery/CouldUseTopic(var/mob/user)
+/obj/machinery/CouldUseTopic(mob/user)
 	..()
 	if(clicksound && world.time > next_clicksound && istype(user, /mob/living/carbon))
 		next_clicksound = world.time + CLICKSOUND_INTERVAL
 		playsound(src, clicksound, clickvol)
 
+/// Displays all components in the machine to the user.
 /obj/machinery/proc/display_parts(mob/user)
-	to_chat(user, "<span class='notice'>Following parts detected in the machine:</span>")
+	to_chat(user, SPAN_NOTICE("Following parts detected in the machine:"))
 	for(var/obj/item/C in component_parts)
-		to_chat(user, "<span class='notice'>	[C.name]</span>")
+		to_chat(user, SPAN_NOTICE("	[C.name]"))
 	for(var/path in uncreated_component_parts)
 		var/obj/item/thing = path
-		to_chat(user, "<span class='notice'>	[initial(thing.name)] ([uncreated_component_parts[path] || 1])</span>")
+		to_chat(user, SPAN_NOTICE("	[initial(thing.name)] ([uncreated_component_parts[path] || 1])"))
 
 /obj/machinery/examine(mob/user)
 	. = ..()
 	if (panel_open)
-		to_chat(user, "The service panel is open.")
+		to_chat(user, SPAN_NOTICE("The service panel is open."))
 	if(component_parts && hasHUD(user, HUD_SCIENCE))
 		display_parts(user)
 	if(stat & NOSCREEN)
-		to_chat(user, "It is missing a screen, making it hard to interact with.")
+		to_chat(user, SPAN_WARNING("It is missing a screen, making it hard to interact with."))
 	else if(stat & NOINPUT)
-		to_chat(user, "It is missing any input device.")
+		to_chat(user, SPAN_WARNING("It is missing any input device."))
 	else if((stat & NOPOWER) && !interact_offline)
-		to_chat(user, "It is not receiving power.")
+		to_chat(user, SPAN_WARNING("It is not receiving power."))
 	if(construct_state && construct_state.mechanics_info())
-		to_chat(user, "It can be <a href='?src=\ref[src];mechanics_text=1'>manipulated</a> using tools.")
+		to_chat(user, SPAN_NOTICE("It can be <a href='?src=\ref[src];mechanics_text=1'>manipulated</a> using tools."))
 	var/list/missing = missing_parts()
 	if(missing)
 		var/list/parts = list()
 		for(var/type in missing)
 			var/obj/item/fake_thing = type
 			parts += "[num2text(missing[type])] [initial(fake_thing.name)]"
-		to_chat(user, "\The [src] is missing [english_list(parts)], rendering it inoperable.")
+		to_chat(user, SPAN_WARNING("\The [src] is missing [english_list(parts)], rendering it inoperable."))
 	if (user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC) || isobserver(user))
 		to_chat(user, SPAN_NOTICE(machine_desc))
 
 // This is really pretty crap and should be overridden for specific machines.
-/obj/machinery/water_act(var/depth)
+/obj/machinery/water_act(depth)
 	..()
 	if(!(stat & (NOPOWER|BROKEN)) && !waterproof && (depth > FLUID_DEEP))
 		ex_act(3)
@@ -462,5 +512,6 @@ Class Procs:
 	if(battery)
 		return battery.get_cell()
 
+/// Called by `/mob/Login()` if the mob has an associated `machine`.
 /obj/machinery/proc/on_user_login(mob/M)
 	return

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -14,8 +14,11 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		.[initial(board.build_path)] = board_path
 
 // Code concerning machinery interaction with components/stock parts.
-
-/obj/machinery/proc/populate_parts(var/full_populate) // Full populate creates a circuitboard and all needed components automatically.
+/**
+ * Creates all components listed in `uncreated_component_parts`.
+ * `full_populate` also creates a circuitboard and all needed components.
+ */
+/obj/machinery/proc/populate_parts(full_populate = FALSE)
 	if(full_populate)
 		var/path_to_check = base_type || type
 		var/board_path = GLOB.machine_path_to_circuit_type[path_to_check]
@@ -59,8 +62,8 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 				if(number == 0)
 					break
 
-// Returns the first valid preset decl for a given part, or null
-/obj/machinery/proc/can_apply_preset_to(var/obj/item/stock_parts/part)
+/// Returns the first valid preset decl for a given part, or `null`
+/obj/machinery/proc/can_apply_preset_to(obj/item/stock_parts/part)
 	if(!stock_part_presets)
 		return
 	for(var/path in stock_part_presets)
@@ -69,14 +72,14 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 			return preset
 
 // Applies the first valid preset to the given part. Returns preset applied, or null.
-/obj/machinery/proc/apply_preset_to(var/obj/item/stock_parts/part)
+/obj/machinery/proc/apply_preset_to(obj/item/stock_parts/part)
 	var/decl/stock_part_preset/preset = can_apply_preset_to(part)
 	if(preset)
 		preset.apply(null, part)
 		return preset
 
-// Returns a list of subtypes of the given component type, with associated value = number of that component.
-/obj/machinery/proc/types_of_component(var/part_type)
+/// Returns a list of subtypes of the given component type, with associated value = number of that component.
+/obj/machinery/proc/types_of_component(part_type)
 	. = list()
 	for(var/obj/component in component_parts)
 		if(istype(component, part_type))
@@ -85,8 +88,8 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		if(ispath(path, part_type))
 			.[path] += uncreated_component_parts[path]
 
-// Returns a component instance of the given type, or null if no such type is present.
-/obj/machinery/proc/get_component_of_type(var/part_type, var/strict = FALSE)
+/// Returns a component instance of the given `part_type`, or `null` if no such type is present. `strict` forces strict type comparisons and disallows subtypes.
+/obj/machinery/proc/get_component_of_type(part_type, strict = FALSE)
 	if(strict)
 		for(var/obj/component in component_parts)
 			if(component.type == part_type)
@@ -100,7 +103,11 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		if(ispath(path, part_type))
 			return force_init_component(path)
 
-/obj/machinery/proc/force_init_component(var/path)
+/**
+ * Forces initialization of a component in the `uncreated_component_parts` list.
+ * Returns the result of `install_component()`, or `null` if the path does not exist in the list.
+ */
+/obj/machinery/proc/force_init_component(path)
 	if(!uncreated_component_parts[path])
 		return
 	uncreated_component_parts[path]-- //bookkeeping to make sure tally is correct.
@@ -110,7 +117,7 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 
 // Can be given a path or an instance. False will guarantee part creation.
 // If an instance is given or created, it is returned, otherwise null is returned.
-/obj/machinery/proc/install_component(var/obj/item/stock_parts/part, force = FALSE, refresh_parts = TRUE)
+/obj/machinery/proc/install_component(obj/item/stock_parts/part, force = FALSE, refresh_parts = TRUE)
 	if(ispath(part))
 		if(force || !(ispath(part, /obj/item/stock_parts) && initial(part.part_flags) & PART_FLAG_LAZY_INIT))
 			part = new part(src) // Forced to make, or we don't lazy-init, so create.
@@ -140,8 +147,12 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 	if(refresh_parts)
 		RefreshParts()
 
-// This will force-init components.
-/obj/machinery/proc/uninstall_component(var/obj/item/stock_parts/part, refresh_parts = TRUE)
+/**
+ * Uninstalls the provided component, if it exists in `component_parts`.
+ * `refresh_parts` will call `RefreshParts()` after uninstallation.
+ * Returns the uninstalled part.
+ */
+/obj/machinery/proc/uninstall_component(obj/item/stock_parts/part, refresh_parts = TRUE)
 	if(ispath(part))
 		part = get_component_of_type(part)
 	else if(!(part in component_parts))
@@ -158,23 +169,26 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 		GLOB.destroyed_event.unregister(part, src)
 		return part
 
-/obj/machinery/proc/replace_part(mob/user, var/obj/item/storage/part_replacer/R, var/obj/item/stock_parts/old_part, var/obj/item/stock_parts/new_part)
+/// Replaces a single component in the machine.
+/obj/machinery/proc/replace_part(mob/user, obj/item/storage/part_replacer/part_replacer, obj/item/stock_parts/old_part, obj/item/stock_parts/new_part)
 	if(ispath(old_part))
 		old_part = get_component_of_type(old_part, TRUE)
 	old_part = uninstall_component(old_part)
-	if(R)
-		R.remove_from_storage(new_part, src)
-		R.handle_item_insertion(old_part, 1)
+	if(part_replacer)
+		part_replacer.remove_from_storage(new_part, src)
+		part_replacer.handle_item_insertion(old_part, TRUE)
 	install_component(new_part)
-	to_chat(user, "<span class='notice'>[old_part.name] replaced with [new_part.name].</span>")
+	to_chat(user, SPAN_NOTICE("[old_part.name] replaced with [new_part.name]."))
 
-/obj/machinery/proc/component_destroyed(var/obj/item/component)
+/// Handles destroying the provided component. `component` should be an item within the machine.
+/obj/machinery/proc/component_destroyed(obj/item/component)
 	GLOB.destroyed_event.unregister(component, src)
 	LAZYREMOVE(component_parts, component)
 	LAZYREMOVE(processing_parts, component)
 	power_components -= component
 
-/obj/machinery/proc/total_component_rating_of_type(var/part_type)
+/// Returns the total combined component ratings for the provided `part_type`.
+/obj/machinery/proc/total_component_rating_of_type(part_type)
 	. = 0
 	for(var/thing in component_parts)
 		if(istype(thing, part_type))
@@ -185,7 +199,8 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 			var/obj/item/stock_parts/comp = path
 			. += initial(comp.rating) * uncreated_component_parts[path]
 
-/obj/machinery/proc/number_of_components(var/part_type)
+/// Returns the number of components of the given `part_type` currently installed in the machine.
+/obj/machinery/proc/number_of_components(part_type)
 	if(!ispath(part_type, /obj/item/stock_parts))
 		var/obj/item/stock_parts/building_material/material = get_component_of_type(/obj/item/stock_parts/building_material)
 		return material && material.number_of_type(part_type)
@@ -194,12 +209,12 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 	for(var/path in comps)
 		. += comps[path]
 
-// Use to block interactivity if panel is not open, etc.
-/obj/machinery/proc/components_are_accessible(var/path)
+/// Use to block interactivity if panel is not open, etc. `path` is the type path to check accessibility for. Returns boolean.
+/obj/machinery/proc/components_are_accessible(path)
 	return panel_open
 
-// Installation. Returns number of such components which can be inserted, or 0.
-/obj/machinery/proc/can_add_component(var/obj/item/stock_parts/component, var/mob/user)
+/// Installation. Returns number of such components which can be inserted.
+/obj/machinery/proc/can_add_component(obj/item/stock_parts/component, mob/user)
 	if(!istype(component)) // Random items. Only insert if actually needed.
 		var/list/missing = missing_parts()
 		for(var/path in missing)
@@ -217,14 +232,15 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 			return 0
 	return 1
 
-// Hook to get updates.
-/obj/machinery/proc/component_stat_change(var/obj/item/stock_parts/part, old_stat, flag)
+/// Called whenever an attached component updates it's status. Override to handle updates to the machine.
+/obj/machinery/proc/component_stat_change(obj/item/stock_parts/part, old_stat, flag)
 
 /obj/machinery/attackby(obj/item/I, mob/user)
 	if(component_attackby(I, user))
 		return TRUE
 	return ..()
 
+/// Passes `attackby()` calls through to components within the machine, if they are accessible.
 /obj/machinery/proc/component_attackby(obj/item/I, mob/user)
 	for(var/obj/item/stock_parts/part in component_parts)
 		if(!components_are_accessible(part.type))
@@ -233,6 +249,7 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 			return
 	return construct_state && construct_state.attackby(I, user, src)
 
+/// Passes `attack_hand()` calls through to components within the machine, if they are accessible.
 /obj/machinery/proc/component_attack_hand(mob/user)
 	for(var/obj/item/stock_parts/part in component_parts)
 		if(!components_are_accessible(part.type))
@@ -245,27 +262,29 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 Standard helpers for users interacting with machinery parts.
 */
 
-/obj/machinery/proc/part_replacement(mob/user, obj/item/storage/part_replacer/R)
-	for(var/obj/item/stock_parts/A in component_parts)
-		if(!A.base_type)
+/// Handles replacement of components by a user using a part replacer. Returns boolean.
+/obj/machinery/proc/part_replacement(mob/user, obj/item/storage/part_replacer/part_replacer)
+	for(var/obj/item/stock_parts/component_part in component_parts)
+		if(!component_part.base_type)
 			continue
-		if(!(A.part_flags & PART_FLAG_HAND_REMOVE))
+		if(!(component_part.part_flags & PART_FLAG_HAND_REMOVE))
 			continue
-		for(var/obj/item/stock_parts/B in R.contents)
-			if(istype(B, A.base_type) && B.rating > A.rating)
-				replace_part(user, R, A, B)
+		for(var/obj/item/stock_parts/new_component_part in part_replacer.contents)
+			if(istype(new_component_part, component_part.base_type) && new_component_part.rating > component_part.rating)
+				replace_part(user, part_replacer, component_part, new_component_part)
 				return TRUE
 	for(var/path in uncreated_component_parts)
-		var/obj/item/stock_parts/A = path
-		if(!(initial(A.part_flags) & PART_FLAG_HAND_REMOVE))
+		var/obj/item/stock_parts/component_part = path
+		if(!(initial(component_part.part_flags) & PART_FLAG_HAND_REMOVE))
 			continue
-		var/base_type = initial(A.base_type)
+		var/base_type = initial(component_part.base_type)
 		if(base_type)
-			for(var/obj/item/stock_parts/B in R.contents)
-				if(istype(B, base_type) && B.rating > initial(A.rating))
-					replace_part(user, R, A, B)
+			for(var/obj/item/stock_parts/new_component_part in part_replacer.contents)
+				if(istype(new_component_part, base_type) && new_component_part.rating > initial(component_part.rating))
+					replace_part(user, part_replacer, component_part, new_component_part)
 					return TRUE
 
+/// Handles inserting a component or item into the machine by a user. Returns boolean. `TRUE` should halt further processing in `attack*()` procs.
 /obj/machinery/proc/part_insertion(mob/user, obj/item/stock_parts/part) // Second argument may actually be an arbitrary item.
 	if(!user.canUnEquip(part) && !isstack(part))
 		return FALSE
@@ -278,9 +297,13 @@ Standard helpers for users interacting with machinery parts.
 	else
 		user.unEquip(part, src)
 		install_component(part)
-	user.visible_message(SPAN_NOTICE("\The [user] installs \the [part] in \the [src]!"), SPAN_NOTICE("You install \the [part] in \the [src]!"))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] installs \the [part] in \the [src]!"),
+		SPAN_NOTICE("You install \the [part] in \the [src]!")
+	)
 	return TRUE
 
+/// Handles removal of a component by a user. Returns boolean.
 /obj/machinery/proc/part_removal(mob/user)
 	var/list/removable_parts = list()
 	for(var/path in types_of_component(/obj/item/stock_parts))
@@ -299,12 +322,17 @@ Standard helpers for users interacting with machinery parts.
 		remove_part_and_give_to_user(path, user)
 		return TRUE
 
-/obj/machinery/proc/remove_part_and_give_to_user(var/path, mob/user)
+/// Removes a part of the given `path` and places it in the hands of `user`.
+/obj/machinery/proc/remove_part_and_give_to_user(path, mob/user)
 	var/obj/item/stock_parts/part = uninstall_component(get_component_of_type(path, TRUE))
 	if(part)
 		user.put_in_hands(part) // Already dropped at loc, so that's the fallback.
-		user.visible_message(SPAN_NOTICE("\The [user] removes \the [part] from \the [src]."), SPAN_NOTICE("You remove \the [part] from \the [src]."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [part] from \the [src]."),
+			SPAN_NOTICE("You remove \the [part] from \the [src].")
+		)
 
+/// Returns a list of required components that are missing from the machine, or `null` if no components are missing or the machine lacks a `construct_state`.
 /obj/machinery/proc/missing_parts()
 	if(!construct_state)
 		return

--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -8,12 +8,14 @@ This is /obj/machinery level code to properly manage power usage from the area.
 		var/area/A = get_area(src);\
 		if(A) A.power_use_change(old_power, new_power, power_channel)}
 
-// returns true if the area has power on given channel (or doesn't require power), defaults to power_channel.
-// May also optionally specify an area, otherwise defaults to src.loc.loc
-/obj/machinery/proc/powered(var/chan = -1, var/area/check_area = null)
+/**
+ * Returns `TRUE` if the area has power on given channel (or doesn't require power), defaults to `power_channel`.
+ * May also optionally specify an area, otherwise defaults to `loc.loc`.
+ */
+/obj/machinery/proc/powered(chan = POWER_CHAN, area/check_area = null)
 
-	if(!src.loc)
-		return 0
+	if(!loc)
+		return FALSE
 
 	//Don't do this. It allows machines that set use_power to 0 when off (many machines) to
 	//be turned on again and used after a power failure because they never gain the NOPOWER flag.
@@ -21,10 +23,10 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	//	return 1
 
 	if(!check_area)
-		check_area = src.loc.loc		// make sure it's in an area
+		check_area = loc.loc		// make sure it's in an area
 	if(!check_area || !isarea(check_area))
-		return 0					// if not, then not powered
-	if(chan == -1)
+		return FALSE					// if not, then not powered
+	if(chan == POWER_CHAN)
 		chan = power_channel
 	return check_area.powered(chan)			// return power status of the area
 
@@ -47,6 +49,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	if(.)
 		queue_icon_update()
 
+/// Returns the current power usage draw, based on the state of `use_power`.
 /obj/machinery/proc/get_power_usage()
 	switch(use_power)
 		if(POWER_USE_IDLE)
@@ -56,8 +59,11 @@ This is /obj/machinery level code to properly manage power usage from the area.
 		else
 			return 0
 
-// This will have this machine have its area eat this much power next tick, and not afterwards. Do not use for continued power draw.
-/obj/machinery/proc/use_power_oneoff(var/amount, var/chan = POWER_CHAN)
+/**
+ *  This will have this machine have its area eat this much power next tick, and not afterwards. Do not use for continued power draw.
+ * `chan` can be one of the possible values for `power_channel`, or `POWER_CHAN` to use the machine's current configured power channel.
+ */
+/obj/machinery/proc/use_power_oneoff(amount, chan = POWER_CHAN)
 	if(chan == POWER_CHAN)
 		chan = power_channel
 	. = amount
@@ -68,8 +74,8 @@ This is /obj/machinery level code to properly manage power usage from the area.
 		if(. <= 0)
 			return
 
-// Same thing, but dry run; doesn't actually do it.
-/obj/machinery/proc/can_use_power_oneoff(var/amount, var/chan = POWER_CHAN)
+// Same as `use_power_oneoff()`, but dry run; doesn't actually do it. Useful for pre-operation checks.
+/obj/machinery/proc/can_use_power_oneoff(amount, chan = POWER_CHAN)
 	if(chan == POWER_CHAN)
 		chan = power_channel
 	. = amount
@@ -93,9 +99,11 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	REPORT_POWER_CONSUMPTION_CHANGE(get_power_usage(), 0)
 	. = ..()
 
+/// Handles updating machinery power whenever the machine is moved. Calls `area_changed()` by default.
 /obj/machinery/proc/update_power_on_move(atom/movable/mover, atom/old_loc, atom/new_loc)
 	area_changed(get_area(old_loc), get_area(new_loc))
 
+/// Handles machinery power updates if the area the machine is in changes. Called by `update_power_on_move()`.
 /obj/machinery/proc/area_changed(area/old_area, area/new_area)
 	if(old_area == new_area)
 		return
@@ -110,6 +118,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	power_change() // Force check in case the old area was powered and the new one isn't or vice versa.
 
 // The three procs below are the only allowed ways of modifying the corresponding variables.
+/// Updates the `use_power` variable to the new value and updates the machine's area's power grid.
 /obj/machinery/proc/update_use_power(new_use_power)
 	if(!power_init_complete)
 		use_power = new_use_power
@@ -121,6 +130,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	var/new_power = get_power_usage()
 	REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power)
 
+/// Updates the machine's `power_channel` to the new value and updates the machine's area's power grid.
 /obj/machinery/proc/update_power_channel(new_channel)
 	if(power_channel == new_channel)
 		return
@@ -132,6 +142,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	power_channel = new_channel
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
 
+/// Updates the machine's `*_power_usage` to the new value and updates the machine's current power consumption state if applicable.
 /obj/machinery/proc/change_power_consumption(new_power_consumption, use_power_mode = POWER_USE_IDLE)
 	var/old_power
 	switch(use_power_mode)

--- a/code/game/machinery/_machines_base/machinery_public_vars.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars.dm
@@ -99,9 +99,10 @@ Public methods machines can expose. Pretty bare-bones; just wraps a proc and giv
 Machinery implementation
 */
 
-/obj/machinery
-	var/list/public_variables
-	var/list/public_methods
+/// List of all registered `public_variable` decls.
+/obj/machinery/var/list/public_variables
+/// List of all registered `public_method` decls.
+/obj/machinery/var/list/public_methods
 
 /obj/machinery/Initialize()
 	for(var/path in public_variables)

--- a/code/game/machinery/_machines_base/machinery_public_vars_common.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars_common.dm
@@ -2,9 +2,10 @@
 Public vars at /obj/machinery level. Just because they are here does not mean that every machine exposes them; you must add them to the appropriate list.
 */
 
-/obj/machinery
-	var/input_toggle = FALSE
-	var/identifier = ""
+/// Stores the on/off state of an input toggle. Used for the `input_toggle` public variable.
+/obj/machinery/var/input_toggle = FALSE
+/// Stores the identifier string of an input toggle. Used for the `input_toggle` public variable.
+/obj/machinery/var/identifier = ""
 
 /decl/public_access/public_variable/input_toggle
 	expected_type = /obj/machinery
@@ -26,6 +27,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	desc = "Toggles the input toggle variable."
 	call_proc = /obj/machinery/proc/toggle_input_toggle
 
+/// Handles toggling the machine's toggle variable. Used by the `toggle_input_toggle` public method.
 /obj/machinery/proc/toggle_input_toggle()
 	var/decl/public_access/public_variable/variable = decls_repository.get_decl(/decl/public_access/public_variable/input_toggle)
 	variable.write_var(src, !input_toggle)
@@ -41,6 +43,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 /decl/public_access/public_variable/area_uid/access_var(obj/machinery/machine)
 	return machine.area_uid()
 
+/// Retrieves the unique id of the machine's current area.
 /obj/machinery/proc/area_uid()
 	var/area/A = get_area(src)
 	return A ? A.uid : "NONE"
@@ -100,6 +103,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	desc = "Turns the machine on or off."
 	call_proc = /obj/machinery/proc/toggle_power
 
+/// Toggles the machine's power state. Used by the `toggle_power` public method.
 /obj/machinery/proc/toggle_power()
 	update_use_power(!use_power)
 
@@ -108,5 +112,6 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	desc = "Attempts to refresh the machine's status. Implementation may vary."
 	call_proc = /obj/machinery/proc/refresh
 
+/// Refreshes the machine's status. Used by the `refresh` public method.
 /obj/machinery/proc/refresh()
 	queue_icon_update()

--- a/code/game/machinery/_machines_base/stock_parts/power/power.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/power.dm
@@ -1,7 +1,7 @@
 // Power component for machines. Handles power interactions.
 
-/obj/machinery
-	var/list/power_components = list() // this is an optimization, as power code is expensive.
+/// List of all machine components that are of the `power` subtype. This is an optimization, as power code is expensive.
+/obj/machinery/var/list/power_components = list()
 
 /obj/item/stock_parts/power
 	part_flags = PART_FLAG_QDEL // For integrated components, which are built from uncreated_component_parts. Use subtypes with this off for buildable ones.

--- a/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
+++ b/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
@@ -4,8 +4,8 @@ They are abstracted from machines to potentially share code and simplify inherit
 Do not work with lazy-initialized parts.
 */
 
-/obj/machinery
-	var/list/stock_part_presets  // Format: assotiative list of decl path -> number to apply.
+/// Associative list of decl path -> number to apply.
+/obj/machinery/var/list/stock_part_presets
 
 /decl/stock_part_preset
 	var/expected_part_type

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -69,7 +69,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/proc/add_underlay(var/turf/T, var/obj/machinery/atmospherics/node, var/direction, var/icon_connect_type)
 	if(node)
-		if(!T.is_plating() && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))			
+		if(!T.is_plating() && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
 		else
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
@@ -165,7 +165,7 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 	. = ..()
 	initialize_directions = get_initialze_directions()
 
-// Used by constructors. Shouldn't generally be called from elsewhere.
+/// Used by constructors. Shouldn't generally be called from elsewhere.
 /obj/machinery/proc/set_initial_level()
 	var/turf/T = get_turf(src)
 	if(T)

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -96,7 +96,7 @@
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/physical_attack_hand(var/mob/user)
 	update_use_power(use_power == POWER_USE_ACTIVE ? POWER_USE_IDLE : POWER_USE_ACTIVE)
-	user.visible_message("<span class='notice'>\The [user] switches \the [src] [use_power == 2 ? "on" : "off"].</span>")
+	user.visible_message("<span class='notice'>\The [user] switches \the [src] [use_power == POWER_USE_ACTIVE ? "on" : "off"].</span>")
 	update_icon()
 	return TRUE
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -40,7 +40,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 437 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 436 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 5 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
Part 1 of Sierra's Document Everything Quest

:cl: SierraKomodo
tweak: Machinery now has general codex mechanics information detailing power usage, skill requirements, silicon restrictions, and capacity for components.
/:cl:

Adds dmdocs to basically everything machinery related that needs it.