### PR TITLE
Allow autolathes and light replacers to select the tone of light to print

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -63,6 +63,22 @@
 
 #define LIGHT_STANDARD_COLORS list(LIGHT_COLOUR_WHITE, LIGHT_COLOUR_WARM, LIGHT_COLOUR_COOL) // List of standard light colors used for randomized lighting and selectable printed lights.
 
+// Light replacer color options
+#define LIGHT_REPLACE_AREA     "AREA"     // Match the areas defined light color(s)
+#define LIGHT_REPLACE_EXISTING "EXISTING" // Mimic the existing bulb's color
+#define LIGHT_REPLACE_RANDOM   "RANDOM"   // Default behaviour. Randomize the light color from LIGHT_STANDARD_COLORS.
+
+// Options available for users to set light replacer colors.
+#define LIGHT_REPLACE_OPTIONS list(\
+	"Random (Default)",\
+	"Match Blueprint",\
+	"Match Existing",\
+	"Warm",\
+	"Cool",\
+	"White",\
+	"Custom"\
+)
+
 // Area lighting modes
 #define AREA_LIGHTING_WHITE		"white"
 #define AREA_LIGHTING_WARM		"warm"

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -48,11 +48,22 @@
 	var/uses = 32
 	var/emagged = FALSE
 	var/charge = 0
+	/// The lighting tone to use for placed light bulbs. One of `LIGHT_COLOR_*` or `LIGHT_REPLACE_*`, or a valid hex color code. Default `LIGHT_REPLACE_RANDOM`.
+	var/lighting_tone = LIGHT_REPLACE_RANDOM
 
 /obj/item/device/lightreplacer/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 2)
 		to_chat(user, "It has [uses] light\s remaining.")
+		switch (lighting_tone)
+			if (LIGHT_REPLACE_AREA)
+				to_chat(user, "It is configured to match the room's blueprints for bulb color and tone.")
+			if (LIGHT_REPLACE_EXISTING)
+				to_chat(user, "It is configured to match the replaced bulb's color and tone.")
+			if (LIGHT_REPLACE_RANDOM)
+				to_chat(user, "It is configured to print bulbs in random tones.")
+			else
+				to_chat(user, "It is configured to print bulbs in this color: <span style='color: [lighting_tone];'>■</span>")
 
 /obj/item/device/lightreplacer/resolve_attackby(var/atom/A, mob/user)
 
@@ -125,6 +136,37 @@
 	icon_state = "lightreplacer[emagged]"
 
 
+/obj/item/device/lightreplacer/attack_self(mob/user)
+	var/selection = input(user, "Select a color, tone, or matching option:", "Light Replace Color", LIGHT_REPLACE_OPTIONS[1]) in LIGHT_REPLACE_OPTIONS
+	if (!selection)
+		return
+	switch (selection)
+		if ("Random (Default)")
+			lighting_tone = LIGHT_REPLACE_RANDOM
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to print bulbs in random tones."))
+		if ("Match Blueprint")
+			lighting_tone = LIGHT_REPLACE_AREA
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to match the room's blueprints for bulb color and tone."))
+		if ("Match Existing")
+			lighting_tone = LIGHT_REPLACE_EXISTING
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to match the replaced bulb's color and tone."))
+		if ("Warm")
+			lighting_tone = LIGHT_COLOUR_WARM
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to print bulbs in warm tones."))
+		if ("Cool")
+			lighting_tone = LIGHT_COLOUR_COOL
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to print bulbs in cool tones."))
+		if ("White")
+			lighting_tone = LIGHT_COLOUR_WHITE
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to print bulbs in white tones."))
+		if ("Custom")
+			var/new_lighting_tone = input(user, "Select a color:", "Light Replace Color") as color
+			if (!new_lighting_tone)
+				return
+			lighting_tone = new_lighting_tone
+			to_chat(user, SPAN_NOTICE("You configure \the [src] to print bulbs in the color: <span style='color: [lighting_tone];'>■</span>"))
+
+
 /obj/item/device/lightreplacer/proc/Use(var/mob/user)
 
 	playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
@@ -150,13 +192,25 @@
 	else if(Use(U))
 		to_chat(U, "<span class='notice'>You replace the [target.get_fitting_name()] with the [src].</span>")
 
+		var/bulb_color = null
+		if (lighting_tone == LIGHT_REPLACE_AREA)
+			bulb_color = target.get_color_from_area()
+		else if (lighting_tone == LIGHT_REPLACE_EXISTING)
+			bulb_color = target.lightbulb?.get_color()
+		else if (lighting_tone == LIGHT_REPLACE_RANDOM)
+			bulb_color = pick(LIGHT_STANDARD_COLORS)
+		else
+			bulb_color = lighting_tone
+		if (!bulb_color)
+			bulb_color = pick(LIGHT_STANDARD_COLORS)
+
 		if(target.lightbulb)
 			var/obj/item/bulb = target.lightbulb
 			target.remove_bulb()
 			if (isrobot(U))
 				qdel(bulb)
 
-		var/obj/item/light/L = new target.light_type()
+		var/obj/item/light/L = new target.light_type(target, bulb_color)
 		if (emagged)
 			log_and_message_admins("used an emagged light replacer.", U)
 			L.create_reagents(5)

--- a/code/modules/codex/entries/tools.dm
+++ b/code/modules/codex/entries/tools.dm
@@ -63,7 +63,8 @@
 
 /datum/codex_entry/light_replacer
 	associated_paths = list(/obj/item/device/lightreplacer)
-	mechanics_text = "Examine or use this item to see how many lights are remaining. You can feed it lightbulbs or sheets of glass to refill it."
+	mechanics_text = "<p>Examine or use this item to see how many lights are remaining and what color it's configured to print. You can feed it lightbulbs or sheets of glass to refill it.</p>\
+		<p>Use this item in hand to change it's light color.</p>"
 	lore_text = "Can you believe they used to have to screw lightbulbs in by hand?"
 	antag_text = "Using a cryptographic sequencer on this device will cause it to overload each light it replaces; when turned on, the new lights will explode!"
 

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -37,14 +37,32 @@
 /datum/fabricator_recipe/tape
 	path = /obj/item/device/tape
 
-/datum/fabricator_recipe/tube/large
-	path = /obj/item/light/tube/large
+/datum/fabricator_recipe/tube/large/warm
+	path = /obj/item/light/tube/large/warm
 
-/datum/fabricator_recipe/tube
-	path = /obj/item/light/tube
+/datum/fabricator_recipe/tube/large/cool
+	path = /obj/item/light/tube/large/cool
 
-/datum/fabricator_recipe/bulb
-	path = /obj/item/light/bulb
+/datum/fabricator_recipe/tube/large/white
+	path = /obj/item/light/tube/large/white
+
+/datum/fabricator_recipe/tube/warm
+	path = /obj/item/light/tube/warm
+
+/datum/fabricator_recipe/tube/cool
+	path = /obj/item/light/tube/cool
+
+/datum/fabricator_recipe/tube/white
+	path = /obj/item/light/tube/white
+
+/datum/fabricator_recipe/bulb/warm
+	path = /obj/item/light/bulb/warm
+
+/datum/fabricator_recipe/bulb/cool
+	path = /obj/item/light/bulb/cool
+
+/datum/fabricator_recipe/bulb/white
+	path = /obj/item/light/bulb/white
 
 /datum/fabricator_recipe/ashtray_glass
 	path = /obj/item/material/ashtray/glass

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -230,21 +230,26 @@
 		construct.transfer_fingerprints_to(src)
 		set_dir(construct.dir)
 	else
-		var/light_color = null
-		var/area/A = get_area(src)
-		switch (A.lighting_tone)
-			if (AREA_LIGHTING_WHITE)
-				light_color = LIGHT_COLOUR_WHITE
-			if (AREA_LIGHTING_WARM)
-				light_color = LIGHT_COLOUR_WARM
-			if (AREA_LIGHTING_COOL)
-				light_color = LIGHT_COLOUR_COOL
+		var/light_color = get_color_from_area()
 		lightbulb = new light_type(src, light_color)
 		if(prob(lightbulb.broken_chance))
 			broken(TRUE)
 
 	on = powered()
 	update_icon(FALSE)
