### PR TITLE
wallets can hold pronouns, hoodies can take pins

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -38,7 +38,9 @@
 		/obj/item/clothing/accessory/medal,
 		/obj/item/clothing/accessory/armor_tag,
 		/obj/item/clothing/ring,
-		/obj/item/passport
+		/obj/item/passport,
+		/obj/item/clothing/accessory/pride_pin,
+		/obj/item/clothing/accessory/pronouns
 	)
 
 	slot_flags = SLOT_ID

--- a/code/modules/clothing/buttons.dm
+++ b/code/modules/clothing/buttons.dm
@@ -23,6 +23,8 @@
 
 
 /obj/item/clothing/suit/storage/toggle/buttons_suffix = "_open"
+/obj/item/clothing/suit/storage/toggle/valid_accessory_slots = ACCESSORY_SLOT_INSIGNIA
+
 
 
 /obj/item/clothing/suit/storage/toggle/inherit_custom_item_data(datum/custom_item/citem)


### PR DESCRIPTION
:cl:
tweak: Wallets can hold pronoun and pride pins. Ranks, pronoun pins, and other insignia slot accessories can go on toggled suits - labcoats, hoodies, etc.
/:cl: