### PR TITLE
Fix simple mobs not having movement cooldowns

### DIFF
--- a/code/modules/ai/interfaces.dm
+++ b/code/modules/ai/interfaces.dm
@@ -79,9 +79,6 @@
 
 	var/dir = get_dir(src, newloc)
 
-	if (!checkMoveCooldown())
-		return MOVEMENT_ON_COOLDOWN
-
 	// Check to make sure moving to newloc won't actually kill us. e.g. we're a slime and trying to walk onto water.
 	if (istype(newloc))
 		if (safety && !newloc.is_safe_to_enter(src))
@@ -99,10 +96,7 @@
 	if (!old_T.Adjacent(newloc))
 		return MOVEMENT_FAILED
 
-	. = Move(newloc, dir) ? MOVEMENT_SUCCESSFUL : MOVEMENT_FAILED
+	. = SelfMove(dir) ? MOVEMENT_SUCCESSFUL : MOVEMENT_FAILED
 	if (. == MOVEMENT_SUCCESSFUL)
 		set_dir(get_dir(old_T, newloc))
-		// Apply movement delay.
-		// Player movement has more factors but its all in the client and fixing that would be its own project.
-		SetMoveCooldown(movement_delay())
 	return

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
@@ -21,7 +21,6 @@
 	health = 125
 	natural_weapon = /obj/item/natural_weapon/bite/spider
 	pass_flags = PASS_FLAG_TABLE
-	movement_cooldown = 10
 	poison_resist = 0.5
 
 	see_in_dark = 10

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/carrier.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/carrier.dm
@@ -14,7 +14,7 @@
 	poison_per_bite = 3
 	poison_type = /datum/reagent/chloralhydrate
 
-	movement_cooldown = 5
+	movement_cooldown = 8
 
 	var/spiderling_count = 0
 	var/spiderling_type = /obj/effect/spider/spiderling

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/lurker.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/lurker.dm
@@ -15,7 +15,7 @@
 
 	poison_per_bite = 5
 
-	movement_cooldown = 5
+	movement_cooldown = 3
 
 	natural_weapon = /obj/item/natural_weapon/bite/spider/lurker
 	poison_chance = 30

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -12,7 +12,7 @@
 	maxHealth = 40
 	health = 40
 
-	movement_cooldown = 5	// A bit faster so that they can inject the eggs easier.
+	movement_cooldown = 3	// A bit faster so that they can inject the eggs easier.
 
 	poison_per_bite = 5
 	poison_type = /datum/reagent/soporific

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
@@ -16,7 +16,7 @@
 
 	attack_armor_pen = 15
 
-	movement_cooldown = 15
+	movement_cooldown = 10
 
 	poison_chance = 30
 	poison_per_bite = 0.5

--- a/code/modules/mob/living/simple_animal/hostile/meat_horrors.dm
+++ b/code/modules/mob/living/simple_animal/hostile/meat_horrors.dm
@@ -13,6 +13,7 @@
 	response_harm   = "pokes"
 	maxHealth = 250
 	health = 250
+	movement_cooldown = 7
 	natural_weapon = /obj/item/natural_weapon/meatbits
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 0
@@ -56,6 +57,7 @@
 	response_harm   = "pokes"
 	maxHealth = 250
 	health = 250
+	movement_cooldown = 8
 	natural_weapon = /obj/item/natural_weapon/meatbits
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 0
@@ -122,6 +124,7 @@
 	response_harm   = "pokes"
 	maxHealth = 100
 	health = 100
+	movement_cooldown = 5
 	natural_weapon = /obj/item/natural_weapon/claws/weak
 	heat_damage_per_tick = 100
 	cold_damage_per_tick = 0
@@ -157,6 +160,7 @@
 	response_harm   = "pokes"
 	maxHealth = 200
 	health = 200
+	movement_cooldown = 5
 	natural_weapon = /obj/item/natural_weapon/claws
 	heat_damage_per_tick = 100
 	cold_damage_per_tick = 0
@@ -190,6 +194,7 @@
 	response_harm   = "pokes"
 	maxHealth = 150
 	health = 150
+	movement_cooldown = 5
 	natural_weapon = /obj/item/natural_weapon/claws
 	heat_damage_per_tick = 100
 	cold_damage_per_tick = 0
@@ -223,6 +228,7 @@
 	response_harm   = "pokes"
 	maxHealth = 50
 	health = 50
+	movement_cooldown = 2
 	natural_weapon = /obj/item/natural_weapon/claws
 	heat_damage_per_tick = 100
 	cold_damage_per_tick = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -172,17 +172,6 @@
 
 	. = ..()
 
-/mob/living/simple_animal/movement_delay()
-	var/tally = ..() //Incase I need to add stuff other than "speed" later
-
-	tally += speed
-	if(purge)//Purged creatures will move more slowly. The more time before their purge stops, the slower they'll move.
-		if(tally <= 0)
-			tally = 1
-		tally *= purge
-
-	return tally
-
 /mob/living/simple_animal/Stat()
 	. = ..()
 


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed mobs not respecting their movement cooldowns. Most will now move slower.
/:cl:

This will probably make simple mobs easier to fight, so we'll see what adjustments need to be made after this is in.