### PR TITLE
Exo event tweaks

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -192,6 +192,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/exo
 	severity = EVENT_LEVEL_EXO
 	available_events = list(
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",							/datum/event/nothing,				100),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,         0,  list(ASSIGNMENT_ANY = 45))
 	)
 

--- a/code/modules/events/exo_awakening/_datums.dm
+++ b/code/modules/events/exo_awakening/_datums.dm
@@ -18,7 +18,7 @@
 			)
 	arrival_message = "A blood-curdling howl echoes through the air as the planet starts to shake violently. Something has woken up..."
 	arrival_sound   = 'sound/ambience/meat_monster_arrival.ogg'
-	limit = 55
+	limit = 30
 	spawn_near_chance = 30
 
 /datum/mob_list/major/spiders
@@ -40,7 +40,7 @@
 			)
 	arrival_message = "The ground beneath you shakes and rumbles, and is accompanied by an approaching skittering sound..."
 	arrival_sound   = 'sound/effects/wind/wind_3_1.ogg'
-	limit = 25
+	limit = 15
 	length = 45
 	spawn_near_chance = 10
 
@@ -53,7 +53,7 @@
 			)
 	arrival_message = "The ground beneath you rumbles as you hear the sounds of machinery from all around you..."
 	arrival_sound   = 'sound/effects/wind/wind_3_1.ogg'
-	limit = 45
+	limit = 25
 	length = 50
 	spawn_near_chance = 10
 
@@ -67,7 +67,7 @@
 			)
 	arrival_message = "You feel uneasy as you hear something skittering about..."
 	arrival_sound = 'sound/effects/wind/wind_3_1.ogg'
-	limit = 15
+	limit = 8
 	length = 40
 	spawn_near_chance = 5
 
@@ -78,6 +78,6 @@
 			)
 	arrival_message = "You hear the distant sound of creaking metal joints, what is that?"
 	arrival_sound = 'sound/effects/wind/wind_3_1.ogg'
-	limit = 25
+	limit = 10
 	length = 50
 	spawn_near_chance = 15

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -131,7 +131,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 /datum/event/exo_awakening/announce()
 	var/announcement = ""
 	if (severity > EVENT_LEVEL_MODERATE)
-		announcement = "Extreme biological activity spike detected on [location_name()]. Recommend away team evacuation."
+		announcement = "Extreme biological activity spike detected on [location_name()]."
 	else
 		announcement = "Anomalous biological activity detected on [location_name()]."
 


### PR DESCRIPTION
:cl: Mucker
tweak: Lowered the number of mobs that spawn via Exo awakening events.
/:cl:

Should hopefully make the event less of an 'oh no run away' thing and into something more survivable, so that people don't just need to up and leave at the first sign of it.

NUFC: added 'nothing' event to the exoplanet event container so the only current even in there won't be guaranteed to occur.