### PR TITLE
Set cyborg base speed to match human base speed

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -126,7 +126,6 @@
 	if(R.vtec)
 		return FALSE
 
-	R.speed--
 	R.vtec = TRUE
 	return TRUE
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -38,7 +38,6 @@ var/list/mob_hat_cache = list()
 	integrated_light_max_bright = 0.5
 	local_transmit = 1
 	possession_candidate = 1
-	speed = -1
 
 	can_pull_size = ITEM_SIZE_NORMAL
 	can_pull_mobs = MOB_PULL_SMALLER

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -4,7 +4,6 @@
 	icon_state = "drone-standard"
 	module_category = ROBOT_MODULE_TYPE_FLYING
 	dismantle_type = /obj/item/robot_parts/robot_suit/flyer
-	speed = -1 // nyoom
 	power_efficiency = 0.75
 
 	// They are not very heavy or strong.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -82,7 +82,6 @@
 	var/datum/effect/effect/system/spark_spread/spark_system //So they can initialize sparks whenever/N
 	var/lawupdate = TRUE //Cyborgs will sync their laws with their AI by default
 	var/lockcharge //If a robot is locked down
-	var/speed = 0
 	var/scrambledcodes = FALSE // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
 	var/braintype = "Cyborg"

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -16,13 +16,16 @@
 	. = ..()
 
 
- //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()
-	var/tally = ..() //Incase I need to add stuff other than "speed" later
+	var/tally = ..()
 
-	tally += speed
+	// Subtract 1 to match Human base movement_delay of -1
+	tally -= 1
+
+	if (vtec)
+		tally -= 1
 
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
-		tally-=3
+		tally -= 3
 
 	return tally


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Cyborg base movement speed now matches human base movement speed.
/:cl:

Cyborgs now move at the same speed as a walking human. VTEC modules boost this speed, but should still be slower than a sprinting human.