### PR TITLE
Emitter access fix

### DIFF
--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/machines/power/fusion.dmi'
 	desc = "A heavy-duty, highly configurable industrial gyrotron suited for powering fusion reactors."
 	icon_state = "emitter-off"
-	req_access = list(access_engine)
+	req_lock_access = list(access_engine)
 	use_power = POWER_USE_IDLE
 	active_power_usage = GYRO_POWER
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -7,10 +7,11 @@
 	icon_state = "emitter"
 	anchored = FALSE
 	density = TRUE
-	req_access = list(access_engine_equip)
 	active_power_usage = 100 KILOWATTS
 	obj_flags = OBJ_FLAG_ROTATABLE
 
+	/// Access required to lock or unlock the emitter. Separate variable to prevent `req_access` from blocking use of the emitter while unlocked.
+	var/list/req_lock_access = list(access_engine_equip)
 	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.
 	var/active = FALSE
 	var/powered = FALSE
@@ -270,7 +271,7 @@
 		if (emagged)
 			to_chat(user, SPAN_WARNING("The control lock seems to be broken."))
 			return
-		if (allowed(user))
+		if (has_access(req_lock_access, W.GetAccess()))
 			locked = !locked
 			user.visible_message(
 				SPAN_NOTICE("\The [user] [locked ? "locks" : "unlocks"] \the [src]'s controls."),
@@ -287,6 +288,7 @@
 		locked = FALSE
 		emagged = TRUE
 		req_access.Cut()
+		req_lock_access.Cut()
 		user.visible_message(SPAN_WARNING("\The [user] messes with \the [src]'s controls."), SPAN_WARNING("You short out the control lock."))
 		user.playsound_local(loc, "sparks", 50, TRUE)
 		return TRUE

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1024,7 +1024,9 @@
 "cf" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/emitter/gyrotron,
+/obj/machinery/power/emitter/gyrotron{
+	req_lock_access = list()
+	},
 /turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cg" = (

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -13016,7 +13016,11 @@
 /area/shuttle/petrov/rd)
 "Hc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/emitter,
+/obj/machinery/power/emitter{
+	desc = "A massive, heavy-duty industrial laser. This design is a fixed installation, capable of shooting in only one direction. It has a label on it reading 'SRV Petrov Analysis Lab.'";
+	name = "emitter (Petrov)";
+	req_lock_access = list("ACCESS_TORCH_PETROV_ANALYSIS")
+	},
 /obj/machinery/light{
 	dir = 8
 	},


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Unlocked emitters no longer require access to turn on or off.
map: The colony gyrotron no longer has access requirements.
map: The Petrov's emitter now requires Petrov access to lock instead of Engine access.
/:cl:

Moved the access flags to a separate var because `req_access` is used in some checks buried in topic handlers that the emitter uses to determine if it can be activated or not.