### PR TITLE
Fix windows not breaking when dead

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -173,6 +173,11 @@
 /obj/structure/window/proc/get_repaired_per_unit()
 	return round(get_max_health() / get_glass_cost())
 
+/obj/structure/window/handle_death_change(new_death_state)
+	. = ..()
+	if (new_death_state)
+		shatter()
+
 /obj/structure/window/proc/shatter(var/display_message = 1)
 	playsound(src, "shatter", 70, 1)
 	if(display_message)


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Windows now properly break when hit enough, instead of sometimes not breaking.
/:cl: