### PR TITLE
Fix(?) regex for spawn counts

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -41,7 +41,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 430 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 381 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 4 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 5 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
NUFC

Did some experimenting and this regex (`^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)`) seemed to perform better when detecting spawns, and avoids some false-positives. The change (`'^\s*'`) checks that `spawn()` is the beginning of the line, and isn't preceded by anything other than whitespace.

Every time I do Regex I have to relearn it, so this may not be the solution we're looking for, but from my limited testing, it seemed to work.