### PR TITLE
Runtimes batch aug 21

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -173,7 +173,7 @@ proc/age2agedescription(age)
 		if (QDELETED(user))
 			. = DO_MISSING_USER
 			break
-		if (target_type && QDELETED(target))
+		if (target_type && (QDELETED(target) || target_type != target.type))
 			. = DO_MISSING_TARGET
 			break
 		if (user.incapacitated(incapacitation_flags))

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -353,7 +353,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/select_active_ai(mob/user, z)
 	var/list/ais = active_ais(z)
 	if(ais.len)
-		if(user)
+		if(user?.client)
 			. = input(user,"AI signals detected:", "AI selection") in ais
 		else
 			. = pick(ais)
@@ -666,7 +666,7 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 	if(perfectcopy)
 		if((O) && (original))
 			for(var/V in original.vars)
-				if(!(V in list("type","loc","locs","vars", "parent", "parent_type","verbs","ckey","key")))
+				if(!(V in list("type","loc","locs","vars", "parent", "parent_type","verbs","ckey","key", "group", "ai_holder", "natural_weapon")))
 					O.vars[V] = original.vars[V]
 	return O
 
@@ -1118,4 +1118,3 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		M.start_pulling(t)
 	else
 		step(user.pulling, get_dir(user.pulling.loc, A))
-

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -83,7 +83,7 @@
 				M.client.screen -= W
 
 /datum/storage_ui/default/on_post_remove(var/mob/user)
-	if(user.s_active)
+	if(user?.s_active)
 		user.s_active.show_to(user)
 
 /datum/storage_ui/default/on_hand_attack(var/mob/user)
@@ -92,6 +92,7 @@
 			storage.close(M)
 
 /datum/storage_ui/default/show_to(var/mob/user)
+	if(!user.client) return
 	if(user.s_active != storage)
 		for(var/obj/item/I in storage)
 			if(I.on_found(user))

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -105,7 +105,8 @@
 			if(I_DISARM, I_GRAB)
 				try_touch(M, rotting)
 			if(I_HURT)
-				if (!(M.organs_by_name[M.hand ? BP_L_HAND : BP_R_HAND].is_usable()))
+				var/obj/item/organ/external/organ_hand = M.organs_by_name[M.hand ? BP_L_HAND : BP_R_HAND]
+				if (!(organ_hand?.is_usable()))
 					to_chat(user, SPAN_WARNING("You can't use that hand."))
 					return
 				if(rotting && !reinf_material)
@@ -297,7 +298,7 @@
 				if(isScrewdriver(W))
 					to_chat(user, "<span class='notice'>You begin removing the support lines.</span>")
 					playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
-					if(!do_after(user,40,src) || !istype(src, /turf/simulated/wall) || construction_stage != 5)
+					if(!do_after(user,40,src) || construction_stage != 5)
 						return
 					construction_stage = 4
 					update_icon()
@@ -327,7 +328,7 @@
 				if(cut_cover)
 					to_chat(user, "<span class='notice'>You begin slicing through the metal cover.</span>")
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)
-					if(!do_after(user, 60, src) || !istype(src, /turf/simulated/wall) || construction_stage != 4)
+					if(!do_after(user, 60, src) || construction_stage != 4)
 						return
 					construction_stage = 3
 					update_icon()
@@ -337,7 +338,7 @@
 				if(isCrowbar(W))
 					to_chat(user, "<span class='notice'>You struggle to pry off the cover.</span>")
 					playsound(src, 'sound/items/Crowbar.ogg', 100, 1)
-					if(!do_after(user,100,src) || !istype(src, /turf/simulated/wall) || construction_stage != 3)
+					if(!do_after(user,100,src) || construction_stage != 3)
 						return
 					construction_stage = 2
 					update_icon()
@@ -347,7 +348,7 @@
 				if(isWrench(W))
 					to_chat(user, "<span class='notice'>You start loosening the anchoring bolts which secure the support rods to their frame.</span>")
 					playsound(src, 'sound/items/Ratchet.ogg', 100, 1)
-					if(!do_after(user,40,src) || !istype(src, /turf/simulated/wall) || construction_stage != 2)
+					if(!do_after(user,40,src) || construction_stage != 2)
 						return
 					construction_stage = 1
 					update_icon()
@@ -370,7 +371,7 @@
 				if(cut_cover)
 					to_chat(user, "<span class='notice'>You begin slicing through the support rods.</span>")
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)
-					if(!do_after(user,70,src) || !istype(src, /turf/simulated/wall) || construction_stage != 1)
+					if(!do_after(user,70,src) || construction_stage != 1)
 						return
 					construction_stage = 0
 					update_icon()
@@ -381,7 +382,7 @@
 				if(isCrowbar(W))
 					to_chat(user, "<span class='notice'>You struggle to pry off the outer sheath.</span>")
 					playsound(src, 'sound/items/Crowbar.ogg', 100, 1)
-					if(!do_after(user,100,src) || !istype(src, /turf/simulated/wall) || !user || !W || !T )	return
+					if(!do_after(user,100,src) || !W || !T )	return
 					if(user.loc == T && user.get_active_hand() == W )
 						to_chat(user, "<span class='notice'>You pry off the outer sheath.</span>")
 						dismantle_wall()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1135,7 +1135,7 @@
 			reset_view(null)
 	else
 		var/isRemoteObserve = 0
