### PR TITLE
Display warrant type in warrant projector list

### DIFF
--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -40,15 +40,17 @@
 	var/list/warrants = list()
 	for(var/datum/computer_file/data/warrant/W in GLOB.all_warrants)
 		if(!W.archived)
-			warrants += W.fields["namewarrant"]
+			warrants["[W.fields["namewarrant"]] ([capitalize(W.fields["arrestsearch"])])"] = W
 	if(warrants.len == 0)
 		to_chat(user,"<span class='notice'>There are no warrants available</span>")
 		return
-	var/temp
+	var/datum/computer_file/data/warrant/temp
 	temp = input(user, "Which warrant would you like to load?") as null|anything in warrants
-	for(var/datum/computer_file/data/warrant/W in GLOB.all_warrants)
-		if(W.fields["namewarrant"] == temp)
-			active = W
+	if (!temp)
+		update_icon()
+		return
+	temp = warrants[temp]
+	active = temp
 	update_icon()
 
 /obj/item/device/holowarrant/attackby(obj/item/W, mob/user)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Warrant projectors now display the warrant type in the list of available warrants.
bugfix: Warrant projectors no longer hide a warrant if a person has both a search and arrest warrant targeting them.
/:cl:

Fixes #31481 