### PR TITLE
Remove certain messages for removing handcuffs

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -58,17 +58,11 @@
 		if(do_after(src, breakouttime*0.25, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
 			if(!handcuffed || buckled)
 				return
-			visible_message(
-				SPAN_WARNING("\The [src] fiddles with \the [handcuffed]."),
-				SPAN_WARNING("You try to slip free of \the [handcuffed] ([i*100/stages]% done)."), range = 2
-				)
+			to_chat(src, SPAN_WARNING("You try to slip free of \the [handcuffed] ([i*100/stages]% done)."))
 		else
 			if(!handcuffed || buckled)
 				return
-			visible_message(
-				SPAN_WARNING("\The [src] stops fiddling with \the [handcuffed]."),
-				SPAN_WARNING("You stop trying to slip free of \the [handcuffed]."), range = 2
-				)
+			to_chat(src, SPAN_WARNING("You stop trying to slip free of \the [handcuffed]."))
 			return
 		if(!handcuffed || buckled)
 			return
@@ -150,21 +144,12 @@
 			if(!unbuckle_time || do_after(usr, unbuckle_time*0.5, incapacitation_flags = INCAPACITATION_DISABLED))
 				if(!buckled)
 					return
-				visible_message(
-					SPAN_WARNING("\The [src] tries to unbuckle themself."),
-					SPAN_WARNING("You try to unbuckle yourself ([i*100/stages]% done)."), range = 2
-					)
+				to_chat(src, SPAN_WARNING("You try to unbuckle yourself ([i*100/stages]% done)."))
 			else
 				if(!buckled)
 					return
-				visible_message(
-					SPAN_WARNING("\The [src] stops trying to unbuckle themself."),
-					SPAN_WARNING("You stop trying to unbuckle yourself."), range = 2
-					)
+				to_chat(src, SPAN_WARNING("You stop trying to unbuckle yourself."))
 				return
-		visible_message(
-			SPAN_DANGER("\The [src] manages to unbuckle themself!"),
-			SPAN_NOTICE("You successfully unbuckle yourself."), range = 2
-			)
+		to_chat(src, SPAN_NOTICE("You successfully unbuckle yourself."))
 		buckled.user_unbuckle_mob(src)
 		return


### PR DESCRIPTION
:cl: Ryan180602
tweak: Removed continuous messages for when you're fiddling with cuffs/unbuckling.
/:cl:

Uncuffing yourself/unbuckling provided feedback messages for anyone near you every time you completed a progress bar.
This keeps the timers and everything untouched, but provides this a bit more use by not reminding your captors you're trying to escape every two minutes.