### PR TITLE
1.5x the antag scaling coefficient for ling

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -14,5 +14,5 @@
 	required_players = 2
 	required_enemies = 1
 	end_on_antag_death = FALSE
-	antag_scaling_coeff = 10
+	antag_scaling_coeff = 15
 	antag_tags = list(MODE_CHANGELING)


### PR DESCRIPTION
Brings the coefficient down to the default of 5 from 10, putting it in line with most other antag types.
🆑 Jux
tweak: Reduced ling spawning relative to pop.
/🆑 