### PR TITLE
Fixes health death state calls being reversed

### DIFF
--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -117,10 +117,10 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return
-	var/death_state = is_alive()
+	var/death_state = !is_alive()
 	health_current = round(Clamp(health_current + health_mod, 0, get_max_health()))
 	post_health_change(health_mod, damage_type)
-	var/new_death_state = is_alive()
+	var/new_death_state = !is_alive()
 	if (death_state == new_death_state)
 		return FALSE
 	if (!skip_death_state_change)


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Blobs and other things using standardized health can die once more.
/:cl: