### PR TITLE
All body armour now has a two second equip delay

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -9,7 +9,7 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.6
-
+	equip_delay = 2 SECONDS
 
 /obj/item/clothing/suit/armor/vest/old //just realized these had never been removed
 	name = "armor"


### PR DESCRIPTION
🆑 Jux
tweak: All body armour  - Plates, armor suits, the weird legacy stuff - now has a two second equip time.
/🆑

Just applies the two seconds to the parent armor. If it's more desirable, I can go through and do some of them individually - higher on things like the riot/ablative/deathsquad armours, lower on plate carriers 