### PR TITLE
check_rights uses resolve_client, aghosts can vote

### DIFF
--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -33,10 +33,10 @@
 
 /// Null, or a client if thing is a client, a mob with a client, a connected ckey, or null
 /proc/resolve_client(client/thing)
-	if (!thing)
-		return usr
 	if (istype(thing))
 		return thing
+	if (!thing)
+		thing = usr
 	if (ismob(thing))
 		var/mob/M = thing
 		return M.client

--- a/code/datums/vote/vote.dm
+++ b/code/datums/vote/vote.dm
@@ -151,8 +151,8 @@
 
 // Checks if the mob is participating in the round sufficiently to vote, as per config settings.
 /datum/vote/proc/mob_not_participating(mob/voter)
-	if(config.vote_no_dead && voter.stat == DEAD && !voter.client.holder)
-		return 1
+	if (config.vote_no_dead && voter.stat == DEAD && !check_rights(EMPTY_BITFIELD, FALSE, voter))
+		return TRUE
 
 //null = no toggle set. This is for UI purposes; a text return will give a link (toggle; currently "return") in the vote panel.
 /datum/vote/proc/check_toggle()

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -69,26 +69,21 @@ proc/admin_proc()
 
 NOTE: It checks usr by default. Supply the "user" argument if you wish to check for a specific mob.
 */
-/proc/check_rights(rights_required, show_msg=1, var/client/C = usr)
-	if(ismob(C))
-		var/mob/M = C
-		C = M.client
-	if(!C)
+/proc/check_rights(rights_required, show_msg = TRUE, client/C = usr)
+	C = resolve_client(C)
+	if (!C)
 		return FALSE
-	if(!C.holder)
-		if(show_msg)
-			to_chat(C, "<span class='warning'>Error: You are not an admin.</span>")
+	if (!C.holder)
+		if (show_msg)
+			to_chat(C, SPAN_WARNING("You are not a staff member."))
 		return FALSE
-
-	if(rights_required)
-		if(rights_required & C.holder.rights)
+	if (rights_required)
+		if (rights_required & C.holder.rights)
 			return TRUE
-		else
-			if(show_msg)
-				to_chat(C, "<span class='warning'>Error: You do not have sufficient rights to do that. You require one of the following flags:[rights2text(rights_required," ")].</span>")
-			return FALSE
-	else
-		return TRUE
+		if (show_msg)
+			to_chat(C, SPAN_WARNING("You lack the rights to do that. You need one of: [rights2text(rights_required," ")]"))
+		return FALSE
+	return TRUE
 
 //probably a bit iffy - will hopefully figure out a better solution
 /proc/check_if_greater_rights_than(client/other)


### PR DESCRIPTION
:cl:
bugfix: Aghosted staff can vote.
/:cl:

also updated check_rights to use resolve_client instead of rolling its own

also fixed a case where resolve_client would return a mob because I'm stupid
