### PR TITLE
Mob AI adjustments

### DIFF
--- a/code/modules/mob/living/simple_animal/combat.dm
+++ b/code/modules/mob/living/simple_animal/combat.dm
@@ -29,13 +29,12 @@
 /mob/living/simple_animal/proc/do_attack(atom/A, turf/T)
 	face_atom(A)
 	var/missed = FALSE
-	if(!isturf(A) && !(A in T) ) // Turfs don't contain themselves so checking contents is pointless if we're targeting a turf.
+	if (get_dir(src, A) == facing_dir && get_dist(src, A) <= 1) // Turfs don't contain themselves so checking contents is pointless if we're targeting a turf.
 		missed = TRUE
-	else if(!T.AdjacentQuick(src))
+	else if (!T.AdjacentQuick(src))
 		missed = TRUE
 
 	if(missed) // Most likely we have a slow attack and they dodged it or we somehow got moved.
-		// admin_attack_log(src, A, "Animal-attacked (dodged)", admin_notify = FALSE)
 		playsound(src, 'sound/weapons/punchmiss.ogg', 75, 1)
 		visible_message(SPAN_WARNING("\The [src] misses their attack."))
 		return FALSE


### PR DESCRIPTION
:cl: Mucker
tweak: Made it more difficult to dodge simple mobs melee attacks.
tweak: Mobs calling for help will no longer cascade and bring the entire map toward them.
/:cl:

Mobs targetting is now based on direction. If a target is adjacent to the mob as it melees, and the target is in the direction the mob is facing, then it will count as a hit, despite movement from the target.

Mobs that are called upon for help will no longer immediately call out for help as well, and the range at which the call for help is heard was reduced, which seems to fix the problem of mobs coming from all corners when one called for help.