### PR TITLE
Dynamic AI assigning

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -616,9 +616,9 @@
 			if(sleeping)
 				if (!dream_timer && client)
 					dream_timer = addtimer(CALLBACK(src, .proc/dream), 10 SECONDS, TIMER_STOPPABLE)
-				if (mind)
+				if (mind || ai_holder)
 					//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of stoxin or similar.
-					if(client || sleeping > 3)
+					if (client || ai_holder || sleeping > 3)
 						AdjustSleeping(-1)
 				species.handle_sleeping(src)
 			if(prob(2) && is_asystole() && isSynthetic())
@@ -1151,3 +1151,11 @@
 	..()
 	if((CE_THIRDEYE in chem_effects) || (MUTATION_XRAY in mutations))
 		set_sight(sight|SEE_TURFS|SEE_MOBS|SEE_OBJS)
+
+/mob/living/ssd_check()
+	. = ..()
+
+	if (!.)
+		return
+
+	return !ai_holder

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -44,6 +44,9 @@
 	return ((H && H.isSynthetic()) ? "gives one shrill beep before falling lifeless." : death_message)
 
 /datum/species/proc/get_ssd(var/mob/living/carbon/human/H)
+	if (H.ai_holder)
+		return
+
 	if (H.key)
 		return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
 	else

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -103,6 +103,9 @@
 				H.custom_emote("clutches [T.his] [parent.name]!")
 
 /datum/species/human/get_ssd(var/mob/living/carbon/human/H)
+	if (H.ai_holder)
+		return
+
 	if(H.stat == CONSCIOUS)
 		return "staring blankly, not reacting to your presence"
 	return ..()
@@ -244,14 +247,14 @@
 	else if (effective_dose > 10)
 		M.vomit(4, 2, rand(3 SECONDS, 10 SECONDS))
 	else
-		M.vomit(1, 1, rand(5 SECONDS, 15 SECONDS))	
+		M.vomit(1, 1, rand(5 SECONDS, 15 SECONDS))
 
 /datum/species/skrell/get_sex(var/mob/living/carbon/human/H)
 	return istype(H) && (H.descriptors["headtail length"] == 1 ? MALE : FEMALE)
 
 /datum/species/skrell/check_background()
 	return TRUE
-	
+
 /datum/species/skrell/can_float(mob/living/carbon/human/H)
 	if(!H.is_physically_disabled())
 		if(H.encumbrance() < 2)
@@ -397,7 +400,7 @@
 		if(101 to 200)	. = 12 // age bracket before this is 46 to 100 . = 8 making this +4
 		if(201 to 300)	. = 16 // + 8
 		else			. = ..()
-		
+
 // Dionaea spawned by hand or by joining will not have any
 // nymphs passed to them. This should take care of that.
 /datum/species/diona/handle_post_spawn(var/mob/living/carbon/human/H)


### PR DESCRIPTION
:cl: Mucker
admin: Added new functionality to AI buildmode to allow assigning mobs new AI types on the fly.
/:cl:

a NUFC (ish) also included is some partial edit to existing checks so that `/human/` derived mobs will stay awake and active if they have an assigned `ai_holder`. Currently, they can't actually _do_ much with an AI in control of them, but this can be expanded upon in the future.