### PR TITLE
divides head augments in two

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -266,6 +266,9 @@
 /// The augment can be installed on the chest separately to AUGMENT_CHEST
 #define AUGMENT_ARMOR FLAG(7)
 
+/// The augment can be installed in the head separately to AUGMENT_HEAD
+#define AUGMENT_FLUFF FLAG(8)
+
 
 /**
 * Augment Flags

--- a/code/modules/augment/augment.dm
+++ b/code/modules/augment/augment.dm
@@ -45,6 +45,10 @@
 		style = ORGAN_STYLE
 		if (ORGAN_STYLE_OK)
 			return organ
+	if ((augment_slots & AUGMENT_FLUFF) && !organs["[BP_HEAD]_aug_fluff"] && (organ = organs[BP_HEAD]))
+		style = ORGAN_STYLE
+		if (ORGAN_STYLE_OK)
+			return organ
 	if (augment_slots & AUGMENT_ARM)
 		if (!organs["[BP_L_ARM]_aug"] && (organ = organs[BP_L_ARM]))
 			style = ORGAN_STYLE
@@ -104,7 +108,7 @@
 		if (BP_GROIN)
 			found = augment_slots & AUGMENT_GROIN
 		if (BP_HEAD)
-			found = augment_slots & AUGMENT_HEAD
+			found = augment_slots & (AUGMENT_HEAD | AUGMENT_FLUFF)
 	if (!found)
 		to_chat(user, SPAN_WARNING("\The [src] can't be installed in \the [parent]."))
 		parent_organ = null
@@ -113,6 +117,8 @@
 	parent_organ = parent.organ_tag
 	if (found == AUGMENT_ARMOR)
 		organ_tag = "[parent_organ]_aug_armor"
+	if (found == AUGMENT_FLUFF)
+		organ_tag = "[parent_organ]_aug_fluff"
 	else
 		organ_tag = "[parent_organ]_aug"
 
@@ -169,7 +175,7 @@
 		attach_parts += "chests"
 	if (augment_slots & AUGMENT_GROIN)
 		attach_parts += "lower bodies"
-	if (augment_slots & AUGMENT_HEAD)
+	if (augment_slots & (AUGMENT_HEAD|AUGMENT_FLUFF))
 		attach_parts += "heads"
 	if (augment_slots & AUGMENT_ARM)
 		attach_parts += "arms"

--- a/code/modules/augment/passive/fluff.dm
+++ b/code/modules/augment/passive/fluff.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/internal/augment/circadian_conditioner
 	name = "circadian conditioner"
-	augment_slots = AUGMENT_HEAD
+	augment_slots = AUGMENT_FLUFF
 	icon_state = "cranial_aug"
 	desc = "A small brain implant that carefully regulates the output of certain hormones to assist in controlling the sleep-wake cycle of its owner. May be an effective counter to insomnia, jet lag, and late-night work shifts."
 	augment_flags = AUGMENT_BIOLOGICAL | AUGMENT_SCANNABLE
@@ -9,7 +9,7 @@
 
 /obj/item/organ/internal/augment/codex_access
 	name = "codex access chip"
-	augment_slots = AUGMENT_HEAD
+	augment_slots = AUGMENT_FLUFF
 	icon_state = "cranial_aug"
 	desc = "A neuro-memetic implant or retinal chip used to grant realtime access to the Codex - a distributed encyclopedia of sorts, with editorial offices based in Venusian orbit - either via a server connection or local backups of relevant information."
 	origin_tech = list(TECH_DATA = 2, TECH_DATA = 2)
@@ -17,7 +17,7 @@
 
 /obj/item/organ/internal/augment/neurostimulator_implant
 	name = "neurostimulator implant"
-	augment_slots = AUGMENT_HEAD
+	augment_slots = AUGMENT_FLUFF
 	icon_state = "cranial_aug"
 	desc = "An expensive implant attached to the brain's cortex, this network of signal relays sees mixed success as a treatment to lessen the impact of neurological problems such as Parkinson's disease, epilepsy, and paralysis. It can't prevent or heal brain damage on its own, and simply serves to make the life of its owner easier."
 	augment_flags = AUGMENT_BIOLOGICAL | AUGMENT_SCANNABLE
@@ -26,7 +26,7 @@
 
 /obj/item/organ/internal/augment/pain_assistant
 	name = "pain assistant"
-	augment_slots = AUGMENT_HEAD
+	augment_slots = AUGMENT_FLUFF
 	icon_state = "cranial_aug"
 	desc = "This brain implant blocks the impulses of certain nerves - usually tailored between individuals - and is used to lessen chronic pain from worn joints, headaches, and so on. It does nothing for pain that it isn't specifically tuned to handle, and is ineffective against anything stronger than a tummyache."
 	augment_flags = AUGMENT_BIOLOGICAL | AUGMENT_SCANNABLE
@@ -35,7 +35,7 @@
 
 /obj/item/organ/internal/augment/genetic_backup
 	name = "genetic backup"
-	augment_slots = AUGMENT_HEAD
+	augment_slots = AUGMENT_FLUFF
 	icon_state = "cranial_aug"
 	desc = "This implant is a compact and resilient solid-state drive. It does nothing on its own, but contains the complete DNA sequence of its owner - whether it be to aid in medical treatment, serve for research purposes, or even be used as a template for vat-grown humans in the future."
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 2)
@@ -43,7 +43,7 @@
 
 /obj/item/organ/internal/augment/data_chip
 	name = "data chip"
-	augment_slots = AUGMENT_HEAD
+	augment_slots = AUGMENT_FLUFF
 	icon_state = "cranial_aug"
 	desc = "These durable chips can contain nonspecific data for a variety of potential uses, such as record lookups, work portfolios, authentication codes, contact information, and more. They're useful for carrying information without needing extraneous hardware, and some even see use as high-tech dog tags for private security firms or mercenary coalitions."
 	origin_tech = list(TECH_DATA = 2, TECH_MAGNET = 2)


### PR DESCRIPTION
head augments are being weird and as much as i dislike the idea of massive skull cavities with room for an entire television system this solves a few augment bugs

🆑 Jux
tweak: Divides head augments into functional and fluff augments.
/🆑 

@SomeAngryMiner there are you happy now you screaming goblin man