### PR TITLE
Increase shot delay/decrease ammunition of Ion rifles

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -10,9 +10,9 @@
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BACK
 	one_hand_penalty = 4
-	charge_cost = 30
-	max_shots = 8
-	fire_delay = 30
+	charge_cost = 60
+	max_shots = 5
+	fire_delay = 60
 	projectile_type = /obj/item/projectile/ion
 	wielded_item_state = "ionrifle-wielded"
 	combustion = 0
@@ -31,8 +31,8 @@
 	force = 5
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	one_hand_penalty = 0
-	charge_cost = 20
-	max_shots = 4
+	charge_cost = 40
+	max_shots = 3
 	projectile_type = /obj/item/projectile/ion/small
 
 /obj/item/gun/energy/decloner


### PR DESCRIPTION
:cl: Ryan180602
tweak: Decrease max shots of the ion rifle/pistol to 5 and 3 resp.
tweak: Increase shot delay of ion rifle/pistol
/:cl:

This keeps their AoE the same. So now they're most tactical support weapons meant to disable things, rather than a weapon you can spam and push the frontlines with.

Considering FBPs/IPCs get stunned, and heavily damaged in one ion shot, this is likely an okay delay.