### PR TITLE
Buff the Spider Infestation event

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -3,11 +3,16 @@
 /datum/event/spider_infestation
 	announceWhen	= 90
 	var/spawncount = 1
+	var/guaranteed_to_grow = 0
 
 
 /datum/event/spider_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 60)
-	spawncount = rand(3 * severity, 5 * severity)	//spiderlings only have a 50% chance to grow big and strong
+	if (severity <= EVENT_LEVEL_MODERATE)
+		spawncount = 3 * severity
+	else
+		spawncount = 5 * severity
+	guaranteed_to_grow = round(rand(spawncount / 2, spawncount / 3))
 	sent_spiders_to_station = 0
 
 /datum/event/spider_infestation/announce()
@@ -22,6 +27,10 @@
 
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)
-		new /obj/effect/spider/spiderling(vent.loc)
+		if (guaranteed_to_grow > 0)
+			new /obj/effect/spider/spiderling/growing(vent.loc)
+			guaranteed_to_grow--
+		else
+			new /obj/effect/spider/spiderling(vent.loc)
 		vents -= vent
 		spawncount--


### PR DESCRIPTION
:cl: Mucker
tweak: Tweaked the Spider Infestation event to be more consistent based on the severity.
/:cl:

Previously the infestation event was rather random in how many spiders there could be, causing there to occasionally be next to no large spiders at times - even with a major roll of the event. This aims to make a major event be more consistently dangerous by ensuring a good number of spiderlings achieve their Big forms while keeping a moderate level of the event manageable.