### PR TITLE
Moveable Faucets (take 2)

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -545,6 +545,19 @@
 	var/fill_level = 500
 	var/open = FALSE
 
+/obj/structure/hygiene/faucet/attackby(obj/item/thing, mob/user)
+	..()
+	if(isWrench(thing))
+		new /obj/item/faucet(loc)
+		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+		user.visible_message(
+			SPAN_WARNING("\The [user] unwrenches the \the [src]."),
+			SPAN_WARNING("You unwrench \the [src].")
+		)
+		qdel(src)
+		return
+	return ..()
+
 /obj/structure/hygiene/faucet/attack_hand(mob/user)
 	. = ..()
 	open = !open
@@ -559,6 +572,29 @@
 /obj/structure/hygiene/faucet/on_update_icon()
 	. = ..()
 	icon_state = icon_state = "[initial(icon_state)][open ? "-on" : ""]"
+
+/obj/item/faucet
+	name = "faucet"
+	desc = "An outlet for liquids. Water you waiting for?"
+	icon = 'icons/obj/watercloset.dmi'
+	icon_state = "faucet"
+	var/constructed_type = /obj/structure/hygiene/faucet
+
+/obj/item/faucet/attackby(obj/item/thing, mob/user)
+	if(isWrench(thing))
+		var/turf/simulated/floor/F = loc
+		if (istype(F) && istype(F.flooring, /decl/flooring/pool))
+			new constructed_type(loc)
+			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+			user.visible_message(
+				SPAN_WARNING("\The [user] wrenches the \the [src] down."),
+				SPAN_WARNING("You wrench \the [src] down.")
+			)
+			qdel(src)
+			return
+		else
+			to_chat(user, SPAN_WARNING("\The [src] can only be secured to pool tiles!"))
+	return ..()
 
 /obj/structure/hygiene/faucet/proc/water_flow()
 	if(!isturf(src.loc))


### PR DESCRIPTION
🆑 cdbrunow
rscadd: Faucets may now be moved around with a wrench for all your pool creating needs
rscadd: Faucets have been added to the pipe dispenser
bugfix: You can now put gutters back into the pipe dispenser. Along with Faucets
/🆑
Take two of #31405
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->