### PR TITLE
Fix mobs not breaking through turfs when attacking

### DIFF
--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -63,7 +63,7 @@
 			// Nudge them a bit, maybe they can shoot next time.
 			var/turf/T = get_step(holder, pick(GLOB.cardinal))
 			if (T)
-				holder.IMove(get_dir(holder, T)) // IMove() will respect movement cooldown.
+				holder.IMove(get_step_towards(holder, T)) // IMove() will respect movement cooldown.
 				holder.face_atom(target)
 			ai_log("engage_target() : Could not safely fire at target. Exiting.", AI_LOG_DEBUG)
 			return

--- a/code/modules/ai/ai_holder_movement.dm
+++ b/code/modules/ai/ai_holder_movement.dm
@@ -125,7 +125,7 @@
 		var/turf/T = src.path[1]
 		T.overlays -= path_overlay
 
-	if (holder.IMove(get_dir(holder, src.path[1])) != MOVEMENT_ON_COOLDOWN)
+	if (holder.IMove(get_step_towards(holder, src.path[1])) != MOVEMENT_ON_COOLDOWN)
 		if (holder.loc != src.path[1])
 			ai_log("move_once() : Failed step. Exiting.", AI_LOG_TRACE)
 			return MOVEMENT_FAILED
@@ -152,7 +152,7 @@
 			var/moving_to = 0 // Apparently this is required or it always picks 4, according to the previous developer for simplemob AI.
 			moving_to = pick(GLOB.cardinal)
 			holder.set_dir(moving_to)
-			holder.IMove(moving_to)
+			holder.IMove(get_step(holder, moving_to))
 			wander_delay = base_wander_delay
 	ai_log("handle_wander_movement() : Exited.", AI_LOG_TRACE)
 

--- a/code/modules/ai/interfaces.dm
+++ b/code/modules/ai/interfaces.dm
@@ -72,14 +72,12 @@
 
 // Respects move cooldowns as if it had a client.
 // Also tries to avoid being superdumb with moving into certain tiles (unless that's desired).
-/mob/living/proc/IMove(dir, safety = TRUE)
+/mob/living/proc/IMove(turf/newloc, safety = TRUE)
 
-	var/turf/newloc
-	if (istype(dir, /turf))
-		newloc = dir
-		dir = get_dir(src, dir)
-	else
-		newloc = get_step(src, dir)
+	if (!newloc)
+		return MOVEMENT_FAILED
+
+	var/dir = get_dir(src, newloc)
 
 	if (!checkMoveCooldown())
 		return MOVEMENT_ON_COOLDOWN


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed mobs not trying to break through solid turfs when attacking a target.
/:cl:

Also did some small cleanup to the `IMove()` proc, now it just takes turfs as input instead of either turfs or directions.