### PR TITLE
Personal shield changes

### DIFF
--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -3,7 +3,7 @@
 	desc = "Truly a life-saver: this device protects its user from being hit by objects moving very, very fast, as long as it holds a charge."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "battereroff"
-	slot_flags = SLOT_BELT
+	slot_flags = SLOT_BELT | SLOT_BACK
 	var/open = FALSE
 	var/obj/item/cell/power_cell = /obj/item/cell/high
 	var/shield_type = /obj/aura/personal_shield/device
@@ -76,7 +76,7 @@
 	if(open && (loc == user))
 		if(power_cell)
 			user.visible_message("\The [user] removes \the [power_cell] from \the [src].", SPAN_NOTICE("You remove \the [power_cell] from \the [src]."))
-			turn_off()	
+			turn_off()
 			user.put_in_active_hand(power_cell)
 			on_remove_cell()
 		else
@@ -85,7 +85,6 @@
 
 /obj/item/device/personal_shield/proc/on_remove_cell()
 	power_cell = null
-	currently_stored_power = 0
 	enable_when_powered = FALSE
 	update_icon()
 
@@ -94,7 +93,7 @@
 	. = ..()
 
 /obj/item/device/personal_shield/equipped(var/mob/user, var/slot)
-	if(slot != slot_belt && slot != slot_l_hand && slot != slot_r_hand)
+	if(slot != slot_belt && slot != slot_l_hand && slot != slot_r_hand && slot != slot_back && slot != slot_s_store)
 		turn_off()
 	. = ..()
 
@@ -156,7 +155,7 @@
 
 	currently_stored_power -= shield_power_cost
 	START_PROCESSING(SSobj, src)
-	
+
 	if(currently_stored_power < shield_power_cost)
 		enable_when_powered = TRUE
 		return FALSE

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -336,7 +336,7 @@
 	boot_type = /obj/item/clothing/shoes/magboots/rig/hazard
 	glove_type = /obj/item/clothing/gloves/rig/hazard
 
-	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/handcuffs,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
+	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/handcuffs,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton,/obj/item/device/personal_shield)
 
 /obj/item/clothing/head/helmet/space/rig/hazard
 	light_overlay = "helmet_light_dual"
@@ -383,7 +383,7 @@
 	min_pressure_protection = 0
 
 
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
+	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/device/personal_shield)
 	//Bans the most common combat items, idea is that this isn't a mass built shouldergun rig.
 	banned_modules = list(/obj/item/rig_module/grenade_launcher,/obj/item/rig_module/mounted,/obj/item/rig_module/fabricator )
 	req_access = list()

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -168,7 +168,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
+	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton,/obj/item/device/personal_shield)
 	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/void/security/prepared
@@ -337,7 +337,7 @@
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR)
-	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
+	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton,/obj/item/device/personal_shield)
 
 /obj/item/clothing/suit/space/void/security/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/security/alt

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,6 +1,6 @@
 
 /obj/item/clothing/suit/armor
-	allowed = list(/obj/item/gun/energy,/obj/item/device/radio,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/gun/magnetic,/obj/item/clothing/head/helmet,/obj/item/device/flashlight)
+	allowed = list(/obj/item/gun/energy,/obj/item/device/radio,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/gun/magnetic,/obj/item/clothing/head/helmet,/obj/item/device/flashlight,/obj/item/device/personal_shield)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	flags_inv = CLOTHING_BULKY

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -218,7 +218,8 @@
 	   			  /obj/item/device/flashlight,
 	    		  /obj/item/tank,
 				  /obj/item/device/suit_cooling_unit,
-				  /obj/item/melee/baton)
+				  /obj/item/melee/baton,
+				  /obj/item/device/personal_shield)
 
 	req_access = list(access_hos)
 


### PR DESCRIPTION
:cl: Ryan180602
tweak: Personal Shields now store charge (they can be charged to 100% with multiple cells)
tweak: Personal Shields can now be put in suit storage of plate-carriers, sec voidsuits and CoS RIG, and on the backpack slot.
/:cl:

You could never recharge a shield to 100% because removing a cell not only drained the cell, but also drained the charge in the shield. Now you can use multiple cells to charge it up to 100%.

And to make the shield more viable in combat, it can be attached in the back, belt and suit storage slot for plate carriers, CoS' rig and security voidsuits.