### PR TITLE
Additional info for admins in lobby and for 'Who' verb

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -43,7 +43,7 @@
 			entry += " - [age]"
 
 			if(is_special_character(C.mob))
-				entry += " - <b><span class=\"who_antagonist\">Antagonist</span></b>"
+				entry += " - <b><span class=\"who_antagonist\">[C.mob.mind.special_role]</span></b>"
 			if(C.is_afk())
 				entry += " (AFK - [C.inactivity2text()])"
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -89,7 +89,16 @@
 					if (player.client.prefs?.job_high)
 						highjob = " as [player.client.prefs.job_high]"
 					if (!player.is_stealthed())
-						stat("[player.key]", (player.ready && show_ready)?("(Playing[highjob])"):(null))
+						var/can_see_hidden = check_rights(R_INVESTIGATE, 0)
+						var/datum/game_mode/mode = config.pick_mode(SSticker.master_mode)
+						var/list/readied_antag_roles = list()
+						if (mode)
+							for (var/role in player.client.prefs.be_special_role)
+								if (role in mode.antag_tags)
+									readied_antag_roles += role
+
+						var/antag_role_text = "[readied_antag_roles.len ? "Readied for ([english_list(readied_antag_roles)])" : ""]"
+						stat("[player.key]", (player.ready && (show_ready || can_see_hidden)?("(Playing[highjob]) [(can_see_hidden && !show_ready) ? "(Hidden)" : ""] [antag_role_text]"):(null)))
 				totalPlayers++
 				if(player.ready)totalPlayersReady++
 		else


### PR DESCRIPTION
:cl: Mucker
admin: The 'Who' verb will now list the specific antag type next to a player's name if they are playing as one.
admin: Staff can now see all players' readied status regardless of hidden status, and can now see what antag roles they are readied for in respect to the current gamemode (other than secret).
/:cl: