### PR TITLE
IC minor tweaks and some maintenance

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -66,10 +66,10 @@
 #define STAGE_SUPER	11
 
 // NanoUI flags
-#define STATUS_INTERACTIVE 2 // GREEN Visability
-#define STATUS_UPDATE 1 // ORANGE Visability
-#define STATUS_DISABLED 0 // RED Visability
 #define STATUS_CLOSE -1 // Close the interface
+#define STATUS_DISABLED 0 // RED Visability
+#define STATUS_UPDATE 1 // ORANGE Visability
+#define STATUS_INTERACTIVE 2 // GREEN Visability
 
 /*
  *	Atmospherics Machinery.

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -162,12 +162,13 @@
 /obj/item/melee/energy/sword/purple
 	blade_color = "purple"
 
-/obj/item/melee/energy/sword/dropped(var/mob/user)
+/obj/item/melee/energy/sword/dropped(mob/user)
 	..()
 	if(!istype(loc,/mob))
 		deactivate(user)
 
-/obj/item/melee/energy/sword/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+/obj/item/melee/energy/sword/handle_shield(mob/user, damage, atom/damage_source = null, mob/attacker = null, def_zone = null, attack_text = "the attack")
+	. = ..()
 	if(.)
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 		spark_system.set_up(5, 0, user.loc)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -25,9 +25,9 @@
 	var/creator // circuit creator if any
 	var/static/next_assembly_id = 0
 	var/interact_page = 0
-	var/components_per_page = 5
+	var/components_per_page = 10
 	/// Spark system used for creating sparks while the assembly is damaged and destroyed.
-	var/datum/effect/effect/system/spark_spread/spark_system	
+	var/datum/effect/effect/system/spark_spread/spark_system
 	var/adrone = FALSE
 	health = 30
 	pass_flags = 0
@@ -68,7 +68,7 @@
 			to_chat(user, SPAN_DANGER("\The [src] is covered in dents and punctured in several places."))
 		if(0.25 to 0.5)
 			to_chat(user, SPAN_DANGER("\The [src] looks seriously damaged!"))
-		else	
+		else
 			to_chat(user, SPAN_WARNING("\The [src] is barely holding together!"))
 
 	if((isobserver(user) && ckeys_allowed_to_scan[user.ckey]) || check_rights(R_ADMIN, 0, user))

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -645,13 +645,20 @@
 	controlling = null
 
 
-/obj/item/integrated_circuit/manipulation/ai/attackby(var/obj/item/I, var/mob/user)
+/obj/item/integrated_circuit/manipulation/ai/attackby(obj/item/I, mob/user)
 	if(is_type_in_list(I, list(/obj/item/aicard, /obj/item/device/paicard, /obj/item/device/mmi)))
 		load_ai(user, I)
 	else return ..()
 
 /obj/item/integrated_circuit/manipulation/ai/attack_self(user)
 	unload_ai()
+
+/obj/item/integrated_circuit/manipulation/ai/contents_nano_distance(src_object, mob/living/user)
+	if(istype(src_object, /obj/item/device/electronic_assembly))
+		var/obj/item/device/electronic_assembly/assembly = src_object
+		if(src in assembly.assembly_components)
+			return STATUS_INTERACTIVE
+	return ..()
 
 /obj/item/integrated_circuit/manipulation/ai/Destroy()
 	unload_ai()

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -60,10 +60,10 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 	return STATUS_CLOSE
 
 //Some atoms such as vehicles might have special rules for how mobs inside them interact with NanoUI.
-/atom/proc/contents_nano_distance(var/src_object, var/mob/living/user)
+/atom/proc/contents_nano_distance(src_object, mob/living/user)
 	return user.shared_living_nano_distance(src_object)
 
-/mob/living/proc/shared_living_nano_distance(var/atom/movable/src_object)
+/mob/living/proc/shared_living_nano_distance(atom/movable/src_object)
 	if (!(src_object in view(4, src))) 	// If the src object is not visable, disable updates
 		return STATUS_CLOSE
 


### PR DESCRIPTION
🆑 Nirnael
bugfix: pAIs/MMIs/AIs inside IC drones can again access the drone's inputs through the Control Inputs verb.
tweak: Increased IC editor interface lines to 10 per page.
/:cl:

Some code maintenance, interaction fix for players inside ICs and a buff to IC assembly list size to 10 per page because complex IC assemblies can get into the 7-10 pages and it's not fun going through them all. This halves the pages and any balancing that might be done through this page lines control is probably irrelevant. The whole editor should be modernized, but anyway.