### PR TITLE
Rework `health_resistance` overrides

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -7,10 +7,6 @@
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
 	layer = ABOVE_WINDOW_LAYER
 
-	health_resistances = list(
-		BRUTE = 0.75
-	)
-
 	var/spiky = FALSE
 
 /obj/structure/barricade/Initialize(var/mapload, var/material_name)
@@ -23,7 +19,7 @@
 	SetName("[material.display_name] barricade")
 	desc = "A heavy, solid barrier made of [material.display_name]."
 	color = material.icon_colour
-	set_max_health(material.integrity)
+	set_max_health(round(material.integrity * 1.33)) // Equivalent to a global resistance value of 0.75
 
 /obj/structure/barricade/get_material()
 	return material

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -11,9 +11,6 @@
 	explosion_resistance = 1
 	rad_resistance_modifier = 0.1
 	health_max = 10
-	health_resistances = list(
-		BRUTE = 0.1
-	)
 	damage_hitsound = 'sound/effects/grillehit.ogg'
 	var/init_material = MATERIAL_STEEL
 


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Barricades and grilles no longer take damage from radiation, EMPs, and other non-physical damage sources.
tweak: Grilles no longer have a 90% resistance to brute damage (Why was that even a thing?).
tweak: Barricades now have a flat 133% health modifier instead of a resistance boost to some damage types.
/:cl:
