### PR TITLE
Fixes crashed ship catwalks spawning inside walls

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dmm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dmm
@@ -33,6 +33,7 @@
 /area/map_template/ecship/cockpit)
 "ag" = (
 /obj/structure/grille,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "ak" = (
@@ -493,6 +494,7 @@
 "bi" = (
 /obj/structure/catwalk,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bj" = (
@@ -515,6 +517,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bl" = (
@@ -635,6 +638,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bx" = (
@@ -736,6 +740,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bD" = (
@@ -928,6 +933,7 @@
 	dir = 4;
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bW" = (
@@ -959,6 +965,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bZ" = (
@@ -1093,12 +1100,14 @@
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "cj" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "ck" = (
@@ -1558,6 +1567,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dd" = (
@@ -1641,6 +1651,7 @@
 /obj/structure/catwalk,
 /obj/structure/handrail,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dm" = (
@@ -1651,6 +1662,7 @@
 	icon_state = "intact"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dn" = (
@@ -1796,6 +1808,7 @@
 	icon_state = "intact"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dw" = (
@@ -1805,12 +1818,14 @@
 	icon_state = "intact"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dx" = (
 /obj/structure/catwalk,
 /obj/effect/landmark/scorcher,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dy" = (
@@ -1840,6 +1855,7 @@
 	pixel_y = 0
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dA" = (
@@ -1895,6 +1911,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dH" = (
@@ -1916,6 +1933,7 @@
 	icon_state = "intact"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dJ" = (
@@ -1950,6 +1968,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dR" = (
@@ -1959,6 +1978,7 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dT" = (
@@ -1989,6 +2009,7 @@
 	icon_state = "intact"
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dY" = (
@@ -2087,6 +2108,7 @@
 /area/map_template/ecship/engine)
 "ei" = (
 /obj/structure/catwalk,
+/obj/effect/landmark/clear,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "ej" = (
@@ -2152,6 +2174,7 @@
 "yZ" = (
 /obj/structure/grille,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "NM" = (
@@ -2178,6 +2201,7 @@
 "YW" = (
 /obj/structure/catwalk,
 /obj/effect/landmark/scorcher,
+/obj/effect/landmark/clear,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "ZF" = (


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: Crashed EC ship ruin will no longer spawn catwalks inside planetary walls.
/:cl: