### PR TITLE
Prevents disposal unit atom deletion, Fixes broken grilles

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -23,6 +23,7 @@
 	name = "broken grille"
 	desc = "The remains of a flimsy lattice of metal rods, with screws to secure it to the floor."
 	icon_state = "broken"
+	density = FALSE
 	health_max = 6
 
 /obj/structure/grille/get_material()
@@ -64,7 +65,7 @@
 	overlays.Cut()
 	if (is_broken())
 		if(on_frame)
-			icon_state = "broke_onframe"
+			icon_state = "broken_onframe"
 		else
 			icon_state = "broken"
 	else

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -789,6 +789,9 @@ obj/structure/disposalpipe/Destroy()
 			sleep(30)
 			if(!W.isOn()) return
 			if(user.loc == uloc && wloc == W.loc)
+				if(linked && istype(linked,/obj/machinery/disposal))
+					var/obj/machinery/disposal/D = linked
+					D.trunk = null
 				welded()
 			else
 				to_chat(user, "You must stay still while welding the pipe.")


### PR DESCRIPTION
:cl: Slywater
bugfix: Prevents unconnected disposal units from deleting atoms upon flushing
bugfix: Fixes broken grille density icon states
/:cl:

I discovered that disposal units could delete mobs (and atoms generally), if you disconnect it from its designated trunk pipe, and then send the mob or item through.
Seems the issue was caused by the disposal unit not recognizing that the connected trunk no longer exists. If the trunk reference is set to null, the disposalholder will correctly eject any atoms from the system instead of obliterating them.

Also fixes a typo which broke grille icons.