### PR TITLE
Area lighting

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -62,3 +62,9 @@
 #define LIGHT_COLOUR_SKRELL	"#66ccff" // Skrellian cyan lighting
 
 #define LIGHT_STANDARD_COLORS list(LIGHT_COLOUR_WHITE, LIGHT_COLOUR_WARM, LIGHT_COLOUR_COOL) // List of standard light colors used for randomized lighting and selectable printed lights.
+
+// Area lighting modes
+#define AREA_LIGHTING_WHITE		"white"
+#define AREA_LIGHTING_WARM		"warm"
+#define AREA_LIGHTING_COOL		"cool"
+#define AREA_LIGHTING_DEFAULT	"default" // For light replacers, defaults to whatever the area is set to. For areas, uses the initial lighting value from the light bulb itself.

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -46,3 +46,13 @@
 #define CL_MATRIX_CG 18
 #define CL_MATRIX_CB 19
 #define CL_MATRIX_CA 20
+
+// Lighting color presets
+#define LIGHT_COLOUR_WHITE	"#fefefe" // Clinical white light bulbs
+#define LIGHT_COLOUR_WARM	"#fffee0" // Warm yellowish light bulbs
+#define LIGHT_COLOUR_COOL	"#e0fefe" // Cool bluish light bulbs
+#define LIGHT_COLOUR_E_RED	"#da0205" // Emergency red lighting
+#define LIGHT_COLOUR_READY	"#00ff00" // Green 'READY' lighting
+#define LIGHT_COLOUR_SKRELL	"#66ccff" // Skrellian cyan lighting
+
+#define LIGHT_STANDARD_COLORS list(LIGHT_COLOUR_WHITE, LIGHT_COLOUR_WARM, LIGHT_COLOUR_COOL) // List of standard light colors used for randomized lighting and selectable printed lights.

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -47,6 +47,12 @@
 #define CL_MATRIX_CB 19
 #define CL_MATRIX_CA 20
 
+// Lightbulb statuses
+#define LIGHT_OK 		0 // A light bulb is installed and functioning.
+#define LIGHT_EMPTY		1 // There is no light bulb installed.
+#define LIGHT_BROKEN	2 // The light bulb is broken/shattered.
+#define LIGHT_BURNED	3 // The light bulb is burned out.
+
 // Lighting color presets
 #define LIGHT_COLOUR_WHITE	"#fefefe" // Clinical white light bulbs
 #define LIGHT_COLOUR_WARM	"#fffee0" // Warm yellowish light bulbs

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -109,6 +109,7 @@ area/space/atmosalert()
 /area/chapel
 	name = "\improper Chapel"
 	icon_state = "chapel"
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/centcom/specops
 	name = "\improper Centcom Special Ops"
@@ -119,6 +120,7 @@ area/space/atmosalert()
 
 /area/medical
 	req_access = list(access_medical)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/security
 	req_access = list(access_sec_doors)
@@ -142,6 +144,7 @@ area/space/atmosalert()
 
 /area/rnd
 	req_access = list(access_research)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/rnd/xenobiology
 	name = "\improper Xenobiology Lab"

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -32,11 +32,6 @@
 //
 // The explosion cannot insta-kill anyone with 30% or more health.
 
-#define LIGHT_OK 0
-#define LIGHT_EMPTY 1
-#define LIGHT_BROKEN 2
-#define LIGHT_BURNED 3
-
 
 /obj/item/device/lightreplacer
 	name = "light replacer"
@@ -67,7 +62,7 @@
 		var/amt_inserted = 0
 		var/turf/T = get_turf(user)
 		for(var/obj/item/light/L in S.contents)
-			if(!user.stat && src.uses < src.max_uses && L.status == 0)
+			if(!user.stat && src.uses < src.max_uses && L.status == LIGHT_OK)
 				src.AddUses(1)
 				amt_inserted++
 				S.remove_from_storage(L, T, 1)
@@ -103,7 +98,7 @@
 
 	if(istype(W, /obj/item/light))
 		var/obj/item/light/L = W
-		if(L.status == 0) // LIGHT OKAY
+		if(L.status == LIGHT_OK)
 			if(uses < max_uses)
 				if(!user.unEquip(L))
 					return
@@ -184,8 +179,3 @@
 		return 1
 	else
 		return 0
-
-#undef LIGHT_OK
-#undef LIGHT_EMPTY
-#undef LIGHT_BROKEN
-#undef LIGHT_BURNED

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -1,6 +1,5 @@
-/area
-	luminosity           = TRUE
-	var/dynamic_lighting = TRUE
+/area/luminosity = TRUE
+/area/var/dynamic_lighting = TRUE
 
 /area/New()
 	..()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -1,5 +1,7 @@
 /area/luminosity = TRUE
 /area/var/dynamic_lighting = TRUE
+/// The light tone selection mode used for the area
+/area/var/lighting_tone = AREA_LIGHTING_DEFAULT
 
 /area/New()
 	..()

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -366,7 +366,7 @@
 				plastic.add_charge(2000)
 		else if(istype(W,/obj/item/light))
 			var/obj/item/light/L = W
-			if(L.status >= 2)
+			if(L.status >= LIGHT_BROKEN)
 				if(metal)
 					metal.add_charge(250)
 				if(glass)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -4,11 +4,6 @@
 
 
 // status values shared between lighting fixtures and items
-#define LIGHT_OK 0
-#define LIGHT_EMPTY 1
-#define LIGHT_BROKEN 2
-#define LIGHT_BURNED 3
-
 #define LIGHT_STAGE_EMPTY 1
 #define LIGHT_STAGE_WIRED 2
 #define LIGHT_STAGE_COMPLETE 3
@@ -32,11 +27,14 @@
 	anchored = TRUE
 	layer = ABOVE_HUMAN_LAYER
 
+	/// The light fixture's construction state. One of `LIGHT_STAGE_*`.
 	var/stage = LIGHT_STAGE_EMPTY
+	/// The final light machine to create when construction is finished. Should be `/obj/machinery/light` or a subtype thereof.
 	var/fixture_type = /obj/machinery/light
+	/// Number of metal sheets created when dismantled.
 	var/sheets_refunded = 2
 
-/obj/machinery/light_construct/New(atom/newloc, var/newdir, atom/fixture = null)
+/obj/machinery/light_construct/New(atom/newloc, newdir, atom/fixture = null)
 	..(newloc)
 
 	if(newdir)
@@ -65,20 +63,22 @@
 		if(LIGHT_STAGE_WIRED) to_chat(user, "It's wired.")
 		if(LIGHT_STAGE_COMPLETE) to_chat(user, "The casing is closed.")
 
-/obj/machinery/light_construct/attackby(obj/item/W as obj, mob/living/user)
+/obj/machinery/light_construct/attackby(obj/item/W, mob/living/user)
 	add_fingerprint(user)
 	if(isWrench(W))
 
 		switch(stage)
 			if (LIGHT_STAGE_EMPTY)
 				playsound(loc, 'sound/items/Ratchet.ogg', 50, TRUE)
-				to_chat(user, SPAN_NOTICE("You begin deconstructing [src]."))
+				to_chat(user, SPAN_NOTICE("You begin deconstructing \the [src]."))
 				if (!user.do_skilled(30, SKILL_CONSTRUCTION, src))
 					return
 				new /obj/item/stack/material/steel( get_turf(loc), sheets_refunded )
-				user.visible_message(SPAN_NOTICE("[user] deconstructs [src]."), \
-					SPAN_NOTICE("You deconstruct [src]!"), \
-					SPAN_ITALIC("You hear ratcheting and metal scraping."))
+				user.visible_message(
+					SPAN_NOTICE("\The [user] deconstructs \the [src]."),
+					SPAN_NOTICE("You deconstruct \the [src]!"),
+					SPAN_ITALIC("You hear ratcheting and metal scraping.")
+				)
 				playsound(loc, 'sound/items/Deconstruct.ogg', 75, TRUE)
 				qdel(src)
 				return
@@ -97,9 +97,11 @@
 		stage = LIGHT_STAGE_EMPTY
 		update_icon()
 		new /obj/item/stack/cable_coil(get_turf(loc), 1, "red")
-		user.visible_message(SPAN_NOTICE("[user] cuts the wires from [src]."), \
-			SPAN_NOTICE("You cut [src]'s wires and remove them from the frame'."), \
-			SPAN_ITALIC("You hear snipping and cables being cut."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts the wires from \the [src]."),
+			SPAN_NOTICE("You cut \the [src]'s wires and remove them from the frame'."),
+			SPAN_ITALIC("You hear snipping and cables being cut.")
+		)
 		playsound(loc, 'sound/items/Wirecutter.ogg', 50, TRUE)
 		return
 
@@ -110,8 +112,10 @@
 		if (coil.use(1))
 			stage = LIGHT_STAGE_WIRED
 			update_icon()
-			user.visible_message(SPAN_NOTICE("[user] adds wires to [src]."), \
-				SPAN_NOTICE("You add wires to [src]."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] adds wires to \the [src]."),
+				SPAN_NOTICE("You add wires to \the [src].")
+			)
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, TRUE)
 		return
 
@@ -119,9 +123,11 @@
 		if (stage == LIGHT_STAGE_WIRED)
 			stage = LIGHT_STAGE_COMPLETE
 			update_icon()
-			user.visible_message(SPAN_NOTICE("[user] closes [src]'s casing."), \
-				SPAN_NOTICE("You close [src]'s casing."), \
-				SPAN_ITALIC("You hear screws being tightened."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] closes \the [src]'s casing."),
+				SPAN_NOTICE("You close \the [src]'s casing."),
+				SPAN_ITALIC("You hear screws being tightened.")
+			)
 			playsound(loc, 'sound/items/Screwdriver.ogg', 50, TRUE)
 
 			var/obj/machinery/light/newlight = new fixture_type(loc, src)
@@ -135,11 +141,7 @@
 /obj/machinery/light_construct/small
 	name = "small light fixture frame"
 	desc = "A small light fixture under construction."
-	icon = 'icons/obj/lighting.dmi'
 	icon_state = "bulb-construct-stage1"
-	anchored = TRUE
-	layer = ABOVE_HUMAN_LAYER
-	stage = 1
 	fixture_type = /obj/machinery/light/small
 	sheets_refunded = 1
 
@@ -152,7 +154,6 @@
 /obj/machinery/light_construct/spot
 	name = "large light fixture frame"
 	desc = "A large light fixture under construction."
-	icon = 'icons/obj/lighting.dmi'
 	fixture_type = /obj/machinery/light/spot
 	sheets_refunded = 3
 
@@ -160,25 +161,33 @@
 /obj/machinery/light
 	name = "light fixture"
 	icon = 'icons/obj/lighting.dmi'
-	var/base_state = "tube"		// base description and icon_state
+	/// Base description and `icon_state`.
+	var/base_state = "tube"
 	icon_state = "tube_map"
 	desc = "A lighting fixture."
 	anchored = TRUE
-	layer = ABOVE_HUMAN_LAYER  					// They were appearing under mobs which is a little weird - Ostaf
+	layer = ABOVE_HUMAN_LAYER
 	use_power = POWER_USE_ACTIVE
 	idle_power_usage = 2
 	active_power_usage = 20
 	power_channel = LIGHT //Lights are calc'd via area so they don't need to be in the machine list
 
-	var/on = 0					// 1 if on, 0 if off
-	var/flickering = 0
-	var/light_type = /obj/item/light/tube		// the type of light item
+	/// Whether or not the light is turned on.
+	var/on = TRUE
+	/// Whether or not the light is currently flickering.
+	var/flickering = FALSE
+	/// Type path of the light bulb item. Used for initialization and to determine what bulbs fit.
+	var/light_type = /obj/item/light/tube
+	/// Type path for the machine to create when dismantled. Should be `/obj/machinery/light_construct` or a subtype.
 	var/construct_type = /obj/machinery/light_construct
 
+	/// `spark_spread` effect datum.
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 
+	/// The installed light bolb.
 	var/obj/item/light/lightbulb
 
+	/// The light's current lighting mode. One of `LIGHTMODE_*`.
 	var/current_mode = null
 
 /obj/machinery/light/get_color()
@@ -223,17 +232,17 @@
 	else
 		lightbulb = new light_type(src)
 		if(prob(lightbulb.broken_chance))
-			broken(1)
+			broken(TRUE)
 
 	on = powered()
-	update_icon(0)
+	update_icon(FALSE)
 
 /obj/machinery/light/Destroy()
 	QDEL_NULL(lightbulb)
 	QDEL_NULL(s)
 	. = ..()
 
-/obj/machinery/light/on_update_icon(var/trigger = 1)
+/obj/machinery/light/on_update_icon(trigger = TRUE)
 	overlays.Cut()
 	icon_state = "[base_state]_empty" //Never use the initial state. That'll just reset it to the mapping icon.
 	atom_flags = atom_flags & ~ATOM_FLAG_CAN_BE_PAINTED
@@ -254,13 +263,13 @@
 			_state = "[base_state][on]"
 			atom_flags |= ATOM_FLAG_CAN_BE_PAINTED
 		if(LIGHT_EMPTY)
-			on = 0
+			on = FALSE
 		if(LIGHT_BURNED)
 			_state = "[base_state]_burned"
-			on = 0
+			on = FALSE
 		if(LIGHT_BROKEN)
 			_state = "[base_state]_broken"
-			on = 0
+			on = FALSE
 
 	if(istype(lightbulb, /obj/item/light/))
 		var/image/I = image(icon, src, _state)
@@ -274,7 +283,7 @@
 
 		update_use_power(POWER_USE_ACTIVE)
 
-		var/changed = 0
+		var/changed = FALSE
 		if(current_mode && (current_mode in lightbulb.lighting_modes))
 			changed = set_light(arglist(lightbulb.lighting_modes[current_mode]))
 		else
@@ -287,19 +296,21 @@
 		set_light(0)
 	change_power_consumption((light_outer_range * light_max_bright) * LIGHTING_POWER_FACTOR, POWER_USE_ACTIVE)
 
+/// Returns `lightbulb.status`.
 /obj/machinery/light/proc/get_status()
 	if(!lightbulb)
 		return LIGHT_EMPTY
 	else
 		return lightbulb.status
 
+/// Calls `lightbulb.switch_on()` and updates the lighting and icon accordingly.
 /obj/machinery/light/proc/switch_check()
 	lightbulb.switch_on()
 	if(get_status() != LIGHT_OK)
 		set_light(0)
 	update_icon()
 
-/obj/machinery/light/attack_generic(var/mob/user, var/damage)
+/obj/machinery/light/attack_generic(mob/user, damage)
 	if(!damage)
 		return
 	var/status = get_status()
@@ -308,23 +319,31 @@
 		return
 	if(!(status == LIGHT_OK || status == LIGHT_BURNED))
 		return
-	user.visible_message(SPAN_WARNING("[user] smashes the light!"), SPAN_WARNING("You smash the light!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user] smashes \the [src]!"),
+		SPAN_WARNING("You smash \the [src]!")
+	)
 	attack_animation(user)
 	broken()
-	return 1
+	return TRUE
 
-/obj/machinery/light/proc/set_mode(var/new_mode)
+/// Set's the lights `current_mode`. `new_mode` should be one of `LIGHTMODE_*`.
+/obj/machinery/light/proc/set_mode(new_mode)
 	if(current_mode != new_mode)
 		current_mode = new_mode
-		update_icon(0)
+		update_icon(FALSE)
 
+/// Return's the current mode's `l_color` value or, if there is no `current_mode`, the lightbulb's color.
 /obj/machinery/light/proc/get_mode_color()
 	if (current_mode && (current_mode in lightbulb.lighting_modes))
 		return lightbulb.lighting_modes[current_mode]["l_color"]
-	else
+	else if (lightbulb)
 		return lightbulb.b_colour
+	else
+		return null
 
-/obj/machinery/light/proc/set_emergency_lighting(var/enable)
+/// Toggles the light's emergency lighting mode (`LIGHTMODE_EMERGENCY`).
+/obj/machinery/light/proc/set_emergency_lighting(enable)
 	if(!lightbulb)
 		return
 
@@ -337,13 +356,11 @@
 			set_mode(null)
 			update_power_channel(initial(power_channel))
 
-// attempt to set the light's on/off status
-// will not switch on if broken/burned/empty
-/obj/machinery/light/proc/seton(var/state)
+/// Sets the light's `on` state, if there's a functional light bulb installed.
+/obj/machinery/light/proc/seton(state)
 	on = (state && get_status() == LIGHT_OK)
 	queue_icon_update()
 
-// examine verb
 /obj/machinery/light/examine(mob/user)
 	. = ..()
 	var/fitting = get_fitting_name()
@@ -357,24 +374,26 @@
 		if(LIGHT_BROKEN)
 			to_chat(user, "The [fitting] has been smashed.")
 
+/// Fetches the name of `light_type`.
 /obj/machinery/light/proc/get_fitting_name()
 	var/obj/item/light/L = light_type
 	return initial(L.name)
 
-// attack with item - insert light (if right type), otherwise try to break the light
-
+/// Attempts to insert a given light bulb. Called by `attackby()`.
 /obj/machinery/light/proc/insert_bulb(obj/item/light/L)
 	L.forceMove(src)
 	lightbulb = L
 
