### PR TITLE
auto close/mark issues as stale, mark prs as stale

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue has not been updated in 30 days, and will close in 5 days from now if no updates are made.'
+          days-before-stale: 30
+          days-before-close: 5
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-issue-labels: 'Runtime Error'


### PR DESCRIPTION
NUFC
Basic setup to auto close stale issues and mark issues/PRs as stale after a 30 day period of inactivity.

Job can be run manually, else it runs once per day. Currently doesn't close open PR's that are stale, as I wasn't sure if those should be left to manually close or not.