### PR TITLE
Reduce number of teleporter beacons

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -5153,7 +5153,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/tele_beacon,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9;
 	icon_state = "corner_white"
@@ -5293,6 +5292,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "sB" = (
@@ -5411,7 +5411,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
 "sI" = (
@@ -5946,7 +5945,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "ub" = (

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -5876,7 +5876,6 @@
 	dir = 8;
 	icon_state = "techfloor_corners"
 	},
-/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
 "lH" = (
@@ -7344,6 +7343,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "pf" = (
@@ -8566,7 +8566,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/tele_beacon,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -8977,6 +8976,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "sW" = (
@@ -10981,7 +10981,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/tele_beacon,
 /obj/effect/landmark{
 	name = "Observer-Start"
 	},

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -7510,6 +7510,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/tele_beacon{
+	autoset_name = 0;
+	beacon_name = "Engineering - Lobby"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/foyer)
 "qK" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -7948,7 +7948,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/tele_beacon,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/fore)
@@ -8049,7 +8048,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/tele_beacon,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/center)
@@ -8116,7 +8114,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/tele_beacon,
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j1"
@@ -10355,10 +10352,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo/aux)
-"aIw" = (
-/obj/machinery/tele_beacon,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/cryo/aux)
 "aIx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -10782,7 +10775,6 @@
 /turf/simulated/wall/prepainted,
 /area/security/brig)
 "aKJ" = (
-/obj/machinery/tele_beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -18677,7 +18669,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/tele_beacon,
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j1"
@@ -18813,6 +18804,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/machinery/tele_beacon{
+	autoset_name = 0;
+	beacon_name = "Security - Lobby"
 	},
 /turf/simulated/floor/plating,
 /area/security/wing)
@@ -23296,7 +23291,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/tele_beacon,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -23957,6 +23951,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/torchltdlogo{
 	icon_state = "topleft"
+	},
+/obj/machinery/tele_beacon{
+	autoset_name = 0;
+	beacon_name = "Research - Lobby"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
@@ -25524,7 +25522,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "pEr" = (
@@ -48435,7 +48432,7 @@ aDY
 aDY
 aDY
 aHe
-aIw
+aDY
 aJP
 aDY
 aDY

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1205,7 +1205,6 @@
 "cs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/tele_beacon,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -28;
@@ -5152,13 +5151,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/tele_beacon,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j1s";
 	name = "Chief Medical Officer";
 	sort_type = "Chief Medical Officer"
 	},
+/obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "lD" = (
@@ -7084,7 +7083,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/tele_beacon,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;


### PR DESCRIPTION
:cl: SierraKomodo
map: The number of teleporter beacons in public hallways has been drastically reduced. No more massive lists of teleport options.
/:cl:

Essentially limits the beacons to the following categories:
- Teleporters.
- Shuttles.
- Departmental lobbies or directly outside a department's front door.
- Fore and aft sections of each deck if it doesn't already have a publically accessible beacon from a departmental lobby.
- The hanger, because people teleporting into hellgas and sparking fires is always fun.