-	on = powered()
+	seton(powered())
 	update_icon()
 
+/// Attempts to remove an installed light bulb. Called by `attack_hand()`.
 /obj/machinery/light/proc/remove_bulb()
 	. = lightbulb
 	lightbulb.dropInto(loc)
 	lightbulb.update_icon()
 	lightbulb = null
+	seton(FALSE)
 	update_icon()
 
 /obj/machinery/light/attackby(obj/item/W, mob/user)
@@ -389,25 +408,33 @@
 			return
 		if(!user.unEquip(W, src))
 			return
-		user.visible_message(SPAN_NOTICE("[user] inserts [W] into [src]."), SPAN_NOTICE("You insert [W]."), SPAN_ITALIC("You hear something being screwed in."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [W] into \the [src]."),
+			SPAN_NOTICE("You insert \the [W] into \the [src]."),
+			SPAN_ITALIC("You hear something being screwed in.")
+		)
 		insert_bulb(W)
 		add_fingerprint(user)
 
-		// attempt to break the light
-		//If xenos decide they want to smash a light bulb with a toolbox, who am I to stop them? /N
-
+	// attempt to break the light
 	else if(lightbulb && (lightbulb.status != LIGHT_BROKEN) && user.a_intent != I_HELP)
-
 		if(prob(1 + W.force * 5))
-
-			user.visible_message(SPAN_WARNING("[user] smashes the light!"), SPAN_WARNING("You smash the light!"), SPAN_WARNING("You hear a small glass object shatter."))
+			user.visible_message(
+				SPAN_WARNING("\The [user] smashes \the [src]!"),
+				SPAN_WARNING("You smash \the [src]!"),
+				SPAN_WARNING("You hear a small glass object shatter.")
+			)
 			if(on && (W.obj_flags & OBJ_FLAG_CONDUCTIBLE))
 				if (prob(12))
 					electrocute_mob(user, get_area(src), src, 0.3)
 			broken()
 
 		else
-			user.visible_message(SPAN_WARNING("[user] hits the light!"), SPAN_WARNING("You hit the light!"), SPAN_WARNING("You hear glass cracking."))
+			user.visible_message(
+				SPAN_WARNING("\The [user] hits \the [src]!"),
+				SPAN_WARNING("You hit \the [src]!"),
+				SPAN_WARNING("You hear glass cracking.")
+			)
 			playsound(loc, "glasscrack", 40, TRUE)
 		attack_animation(user)
 
@@ -415,14 +442,21 @@
 	else if(!lightbulb)
 		if(istype(W, /obj/item/screwdriver)) //If it's a screwdriver open it.
 			playsound(loc, 'sound/items/Screwdriver.ogg', 50, TRUE)
-			user.visible_message(SPAN_NOTICE("[user] opens [src]'s casing."), SPAN_NOTICE("You open up [src]'s casing."), SPAN_ITALIC("You hear screws being loosened."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] opens \the [src]'s casing."),
+				SPAN_NOTICE("You open up \the [src]'s casing."),
+				SPAN_ITALIC("You hear screws being loosened.")
+			)
 			var/obj/machinery/light_construct/C = new construct_type(loc, dir, src)
 			C.stage = LIGHT_STAGE_WIRED
 			C.update_icon()
 			qdel(src)
 			return
 
-		user.visible_message(SPAN_WARNING("[user] shoves [W] into [src]!"), SPAN_DANGER("You stick [W] into [src]!"))
+		user.visible_message(
+			SPAN_WARNING("\The [user] shoves \a [W] into \the [src]!"),
+			SPAN_DANGER("You stick \the [W] into \the [src]!")
+		)
 		if(powered() && (W.obj_flags & OBJ_FLAG_CONDUCTIBLE))
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(3, 1, src)
@@ -437,24 +471,25 @@
 	var/area/A = get_area(src)
 	return A && A.lightswitch && ..(power_channel)
 
-/obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
+/// Causes the light to start flickering.
+/obj/machinery/light/proc/flicker(amount = rand(10, 20))
 	if(flickering) return
-	flickering = 1
+	flickering = TRUE
 	spawn(0)
 		if(on && get_status() == LIGHT_OK)
 			for(var/i = 0; i < amount; i++)
 				if(get_status() != LIGHT_OK) break
 				on = !on
-				update_icon(0)
+				update_icon(FALSE)
 				sleep(rand(5, 15))
 			on = (get_status() == LIGHT_OK)
 			update_icon(0)
-		flickering = 0
+		flickering = FALSE
 
 // ai attack - make lights flicker, because why not
 
 /obj/machinery/light/attack_ai(mob/user)
-	to_chat(user, SPAN_NOTICE("You cause [src] to flick on and off."))
+	to_chat(user, SPAN_NOTICE("You cause \the [src] to flick on and off."))
 	flicker(1)
 
 // attack with hand - remove tube/bulb
@@ -467,13 +502,16 @@
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.species.can_shred(H))
-			H.visible_message(SPAN_WARNING("[user] shreds the light!"), SPAN_WARNING("You shred the light!"), SPAN_WARNING("You hear glass shattering!"))
+			H.visible_message(
+				SPAN_WARNING("\The [user] shreds \the [src]!"),
+				SPAN_WARNING("You shred \the [src]!"),
+				SPAN_WARNING("You hear glass shattering!"))
 			broken()
 			return TRUE
 
 	// make it burn hands if not wearing fire-insulated gloves
 	if(on)
-		var/prot = 0
+		var/prot = FALSE
 		var/mob/living/carbon/human/H = user
 
 		if(istype(H))
