### PR TITLE
Apply standardized health to machinery and components

### DIFF
--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -34,3 +34,29 @@
 #define DAMAGE_ELECTRICAL list(DAMAGE_SHOCK, DAMAGE_EMP)
 /// All damage flags
 #define DAMAGE_ALL        list(DAMAGE_BRUTE, DAMAGE_BURN, DAMAGE_STUN, DAMAGE_SHOCK, DAMAGE_EMP, DAMAGE_EXPLODE, DAMAGE_FIRE, DAMAGE_RADIATION, DAMAGE_BIO, DAMAGE_PAIN, DAMAGE_TOXIN, DAMAGE_GENETIC, DAMAGE_OXY, DAMAGE_BRAIN)
+
+
+/// Damage resistance preset for physical inorganic objects - Walls, structures, items, etc.
+#define DAMAGE_RESIST_PHYSICAL list(\
+	DAMAGE_STUN = 0,\
+	DAMAGE_EMP = 0,\
+	DAMAGE_RADIATION = 0,\
+	DAMAGE_BIO = 0,\
+	DAMAGE_PAIN = 0,\
+	DAMAGE_TOXIN = 0,\
+	DAMAGE_GENETIC = 0,\
+	DAMAGE_OXY = 0,\
+	DAMAGE_BRAIN = 0\
+)
+
+/// Damage resistance preset for electronic equipment - Computers, machinery, etc.
+#define DAMAGE_RESIST_ELECTRICAL list(\
+	DAMAGE_STUN = 0.5,\
+	DAMAGE_RADIATION = 0,\
+	DAMAGE_BIO = 0,\
+	DAMAGE_PAIN = 0,\
+	DAMAGE_TOXIN = 0,\
+	DAMAGE_GENETIC = 0,\
+	DAMAGE_OXY = 0,\
+	DAMAGE_BRAIN = 0\
+)

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -153,8 +153,10 @@
 /**
  * Damage's the atom's health by the given value. Returns `TRUE` if the damage resulted in a death state change.
  * Resistance and weakness modifiers are applied here.
+ * - `skip_death_state_change` will skip calling `handle_death_change()` when applicable. Used for when the originally calling proc needs handle it in a unique way.
+ * - `severity` should be a passthrough of `severity` from `ex_act()` and `emp_act()` for `DAMAGE_EXPLODE` and `DAMAGE_EMP` types respectively.
  */
-/atom/proc/damage_health(damage, damage_type = null, skip_death_state_change = FALSE)
+/atom/proc/damage_health(damage, damage_type = null, skip_death_state_change = FALSE, severity)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
 		return

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -11,10 +11,13 @@
  * Value should be a multiplier that is applied against damage. Values below 1 are a resistance, above 1 are a weakness.
  * Value of `0` is considered immunity.
  */
-/atom/var/list/health_resistances
+/atom/var/list/health_resistances = DAMAGE_RESIST_PHYSICAL
 
 /// Minimum damage required to actually affect health in `can_damage_health()`.
 /atom/var/health_min_damage = 0
+
+/// Sound effect played when hit
+/atom/var/damage_hitsound = 'sound/weapons/genhit.ogg'
 
 /**
  * Retrieves the atom's current health, or `null` if not using health
@@ -279,3 +282,58 @@
 	target_atom.health_max = source_atom.health_max
 	target_atom.health_resistances = source_atom.health_resistances
 	target_atom.health_min_damage = source_atom.health_min_damage
+
+
+// Generalized *_act() handlers
+/atom/emp_act(severity)
+	..()
+	// No hitsound here - Doesn't make sense for EMPs.
+	// Generalized - 75-125 damage at max, 38-63 at medium, 25-42 at minimum severities.
+	damage_health(rand(75, 125) / severity, DAMAGE_EMP, severity = severity)
+
+
+/atom/ex_act(severity)
+	..()
+	// No hitsound here to avoid noise spam.
+	// Generalized - 75-125 damage at max, 38-63 at medium, 25-42 at minimum severities.
+	damage_health(rand(75, 125) / severity, DAMAGE_EXPLODE, severity = severity)
+
+
+/atom/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	..()
+	// No hitsound here to avoid noise spam.
+	// 1 point of damage for every 100 kelvin above 300 (~27 C).
+	damage_health(round(max(exposed_temperature - 300, 0) / 100), DAMAGE_FIRE)
+
+
+/atom/bullet_act(obj/item/projectile/P, def_zone)
+	. = ..()
+	if (get_max_health())
+		var/damage = P.damage
+		if (istype(src, /obj/structure) || istype(src, /turf/simulated/wall)) // TODO Better conditions for non-structures that want to use structure damage
+			damage = P.get_structure_damage()
+		if (!can_damage_health(damage, P.damage_type))
+			return
+		playsound(damage_hitsound, src, 75)
+		damage_health(damage, P.damage_type)
+		return 0
+
+
+/atom/attackby(obj/item/W, mob/user, click_params)
+	. = ..()
+	if (user.a_intent == I_HURT && get_max_health())
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+		if (!can_damage_health(W.force, W.damtype))
+			playsound(damage_hitsound, src, 50)
+			user.visible_message(
+				SPAN_WARNING("\The [user] hits \the [src] with \a [W], but it bounces off!"),
+				SPAN_WARNING("You hit \the [src] with \the [W], but it bounces off!")
+			)
+			return
+		playsound(damage_hitsound, src, 75)
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [src] with \a [W]!"),
+			SPAN_DANGER("You hit \the [src] with \the [W]!")
+		)
+		damage_health(W.force, W.damtype)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -25,9 +25,9 @@
 	light_color = "#3e0000"
 	health_max = 20
 	health_min_damage = 4
+	damage_hitsound = 'sound/effects/Glasshit.ogg'
 
 /obj/structure/cult/pylon/attackby(obj/item/W, mob/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if (istype(W, /obj/item/natural_weapon/cult_builder))
 		if (!health_damaged())
 			to_chat(user, SPAN_WARNING("\The [src] is fully repaired."))
@@ -38,30 +38,8 @@
 			)
 			restore_health(5)
 		return
-	user.do_attack_animation(src)
-	if (!can_damage_health(W.force, W.damtype))
-		user.visible_message(
-			SPAN_DANGER("\The [user] hits \the [src], but they bounce off!"),
-			SPAN_DANGER("You hit \the [src], but bounce off!"),
-			SPAN_WARNING("You hear thick glass being struck with something.")
-		)
-		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 50, TRUE)
-		return
-	if(damage_health(W.force, W.damtype, TRUE))
-		user.visible_message(
-			SPAN_DANGER("\The [user] smashes \the [src]!"),
-			SPAN_DANGER("You smash \the [src] into pieces!"),
-			SPAN_WARNING("You hear glass shattering, and a tinkle of shards.")
-		)
-		playsound(get_turf(src), 'sound/effects/Glassbr3.ogg', 75, TRUE)
-		qdel(src)
-	else
-		user.visible_message(
-			SPAN_DANGER("\The [user] hits \the [src]!"),
-			SPAN_DANGER("You hit \the [src]!"),
-			SPAN_WARNING("You hear thick glass being struck with something.")
-		)
-		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, TRUE)
+
+	..()
 
 /obj/structure/cult/tome
 	name = "Desk"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -289,18 +289,12 @@
 		to_chat(user, "<span class='notice'>You touch \the [src]. It feels wet and becomes harder the further you push your arm.</span>")
 
 /obj/effect/cultwall/attackby(var/obj/item/I, var/mob/living/user)
-	if(istype(I, /obj/item/nullrod))
+	if (istype(I, /obj/item/nullrod))
 		user.visible_message("<span class='notice'>\The [user] touches \the [src] with \the [I], and it disappears.</span>", "<span class='notice'>You disrupt the vile magic with the deadening field of \the [I].</span>")
 		qdel(src)
-	else if(I.force)
-		user.visible_message("<span class='notice'>\The [user] hits \the [src] with \the [I].</span>", "<span class='notice'>You hit \the [src] with \the [I].</span>")
-		damage_health(I.force, I.damtype)
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.do_attack_animation(src)
+		return
 
-/obj/effect/cultwall/bullet_act(var/obj/item/projectile/Proj)
-	damage_health(Proj.get_structure_damage(), Proj.damage_type)
-	. = ..()
+	..()
 
 /obj/effect/cultwall/handle_death_change(new_death_state)
 	. = ..()

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -38,10 +38,10 @@
 #define CYBORG_AIRLOCKCRUSH_RESISTANCE 2 // Damage caused to silicon mobs (usually cyborgs) from being crushed by airlocks is divided by this number. Unlike organics cyborgs don't have passive regeneration.
 
 /atom/movable/proc/airlock_crush(var/crush_damage)
-	return
+	damage_health(crush_damage, BRUTE)
 
 /obj/structure/window/airlock_crush(var/crush_damage)
-	ex_act(2)//Smashin windows
+	shatter(TRUE)
 
 /obj/machinery/portable_atmospherics/canister/airlock_crush(var/crush_damage)
 	. = ..()
@@ -52,11 +52,9 @@
 	Stress(crush_damage)
 
 /obj/structure/closet/airlock_crush(var/crush_damage)
-	..()
-	damage_health(crush_damage, BRUTE)
 	for(var/atom/movable/AM in src)
-		AM.airlock_crush()
-	return
+		AM.airlock_crush(crush_damage)
+	..()
 
 /mob/living/airlock_crush(var/crush_damage)
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -118,6 +118,7 @@
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'
+	health_resistances = DAMAGE_RESIST_ELECTRICAL
 
 //Checks if the item is being held by a mob, and if so, updates the held icons
 /obj/item/proc/update_twohanding()
@@ -154,6 +155,7 @@
 	return FALSE
 
 /obj/item/ex_act(severity)
+	..()
 	switch(severity)
 		if(1)
 			qdel(src)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -17,7 +17,7 @@
 
 	for(var/obj/effect/blob/B in objs)       		//Blob damage here
 		var/damage = round(30/(get_dist(B,T)+1))
-		B.damage_health(damage)
+		B.damage_health(damage, DAMAGE_SHOCK)
 
 	new/obj/effect/sparks(src.loc)
 	new/obj/effect/effect/smoke/illumination(src.loc, 5, range=30, power=1, color="#ffffff")

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -22,7 +22,7 @@
 	START_PROCESSING(SSobj, src)
 	for(var/obj/effect/blob/B in view(8,src))
 		var/damage = round(30/(get_dist(B,src)+1))
-		B.damage_health(damage)
+		B.damage_health(damage, DAMAGE_BURN)
 		B.update_icon()
 	QDEL_IN(src, 8 SECONDS)
 

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -29,6 +29,11 @@
 /obj/item/material/ashtray/attackby(obj/item/W as obj, mob/user as mob)
 	if (!is_alive())
 		return
+
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if (istype(W,/obj/item/trash/cigbutt) || istype(W,/obj/item/clothing/mask/smokable/cigarette) || istype(W, /obj/item/flame/match))
 		if (contents.len >= max_butts)
 			to_chat(user, "\The [src] is full.")
@@ -46,9 +51,9 @@
 			visible_message("[user] places [W] in [src].")
 			set_extension(src, /datum/extension/scent/ashtray)
 			update_icon()
-	else
-		..()
-		damage_health(W.force)
+		return
+
+	..()
 
 /obj/item/material/ashtray/throw_impact(atom/hit_atom)
 	if (health_max)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -76,18 +76,6 @@
 	material.place_dismantled_product(get_turf(src))
 	qdel(src)
 
-/obj/structure/barricade/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			visible_message("<span class='danger'>\The [src] is blown apart!</span>")
-			qdel(src)
-			return
-		if(2.0)
-			if (damage_health(25, BRUTE, TRUE))
-				visible_message("<span class='danger'>\The [src] is blown apart!</span>")
-				dismantle()
-			return
-
 /obj/structure/barricade/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)//So bullets will fly over and stuff.
 	if(air_group || (height==0))
 		return 1

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -247,6 +247,10 @@
 	. = ..()
 
 /obj/structure/closet/attackby(obj/item/W as obj, mob/user as mob)
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if (src.opened)
 		if(istype(W, /obj/item/grab))
 			var/obj/item/grab/G = W
@@ -311,11 +315,7 @@
 		src.togglelock(user, W)
 		return
 
-	if (user.a_intent != I_HURT)
-		src.attack_hand(user)
-		return
-
-	..()
+	attack_hand(user)
 
 /obj/structure/closet/proc/slice_into_parts(obj/W, mob/user)
 	new /obj/item/stack/material/steel(src.loc, 2)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -85,24 +85,9 @@
 		for (var/mob/M in src)
 			shatter(M)
 
-/obj/structure/closet/statue/bullet_act(var/obj/item/projectile/Proj)
-	damage_health(Proj.get_structure_damage(), Proj.damage_type)
-
-	return
-
 /obj/structure/closet/statue/attack_generic(var/mob/user, damage, attacktext, environment_smash)
 	if(damage && environment_smash)
 		kill_health()
-
-/obj/structure/closet/statue/ex_act(severity)
-	for(var/mob/M in src)
-		M.ex_act(severity)
-		damage_health(60 / severity, BRUTE)
-
-/obj/structure/closet/statue/attackby(obj/item/I as obj, mob/user as mob)
-	damage_health(I.force, I.damtype)
-	user.do_attack_animation(src)
-	visible_message("<span class='danger'>[user] strikes [src] with [I].</span>")
 
 /obj/structure/closet/statue/MouseDrop_T()
 	return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -23,19 +23,26 @@
 		to_chat(user, "Inside you see [english_list(contents)].")
 
 /obj/structure/displaycase/ex_act(severity)
-	switch(severity)
-		if (1)
-			kill_health()
-		if (2)
-			if (prob(50))
-				damage_health(15, BRUTE)
-		if (3)
-			if (prob(50))
-				damage_health(5, BRUTE)
-
-/obj/structure/displaycase/bullet_act(var/obj/item/projectile/Proj)
+	if (severity < 3)
+		var/shuffled_contents = shuffle(contents)
+		for (var/atom/A as anything in shuffled_contents)
+			A.ex_act(severity + 1)
 	..()
-	damage_health(Proj.get_structure_damage(), Proj.damage_type)
+
+/obj/structure/displaycase/bullet_act(obj/item/projectile/Proj)
+	if (Proj.penetrating)
+		var/distance = get_dist(Proj.starting, get_turf(loc))
+		var/list/items = contents.Copy()
+		while (items.len)
+			var/atom/A = pick_n_take(items)
+			if (isliving(A))
+				Proj.attack_mob(A, distance)
+			else
+				A.bullet_act(Proj)
+			Proj.penetrating -= 1
+			if(!Proj.penetrating)
+				break
+	. = ..()
 
 /obj/structure/displaycase/handle_death_change(new_death_state)
 	if (new_death_state)
@@ -46,11 +53,6 @@
 		playsound(src, "shatter", 70, 1)
 		update_icon()
 
-/obj/structure/displaycase/damage_health(damage, damage_type, skip_death_state_change, severity)
-	. = ..()
-	if (!.)
-		playsound(src, 'sound/effects/Glasshit.ogg', 75, 1)
-
 /obj/structure/displaycase/on_update_icon()
 	if(!is_alive())
 		icon_state = "glassboxb"
@@ -59,11 +61,6 @@
 	underlays.Cut()
 	for(var/atom/movable/AM in contents)
 		underlays += AM.appearance
-
-/obj/structure/displaycase/attackby(obj/item/W as obj, mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	damage_health(W.force, W.damtype)
-	..()
 
 /obj/structure/displaycase/attack_hand(mob/user as mob)
 	add_fingerprint(user)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -46,7 +46,7 @@
 		playsound(src, "shatter", 70, 1)
 		update_icon()
 
-/obj/structure/displaycase/damage_health(damage, damage_type, skip_death_state_change)
+/obj/structure/displaycase/damage_health(damage, damage_type, skip_death_state_change, severity)
 	. = ..()
 	if (!.)
 		playsound(src, 'sound/effects/Glasshit.ogg', 75, 1)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -36,16 +36,7 @@
 	//Girders only provide partial cover. There's a chance that the projectiles will just pass through. (unless you are trying to shoot the girder)
 	if(Proj.original != src && !prob(cover))
 		return PROJECTILE_CONTINUE //pass through
-
-	var/damage = Proj.get_structure_damage()
-	if(!damage)
-		return
-
-	if(!istype(Proj, /obj/item/projectile/beam))
-		damage *= 0.4 //non beams do reduced damage
-
-	..()
-	damage_health(damage, Proj.damage_type)
+	. = ..()
 
 /obj/structure/girder/handle_death_change(new_death_state)
 	..()
@@ -65,7 +56,7 @@
 	if(reinf_material)
 		reinforce_girder()
 
-/obj/structure/girder/attackby(var/obj/item/W, var/mob/user)
+/obj/structure/girder/attackby(obj/item/W, mob/user)
 	if(isWrench(W) && state == 0)
 		if(anchored && !reinf_material)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
@@ -79,8 +70,9 @@
 			if(do_after(user, 40,src))
 				to_chat(user, "<span class='notice'>You secured the girder!</span>")
 				reset_girder()
+		return
 
-	else if(istype(W, /obj/item/gun/energy/plasmacutter) || istype(W, /obj/item/psychic_power/psiblade/master/grand/paramount))
+	if(istype(W, /obj/item/gun/energy/plasmacutter) || istype(W, /obj/item/psychic_power/psiblade/master/grand/paramount))
 		if(istype(W, /obj/item/gun/energy/plasmacutter))
 			var/obj/item/gun/energy/plasmacutter/cutter = W
 			if(!cutter.slice(user))
@@ -92,16 +84,18 @@
 			if(reinf_material)
 				reinf_material.place_dismantled_product(get_turf(src))
 			dismantle()
+		return
 
-	else if(istype(W, /obj/item/pickaxe/diamonddrill))
+	if(istype(W, /obj/item/pickaxe/diamonddrill))
 		playsound(src.loc, 'sound/weapons/Genhit.ogg', 100, 1)
 		if(do_after(user,reinf_material ? 60 : 40,src))
 			to_chat(user, "<span class='notice'>You drill through the girder!</span>")
 			if(reinf_material)
 				reinf_material.place_dismantled_product(get_turf(src))
 			dismantle()
+		return
 
-	else if(isScrewdriver(W))
+	if(isScrewdriver(W))
 		if(state == 2)
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>Now unsecuring support struts...</span>")
@@ -112,8 +106,9 @@
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			reinforcing = !reinforcing
 			to_chat(user, "<span class='notice'>\The [src] can now be [reinforcing? "reinforced" : "constructed"]!</span>")
+		return
 
-	else if(isWirecutter(W) && state == 1)
+	if(isWirecutter(W) && state == 1)
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now removing support struts...</span>")
 		if(do_after(user, 40,src))
@@ -124,8 +119,9 @@
 				reinf_material = null
 
 			reset_girder()
+		return
 
-	else if(isCrowbar(W) && state == 0 && anchored)
+	if(isCrowbar(W) && state == 0 && anchored)
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now dislodging the girder...</span>")
 		if(do_after(user, 40,src))
@@ -134,18 +130,18 @@
 			anchored = FALSE
 			health_max = 50
 			cover = 25
+		return
 
-	else if(istype(W, /obj/item/stack/material))
+	if(istype(W, /obj/item/stack/material))
 		if(reinforcing && !reinf_material)
 			if(!reinforce_with_material(W, user))
 				return ..()
 		else
 			if(!construct_wall(W, user))
 				return ..()
+		return
 
-	else
-		damage_health(W.force, W.damtype)
-		return ..()
+	..()
 
 /obj/structure/girder/proc/construct_wall(obj/item/stack/material/S, mob/user)
 	if(S.get_amount() < 2)
@@ -224,23 +220,6 @@
 		dismantle()
 		return
 	return ..()
-
-
-/obj/structure/girder/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			qdel(src)
-			return
-		if(2.0)
-			if (prob(30))
-				dismantle()
-			return
-		if(3.0)
-			if (prob(5))
-				dismantle()
-			return
-		else
-	return
 
 /obj/structure/girder/cult
 	icon= 'icons/obj/cult.dmi'

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -57,6 +57,10 @@
 		reinforce_girder()
 
 /obj/structure/girder/attackby(obj/item/W, mob/user)
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if(isWrench(W) && state == 0)
 		if(anchored && !reinf_material)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -155,6 +155,11 @@
 	damage_health(damage, Proj.damage_type)
 
 /obj/structure/grille/attackby(obj/item/W as obj, mob/user as mob)
+	if (user.a_intent == I_HURT)
+		if (!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
+			..()
+		return
+
 	if(isWirecutter(W))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -14,6 +14,7 @@
 	health_resistances = list(
 		BRUTE = 0.1
 	)
+	damage_hitsound = 'sound/effects/grillehit.ogg'
 	var/init_material = MATERIAL_STEEL
 
 	blend_objects = list(/obj/machinery/door, /turf/simulated/wall) // Objects which to blend with
@@ -55,9 +56,6 @@
 	for(var/obj/structure/grille/G in orange(1, location))
 		G.update_connections()
 		G.queue_icon_update()
-
-/obj/structure/grille/ex_act(severity)
-	qdel(src)
 
 /obj/structure/grille/on_update_icon()
 	var/on_frame = is_on_frame()
@@ -162,7 +160,9 @@
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
 			new /obj/item/stack/material/rods(get_turf(src), is_broken() ? 1 : 2, material.name)
 			qdel(src)
-	else if((isScrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
+		return
+
+	if((isScrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
 		if(!shock(user, 90))
 			playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			anchored = !anchored
@@ -170,10 +170,10 @@
 								 "<span class='notice'>You have [anchored ? "fastened the grille to" : "unfastened the grill from"] the floor.</span>")
 			update_connections(1)
 			update_icon()
-			return
+		return
 
 //window placing
-	else if(istype(W,/obj/item/stack/material))
+	if(istype(W,/obj/item/stack/material))
 		var/obj/item/stack/material/ST = W
 		if(ST.material.opacity > 0.7)
 			return 0
@@ -190,12 +190,8 @@
 		place_window(user, loc, dir_to_set, ST)
 		return
 
-	else if(!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.do_attack_animation(src)
-		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
-		damage_health(W.force, W.damtype)
-	..()
+	if (!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
+		..()
 
 /obj/structure/grille/handle_death_change(new_death_state)
 	if (new_death_state)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -144,6 +144,11 @@
 /obj/structure/inflatable/attackby(obj/item/W, mob/user)
 	if(!istype(W) || istype(W, /obj/item/inflatable_dispenser)) return
 
+	if (user.a_intent == I_HURT)
+		if (W.can_puncture() || W.force > 10)
+			..()
+		return
+
 	if(istype(W, /obj/item/tape_roll) && get_damage_value() >= 3)
 		if(taped)
 			to_chat(user, SPAN_NOTICE("\The [src] can't be patched any more with \the [W]!"))

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -67,6 +67,7 @@
 	icon_state = "wall"
 	atmos_canpass = CANPASS_DENSITY
 	health_max = 10
+	damage_hitsound = 'sound/effects/Glasshit.ogg'
 
 	var/undeploy_path = null
 	var/taped
@@ -125,22 +126,16 @@
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 0
 
-/obj/structure/inflatable/bullet_act(var/obj/item/projectile/Proj)
-	if (damage_health(Proj.get_structure_damage(), Proj.damage_type))
+/obj/structure/inflatable/bullet_act(obj/item/projectile/Proj)
+	. = ..()
+	if (!is_alive())
 		return PROJECTILE_CONTINUE
 
 /obj/structure/inflatable/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			qdel(src)
-			return
-		if(2.0)
-			deflate(1)
-			return
-		if(3.0)
-			if(prob(50))
-				deflate(1)
-				return
+	if (severity == 1)
+		qdel(src)
+		return
+	..()
 
 /obj/structure/inflatable/attack_hand(mob/user as mob)
 	add_fingerprint(user)
@@ -158,16 +153,8 @@
 			to_chat(user, SPAN_NOTICE("You patch some damage in \the [src] with \the [W]!"))
 			restore_health(3)
 			return TRUE
-	else if((W.damtype == BRUTE || W.damtype == BURN) && (W.can_puncture() || W.force > 10))
-		..()
-		if(hit(W.force))
-			visible_message("<span class='danger'>[user] pierces [src] with [W]!</span>")
-	return
 
-/obj/structure/inflatable/proc/hit(var/damage, var/sound_effect = 1)
-	if(sound_effect)
-		playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
-	return damage_health(damage)
+	..()
 
 /obj/structure/inflatable/handle_death_change(new_death_state)
 	. = ..()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -213,7 +213,7 @@
 					visible_message("<span class='danger'>[G.assailant] throws \the [G.affecting] over \the [src].</span>")
 			else
 				to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
-			return
+		return
 
 	// Dismantle
 	if(isWrench(W))
@@ -225,7 +225,6 @@
 				user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
 				material.place_sheet(loc, 2)
 				qdel(src)
-			return
 	// Wrench Open
 		else
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
@@ -236,7 +235,8 @@
 				user.visible_message("<span class='notice'>\The [user] wrenches \the [src] closed.</span>", "<span class='notice'>You wrench \the [src] closed.</span>")
 				set_density(TRUE)
 			update_icon()
-			return
+		return
+
 	// Repair
 	if(isWelder(W))
 		var/obj/item/weldingtool/F = W
@@ -250,7 +250,7 @@
 					return
 				user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
 				restore_health(get_max_health() / 5)
-			return
+		return
 
 	// Install
 	if(isScrewdriver(W))
@@ -265,15 +265,7 @@
 			update_icon()
 		return
 
-	if(W.force && (W.damtype == "fire" || W.damtype == "brute"))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		visible_message("<span class='danger'>\The [src] has been [LAZYLEN(W.attack_verb) ? pick(W.attack_verb) : "attacked"] with \the [W] by \the [user]!</span>")
-		damage_health(W.force, W.damtype)
-		return
-	. = ..()
-
-/obj/structure/railing/ex_act(severity)
-	qdel(src)
+	..()
 
 /obj/structure/railing/can_climb(var/mob/living/user, post_climb_check=FALSE, check_silicon=TRUE)
 	. = ..()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -187,6 +187,10 @@
 	return 1
 
 /obj/structure/railing/attackby(var/obj/item/W, var/mob/user)
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	// Handle harm intent grabbing/tabling.
 	if(istype(W, /obj/item/grab) && get_dist(src,user)<2)
 		var/obj/item/grab/G = W

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -65,6 +65,10 @@
 		to_chat(user, "<span class='warning'>Someone is already rummaging here!</span>")
 
 /obj/structure/rubble/attackby(var/obj/item/I, var/mob/user)
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if (istype(I, /obj/item/pickaxe))
 		var/obj/item/pickaxe/P = I
 		visible_message("[user] starts clearing away \the [src].")

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -74,11 +74,9 @@
 				var/obj/item/booty = pickweight(loot)
 				booty = new booty(loc)
 			qdel(src)
-	else
-		..()
-		if (damage_health(I.force, I.damtype, TRUE))
-			visible_message("[user] clears away \the [src].")
-			qdel(src)
+		return
+
+	..()
 
 /obj/structure/rubble/house
 	loot = list(/obj/item/archaeological_find/bowl,

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -156,7 +156,7 @@ FLOOR SAFES
 			return
 
 
-obj/structure/safe/ex_act(severity)
+/obj/structure/safe/ex_act(severity)
 	return
 
 //FLOOR SAFES

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -56,7 +56,7 @@
 
 
 // When destroyed by explosions, properly handle contents.
-obj/structure/ex_act(severity)
+/obj/structure/transit_tube_pod/ex_act(severity)
 	switch(severity)
 		if(1.0)
 			for(var/atom/movable/AM in contents)

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -54,6 +54,10 @@
 /obj/structure/wall_frame/attackby(var/obj/item/W, var/mob/user)
 	src.add_fingerprint(user)
 
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	//grille placing
 	if(istype(W, /obj/item/stack/material/rods))
 		for(var/obj/structure/window/WINDOW in loc)

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -64,11 +64,12 @@
 		return
 
 	//window placing
-	else if(istype(W,/obj/item/stack/material))
+	if(istype(W,/obj/item/stack/material))
 		var/obj/item/stack/material/ST = W
 		if(ST.material.opacity > 0.7)
 			return 0
 		place_window(user, loc, SOUTHWEST, ST)
+		return
 
 	if(isWrench(W))
 		for(var/obj/structure/S in loc)
@@ -83,8 +84,9 @@
 		if(do_after(user, 40,src))
 			to_chat(user, "<span class='notice'>You dissasembled the low wall!</span>")
 			dismantle()
+		return
 
-	else if(istype(W, /obj/item/gun/energy/plasmacutter))
+	if(istype(W, /obj/item/gun/energy/plasmacutter))
 		var/obj/item/gun/energy/plasmacutter/cutter = W
 		if(!cutter.slice(user))
 			return
@@ -93,7 +95,9 @@
 		if(do_after(user, 20,src))
 			to_chat(user, "<span class='warning'>You have sliced through the low wall!</span>")
 			dismantle()
-	return ..()
+		return
+
+	..()
 
 /obj/structure/wall_frame/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1
@@ -141,12 +145,6 @@
 			var/bleach_factor = rand(10,50)
 			paint_color = adjust_brightness(paint_color, bleach_factor)
 		update_icon()
-
-/obj/structure/wall_frame/bullet_act(var/obj/item/projectile/Proj)
-	var/proj_damage = Proj.get_structure_damage()
-	var/damage = min(proj_damage, 100)
-	damage_health(damage, Proj.damage_type)
-	return
 
 /obj/structure/wall_frame/hitby(AM as mob|obj, var/datum/thrownthing/TT)
 	..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -294,6 +294,10 @@
 		to_chat(user, SPAN_NOTICE("There appears to be no way to dismantle \the [src]!"))
 		return
 
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if (isScrewdriver(W))
 		if(reinf_material && construction_state >= 1)
 			construction_state = 3 - construction_state

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -160,11 +160,6 @@
 /turf/simulated/wall/alium/New(var/newloc)
 	..(newloc,MATERIAL_ALIENALLOY)
 
-/turf/simulated/wall/alium/ex_act(severity)
-	if(prob(explosion_resistance))
-		return
-	..()
-
 //Cult wall
 /turf/simulated/wall/cult
 	icon_state = "cult"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -101,16 +101,10 @@
 	else if(istype(Proj,/obj/item/projectile/ion))
 		burn(500)
 
-	var/proj_damage = Proj.get_structure_damage()
-
 	if(Proj.ricochet_sounds && prob(15))
 		playsound(src, pick(Proj.ricochet_sounds), 100, 1)
 
-	//cap the amount of damage, so that things like emitters can't destroy walls in one hit.
-	var/damage = min(proj_damage, 100)
-
-	damage_health(damage, Proj.damage_type)
-	return
+	..()
 
 /turf/simulated/wall/hitby(AM as mob|obj, var/datum/thrownthing/TT)
 	if(!ismob(AM))
@@ -222,19 +216,12 @@
 	ChangeTurf(floor_type)
 
 /turf/simulated/wall/ex_act(severity)
-	switch(severity)
-		if(1)
-			ChangeTurf(get_base_turf(src.z))
-			return
-		if(2)
-			if(prob(75))
-				damage_health(rand(150, 250))
-			else
-				kill_health()
-		if(3)
-			damage_health(rand(0, 250))
-		else
-	return
+	if (prob(explosion_resistance))
+		return
+	if (severity == 1)
+		ChangeTurf(get_base_turf(src.z))
+		return
+	..()
 
 // Wall-rot effect, a nasty fungus that destroys walls.
 /turf/simulated/wall/proc/rot()

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -180,6 +180,12 @@
 	return 0
 
 /obj/effect/blob/attackby(obj/item/W, mob/user)
+	if (user.a_intent == I_HURT)
+		if(isWelder(W))
+			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
+		..()
+		return
+
 	if (isWirecutter(W))
 		if(prob(user.skill_fail_chance(SKILL_SCIENCE, 90, SKILL_EXPERT)))
 			to_chat(user, SPAN_WARNING("You fail to collect a sample from \the [src]."))

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -14,11 +14,21 @@
 
 	health_max = 30
 	health_resistances = list(
-		DAMAGE_BRUTE   = 0.23,
-		DAMAGE_BURN    = 1.24,
-		DAMAGE_FIRE    = 1.24,
-		DAMAGE_EXPLODE = 0.23
+		DAMAGE_BRUTE     = 0.23,
+		DAMAGE_BURN      = 1.24,
+		DAMAGE_FIRE      = 1.24,
+		DAMAGE_EXPLODE   = 0.23,
+		DAMAGE_STUN      = 0,
+		DAMAGE_EMP       = 0,
+		DAMAGE_RADIATION = 0,
+		DAMAGE_BIO       = 0,
+		DAMAGE_PAIN      = 0,
+		DAMAGE_TOXIN     = 0,
+		DAMAGE_GENETIC   = 0,
+		DAMAGE_OXY       = 0,
+		DAMAGE_BRAIN     = 0
 	)
+	damage_hitsound = 'sound/effects/attackblob.ogg'
 
 	var/regen_rate = 5
 	var/laser_resist = 2	// Special resist for laser based weapons - Emitters or handheld energy weaponry. Damage is divided by this and THEN by fire_resist.
@@ -42,9 +52,6 @@
 	if(air_group || height == 0)
 		return 1
 	return 0
-
-/obj/effect/blob/ex_act(var/severity)
-	damage_health(rand(140 - (severity * 40), 140 - (severity * 20)), DAMAGE_EXPLODE)
 
 /obj/effect/blob/on_update_icon()
 	switch (get_damage_percentage())
@@ -162,38 +169,30 @@
 			continue
 		attack_living(victim)
 
-/obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
+/obj/effect/blob/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return
 	var/damage = Proj.damage
 	if (Proj.damage_type == BURN)
 		damage = round(damage / laser_resist)
+	playsound(damage_hitsound, src, 75)
 	damage_health(damage, Proj.damage_type)
 	return 0
 
-/obj/effect/blob/attackby(var/obj/item/W, var/mob/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(src)
-	playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)
-	if(isWirecutter(W))
+/obj/effect/blob/attackby(obj/item/W, mob/user)
+	if (isWirecutter(W))
 		if(prob(user.skill_fail_chance(SKILL_SCIENCE, 90, SKILL_EXPERT)))
 			to_chat(user, SPAN_WARNING("You fail to collect a sample from \the [src]."))
-			return
 		else
 			if(!pruned)
 				to_chat(user, SPAN_NOTICE("You collect a sample from \the [src]."))
 				new product(user.loc)
 				pruned = TRUE
-				return
 			else
 				to_chat(user, SPAN_WARNING("\The [src] has already been pruned."))
-				return
+		return
 
-	if(isWelder(W))
-		playsound(loc, 'sound/items/Welder.ogg', 100, 1)
-
-	damage_health(W.force, W.damtype)
-	return
+	..()
 
 /obj/effect/blob/core
 	name = "master nucleus"

--- a/code/modules/events/computer_damage.dm
+++ b/code/modules/events/computer_damage.dm
@@ -18,6 +18,6 @@
 			victim.visible_message("<span class='warning'>[victim] emits some ominous clicks.</span>")
 			var/obj/item/stock_parts/computer/hard_drive/HDD = victim.get_component_of_type(/obj/item/stock_parts/computer/hard_drive)
 			if(prob(60))
-				HDD.take_damage(HDD.damage_failure)
+				HDD.set_damage_failing()
 			else
-				HDD.take_damage(HDD.damage_malfunction)
+				HDD.set_damage_malfunctioning()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -435,6 +435,10 @@
 
 
 /obj/item/device/electronic_assembly/attackby(obj/item/I, mob/living/user)
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if(istype(I, /obj/item/wrench))
 		if(istype(loc, /turf) && (IC_FLAG_ANCHORABLE & circuit_flags))
 			user.visible_message(SPAN_NOTICE("\The [user] wrenches \the [src]'s anchoring bolts [anchored ? "back" : "into position"]."))

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -435,14 +435,15 @@
 
 
 /obj/item/device/electronic_assembly/attackby(obj/item/I, mob/living/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(istype(I, /obj/item/wrench))
 		if(istype(loc, /turf) && (IC_FLAG_ANCHORABLE & circuit_flags))
 			user.visible_message(SPAN_NOTICE("\The [user] wrenches \the [src]'s anchoring bolts [anchored ? "back" : "into position"]."))
 			playsound(get_turf(user), 'sound/items/Ratchet.ogg',50)
 			if(user.do_skilled(5 SECONDS, SKILL_CONSTRUCTION, src))
 				anchored = !anchored
-	else if(istype(I, /obj/item/integrated_circuit))
+		return
+
+	if(istype(I, /obj/item/integrated_circuit))
 		if(!user.canUnEquip(I))
 			return FALSE
 		if(try_add_component(I, user))
@@ -451,7 +452,8 @@
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
 				S.attackby_react(I,user,user.a_intent)
 			return ..()
-	else if(istype(I, /obj/item/device/multitool) || istype(I, /obj/item/device/integrated_electronics/wirer) || istype(I, /obj/item/device/integrated_electronics/debugger))
+
+	if(istype(I, /obj/item/device/multitool) || istype(I, /obj/item/device/integrated_electronics/wirer) || istype(I, /obj/item/device/integrated_electronics/debugger))
 		if(opened)
 			interact(user)
 			return TRUE
@@ -460,7 +462,8 @@
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
 				S.attackby_react(I,user,user.a_intent)
 			return ..()
-	else if(istype(I, /obj/item/cell))
+
+	if(istype(I, /obj/item/cell))
 		if(!opened)
 			to_chat(user, SPAN_DANGER("\The [src]'s hatch is closed, so you can't access \the [src]'s power supply."))
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
@@ -480,11 +483,14 @@
 			to_chat(user, SPAN_NOTICE("You slot \the [cell] inside \the [src]."))
 			return TRUE
 		return FALSE
-	else if(istype(I, /obj/item/device/integrated_electronics/detailer))
+
+	if(istype(I, /obj/item/device/integrated_electronics/detailer))
 		var/obj/item/device/integrated_electronics/detailer/D = I
 		detail_color = D.detail_color
 		update_icon()
-	else if(istype(I, /obj/item/screwdriver))
+		return
+
+	if(istype(I, /obj/item/screwdriver))
 		var/hatch_locked = FALSE
 		for(var/obj/item/integrated_circuit/manipulation/hatchlock/H in assembly_components)
 			// If there's more than one hatch lock, only one needs to be enabled for the assembly to be locked
@@ -500,30 +506,28 @@
 		opened = !opened
 		to_chat(user, SPAN_NOTICE("You [opened ? "open" : "close"] the maintenance hatch of \the [src]."))
 		update_icon()
-	else if(isCoil(I))
+		return
+
+	if(isCoil(I))
 		var/obj/item/stack/cable_coil/C = I
 		if(health_damaged() && do_after(user, 10, src) && C.use(1))
 			user.visible_message(SPAN_NOTICE("\The [user] patches up \the [src]."))
 			restore_health(5)
-	else
-		if(user.a_intent == I_HURT && (!(user.l_hand == src || user.r_hand == src))) // Kill it
-			user.do_attack_animation(src)
-			playsound(loc, 'sound/weapons/genhit1.ogg', 100, 1)
-			to_chat(user, SPAN_WARNING("\The [user] hits \the [src] with \the [I]!"))
-			damage_health(I.force)
-		else
-			for(var/obj/item/integrated_circuit/input/S in assembly_components)
-				S.attackby_react(I,user,user.a_intent)
+		return
+
+	for(var/obj/item/integrated_circuit/input/S in assembly_components)
+		S.attackby_react(I,user,user.a_intent)
+	..()
 
 /obj/item/device/electronic_assembly/attack_self(mob/user)
 	interact(user)
 
-/obj/item/device/electronic_assembly/bullet_act(var/obj/item/projectile/P)
+/obj/item/device/electronic_assembly/bullet_act(obj/item/projectile/P)
 	if(istype(P,/obj/item/projectile/beam))
 		playsound(loc, SOUNDS_LASER_METAL, 100, 1)
 	else if(istype(P,/obj/item/projectile/bullet))
 		playsound(loc, SOUNDS_BULLET_METAL, 100, 1)
-	damage_health(P.damage, P.damage_type)
+	..()
 
 /obj/item/device/electronic_assembly/attack_generic(mob/user, damage)
 	user.visible_message(SPAN_WARNING("\The [user] smashes \the [src]!"), SPAN_WARNING("You smash \the [src]!"))
@@ -531,10 +535,10 @@
 	damage_health(damage)
 
 /obj/item/device/electronic_assembly/emp_act(severity)
-	. = ..()
 	for(var/I in src)
 		var/atom/movable/AM = I
 		AM.emp_act(severity)
+	. = ..()
 
 // Returns true if power was successfully drawn.
 /obj/item/device/electronic_assembly/proc/draw_power(amount)

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/building_chorus.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/building_chorus.dm
@@ -52,23 +52,9 @@
 /obj/structure/chorus/proc/activate(mob/living/carbon/alien/chorus/C)
 	return
 
-/obj/structure/chorus/attackby(obj/item/W as obj, mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(src)
-	playsound(get_turf(src), "swing_hit", 50, 1)
-	user.visible_message(
-		SPAN_DANGER("[user] hits \the [src] with \the [W]!"),
-		SPAN_DANGER("You hit \the [src] with \the [W]!"),
-		SPAN_DANGER("You hear something breaking!")
-		)
-	damage_health(W.force, W.damtype)
-
 /obj/structure/chorus/handle_death_change(new_death_state)
 	..()
 	if (new_death_state)
 		visible_message(SPAN_WARNING("\The [src] [death_message]"))
 		playsound(loc, death_sound, 50, TRUE)
 		qdel(src)
-
-/obj/structure/chorus/bullet_act(var/obj/item/projectile/P)
-	damage_health(P.damage, P.damage_type)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -5,7 +5,7 @@
 
 	handle_power() // Handles all power interaction
 
-	if(damage > broken_damage)
+	if (damage_broken())
 		shutdown_computer()
 		return
 
@@ -96,7 +96,7 @@
 	if(tesla_link)
 		tesla_link.enabled = TRUE
 	var/issynth = issilicon(user) // Robots and AIs get different activation messages.
-	if(damage > broken_damage)
+	if (damage_broken())
 		if(issynth)
 			to_chat(user, "You send an activation signal to \the [src], but it responds with an error code. It must be damaged.")
 		else

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -13,7 +13,7 @@
 		uninstall_component(null, H)
 		H.forceMove(newloc)
 		if(prob(25))
-			H.take_damage(rand(10,30))
+			H.damage_health(rand(10, 30), BRUTE)
 	qdel(src)
 
 /obj/item/modular_computer/proc/take_damage(var/amount, var/component_probability, var/damage_casing = 1, var/randomize = 1)
@@ -31,7 +31,7 @@
 	if(component_probability)
 		for(var/obj/item/stock_parts/computer/H in get_all_components())
 			if(prob(component_probability))
-				H.take_damage(round(amount / 2))
+				H.damage_health(round(amount / 2))
 
 	if(damage >= max_damage)
 		break_apart()

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -1,58 +1,100 @@
-/obj/item/modular_computer/examine(mob/user)
+/obj/item/modular_computer/examine_damage_state(mob/user)
 	. = ..()
-	if(damage > broken_damage)
-		to_chat(user, "<span class='danger'>It is heavily damaged!</span>")
-	else if(damage)
-		to_chat(user, "It is damaged.")
+	if (damage_broken())
+		to_chat(user, SPAN_DANGER("It is completely non-functional from damage."))
 
+
+/obj/item/modular_computer/handle_death_change(new_death_state)
+	. = ..()
+	if (new_death_state)
+		break_apart()
+
+
+/obj/item/modular_computer/can_damage_health(damage, damage_type)
+	if (!modifiable)
+		return FALSE
+	. = ..()
+
+
+/obj/item/modular_computer/post_health_change(health_mod, damage_type)
+	. = ..()
+	if (damage_broken())
+		shutdown_computer()
+
+
+/// `damage_casing` - Whether or not to pass damage through to the computer itself. If false, skips calling the parent.
+/obj/item/modular_computer/damage_health(damage, damage_type, skip_death_state_change, severity, damage_casing = TRUE)
+	// "Stun" weapons can cause minor damage to components (short-circuits?)
+	// "Burn" damage is equally strong against internal components and exterior casing
+	// "Brute" damage mostly damages the casing.
+	var/component_probability = 0
+	switch (damage_type)
+		if (DAMAGE_BRUTE)
+			component_probability = damage / 2
+		if (DAMAGE_PAIN || DAMAGE_STUN || DAMAGE_SHOCK)
+			component_probability = damage / 3
+		if (DAMAGE_BURN || DAMAGE_FIRE)
+			component_probability = damage / 1.5
+		if (DAMAGE_EXPLODE)
+			component_probability = 30 / severity
+		if (DAMAGE_EMP)
+			// Some attacks don't send a severity, such as ion projectiles.
+			component_probability = severity ? 30 / severity : 30
+			// EMP weapons don't deal direct damage, but do fry the components.
+			damage_casing = FALSE
+
+	// Handle component damage
+	if (component_probability)
+		for (var/obj/item/stock_parts/computer/H in get_all_components())
+			if (prob(component_probability))
+				H.damage_health(round(damage / 2), damage_type)
+
+	if (!damage_casing)
+		. = ..()
+
+
+/// Handles ejecting components and destroying the computer from damage.
 /obj/item/modular_computer/proc/break_apart()
-	visible_message("\The [src] breaks apart!")
+	visible_message(SPAN_DANGER("\The [src] breaks apart!"))
 	var/turf/newloc = get_turf(src)
-	new /obj/item/stack/material/steel(newloc, round(steel_sheet_cost/2))
-	for(var/obj/item/stock_parts/computer/H in get_all_components())
+	new /obj/item/stack/material/steel(newloc, round(steel_sheet_cost / 2))
+	for (var/obj/item/stock_parts/computer/H in get_all_components())
 		uninstall_component(null, H)
 		H.forceMove(newloc)
 		if(prob(25))
 			H.damage_health(rand(10, 30), BRUTE)
 	qdel(src)
 
-/obj/item/modular_computer/proc/take_damage(var/amount, var/component_probability, var/damage_casing = 1, var/randomize = 1)
-	if(!modifiable)
-		return
 
-	if(randomize)
-		// 75%-125%, rand() works with integers, apparently.
-		amount *= (rand(75, 125) / 100.0)
-	amount = round(amount)
-	if(damage_casing)
-		damage += amount
-		damage = clamp(damage, 0, max_damage)
+/// Whether or not the computer's damage is at the broken threshhold. Returns `TRUE` if `get_damage_value()` meets or exceeds `damage_broken`.
+/obj/item/modular_computer/proc/damage_broken()
+	if (get_damage_value() >= (damage_broken / 100) * get_max_health())
+		return TRUE
+	return FALSE
 
-	if(component_probability)
-		for(var/obj/item/stock_parts/computer/H in get_all_components())
-			if(prob(component_probability))
-				H.damage_health(round(amount / 2))
-
-	if(damage >= max_damage)
-		break_apart()
 
 // Stronger explosions cause serious damage to internal components
 // Minor explosions are mostly mitigitated by casing.
-/obj/item/modular_computer/ex_act(var/severity)
-	take_damage(rand(100,200) / severity, 30 / severity)
+/obj/item/modular_computer/ex_act(severity)
+	damage_health(rand(100, 200) / severity, DAMAGE_EXPLODE, severity = severity)
+
 
 // EMPs are similar to explosions, but don't cause physical damage to the casing. Instead they screw up the components
-/obj/item/modular_computer/emp_act(var/severity)
-	take_damage(rand(100,200) / severity, 50 / severity, 0)
+/obj/item/modular_computer/emp_act(severity)
+	damage_health(rand(100, 200) / severity, DAMAGE_EMP, severity = severity, damage_casing = FALSE)
 
-// "Stun" weapons can cause minor damage to components (short-circuits?)
-// "Burn" damage is equally strong against internal components and exterior casing
-// "Brute" damage mostly damages the casing.
-/obj/item/modular_computer/bullet_act(var/obj/item/projectile/Proj)
-	switch(Proj.damage_type)
-		if(BRUTE)
-			take_damage(Proj.damage, Proj.damage / 2)
-		if(PAIN)
-			take_damage(Proj.damage, Proj.damage / 3, 0)
-		if(BURN)
-			take_damage(Proj.damage, Proj.damage / 1.5)
+
+/obj/item/modular_computer/bullet_act(obj/item/projectile/Proj)
+	damage_health(Proj.damage, Proj.damage_type)
+
+
+/obj/item/modular_computer/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	damage_health(round(exposed_temperature / 100), DAMAGE_FIRE) // TODO Test and tweak this value
+
+
+/obj/item/modular_computer/attackby(obj/item/W, mob/user)
+	if (user.a_intent == I_HURT)
+		damage_health(W.force, W.damtype)
+		return
+
+	. = ..()

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -123,7 +123,7 @@
 		if(card_slot.insert_id(I, user))
 			update_verbs()
 		return
-		
+
 	if(istype(W, /obj/item/pen) && stores_pen)
 		if(istype(stored_pen))
 			to_chat(user, "<span class='notice'>There is already a pen in [src].</span>")
@@ -168,17 +168,23 @@
 	if(isWelder(W))
 		var/obj/item/weldingtool/WT = W
 		if(!WT.isOn())
-			to_chat(user, "\The [W] is off.")
+			to_chat(user, SPAN_WARNING("\The [W] is off."))
 			return
 
-		if(!damage)
-			to_chat(user, "\The [src] does not require repairs.")
+		if (!health_damaged())
+			to_chat(user, SPAN_WARNING("\The [src] does not require repairs."))
 			return
 
-		to_chat(user, "You begin repairing damage to \the [src]...")
-		if(WT.remove_fuel(round(damage/75)) && do_after(usr, damage/10))
-			damage = 0
-			to_chat(user, "You repair \the [src].")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] beings repairing damage to \the [src]..."),
+			SPAN_NOTICE("You begin repairing damage to \the [src]...")
+		)
+		if (WT.remove_fuel(round(get_damage_value() / 75)) && do_after(usr, round(get_damage_value() / 10)))
+			revive_health()
+			user.visible_message(
+				SPAN_NOTICE("\The [user] repairs \the [src]."),
+				SPAN_NOTICE("You repair \the [src].")
+			)
 		return
 
 	if(isScrewdriver(W))

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -4,6 +4,10 @@
 	name = "Modular Computer"
 	desc = "A modular computer. You shouldn't see this."
 
+	health_max = 100
+	/// Damage level at which the computer ceases to operate as a percentage of `health_max`.
+	var/damage_broken = 50
+
 	var/enabled = 0											// Whether the computer is turned on.
 	var/screen_on = 1										// Whether the computer is active/opened/it's screen is on.
 	var/hardware_flag = 0									// A flag that describes this device type
@@ -28,10 +32,6 @@
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 	var/light_strength = 0									// Intensity of light this computer emits. Comparable to numbers light fixtures use.
 
-	// Damage of the chassis. If the chassis takes too much damage it will break apart.
-	var/damage = 0				// Current damage level
-	var/broken_damage = 50		// Damage level at which the computer ceases to operate
-	var/max_damage = 100		// Damage level at which the computer breaks apart.
 	var/list/terminals          // List of open terminal datums.
 
 	// Important hardware (must be installed for computer to work)

--- a/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
@@ -11,13 +11,12 @@
 	base_active_power_usage = 200
 	max_hardware_size = 2
 	light_strength = 3
-	max_damage = 200
-	broken_damage = 100
+	health_max = 200
 	w_class = ITEM_SIZE_NORMAL
 	var/icon_state_closed = "laptop-closed"
 	interact_sounds = list("keyboard", "keystroke")
 	interact_sound_volume = 20
-	
+
 /obj/item/modular_computer/laptop/Initialize()
 	. = ..()
 	screen_on = anchored

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -12,8 +12,7 @@
 	max_hardware_size = 2
 	steel_sheet_cost = 10
 	light_strength = 4
-	max_damage = 300
-	broken_damage = 150
+	health_max = 300
 	w_class = ITEM_SIZE_HUGE
 
 /obj/item/modular_computer/telescreen/New()

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/modular_components.dmi'
 	part_flags = PART_FLAG_HAND_REMOVE
 
+	health_max = 100
+
 	/// If the hardware uses extra power, change this.
 	var/power_usage = 0
 	/// If the hardware is turned off set this to FALSE.
@@ -12,13 +14,9 @@
 	var/critical = 1
 	/// Limits which devices can contain this component. 1: All, 2: Laptops/Consoles, 3: Consoles only
 	var/hardware_size = 1
-	/// Current damage level
-	var/damage = 0
-	/// Maximum damage level.
-	var/max_damage = 100
-	/// "Malfunction" threshold. When damage exceeds this value the hardware piece will semi-randomly fail and do !!FUN!! things
+	/// "Malfunction" damage threshold as a percentage of `health_max`. When damage exceeds this value the hardware piece will semi-randomly fail and do !!FUN!! things
 	var/damage_malfunction = 20
-	/// "Failure" threshold. When damage exceeds this value the hardware piece will not work at all.
+	/// "Failure" threshold as a percentage of `health_max`. When damage exceeds this value the hardware piece will not work at all.
 	var/damage_failure = 50
 	/// Chance of malfunction when the component is damaged
 	var/malfunction_probability = 10
@@ -36,28 +34,28 @@
 	// Nanopaste. Repair all damage if present for a single unit.
 	var/obj/item/stack/S = W
 	if(istype(S, /obj/item/stack/nanopaste))
-		if(!damage)
-			to_chat(user, "\The [src] doesn't seem to require repairs.")
+		if(!health_damaged())
+			to_chat(user, SPAN_WARNING("\The [src] doesn't seem to require repairs."))
 			return TRUE
 		if(S.use(1))
-			to_chat(user, "You apply a bit of \the [W] to \the [src]. It immediately repairs all damage.")
-			damage = 0
+			to_chat(user, SPAN_NOTICE("You apply a bit of \the [W] to \the [src]. It immediately repairs all damage."))
+			revive_health()
 		return TRUE
 	// Cable coil. Works as repair method, but will probably require multiple applications and more cable.
 	if(isCoil(S))
-		if(!damage)
-			to_chat(user, "\The [src] doesn't seem to require repairs.")
+		if(!health_damaged())
+			to_chat(user, SPAN_WARNING("\The [src] doesn't seem to require repairs."))
 			return TRUE
 		if(S.use(1))
-			to_chat(user, "You patch up \the [src] with a bit of \the [W].")
-			take_damage(-10)
+			to_chat(user, SPAN_NOTICE("You patch up \the [src] with a bit of \the [W]."))
+			restore_health(10)
 		return TRUE
 	return ..()
 
 
 /// Returns a list of lines containing diagnostic information for display.
 /obj/item/stock_parts/computer/proc/diagnostics()
-	return list("Hardware Integrity Test... (Corruption: [damage]/[max_damage]) [damage > damage_failure ? "FAIL" : damage > damage_malfunction ? "WARN" : "PASS"]")
+	return list("Hardware Integrity Test... (Corruption: [get_damage_percentage()]%) [damage_failing() ? "FAIL" : damage_malfunctioning() ? "WARN" : "PASS"]")
 
 /obj/item/stock_parts/computer/Initialize()
 	. = ..()
@@ -75,28 +73,14 @@
 	if(!enabled)
 		return FALSE
 	// Too damaged to work at all.
-	if(damage >= damage_failure)
+	if (damage_failing())
 		return FALSE
 	// Still working. Well, sometimes...
-	if(damage >= damage_malfunction)
+	if (damage_malfunctioning())
 		if(prob(malfunction_probability))
 			return FALSE
 	// Good to go.
 	return TRUE
-
-/obj/item/stock_parts/computer/examine(mob/user)
-	. = ..()
-	if(damage > damage_failure)
-		to_chat(user, "<span class='danger'>It seems to be severely damaged!</span>")
-	else if(damage > damage_malfunction)
-		to_chat(user, "<span class='notice'>It seems to be damaged!</span>")
-	else if(damage)
-		to_chat(user, "It seems to be slightly damaged.")
-
-/// Damages the component. Contains necessary checks. Negative damage "heals" the component.
-/obj/item/stock_parts/computer/proc/take_damage(var/amount)
-	damage += round(amount) 					// We want nice rounded numbers here.
-	damage = clamp(damage, 0, max_damage)		// Clamp the value.
 
 /// Called when component is disabled/enabled by the OS
 /obj/item/stock_parts/computer/proc/on_disable()
@@ -106,3 +90,29 @@
 	var/datum/extension/interactive/ntos/os = get_extension(loc, /datum/extension/interactive/ntos)
 	if(os)
 		os.recalc_power_usage()
+
+/// Whether or not the component has received enough damage to be malfunctioning.
+/obj/item/stock_parts/computer/proc/damage_malfunctioning()
+	if (get_damage_percentage() >= damage_malfunction)
+		return TRUE
+	return FALSE
+
+/// Whether or not the component has received enough damage to be failing.
+/obj/item/stock_parts/computer/proc/damage_failing()
+	if (get_damage_percentage() >= damage_failure)
+		return TRUE
+	return FALSE
+
+/// Immediately sets the part's damage to the malfunction threshhold. If damage is already past this point, it will not be changed.
+/obj/item/stock_parts/computer/proc/set_damage_malfunctioning()
+	if (damage_malfunctioning())
+		return
+	var/max_health = get_max_health()
+	set_health(max_health - ((damage_malfunction / 100) * max_health))
+
+/// Immediately sets the part's damage to the failure threshhold. If damage is already past this point, it will not be changed.
+/obj/item/stock_parts/computer/proc/set_damage_failing()
+	if (damage_failing())
+		return
+	var/max_health = get_max_health()
+	set_health(max_health - ((damage_failure / 100) * max_health))

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -18,7 +18,7 @@
 	. += "[name] status: [stored_card ? "Card Inserted" : "Card Not Present"]\n"
 	if(stored_card)
 		. += "Testing card read...\n"
-		if( damage >= damage_failure )
+		if (get_damage_value() >= damage_failure)
 			. += "...FAILURE!\n"
 		else
 			var/read_string_stability

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -21,7 +21,7 @@
 	if(printer_ready())
 		last_print = world.time
 		// Damaged printer causes the resulting paper to be somewhat harder to read.
-		if(damage > damage_malfunction)
+		if (damage_malfunctioning())
 			text_to_print = stars(text_to_print, 100-malfunction_probability)
 		var/turf/T = get_turf(src)
 		new paper_type(T, text_to_print, paper_title, md, print_language)

--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -56,25 +56,6 @@
 
 /obj/item/stock_parts/computer/scanner/attackby(obj/W, mob/living/user)
 	do_on_attackby(user, W)
-	// Nanopaste. Repair all damage if present for a single unit.
-	var/obj/item/stack/S = W
-	if (istype(S, /obj/item/stack/nanopaste))
-		if (!damage)
-			to_chat(user, "\The [src] doesn't seem to require repairs.")
-			return TRUE
-		if (S.use(1))
-			to_chat(user, "You apply a bit of \the [W] to \the [src]. It immediately repairs all damage.")
-			damage = 0
-		return TRUE
-	// Cable coil. Works as repair method, but will probably require multiple applications and more cable.
-	if (isCoil(S))
-		if (!damage)
-			to_chat(user, "\The [src] doesn't seem to require repairs.")
-			return TRUE
-		if (S.use(1))
-			to_chat(user, "You patch up \the [src] with a bit of \the [W].")
-			take_damage(-10)
-		return TRUE
 	return ..()
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_attackby(mob/user, atom/target)

--- a/code/modules/modular_computers/ntos/ntos.dm
+++ b/code/modules/modular_computers/ntos/ntos.dm
@@ -83,12 +83,12 @@
 		update_progress = 0
 		var/obj/item/stock_parts/computer/hard_drive/hard_drive = get_component(PART_HDD)
 		if(hard_drive)
-			if(prob(10))
-				hard_drive.visible_message("<span class='warning'>[src] emits some ominous clicks.</span>")
-				hard_drive.take_damage(hard_drive.damage_malfunction)
-			else if(prob(5))
-				hard_drive.visible_message("<span class='warning'>[src] emits some ominous clicks.</span>")
-				hard_drive.take_damage(hard_drive.damage_failure)
+			if(prob(10) && !hard_drive.damage_malfunctioning())
+				hard_drive.visible_message(SPAN_WARNING("\The [src] emits some ominous clicks."))
+				hard_drive.set_damage_malfunctioning()
+			else if(prob(5) && !hard_drive.damage_failing())
+				hard_drive.visible_message(SPAN_WARNING("\The [src] emits some ominous clicks."))
+				hard_drive.set_damage_failing()
 	update_host_icon()
 
 /// Handles all setup when the system is booted up.

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -206,6 +206,11 @@ obj/structure/disposalpipe/Destroy()
 	if(!T.is_plating())
 		return		// prevent interaction with T-scanner revealed pipes
 	src.add_fingerprint(user, 0, I)
+
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if(istype(I, /obj/item/weldingtool))
 		var/obj/item/weldingtool/W = I
 		if(W.remove_fuel(0,user))

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -194,21 +194,6 @@ obj/structure/disposalpipe/Destroy()
 	spawn(2)	// delete pipe after 2 ticks to ensure expel proc finished
 		qdel(src)
 
-
-// pipe affected by explosion
-/obj/structure/disposalpipe/ex_act(severity)
-
-	switch(severity)
-		if(1.0)
-			kill_health()
-			return
-		if(2.0)
-			damage_health(rand(5, 15), BRUTE)
-			return
-		if(3.0)
-			damage_health(rand(0, 15), BRUTE)
-			return
-
 /obj/structure/disposalpipe/handle_death_change(new_death_state)
 	if (new_death_state)
 		broken(prob(0.5))
@@ -216,8 +201,7 @@ obj/structure/disposalpipe/Destroy()
 //attack by item
 //weldingtool: unfasten and convert to obj/disposalconstruct
 
-/obj/structure/disposalpipe/attackby(var/obj/item/I, var/mob/user)
-
+/obj/structure/disposalpipe/attackby(obj/item/I, mob/user)
 	var/turf/T = src.loc
 	if(!T.is_plating())
 		return		// prevent interaction with T-scanner revealed pipes
@@ -238,7 +222,9 @@ obj/structure/disposalpipe/Destroy()
 				to_chat(user, "You must stay still while welding the pipe.")
 		else
 			to_chat(user, "You need more welding fuel to cut the pipe.")
-			return
+		return
+
+	..()
 
 	// called when pipe is cut with welder
 /obj/structure/disposalpipe/proc/welded()

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -43,15 +43,9 @@
 	return 1
 
 /obj/structure/table/bullet_act(obj/item/projectile/P)
-	if(!(P.damage_type == BRUTE || P.damage_type == BURN))
-		return 0
-
-	if(damage_health(P.damage / 2, P.damage_type))
-		//prevent tables with 1 health left from stopping bullets outright
-		return PROJECTILE_CONTINUE //the projectile destroyed the table, so it gets to keep going
-
-	visible_message("<span class='warning'>\The [P] hits [src]!</span>")
-	return 0
+	. = ..()
+	if (!is_alive())
+		return PROJECTILE_CONTINUE
 
 /obj/structure/table/CheckExit(atom/movable/O as mob|obj, target as turf)
 	if(istype(O) && O.checkpass(PASS_FLAG_TABLE))

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -112,6 +112,8 @@
 			return 1
 		else
 			to_chat(user, "<span class='warning'>You don't have enough carpet!</span>")
+		return
+
 	if(!reinforced && !carpeted && material && isWrench(W) && user.a_intent == I_HURT) //robots dont have disarm so it's harm
 		remove_material(W, user)
 		if(!material)
@@ -138,6 +140,7 @@
 			                              "<span class='notice'>You repair some damage to \the [src].</span>")
 			restore_health(get_max_health() / 5) // 20% repair per application
 			return 1
+		return
 
 	if(!material && can_plate && istype(W, /obj/item/stack/material))
 		material = common_material_add(W, user, "plat")
@@ -147,10 +150,13 @@
 			update_desc()
 			update_material()
 		return 1
+
 	if(istype(W, /obj/item/hand)) //playing cards
 		var/obj/item/hand/H = W
 		if(H.cards && H.cards.len == 1)
 			usr.visible_message("\The [user] plays \the [H.cards[1].name].")
+		return
+
 	return ..()
 
 /obj/structure/table/MouseDrop_T(obj/item/stack/material/what)

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -86,6 +86,10 @@
 	. = ..()
 
 /obj/structure/table/attackby(obj/item/W, mob/user)
+	if (user.a_intent == I_HURT)
+		..()
+		return
+
 	if(reinforced && isScrewdriver(W))
 		remove_reinforced(W, user)
 		if(!reinforced)

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -42,7 +42,7 @@
 			new_health += reinforced.integrity / 2
 	set_max_health(new_health)
 
-/obj/structure/table/damage_health(damage, damage_type, skip_death_state_change)
+/obj/structure/table/damage_health(damage, damage_type, skip_death_state_change, severity)
 	// If the table is made of a brittle material, and is *not* reinforced with a non-brittle material, damage is multiplied by TABLE_BRITTLE_MATERIAL_MULTIPLIER
 	if (material?.is_brittle())
 		if (reinforced)


### PR DESCRIPTION
:cl: SierraKomodo
refactor: Modular computers and computer components now use standardized health. Please bug report any damage-related issues with computers and computer parts.
rscadd: Modular computers now handle damage from fire and melee attacks (If on harm intent).
tweak: Modular computers now handle a wider array of damage types uniquely. I.e., EMP/ion damage will cripple components but not damage the computer itself, while shock or stun weaponry will short circuit components and the chassis.
/:cl:

## TODO
- [ ] ~~Transfer computer part health processing to all stock parts~~ Scrapped idea for now - Out of scope
- [ ] Apply standardized health processing to machinery

## DEPENDENCIES
- [X] Depends on #31459
- [x] Depends on #31470