### PR TITLE
Add Robotic Analyser to Roboticist PDA (Take 2)

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2415,6 +2415,7 @@
 #include "code\modules\modular_computers\hardware\scanners\scanner.dm"
 #include "code\modules\modular_computers\hardware\scanners\scanner_atmos.dm"
 #include "code\modules\modular_computers\hardware\scanners\scanner_medical.dm"
+#include "code\modules\modular_computers\hardware\scanners\scanner_robotic.dm"
 #include "code\modules\modular_computers\hardware\scanners\scanner_paper.dm"
 #include "code\modules\modular_computers\hardware\scanners\scanner_reagent.dm"
 #include "code\modules\modular_computers\NTNet\NTNet.dm"

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -16,7 +16,7 @@
 	matter = list(MATERIAL_STEEL = 250, MATERIAL_GLASS = 100, MATERIAL_PLASTIC = 75)
 	var/mode = 1;
 
-/obj/item/device/robotanalyzer/attack(mob/living/M as mob, mob/living/user as mob)
+/proc/roboscan(mob/living/M, mob/living/user)
 	if((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, text("<span class='warning'>You try to analyze the floor's vitals!</span>"))
 		for(var/mob/O in viewers(M, null))
@@ -93,6 +93,9 @@
 				to_chat(user, "[O.name]: <font color='red'>[(O.status & ORGAN_DEAD) ? "DESTROYED" : O.damage]</font>")
 			if(!organ_found)
 				to_chat(user, "No prosthetics located.")
+	return
 
+/obj/item/device/robotanalyzer/attack(mob/living/M, mob/living/user)
+	roboscan(M, user)
 	src.add_fingerprint(user)
 	return

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -88,3 +88,7 @@
 /obj/item/modular_computer/pda/captain/install_default_hardware()
 	..()
 	scanner = new /obj/item/stock_parts/computer/scanner/paper(src)
+
+/obj/item/modular_computer/pda/roboticist/install_default_hardware()
+	..()
+	scanner = new /obj/item/stock_parts/computer/scanner/robotic(src)

--- a/code/modules/modular_computers/hardware/scanners/scanner_robotic.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_robotic.dm
@@ -1,0 +1,13 @@
+/obj/item/stock_parts/computer/scanner/robotic
+	name = "robotic scanner module"
+	desc = "A robotic scanner module. It is used to analyse the integrity of synthetic components."
+
+/obj/item/stock_parts/computer/scanner/robotic/do_on_afterattack(mob/user, atom/target, proximity)
+	if(!can_use_scanner(user, target, proximity))
+		return
+
+	var/scan_type = roboscan(target, user)
+
+	if(scan_type && driver?.using_scanner)
+		driver.data_buffer = html2pencode(scan_type)
+		SSnano.update_uis(driver.NM)

--- a/code/modules/research/designs/designs_modular_computer.dm
+++ b/code/modules/research/designs/designs_modular_computer.dm
@@ -219,6 +219,15 @@
 	build_path = /obj/item/stock_parts/computer/scanner/medical
 	sort_string = "VBADI"
 
+/datum/design/item/modularcomponent/accessory/robotic_scanner
+	name = "robotic scanner module"
+	id = "scan_robotic"
+	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_MAGNET = 2, TECH_BIO = 1)
+	build_type = PROTOLATHE
+	materials = list(MATERIAL_STEEL = 600, MATERIAL_GLASS = 200)
+	build_path = /obj/item/stock_parts/computer/scanner/robotic
+	sort_string = "VBADJ"
+
 // Batteries
 /datum/design/item/modularcomponent/battery/AssembleDesignName()
 	..()


### PR DESCRIPTION
:cl: Ryan180602
rscadd: Add Robotic Analyser to Roboticist PDA
/:cl:

last PR became weird because the original commit was a month old. 

made new PR for tidiness, thus shoving all the badness under the rug

(sorry)

Just like medical PDAs, now.
Shift's the whole robotics analyser interaction into a proc of its own instead of it just being under a `attack()`