### PR TITLE
Add FBP, Adherent to rogue drone target whitelist

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
@@ -39,7 +39,7 @@
 			. -= S
 		else if (ishuman(S))
 			var/mob/living/carbon/human/H = S
-			if (istype(H.wear_suit, /obj/item/clothing/suit/cardborg) && istype(H.head, /obj/item/clothing/head/cardborg))
+			if (H.species.name == SPECIES_ADHERENT || H.isFBP() || (istype(H.wear_suit, /obj/item/clothing/suit/cardborg) && istype(H.head, /obj/item/clothing/head/cardborg)))
 				. -= H
 
 /datum/say_list/rogue_drone


### PR DESCRIPTION
:cl: Mucker
tweak: Rogue drones will no longer target FBP's or Adherent.
/:cl: