### PR TITLE
Fixes suicide admin logs not showing the gun name

### DIFF
--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -160,7 +160,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 
 	if (istype(user))
 		if (user.zone_sel.selecting == BP_MOUTH)
-			admin_attacker_log(user, "is getting ready to suicide with \a [src]")
+			admin_attacker_log(user, "is getting ready to suicide with \a [thing]")
 			if (user.check_has_mouth() && !(user.check_mouth_coverage()))
 				gunpointedself = SPAN_DANGER("\The [owner] puts the barrel of \the [thing] in their mouth, ready to pull the trigger...")
 			else


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Gun-to-mouth suicide logs now properly display the gun instead of just saying `a <blank>`.
/:cl: