### PR TITLE
stoplag & mc doc

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -1,7 +1,12 @@
 #define MC_TICK_CHECK ( ( TICK_USAGE > Master.current_ticklimit || src.state != SS_RUNNING ) ? pause() : 0 )
+
+
 #define GAME_STATE 2 ** (Master.current_runlevel - 1)
 
+
 #define MC_SPLIT_TICK_INIT(phase_count) var/original_tick_limit = Master.current_ticklimit; var/split_tick_phases = ##phase_count
+
+
 #define MC_SPLIT_TICK \
 	if(split_tick_phases > 1){\
 		Master.current_ticklimit = ((original_tick_limit - TICK_USAGE) / split_tick_phases) + TICK_USAGE;\
@@ -10,108 +15,27 @@
 		Master.current_ticklimit = original_tick_limit;\
 	}
 
+
 // Used to smooth out costs to try and avoid oscillation.
 #define MC_AVERAGE_FAST(average, current) (0.7 * (average) + 0.3 * (current))
+
 #define MC_AVERAGE(average, current) (0.8 * (average) + 0.2 * (current))
+
 #define MC_AVERAGE_SLOW(average, current) (0.9 * (average) + 0.1 * (current))
 
 #define MC_AVG_FAST_UP_SLOW_DOWN(average, current) (average > current ? MC_AVERAGE_SLOW(average, current) : MC_AVERAGE_FAST(average, current))
+
 #define MC_AVG_SLOW_UP_FAST_DOWN(average, current) (average < current ? MC_AVERAGE_SLOW(average, current) : MC_AVERAGE_FAST(average, current))
 
+
+/****
+* Subsystem helper macros
+****/
+
+/// Attempt to ensure that the subsystem is a singleton. Do not use directly.
 #define NEW_SS_GLOBAL(varname) if(varname != src){if(istype(varname)){Recover(varname);qdel(varname);}varname = src;}
 
-#define START_PROCESSING(Processor, Datum) \
-if (Datum.is_processing) {\
-	if(Datum.is_processing != #Processor)\
-	{\
-		crash_with("Failed to start processing. [log_info_line(Datum)] is already being processed by [Datum.is_processing] but queue attempt occured on [#Processor]."); \
-	}\
-} else {\
-	Datum.is_processing = #Processor;\
-	Processor.processing += Datum;\
-}
-
-#define STOP_PROCESSING(Processor, Datum) \
-if(Datum.is_processing) {\
-	if(Processor.processing.Remove(Datum)) {\
-		Datum.is_processing = null;\
-	} else {\
-		crash_with("Failed to stop processing. [log_info_line(Datum)] is being processed by [Datum.is_processing] but de-queue attempt occured on [#Processor]."); \
-	}\
-}
-
-// For SSmachines, use these instead
-
-#define START_PROCESSING_MACHINE(machine, flag)\
-	if(!istype(machine, /obj/machinery)) CRASH("A non-machine [log_info_line(machine)] was queued to process on the machinery subsystem.");\
-	machine.processing_flags |= flag;\
-	START_PROCESSING(SSmachines, machine)
-
-#define STOP_PROCESSING_MACHINE(machine, flag)\
-	machine.processing_flags &= ~flag;\
-	if(machine.processing_flags == 0) STOP_PROCESSING(SSmachines, machine)
-
-//SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)
-
-//subsystem does not initialize.
-#define SS_NO_INIT 1
-
-//subsystem does not fire.
-//	(like can_fire = 0, but keeps it from getting added to the processing subsystems list)
-//	(Requires a MC restart to change)
-#define SS_NO_FIRE 2
-
-//subsystem only runs on spare cpu (after all non-background subsystems have ran that tick)
-//	SS_BACKGROUND has its own priority bracket
-#define SS_BACKGROUND 4
-
-//subsystem does not tick check, and should not run unless there is enough time (or its running behind (unless background))
-#define SS_NO_TICK_CHECK 8
-
-//Treat wait as a tick count, not DS, run every wait ticks.
-//	(also forces it to run first in the tick, above even SS_NO_TICK_CHECK subsystems)
-//	(implies all runlevels because of how it works)
-//	(overrides SS_BACKGROUND)
-//	This is designed for basically anything that works as a mini-mc (like SStimer)
-#define SS_TICKER 16
-
-//keep the subsystem's timing on point by firing early if it fired late last fire because of lag
-//	ie: if a 20ds subsystem fires say 5 ds late due to lag or what not, its next fire would be in 15ds, not 20ds.
-#define SS_KEEP_TIMING 32
-
-//Calculate its next fire after its fired.
-//	(IE: if a 5ds wait SS takes 2ds to run, its next fire should be 5ds away, not 3ds like it normally would be)
-//	This flag overrides SS_KEEP_TIMING
-#define SS_POST_FIRE_TIMING 64
-
-// Run Shutdown() on server shutdown so the SS can finalize state.
-#define SS_NEEDS_SHUTDOWN 128
-
-// -- SStimer stuff --
-
-#define TIMER_UNIQUE       FLAG(0) // Don't run if there is an identical unique timer active
-#define TIMER_OVERRIDE     FLAG(1) // For unique timers: Replace the old timer rather then not start this one
-#define TIMER_CLIENT_TIME  FLAG(2) // Timing should be based on how timing progresses on clients, not the server - this is more expensive, so should only be used with things that need to progress client-side (like animate or sound)
-#define TIMER_STOPPABLE    FLAG(3) // Timer can be stopped using deltimer()
-#define TIMER_NO_HASH_WAIT FLAG(4) // For unique timers: don't distinguish timers by wait
-#define TIMER_LOOP         FLAG(5) // Repeat the timer until it's deleted.
-
-#define TIMER_ID_NULL -1
-
-//SUBSYSTEM STATES
-#define SS_IDLE 0		//aint doing shit.
-#define SS_QUEUED 1		//queued to run
-#define SS_RUNNING 2	//actively running
-#define SS_PAUSED 3		//paused by mc_tick_check
-#define SS_SLEEPING 4	//fire() slept.
-#define SS_PAUSING 5 	//in the middle of pausing
-
-// Subsystem init-states, used for the initialization MC panel.
-#define SS_INITSTATE_NONE 0
-#define SS_INITSTATE_STARTED 1
-#define SS_INITSTATE_DONE 2
-
-
+/// Boilerplate for a new global subsystem object and its associated type.
 #define SUBSYSTEM_DEF(X) GLOBAL_REAL(SS##X, /datum/controller/subsystem/##X);\
 /datum/controller/subsystem/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\
@@ -119,6 +43,7 @@ if(Datum.is_processing) {\
 }\
 /datum/controller/subsystem/##X
 
+/// Boilerplate for a new global processing subsystem object and its associated type.
 #define PROCESSING_SUBSYSTEM_DEF(X) GLOBAL_REAL(SS##X, /datum/controller/subsystem/processing/##X);\
 /datum/controller/subsystem/processing/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\
@@ -130,3 +55,127 @@ if(Datum.is_processing) {\
 	}\
 }\
 /datum/controller/subsystem/processing/##X
+
+/// Register a datum to be processed with a processing subsystem.
+#define START_PROCESSING(Processor, Datum) \
+if (Datum.is_processing) {\
+	if(Datum.is_processing != #Processor)\
+	{\
+		crash_with("Failed to start processing. [log_info_line(Datum)] is already being processed by [Datum.is_processing] but queue attempt occured on [#Processor]."); \
+	}\
+} else {\
+	Datum.is_processing = #Processor;\
+	Processor.processing += Datum;\
+}
+
+/// Unregister a datum with a processing subsystem.
+#define STOP_PROCESSING(Processor, Datum) \
+if(Datum.is_processing) {\
+	if(Processor.processing.Remove(Datum)) {\
+		Datum.is_processing = null;\
+	} else {\
+		crash_with("Failed to stop processing. [log_info_line(Datum)] is being processed by [Datum.is_processing] but de-queue attempt occured on [#Processor]."); \
+	}\
+}
+
+/// START specific to SSmachines
+#define START_PROCESSING_MACHINE(machine, flag)\
+	if(!istype(machine, /obj/machinery)) CRASH("A non-machine [log_info_line(machine)] was queued to process on the machinery subsystem.");\
+	machine.processing_flags |= flag;\
+	START_PROCESSING(SSmachines, machine)
+
+/// STOP specific to SSmachines
+#define STOP_PROCESSING_MACHINE(machine, flag)\
+	machine.processing_flags &= ~flag;\
+	if(machine.processing_flags == 0) STOP_PROCESSING(SSmachines, machine)
+
+
+/****
+* Subsystem Flags
+****/
+
+/// The subsystem's Initialize() will not be called.
+#define SS_NO_INIT FLAG(0)
+
+/// The subsystem's fire() will not be called. This is preferable to can_fire = FALSE because it will not be added to the MC's list of active systems.
+#define SS_NO_FIRE FLAG(1)
+
+/// The subsystem runs on spare CPU time, after all non-background subsystems have run that tick. Priority is considered against other SS_BACKGROUND subsystems.
+#define SS_BACKGROUND FLAG(2)
+
+/// The subsystem does not tick check and should not run unless enough time can be guaranteed or it must to stay current.
+#define SS_NO_TICK_CHECK FLAG(3)
+
+/// Treat the value of the subsystem's wait as ticks, not time. Forces it to run in the first tick. Implicitly has all runlevels. Ignores SS_BACKGROUND if set. Intended for systems that act like a mini-MC, like timers.
+#define SS_TICKER FLAG(4)
+
+/// Attempt to keep the subsystem's timing real-world regular by adjusting fire timing to be earlier the later it previously ran.
+#define SS_KEEP_TIMING FLAG(5)
+
+/// Calculate the subsystem's next fire time from when it finished, not when it started.
+#define SS_POST_FIRE_TIMING FLAG(6)
+
+/// Run Shutdown() on server shutdown so the SS can finalize state.
+#define SS_NEEDS_SHUTDOWN FLAG(7)
+
+
+/****
+* Subsystem states
+****/
+
+/// The subsystem is not running.
+#define SS_IDLE 0
+
+/// The subsystem is queued to be run.
+#define SS_QUEUED 1
+
+/// The subsystem is currently being run.
+#define SS_RUNNING 2
+
+/// The subsystem's run is paused by MC_TICK_CHECK and will resume later.
+#define SS_PAUSED 3
+
+/// The subsystem is sleeping during its run.
+#define SS_SLEEPING 4
+
+/// The subsystem is in the process of being paused.
+#define SS_PAUSING 5
+
+/****
+* Subsystem initialization states
+****/
+
+#define SS_INITSTATE_NONE 0
+
+#define SS_INITSTATE_STARTED 1
+
+#define SS_INITSTATE_DONE 2
+
+
+/****
+* SStimer
+****/
+
+/// Create a hash from the timer's configuration and don't run it if one already exists.
+#define TIMER_UNIQUE FLAG(0)
+
+/// For timers with TIMER_UNIQUE, do not include the timer's delay as part of its uniquenes.
+#define TIMER_NO_HASH_WAIT FLAG(4)
+
+/// For timers with TIMER_UNIQUE, replace the old timer instead of discarding the new one.
+#define TIMER_OVERRIDE FLAG(1)
+
+/// Use real world time instead of server time. More expensive and should be reserved for client display like animations and sounds.
+#define TIMER_CLIENT_TIME FLAG(2)
+
+/// The call to addtimer() will return a timer ID which may be passed to deltimer() to stop it if it still exists.
+#define TIMER_STOPPABLE FLAG(3)
+
+/// Repeat the timer until it's deleted or the parent is destroyed.
+#define TIMER_LOOP FLAG(5)
+
+/// The default timer ID.
+#define TIMER_ID_NULL -1
+
+/// Automatically adding filename and line to the timer's arguments for debugging purposes.
+#define addtimer(args...) _addtimer(args, file = __FILE__, line = __LINE__)

--- a/code/__defines/lists.dm
+++ b/code/__defines/lists.dm
@@ -28,49 +28,17 @@
 // Reads L or an empty list if L is not a list.  Note: Does NOT assign, L may be an expression.
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 
-// binary search sorted insert
-// IN: Object to be inserted
-// LIST: List to insert object into
-// TYPECONT: The typepath of the contents of the list
-// COMPARE: The variable on the objects to compare
-#define BINARY_INSERT(IN, LIST, TYPECONT, COMPARE) \
-	var/__BIN_CTTL = length(LIST);\
-	if(!__BIN_CTTL) {\
-		LIST += IN;\
-	} else {\
-		var/__BIN_LEFT = 1;\
-		var/__BIN_RIGHT = __BIN_CTTL;\
-		var/__BIN_MID = SHIFTR(__BIN_LEFT + __BIN_RIGHT, 1);\
-		var/##TYPECONT/__BIN_ITEM;\
-		while(__BIN_LEFT < __BIN_RIGHT) {\
-			__BIN_ITEM = LIST[__BIN_MID];\
-			if(__BIN_ITEM.##COMPARE <= IN.##COMPARE) {\
-				__BIN_LEFT = __BIN_MID + 1;\
-			} else {\
-				__BIN_RIGHT = __BIN_MID;\
-			};\
-			__BIN_MID = SHIFTR(__BIN_LEFT + __BIN_RIGHT, 1);\
-		};\
-		__BIN_ITEM = LIST[__BIN_MID];\
-		__BIN_MID = __BIN_ITEM.##COMPARE > IN.##COMPARE ? __BIN_MID : __BIN_MID + 1;\
-		LIST.Insert(__BIN_MID, IN);\
-	}
-
-/// Passed into BINARY_INSERT to compare keys
-#define COMPARE_KEY __BIN_LIST[__BIN_MID]
-/// Passed into BINARY_INSERT to compare values
-#define COMPARE_VALUE __BIN_LIST[__BIN_LIST[__BIN_MID]]
 
 /****
-	* Binary search sorted insert from TG
-	* INPUT: Object to be inserted
-	* LIST: List to insert object into
-	* TYPECONT: The typepath of the contents of the list
-	* COMPARE: The object to compare against, usualy the same as INPUT
-	* COMPARISON: The variable on the objects to compare
-	* COMPTYPE: How should the values be compared? Either COMPARE_KEY or COMPARE_VALUE.
-	*/
-#define BINARY_INSERT_TG(INPUT, LIST, TYPECONT, COMPARE, COMPARISON, COMPTYPE) \
+* Binary search sorted insert
+* INPUT: Object to be inserted
+* LIST: List to insert object into
+* TYPECONT: The typepath of the contents of the list
+* COMPARE: The object to compare against, usualy the same as INPUT
+* COMPARISON: The variable on the objects to compare
+* COMPTYPE: How should the values be compared? Either COMPARE_KEY or COMPARE_VALUE.
+****/
+#define BINARY_INSERT(INPUT, LIST, TYPECONT, COMPARE, COMPARISON, COMPTYPE) \
 	do {\
 		var/list/__BIN_LIST = LIST;\
 		var/__BIN_CTTL = length(__BIN_LIST);\
@@ -79,7 +47,7 @@
 		} else {\
 			var/__BIN_LEFT = 1;\
 			var/__BIN_RIGHT = __BIN_CTTL;\
-			var/__BIN_MID = SHIFTR(__BIN_LEFT + __BIN_RIGHT, 1);\
+			var/__BIN_MID = SHIFTR((__BIN_LEFT + __BIN_RIGHT), 1);\
 			var ##TYPECONT/__BIN_ITEM;\
 			while(__BIN_LEFT < __BIN_RIGHT) {\
 				__BIN_ITEM = COMPTYPE;\
@@ -88,10 +56,16 @@
 				} else {\
 					__BIN_RIGHT = __BIN_MID;\
 				};\
-				__BIN_MID = SHIFTR(__BIN_LEFT + __BIN_RIGHT, 1);\
+				__BIN_MID = SHIFTR((__BIN_LEFT + __BIN_RIGHT), 1);\
 			};\
 			__BIN_ITEM = COMPTYPE;\
 			__BIN_MID = __BIN_ITEM.##COMPARISON > COMPARE.##COMPARISON ? __BIN_MID : __BIN_MID + 1;\
 			__BIN_LIST.Insert(__BIN_MID, INPUT);\
 		};\
 	} while(FALSE)
+
+/// Passed into BINARY_INSERT to compare keys
+#define COMPARE_KEY __BIN_LIST[__BIN_MID]
+
+/// Passed into BINARY_INSERT to compare values
+#define COMPARE_VALUE __BIN_LIST[__BIN_LIST[__BIN_MID]]

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -1,7 +1,12 @@
 // Macro functions.
 #define RAND_F(LOW, HIGH) (rand()*(HIGH-LOW) + LOW)
+
+/// Return x or the next integer in a positive direction: ceil(-1.5) = -1 , ceil(1.5) = 2
 #define ceil(x) (-round(-(x)))
-#define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
+
+/// Return x or the next multiple of y in a positive direction. mceil(-1.5, 0.3) = -1.5 , mceil(-1.5, 0.4) = -1.2
+#define mceil(x, y) ( -round(-(x) / (y)) * (y) )
+
 #define MULT_BY_RANDOM_COEF(VAR,LO,HI) VAR =  round((VAR * rand(LO * 100, HI * 100))/100, 0.1)
 #define PERCENT(val, max, places) round((val) / (max) * 100, !(places) || 10 ** -(places))
 

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -158,23 +158,22 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 		return GLOB.midnight_rollovers++
 	return GLOB.midnight_rollovers
 
-//Increases delay as the server gets more overloaded,
-//as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
-#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
 
-/proc/stoplag()
+/proc/stoplag(initial_delay = world.tick_lag)
 	if (!Master || !(GAME_STATE & RUNLEVELS_DEFAULT))
 		sleep(world.tick_lag)
 		return 1
-	. = 0
-	var/i = 1
+	var/delta
+	var/total = 0
+	var/delay = DS2TICKS(initial_delay)
 	do
-		. += round(i*DELTA_CALC)
-		sleep(i*world.tick_lag*DELTA_CALC)
-		i *= 2
+		delta = delay * max(0.01 * max(world.tick_usage, world.cpu) * max(Master.sleep_delta, 1), 1) // Scale up delay under load; sleeps have entry overhead from proc duplication
+		sleep(world.tick_lag * delta)
+		total += ceil(delta)
+		delay *= 2
 	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
+	return total
 
-#undef DELTA_CALC
 
 /proc/acquire_days_per_month()
 	. = list(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -315,7 +315,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			continue
 
 		//Byond resumed us late. assume it might have to do the same next tick
-		if (last_run + CEILING(world.tick_lag * (processing * sleep_delta), world.tick_lag) < world.time)
+		if (last_run + mceil(world.tick_lag * (processing * sleep_delta), world.tick_lag) < world.time)
 			sleep_delta += 1
 
 		sleep_delta = MC_AVERAGE_FAST(sleep_delta, 1) //decay sleep_delta

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(throwing)
 	last_move = world.time
 
 	//calculate how many tiles to move, making up for any missed ticks.
-	var/tilestomove = CEILING(min(((((world.time+world.tick_lag) - start_time + delayed_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed*MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait), 1)
+	var/tilestomove = mceil(min(((((world.time+world.tick_lag) - start_time + delayed_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed*MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait), 1)
 	while (tilestomove-- > 0)
 		if ((dist_travelled >= maxrange || AM.loc == target_turf) && (A && A.has_gravity()))
 			finalize()

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -129,7 +129,7 @@ SUBSYSTEM_DEF(timer)
 		if(ctime_timer.flags & TIMER_LOOP)
 			ctime_timer.spent = 0
 			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
-			BINARY_INSERT_TG(ctime_timer, clienttime_timers, /datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
+			BINARY_INSERT(ctime_timer, clienttime_timers, /datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
 		else
 			qdel(ctime_timer)
 
@@ -493,7 +493,7 @@ SUBSYSTEM_DEF(timer)
 	else if (timeToRun >= TIMER_MAX)
 		L = SStimer.second_queue
 	if(L)
-		BINARY_INSERT_TG(src, L, /datum/timedevent, src, timeToRun, COMPARE_KEY)
+		BINARY_INSERT(src, L, /datum/timedevent, src, timeToRun, COMPARE_KEY)
 		return
 
 	// Get a local reference to the bucket list, this is faster than referencing the datum
@@ -544,7 +544,7 @@ SUBSYSTEM_DEF(timer)
  * * wait deciseconds to run the timer for
  * * flags flags for this timer, see: code\__DEFINES\subsystems.dm
  */
-/proc/addtimer(datum/callback/callback, wait = 0, flags = 0)
+/proc/_addtimer(datum/callback/callback, wait = 0, flags = 0, file, line)
 	if (!callback)
 		CRASH("addtimer called without a callback")
 
@@ -555,7 +555,7 @@ SUBSYSTEM_DEF(timer)
 		stack_trace("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not \
 			be supported and may refuse to run or run with a 0 wait")
 
-	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
+	wait = max(mceil(wait, world.tick_lag), world.tick_lag)
 
 	if(wait >= INFINITY)
 		CRASH("Attempted to create timer with INFINITY delay")
@@ -584,7 +584,7 @@ SUBSYSTEM_DEF(timer)
 	else if(flags & TIMER_OVERRIDE)
 		stack_trace("TIMER_OVERRIDE used without TIMER_UNIQUE")
 
-	var/datum/timedevent/timer = new(callback, wait, flags, hash)
+	var/datum/timedevent/timer = new(callback, wait, flags, hash, file && "[file]:[line]")
 	return timer.id
 
 /**


### PR DESCRIPTION
renames and documentation
\- CEILING -> mceil, doc line
\- BINARY_INSERT_TG -> BINARY_INSERT
\- MC flags use FLAG, doc lines
\- addtimer -> _addtimer, add #addtimer, file:line as timer source

add stoplag initial_delay, changes pattern for clarity of purpose. not sure on the implications of reusing var delta instead of running DELTA_CALC twice but it seems like it should be preferable 