### PR TITLE
Exploding spider delay

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
@@ -29,9 +29,9 @@
 	var/explosion_flash_range	= 6
 
 	/// Lower bound for explosion delay.
-	var/explosion_delay_lower	= 1 SECOND
+	var/explosion_delay_lower	= 3 SECONDS
 	/// Upper bound for explosion delay.
-	var/explosion_delay_upper	= 2 SECONDS
+	var/explosion_delay_upper	= 5 SECONDS
 
 /mob/living/simple_animal/hostile/giant_spider/phorogenic/Initialize()
 	scale(1.25)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
@@ -61,6 +61,7 @@
 		visible_message(SPAN_DANGER("\The [src]'s body detonates!"))
 		exploded = TRUE
 		explosion(loc, explosion_dev_range, explosion_heavy_range, explosion_light_range, explosion_flash_range)
+		qdel(src)
 
 /obj/item/natural_weapon/bite/spider/phorogenic
 	force = 30


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Exploding spiders now have an additional 2 seconds before they explode, to account for server lag.
tweak: Exploding spiders are now deleted when they explode instead of leaving behind a corpse. They did explode, after all.
/:cl: