### PR TITLE
add hub entry config

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -534,54 +534,12 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 				var/datum/admins/D = new /datum/admins(title, rights, ckey)
 				D.associate(GLOB.ckey_directory[ckey])
 
+
 /world/proc/update_status()
-	var/s = ""
+	if (!config?.hub_visible || !config.hub_entry)
+		return
+	status = config.generate_hub_entry()
 
-	if (config && config.server_name)
-		s += "<b>[config.server_name]</b> &#8212; "
-
-	s += "<b>[station_name()]</b>";
-	s += " ("
-	s += "<a href=\"https://forums.baystation12.net/\">" //Change this to wherever you want the hub to link to.
-	s += "Forums"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
-	s += "</a>"
-	s += ")"
-
-	var/list/features = list()
-
-	if(SSticker.master_mode)
-		features += SSticker.master_mode
-	else
-		features += "<b>STARTING</b>"
-
-	if (!config.enter_allowed)
-		features += "closed"
-
-	features += config.abandon_allowed ? "respawn" : "no respawn"
-
-	if (config && config.allow_vote_mode)
-		features += "vote"
-
-	var/n = 0
-	for (var/mob/M in GLOB.player_list)
-		if (M.client)
-			n++
-
-	if (n > 1)
-		features += "~[n] players"
-	else if (n > 0)
-		features += "~[n] player"
-
-
-	if (config && config.hostedby)
-		features += "hosted by <b>[config.hostedby]</b>"
-
-	if (features)
-		s += ": [jointext(features, ", ")]"
-
-	/* does this help? I do not know */
-	if (src.status != s)
-		src.status = s
 
 /world/proc/SetupLogs()
 	GLOB.log_directory = "data/logs/[time2text(world.realtime, "YYYY/MM/DD")]/round-"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -208,6 +208,10 @@ GUEST_BAN
 ## Where your users can go to complain about problems with the code
 # ISSUE_URL https://example.com
 
+## Discord address
+## Where your users can go to complain at each other in real time
+# DISCORD_URL https://example.com
+
 ## Ban appeals URL
 ## Where your users can go to tell you they've changed
 # BANAPPEALS https://example.com

--- a/config/example/hub.txt
+++ b/config/example/hub.txt
@@ -1,0 +1,23 @@
+# hub.txt allows configuration of the hub listing.
+# You may use html to style the matter of the listing.
+# Multiple newlines are stripped. Newlines are replaced with <br>.
+# Leading and trailing whitespace is stripped.
+# Comment lines begin with # and are stripped.
+# Use $VARIABLE to embed a variable. The following exist:
+#   $SERVER - the value of config.server_name
+#   $HOST - the value of config.hostedby
+#   $WIKI - the value of config.wiki_url
+#   $RULES - the value of config.rules_url
+#   $SOURCE - the value of config.source_url
+#   $DISCORD - the value of config.discord_url
+#   $FORUM - the value of config.forum_url
+#   $MODE - the active mode, otherwise "LOBBY"
+#   $STATION - the value of station_name()
+#   $PLAYERS - current count of connected clients
+#   $ACTIVES - connected clients alive and not AFK
+# If this file is empty or not present the default is:
+#   <b>$SERVER</b> by <b>$HOST</b> &#8212; $ACTIVES of $PLAYERS alive
+# A more fully populated example is provided below:
+
+<b>$SERVER</b> by <b>$HOST</b> &#8212; playing <b>$MODE</b> on <b>$STATION</b> with $ACTIVES of $PLAYERS alive
+[<a href="$WIKI">Wiki</a>] [<a href="$DISCORD">Discord</a>] [<a href="$SOURCE">Source</a>]


### PR DESCRIPTION
hub entry is now based on a configuration file; see config/example/hub.txt

the default hub entry looks like:

**Servername** by **Host** — 3 of 11 alive

the example hub entry looks like:

**Servername** by **Host** — **Secret** on **Station** with 3 of 11 alive
[[Wiki](#)] [[Discord](#)] [[Source](#)]

the fallback hub entry, should someone intentionally blank it but leave listing on, is:

"It Is A Mystery"

And the hub.txt file is config-like, in that it can be commented and strips superfluous whitespace. Otherwise it is HTML with $VAR replacements. The possible replacements at PR time are:

```
#   $SERVER - the value of config.server_name
#   $HOST - the value of config.hostedby
#   $WIKI - the value of config.wiki_url
#   $RULES - the value of config.rules_url
#   $SOURCE - the value of config.source_url
#   $DISCORD - the value of config.discord_url
#   $FORUM - the value of config.forum_url
#   $MODE - the active mode, otherwise "LOBBY"
#   $STATION - the value of station_name()
#   $PLAYERS - current count of connected clients
#   $ACTIVES - connected clients alive and not AFK
```

also adds a DISCORD_URL option to config.txt, but it is only used in this context at the moment.
