### PR TITLE
fix observer-related PrivUpdateListenerLoc error

### DIFF
--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -217,6 +217,9 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	var/turf/source_turf = get_turf(source)
 	var/turf/listener_turf = get_turf(listener)
 
+	if (!source_turf || !listener_turf)
+		return
+
 	var/distance = get_dist(source_turf, listener_turf)
 	if(!listener_turf || (distance > range) || !(listener_turf in can_be_heard_from))
 		if(prefer_mute)


### PR DESCRIPTION
When an observer returns to the lobby or enters a body, it's possible
for them to still be in currently active sound listener event lists,
causing listener_turf to be null if they are picked to hear a sound.

Added a source_turf and listener_turf null skip to prevent this being
a proc crash.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->