### PR TITLE
Allows bucklers to be crafted, also fixes a somewhat hilarious oversight

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -32,6 +32,7 @@
 /obj/item/shield
 	name = "shield"
 	var/base_block_chance = 60
+	var/max_block = 0
 
 /obj/item/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(user.incapacitated())
@@ -64,7 +65,6 @@
 	matter = list(MATERIAL_GLASS = 7500, MATERIAL_STEEL = 1000)
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
-	var/max_block = 15
 	var/can_block_lasers = FALSE
 
 /obj/item/shield/riot/handle_shield(mob/user)
@@ -107,14 +107,15 @@
 
 /obj/item/shield/buckler
 	name = "buckler"
-	desc = "A wooden buckler used to block sharp things from entering your body back in the day.."
+	desc = "A wooden buckler used to block sharp things from entering your body back in the day. Not very good at stopping projectiles, but still better than nothing."
 	icon = 'icons/obj/weapons/melee_physical.dmi'
 	icon_state = "buckler"
 	slot_flags = SLOT_BACK
 	force = 8
 	throwforce = 8
-	base_block_chance = 60
-	throw_speed = 10
+	base_block_chance = 50
+	max_block = 15
+	throw_speed = 6
 	throw_range = 20
 	w_class = ITEM_SIZE_HUGE
 	origin_tech = list(TECH_MATERIAL = 1)
@@ -126,8 +127,11 @@
 	if(.) playsound(user.loc, 'sound/weapons/Genhit.ogg', 50, 1)
 
 /obj/item/shield/buckler/get_block_chance(mob/user, var/damage, atom/damage_source = null, mob/attacker = null)
-	if(istype(damage_source, /obj/item/projectile/bullet))
-		return 0 //No blocking bullets, I'm afraid.
+	if (istype(damage_source, /obj/item/projectile))
+		if (max_block && damage >= max_block)
+			return 0
+		else
+			return (base_block_chance / 2)
 	return base_block_chance
 
 /*

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -136,6 +136,7 @@
 	. += new/datum/stack_recipe/stick(src)
 	. += new/datum/stack_recipe/noticeboard(src)
 	. += new/datum/stack_recipe/furniture/table_frame(src)
+	. += new/datum/stack_recipe/shield(src)
 
 /material/wood/mahogany/generate_recipes(var/reinforce_material)
 	. = ..()

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -226,6 +226,14 @@
 	send_material_data = 1
 	difficulty = 0
 
+/datum/stack_recipe/shield
+	title = "Buckler"
+	result_type = /obj/item/shield/buckler
+	req_amount = 5
+	send_material_data = TRUE
+	time = 20
+	difficulty = 2
+
 /datum/stack_recipe/crossbowframe
 	title = "crossbow frame"
 	result_type = /obj/item/crossbowframe


### PR DESCRIPTION
Allows bucklers to be crafted at the cost of 5 wood and requiring trained construction, reduces the effective blocking power from 60% to 50% and also plays around with their block values to make them less capable of blocking ranged attacks.

Prior to this change a buckler could block any laser 60% of the time and never block any bullets at all, now a buckler has a 25% chance to block any ranged projectile with a force of 15 or less. 

Also fixes the buckler limb gib issue, which while it's honestly super amusing to see probably isn't the best thing to have floating around. 

🆑 Yvesza
rscadd: Bucklers can now be crafted using 5 wooden planks
balance: Bucklers can no longer cause limbs to explode
balance: Buckler block chance reduced from 60% to 50%, which is reduced to 25% when blocking projectiles. Bucklers may only block low force ranged attacks.
🆑 
