### PR TITLE
adds a stack of cardboard to research material storage

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -12158,6 +12158,7 @@
 /area/storage/research)
 "Dh" = (
 /obj/structure/table/rack,
+/obj/item/stack/material/cardboard/fifty,
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/masks,


### PR DESCRIPTION
🆑 Taza
tweak: adds a stack of cardboard to research material storage
/🆑

Currently, research only has ten sheets of cardboard. This adds another fifty sheets. 