### PR TITLE
Revert "Changes the deployable shades to moderate eye protection", makes active augments have job restrictions again

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/augments.dm
+++ b/code/modules/client/preference_setup/loadout/lists/augments.dm
@@ -63,19 +63,27 @@
 	gear_tweaks += new /datum/gear_tweak/path (options)
 
 
-/datum/gear/augment/head_vision
-	display_name = "Head Augments (Vision)"
-	description = "Head augments with vision effects."
-	path = /obj/item/organ/internal/augment
+/datum/gear/augment/corrective_lenses
+	display_name = "corrective lenses"
+	path = /obj/item/organ/internal/augment/active/item/corrective_lenses
 
+/datum/gear/augment/glare_dampeners
+	display_name = "glare dampeners"
+	path = /obj/item/organ/internal/augment/active/item/glare_dampeners
 
-/datum/gear/augment/head_vision/New()
-	..()
-	var/list/options = list()
-	options["corrective lenses"] = /obj/item/organ/internal/augment/active/item/corrective_lenses
-	options["glare dampeners"] = /obj/item/organ/internal/augment/active/item/glare_dampeners
-	options["integrated health HUD"] = /obj/item/organ/internal/augment/active/hud/health
-	options["integrated security HUD"] = /obj/item/organ/internal/augment/active/hud/security
-	options["integrated filth HUD"] = /obj/item/organ/internal/augment/active/hud/janitor
-	options["integrated sciHUD"] = /obj/item/organ/internal/augment/active/hud/science
-	gear_tweaks += new /datum/gear_tweak/path (options)
+/datum/gear/augment/hud_health
+	display_name = "integrated health HUD"
+	path = /obj/item/organ/internal/augment/active/hud/health
+
+/datum/gear/augment/hud_security
+	display_name = "integrated security HUD"
+	path = /obj/item/organ/internal/augment/active/hud/security
+
+/datum/gear/augment/hud_janitor
+	display_name = "integrated janitorial HUD"
+	path = /obj/item/organ/internal/augment/active/hud/janitor
+
+/datum/gear/augment/hud_science
+	display_name = "integrated science HUD"
+	path = /obj/item/organ/internal/augment/active/hud/science
+

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -260,8 +260,8 @@
 	icon_state = "welding-g"
 	item_state = "welding-g"
 	use_alt_layer = TRUE
-	flash_protection = FLASH_PROTECTION_MODERATE
-	darkness_view = -1
+	flash_protection = FLASH_PROTECTION_MAJOR
+	tint = TINT_HEAVY
 
 /obj/item/clothing/glasses/augment_binoculars
 	name = "adaptive binoculars"

--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -1,0 +1,11 @@
+/datum/gear/augment/glare_dampeners/allowed_roles = TECHNICAL_ROLES
+
+/datum/gear/augment/hud_health/allowed_roles = MEDICAL_ROLES
+
+/datum/gear/augment/hud_security/allowed_roles = SECURITY_ROLES
+
+/datum/gear/augment/hud_janitor/allowed_roles = SERVICE_ROLES
+
+/datum/gear/augment/hud_science/New()
+	allowed_roles = RESEARCH_ROLES | EXPLORATION_ROLES
+	..()

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -127,6 +127,7 @@
 
 	#include "loadout/_defines.dm"
 	#include "loadout/loadout_accessories.dm"
+	#include "loadout/loadout_augments.dm"
 	#include "loadout/loadout_ec_skillbadges.dm"
 	#include "loadout/loadout_eyes.dm"
 	#include "loadout/loadout_gloves.dm"


### PR DESCRIPTION
Reverts Baystation12/Baystation12#31523

These are _literally_ welding goggles, as stated by #30752, not sunglasses.

"glare dampeners are like welding goggles that can fold over your eyes and back into your head at will. they lower your vision, but protect from arc-eye."

Was locked for technical roles only at first, for a reason. 

:cl: 
add: Glare dampeners are welding goggles again.
tweak: department oriented augments can only be picked by their respective workers again, instead of being able to be taken by everyone. You will have to reselect them in the loadout 'Augment' section.
/:cl: