### PR TITLE
Apply standardized health to items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -7,7 +7,6 @@
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/randpixel = 6
 	var/r_speed = 1.0
-	var/health = null
 	var/burn_point = null
 	var/burning = null
 	var/hitsound = "swing_hit"

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -4,7 +4,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "handcuff"
-	health = 0
+	use_health_handler = USE_HEALTH_SIMPLE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
 	throwforce = 5
@@ -18,14 +18,6 @@
 	var/breakouttime = 1200 //Deciseconds = 120s = 2 minutes
 	var/cuff_sound = 'sound/weapons/handcuffs.ogg'
 	var/cuff_type = "handcuffs"
-
-/obj/item/handcuffs/examine(mob/user)
-	. = ..()
-	if (health)
-		var display = health / initial(health) * 100
-		if (display > 66)
-			return
-		to_chat(user, SPAN_WARNING("They look [display < 33 ? "badly ": ""]damaged."))
 
 /obj/item/handcuffs/get_icon_state(mob/user_mob, slot)
 	if(slot == slot_handcuffed_str)
@@ -141,7 +133,12 @@ var/last_chew = 0
 	cuff_sound = 'sound/weapons/cablecuff.ogg'
 	cuff_type = "cable restraints"
 	elastic = 1
-	health = 75
+	use_health_handler = USE_HEALTH_SIMPLE
+
+/obj/item/handcuffs/cable/get_initial_health_handler_config()
+	return list(
+		"max_health" = 75
+	)
 
 /obj/item/handcuffs/cable/red
 	color = COLOR_MAROON
@@ -178,4 +175,8 @@ var/last_chew = 0
 	icon = 'icons/obj/bureaucracy.dmi'
 	breakouttime = 200
 	cuff_type = "duct tape"
-	health = 50
+
+/obj/item/handcuffs/cable/tape/get_initial_health_handler_config()
+	return list(
+		"max_health" = 50
+	)

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -27,7 +27,7 @@
 		overlays |= image('icons/obj/objects.dmi',"ashtray_half")
 
 /obj/item/material/ashtray/attackby(obj/item/W as obj, mob/user as mob)
-	if (health <= 0)
+	if (!is_alive())
 		return
 	if (istype(W,/obj/item/trash/cigbutt) || istype(W,/obj/item/clothing/mask/smokable/cigarette) || istype(W, /obj/item/flame/match))
 		if (contents.len >= max_butts)
@@ -48,21 +48,16 @@
 			update_icon()
 	else
 		..()
-		health = max(0,health - W.force)
-		if (health < 1)
-			shatter()
+		damage_health(W.force)
 
 /obj/item/material/ashtray/throw_impact(atom/hit_atom)
-	if (health > 0)
-		health = max(0,health - 3)
+	if (has_health())
 		if (contents.len)
 			visible_message("<span class='danger'>\The [src] slams into [hit_atom], spilling its contents!</span>")
 			for (var/obj/O in contents)
 				O.dropInto(loc)
 			remove_extension(src, /datum/extension/scent)
-		if (health < 1)
-			shatter()
-			return
+		damage_health(3)
 		update_icon()
 	return ..()
 

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -2,12 +2,12 @@
 // This class of weapons takes force and appearance data from a material datum.
 // They are also fragile based on material data and many can break/smash apart.
 /obj/item/material
-	health = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	gender = NEUTER
 	throw_speed = 3
 	throw_range = 7
 	w_class = ITEM_SIZE_NORMAL
+	use_health_handler = USE_HEALTH_SIMPLE
 
 	var/default_material = MATERIAL_STEEL
 	var/material/material
@@ -24,6 +24,12 @@
 	var/unbreakable
 	var/drops_debris = 1
 	var/worth_multiplier = 1
+
+/obj/item/material/get_initial_health_handler_config()
+	return list(
+		"max_health" = 10
+	)
+
 
 /obj/item/material/New(var/newloc, var/material_key)
 	if(!material_key)
@@ -67,7 +73,8 @@
 	if(!material)
 		qdel(src)
 	else
-		health = round(material.integrity/5)
+		set_max_health(round(material.integrity / 5))
+		restore_health(get_max_health())
 		if(material.products_need_process())
 			START_PROCESSING(SSobj, src)
 		if(material.conductive)
@@ -105,19 +112,19 @@
 /obj/item/material/proc/check_shatter()
 	if(!unbreakable && prob(material.hardness))
 		if(material.is_brittle())
-			health = 0
+			kill_health()
 		else
-			health--
-		check_health()
+			damage_health(1)
 
-/obj/item/material/proc/check_health(var/consumed)
-	if(health<=0)
-		shatter(consumed)
+/obj/item/material/handle_death_change(new_death_state)
+	. = ..()
+	if (new_death_state)
+		shatter()
 
-/obj/item/material/proc/shatter(var/consumed)
+/obj/item/material/proc/shatter()
 	var/turf/T = get_turf(src)
 	T.visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")
 	playsound(src, "shatter", 70, 1)
-	if(!consumed && drops_debris)
+	if(drops_debris)
 		material.place_shard(T)
 	qdel(src)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -2,8 +2,13 @@
 	name = "inflatable"
 	w_class = ITEM_SIZE_NORMAL
 	icon = 'icons/obj/inflatable.dmi'
+	use_health_handler = USE_HEALTH_SIMPLE
 	var/deploy_path = null
-	var/inflatable_health
+
+/obj/item/inflatable/get_initial_health_handler_config()
+	return list(
+		"max_health" = 10
+	)
 
 /obj/item/inflatable/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!deploy_path)
@@ -41,8 +46,7 @@
 	var/obj/structure/inflatable/R = new deploy_path(T)
 	transfer_fingerprints_to(R)
 	R.add_fingerprint(user)
-	if(inflatable_health)
-		R.health = inflatable_health
+	copy_health(src, R)
 	qdel(src)
 
 /obj/item/inflatable/wall
@@ -67,13 +71,18 @@
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"
 	atmos_canpass = CANPASS_DENSITY
+	use_health_handler = USE_HEALTH_SIMPLE
 
 	var/undeploy_path = null
-	var/health = 10
 	var/taped
 
 	var/max_pressure_diff = RIG_MAX_PRESSURE
 	var/max_temp = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/obj/structure/inflatable/get_initial_health_handler_config()
+	return list(
+		"max_health" = 10
+	)
 
 /obj/structure/inflatable/wall
 	name = "inflatable wall"
@@ -110,28 +119,24 @@
 		max_local_temp = max(max_local_temp, env.temperature)
 
 	if(prob(50) && (max_pressure - min_pressure > max_pressure_diff || max_local_temp > max_temp))
-		take_damage(1)
-		if(health == round(0.7*initial(health)))
-			visible_message(SPAN_WARNING("\The [src] is taking damage!"))
-		if(health == round(0.3*initial(health)))
+		var/initial_damage_percentage = get_damage_percentage()
+		damage_health(1)
+		var/damage_percentage = get_damage_percentage()
+		if (damage_percentage >= 0.7 && initial_damage_percentage < 0.7)
 			visible_message(SPAN_WARNING("\The [src] is barely holding up!"))
+		else if (damage_percentage >= 0.3 && initial_damage_percentage < 0.3)
+			visible_message(SPAN_WARNING("\The [src] is taking damage!"))
 
 /obj/structure/inflatable/examine(mob/user)
 	. = ..()
-	if(health >= initial(health))
-		to_chat(user, SPAN_NOTICE("It's undamaged."))
-	else if(health >= 0.5 * initial(health))
-		to_chat(user, SPAN_WARNING("It's showing signs of damage."))
-	else if(health >= 0)
-		to_chat(user, SPAN_DANGER("It's heavily damaged!"))
-	to_chat(user, SPAN_NOTICE("It's been duct taped in few places."))
+	if (taped)
+		to_chat(user, SPAN_NOTICE("It's been duct taped in few places."))
 
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 0
 
 /obj/structure/inflatable/bullet_act(var/obj/item/projectile/Proj)
