### PR TITLE
VV options for adding/removing movement handlers

### DIFF
--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -14,6 +14,12 @@
 		</font>
 		"}
 
+/atom/movable/get_view_variables_options()
+	return ..() + {"
+		<option value='?_src_=vars;addmovementhandler=\ref[src]'>Add Movement Handler</option>
+		<option value='?_src_=vars;removemovementhandler=\ref[src]'>Remove Movement Handler</option>
+		"}
+
 /mob/living/get_view_variables_header()
 	return {"
 		<a href='?_src_=vars;rename=\ref[src]'><b>[src]</b></a><font size='1'>

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -564,6 +564,30 @@
 		var/mob/living/L = locate(href_list["debug_mob_ai"])
 		log_debug("AI Debugging toggled [L.ai_holder.debug() ? "ON" : "OFF"] for \the [L]")
 
+	else if (href_list["addmovementhandler"])
+		if (!check_rights(R_DEBUG))
+			return
+		var/datum/movement_handler/M = input("Add a movement handler to the mob.", "Movement Handler", null) as null|anything in typesof(/datum/movement_handler)
+		if (!M)
+			return
+		var/atom/movable/A = locate(href_list["addmovementhandler"])
+		if (!istype(A))
+			return
+		A.AddMovementHandler(M)
+		log_and_message_admins("Added the [M] movement handler to \the [A]")
+
+	else if (href_list["removemovementhandler"])
+		if (!check_rights(R_DEBUG))
+			return
+		var/atom/movable/A = locate(href_list["removemovementhandler"])
+		if (!istype(A))
+			return
+		var/choice = input("Remove which movement handler?", "Movement Handler", null) as null|anything in A.movement_handlers
+		if (!choice)
+			return
+		A.RemoveMovementHandler(choice)
+		log_and_message_admins("Removed the [choice] movement handler from \the [A]")
+
 	if(href_list["datumrefresh"])
 		var/datum/DAT = locate(href_list["datumrefresh"])
 		if(istype(DAT, /datum) || istype(DAT, /client))


### PR DESCRIPTION
:cl: Mucker
admin: The VV dropdown menu now has options for adding/removing movement handlers to movable atoms.
/:cl: