### PR TITLE
Adds an extra detail to concealed powerfist

### DIFF
--- a/code/datums/uplink/augments.dm
+++ b/code/datums/uplink/augments.dm
@@ -46,6 +46,6 @@
 /datum/uplink_item/item/augment/aug_power_fist
 	name = "Concealed Powerfist CBM (arm)"
 	desc = "A bulky augment that slots in the AG-23 Pneumatic Powerfist. Perfect for when you need something with more oomph. Comes with it's own tank. \
-	It is unconcealable from body-scanners, and easily detectable due to it's weight."
+	It is unconcealable from body-scanners, and easily detectable due to it's weight. It requires NON-ORGANIC arms."
 	item_cost = 60
 	path = /obj/item/device/augment_implanter/powerfist


### PR DESCRIPTION
:cl: Ryan180602
tweak: Specifies that concealed powerfist antag augment is for synthetic arms only.
/:cl: