### PR TITLE
Adds config option for maximum round length

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -14,7 +14,10 @@ var/datum/controller/transfer_controller/transfer_controller
 
 /datum/controller/transfer_controller/Process()
 	if (time_till_transfer_vote() <= 0)
-		if (do_continue_vote)
+
+		if (config.maximum_round_length && round_duration_in_ticks >= config.maximum_round_length)
+			init_autotransfer()
+		else if (do_continue_vote)
 			SSvote.initiate_vote(/datum/vote/transfer, automatic = 1)
 		else
 			init_autotransfer()

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -15,7 +15,7 @@ var/datum/controller/transfer_controller/transfer_controller
 /datum/controller/transfer_controller/Process()
 	if (time_till_transfer_vote() <= 0)
 
-		if (config.maximum_round_length && round_duration_in_ticks >= config.maximum_round_length)
+		if (config.maximum_round_length > 0 && round_duration_in_ticks >= config.maximum_round_length)
 			init_autotransfer()
 		else if (do_continue_vote)
 			SSvote.initiate_vote(/datum/vote/transfer, automatic = 1)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -418,6 +418,9 @@
 	/// Logs all timers in buckets on automatic bucket reset
 	var/static/log_timers_on_bucket_reset = FALSE
 
+	/// The maximum amount of time a round can last before it is forcefully ended.
+	var/static/maximum_round_length
+
 
 /configuration/New()
 	build_mode_cache()
@@ -815,6 +818,8 @@
 				game_version = value
 			if ("log_timers_on_bucket_reset")
 				log_timers_on_bucket_reset = TRUE
+			if ("maximum_round_length")
+				maximum_round_length = text2num(value) MINUTES
 			else
 				log_misc("Unknown setting in config/config.txt: '[name]'")
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -419,3 +419,7 @@ RADIATION_LOWER_LIMIT 0.15
 ## Add lines of 'DISALLOW_VOTABLE_MODE config_tag' to prevent a normally votable mode from being votable, eg:
 ## DISALLOW_VOTABLE_MODE changeling
 ## DISALLOW_VOTABLE_MODE malfunction
+
+## Maximum time a round can last for (in minutes). If this time is exceeded,
+## the round will autotransfer without a vote at the next continue vote. Leave disabled for no limit.
+#MAXIMUM_ROUND_LENGTH 120


### PR DESCRIPTION
NUFC

Adds a config option that sets the maximum time a round can go for. Once the time is exceeded, the next 'Continue Vote' will just initiate the autotransfer sequence instead of prompting anyone to vote. Disabled by default.