### PR TITLE
Add master list of ignored revisions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,25 @@
+# git blame master ignore list.
+#
+# This file contains a list of git hashes of revisions to be ignored by git
+# blame. These revisions are considered "unimportant" in that they
+# are unlikely to be what you are interested in when blaming.
+#
+# Requires git 2.23 or later (or equivalent)
+# To enable execute: git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Instructions:
+# - Only large (generally automated) reformatting or renaming CLs should be
+#   added to this list. Do not put things here just because you feel they are
+#   trivial or unimportant. If in doubt, do not put it on this list.
+# - Precede each revision with a comment containing the first line of its log.
+#   For bulk work over many commits, place all commits in a block with a single
+#   comment at the top describing the work done in those commits.
+# - Only put full 40-character hashes on this list (not short hashes or any
+#   other revision reference).
+# - Append to the bottom of the file (revisions should be in chronological order
+#   from oldest to newest).
+# - Because you must use a hash, you need to append to this list in a follow-up
+#   CL to the actual reformatting CL that you are trying to ignore.
+
+# Major whitespace changes but nothing else
+bfa20cdc17d1794969331c4272c4a8d7ad523a44


### PR DESCRIPTION
Allegedly adding `"gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]` to `.vscode\settings.json` also allows the GitLens extension for Visual Studio Code to utilize the ignore file but I couldn't get it to work.

Does appear to work when using the standard git blame command.

May eventually be supported natively on GitHub - Or at least there is a community request to add support.