### PR TITLE
Increase exo awakening rarity

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -192,7 +192,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 /datum/event_container/exo
 	severity = EVENT_LEVEL_EXO
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",							/datum/event/nothing,				100),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",							/datum/event/nothing,				1230),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,         0,  list(ASSIGNMENT_ANY = 45))
 	)
 


### PR DESCRIPTION
:cl: Mucker
tweak: Made the exo-awakening event rarer.
/:cl:

Still way too frequent as it is, happening more often than not if a person stays on a planet for ~30 minutes or more.