-	take_damage(Proj.get_structure_damage())
-	if(health <= 0)
+	if (damage_health(Proj.get_structure_damage(), Proj.damage_type))
 		return PROJECTILE_CONTINUE
 
 /obj/structure/inflatable/ex_act(severity)
@@ -154,14 +159,14 @@
 /obj/structure/inflatable/attackby(obj/item/W, mob/user)
 	if(!istype(W) || istype(W, /obj/item/inflatable_dispenser)) return
 
-	if(istype(W, /obj/item/tape_roll) && health < initial(health) - 3)
+	if(istype(W, /obj/item/tape_roll) && get_damage_value() >= 3)
 		if(taped)
 			to_chat(user, SPAN_NOTICE("\The [src] can't be patched any more with \the [W]!"))
 			return TRUE
 		else
 			taped = TRUE
 			to_chat(user, SPAN_NOTICE("You patch some damage in \the [src] with \the [W]!"))
-			take_damage(-3)
+			restore_health(3)
 			return TRUE
 	else if((W.damtype == BRUTE || W.damtype == BURN) && (W.can_puncture() || W.force > 10))
 		..()
@@ -170,15 +175,14 @@
 	return
 
 /obj/structure/inflatable/proc/hit(var/damage, var/sound_effect = 1)
-	take_damage(damage)
 	if(sound_effect)
 		playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
-	return health <= 0
+	return damage_health(damage)
 
-/obj/structure/inflatable/take_damage(damage)
-	health = max(0, health - damage)
-	if(health <= 0)
-		deflate(1)
+/obj/structure/inflatable/handle_death_change(new_death_state)
+	. = ..()
+	if (new_death_state)
+		deflate(TRUE)
 
 /obj/structure/inflatable/CtrlClick()
 	return hand_deflate()
@@ -197,7 +201,7 @@
 		spawn(50)
 			var/obj/item/inflatable/R = new undeploy_path(src.loc)
 			src.transfer_fingerprints_to(R)
-			R.inflatable_health = health
+			copy_health(src, R)
 			qdel(src)
 
 /obj/structure/inflatable/verb/hand_deflate()
@@ -213,11 +217,9 @@
 	return TRUE
 
 /obj/structure/inflatable/attack_generic(var/mob/user, var/damage, var/attack_verb)
-	health -= damage
 	attack_animation(user)
-	if(health <= 0)
+	if (damage_health(damage))
 		user.visible_message("<span class='danger'>[user] [attack_verb] open the [src]!</span>")
-		spawn(1) deflate(1)
 	else
 		user.visible_message("<span class='danger'>[user] [attack_verb] at [src]!</span>")
 	return 1

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -720,14 +720,11 @@ BLIND     // can't see anything
 	return TRUE
 
 /obj/item/clothing/shoes/proc/handle_movement(var/turf/walking, var/running)
-	if (attached_cuffs && running)
-		if (attached_cuffs.health)
-			attached_cuffs.health -= 1
-			if (attached_cuffs.health < 1)
-				visible_message(SPAN_WARNING("\The [attached_cuffs] attached to \the [src] snap and fall away!"), range = 1)
-				verbs -= /obj/item/clothing/shoes/proc/remove_cuffs
-				slowdown_per_slot[slot_shoes] -= attached_cuffs.elastic ? 10 : 15
-				QDEL_NULL(attached_cuffs)
+	if (running && attached_cuffs?.damage_health(1))
+		visible_message(SPAN_WARNING("\The [attached_cuffs] attached to \the [src] snap and fall away!"), range = 1)
+		verbs -= /obj/item/clothing/shoes/proc/remove_cuffs
+		slowdown_per_slot[slot_shoes] -= attached_cuffs.elastic ? 10 : 15
+		QDEL_NULL(attached_cuffs)
 	return
 
 /obj/item/clothing/shoes/update_clothing_icon()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -29,7 +29,7 @@
 	/// Spark system used for creating sparks while the assembly is damaged and destroyed.
 	var/datum/effect/effect/system/spark_spread/spark_system
 	var/adrone = FALSE
