### PR TITLE
Adds a terminal command that scans the network for NIDs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2426,6 +2426,7 @@
 #include "code\modules\modular_computers\terminal\commands\locate.dm"
 #include "code\modules\modular_computers\terminal\commands\lock.dm"
 #include "code\modules\modular_computers\terminal\commands\log.dm"
+#include "code\modules\modular_computers\terminal\commands\netscan.dm"
 #include "code\modules\modular_computers\terminal\commands\ping.dm"
 #include "code\modules\modular_computers\terminal\commands\prog.dm"
 #include "code\modules\modular_computers\terminal\commands\proxy.dm"

--- a/code/modules/modular_computers/terminal/commands/netscan.dm
+++ b/code/modules/modular_computers/terminal/commands/netscan.dm
@@ -1,0 +1,19 @@
+/// Scans the network for connected devices and returns their NIDs
+/datum/terminal_command/netscan
+	name = "netscan"
+	man_entry = list(
+		"Format: netscan",
+		"Scans the local network for devices and returns their NIDs."
+	)
+	pattern = "^netscan$"
+	skill_needed = SKILL_EXPERT
+
+/datum/terminal_command/netscan/proper_input_entered(text, mob/user, datum/terminal/terminal)
+	if (!ntnet_global || !terminal.computer.get_ntnet_status())
+		return network_error()
+	. = list("Broadcast-pinging local network...")
+	for (var/nid in ntnet_global.registered_nids)
+		var/datum/extension/interactive/ntos/comp = ntnet_global.get_os_by_nid(nid)
+		if (comp && comp.get_ntnet_status_incoming())
+			. += "NID [nid]"
+	. += "Found [length(.) - 1] responding devices."


### PR DESCRIPTION
🆑 Hubblenaut
rscadd: Adds a new terminal command which lets the user scan the network for connected devices.
/:cl:

Since computers can now only be pinged when turned on, this will make finding valid network targets a lot easier.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->