### PR TITLE
Fixes tape recorder printouts not using the correct icon state

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -348,8 +348,9 @@
 		if (findtextEx(printedmessage,"*",1,2)) //replace action sounds
 			printedmessage = "\[[time2text(mytape.timestamp[i]*10,"mm:ss")]\] (Unrecognized sound)"
 		t1 += "[printedmessage]<BR>"
-	P.info = t1
-	P.SetName("Transcript")
+	P.set_content(t1, "Transcript", FALSE)
+	usr.put_in_hands(P)
+	playsound(src, "sound/machines/dotprinter.ogg", 30)
 	canprint = 0
 	sleep(300)
 	canprint = 1
@@ -496,7 +497,7 @@
 		var/index = text2num(href_list["cut_after"])
 		if(index >= timestamp.len)
 			return
-		
+
 		to_chat(user, "<span class='notice'>You remove part of the tape off.</span>")
 		get_loose_tape(user, index)
 		cut(user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -64,11 +64,10 @@
 		log_debug("[src] ([type]) initialized with invalid or missing language `[old_language]` defined.")
 		set_language(LANGUAGE_HUMAN_EURO, TRUE)
 
-/obj/item/paper/proc/set_content(text,title)
+/obj/item/paper/proc/set_content(text, title, parse_pencode = TRUE)
 	if(title)
 		SetName(title)
-	info = html_encode(text)
-	info = parsepencode(text)
+	info = parse_pencode ? parsepencode(text) : text
 	update_icon()
 	update_space(info)
 	updateinfolinks()


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Tape recoder printouts will now have the correct sprite.
tweak: Tape recorder printouts now spawn in your free hand if possible.
soundadd: Tape recorders now have a printing sound.
/:cl:

Also got rid of a redundant line of code in `paper.dm`.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->