### PR TITLE
Extends running into things when confused

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -625,3 +625,8 @@ its easier to just keep the beam vertical.
 
 /atom/proc/get_cell()
 	return
+
+/atom/proc/slam_into(mob/living/L)
+	L.Weaken(2)
+	L.visible_message(SPAN_WARNING("\The [L] [pick("ran", "slammed")] into \the [src]!"))
+	playsound(L, "punch", 25, 1, FALSE)

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -65,6 +65,14 @@
 	START_PROCESSING(SSobj, src)
 	return TRUE
 
+/obj/structure/adherent_bath/slam_into(mob/living/L)
+	L.forceMove(src)
+	occupant = L
+	L.Weaken(2)
+	L.visible_message(SPAN_WARNING("\The [L] falls into \the [src]!"))
+	playsound(L, "punch", 25, 1, FALSE)
+	START_PROCESSING(SSobj, src)
+
 /obj/structure/adherent_bath/attack_hand(var/mob/user)
 	eject_occupant()
 
@@ -84,7 +92,7 @@
 	enter_bath(O, user)
 
 /obj/structure/adherent_bath/relaymove(var/mob/user)
-	if(user == occupant)
+	if (!user.incapacitated() && (user == occupant))
 		eject_occupant()
 
 /obj/structure/adherent_bath/Process()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -171,7 +171,6 @@
 				if (density)
 					overlays += image(icon, "_mcorneroverlay1", pixel_x = pix_offset_x, pixel_y = pix_offset_y, layer = ABOVE_HUMAN_LAYER)
 
-
 /obj/structure/railing/verb/flip() // This will help push railing to remote places, such as open space turfs
 	set name = "Flip Railing"
 	set category = "Object"
@@ -292,9 +291,9 @@
 
 /obj/structure/railing/can_climb(var/mob/living/user, post_climb_check=FALSE, check_silicon=TRUE)
 	. = ..()
-	if(. && get_turf(user) == get_turf(src))
+	if (. && get_turf(user) == get_turf(src))
 		var/turf/T = get_step(src, src.dir)
-		if(T.turf_is_crowded(user))
+		if (T.density || T.turf_is_crowded(user))
 			to_chat(user, "<span class='warning'>You can't climb there, the way is blocked.</span>")
 			return 0
 
@@ -306,6 +305,18 @@
 
 	user.jump_layer_shift()
 	addtimer(CALLBACK(user, /mob/living/proc/jump_layer_shift_end), 2)
+
+/obj/structure/railing/slam_into(mob/living/L)
+	var/turf/target_turf = get_turf(src)
+	if (target_turf == get_turf(L))
+		target_turf = get_step(src, dir)
+	if (!target_turf.density && !target_turf.turf_is_crowded(L))
+		L.forceMove(target_turf)
+		L.visible_message(SPAN_WARNING("\The [L] [pick("falls", "flies")] over \the [src]!"))
+		L.Weaken(2)
+		playsound(L, 'sound/effects/grillehit.ogg', 25, 1, FALSE)
+	else
+		..()
 
 /obj/structure/railing/set_color(color)
 	src.color = color ? color : material.icon_colour

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -139,12 +139,9 @@ default behaviour is:
 		spawn(0)
 			..()
 			var/saved_dir = AM.dir
+			if ((confused || (MUTATION_CLUMSY in mutations)) && !MOVING_DELIBERATELY(src))
+				AM.slam_into(src)
 			if (!istype(AM, /atom/movable) || AM.anchored)
-				if(confused && prob(50) && !MOVING_DELIBERATELY(src))
-					Weaken(2)
-					playsound(loc, "punch", 25, 1, -1)
-					visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [AM]!</span>")
-					src.apply_damage(5, BRUTE)
 				return
 			if (!now_pushing)
 				now_pushing = 1

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -206,9 +206,9 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 
 // attempt to move while inside
 /obj/machinery/disposal/relaymove(mob/user as mob)
-	if(user.stat || src.flushing)
+	if (user.incapacitated() || src.flushing)
 		return
-	if(user.loc == src)
+	if (user.loc == src)
 		src.go_out(user)
 	return
 
@@ -479,6 +479,12 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 		return 0
 	else
 		return ..(mover, target, height, air_group)
+
+/obj/machinery/disposal/slam_into(mob/living/L)
+	L.forceMove(src)
+	L.Weaken(5)
+	L.visible_message(SPAN_WARNING("\The [L] falls into \the [src]!"))
+	playsound(L, "punch", 25, 1, FALSE)
 
 /obj/machinery/disposal_switch
 	name = "disposal switch"


### PR DESCRIPTION
🆑 Hubblenaut
tweak: When confused or being clumsy, you will now fall over railings, into disposal bins, mineral baths or slam into objects and walls when sprinting.
tweak: You can't get out of disposal bins or mineral baths when you're incapacitated.
bugfix: No longer phasing through walls using railings.
/:cl:

Extended slamming into things to its own proc `slam_into(mob/living/L)`, which can be overriden by subtypes as necessary.
It will be called on anything solid you run in to while being confused or being clumsy.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->