### PR TITLE
goonchat only adds to payload if opted in

### DIFF
--- a/code/controllers/subsystems/chat.dm
+++ b/code/controllers/subsystems/chat.dm
@@ -43,6 +43,8 @@ SUBSYSTEM_DEF(chat)
 	if (!C)
 		return
 	legacy_chat(C, original)
+	if (C.get_preference_value(/datum/client_preference/goonchat) != GLOB.PREF_YES)
+		return
 	if (!C?.chatOutput || C.chatOutput.broken)
 		return
 	if (!C.chatOutput.loaded)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -239,6 +239,8 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/tmp/iconCache.sav"))
 			//Send it to the old style output window.
 			legacy_chat(C, original_message)
 
+			if (C.get_preference_value(/datum/client_preference/goonchat) != GLOB.PREF_YES)
+				continue
 			if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
 				continue
 
@@ -253,6 +255,8 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/tmp/iconCache.sav"))
 		if (!C)
 			return
 		legacy_chat(C, original_message) //Send it to the old style output window.
+		if (C.get_preference_value(/datum/client_preference/goonchat) != GLOB.PREF_YES)
+			return
 		if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
 			return
 		if(!C.chatOutput.loaded)


### PR DESCRIPTION
should in effect prevent the entire round from each X's perspective being backed up and ready to send to each X if they don't actually want to use goonchat in the first place