### PR TITLE
modes that cannot be started cannot be voted for

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -139,6 +139,9 @@
 	/// Whether or not secret modes show list of possible round types
 	var/static/secret_hide_possibilities = FALSE
 
+	/// Whether or not secret - a hidden random pick from available modes - can be voted for
+	var/static/secret_disabled = FALSE
+
 	/// enables random events mid-round when set to 1
 	var/static/allow_random_events = FALSE
 
@@ -669,6 +672,8 @@
 				antag_hud_restricted = TRUE
 			if ("secret_hide_possibilities")
 				secret_hide_possibilities = TRUE
+			if ("secret_disabled")
+				secret_disabled = TRUE
 			if ("usealienwhitelist")
 				usealienwhitelist = TRUE
 			if ("usealienwhitelist_sql")
@@ -930,7 +935,6 @@
 		probabilities[tag] = M.probability
 		if (M.votable)
 			votable_modes += tag
-	votable_modes += "secret"
 
 
 /configuration/proc/pick_mode(mode_name)
@@ -943,9 +947,10 @@
 
 
 /configuration/proc/get_runnable_modes()
+	var/list/lobby_players = SSticker.lobby_players()
 	var/list/result = list()
 	for (var/tag in gamemode_cache)
-		var/datum/game_mode/M = gamemode_cache[tag]
-		if (probabilities[tag] > 0 && !M.startRequirements())
+		var/datum/game_mode/mode = gamemode_cache[tag]
+		if (probabilities[tag] > 0 && !mode.check_startable(lobby_players))
 			result[tag] = probabilities[tag]
 	return result

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -231,7 +231,7 @@ Helpers
 
 	//Find the relevant datum, resolving secret in the process.
 	var/list/base_runnable_modes = config.get_runnable_modes() //format: list(config_tag = weight)
-	if((mode_to_try=="random") || (mode_to_try=="secret"))
+	if (mode_to_try=="secret")
 		var/list/runnable_modes = base_runnable_modes - bad_modes
 		if(secret_force_mode != "secret") // Config option to force secret to be a specific mode.
 			mode_datum = config.pick_mode(secret_force_mode)
@@ -255,8 +255,8 @@ Helpers
 	mode_datum.create_antagonists() // Init operation on the mode; sets up antag datums and such.
 	mode_datum.pre_setup() // Makes lists of viable candidates; performs candidate draft for job-override roles; stores the draft result both internally and on the draftee.
 	SSjobs.divide_occupations(mode_datum) // Gives out jobs to everyone who was not selected to antag.
-
-	var/result = mode_datum.startRequirements()
+	var/list/lobby_players = SSticker.lobby_players()
+	var/result = mode_datum.check_startable(lobby_players)
 	if(result)
 		mode_datum.fail_setup()
 		SSjobs.reset_occupations()
@@ -293,6 +293,28 @@ Helpers
 			else
 				if(player.create_character())
 					qdel(player)
+
+/datum/controller/subsystem/ticker/proc/lobby_players(list/players)
+	if (!players)
+		players = GLOB.player_list
+	var/list/lobby_players = list()
+	for (var/mob/new_player/player in players)
+		if (!player.client)
+			continue
+		lobby_players += player
+	return lobby_players
+
+
+/datum/controller/subsystem/ticker/proc/ready_players(list/players)
+	if (!players)
+		players = lobby_players()
+	var/list/ready_players = list()
+	for (var/mob/new_player/player as anything in players)
+		if (!player.ready)
+			continue
+		ready_players += player
+	return ready_players
+
 
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/mob/living/player in GLOB.player_list)

--- a/code/datums/vote/gamemode.dm
+++ b/code/datums/vote/gamemode.dm
@@ -1,6 +1,6 @@
 /datum/vote/gamemode
 	name = "game mode"
-	additional_header = "<th>Minimum Players</th>"
+	additional_header = "<th>Required Players / Antags</th>"
 	win_x = 500
 	win_y = 1100
 	result_length = 3
@@ -18,21 +18,36 @@
 		return VOTE_PROCESS_ABORT
 	return ..()
 
+
 /datum/vote/gamemode/setup_vote(mob/creator, automatic)
 	..()
-	choices += config.votable_modes
-	for (var/F in choices)
-		var/datum/game_mode/M = config.gamemode_cache[F]
-		if(!M)
+	var/list/lobby_players = SSticker.lobby_players()
+	log_debug("MODE VOTE: Lobby Players: [lobby_players.len]")
+	var/list/skipped = list()
+	for (var/tag in config.votable_modes)
+		var/datum/game_mode/mode = config.gamemode_cache[tag]
+		var/cause = mode.check_votable(lobby_players)
+		if (cause)
+			skipped[tag] = cause
 			continue
-		display_choices[F] = capitalize(M.name)
-		additional_text[F] ="<td align = 'center'>[M.required_players]</td>"
-	display_choices["secret"] = "Secret"
+		choices += tag
+	log_debug("MODE VOTE: Non-Votable Modes: [json_encode(skipped)]")
+	for (var/tag in choices)
+		var/datum/game_mode/mode = config.gamemode_cache[tag]
+		var/text = " / <span style='color:red;font-weight:bold'>[mode.required_enemies]</span>"
+		additional_text[tag] = "<td align='center'><span style='font-weight:bold'>[mode.required_players]</span> [text]</td>"
+		display_choices[tag] = capitalize(mode.name)
+	if (!config.secret_disabled)
+		display_choices["secret"] = "Secret"
+		choices += "secret"
+	log_debug("MODE VOTE: Votable Modes: [json_encode(choices)]")
+
 
 /datum/vote/gamemode/handle_default_votes()
 	var/non_voters = ..()
 	if(SSticker.master_mode in choices)
 		choices[SSticker.master_mode] += non_voters
+
 
 /datum/vote/gamemode/report_result()
 	if(!SSticker.round_progressing) //Unpause any holds. If the vote failed, SSticker is responsible for fielding the result.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -150,17 +150,18 @@ var/global/list/additional_antag_types = list()
 		else
 			message_admins("[antag_summary]")
 
-// startRequirements()
-// Checks to see if the game can be setup and ran with the current number of players or whatnot.
-// Returns 0 if the mode can start and a message explaining the reason why it can't otherwise.
-/datum/game_mode/proc/startRequirements()
-	var/playerC = 0
-	for(var/mob/new_player/player in GLOB.player_list)
-		if((player.client)&&(player.ready))
-			playerC++
 
-	if(playerC < required_players)
-		return "Not enough players, [src.required_players] players needed."
+/// Run prior to a mode vote to determine if the mode should be included. Falsy if yes, otherwise a status message.
+/datum/game_mode/proc/check_votable(list/lobby_players)
+	if (lobby_players.len < required_players)
+		return "Not enough players are in the lobby. [lobby_players.len] of the required [required_players]."
+
+
+/// Check to see if the currently selected mode can be started. Falsy if yes, otherwise a status message.
+/datum/game_mode/proc/check_startable(list/lobby_players)
+	var/list/ready_players = SSticker.ready_players(lobby_players)
+	if (ready_players.len < required_players)
+		return "Not enough players. [ready_players.len] ready of the required [required_players]."
 
 	var/enemy_count = 0
 	var/list/all_antag_types = GLOB.all_antag_types_

--- a/code/game/gamemodes/mixed/pirates.dm
+++ b/code/game/gamemodes/mixed/pirates.dm
@@ -25,14 +25,10 @@
 		raiders.attempt_spawn()
 		antag_templates = list(raiders)
 
-/datum/game_mode/pirates/startRequirements()
-	var/playerC = 0
-	for(var/mob/new_player/player in GLOB.player_list)
-		if(player.client && player.ready)
-			playerC++
-
-	if(playerC < required_players)
-		return "Not enough players, [required_players] players needed."
+/datum/game_mode/pirates/check_startable(list/lobby_players)
+	var/list/ready_players = SSticker.ready_players(lobby_players)
+	if (ready_players.len < required_players)
+		return "Not enough players. [ready_players.len] ready of the required [required_players]."
 	var/list/all_antag_types = GLOB.all_antag_types_
 	if(antag_tags?.len)
 		var/datum/antagonist/vox/antag_vox = all_antag_types[antag_tags[1]]

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -82,17 +82,19 @@ LOG_ATTACK
 ## disconnect players who did nothing during the set amount of minutes
 # KICK_INACTIVE 10
 
-## probablities for game modes chosen in "secret" and "random" modes
-##
+## Prevent Secret from being added to mode votes
+# SECRET_DISABLED
+
+## probablities for game modes chosen in Secret
 ## default probablity is 1, increase to make that mode more likely to be picked
 ## set to 0 to disable that mode
 PROBABILITY EXTENDED 1
-PROBABILITY MALFUNCTION 1
+PROBABILITY TRAITOR 1
+PROBABILITY SPYVSPY 1
 PROBABILITY MERCENARY 1
-PROBABILITY WIZARD 1
-PROBABILITY CHANGELING 1
+PROBABILITY HEIST 1
 PROBABILITY CULT 1
-PROBABILITY EXTEND-A-TRAITORMONGOUS 6
+PROBABILITY CHANGELING 1
 
 ## if possible round types will be hidden from players for secret rounds
 #SECRET_HIDE_POSSIBILITIES


### PR DESCRIPTION
:cl:
tweak: Modes that would be impossible to start based on the number of players in the lobby at vote time cannot be voted for.
/:cl:

achieves this by adding a check_votable proc that can be overridden per mode - the base implementation simply checks how many players are in the lobby at vote time

also adds antag count requirement to vote info

also adds config option to disable secret

![https://i.imgur.com/N8Afl6R.png](https://i.imgur.com/N8Afl6R.png)

![https://i.imgur.com/H8R78gm.png](https://i.imgur.com/H8R78gm.png)