### PR TITLE
Various standardized health tweaks

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -276,6 +276,8 @@ its easier to just keep the beam vertical.
 
 	to_chat(user, "[icon2html(src, user)] That's [f_name] [suffix]")
 	to_chat(user, desc)
+	if (health_max)
+		examine_damage_state(user)
 	return TRUE
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -33,6 +33,16 @@
 	return health_max
 
 /**
+ * Whether or not the atom's health is damaged.
+ */
+/atom/proc/health_damaged(use_raw_values)
+	if (!health_max)
+		return
+	if (use_raw_values)
+		return health_current < health_max
+	return get_current_health() < get_max_health()
+
+/**
  * Retrieves the atom's current damage, or `null` if not using health.
  * If `use_raw_values` is `TRUE`, uses the raw var values instead of the `get_*` proc results.
  */

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -177,14 +177,14 @@
  */
 /atom/proc/kill_health()
 	SHOULD_CALL_PARENT(TRUE)
-	return mod_health(-health_max)
+	return set_health(0)
 
 /**
  * Returns health to full, resetting the death state as well.
  */
 /atom/proc/revive_health()
 	SHOULD_CALL_PARENT(TRUE)
-	return mod_health(health_max)
+	return set_health(health_max)
 
 /**
  * Proc called when death state changes.

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -284,11 +284,6 @@
 		else
 			to_chat(user, SPAN_DANGER("They look severely hurt."))
 
-/atom/examine(mob/user, distance, infix, suffix)
-	. = ..()
-	if (health_max)
-		examine_damage_state(user)
-
 /**
  * Copies the state of health from one atom to another.
  */

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -134,6 +134,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
+	if (!can_restore_health(damage, damage_type))
+		return FALSE
 	return mod_health(damage, damage_type = null)
 
 /**
@@ -144,6 +146,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
+	if (!can_damage_health(damage, damage_type))
+		return FALSE
 
 	// Apply resistance/weakness modifiers
 	damage *= get_damage_resistance(damage_type)

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -1,22 +1,23 @@
-/atom
-	/// Current health for health processing. Use `get_current_health()`, `damage_health()`, or `restore_health()` for general health references.
-	var/health_current
-	/// Maximum health for simple health processing. Use `get_max_health()` or `set_max_health()` to reference/modify.
-	var/health_max
-	/// Whether or not the atom is considered 'dead'. Use `is_alive()` for general checks.
-	var/health_dead = FALSE
+/// Current health for health processing. Use `get_current_health()`, `damage_health()`, or `restore_health()` for general health references.
+/atom/var/health_current
 
-	/**
-	 * LAZY List of damage type resistance or weakness multipliers, decimal form. Only applied to health reduction. Use `set_damage_resistance()`, `remove_damage_resistance()`, and `get_damage_resistance()` to reference/modify.
-	 *
-	 * Index should be one of the `DAMAGE_` flags.
-	 * Value should be a multiplier that is applied against damage. Values below 1 are a resistance, above 1 are a weakness.
-	 * Value of `0` is considered immunity.
-	 */
-	var/list/health_resistances
+/// Maximum health for simple health processing. Use `get_max_health()` or `set_max_health()` to reference/modify.
+/atom/var/health_max
 
-	/// Minimum damage required to actually affect health in `can_damage_health()`.
-	var/health_min_damage = 0
+/// Whether or not the atom is considered 'dead'. Use `is_alive()` for general checks.
+/atom/var/health_dead = FALSE
+
+/**
+ * LAZY List of damage type resistance or weakness multipliers, decimal form. Only applied to health reduction. Use `set_damage_resistance()`, `remove_damage_resistance()`, and `get_damage_resistance()` to reference/modify.
+ *
+ * Index should be one of the `DAMAGE_` flags.
+ * Value should be a multiplier that is applied against damage. Values below 1 are a resistance, above 1 are a weakness.
+ * Value of `0` is considered immunity.
+ */
+/atom/var/list/health_resistances
+
+/// Minimum damage required to actually affect health in `can_damage_health()`.
+/atom/var/health_min_damage = 0
 
 /**
  * Retrieves the atom's current health, or `null` if not using health

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -19,20 +19,11 @@
 	var/health_min_damage = 0
 
 /**
- * Whether or not the atom has health. Checks for a value in `health_max`.
- * Can be overridden for additional checks.
- * Returns `TRUE` or `FALSE`.
- */
-/atom/proc/has_health()
-	SHOULD_CALL_PARENT(TRUE)
-	return !!health_max
-
-/**
  * Retrieves the atom's current health, or `null` if not using health
  */
 /atom/proc/get_current_health()
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	return health_current
 
@@ -41,7 +32,7 @@
  */
 /atom/proc/get_max_health()
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	return health_max
 
@@ -50,7 +41,7 @@
  * If `use_raw_values` is `TRUE`, uses the raw var values instead of the `get_*` proc results.
  */
 /atom/proc/get_damage_value(use_raw_values)
-	if (!has_health())
+	if (!health_max)
 		return
 	if (use_raw_values)
 		return health_max - health_current
@@ -62,7 +53,7 @@
  * If `use_raw_values` is `TRUE`, uses the raw var values instead of the `get_*` proc results.
  */
 /atom/proc/get_damage_percentage(use_raw_values)
-	if (!has_health())
+	if (!health_max)
 		return
 	var/max_health = use_raw_values ? health_max : get_max_health()
 	return round(get_damage_value(use_raw_values) / max_health, 0.01)
@@ -75,7 +66,7 @@
  */
 /atom/proc/can_restore_health(damage, damage_type = null)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	if (!damage)
 		return FALSE
@@ -90,7 +81,7 @@
  */
 /atom/proc/can_damage_health(damage, damage_type = null)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	if (!is_alive())
 		return FALSE
@@ -106,7 +97,7 @@
  */
 /atom/proc/is_alive()
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	return !health_dead
 
@@ -117,7 +108,7 @@
  */
 /atom/proc/mod_health(health_mod, damage_type)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	health_current = Clamp(health_current + health_mod, 0, get_max_health())
 	post_health_change(health_mod, damage_type)
@@ -130,7 +121,7 @@
  */
 /atom/proc/set_health(new_health)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	var/health_mod = new_health - health_current
 	return mod_health(health_mod)
@@ -140,7 +131,7 @@
  */
 /atom/proc/restore_health(damage, damage_type = null)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	return mod_health(damage, damage_type = null)
 
@@ -150,7 +141,7 @@
  */
 /atom/proc/damage_health(damage, damage_type = null)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 
 	// Apply resistance/weakness modifiers
@@ -170,7 +161,7 @@
  */
 /atom/proc/check_death_state()
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	var/health_current = get_current_health()
 	if (health_current > 0 && health_dead)
@@ -188,7 +179,7 @@
  */
 /atom/proc/set_death_state(new_death_state)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!has_health())
+	if (!health_max)
 		return
 	if (new_death_state == health_dead)
 		return FALSE
@@ -294,14 +285,14 @@
 
 /atom/examine(mob/user, distance, infix, suffix)
 	. = ..()
-	if (has_health())
+	if (health_max)
 		examine_damage_state(user)
 
 /**
  * Copies the state of health from one atom to another.
  */
 /proc/copy_health(atom/source_atom, atom/target_atom)
-	if (!source_atom || QDELETED(target_atom) || !source_atom.has_health() || !target_atom.has_health())
+	if (!source_atom || QDELETED(target_atom) || !source_atom.health_max || !target_atom.health_max)
 		return
 	target_atom.health_current = source_atom.health_current
 	target_atom.health_max = source_atom.health_max

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -108,7 +108,7 @@
 	if (!health_max)
 		return
 	var/death_state = is_alive()
-	health_current = Clamp(health_current + health_mod, 0, get_max_health())
+	health_current = round(Clamp(health_current + health_mod, 0, get_max_health()))
 	post_health_change(health_mod, damage_type)
 	var/new_death_state = is_alive()
 	if (death_state == new_death_state)
@@ -189,7 +189,7 @@
  */
 /atom/proc/set_max_health(new_max_health, set_current_health = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
-	health_max = new_max_health
+	health_max = round(new_max_health)
 	health_current = set_current_health ? get_max_health() : min(health_current, get_max_health())
 
 /**

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -100,9 +100,10 @@
 /**
  * Health modification for the health system. Applies `health_mod` directly to `simple_health` via addition and calls `handle_death_change` as needed.
  * Has no pre-modification checks, you should be using `damage_health()` or `restore_health()` instead of this.
+ * `skip_death_state_change` will skip calling `handle_death_change()` when applicable. Used for when the originally calling proc needs handle it in a unique way.
  * Returns `TRUE` if the death state changes, `null` if the atom is not using health, `FALSE` otherwise.
  */
-/atom/proc/mod_health(health_mod, damage_type)
+/atom/proc/mod_health(health_mod, damage_type, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
@@ -112,7 +113,8 @@
 	var/new_death_state = is_alive()
 	if (death_state == new_death_state)
 		return FALSE
-	handle_death_change(new_death_state)
+	if (!skip_death_state_change)
+		handle_death_change(new_death_state)
 	return TRUE
 
 /**
@@ -120,29 +122,29 @@
  * Has no pre-modification checks.
  * Returns `TRUE` if the death state changes, `null` if the atom is not using health, `FALSE` otherwise.
  */
-/atom/proc/set_health(new_health)
+/atom/proc/set_health(new_health, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
 	var/health_mod = new_health - health_current
-	return mod_health(health_mod)
+	return mod_health(health_mod, skip_death_state_change = skip_death_state_change)
 
 /**
  * Restore's the atom's health by the given value. Returns `TRUE` if the restoration resulted in a death state change.
  */
-/atom/proc/restore_health(damage, damage_type = null)
+/atom/proc/restore_health(damage, damage_type = null, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
 	if (!can_restore_health(damage, damage_type))
 		return FALSE
-	return mod_health(damage, damage_type = null)
+	return mod_health(damage, damage_type, skip_death_state_change)
 
 /**
  * Damage's the atom's health by the given value. Returns `TRUE` if the damage resulted in a death state change.
  * Resistance and weakness modifiers are applied here.
  */
-/atom/proc/damage_health(damage, damage_type = null)
+/atom/proc/damage_health(damage, damage_type = null, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
@@ -152,7 +154,7 @@
 	// Apply resistance/weakness modifiers
 	damage *= get_damage_resistance(damage_type)
 
-	return mod_health(-damage, damage_type = null)
+	return mod_health(-damage, damage_type, skip_death_state_change)
 
 /**
  * Proc called after any health changes made by the system

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -240,7 +240,7 @@
 /obj/effect/rune/wall/cast(var/mob/living/user)
 	var/t
 	if(wall)
-		if(!wall.get_damage_value())
+		if(!wall.health_damaged())
 			to_chat(user, "<span class='notice'>The wall doesn't need mending.</span>")
 			return
 		t = wall.get_damage_value()

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -51,7 +51,7 @@
 		damage_health(W.force)
 
 /obj/item/material/ashtray/throw_impact(atom/hit_atom)
-	if (has_health())
+	if (health_max)
 		if (contents.len)
 			visible_message("<span class='danger'>\The [src] slams into [hit_atom], spilling its contents!</span>")
 			for (var/obj/O in contents)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -133,7 +133,7 @@
 
 	for (var/atom/A in T)
 		// Catch any atoms that use health processing
-		if (A.has_health() && A.is_alive())
+		if (A.health_max && A.is_alive())
 			var/damage_type = pick(BRUTE, BURN)
 			visible_message(SPAN_DANGER("A tendril flies out from \the [src] and smashes into \the [A]!"))
 			playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -502,7 +502,7 @@
 		update_icon()
 	else if(isCoil(I))
 		var/obj/item/stack/cable_coil/C = I
-		if(get_damage_value() && do_after(user, 10, src) && C.use(1))
+		if(health_damaged() && do_after(user, 10, src) && C.use(1))
 			user.visible_message(SPAN_NOTICE("\The [user] patches up \the [src]."))
 			restore_health(5)
 	else

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -72,7 +72,7 @@
 			return
 		if(!handcuffed || buckled)
 			return
-	if (handcuffed.has_health()) // Improvised cuffs can break because their health is > 0
+	if (handcuffed.health_max) // Improvised cuffs can break because their health is > 0
 		if (handcuffed.damage_health(handcuffed.get_max_health() / 2))
 			visible_message(
 				SPAN_DANGER("\The [src] manages to remove \the [handcuffed], breaking them!"),


### PR DESCRIPTION
NUFC

Updates some of the backend standardized health stuff to match the current Nebula version after feedback. Removes some unused/unnecessary vars and procs, reorganizes some code for VSC `Go To Source` stuff, fixes the 'can_damage_health' and 'can_restore_health' procs not being used, etc.