### PR TITLE
Disambiguate some artifact triggers

### DIFF
--- a/code/modules/xenoarcheaology/triggers/chemical.dm
+++ b/code/modules/xenoarcheaology/triggers/chemical.dm
@@ -4,6 +4,7 @@
 
 /datum/artifact_trigger/chemical/New()
 	if(isnull(required_chemicals))
+		name = "presence of either an acid, toxin, or water"
 		required_chemicals = list(pick(/datum/reagent/acid, /datum/reagent/toxin, /datum/reagent/water))
 
 /datum/artifact_trigger/chemical/on_hit(obj/O, mob/user)

--- a/code/modules/xenoarcheaology/triggers/gas.dm
+++ b/code/modules/xenoarcheaology/triggers/gas.dm
@@ -5,7 +5,10 @@
 
 /datum/artifact_trigger/gas/New()
 	if(!gas_needed)
-		gas_needed = list(pick(gas_data.gases) = rand(1,10))
+		//pick from the subtypes traits if we don't spawn as one
+		var/gas = pick(GAS_CO2, GAS_OXYGEN, GAS_NITROGEN, GAS_PHORON)
+		name = "concentration of [gas]"
+		gas_needed = list("[gas]" = 5)
 
 /datum/artifact_trigger/gas/on_gas_exposure(datum/gas_mixture/gas)
 	. = TRUE

--- a/code/modules/xenoarcheaology/triggers/temperature.dm
+++ b/code/modules/xenoarcheaology/triggers/temperature.dm
@@ -9,6 +9,13 @@
 		min_temp = rand(T0C - 100, T0C + 200)
 		max_temp = min_temp + rand(10, 30)
 
+		if (max_temp < T20C)
+			name = "low temperature"
+		else if (min_temp > T20C)
+			name = "high temperature"
+		else
+			name = "room temperature"
+
 /datum/artifact_trigger/temperature/on_gas_exposure(datum/gas_mixture/gas)
 	return gas.temperature >= min_temp && gas.temperature <= max_temp
 


### PR DESCRIPTION
:cl: Mucker
tweak: Tweaked some artifact effect triggers to ensure they are always usable and not ambiguous.
/:cl:

Tweaks the gas, temperature, and chemical triggers. 

Gas triggers could sometimes spawn as a random gas picked from the global list of gasses, and it wouldn't update the name to say what gas that was, leaving the player the only option of trying every single gas they can find (not fun!).

The temperature trigger was unchanged, except now it'll always tell you if it needs a high or low temperature, with 'room temperature' (20C) as a base.

Chemical triggers will tell you your options if it picks the generic subtype.

The purpose of all this is to avoid giving the player unknown or very hard to activate triggers so that the artifact's effects can be more often seen and interacted with.