-	health = 30
+	use_health_handler = USE_HEALTH_SIMPLE
 	pass_flags = 0
 	anchored = FALSE
 	var/detail_color = COLOR_ASSEMBLY_BLACK
@@ -52,6 +52,11 @@
 		COLOR_ASSEMBLY_PURPLE
 		)
 
+/obj/item/device/electronic_assembly/get_initial_health_handler_config()
+	return list(
+		"max_health" = 30
+	)
+
 /obj/item/device/electronic_assembly/examine(mob/user)
 	. = ..()
 	if(IC_FLAG_ANCHORABLE & circuit_flags)
@@ -59,26 +64,12 @@
 	else
 		to_chat(user, SPAN_NOTICE("The maintenance panel [opened ? "can be" : "is"] <b>screwed</b> in place."))
 
-	switch (health / initial(health))
-		if(0.99 to INFINITY)
-			to_chat(user, SPAN_NOTICE("\The [src] is in good condition."))
-		if(0.75 to 0.99)
-			to_chat(user, SPAN_NOTICE("\The [src] has a few scuffs and scratches."))
-		if(0.5 to 0.75)
-			to_chat(user, SPAN_DANGER("\The [src] is covered in dents and punctured in several places."))
-		if(0.25 to 0.5)
-			to_chat(user, SPAN_DANGER("\The [src] looks seriously damaged!"))
-		else
-			to_chat(user, SPAN_WARNING("\The [src] is barely holding together!"))
-
 	if((isobserver(user) && ckeys_allowed_to_scan[user.ckey]) || check_rights(R_ADMIN, 0, user))
 		to_chat(user, "You can <a href='?src=\ref[src];ghostscan=1'>scan</a> this circuit.");
 
-
-/obj/item/device/electronic_assembly/proc/take_damage(var/amnt)
-	health = health - amnt
-
-	if(health <= 0)
+/obj/item/device/electronic_assembly/handle_death_change(new_death_state)
+	. = ..()
+	if (new_death_state)
 		visible_message(SPAN_WARNING("\The [src] falls to pieces!"))
 		if(w_class == ITEM_SIZE_HUGE)
 			if(adrone)
@@ -97,7 +88,10 @@
 		playsound(loc, 'sound/items/electronic_assembly_empty.ogg', 100, 1)
 		icon = 0
 		addtimer(CALLBACK(src, .proc/fall_apart), 5.1)
-	else if(health <= initial(health)*0.25)
+
+/obj/item/device/electronic_assembly/post_health_change(damage, damage_type)
+	..()
+	if (get_damage_percentage() >= 0.75)
 		if(battery && battery.charge > 0)
 			visible_message(SPAN_WARNING("\The [src] sputters and sparks!"))
 			spark_system.start()
@@ -146,7 +140,7 @@
 		P.make_energy()
 
 	var/power_failure = FALSE
-	if(health <= initial(health)*0.25 && prob(1))
+	if(get_damage_percentage() >= 0.75 && prob(1))
 		if(battery && battery.charge > 0)
 			visible_message(SPAN_WARNING("\The [src] sparks violently!"))
 			spark_system.start()
@@ -513,15 +507,15 @@
 		update_icon()
 	else if(isCoil(I))
 		var/obj/item/stack/cable_coil/C = I
-		if(health != initial(health) && do_after(user, 10, src) && C.use(1))
+		if(get_damage_value() && do_after(user, 10, src) && C.use(1))
 			user.visible_message(SPAN_NOTICE("\The [user] patches up \the [src]."))
-			health = min(initial(health), health + 5)
+			restore_health(5)
 	else
 		if(user.a_intent == I_HURT && (!(user.l_hand == src || user.r_hand == src))) // Kill it
 			user.do_attack_animation(src)
 			playsound(loc, 'sound/weapons/genhit1.ogg', 100, 1)
 			to_chat(user, SPAN_WARNING("\The [user] hits \the [src] with \the [I]!"))
-			take_damage(I.force)
+			damage_health(I.force)
 		else
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
 				S.attackby_react(I,user,user.a_intent)
