### PR TITLE
Fixes xenobotany breaking after x number of seeds modified

### DIFF
--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -81,6 +81,7 @@ PROCESSING_SUBSYSTEM_DEF(plants)
 /datum/controller/subsystem/processing/plants/proc/create_random_seed(var/survive_on_station)
 	var/datum/seed/seed = new()
 	seed.randomize()
+	seed.uid = seeds.len + 1
 	seed.name = "[seed.uid]"
 	seeds[seed.name] = seed
 


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: After a certain number of modified seeds created, every newly modified seed would overwrite all seeds created afterward, effectively limiting xenobotany in the number of seeds that can be modified before the entire system breaks. This is now fixed.
/:cl:

Fixes #31079

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->