### PR TITLE
Add quick-deconstructing to the rnd deconstructor

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -16,7 +16,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	idle_power_usage = 30
 	active_power_usage = 2500
 	construct_state = /decl/machine_construction/default/panel_closed
-	
+
 	machine_name = "destructive analyzer"
 	machine_desc = "Breaks down objects into their component parts, gaining new information in the process. Part of an R&D network."
 
@@ -84,5 +84,9 @@ Note: Must be placed within 3 tiles of the R&D Console
 		spawn(10)
 			update_icon()
 			busy = 0
+
+			if (linked_console.quick_deconstruct)
+				linked_console.deconstruct(weakref(user))
+
 		return 1
 	return

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -70,6 +70,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/protolathe_search = ""
 	var/imprinter_show_tech = TRUE
 	var/imprinter_search = ""
+	var/quick_deconstruct = FALSE
 
 	req_access = list(access_research)	//Data and setting manipulation requires scientist access.
 
@@ -273,10 +274,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(alert("Proceeding will destroy loaded item. Continue?", "Destructive analyzer confirmation", "Yes", "No") == "No")
 			return TOPIC_HANDLED
 		CHECK_DESTROY
-		linked_destroy.busy = 1
-		screen = 0.1
-		flick("d_analyzer_process", linked_destroy)
-		addtimer(CALLBACK(src, .proc/finish_deconstruct, weakref(user)), 24)
+		deconstruct(weakref(usr))
 
 	else if(href_list["lock"]) //Lock the console from use by anyone without tox access.
 		if(allowed(usr))
@@ -475,6 +473,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	else if (href_list["imprinter_show_tech"])
 		imprinter_show_tech = !imprinter_show_tech
 		interact(user)
+	else if (href_list["decon_mode"])
+		quick_deconstruct = !quick_deconstruct
+		interact(user)
+
+/obj/machinery/computer/rdconsole/proc/deconstruct(weakref/W)
+	linked_destroy.busy = TRUE
+	screen = 0.1
+	flick("d_analyzer_process", linked_destroy)
+	addtimer(CALLBACK(src, .proc/finish_deconstruct, W), 24)
 
 /obj/machinery/computer/rdconsole/proc/finish_deconstruct(weakref/W)
 	CHECK_DESTROY
@@ -716,16 +723,19 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "</UL>"
 
 		////////////////////DESTRUCTIVE ANALYZER SCREENS////////////////////////////
+
 		if(2.0)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += "NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE<BR><BR>"
 
 		if(2.1)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='?src=\ref[src];decon_mode=1'>Automatic Deconstruction: [quick_deconstruct ? "ON" : "OFF"]</A><HR>"
 			dat += "No Item Loaded. Standing-by...<BR><HR>"
 
 		if(2.2)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='?src=\ref[src];decon_mode=1'>Automatic Deconstruction: [quick_deconstruct ? "ON" : "OFF"]</A><HR>"
 			dat += "Deconstruction Menu<HR>"
 			dat += "Name: [linked_destroy.loaded_item.name]<BR>"
 
@@ -753,7 +763,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=3.2'>Material Storage</A> || "
 			dat += "<A href='?src=\ref[src];menu=3.3'>Chemical Storage</A><HR>"
 			dat += "Protolathe Menu:<BR><BR>"
-			dat += "<A href='?src=\ref[src];protolathe_show_tech=1'>Show Recipe Tech Levels: [protolathe_show_tech ? "YES" : "NO"]"
+			dat += "<A href='?src=\ref[src];protolathe_show_tech=1'>Show Recipe Tech Levels: [protolathe_show_tech ? "YES" : "NO"]</A>"
 			dat += "<A href='?src=\ref[src];protolathe_search=1'>Search</A>"
 			dat += "<A href='?src=\ref[src];protolathe_reset_search=1'>Reset Search</A><BR>"
 			dat += "[FONT_COLORED(COLOR_GREEN, "Green")] = Tech level higher than current<HR>"
@@ -864,7 +874,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=4.3'>Material Storage</A> || "
 			dat += "<A href='?src=\ref[src];menu=4.2'>Chemical Storage</A><HR>"
 			dat += "Circuit Imprinter Menu:<BR><BR>"
-			dat += "<A href='?src=\ref[src];imprinter_show_tech=1'>Show Recipe Tech Levels: [imprinter_show_tech ? "YES" : "NO"]"
+			dat += "<A href='?src=\ref[src];imprinter_show_tech=1'>Show Recipe Tech Levels: [imprinter_show_tech ? "YES" : "NO"]</A>"
 			dat += "<A href='?src=\ref[src];imprinter_search=1'>Search</A>"
 			dat += "<A href='?src=\ref[src];imprinter_reset_search=1'>Reset Search</A><BR>"
 			dat += "[FONT_COLORED(COLOR_GREEN, "Green")] = Tech level higher than current<HR>"


### PR DESCRIPTION
:cl: Mucker
rscadd: Added the 'quick deconstruction' option to the R&D deconstructor, which will deconstruct items as they are added to the deconstructor without a prompt.
/:cl:

Also added some missing `</a>` ending tags I missed before.