### PR TITLE
bugfixes for terminal commands

### DIFF
--- a/code/modules/modular_computers/terminal/commands/status.dm
+++ b/code/modules/modular_computers/terminal/commands/status.dm
@@ -11,6 +11,8 @@
 	skill_needed = SKILL_EXPERT
 
 /datum/terminal_command/status/proper_input_entered(text, mob/user, datum/terminal/terminal)
+	if(!terminal.computer.get_ntnet_status())
+		return network_error()
 	. = list()
 	. += "NTnet status: [ntnet_global.check_function() ? "ENABLED" : "DISABLED"]"
 	. += "Alarm status: [ntnet_global.intrusion_detection_enabled ? "ENABLED" : "DISABLED"]"

--- a/code/modules/modular_computers/terminal/terminal.dm
+++ b/code/modules/modular_computers/terminal/terminal.dm
@@ -94,4 +94,5 @@
 		if(scf.can_run(user, src))
 			candidates[scf] = scf.weight
 	var/datum/terminal_skill_fail/chosen = pickweight(candidates)
-	return chosen.execute(src)
+	if(istype(chosen))
+		return chosen.execute(src)

--- a/code/modules/modular_computers/terminal/terminal_skill_fail.dm
+++ b/code/modules/modular_computers/terminal/terminal_skill_fail.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(terminal_fails, init_subtypes(/datum/terminal_skill_fail))
 /datum/terminal_skill_fail/proc/can_run(mob/user, datum/terminal/terminal)
 	if (require_ntnet)
 		return !!terminal.computer.get_ntnet_status()
-	return FALSE
+	return TRUE
 
 /datum/terminal_skill_fail/proc/execute(datum/terminal/terminal)
 	return message
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(terminal_fails, init_subtypes(/datum/terminal_skill_fail))
 		"Voice Recognition Interface unavailable to process commands. Please enter input instead of speaking to device.",
 		"Cannot access personal folder 'XXXAdult' in NTNet Nebula Storage; service unreachable.",
 		"Unable to send new friend request to user 'SsswoleUnathi99' while a request is already pending.",
-		"Hi! It looks like you are attempting to activate a <STRING_MK87_NUCLEARSELFDESTRUCT_SYSTEM_DESCRIPTION_INFORMAL>. Would you like help?"
+		"Hi! It looks like you are attempting to activate a \<STRING_MK87_NUCLEARSELFDESTRUCT_SYSTEM_DESCRIPTION_INFORMAL\>. Would you like help?"
 	))
 	terminal.computer.audible_notification("sound/machines/ping.ogg")
 	terminal.computer.visible_notification(message)


### PR DESCRIPTION
Fixes #31073

Also fixes a skill failure string rendered incorrectly, and the status command not checking for NTNet connectivity before returning NTNet status information