### PR TITLE
Fix presence not counting players in objects

### DIFF
--- a/code/controllers/subsystems/presence.dm
+++ b/code/controllers/subsystems/presence.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(presence)
 		player = queue[i]
 		if (QDELETED(player) || !istype(player))
 			continue
-		++build["[player.z]"]
+		++build["[get_z(player)]"]
 		if (no_mc_tick)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed players in objects (mechs, lockers, etc) not counting toward z-level counts for SSpresence.
/:cl: