### PR TITLE
Mech cargo spills

### DIFF
--- a/code/modules/mechs/equipment/_equipment.dm
+++ b/code/modules/mechs/equipment/_equipment.dm
@@ -67,6 +67,9 @@
 	owner = null
 	canremove = TRUE
 
+/obj/item/mech_equipment/proc/wreck() //Module has been destroyed
+	return
+
 /obj/item/mech_equipment/Destroy()
 	owner = null
 	. = ..()

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -1,3 +1,56 @@
+//Pile of garbage for when a clam is uninstalled or destroyed with +1 dense items inside
+/obj/structure/cargopile
+	name = "\improper spilled cargo"
+	desc = "The jetsam of some unfortunate power loader."
+	icon = 'icons/obj/rubble.dmi'
+	icon_state = "base"
+	appearance_flags = DEFAULT_APPEARANCE_FLAGS | PIXEL_SCALE
+	atom_flags = ATOM_FLAG_CLIMBABLE
+	opacity = 1
+	density = TRUE
+	anchored = TRUE
+
+
+/obj/structure/cargopile/on_update_icon()
+	overlays.Cut()
+	for(var/obj/thing in contents)
+		var/image/I = new
+		I.appearance = thing.appearance
+		I.appearance_flags = DEFAULT_APPEARANCE_FLAGS | PIXEL_SCALE
+		I.pixel_x = rand(-16,16)
+		I.pixel_y = rand(-16,16)
+		var/matrix/M = matrix()
+		M.Turn(rand(0,360))
+		I.transform = M
+		overlays += I
+
+/obj/structure/cargopile/attack_hand(mob/user)
+	. = ..()
+	if(Adjacent(user))
+		var/obj/chosen_obj = input(user, "Choose an object to grab.", "Cargo pile") as null|anything in contents
+		if(!chosen_obj)
+			return
+		if(chosen_obj.density)
+			for(var/atom/A in get_turf(src))
+				if(A != src && A.density && !(A.atom_flags & ATOM_FLAG_CHECKS_BORDER))
+					to_chat(user, SPAN_WARNING("\The [A] blocks you from pulling out \the [chosen_obj]."))
+					return
+		if(!do_after(user, 5, src)) return
+		if(!chosen_obj) return
+		if(chosen_obj.density)
+			for(var/atom/A in get_turf(src))
+				if(A != src && A.density && !(A.atom_flags & ATOM_FLAG_CHECKS_BORDER))
+					to_chat(user, SPAN_WARNING("\The [A] blocks you from pulling out \the [chosen_obj]."))
+					return
+		if(user.put_in_active_hand(chosen_obj))
+			src.visible_message(SPAN_NOTICE("\The [user] carefully grabs \the [chosen_obj] from \the [src]."))
+		else if(chosen_obj.dropInto(get_turf(src)))
+			src.visible_message(SPAN_NOTICE("\The [user] pulls \the [chosen_obj] from \the [src]."))
+
+		if(!contents.len)
+			qdel_self()
+		else update_icon()
+
 /obj/item/mech_equipment/clamp
 	name = "mounted clamp"
 	desc = "A large, heavy industrial cargo loading clamp."
@@ -31,9 +84,6 @@
 	. = ..()
 
 	if(.)
-		if(length(carrying) >= carrying_capacity)
-			to_chat(user, SPAN_WARNING("\The [src] is fully loaded!"))
-			return
 		if(istype(target, /obj))
 			var/obj/O = target
 			if(O.buckled_mob)
@@ -99,6 +149,10 @@
 					return
 
 				to_chat(user, SPAN_WARNING("\The [target] is firmly secured."))
+				return
+
+			if(length(carrying) >= carrying_capacity)
+				to_chat(user, SPAN_WARNING("\The [src] is fully loaded!"))
 				return
 
 			owner.visible_message(SPAN_NOTICE("\The [owner] begins loading \the [O]."))
@@ -174,23 +228,43 @@
 		return "Multiple"
 	. = ..()
 
-/obj/item/mech_equipment/clamp/uninstalled()
+/obj/item/mech_equipment/clamp/proc/create_spill()
 	if(length(carrying))
+		var/denseCount = 0
 		for(var/obj/load in carrying)
-			var/turf/location = get_turf(src)
-			var/list/turfs = location.AdjacentTurfsSpace()
 			if(load.density)
-				if(turfs.len > 0)
-					location = pick(turfs)
-					turfs -= location
-				else
+				denseCount += 1
+			if(denseCount > 1)
+				break
+
+		if(denseCount > 1)
+			var/obj/structure/cargopile/pile = new(get_turf(src))
+			for(var/obj/load in carrying)
+				load.forceMove(pile)
+				carrying -= load
+			pile.update_icon()
+		else
+			for(var/obj/load in carrying)
+				var/turf/location = get_turf(src)
+				var/list/turfs = location.AdjacentTurfsSpace()
+				if(load.density)
+					if(turfs.len > 0)
+						location = pick(turfs)
+						turfs -= location
+					else
+						load.dropInto(location)
+						load.throw_at_random(FALSE, rand(2,4), 4)
+						location = null
+				if(location)
 					load.dropInto(location)
-					load.throw_at_random(FALSE, rand(2,4), 4)
-					location = null
-			if(location)
-				load.dropInto(location)
-			carrying -= load
+				carrying -= load
+
+/obj/item/mech_equipment/clamp/uninstalled()
+	create_spill()
 	. = ..()
+
+/obj/item/mech_equipment/clamp/wreck()
+	create_spill()
 
 // A lot of this is copied from floodlights.
 /obj/item/mech_equipment/light

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -16,10 +16,16 @@
 				if(thing && prob(40))
 					thing.forceMove(src)
 			for(var/hardpoint in exosuit.hardpoints)
-				if(exosuit.hardpoints[hardpoint] && prob(40))
-					var/obj/item/thing = exosuit.hardpoints[hardpoint]
-					if(exosuit.remove_system(hardpoint))
-						thing.forceMove(src)
+				if(exosuit.hardpoints[hardpoint])
+					if(prob(40))
+						var/obj/item/thing = exosuit.hardpoints[hardpoint]
+						if(exosuit.remove_system(hardpoint))
+							thing.forceMove(src)
+					else
+						//This has been destroyed, some modules may need to perform bespoke logic
+						var/obj/item/mech_equipment/E = exosuit.hardpoints[hardpoint]
+						if(istype(E))
+							E.wreck()
 
 	..()
 


### PR DESCRIPTION
🆑 CrimsonShrike
rscadd: cargo clamps carrying more than one dense item will now create cargo piles on destruction or uninstall instead of dumping a bunch of items all over the place.
/🆑


![image](https://user-images.githubusercontent.com/29737699/140671484-07cb6472-6efc-4fca-aa29-2eda5ac0da82.png)
