### PR TITLE
Fix missing icon on device/uplink_service

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -52,6 +52,7 @@
 	name = "tiny device"
 	desc = "Press button to activate. Can be done once and only once."
 	w_class = ITEM_SIZE_TINY
+	icon = 'icons/obj/flash_synthetic.dmi'
 	icon_state = "sflash"
 	var/state = AWAITING_ACTIVATION
 	var/service_label = "Unnamed Service"


### PR DESCRIPTION
and children, etc

:cl: Lorwp
bugfix: Antag fake announcements (ion storm, fake centcom announcement, etc) now again have an icon
/:cl: