### PR TITLE
Fix some bad darkmode text colours

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -23,11 +23,11 @@
 					if(isghost(C.mob))
 						var/mob/observer/ghost/O = C.mob
 						if(O.started_as_observer)
-							entry += " - <font color='gray'>Observing</font>"
+							entry += " - <span class=\"who_observing\">Observing</span>"
 						else
-							entry += " - <font color='black'><b>DEAD</b></font>"
+							entry += " - <span class=\"who_dead\"><b>DEAD</b></span>"
 					else
-						entry += " - <font color='black'><b>DEAD</b></font>"
+						entry += " - <span class=\"who_dead\"><b>DEAD</b></span>"
 
 			var/age
 			if(isnum(C.player_age))
@@ -36,14 +36,14 @@
 				age = 0
 
 			if(age <= 1)
-				age = "<font color='#ff0000'><b>[age]</b></font>"
+				age = "<span class=\"who_new_account\"><b>[age]</b></span>"
 			else if(age < 10)
-				age = "<font color='#ff8c00'><b>[age]</b></font>"
+				age = "<span class=\"who_newish_account\"><b>[age]</b></span>"
 
 			entry += " - [age]"
 
 			if(is_special_character(C.mob))
-				entry += " - <b><font color='red'>Antagonist</font></b>"
+				entry += " - <b><span class=\"who_antagonist\">Antagonist</span></b>"
 			if(C.is_afk())
 				entry += " (AFK - [C.inactivity2text()])"
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -422,8 +422,8 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 		if(rank == "Unknown")
 			rank = "Staff"
 
-		var/message =	"<font color='red'>[rank] PM from <b><a href='?irc_msg=[input["sender"]]'>[input["sender"]]</a></b>: [input["msg"]]</font>"
-		var/amessage =  "<font color='blue'>[rank] PM from <a href='?irc_msg=[input["sender"]]'>[input["sender"]]</a> to <b>[key_name(C)]</b> : [input["msg"]]</font>"
+		var/message =	"<span class=\"pm\">[rank] PM from <b><a href='?irc_msg=[input["sender"]]'>[input["sender"]]</a></b>: [input["msg"]]</span>"
+		var/amessage =  "<span class=\"staff_pm\">[rank] PM from <a href='?irc_msg=[input["sender"]]'>[input["sender"]]</a> to <b>[key_name(C)]</b> : [input["msg"]]</span>"
 
 		C.received_irc_pm = world.time
 		C.irc_admin = input["sender"]

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -126,7 +126,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 				sound_to(X, 'sound/effects/adminhelp.ogg')
 			to_chat(X, msg)
 	//show it to the person adminhelping too
-	to_chat(src, "<font color='blue'>PM to-<b>Staff</b> (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): [original_msg]</font>")
+	to_chat(src, "<span class=\"staff_pm\">PM to-<b>Staff</b> (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): [original_msg]</span>")
 	var/admin_number_present = GLOB.admins.len - admin_number_afk
 	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins.")
 	if(admin_number_present <= 0)
@@ -136,4 +136,3 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	SSstatistics.add_field_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
-

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -367,6 +367,17 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .good                   {color: #4f7529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}
 
+/* Admin: Who */
+.who_dead		{color: #5f5f5f;}
+.who_observing		{color: #9e9e9e;}
+.who_new_account	{color: #ff0000;}
+.who_newish_account	{color: #ff8c00;}
+.who_antag		{color: #ff0000;}
+
+/* Admin: PM */
+.pm			{color: #ff0000;}
+.staff_pm		{color: #0059ff;}
+
 @keyframes hypnocolor {
 	0%		{color: #202020;}
 	25%		{color: #4b02ac;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -364,6 +364,17 @@ h1.alert, h2.alert		{color: #000080;}
 .good                   {color: #4f7529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}
 
+/* Admin: Misc */
+.who_dead		{color: #000000;}
+.who_observing		{color: #808080;}
+.who_new_account	{color: #ff0000;}
+.who_newish_account	{color: #ff8c00;}
+.who_antag		{color: #ff0000;}
+
+/* Admin: PM */
+.pm			{color: #ff0000;}
+.staff_pm		{color: #0000FF;}
+
 @keyframes hypnocolor {
 	0%		{color: #0d0d0d;}
 	25%		{color: #410194;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -131,4 +131,16 @@ h1.alert, h2.alert		{color: #000080;}
 
 BIG IMG.icon 			{width: 32px; height: 32px;}
 
+/* Admin: Misc */
+.who_dead				{color: #000000;}
+.who_observing			{color: #808080;}
+.who_new_account		{color: #ff0000;}
+.who_newish_account		{color: #ff8c00;}
+.who_new_account		{color: #000000;}
+.who_antag				{color: #ff0000;}
+
+/* Admin: PM */
+.pm						{color: #ff0000;}
+.staff_pm				{color: #0000FF;}
+
 </style>"}

--- a/maps/torch/items/memos.dm
+++ b/maps/torch/items/memos.dm
@@ -153,10 +153,13 @@
 		. = INITIALIZE_HINT_QDEL
 		crash_with("base [type] instantiated erroneously")
 
+/obj/item/paper/memo/set_content(text, title, parse_pencode)
+	return
+
 /obj/item/paper/memo/examine(mob/user, distance)
 	. = ..()
 	if (distance < 2)
-		to_chat(user, info)
+		to_chat(user, SPAN_NOTICE(info))
 
 
 


### PR DESCRIPTION
:cl: Mucker
tweak: Tweaked the memo text colour to be readable in darkmode.
admin: Tweaked darkmode colours for some text that come from the 'Who' verb and staff-pm's.
/:cl:

Might be some stuff I missed, do shout if there's anything else to be tweaked.

'Who' verb tweaks:
![image](https://user-images.githubusercontent.com/1161516/146837491-5c1c81dd-8304-46e6-a5a4-620121d766f5.png)
![image](https://user-images.githubusercontent.com/1161516/146837504-1d6a8f6d-5c05-47a1-9e9a-d9f86c26b447.png)

Memos:
![image](https://user-images.githubusercontent.com/1161516/146837537-96640249-653f-459b-b184-a93de1278ad4.png)

Staff PM:
![image](https://user-images.githubusercontent.com/1161516/146837551-bf5a3841-e8e0-4e66-a12a-8a23ae762ac2.png)
