### PR TITLE
disable release, update test byond version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,29 @@
-name: Build Release
-
-on:
-  push:
-    branches:
-    - dev
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-    - name: Clone custom items
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      with:
-        repository: Baystation12/custom-items
-        path: custom-items
-    - name: Build and Publish Image to Registry
-      env:
-        BUILD_ARGS: -Icustom-items/inc.dm
-      uses: elgohr/Publish-Docker-Github-Action@191af57e15535d28b83589e3b5f0c31e76aa8733
-      with:
-        name: ${{ secrets.IMAGE_NAME }}
-        username: ${{ secrets.REG_USER }}
-        password: ${{ secrets.REG_PASS }}
-        tags: "latest"
-        buildargs: BUILD_ARGS
-        registry: ${{ secrets.REG_URL }}
-        cache: true
+#name: Build Release
+#
+#on:
+#  push:
+#    branches:
+#    - dev
+#
+#jobs:
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+#    - name: Clone custom items
+#      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+#      with:
+#        repository: Baystation12/custom-items
+#        path: custom-items
+#    - name: Build and Publish Image to Registry
+#      env:
+#        BUILD_ARGS: -Icustom-items/inc.dm
+#      uses: elgohr/Publish-Docker-Github-Action@191af57e15535d28b83589e3b5f0c31e76aa8733
+#      with:
+#        name: ${{ secrets.IMAGE_NAME }}
+#        username: ${{ secrets.REG_USER }}
+#        password: ${{ secrets.REG_PASS }}
+#        tags: "latest"
+#        buildargs: BUILD_ARGS
+#        registry: ${{ secrets.REG_URL }}
+#        cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - dev
 env:
   BYOND_MAJOR: "514"
-  BYOND_MINOR: "1568"
+  BYOND_MINOR: "1572"
   SPACEMAN_DMM_VERSION: suite-1.7
 
 jobs:


### PR DESCRIPTION
Not using actions builds and a registry at the moment, if ever again. Release is commented to reduce useless work.

Tests updated to current byond.