### PR TITLE
Fix for incorrect tech level readouts in R&D console

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -796,7 +796,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					for (var/T in origin_tech)
 						for (var/datum/tech/F in files.known_tech)
 							if (F.name == CallTechName(T))
-								if (F.level <= D.req_tech[T])
+								if (F.level <= origin_tech[T])
 									dat += FONT_COLORED(COLOR_GREEN, " [F.name] = [origin_tech[T]] ")
 								else
 									dat += " [F.name] = [origin_tech[T]] "


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed some tech-level readouts in the protolathe console being wrong.
/:cl:

Missed this the first time as most of the readouts are actually correct, but it turns out I wasn't comparing against the item's origin tech levels when I should have been which causes a few items to read as giving higher or lower tech levels when they, in fact, don't.