### PR TITLE
mobs add NOTARGET on init if not living

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -52,6 +52,8 @@
 		move_intent = move_intents[1]
 	if(ispath(move_intent))
 		move_intent = decls_repository.get_decl(move_intent)
+	if (!isliving(src))
+		status_flags |= NOTARGET
 	START_PROCESSING_MOB(src)
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)


### PR DESCRIPTION
:cl:
bugfix: Non-living mobs (ghosts, observers, etc) can't be targeted by AI by default.
/:cl:

closes #31548

In practical terms, this applies the flag to anything of:
```
/mob
/mob/observer
/mob/new_player
/mob/fake_mob
```
which covers ghosts and system mobs