### PR TITLE
Removes Solgov utes parent object from random spawn list

### DIFF
--- a/maps/torch/items/items.dm
+++ b/maps/torch/items/items.dm
@@ -14,7 +14,7 @@ Random item spawning
 				/obj/item/clothing/head/soft/solgov/fleet = 4,
 				/obj/item/clothing/head/helmet/solgov = 1,
 				/obj/item/clothing/suit/storage/vest/solgov = 2,
-				/obj/item/clothing/under/solgov/utility = 5,
+				/obj/item/clothing/under/solgov/utility/expeditionary = 5,
 				/obj/item/clothing/under/solgov/utility/fleet = 3,
 				/obj/item/clothing/under/solgov/pt/expeditionary = 4,
 				/obj/item/clothing/under/solgov/pt/fleet = 4


### PR DESCRIPTION
🆑 Jux
tweak: Formless and Factionless solgov utility clothing will spawn on the Torch no more. Rejoice in proper expeditionary utes.
/🆑

 