### PR TITLE
Standardized health fixes

### DIFF
--- a/code/datums/extensions/health/atom.dm
+++ b/code/datums/extensions/health/atom.dm
@@ -262,11 +262,11 @@
 		to_chat(user, SPAN_DANGER("It looks broken."))
 		return
 
-	var/health_percentage = get_damage_percentage()
-	switch (health_percentage)
-		if (1)
+	var/damage_percentage = get_damage_percentage()
+	switch (damage_percentage)
+		if (0.00)
 			to_chat(user, SPAN_NOTICE("It looks fully intact."))
-		if (0.66 to 0.99)
+		if (0.01 to 0.32)
 			to_chat(user, SPAN_WARNING("It looks slightly damaged."))
 		if (0.33 to 0.65)
 			to_chat(user, SPAN_WARNING("It looks moderately damaged."))
@@ -280,11 +280,11 @@
 		to_chat(user, SPAN_DANGER("They look severely hurt and is not moving or responding to anything around them."))
 		return
 
-	var/health_percentage = get_damage_percentage()
-	switch (health_percentage)
-		if (1)
+	var/damage_percentage = get_damage_percentage()
+	switch (damage_percentage)
+		if (0.00)
 			to_chat(user, SPAN_NOTICE("They appear unhurt."))
-		if (0.66 to 0.99)
+		if (0.01 to 0.32)
 			to_chat(user, SPAN_WARNING("They look slightly hurt."))
 		if (0.33 to 0.65)
 			to_chat(user, SPAN_WARNING("They look moderately hurt."))

--- a/code/datums/extensions/health/atom.dm
+++ b/code/datums/extensions/health/atom.dm
@@ -1,5 +1,5 @@
 /atom
-	/// Whether or not the atom should use the health handler when initialized.
+	/// Whether or not the atom should use the health handler when initialized. If set to `USE_HEALTH_SIMPLE`, uses the simple health system.
 	var/use_health_handler = FALSE
 	/// Ease-of-use holder for the health extension.
 	var/datum/extension/health/health_handler
@@ -160,7 +160,7 @@
 	return FALSE
 
 /**
- * Restore's the atom's health by the given value.
+ * Restore's the atom's health by the given value. Returns `TRUE` if the restoration resulted in a death state change.
  * If using the `damage_sources` extension subtype, will only restore damage from the given damage type.
  * Override only for modifying damage. Do not override to apply additional effects - Use `post_restore_health()` instead.
  */
@@ -173,7 +173,7 @@
 	return health_handler.adjust_health(damage, damage_type)
 
 /**
- * Damage's the atom's health by the given value.
+ * Damage's the atom's health by the given value. Returns `TRUE` if the damage resulted in a death state change.
  * If using the `damage_sources` extension subtype, will apply damage to the given damage type.
  * Override only for modifying damage. Do not override to apply additional effects - Use `post_damage_health()` instead.
  */

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -55,7 +55,7 @@
 
 /obj/effect/blob/on_update_icon()
 	switch (get_damage_percentage())
-		if (0.50 to 1.00)
+		if (0.00 to 0.49)
 			icon_state = "blob"
 		else
 			icon_state = "blob_damaged"
@@ -227,7 +227,7 @@ regen() will cover update_icon() for this proc
 */
 /obj/effect/blob/core/proc/process_core_health()
 	switch (get_damage_percentage())
-		if (0.75 to 1.00)
+		if (0.00 to 0.24)
 			if (core_health_state == 4)
 				return
 			core_health_state = 4
@@ -240,7 +240,7 @@ regen() will cover update_icon() for this proc
 			times_to_pulse = 4
 			if(reported_low_damage)
 				report_shield_status("high")
-		if (0.50 to 0.74)
+		if (0.25 to 0.49)
 			if (core_health_state == 3)
 				return
 			core_health_state = 3
@@ -251,7 +251,7 @@ regen() will cover update_icon() for this proc
 			attack_freq = 4
 			regen_rate = 3
 			times_to_pulse = 3
-		if (0.34 to 0.49)
+		if (0.35 to 0.74)
 			if (core_health_state == 2)
 				return
 			core_health_state = 2
@@ -286,9 +286,9 @@ regen() will cover update_icon() for this proc
 // Rough icon state changes that reflect the core's health
 /obj/effect/blob/core/on_update_icon()
 	switch (get_damage_percentage())
-		if(0.66 to 1.00)
+		if(0.00 to 0.32)
 			icon_state = "blob_core"
-		if(0.33 to 0.66)
+		if(0.33 to 0.65)
 			icon_state = "blob_node"
 		else
 			icon_state = "blob_factory"
@@ -329,7 +329,7 @@ regen() will cover update_icon() for this proc
 
 /obj/effect/blob/core/secondary/on_update_icon()
 	switch (get_damage_percentage())
-		if (0.50 to 1.00)
+		if (0.00 to 0.49)
 			icon_state = "blob_node"
 		else
 			icon_state = "blob_factory"
@@ -360,7 +360,7 @@ regen() will cover update_icon() for this proc
 
 /obj/effect/blob/shield/on_update_icon()
 	switch (get_damage_percentage())
-		if (0.66 to 1.00)
+		if (0.00 to 0.32)
 			icon_state = "blob_idle"
 		if (0.33 to 0.65)
 			icon_state = "blob"


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Examining objects using standardized health now displays the correct damage hint text.
bugfix: Blobs now show the correct damage state sprite instead of being inverted.
/:cl:

Also tweaks some dmdocs.