-		if(z_eye && client.eye == z_eye && !is_physically_disabled())
+		if(z_eye && client?.eye == z_eye && !is_physically_disabled())
 			isRemoteObserve = 1
 		else if((mRemote in mutations) && remoteview_target)
 			if(remoteview_target.stat == CONSCIOUS)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -467,7 +467,7 @@
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.species.can_shred(H))
-			visible_message(SPAN_WARNING("[user] shreds the light!"), SPAN_WARNING("You shred the light!"), SPAN_WARNING("You hear glass shattering!"))
+			H.visible_message(SPAN_WARNING("[user] shreds the light!"), SPAN_WARNING("You shred the light!"), SPAN_WARNING("You hear glass shattering!"))
 			broken()
 			return TRUE
 

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -50,7 +50,7 @@
 		to_chat(M, "It is fizzing slightly.")
 
 /obj/item/reagent_containers/food/drinks/glass2/proc/has_ice()
-	if(reagents.reagent_list.len > 0)
+	if(length(reagents?.reagent_list))
 		var/datum/reagent/R = reagents.get_master_reagent()
 		if(!((R.type == /datum/reagent/drink/ice) || ("ice" in R.glass_special))) // if it's not a cup of ice, and it's not already supposed to have ice in, see if the bartender's put ice in it
 			if(reagents.has_reagent(/datum/reagent/drink/ice, reagents.total_volume / 10)) // 10% ice by volume
@@ -59,7 +59,7 @@
 	return 0
 
 /obj/item/reagent_containers/food/drinks/glass2/proc/has_fizz()
-	if(reagents.reagent_list.len > 0)
+	if(length(reagents?.reagent_list))
 		var/datum/reagent/R = reagents.get_master_reagent()
 		if(("fizz" in R.glass_special))
 			return 1
@@ -72,7 +72,7 @@
 	return 0
 
 /obj/item/reagent_containers/food/drinks/glass2/proc/has_vapor()
-	if(reagents.reagent_list.len > 0)
+	if(length(reagents?.reagent_list))
 		if(temperature > T0C + 40)
 			return 1
 		var/datum/reagent/R = reagents.get_master_reagent()
@@ -98,7 +98,7 @@
 	if(QDELETED(src))
 		return
 	if(prob(80))
-		if(reagents.reagent_list.len > 0)
+		if(length(reagents?.reagent_list))
 			visible_message(
 				SPAN_DANGER("\The [src] shatters from the impact and spills all its contents!"),
 				SPAN_DANGER("You hear the sound of glass shattering!")
@@ -113,7 +113,7 @@
 		new /obj/item/material/shard(src.loc)
 		qdel(src)
 	else
-		if (reagents.reagent_list.len > 0)
+		if (length(reagents?.reagent_list))
 			visible_message(
 				SPAN_DANGER("\The [src] bounces and spills all its contents!"),
 				SPAN_WARNING("You hear the sound of glass hitting something.")

--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -48,7 +48,8 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode, var/mob/Alt)
 proc/process_jani_hud(var/mob/M, var/mob/Alt)
 	var/datum/arranged_hud_process/P = arrange_hud_process(M, Alt, GLOB.jani_hud_users)
 	for (var/obj/effect/decal/cleanable/dirtyfloor in view(P.Mob))
-		P.Client.images += dirtyfloor.hud_overlay
+		if(P.Client)
+			P.Client.images += dirtyfloor.hud_overlay
 
 datum/arranged_hud_process
 	var/client/Client


### PR DESCRIPTION
Unsquished until approval for easier viewing.
Commits organized by issues pertaining to a single file.

drinkingglass.dm
some reagents null guards

unsorted.dm
A client guard, visible_message call correction and fix for holodeck object duplication.
The holodeck duplication is used by admins to place mobs on the holodeck submap originals which are then copied over to the Torch holodeck when selecting the submap through the console. This has been fixed and mobs on the originals are now copied over to the holodeck for events or whatever.
One related problem is that some reference variables cause runtimes. I've added the most common vars to the blacklist (the ones usually necessary for spawning a green creature, or a faithless or any simple_animal). Since this is such a minuscule issue, depending on how admins use it, I've opted for a simpler solution that can be improved with little trouble if needed in the future.

hud.dm
client guard

life.dm
client guard

default.dm
UI removal when an item is destroyed doesn't require a user present so guard against that. 
Client guard is ideally necessary up the chain for all UI to prevent NPCs entering UI code that they don't care about, but I've patched just this one runtime for now.

wall_attacks.dm
null guard for missing limbs
There appears to be a race condition with do_after and other actions on the same object. DIsassembling a wall is done with a do_after timer which has a qdel guard, but which fails many times due to the nature of interactions like for example thermite before disassembly is done. ~This weirdly causes byond to call the deleted object's proc (which initiated the do_after) on a different type on the same tile as the now deleted object such as a plating after deleting a wall as in the runtimes~ Apparently turf can't be unreferenced. This should cover the type change due to byond's issues.

fix Baystation12#31029, fix Baystation12#31028, fix Baystation12#28935, fix Baystation12#28934, fix Baystation12#28317, fix Baystation12#28316, fix Baystation12#30287, fix Baystation12#30239, fix Baystation12#28352, fix Baystation12#28355, fix Baystation12#30620, fix Baystation12#28765,  fix Baystation12#28903, fix Baystation12#23481, fix Baystation12#23827, fix Baystation12#23686, fix Baystation12#23149, fix Baystation12#31088, fix Baystation12#30925, fix Baystation12#30144, fix Baystation12#29392, fix Baystation12#28755