### PR TITLE
Add Powerfist to Uplink

### DIFF
--- a/code/datums/uplink/augments.dm
+++ b/code/datums/uplink/augments.dm
@@ -42,3 +42,10 @@
 	Due to its bulk, it is impossible to conceal from body scanners, and will be discovered by anyone feeling your bones - install with caution!"
 	item_cost = 60
 	path = /obj/item/device/augment_implanter/popout_shotgun
+
+/datum/uplink_item/item/augment/aug_power_fist
+	name = "Concealed Powerfist CBM (arm)"
+	desc = "A bulky augment that slots in the AG-23 Pneumatic Powerfist. Perfect for when you need something with more oomph. Comes with it's own tank. \
+	It is unconcealable from body-scanners, and easily detectable due to it's weight."
+	item_cost = 60
+	path = /obj/item/device/augment_implanter/powerfist

--- a/code/modules/augment/active/powerfist.dm
+++ b/code/modules/augment/active/powerfist.dm
@@ -207,6 +207,3 @@
 
 /obj/item/organ/internal/augment/active/item/powerfist/prepared
 	item = /obj/item/powerfist/prepared
-
-/obj/item/device/augment_implanter/powerfist
-	augment = /obj/item/organ/internal/augment/active/item/powerfist/prepared

--- a/code/modules/augment/implanter.dm
+++ b/code/modules/augment/implanter.dm
@@ -171,3 +171,6 @@
 
 /obj/item/device/augment_implanter/engineering_toolset
 	augment = /obj/item/organ/internal/augment/active/polytool/engineer
+
+/obj/item/device/augment_implanter/powerfist
+	augment = /obj/item/organ/internal/augment/active/item/powerfist/prepared


### PR DESCRIPTION
:cl: Ryan180602
rscadd: Adds the powerfist augment to the uplink for 60 TC.
/:cl:

Unsure if this would be too powerful for antags. Comes with a double-emergency tank.
Meant to give the antags an extra weapon to play with that they can acquire somewhat easily now.