### PR TITLE
Fixes doors incorrectly updating connections

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -83,15 +83,16 @@
 	if (turf_hand_priority)
 		set_extension(src, /datum/extension/turf_hand, turf_hand_priority)
 
+/obj/machinery/door/Initialize()
+	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
+	. = ..()
+
 	health = maxhealth
 	update_connections(1)
 	update_icon()
 
 	update_nearby_tiles(need_rebuild=1)
 
-/obj/machinery/door/Initialize()
-	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
-	. = ..()
 	if(autoset_access)
 #ifdef UNIT_TEST
 		if(length(req_access))


### PR DESCRIPTION
Looks like multi-z away sites load things differently from everything else, the doors don't seem to detect surrounding walls if they aren't loaded in before the door itself is. This moves the problematic part, and a few extra things, to Initialize(), making it run through those a bit later and fixing the problem.

Moving everything to Initialize() breaks multitile doors, so some of the code was left in New().

As I was doing a final test I noticed the cryofreezers seem to be suffering from the same problem, the maploader error should probably be addressed eventually, but we should put things into Initialize() as much as we can anyway, so this fix is probably fine.

Before:
![WrongDirBefore](https://user-images.githubusercontent.com/36898682/137638965-5cfb3012-8220-47c5-a82e-b6d11aa7e6ba.png)

After:
![WrongDirNow](https://user-images.githubusercontent.com/36898682/137638978-a2be70b0-aae0-42d0-a924-5f68b3372b20.png)