### PR TITLE
Removes the 'finger down throat' message from vomit emotes

### DIFF
--- a/code/modules/emotes/definitions/human.dm
+++ b/code/modules/emotes/definitions/human.dm
@@ -5,7 +5,7 @@
 	return (istype(user) && user.check_has_mouth() && !user.isSynthetic())
 
 /decl/emote/human/do_emote(var/mob/living/carbon/human/user)
-	user.vomit(deliberate = TRUE)
+	user.vomit()
 
 /decl/emote/human/deathgasp
 	key = "deathgasp"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -738,22 +738,12 @@
 		handle_additional_vomit_reagents(splat)
 		splat.update_icon()
 
-/mob/living/carbon/human/proc/vomit(timevomit = 1, level = 3, delay = 0, deliberate = FALSE)
+/mob/living/carbon/human/proc/vomit(timevomit = 1, level = 3, delay = 0)
 
 	set waitfor = 0
 
 	if(!check_has_mouth() || isSynthetic() || !timevomit || !level || stat == DEAD || lastpuke)
 		return
-
-	if(deliberate)
-		if(incapacitated())
-			to_chat(src, SPAN_WARNING("You cannot do that right now."))
-			return
-		var/datum/gender/G = gender_datums[gender]
-		visible_message(SPAN_DANGER("\The [src] starts sticking a finger down [G.his] own throat. It looks like [G.he] [G.is] trying to throw up!"))
-		if(!do_after(src, 30))
-			return
-		timevomit = max(timevomit, 5)
 
 	timevomit = clamp(timevomit, 1, 10)
 	level = clamp(level, 1, 3)


### PR DESCRIPTION
Because vomiting without it doing the whole 'Your shoving your finger down your throat' thing is good for RP use.

:cl: SierraKomodo
tweak: The `/vomit` emote no longer displays a message about you shoving a finger down your throat. RP being sickened by that mutilated corpse to your heart's content.
/:cl: