### PR TITLE
Add 'set round length' and 'toggle continue vote' buttons

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -2,6 +2,7 @@ var/datum/controller/transfer_controller/transfer_controller
 
 /datum/controller/transfer_controller
 	var/timerbuffer = 0 //buffer for time check
+	var/do_continue_vote = TRUE
 
 /datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
@@ -13,7 +14,11 @@ var/datum/controller/transfer_controller/transfer_controller
 
 /datum/controller/transfer_controller/Process()
 	if (time_till_transfer_vote() <= 0)
-		SSvote.initiate_vote(/datum/vote/transfer, automatic = 1)
+		if (do_continue_vote)
+			SSvote.initiate_vote(/datum/vote/transfer, automatic = 1)
+		else
+			init_autotransfer()
+
 		timerbuffer += config.vote_autotransfer_interval
 
 /datum/controller/transfer_controller/proc/time_till_transfer_vote()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1592,3 +1592,32 @@ datum/admins/var/obj/item/paper/admin/faxreply // var to hold fax replies in
 		qdel(P)
 		faxreply = null
 	return
+
+/datum/admins/proc/setroundlength()
+	set category = "Server"
+	set desc = "Set the time the round-end vote will start in minutes."
+	set name = "Set Round Length"
+
+	if (GAME_STATE > RUNLEVEL_LOBBY)
+		to_chat(usr, SPAN_WARNING("You cannot change the round length after the game has started!"))
+		return
+
+	var/time = input("Set the time until the round-end vote occurs (IN MINUTES). Default is [config.vote_autotransfer_initial]", "Set Round Length", 0) as null | num
+
+	if (!time || !isnum(time) || time < 0)
+		return
+
+	transfer_controller.timerbuffer = time MINUTES
+	log_and_message_admins("set the initial round-end vote time to [time] minutes after round-start.")
+
+/datum/admins/proc/toggleroundendvote()
+	set category = "Server"
+	set desc = "Toggle the continue vote on/off. Toggling off will cause round-end to occur when the next continue vote time would be."
+	set name = "Toggle Continue Vote"
+
+	if (GAME_STATE > RUNLEVEL_GAME)
+		to_chat(usr, SPAN_WARNING("The game is already ending!"))
+		return
+
+	transfer_controller.do_continue_vote = !transfer_controller.do_continue_vote
+	log_and_message_admins("toggled the continue vote [transfer_controller.do_continue_vote ? "ON" : "OFF"]")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -94,7 +94,9 @@ var/list/admin_verbs_admin = list(
 	/client/proc/remove_trader,
 	/datum/admins/proc/sendFax,
 	/client/proc/check_fax_history,
-	/client/proc/cmd_admin_notarget
+	/client/proc/cmd_admin_notarget,
+	/datum/admins/proc/setroundlength,
+	/datum/admins/proc/toggleroundendvote
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,


### PR DESCRIPTION
:cl: Mucker
admin: Add 'set round length' and 'toggle continue vote' buttons
/:cl:

Set Round Length: Set how long (in minutes) before the initial continue vote occurs. Can only be set pre-round-start.
Toggle Continue Vote: Does what it says. If toggled off, the transfer/jump phase will immediately begin once the next Continue vote time is reached instead of prompting users to vote to extend or not.