### PR TITLE
Vox shtuff

### DIFF
--- a/code/datums/outfits/misc.dm
+++ b/code/datums/outfits/misc.dm
@@ -65,6 +65,7 @@
 	l_ear = /obj/item/device/radio/headset/vox_raider
 	belt = /obj/item/storage/belt/utility/full
 	gloves = /obj/item/clothing/gloves/vox
+	r_hand = /obj/item/gun/launcher/alien/spikethrower
 
 	id_slot = slot_wear_id
 	id_types = list(/obj/item/card/id/syndicate)

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -90,8 +90,8 @@
 	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs,/obj/item/tank,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/inflatable_dispenser,/obj/item/rcd)
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_RIFLE,
-		laser = ARMOR_LASER_MAJOR,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SMALL,
@@ -105,8 +105,8 @@
 	desc = "A tight-fitting, beaked mask with three menacing eyeslits."
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_RIFLE,
-		laser = ARMOR_LASER_MAJOR,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SMALL,

--- a/maps/antag_spawn/vox/vox_raider.dmm
+++ b/maps/antag_spawn/vox/vox_raider.dmm
@@ -9,11 +9,7 @@
 /turf/simulated/wall/titanium,
 /area/map_template/vox_raider)
 "af" = (
-/obj/structure/table/rack,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
-/obj/item/tank/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "aj" = (
@@ -158,7 +154,6 @@
 /obj/item/reagent_containers/glass/bottle/stoxin,
 /obj/item/reagent_containers/glass/bottle/kelotane,
 /obj/item/reagent_containers/glass/bottle/kelotane,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	level = 2
@@ -503,11 +498,8 @@
 /area/map_template/vox_raider)
 "tU" = (
 /obj/structure/table/rack,
-/obj/item/gun/launcher/alien/spikethrower,
-/obj/item/gun/launcher/alien/spikethrower,
-/obj/item/gun/launcher/alien/spikethrower,
 /obj/effect/floor_decal/corner/b_green/mono,
-/obj/item/gun/launcher/alien/spikethrower,
+/obj/item/gun/launcher/alien/slugsling,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "tW" = (
@@ -697,15 +689,17 @@
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "Dm" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas/swat/vox,
+/obj/item/rig/vox,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "Dn" = (
 /obj/structure/table/rack,
-/obj/item/gun/launcher/alien/slugsling,
-/obj/machinery/light/vox{
-	dir = 4
-	},
+/obj/item/tank/nitrogen,
+/obj/item/tank/nitrogen,
+/obj/item/tank/nitrogen,
+/obj/item/tank/nitrogen,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "DR" = (
@@ -749,9 +743,19 @@
 /turf/simulated/floor/tiled/dark/vox,
 /area/map_template/vox_raider)
 "Im" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/gas/swat/vox,
-/obj/item/rig/vox,
+/obj/structure/closet/crate{
+	dir = 1;
+	name = "reserve equipment crate"
+	},
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/obj/item/stack/material/rods/fifty,
+/obj/item/device/spaceflare,
+/obj/item/device/spaceflare,
+/obj/item/weldpack,
+/obj/item/weldpack,
 /turf/simulated/floor/tiled/dark/monotile/vox,
 /area/map_template/vox_raider)
 "IF" = (
@@ -869,9 +873,6 @@
 /turf/simulated/floor/plating/vox,
 /area/map_template/vox_raider)
 "Ph" = (
-/obj/structure/hygiene/sink/kitchen{
-	pixel_y = 26
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -984,19 +985,7 @@
 /turf/simulated/floor/tiled/dark/vox,
 /area/map_template/vox_raider)
 "ZC" = (
-/obj/structure/closet/crate{
-	dir = 1;
-	name = "reserve equipment crate"
-	},
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/item/stack/material/rods/fifty,
-/obj/item/device/spaceflare,
-/obj/item/device/spaceflare,
-/obj/item/weldpack,
-/obj/item/weldpack,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/dark/vox,
 /area/map_template/vox_raider)
 


### PR DESCRIPTION
🆑 Jux
tweak: Vox raiders spawn with spikethrowers in-hand instead of them being in the armory.
maptweak: Vox have a water tank.
tweak: Vox raider armor has had the ballistic and laser defense values dropped a notch each.
/🆑 