### PR TITLE
Adds Cool New Uniform Sprites

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -12,9 +12,13 @@
 				/obj/item/clothing/gloves/thick
 			)
 
+	service_under = /obj/item/clothing/under/solgov/service/fleet
+	service_skirt = /obj/item/clothing/under/solgov/service/fleet/skirt
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
 
+	dress_under = /obj/item/clothing/under/solgov/service/fleet/officer
+	dress_skirt = /obj/item/clothing/under/solgov/service/fleet/officer/skirt
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/officer
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	dress_extra = list(
@@ -26,14 +30,23 @@
 	name = "Fleet senior command"
 	min_rank = 15
 
+	service_under = /obj/item/clothing/under/solgov/service/fleet
+	service_skirt = /obj/item/clothing/under/solgov/service/fleet/skirt
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
+
+	dress_under = /obj/item/clothing/under/solgov/service/fleet/command
+	dress_skirt = /obj/item/clothing/under/solgov/service/fleet/command/skirt
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 
 /decl/hierarchy/mil_uniform/fleet/com/flagofficer
 	name = "Fleet flag command"
 	min_rank = 17
 
+	service_under = /obj/item/clothing/under/solgov/service/fleet
+	service_skirt = /obj/item/clothing/under/solgov/service/fleet/skirt
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/flag
+	dress_under = /obj/item/clothing/under/solgov/service/fleet/flag
+	dress_skirt = /obj/item/clothing/under/solgov/service/fleet/flag/skirt
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/flag
 
 /decl/hierarchy/mil_uniform/fleet/eng

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -73,8 +73,14 @@
 /obj/item/clothing/under/solgov/utility/expeditionary_skirt/officer
 	name = "expeditionary officer skirt"
 	desc = "A black turtleneck and skirt, the elusive ladies' uniform of the Expeditionary Corps. This one has gold trim."
-	icon_state = "blackservicefem_com"
-	worn_state = "blackservicefem_com"
+	icon_state = "blackservicefem_off"
+	worn_state = "blackservicefem_off"
+
+/obj/item/clothing/under/solgov/utility/expeditionary_skirt/command
+	name = "expeditionary officer skirt"
+	desc = "A black turtleneck and skirt, the elusive ladies' uniform of the Expeditionary Corps. This one has gold trim."
+	icon_state = "blackservicefem_comm"
+	worn_state = "blackservicefem_comm"
 
 /obj/item/clothing/under/solgov/utility/expeditionary/command
 	accessories = list(/obj/item/clothing/accessory/solgov/department/command)
@@ -281,11 +287,47 @@
 	worn_state = "whiteservice"
 	accessories = list(/obj/item/clothing/accessory/navy)
 
+/obj/item/clothing/under/solgov/service/fleet/command
+	name = "fleet senior officer service uniform"
+	desc = "The senior officer's service uniform of the SCG Fleet, made from immaculate white fabric and a gold stripe."
+	icon_state = "whiteservice_comm"
+	worn_state = "whiteservice_comm"
+
+/obj/item/clothing/under/solgov/service/fleet/officer
+	name = "fleet junior officer's service uniform"
+	desc = "The junior officer's service uniform of the SCG Fleet, made from immaculate white fabric and a silver stripe."
+	icon_state = "whiteservice_off"
+	worn_state = "whiteservice_off"
+
+/obj/item/clothing/under/solgov/service/fleet/flag
+	name = "fleet flag officer's service uniform"
+	desc = "The flag officer's service uniform of the SCG Fleet, made from immaculate white fabric and a ruby stripe."
+	icon_state = "whiteservice_flag"
+	worn_state = "whiteservice_flag"
+
 /obj/item/clothing/under/solgov/service/fleet/skirt
 	name = "fleet service skirt"
 	desc = "The service uniform skirt of the SCG Fleet, made from immaculate white fabric."
 	icon_state = "whiteservicefem"
 	worn_state = "whiteservicefem"
+
+/obj/item/clothing/under/solgov/service/fleet/command/skirt
+	name = "fleet senior officer's service skirt"
+	desc = "The senior officer's service uniform skirt of the SCG Fleet, made from immaculate white fabric and a gold stripe."
+	icon_state = "whiteservicefem_comm"
+	worn_state = "whiteservicefem_comm"
+
+/obj/item/clothing/under/solgov/service/fleet/flag/skirt
+	name = "fleet flag officer's service skirt"
+	desc = "The flag officer's service uniform skirt of the SCG Fleet, made from immaculate white fabric and a ruby stripe."
+	icon_state = "whiteservicefem_flag"
+	worn_state = "whiteservicefem_flag"
+
+/obj/item/clothing/under/solgov/service/fleet/officer/skirt
+	name = "fleet junior officer's service skirt"
+	desc = "The junior officer's service uniform skirt of the SCG Fleet, made from immaculate white fabric and a silver stripe."
+	icon_state = "whiteservicefem_off"
+	worn_state = "whiteservicefem_off"
 
 /obj/item/clothing/under/solgov/service/army
 	name = "army service uniform"


### PR DESCRIPTION
🆑 Farson (AMcIlraith)
rscadd: added code for officer/senior officer sprites for fleet service uniforms that were previously unused
/🆑

Basically, this adds the trim on the fleet service uniforms from the uniform vendor. (Edited fro Dress Uni Only)

The drip is absolutely maddening. (See images below)

Junior Officer
![image](https://user-images.githubusercontent.com/36273472/147373038-9e0de859-daa3-4253-8ef6-2dd4db24a345.png) 
![image](https://user-images.githubusercontent.com/36273472/147373069-361478d2-c158-4bf9-b10a-e5b10371152a.png)

Senior Officer
![image](https://user-images.githubusercontent.com/36273472/147373000-341b527d-ed3e-446b-bfb3-7af5af141cec.png)
![image](https://user-images.githubusercontent.com/36273472/146048906-3f3c0353-4d5e-4a21-beea-80fdccf6ab15.png)

Flag Officer
![image](https://user-images.githubusercontent.com/36273472/147373033-6c8a850e-9160-4682-86e4-804ce194b2db.png)
![image](https://user-images.githubusercontent.com/36273472/147373056-6f9bf5ca-3f37-44e7-ac43-b8183c40e504.png)
