### PR TITLE
Lessen carp stunlocking

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -40,15 +40,6 @@
 /datum/ai_holder/simple_animal/melee/carp
 	speak_chance = 0
 
-/datum/ai_holder/simple_animal/melee/carp/engage_target()
-	. = ..()
-
-	var/mob/living/L = .
-	if(istype(L))
-		if(prob(15))
-			L.Weaken(3)
-			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
-
 /datum/ai_holder/simple_animal/melee/carp/find_target(list/possible_targets, has_targets_list)
 	. = ..()
 


### PR DESCRIPTION
:cl: Mucker
tweak: Removed the extra 15% chance a carp would knock down its target while attacking.
/:cl:

Not really needed anymore with how mobs can already do pretty decent knockdowns.