### PR TITLE
Add VSCode settings to ignore revisions in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,7 +5,7 @@
 # are unlikely to be what you are interested in when blaming.
 #
 # Requires git 2.23 or later (or equivalent)
-# To enable execute: git config blame.ignoreRevsFile .git-blame-ignore-revs
+# To enable, execute: git config blame.ignoreRevsFile .git-blame-ignore-revs
 #
 # Instructions:
 # - Only large (generally automated) reformatting or renaming CLs should be
@@ -22,4 +22,6 @@
 #   CL to the actual reformatting CL that you are trying to ignore.
 
 # Major whitespace changes but nothing else
+51e1a662317e4fc5f4048bbd19375e46187dd91b
+bf996203dfc4b09f8dc4dd73b532f9ee49691776
 bfa20cdc17d1794969331c4272c4a8d7ad523a44

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,9 @@
 	"files.insertFinalNewline": true,
 	"files.trimFinalNewlines": true,
 	"files.trimTrailingWhitespace": true,
-	"gitblame.commitUrl": "https://github.com/baystation12/baystation12/commit/${hash}"
+	"gitblame.commitUrl": "https://github.com/baystation12/baystation12/commit/${hash}",
+	"gitlens.advanced.blame.customArguments": [
+		"--ignore-revs-file",
+		".git-blame-ignore-revs"
+	]
 }


### PR DESCRIPTION
The reason I previously couldn't seem to get the GitLens settings to work was because I didn't realize that there were multiple commits that had major whitespace changes.
This has now been corrected.

In case anyone is interested, I borrowed the header in `.git-blame-ignore-revs` from https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/.git-blame-ignore-revs