+
+/// Fetches the light's color based on area flags. Used for Init and for smartly installing new bulbs during runtime (See light replacers).
+/obj/machinery/light/proc/get_color_from_area()
+	var/light_color = null
+	var/area/A = get_area(src)
+	switch (A.lighting_tone)
+		if (AREA_LIGHTING_WHITE)
+			light_color = LIGHT_COLOUR_WHITE
+		if (AREA_LIGHTING_WARM)
+			light_color = LIGHT_COLOUR_WARM
+		if (AREA_LIGHTING_COOL)
+			light_color = LIGHT_COLOUR_COOL
+	return light_color
 
 /obj/machinery/light/Destroy()
 	QDEL_NULL(lightbulb)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -718,6 +718,21 @@
 	)
 	sound_on = 'sound/machines/lightson.ogg'
 
+/obj/item/light/tube/warm
+	name = "light tube (warm)"
+	desc = "A replacement light tube. This one provides soft, warm lighting."
+	b_colour = LIGHT_COLOUR_WARM
+
+/obj/item/light/tube/cool
+	name = "light tube (cool)"
+	desc = "A replacement light tube. This one provides crisp, cool lighting."
+	b_colour = LIGHT_COLOUR_COOL
+
+/obj/item/light/tube/white
+	name = "light tube (white)"
+	desc = "A replacement light tube. This one provides clean, white lighting."
+	b_colour = LIGHT_COLOUR_WHITE
+
 /obj/item/light/tube/party/Initialize() //Randomly colored light tubes. Mostly for testing, but maybe someone will find a use for them.
 	. = ..()
 	b_colour = rgb(pick(0,255), pick(0,255), pick(0,255))
@@ -729,6 +744,21 @@
 	b_inner_range = 2
 	b_outer_range = 8
 	b_curve = 2.5
+
+/obj/item/light/tube/large/warm
+	name = "large light tube (warm)"
+	desc = "A replacement light tube. This one provides soft, warm lighting."
+	b_colour = LIGHT_COLOUR_WARM
+
+/obj/item/light/tube/large/cool
+	name = "large light tube (cool)"
+	desc = "A replacement light tube. This one provides crisp, cool lighting."
+	b_colour = LIGHT_COLOUR_COOL
+
+/obj/item/light/tube/large/white
+	name = "large light tube (white)"
+	desc = "A replacement light tube. This one provides clean, white lighting."
+	b_colour = LIGHT_COLOUR_WHITE
 
 /obj/item/light/tube/large/party/Initialize() //Randomly colored light tubes. Mostly for testing, but maybe someone will find a use for them.
 	. = ..()
@@ -751,9 +781,20 @@
 		LIGHTMODE_EMERGENCY = list(l_outer_range = 3, l_max_bright = 1, l_color = LIGHT_COLOUR_E_RED)
 	)
 
-/obj/item/light/bulb/warm/b_colour = LIGHT_COLOUR_WARM
-/obj/item/light/bulb/cool/b_colour = LIGHT_COLOUR_COOL
-/obj/item/light/bulb/white/b_colour = LIGHT_COLOUR_WHITE
+/obj/item/light/bulb/warm
+	name = "light bulb (warm)"
+	desc = "A replacement light bulb. This one provides soft, warm lighting."
+	b_colour = LIGHT_COLOUR_WARM
+
+/obj/item/light/bulb/cool
+	name = "light bulb (cool)"
+	desc = "A replacement light bulb. This one provides crisp, cool lighting."
+	b_colour = LIGHT_COLOUR_COOL
+
+/obj/item/light/bulb/white
+	name = "light bulb (white)"
+	desc = "A replacement light bulb. This one provides clean, white lighting."
+	b_colour = LIGHT_COLOUR_WHITE
 
 /obj/item/light/bulb/red
 	color = LIGHT_COLOUR_E_RED


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Autolathes can now print lights of specific tones instead of playing light color lottery - Cool, warm, or white.
rscadd: Light replacers can now print lights of specific tones, match the existing light bulb, match the area's defined color, or use a custom color.
/:cl:

- Relies on #31416 for test failures
- Technically relies on #31415 to fix weirdness with null values appearing in autolathes but not necessary for this to function.