### PR TITLE
Prevent emags from working on already open lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -536,7 +536,7 @@
 	..()
 
 /obj/structure/closet/emag_act(var/remaining_charges, var/mob/user, var/emag_source, var/visual_feedback = "", var/audible_feedback = "")
-	if(make_broken())
+	if(!opened && make_broken())
 		update_icon()
 		if(visual_feedback)
 			visible_message(visual_feedback, audible_feedback)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Emags will no longer break an already open locker when you try to put them in the said locker.
/:cl: