### PR TITLE
Add fake announcements for antags

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -28,6 +28,12 @@
 	item_cost = 16
 	path = /obj/item/device/uplink_service/fake_crew_announcement
 
+/datum/uplink_item/item/services/fake_command_report
+	name = "Fake Command Report"
+	desc = "A single-use device, that when activated, fakes an custom configured command report! "
+	item_cost = 24
+	path = /obj/item/device/uplink_service/fake_command_report
+
 /datum/uplink_item/item/services/suit_sensor_shutdown
 	name = "Complete Suit Sensor Shutdown"
 	desc = "A single-use device, that when activated, completely disables all suit sensors for 10 minutes."
@@ -150,6 +156,96 @@
 /obj/item/device/uplink_service/jamming/garble
 	service_label = "Suit Sensor Garble"
 	ssjm = /suit_sensor_jammer_method/random/moderate
+
+/**********************
+* Fake Command Report *
+**********************/
+/obj/item/device/uplink_service/fake_command_report
+	service_label = "Fake Command Report"
+	/// The message title displayed in the command report
+	var/title
+	/// The message contents of the command report
+	var/message
+	/// Whether the command report should be broadcast to the public or only to command control programs
+	var/public_announce = FALSE
+
+
+/obj/item/device/uplink_service/fake_command_report/Initialize()
+	. = ..()
+	title = "[GLOB.using_map.boss_name] Update"
+
+
+/obj/item/device/uplink_service/fake_command_report/get_antag_info()
+	. = ..()
+	. += {"
+		<p>The fake command report service allows you to send a fake command report to whatever z level you're currently on. You can set the command report's title, message, and whether the full message is broadcast to everyone on the ship, or only to command communications software. The message will appear formatted the same was as legitimate command reports.</p>
+		<p>The fake command report service is one-use and becomes useless once used.</p>
+		<p>Use the device in-hand for a selection of options to configure the fake report and to send the report once configured.</p>
+		<p>You can examine the device in-hand to view the configured title, message, and publicity. Be warned: These are visible even after the device is used. Be sure to properly dispose of it after use!</p>
+	"}
+
+
+/obj/item/device/uplink_service/fake_command_report/examine(mob/user, distance)
+	. = ..()
+	if(distance <= 1)
+		to_chat(user, "The message title is set to '<b>[title]</b>'. The message will be [public_announce ? "broadcast to the public" : "sent only to command consoles"].")
+		to_chat(user, "The message contents are set to:<br />[SPAN_NOTICE(message)]")
+
+
+/obj/item/device/uplink_service/fake_command_report/attack_self(mob/user)
+	if (state != AWAITING_ACTIVATION)
+		to_chat(user, SPAN_WARNING("\The [src] won't activate again."))
+		return
+
+	var/selection = input(user, "What would you like to do?", "Fake Command Report") as anything in list("Set Title", "Set Message", "Set Publicity", "Send Command Report")
+	switch (selection)
+		if ("Set Title")
+			var/new_title = sanitize(input(user, "What would you like the title to be?", "Fake Command Report", title) as text|null)
+			if (!new_title || new_title == title)
+				return
+			title = new_title
+			to_chat(user, SPAN_NOTICE("You set the [service_label]'s title to '[title]'."))
+
+		if ("Set Message")
+			var/old_message = replacetext(message, "<br />", "\n")
+			var/new_message = sanitizeSafe(input(user, "What would you like the message to be?", "Fake Command Report", old_message) as message|null, extra = FALSE)
+			if (!new_message || new_message == message)
+				return
+			message = replacetext(new_message, "\n", "<br />")
+			to_chat(user, SPAN_NOTICE("You set the [service_label]'s message to '[message]'."))
+
+		if ("Set Publicity")
+			var/new_public = alert(user, "Should the command report be public?", "Fake Command Report", "Yes", "No")
+			if (new_public == "Yes") new_public = TRUE
+			else if (new_public == "No") new_public = FALSE
+			if (isnull(new_public) || new_public == public_announce)
+				return
+			public_announce = new_public
+			to_chat(user, SPAN_NOTICE("You set the [service_label]'s publicitiy to '[public_announce ? "public" : "private"]'."))
+
+		if ("Send Command Report")
+			if (!message)
+				to_chat(user, SPAN_WARNING("\The [src] has no message to send. Set a message first!"))
+				return
+			state = HAS_BEEN_ACTIVATED
+			update_icon()
+			user.visible_message(
+				SPAN_NOTICE("\The [user] activates \the [src]."),
+				SPAN_NOTICE("You activate the [service_label] device.")
+			)
+			log_and_message_admins("has activated the fake command report service: [title]", user)
+			enable(user)
+
+
+/obj/item/device/uplink_service/fake_command_report/enable(mob/user)
+	var/z_levels = GetConnectedZlevels(get_z(user))
+	post_comm_message(title, message)
+	if (public_announce)
+		command_announcement.Announce(message, title, GLOB.using_map.command_report_sound, msg_sanitized = TRUE, zlevels = z_levels)
+	else
+		minor_announcement.Announce("New [GLOB.using_map.company_name] Update available at all communication consoles.", zlevels = z_levels)
+	. = ..()
+
 
 /*****************
 * Fake Ion storm *

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -40,18 +40,6 @@
 	item_cost = 40
 	path = /obj/item/device/uplink_service/jamming
 
-/datum/uplink_item/item/services/fake_update_annoncement
-	item_cost = 40
-	path = /obj/item/device/uplink_service/fake_update_announcement
-
-/datum/uplink_item/item/services/fake_update_annoncement/New()
-	..()
-	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
-
-	spawn(2)
-		name = "[GLOB.using_map.boss_name] Update Announcement"
-		desc = "Causes a falsified [GLOB.using_map.boss_name] Update."
-
 /***************
 * Service Item *
 ***************/

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -41,7 +41,7 @@ exactly 22 "text2path uses" 'text2path'
 exactly 6 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 372 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 371 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 2 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 3 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Traitor uplinks can now purchase a fake command report service. Now you don't have to ask admins to send them for you.
/:cl:


![dreamseeker_2021-12-22_11-25-27](https://user-images.githubusercontent.com/11140088/147145788-7312188d-f353-4fc8-8b44-d18cdfbed2d1.png)