@@ -530,16 +524,16 @@
 	interact(user)
 
 /obj/item/device/electronic_assembly/bullet_act(var/obj/item/projectile/P)
-	take_damage(P.damage)
 	if(istype(P,/obj/item/projectile/beam))
 		playsound(loc, SOUNDS_LASER_METAL, 100, 1)
 	else if(istype(P,/obj/item/projectile/bullet))
 		playsound(loc, SOUNDS_BULLET_METAL, 100, 1)
+	damage_health(P.damage, P.damage_type)
 
 /obj/item/device/electronic_assembly/attack_generic(mob/user, damage)
-	take_damage(damage)
 	user.visible_message(SPAN_WARNING("\The [user] smashes \the [src]!"), SPAN_WARNING("You smash \the [src]!"))
 	attack_animation(user)
+	damage_health(damage)
 
 /obj/item/device/electronic_assembly/emp_act(severity)
 	. = ..()
@@ -614,7 +608,11 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_components = IC_MAX_SIZE_BASE * 2
 	max_complexity = IC_COMPLEXITY_BASE * 2
-	health = 45
+
+/obj/item/device/electronic_assembly/medium/get_initial_health_handler_config()
+	return list(
+		"max_health" = 45
+	)
 
 /obj/item/device/electronic_assembly/medium/default
 	name = "type-a electronic mechanism"
@@ -657,8 +655,12 @@
 	w_class = ITEM_SIZE_LARGE
 	max_components = IC_MAX_SIZE_BASE * 4
 	max_complexity = IC_COMPLEXITY_BASE * 4
-	health = 50
 	randpixel = 0
+
+/obj/item/device/electronic_assembly/large/get_initial_health_handler_config()
+	return list(
+		"max_health" = 50
+	)
 
 /obj/item/device/electronic_assembly/large/default
 	name = "type-a electronic machine"
@@ -697,9 +699,13 @@
 	max_complexity = IC_COMPLEXITY_BASE * 3
 	allowed_circuit_action_flags = IC_ACTION_MOVEMENT | IC_ACTION_COMBAT | IC_ACTION_LONG_RANGE
 	circuit_flags = 0
-	health = 60
 	randpixel = 0
 	adrone = TRUE
+
+/obj/item/device/electronic_assembly/drone/get_initial_health_handler_config()
+	return list(
+		"max_health" = 60
+	)
 
 /obj/item/device/electronic_assembly/drone/can_move()
 	return TRUE
@@ -711,19 +717,31 @@
 	name = "type-b electronic drone"
 	icon_state = "setup_drone_arms"
 	desc = "It's a case used for assembling mobile electronics. This one is armed and dangerous."
-	health = 70
+
+/obj/item/device/electronic_assembly/drone/arms/get_initial_health_handler_config()
+	return list(
+		"max_health" = 70
+	)
 
 /obj/item/device/electronic_assembly/drone/secbot
 	name = "type-c electronic drone"
 	icon_state = "setup_drone_secbot"
 	desc = "It's a case used for assembling mobile electronics. This one resembles a Securitron."
-	health = 70
+
+/obj/item/device/electronic_assembly/drone/secbot/get_initial_health_handler_config()
+	return list(
+		"max_health" = 70
+	)
 
 /obj/item/device/electronic_assembly/drone/medbot
 	name = "type-d electronic drone"
 	icon_state = "setup_drone_medbot"
 	desc = "It's a case used for assembling mobile electronics. This one resembles a Medibot."
-	health = 50
+
+/obj/item/device/electronic_assembly/drone/medbot/get_initial_health_handler_config()
+	return list(
+		"max_health" = 50
+	)
 
 /obj/item/device/electronic_assembly/drone/genbot
 	name = "type-e electronic drone"
@@ -737,7 +755,11 @@
 	w_class = ITEM_SIZE_HUGE
 	max_components = IC_MAX_SIZE_BASE * 5
 	max_complexity = IC_COMPLEXITY_BASE * 5
-	health = 100
+
+/obj/item/device/electronic_assembly/drone/android/get_initial_health_handler_config()
+	return list(
+		"max_health" = 100
+	)
 
 /obj/item/device/electronic_assembly/wallmount
 	name = "wall-mounted electronic assembly"
@@ -746,7 +768,11 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_components = IC_MAX_SIZE_BASE * 2
 	max_complexity = IC_COMPLEXITY_BASE * 2
-	health = 40
+
+/obj/item/device/electronic_assembly/wallmount/get_initial_health_handler_config()
+	return list(
+		"max_health" = 40
+	)
 
 /obj/item/device/electronic_assembly/wallmount/afterattack(var/atom/a, var/mob/user, var/proximity)
 	if(proximity && istype(a ,/turf) && a.density)
@@ -759,7 +785,11 @@
 	w_class = ITEM_SIZE_LARGE
 	max_components = IC_MAX_SIZE_BASE * 4
 	max_complexity = IC_COMPLEXITY_BASE * 4
-	health = 80
+
+/obj/item/device/electronic_assembly/wallmount/heavy/get_initial_health_handler_config()
+	return list(
+		"max_health" = 80
+	)
 
 /obj/item/device/electronic_assembly/wallmount/light
 	name = "light wall-mounted electronic assembly"

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -72,9 +72,8 @@
 			return
 		if(!handcuffed || buckled)
 			return
-	if (handcuffed.health) // Improvised cuffs can break because their health is > 0
-		handcuffed.health = handcuffed.health - initial(handcuffed.health) / 2
-		if (handcuffed.health < 1)
+	if (handcuffed.has_health()) // Improvised cuffs can break because their health is > 0
+		if (handcuffed.damage_health(handcuffed.get_max_health() / 2))
 			visible_message(
 				SPAN_DANGER("\The [src] manages to remove \the [handcuffed], breaking them!"),
 				SPAN_NOTICE("You successfully remove \the [handcuffed], breaking them!"), range = 2

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -359,7 +359,7 @@
 		)
 		if (I)
 			var/obj/structure/inflatable/S = target
-			I.health = S.health
+			copy_health(S, I)
 		qdel(target)
 
 	else if (istype(target, /obj/item/inflatable))
@@ -517,7 +517,7 @@
 		if(istype(A, /obj/item/reagent_containers/food/snacks/grown))
 			generating_power = base_power_generation
 			using_item = A
-		else 
+		else
 			for(var/fuel_type in fuel_types)
 				if(istype(A, fuel_type))
 					generating_power = fuel_types[fuel_type] * base_power_generation

--- a/code/modules/psionics/null/material_weapon.dm
+++ b/code/modules/psionics/null/material_weapon.dm
@@ -3,10 +3,9 @@
 
 /obj/item/material/withstand_psi_stress(var/stress, var/atom/source)
 	. = ..(stress, source)
-	if(health >= 0 && . > 0 && disrupts_psionics())
-		health -= .
-		. = max(0, -(health))
-		check_health(consumed = TRUE)
+	if(is_alive() && . > 0 && disrupts_psionics())
+		damage_health(.)
+		. = max(0, -(get_current_health()))
 
 /obj/item/material/shard/nullglass/New(var/newloc)
 	..(newloc, MATERIAL_NULLGLASS)

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -5,7 +5,6 @@
 	icon_state = "meat"
 	slice_path = /obj/item/reagent_containers/food/snacks/rawcutlet
 	slices_num = 3
-	health = 180
 	filling_color = "#ff1c1c"
 	center_of_mass = "x=16;y=14"
 	New()

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -218,7 +218,6 @@
 	desc = "A disgusting slab of meat."
 	icon = 'maps/away/meatstation/meatstation_sprites.dmi'
 	icon_state = "meat"
-	health = 150
 	filling_color = "#f41d7e"
 	slice_path = /obj/item/reagent_containers/food/snacks/rawcutlet/meatstation
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -40,7 +40,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 435 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 434 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 5 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
NUFC

Applies standardized health to all `obj/item` subtypes that were using health implementations:
- Handcuffs
- Material items
- Inflatables
- Integrated Electronics