### PR TITLE
simple mob item weapons can't hit nulled windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -299,7 +299,7 @@
 	if(W.item_flags & ITEM_FLAG_NO_BLUDGEON) return
 
 	var/area/A = get_area(src)
-	if (!A.can_modify_area())
+	if (!A?.can_modify_area())
 		to_chat(user, SPAN_NOTICE("There appears to be no way to dismantle \the [src]!"))
 		return
 


### PR DESCRIPTION
Various mob behavior changes have allowed simple mobs to try to attack things moved to null. This lazy fixes a runtime that happens when they do that.