### PR TITLE
Remove crashed pod from ship command report

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -22,8 +22,6 @@
 
 	var/hide_from_reports = FALSE
 
-	var/has_distress_beacon
-
 /obj/effect/overmap/visitable/Initialize()
 	. = ..()
 	if(. == INITIALIZE_HINT_QDEL)

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	crew_jobs = list(/datum/job/submap/pod)
 
 /datum/submap/crashed_pod/sync_cell(var/obj/effect/overmap/visitable/cell)
-	cell.has_distress_beacon = name
+	return
 
 /datum/job/submap/pod
 	title = "Stranded Survivor"
@@ -38,8 +38,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	if(_owner) // Might be called from admin tools, etc
 		info = "Your ship, the [_owner.name], has been destroyed by a terrible disaster, \
 		leaving you stranded in your survival pod on a hostile exoplanet. Your pod's distress \
-		signal might draw help, but even if you should be so lucky, you must survive long \
-		enough for it to arrive."
+		signal appear to be malfunctioning. All you can do now is survive, and hope for a passing ship..."
 
 /obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor
 	name = "Stranded Survivor"

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -35,7 +35,6 @@
 				continue
 			space_things |= O
 
-		var/list/distress_calls
 		for(var/obj/effect/overmap/visitable/O in space_things)
 			var/location_desc = " at present co-ordinates."
 			if(O.loc != torch.loc)
@@ -43,14 +42,8 @@
 				if(bearing < 0)
 					bearing += 360
 				location_desc = ", bearing [bearing]."
-			if(O.has_distress_beacon)
-				LAZYADD(distress_calls, "[O.has_distress_beacon][location_desc]")
 			welcome_text += "<li>\A <b>[O.name]</b>[location_desc]</li>"
 
-		if(LAZYLEN(distress_calls))
-			welcome_text += "<br><b>Distress calls logged:</b><br>[jointext(distress_calls, "<br>")]<br>"
-		else
-			welcome_text += "<br>No distress calls logged.<br />"
 		welcome_text += "<hr>"
 
 	post_comm_message("SEV Torch Sensor Readings", welcome_text)


### PR DESCRIPTION
:cl: Mucker
tweak: Crashed pod's distress beacon will no longer be listed on the Torch's welcome report.
/:cl:

Exploration hates having to do them as it just forces them to go to one particular place on the map instead of allowing them to choose. Survivors also rarely get to do much on the Torch anyway once rescued, and most people seem to enjoy the survival aspect of it more than being rescued anyway.

In the future, should probably add a 'beacon' item/structure for the pod people to activate that'll signal nearby ships, but that can come next time.