### PR TITLE
Fixes movable atoms not using parent attackby calls

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -33,10 +33,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /atom/proc/attackby(obj/item/W, mob/user, var/click_params)
 	return
 
-/atom/movable/attackby(obj/item/W, mob/user)
-	if(!(W.item_flags & ITEM_FLAG_NO_BLUDGEON))
-		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
-
 /mob/living/attackby(obj/item/I, mob/user)
 	if(!ismob(user))
 		return 0

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -321,7 +321,7 @@
 
 /atom/attackby(obj/item/W, mob/user, click_params)
 	. = ..()
-	if (user.a_intent == I_HURT && get_max_health())
+	if (user.a_intent == I_HURT && get_max_health() && !(W.item_flags & ITEM_FLAG_NO_BLUDGEON))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 		if (!can_damage_health(W.force, W.damtype))


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Movable atoms with health now actually take damage instead of just saying 'You hit the thing'.
/:cl: