### PR TITLE
TRIPLES flare fuel for dramatic flares

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -260,7 +260,7 @@
 
 /obj/item/device/flashlight/flare/Initialize()
 	. = ..()
-	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.v
+	fuel = rand(4 MINUTES, 5 MINUTES) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.v
 	update_icon()
 
 /obj/item/device/flashlight/flare/Destroy()


### PR DESCRIPTION
Are you me? Do you hate how short a time flares burn before they go out? Do you long for dramatic, bright-red, throwable lighting that ISN'T a nerdy glowstick?

Huh. Thought it was just me.

Anyways. I tripled flare fuel.

🆑 
tweak: Throwable flares last three times as long.
/🆑 