### PR TITLE
SSD examine messages now clarify SSD status and are pink

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -180,9 +180,9 @@
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. [T.He] won't be recovering any time soon. (SSD/Ghosted)</span>\n"
+			msg += SPAN_DEBUG("[T.He] [T.is] [ssd_msg]. [T.He] won't be recovering any time soon. (Ghosted)") + "\n"
 		else if(!client)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. (SSD/Disconnected)</span>\n"
+			msg += SPAN_DEBUG("[T.He] [T.is] [ssd_msg]. (Disconnected)") + "\n"
 
 	if (admin_paralyzed)
 		msg += SPAN_DEBUG("OOC: [T.He] [T.has] been paralyzed by staff. Please avoid interacting with [T.him] unless cleared to do so by staff.") + "\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -180,9 +180,9 @@
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. [T.He] won't be recovering any time soon.</span>\n"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. [T.He] won't be recovering any time soon. (SSD/Ghosted)</span>\n"
 		else if(!client)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>\n"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. (SSD/Disconnected)</span>\n"
 
 	if (admin_paralyzed)
 		msg += SPAN_DEBUG("OOC: [T.He] [T.has] been paralyzed by staff. Please avoid interacting with [T.him] unless cleared to do so by staff.") + "\n"


### PR DESCRIPTION
:cl: SierraKomodo
tweak: SSD examine messages now clarify SSD status in the text.
tweak: SSD examine text is now bright pink, similar to staff paralysis text.
/:cl:

Some of the SSD messages, especially robot/fbp specific ones, are a bit ambiguous. Combine this with the fact some of our players are colorblind, and it's hard to tell if the message is indicating SSD or unconsciousness/death. This just adds a `(Ghosted)` or `(Disconnected)` to the end of the message on examine.

The change in color is to help differentiate the text from the dark blue and red of other examine text.