### PR TITLE
Re-add click-dragging to select mobs in buildmode

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -409,6 +409,11 @@ client/verb/character_setup()
 	if(istype(M))
 		M.OnMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 
+	var/datum/click_handler/build_mode/B = M.GetClickHandler()
+	if (istype(B))
+		if(B.current_build_mode && src_control == "mapwindow.map" && src_control == over_control)
+			build_drag(src,B.current_build_mode,src_object,over_object,src_location,over_location,src_control,over_control,params)
+
 /client/verb/toggle_fullscreen()
 	set name = "Toggle Fullscreen"
 	set category = "OOC"


### PR DESCRIPTION
:cl: Mucker
admin: Re-added click-dragging to select units in AI buildmode.
/:cl:

Probably still has the problems that it was initially removed for, but it seems it was more useful than it was buggy, so it's back.