### PR TITLE
Melee accuracy bugfix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1750,14 +1750,6 @@
 		. += 15
 	if(shock_stage > 30)
 		. += 15
-	if(confused)
-		. += 15
-	if(weakened)
-		. += 15
-	if(eye_blurry)
-		. += 15
-	if(eye_blind)
-		. += 60
 
 /mob/living/carbon/human/ranged_accuracy_mods()
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -822,12 +822,14 @@ default behaviour is:
 	. = 0
 	if(incapacitated(INCAPACITATION_UNRESISTING))
 		. += 100
-	if(eye_blind)
-		. += 75
+	if(confused)
+		. += 15
+	if(weakened)
+		. += 15
 	if(eye_blurry)
 		. += 15
-	if(confused)
-		. += 30
+	if(eye_blind)
+		. += 60
 	if(MUTATION_CLUMSY in mutations)
 		. += 40
 


### PR DESCRIPTION
Fixes a bug with incorrect accuracy value calculation

🆑 Yvesza
tweak: Melee accuracy will now be correctly calculated while impaired
🆑 