@@ -481,11 +519,11 @@
 				var/obj/item/clothing/gloves/G = H.gloves
 				if(G.max_heat_protection_temperature)
 					if(G.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
-						prot = 1
+						prot = TRUE
 		else
-			prot = 1
+			prot = TRUE
 
-		if(prot > 0 || (MUTATION_COLD_RESISTANCE in user.mutations))
+		if(prot || (MUTATION_COLD_RESISTANCE in user.mutations))
 			to_chat(user, SPAN_NOTICE("You remove the [get_fitting_name()]."))
 		else if(istype(user) && user.psi && !user.psi.suppressed && user.psi.get_rank(PSI_PSYCHOKINESIS) >= PSI_RANK_OPERANT)
 			to_chat(user, SPAN_NOTICE("You telekinetically remove the [get_fitting_name()]."))
@@ -493,7 +531,10 @@
 			var/obj/item/organ/external/hand = H.organs_by_name[user.hand ? BP_L_HAND : BP_R_HAND]
 			if(hand && hand.is_usable() && !hand.can_feel_pain())
 				user.apply_damage(3, BURN, user.hand ? BP_L_HAND : BP_R_HAND, used_weapon = src)
-				user.visible_message(SPAN_WARNING("\The [user]'s [hand] burns and sizzles as \he touches the hot [get_fitting_name()]."), SPAN_WARNING("Your [hand.name] burns and sizzles as you remove the hot [get_fitting_name()]."))
+				user.visible_message(
+					SPAN_WARNING("\The [user]'s [hand] burns and sizzles as \he touches the hot [get_fitting_name()]."),
+					SPAN_WARNING("Your [hand.name] burns and sizzles as you remove the hot [get_fitting_name()].")
+				)
 		else
 			to_chat(user, SPAN_WARNING("You try to remove the [get_fitting_name()], but it's too hot and you don't want to burn your hand."))
 			return TRUE
@@ -510,8 +551,8 @@
 		flicker(rand(2,5))
 	else return ..()
 
-// break the light and make sparks if was on
-/obj/machinery/light/proc/broken(var/skip_sound_and_sparks = 0)
+/// Break the light and make sparks if it was on.
+/obj/machinery/light/proc/broken(skip_sound_and_sparks = FALSE)
 	if(!lightbulb)
 		return
 
@@ -521,19 +562,18 @@
 		if(on)
 			s.set_up(3, 1, src)
 			s.start()
-	lightbulb.status = LIGHT_BROKEN
+	lightbulb.set_status(LIGHT_BROKEN)
 	update_icon()
 
+/// Fixes a broken light.
 /obj/machinery/light/proc/fix()
 	if(get_status() == LIGHT_OK || !lightbulb)
 		return
-	lightbulb.status = LIGHT_OK
-	on = 1
+	lightbulb.set_status(LIGHT_OK)
+	seton(TRUE)
 	update_icon()
 
-// explosion effect
 // destroy the whole light fixture or just shatter it
-
 /obj/machinery/light/ex_act(severity)
 	switch(severity)
 		if(1)
@@ -546,15 +586,8 @@
 			if (prob(50))
 				broken()
 
-// timed process
-// use power
-
-// called when area power state changes
 /obj/machinery/light/power_change()
-	spawn(10)
-		seton(powered())
-
-// called when on fire
+	seton(powered())
 
 /obj/machinery/light/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(prob(max(0, exposed_temperature - 673)))   //0% at <400C, 100% at >500C
@@ -562,9 +595,11 @@
 
 /obj/machinery/light/small/readylight
 	light_type = /obj/item/light/bulb/red/readylight
-	var/state = 0
+	/// Whether or not the light's 'ready' state is enabled.
+	var/state = FALSE
 
-/obj/machinery/light/small/readylight/proc/set_state(var/new_state)
+/// Sets the lights `state` and updates the light mode accordingly.
+/obj/machinery/light/small/readylight/proc/set_state(new_state)
 	state = new_state
 	if(state)
 		set_mode(LIGHTMODE_READY)
@@ -600,27 +635,45 @@
 // the light item
 // can be tube or bulb subtypes
 // will fit into empty /obj/machinery/light of the corresponding type
-
 /obj/item/light
 	icon = 'icons/obj/lighting.dmi'
 	force = 2
 	throwforce = 5
 	w_class = ITEM_SIZE_TINY
-	var/status = 0		// LIGHT_OK, LIGHT_BURNED or LIGHT_BROKEN
+	/// The light bulb's status. One of `LIGHT_*`.
+	var/status = EMPTY_BITFIELD
+	/// Base `icon_state`.
 	var/base_state
-	var/switchcount = 0	// number of times switched
+	/// Number of times the light bulb has been switched on. Used to 'burn out' the bulb if switched too often.
+	var/switchcount = 0
 	matter = list(MATERIAL_STEEL = 60)
+	/// Probability the light bulb spawns broken.
 	var/broken_chance = 2
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CAN_BE_PAINTED
 
+	/// Lighting `max_bright` value when turned on.
 	var/b_max_bright = 0.9
+	/// Lighting `inner_range` value when turned on.
 	var/b_inner_range = 1
+	/// Lighting `outer_range` value when turned on
 	var/b_outer_range = 5
+	/// Lighting `curve` value when turned on.
 	var/b_curve = 2
+	/// Lighting `colour` value when turned on.
 	var/b_colour = LIGHT_COLOUR_WARM
+
+	/**
+	 * List of lists. Alternative lighting modes the bulb supports. Entry index should be the `LIGHTMODE_*` type supported, and the value should be a list of `l_*` lighting values to be applied when the mode is enabled.
+	 *
+	 * Example: `LIGHTMODE_EMERGENCY = list(l_outer_range = 4, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED)`
+	 */
 	var/list/lighting_modes = list()
+
+	/// Sound file to play when the light is turned on.
 	var/sound_on
+	/// Whether or not to randomly select a lighting color from `random_tone_options` on init.
 	var/random_tone = TRUE
+	/// List of colors to pick from on init if `random_tone` is set.
 	var/list/random_tone_options = LIGHT_STANDARD_COLORS
 
 /obj/item/light/Initialize()
@@ -632,7 +685,7 @@
 /obj/item/light/examine(mob/user)
 	. = ..()
 	if (reagents?.total_volume && Adjacent(user))
-		to_chat(user, SPAN_WARNING("There's some sort of fluid inside [src]."))
+		to_chat(user, SPAN_WARNING("There's some sort of fluid inside \the [src]."))
 
 /obj/item/light/get_color()
 	return b_colour
@@ -685,7 +738,7 @@
 	b_outer_range = 4
 	b_curve = 3
 	lighting_modes = list(
-		LIGHTMODE_EMERGENCY = list(l_outer_range = 3, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED),
+		LIGHTMODE_EMERGENCY = list(l_outer_range = 3, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED)
 	)
 
 /obj/item/light/bulb/red
@@ -695,7 +748,7 @@
 
 /obj/item/light/bulb/red/readylight
 	lighting_modes = list(
-		LIGHTMODE_READY = list(l_outer_range = 5, l_max_bright = 1, l_color = LIGHT_COLOUR_READY),
+		LIGHTMODE_READY = list(l_outer_range = 5, l_max_bright = 1, l_color = LIGHT_COLOUR_READY)
 	)
 
 /obj/item/light/throw_impact(atom/hit_atom)
@@ -733,9 +786,8 @@
 	..()
 	update_icon()
 
-// attack bulb/tube with object
 // if a syringe, can inject phoron to make it explode
-/obj/item/light/attackby(var/obj/item/I, var/mob/user)
+/obj/item/light/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/syringe) && status == LIGHT_OK)
 		var/obj/item/reagent_containers/syringe/S = I
 
@@ -743,18 +795,16 @@
 			if (!reagents)
 				create_reagents(5)
 				S.reagents.trans_to_obj(src, 5)
-				to_chat(user, SPAN_WARNING("You inject the solution into [src]."))
+				to_chat(user, SPAN_WARNING("You inject the solution into \the [src]."))
 				if (reagents.get_reagent_amount(/datum/reagent/toxin/phoron) >= LIGHT_PHORON_EXPLODE_THRESHOLD)
 					log_and_message_admins("injected a light with phoron, rigging it to explode.", user)
 				return
 			else
-				to_chat(user, SPAN_WARNING("[src] is already filled with fluid!"))
+				to_chat(user, SPAN_WARNING("\The [src] is already filled with fluid!"))
 	. = ..()
 
-// called after an attack with a light item
 // shatter light, unless it was an attempt to put it in a light socket
 // now only shatter if the intent was harm
-
 /obj/item/light/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
 		return
@@ -765,38 +815,52 @@
 
 	shatter()
 
+/// Handles updating the light's `status`.
+/obj/item/light/proc/set_status(new_status)
+	if (status == new_status)
+		return
+	status = new_status
+	switch (status)
+		if (LIGHT_BROKEN)
+			force = 5
+			sharp = TRUE
+	update_icon()
+
+/// Handles shattering the light bulb under certain conditions, such as impacts or damage.
 /obj/item/light/proc/shatter()
 	if(status == LIGHT_OK || status == LIGHT_BURNED)
-		visible_message(SPAN_WARNING("[src] shatters!"), SPAN_WARNING("You hear a small glass object shatter."))
-		status = LIGHT_BROKEN
-		force = 5
-		sharp = TRUE
+		visible_message(
+			SPAN_WARNING("\The [src] shatters!"),
+			SPAN_WARNING("You hear a small glass object shatter.")
+		)
+		set_status(LIGHT_BROKEN)
 		playsound(loc, "glasscrack", 75, TRUE)
-		update_icon()
 
+/// Handles switching the light bulb on.
 /obj/item/light/proc/switch_on()
 	switchcount++
 	if(reagents)
 		if (reagents.get_reagent_amount(/datum/reagent/toxin/phoron) >= LIGHT_PHORON_EXPLODE_THRESHOLD)
-			visible_message(SPAN_DANGER("[src] flares brilliantly!"), SPAN_DANGER("You hear a loud crack!"))
+			visible_message(
+				SPAN_DANGER("\The [src] flares brilliantly!"),
+				SPAN_DANGER("You hear a loud crack!")
+			)
 			log_and_message_admins("Rigged light explosion, last touched by [fingerprintslast]")
 			var/turf/T = get_turf(loc)
-			status = LIGHT_BROKEN
-			spawn(0)
-				sleep(2)
-				explosion(T, 0, 0, 3, 5)
+			set_status(LIGHT_BROKEN)
+			addtimer(CALLBACK(src, .proc/explosion, T, 0, 0, 3, 5), 2)
 		else
-			visible_message(SPAN_WARNING("[src] short-circuits as something burns out its filament!"))
-			status = LIGHT_BURNED
+			visible_message(SPAN_WARNING("\The [src] short-circuits as something burns out its filament!"))
+			set_status(LIGHT_BURNED)
 			if (sound_on)
 				playsound(src, sound_on, 100)
 	else if(prob(min(60, switchcount*switchcount*0.01)))
-		status = LIGHT_BURNED
+		set_status(LIGHT_BURNED)
 	else if(sound_on)
 		playsound(src, sound_on, 75)
 	return status
 
-/obj/machinery/light/do_simple_ranged_interaction(var/mob/user)
+/obj/machinery/light/do_simple_ranged_interaction(mob/user)
 	if(lightbulb)
 		remove_bulb()
 	return TRUE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -230,7 +230,16 @@
 		construct.transfer_fingerprints_to(src)
 		set_dir(construct.dir)
 	else
-		lightbulb = new light_type(src)
+		var/light_color = null
+		var/area/A = get_area(src)
+		switch (A.lighting_tone)
+			if (AREA_LIGHTING_WHITE)
+				light_color = LIGHT_COLOUR_WHITE
+			if (AREA_LIGHTING_WARM)
+				light_color = LIGHT_COLOUR_WARM
+			if (AREA_LIGHTING_COOL)
+				light_color = LIGHT_COLOUR_COOL
+		lightbulb = new light_type(src, light_color)
 		if(prob(lightbulb.broken_chance))
 			broken(TRUE)
 
@@ -676,11 +685,12 @@
 	/// List of colors to pick from on init if `random_tone` is set.
 	var/list/random_tone_options = LIGHT_STANDARD_COLORS
 
-/obj/item/light/Initialize()
+/obj/item/light/Initialize(mapload, light_color)
 	. = ..()
-	if (random_tone)
-		b_colour = pick(random_tone_options)
-		update_icon()
+	if (light_color)
+		set_color(light_color)
+	else if (random_tone)
+		set_color(pick(random_tone_options))
 
 /obj/item/light/examine(mob/user)
 	. = ..()
@@ -740,6 +750,10 @@
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_outer_range = 3, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED)
 	)
+
+/obj/item/light/bulb/warm/b_colour = LIGHT_COLOUR_WARM
+/obj/item/light/bulb/cool/b_colour = LIGHT_COLOUR_COOL
+/obj/item/light/bulb/white/b_colour = LIGHT_COLOUR_WHITE
 
 /obj/item/light/bulb/red
 	color = LIGHT_COLOUR_E_RED

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -617,15 +617,11 @@
 	var/b_inner_range = 1
 	var/b_outer_range = 5
 	var/b_curve = 2
-	var/b_colour = "#fffee0"
+	var/b_colour = LIGHT_COLOUR_WARM
 	var/list/lighting_modes = list()
 	var/sound_on
 	var/random_tone = TRUE
-	var/list/random_tone_options = list(
-		"#fffee0",
-		"#e0fefe",
-		"#fefefe",
-	)
+	var/list/random_tone_options = LIGHT_STANDARD_COLORS
 
 /obj/item/light/Initialize()
 	. = ..()
@@ -642,7 +638,7 @@
 	return b_colour
 
 /obj/item/light/set_color(color)
-	b_colour = isnull(color) ? COLOR_WHITE : color
+	b_colour = isnull(color) ? LIGHT_COLOUR_WHITE : color
 	update_icon()
 
 /obj/item/light/tube
@@ -654,10 +650,9 @@
 	matter = list(MATERIAL_GLASS = 100, MATERIAL_ALUMINIUM = 20)
 
 	b_outer_range = 5
-	b_colour = "#fffee0"
 	lighting_modes = list(
-		LIGHTMODE_EMERGENCY = list(l_outer_range = 4, l_max_bright = 1, l_color = "#da0205"),
-		)
+		LIGHTMODE_EMERGENCY = list(l_outer_range = 4, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED),
+	)
 	sound_on = 'sound/machines/lightson.ogg'
 
 /obj/item/light/tube/party/Initialize() //Randomly colored light tubes. Mostly for testing, but maybe someone will find a use for them.
@@ -689,20 +684,19 @@
 	b_inner_range = 0.1
 	b_outer_range = 4
 	b_curve = 3
-	b_colour = "#fcfcc7"
 	lighting_modes = list(
-		LIGHTMODE_EMERGENCY = list(l_outer_range = 3, l_max_bright = 1, l_color = "#da0205"),
-		)
+		LIGHTMODE_EMERGENCY = list(l_outer_range = 3, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED),
+	)
 
 /obj/item/light/bulb/red
-	color = "#da0205"
-	b_colour = "#da0205"
+	color = LIGHT_COLOUR_E_RED
+	b_colour = LIGHT_COLOUR_E_RED
 	random_tone = FALSE
 
 /obj/item/light/bulb/red/readylight
 	lighting_modes = list(
-		LIGHTMODE_READY = list(l_outer_range = 5, l_max_bright = 1, l_color = "#00ff00"),
-		)
+		LIGHTMODE_READY = list(l_outer_range = 5, l_max_bright = 1, l_color = LIGHT_COLOUR_READY),
+	)
 
 /obj/item/light/throw_impact(atom/hit_atom)
 	..()

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -255,15 +255,15 @@
 
 /obj/item/light/tube/skrell
 	name = "skrellian light filament"
-	color = COLOR_LIGHT_CYAN
-	b_colour = COLOR_LIGHT_CYAN
+	color = LIGHT_COLOUR_SKRELL
+	b_colour = LIGHT_COLOUR_SKRELL
 	desc = "Some kind of strange alien lightbulb technology."
 	random_tone = FALSE
 
 /obj/item/light/tube/large/skrell
 	name = "skrellian light filament"
-	color = COLOR_LIGHT_CYAN
-	b_colour = COLOR_LIGHT_CYAN
+	color = LIGHT_COLOUR_SKRELL
+	b_colour = LIGHT_COLOUR_SKRELL
 	desc = "Some kind of strange alien lightbulb technology."
 
 

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -397,6 +397,7 @@
 
 /area/aquila/medical
 	name = "\improper SEV Aquila - Medical"
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/aquila/head
 	name = "\improper SEV Aquila - Head"
@@ -424,6 +425,7 @@
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 	req_access = list(access_petrov)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/shuttle/petrov/cell1
 	name = "\improper SRV Petrov - Isolation Cell 1"
@@ -459,6 +461,7 @@
 	name = "\improper SRV Petrov - Maintenance"
 	icon_state = "engine"
 	req_access = list(access_petrov_maint)
+	lighting_tone = AREA_LIGHTING_DEFAULT
 
 /area/shuttle/petrov/analysis
 	name = "\improper SRV Petrov - Analysis Lab"
@@ -486,6 +489,7 @@
 /area/shuttle/petrov/custodial
 	name = "\improper SRV Petrov - Custodial"
 	icon_state = "decontamination"
+	lighting_tone = AREA_LIGHTING_DEFAULT
 
 /area/shuttle/petrov/equipment
 	name = "\improper SRV Petrov - Equipment Storage"
@@ -541,6 +545,7 @@
 	name = "\improper Medical Lift"
 	icon_state = "shuttle3"
 	base_turf = /turf/simulated/open
+	lighting_tone = AREA_LIGHTING_COOL
 
 //Merchant
 
@@ -598,6 +603,7 @@
 	name = "Officer's Mess"
 	icon_state = "bar"
 	sound_env = MEDIUM_SOFTFLOOR
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/command/pathfinder
 	name = "\improper Pathfinder's Office"
@@ -638,27 +644,32 @@
 	name = "\improper Command - CO's Quarters"
 	sound_env = MEDIUM_SOFTFLOOR
 	req_access = list(access_captain)
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/co
 	icon_state = "heads_cap"
 	name = "\improper Command - CO's Office"
 	sound_env = MEDIUM_SOFTFLOOR
 	req_access = list(access_captain)
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/xo
 	icon_state = "heads_hop"
 	name = "\improper Command - XO's Office"
 	req_access = list(access_hop)
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/rd
 	icon_state = "heads_rd"
 	name = "\improper Command - CSO's Office"
 	req_access = list(access_rd)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/crew_quarters/heads/office/cmo
 	icon_state = "heads_cmo"
 	name = "\improper Command - CMO's Office"
 	req_access = list(access_cmo)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/crew_quarters/heads/office/ce
 	icon_state = "heads_ce"
@@ -674,6 +685,7 @@
 	icon_state = "heads_cl"
 	name = "\improper Command - CL's Office"
 	req_access = list(access_liaison)
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/cl/backroom
 	icon_state = "heads_cl"
@@ -684,6 +696,7 @@
 	icon_state = "heads_sr"
 	name = "\improper Command - SCGR's Office"
 	req_access = list(access_representative)
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/heads/office/sea
 	icon_state = "heads_sea"
@@ -741,6 +754,7 @@
 /area/vacant/mess
 	name = "\improper Old Mess"
 	icon_state = "bar"
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/vacant/chapel
 	name = "\improper Unused Chapel"
@@ -749,6 +763,7 @@
 /area/vacant/infirmary
 	name = "\improper Auxiliary Infirmary"
 	icon_state = "medbay"
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/vacant/monitoring
 	name = "\improper Auxiliary Monitoring Room"
@@ -776,6 +791,7 @@
 /area/vacant/bar
 	name = "\improper Hidden Bar"
 	icon_state = "bar"
+	lighting_tone = AREA_LIGHTING_WARM
 
 // Storage
 /area/storage/auxillary
@@ -800,12 +816,14 @@
 	icon_state = "medbay4"
 	sound_env = SMALL_ENCLOSED
 	req_access = list(access_medical)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/storage/research
 	name = "Research Storage"
 	icon_state = "toxstorage"
 	sound_env = SMALL_ENCLOSED
 	req_access = list(access_research)
+	lighting_tone = AREA_LIGHTING_COOL
 
 // Supply
 
@@ -912,6 +930,7 @@
 	icon_state = "bar"
 	sound_env = LARGE_SOFTFLOOR
 	req_access = list(access_bar)
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/cryolocker
 	name = "\improper Cryogenic Storage Wardrobe"
@@ -936,10 +955,12 @@
 /area/crew_quarters/mess
 	name = "\improper Mess Hall"
 	icon_state = "cafeteria"
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/recreation
 	name = "\improper Recreation"
 	icon_state = "crew_quarters"
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/observation
 	name = "\improper Observation"
@@ -949,11 +970,13 @@
 	name = "\improper Galley"
 	icon_state = "kitchen"
 	req_access = list(access_kitchen)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/crew_quarters/galleybackroom
 	name = "\improper Galley Cold Storage"
 	icon_state = "kitchen"
 	req_access = list(access_kitchen)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/crew_quarters/commissary
 	name = "\improper Commissary"
@@ -964,6 +987,7 @@
 	name = "\improper Lounge"
 	icon_state = "crew_quarters"
 	sound_env = MEDIUM_SOFTFLOOR
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/safe_room
 	name = "\improper Safe Room"
@@ -976,6 +1000,7 @@
 	icon_state = "Sleep"
 	sound_env = SMALL_SOFTFLOOR
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/sleep/cryo/aux
 	name = "\improper First Deck Cryogenic Storage"
@@ -1032,6 +1057,7 @@
 	icon_state = "detective"
 	sound_env = MEDIUM_SOFTFLOOR
 	req_access = list(access_forensics_lockers)
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/security/locker
 	name = "\improper Security - Locker Room"
@@ -1116,6 +1142,7 @@
 /area/medical/counselor/therapy
 	name = "\improper Counselor's Therapy Room"
 	icon_state = "medbay3"
+	lighting_tone = AREA_LIGHTING_WARM
 
 /area/medical/sleeper
 	name = "\improper Emergency Treatment Centre"
@@ -1521,6 +1548,7 @@ area/assembly/robotics/office
 
 /area/assembly/robotics/surgery
 	name = "\improper Robotics Operating Theatre"
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/rnd/misc_lab
 	name = "\improper Miscellaneous Research"
@@ -1582,6 +1610,7 @@ area/assembly/robotics/office
 /area/hydroponics
 	name = "\improper Hydroponics"
 	icon_state = "hydro"
+	lighting_tone = AREA_LIGHTING_COOL
 
 /area/janitor
 	name = "\improper Custodial Closet"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -40,7 +40,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 434 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 432 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 5 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
Includes some refactoring, documentation, and cleanup of lights.

:cl: SierraKomodo
maptweak: Certain parts of the Torch now have specific lighting tones instead of randomized lights. Examples include medical and R&D being a clinical white, while relaxation areas like the lounge use warm yellowing light.
/:cl: