### PR TITLE
Fixes a bug with FBP mmi iconstate

### DIFF
--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -40,7 +40,7 @@
 		return 0
 	return cell && cell.use(amount)
 
-/obj/item/organ/internal/cell/proc/get_power_drain()	
+/obj/item/organ/internal/cell/proc/get_power_drain()
 	var/damage_factor = 1 + 10 * damage/max_damage
 	return servo_cost * damage_factor
 
@@ -138,7 +138,7 @@
 	desc = stored_mmi.desc
 	icon = stored_mmi.icon
 
-	stored_mmi.icon_state = "mmi-full"
+	stored_mmi.update_icon()
 	icon_state = stored_mmi.icon_state
 
 	if(owner && owner.stat == DEAD)


### PR DESCRIPTION
🆑 
bugfix: MMIs removed from FBPs by means other than surgical should now have the correct icon.
/🆑

And by "other than surgical", I mean gibbing. 