### PR TITLE
Space suits have a wear delay

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -211,8 +211,28 @@
 #define HUD_MEDICAL 0x4
 #define HUD_JANITOR 0x8
 
-// Storage
 
+/**
+* flags for /mob/proc/equip_to_slot_if_possible
+*/
+
+/// Cause a mob icon update after equipping
+#define TRYEQUIP_REDRAW 0x1
+
+/// Skip any delays and equip instantly
+#define TRYEQUIP_INSTANT 0x2
+
+/// If the attempt fails, destroy the item
+#define TRYEQUIP_DESTROY 0x4
+
+/// Do not send output to the user about success or failure
+#define TRYEQUIP_SILENT 0x8
+
+/// Always succeed if existentially possible
+#define TRYEQUIP_FORCE 0x10
+
+
+// Storage
 /*
 	A note on w_classes - this is an attempt to describe the w_classes currently in use
 	with an attempt at providing examples of the kinds of things that fit each w_class

--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -729,8 +729,6 @@
 			return global.skin_styles_female_list;
 		if("skipped_unit_tests")
 			return global.skipped_unit_tests;
-		if("slot_equipment_priority")
-			return global.slot_equipment_priority;
 		if("slot_flags_enumeration")
 			return global.slot_flags_enumeration;
 		if("solar_gen_rate")
@@ -1608,8 +1606,6 @@
 			global.skin_styles_female_list=newval;
 		if("skipped_unit_tests")
 			global.skipped_unit_tests=newval;
-		if("slot_equipment_priority")
-			global.slot_equipment_priority=newval;
 		if("slot_flags_enumeration")
 			global.slot_flags_enumeration=newval;
 		if("solar_gen_rate")
@@ -2122,7 +2118,6 @@
 	"side_effects",
 	"skin_styles_female_list",
 	"skipped_unit_tests",
-	"slot_equipment_priority",
 	"slot_flags_enumeration",
 	"solar_gen_rate",
 	"solars_list",

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -191,7 +191,7 @@ proc/age2agedescription(age)
 		if (target_dir && target_dir != target.dir)
 			. = DO_TARGET_CAN_TURN
 			break
-		if (!isnull(user_hand) && user_hand != user.hand)
+		if ((do_flags & DO_USER_SAME_HAND) && user_hand != user.hand)
 			. = DO_USER_SAME_HAND
 			break
 		if (initial_handle && initial_handle != user.do_unique_user_handle)
@@ -218,7 +218,7 @@ proc/age2agedescription(age)
 			if (DO_USER_SAME_HAND)
 				to_chat(user, SPAN_WARNING("You must remain on the same active hand to perform that action!"))
 			if (DO_USER_UNIQUE_ACT)
-				to_chat(user, SPAN_WARNING("You stop what you're doing with \the [user.do_unique_user_handle]."))
+				to_chat(user, SPAN_WARNING("You stop what you're doing with \the [target]."))
 			if (DO_USER_SAME_ZONE)
 				to_chat(user, SPAN_WARNING("You must remain targeting the same zone to perform that action!"))
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -87,6 +87,7 @@
 
 	var/attack_ignore_harm_check = FALSE
 
+
 /obj/item/New()
 	..()
 	if(randpixel && (!pixel_x && !pixel_y) && isturf(loc)) //hopefully this will prevent us from messing with mapper-set pixel_x/y
@@ -895,3 +896,21 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/attack_message_name()
 	return "\a [src]"
+
+
+/// Optional delay for /mob/living/carbon/human/equip_to_slot_if_possible to do_after before succeeding
+/obj/item/var/equip_delay
+
+
+/// Flags to use for do_after when equip_delay is set
+/obj/item/var/equip_delay_flags
+
+
+/// Virtual for behavior to do before do_after if equip_delay is set
+/obj/item/proc/equip_delay_before(mob/user, slot, equip_flags)
+	return
+
+
+/// Virtual for behavior to do after successful do_after if equip_delay is set
+/obj/item/proc/equip_delay_after(mob/user, slot, equip_flags)
+	return

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -29,7 +29,7 @@
 			return
 			
 		if(user.unEquip(src))
-			if(!M.equip_to_slot_if_possible(src, slot_wear_suit, del_on_fail=0, disable_warning=1, redraw_mob=1))
+			if(!M.equip_to_slot_if_possible(src, slot_wear_suit, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 				user.put_in_active_hand(src)
 			return 1
 	else

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -34,11 +34,25 @@
 	var/facial_styles_per_species = list() // Custom facial hair styles, per species -type-, if any. See above as to why
 	var/genders_per_species       = list() // For gender biases per species -type-
 
+
 /obj/effect/landmark/corpse/Initialize()
 	..()
-	var/species_choice = pickweight(species)
-	new/mob/living/carbon/human/corpse (loc, species_choice, src)
-	return INITIALIZE_HINT_QDEL
+	return INITIALIZE_HINT_LATELOAD
+
+
+/obj/effect/landmark/corpse/LateInitialize()
+	var/new_species = pickweight(species)
+	var/mob/living/carbon/human/corpse = new (loc, new_species)
+	corpse.adjustOxyLoss(corpse.maxHealth)
+	corpse.setBrainLoss(corpse.maxHealth)
+	var/obj/item/organ/internal/heart/heart = corpse.internal_organs_by_name[BP_HEART]
+	if (heart)
+		heart.pulse = PULSE_NONE
+	randomize_appearance(corpse, new_species)
+	equip_outfit(corpse)
+	corpse.update_icon()
+	qdel(src)
+
 
 #define HEX_COLOR_TO_RGB_ARGS(X) arglist(GetHexColors(X))
 /obj/effect/landmark/corpse/proc/randomize_appearance(var/mob/living/carbon/human/M, species_choice)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -371,7 +371,7 @@ var/list/gear_datums = list()
 
 /datum/gear/proc/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
 	var/obj/item/item = spawn_item(H, H, metadata)
-	if(H.equip_to_slot_if_possible(item, slot, del_on_fail = 1, force = 1))
+	if(H.equip_to_slot_if_possible(item, slot, TRYEQUIP_REDRAW | TRYEQUIP_DESTROY | TRYEQUIP_FORCE))
 		. = item
 
 /datum/gear/proc/spawn_in_storage_or_drop(var/mob/living/carbon/human/H, var/metadata)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -748,7 +748,7 @@
 			if(check_slot && check_slot == use_obj)
 				return
 			use_obj.forceMove(wearer)
-			if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, 0, 1))
+			if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 				use_obj.forceMove(src)
 				if(check_slot)
 					to_chat(initiator, "<span class='danger'>You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way.</span>")

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -52,6 +52,8 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi',
 		)
 	var/list/supporting_limbs = list() //If not-null, automatically splints breaks. Checked when removing the suit.
+	equip_delay = null
+
 
 /obj/item/clothing/suit/space/rig/equipped(mob/M)
 	check_limb_support(M)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -133,6 +133,27 @@
 	randpixel = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
+	equip_delay = 5 SECONDS
+	equip_delay_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT
+
+
+/obj/item/clothing/suit/space/equip_delay_before(mob/user, slot, equip_flags)
+	user.setClickCooldown(1 SECOND)
+	user.visible_message(
+		SPAN_ITALIC("\The [user] begins to struggle into \the [src]."),
+		SPAN_ITALIC("You begin to struggle into \the [src]."),
+		SPAN_ITALIC("You can hear metal clicking and fabric rustling."),
+		range = 5
+	)
+
+
+/obj/item/clothing/suit/space/equip_delay_after(mob/user, slot, equip_flags)
+	user.visible_message(
+		SPAN_ITALIC("\The [user] finishes putting on \the [src]."),
+		SPAN_NOTICE("You finish putting on \the [src]."),
+		range = 5
+	)
+
 
 /obj/item/clothing/suit/space/New()
 	..()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -50,7 +50,7 @@
 				to_chat(H, "<span class='warning'>You're already wearing something on your head!</span>")
 				return
 			else
-				H.equip_to_slot_if_possible(hood,slot_head,0,0,1)
+				H.equip_to_slot_if_possible(hood, slot_head)
 				suittoggled = 1
 				update_icon()
 				H.update_inv_wear_suit()

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -150,7 +150,7 @@ var/list/holder_mob_icon_cache = list()
 	var/obj/item/holder/H = new holder_type(get_turf(src))
 
 	if(self_grab)
-		if(!grabber.equip_to_slot_if_possible(H, slot_back, del_on_fail=0, disable_warning=1))
+		if(!grabber.equip_to_slot_if_possible(H, slot_back, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 			to_chat(src, "<span class='warning'>You can't climb onto [grabber]!</span>")
 			return
 

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -9,24 +9,6 @@
 	GLOB.human_mob_list -= src
 	delete_inventory()
 
-/mob/living/carbon/human/dummy/selfdress/Initialize()
-	. = ..()
-	for(var/obj/item/I in loc)
-		equip_to_appropriate_slot(I)
-
-/mob/living/carbon/human/corpse/Initialize(mapload, new_species, obj/effect/landmark/corpse/corpse)
-	. = ..(mapload, new_species)
-
-	adjustOxyLoss(maxHealth)//cease life functions
-	setBrainLoss(maxHealth)
-	var/obj/item/organ/internal/heart/corpse_heart = internal_organs_by_name[BP_HEART]
-	if(corpse_heart)
-		corpse_heart.pulse = PULSE_NONE//actually stops heart to make worried explorers not care too much
-	if(corpse)
-		corpse.randomize_appearance(src, new_species)
-		corpse.equip_outfit(src)
-	update_icon()
-
 /mob/living/carbon/human/dummy/mannequin/add_to_living_mob_list()
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -26,7 +26,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 
 /mob/living/carbon/human/proc/equip_in_one_of_slots(obj/item/W, list/slots, del_on_fail = 1)
 	for (var/slot in slots)
-		if (equip_to_slot_if_possible(W, slots[slot], del_on_fail = 0))
+		if (equip_to_slot_if_possible(W, slots[slot]))
 			return slot
 	if (del_on_fail)
 		qdel(W)

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -33,13 +33,16 @@
 	..(new_loc, "Vat-Grown Human")
 
 /mob/living/carbon/human/blank/Initialize()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/mob/living/carbon/human/blank/LateInitialize()
 	var/number = "[pick(possible_changeling_IDs)]-[rand(1,30)]"
 	fully_replace_character_name("Subject [number]")
 	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/blank_subject)
 	outfit.equip(src)
 	var/obj/item/clothing/head/helmet/facecover/F = locate() in src
-	if(F)
+	if (F)
 		F.SetName("[F.name] ([number])")
 
 /mob/living/carbon/human/blank/ssd_check()

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -120,7 +120,7 @@
 		var/obj/item/clothing/C = get_equipped_item(text2num(slot_to_strip_text))
 		if (istype(C) && C.can_attach_accessory(held, user))
 			C.attach_accessory(user, held)
-		else if (!equip_to_slot_if_possible(held, text2num(slot_to_strip_text), del_on_fail = FALSE, disable_warning = FALSE, redraw_mob = TRUE))
+		else if (!equip_to_slot_if_possible(held, text2num(slot_to_strip_text)))
 			user.put_in_active_hand(held)
 
 /mob/living/carbon/human/proc/empty_pockets(mob/living/user)
@@ -137,10 +137,10 @@
 	if(!user.unEquip(I))
 		return
 	if(!r_store)
-		if(equip_to_slot_if_possible(I, slot_r_store, del_on_fail=0, disable_warning=1, redraw_mob=1))
+		if(equip_to_slot_if_possible(I, slot_r_store, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 			return
 	if(!l_store)
-		if(equip_to_slot_if_possible(I, slot_l_store, del_on_fail=0, disable_warning=1, redraw_mob=1))
+		if(equip_to_slot_if_possible(I, slot_l_store, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 			return
 	to_chat(user, "<span class='warning'>You are unable to place [I] in [src]'s pockets.</span>")
 	user.put_in_active_hand(I)

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -36,7 +36,7 @@
 		var/obj/item/I = new etype(get_turf(H))
 		if(istype(I, /obj/item/clothing))
 			I.canremove = 0
-		H.equip_to_slot_if_possible(I,equipment[etype],0,1,1,1)
+		H.equip_to_slot_if_possible(I,equipment[etype], TRYEQUIP_REDRAW | TRYEQUIP_SILENT | TRYEQUIP_FORCE)
 		. += I
 
 /datum/spellbound_type/proc/set_antag(var/datum/mind/M, var/mob/master)

--- a/code/modules/spells/general/toggle_armor.dm
+++ b/code/modules/spells/general/toggle_armor.dm
@@ -32,7 +32,7 @@
 			var/slot = armor_pieces[piece]
 			drop_piece(piece)
 			user.drop_from_inventory(user.get_equipped_item(slot))
-			user.equip_to_slot_if_possible(piece,slot,0,1,1,1)
+			user.equip_to_slot_if_possible(piece, slot, TRYEQUIP_REDRAW | TRYEQUIP_SILENT | TRYEQUIP_FORCE)
 	else
 		for(var/piece in armor_pieces)
 			var/obj/item/I = piece

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -99,12 +99,15 @@
 
 /obj/effect/landmark/deadcap
 	name = "Dead Captain"
-	delete_me = 1
 
 /obj/effect/landmark/deadcap/Initialize()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/landmark/deadcap/LateInitialize()
 	var/turf/T = get_turf(src)
 	var/mob/living/carbon/human/corpse = new(T)
-	scramble(1,corpse,100)
+	scramble(1, corpse, 100)
 	corpse.real_name = "Captain"
 	corpse.name = "Captain"
 	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/deadcap)
@@ -112,9 +115,9 @@
 	corpse.adjustOxyLoss(corpse.maxHealth)
 	corpse.setBrainLoss(corpse.maxHealth)
 	var/obj/structure/bed/chair/C = locate() in T
-	if(C)
+	if (C)
 		C.buckle_mob(corpse)
-	. = ..()
+	qdel(src)
 
 /decl/hierarchy/outfit/deadcap
 	name = "Derelict Captain"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -229,7 +229,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py baystation12.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '71a518e374f7d7f56aeb71ea7b302343 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '7631f2bee8bbeb2447d2d689269cb36e *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH baystation12.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon baystation12.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
:cl: Jux, Spookerton
tweak: Space suits take a flat 5 seconds to put on.
bugfix: User-unique progress bars correctly indicate what you stopped interacting with when interrupted.
bugfix: Same-hand progress bars correctly check for same hand-ness when started right-handed.
/:cl:

closes #31196
other changes are necessary to make that PR viable so I put them together
this could be more extensive (adding a remove_delay, skills, etc) but I'm not doing that now

\- you can set equip_delay on items to make them take time to put in a slot
\- do_flags can be set with equip_delay_flags
\- behavior per-item (messages etc) can be added by overriding equip_delay_before, equip_delay_after
\- equip procs can be configured to skip the delay for round join, scene dolls, etc
