### PR TITLE
Correct a css class name in 'Who' verb output

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -372,7 +372,7 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .who_observing		{color: #9e9e9e;}
 .who_new_account	{color: #ff0000;}
 .who_newish_account	{color: #ff8c00;}
-.who_antag		{color: #ff0000;}
+.who_antagonist		{color: #ff0000;}
 
 /* Admin: PM */
 .pm			{color: #ff0000;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -369,7 +369,7 @@ h1.alert, h2.alert		{color: #000080;}
 .who_observing		{color: #808080;}
 .who_new_account	{color: #ff0000;}
 .who_newish_account	{color: #ff8c00;}
-.who_antag		{color: #ff0000;}
+.who_antagonist		{color: #ff0000;}
 
 /* Admin: PM */
 .pm			{color: #ff0000;}


### PR DESCRIPTION
Quick fix to undo my whoopsy in my previous darkmode updates PR, where the class that made the 'Antagonist' in the 'Who' verb red didn't match up to the one I put in code.