### PR TITLE
Remove hydrobase from round start spawn options

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -4,7 +4,7 @@
 	description = "hydroponics base with random plants and a lot of enemies"
 	suffixes = list("hydrobase/hydrobase.dmm")
 	spawn_cost = 2
-	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
+	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	ruin_tags = RUIN_ALIEN
 	apc_test_exempt_areas = list(
 		/area/map_template/hydrobase = NO_SCRUBBER|NO_VENT|NO_APC,


### PR DESCRIPTION
Because the farmbots lag everything and rewriting their pathing is too much work for me right now. It still remains as an admin spawnable option if someone _really_ wants it.

:cl: SierraKomodo
rscdel: The hydroponics grow farm has been removed from possible round start exoplanet ruins.
/:cl: