### PR TITLE
no legacy jumpsuit in torch bomb closet

### DIFF
--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -162,3 +162,9 @@
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/security, /obj/item/storage/backpack/satchel/sec)),
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/sec, /obj/item/storage/backpack/messenger/sec))
 	)
+
+/obj/structure/closet/bombclosetsecurity/WillContain()
+	return list(
+		/obj/item/clothing/suit/bomb_suit/security,
+		/obj/item/clothing/head/bomb_hood/security
+	)


### PR DESCRIPTION
:cl:
tweak: The ancient red NT security jumpsuit doesn't spawn in the brig bomb suit locker anymore.
/:cl:
