### PR TITLE
Remove Brig Headset/Remove 2/3 Labelers in Sec

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -15904,7 +15904,6 @@
 "cDO" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/evidence,
-/obj/item/hand_labeler,
 /obj/machinery/camera/network/security{
 	c_tag = "Security Wing - Processing";
 	dir = 4
@@ -15931,6 +15930,7 @@
 	dir = 9;
 	icon_state = "corner_white"
 	},
+/obj/item/screwdriver,
 /turf/simulated/floor/tiled/monotile,
 /area/security/processing)
 "cEb" = (
@@ -18764,7 +18764,6 @@
 /area/hallway/primary/firstdeck/aft)
 "hjk" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/item/device/radio/headset,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/security/brig)
@@ -20315,7 +20314,6 @@
 "jft" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/hand_labeler,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "jhb" = (


### PR DESCRIPTION
:cl: Ryan180602
maptweak: Removes Brig Headset, puts a screwdriver in Processing instead.
maptweak: Removes 2 out of 3 labellers in security
/:cl:

Torch headsets have common anyways. If Security needs to not have the antag talk over their radio, they can take the key out. But due to the meta implications of taking headsets away, its best to not have a replacement radio headset in the brig.

Also, too many labellers.