### PR TITLE
Mob AI Buildmode tweaks

### DIFF
--- a/code/modules/admin/buildmode/ai.dm
+++ b/code/modules/admin/buildmode/ai.dm
@@ -139,6 +139,7 @@
 			var/told = 0
 			for(var/mob/living/unit in selected_mobs)
 				var/datum/ai_holder/AI = unit.ai_holder
+				AI.lose_follow()
 				AI.home_turf = T
 				if (unit.get_AI_stance() == STANCE_SLEEP)
 					unit.forceMove(T)

--- a/code/modules/admin/buildmode/ai.dm
+++ b/code/modules/admin/buildmode/ai.dm
@@ -80,6 +80,7 @@
 			if (pa["alt"])
 				if (!isnull(L.get_AI_stance()))
 					AI.hostile = !AI.hostile
+					AI.lose_target()
 					to_chat(user, SPAN_NOTICE("\The [L] is now [AI.hostile ? "hostile" : "passive"]."))
 				else
 					to_chat(user, SPAN_WARNING("\The [L] is not AI controlled."))


### PR DESCRIPTION
:cl: Mucker
admin: Commanding a mob to move in AI buildmode now removes their follower target.
admin: Changing the hostile status of a mob now resets its target, so it stops attacking if made passive.
/:cl: