### PR TITLE
Gives the mercship icy koolaid

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1863,6 +1863,7 @@
 /obj/item/reagent_containers/glass/bottle/dexalin,
 /obj/item/reagent_containers/glass/bottle/kelotane,
 /obj/item/reagent_containers/glass/bottle/kelotane,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_shuttle)
 "uM" = (


### PR DESCRIPTION
APPARENTLY the Cyclopes didn't have cryo fluid for the cryo tube, and _NOBODY_ told me.

🆑 
maptweak: The mercship finally has cryo juice in the medical locker.
/🆑 