### PR TITLE
Bug fixes/tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -289,3 +289,9 @@
 #define INIT_MACHINERY_PROCESS_COMPONENTS FLAG(1)
 #define INIT_MACHINERY_PROCESS_ALL ( INIT_MACHINERY_PROCESS_SELF | INIT_MACHINERY_PROCESS_COMPONENTS )
 //--
+
+
+// Options for /obj/item/device/soulstone/var/owner_flag
+#define SOULSTONE_OWNER_CULT   "cult"   /// The soulstone is owned by the cult faction.
+#define SOULSTONE_OWNER_WIZARD "wizard" /// The soulstone is owned by a wizard.
+#define SOULSTONE_OWNER_PURE   "pure"   /// The soulstone has been purified.

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -263,12 +263,15 @@ datum/ghosttrap/pai/transfer_personality(var/mob/candidate, var/mob/living/silic
 /datum/ghosttrap/cult/welcome_candidate(var/mob/target)
 	var/obj/item/device/soulstone/S = target.loc
 	if(istype(S))
-		if(S.is_evil)
-			GLOB.cult.add_antagonist(target.mind)
-			to_chat(target, "<b>Remember, you serve the one who summoned you first, and the cult second.</b>")
-		else
-			to_chat(target, "<b>This soultone has been purified. You do not belong to the cult.</b>")
-			to_chat(target, "<b>Remember, you only serve the one who summoned you.</b>")
+		switch (S.owner_flag)
+			if (SOULSTONE_OWNER_CULT)
+				GLOB.cult.add_antagonist(target.mind)
+				to_chat(target, "<b>Remember, you serve the one who summoned you first, and the cult second.</b>")
+			if (SOULSTONE_OWNER_WIZARD)
+				to_chat(target, "<b>Remember, you only serve the wizard who summoned you.</b>")
+			else
+				to_chat(target, "<b>This soultone has been purified. You do not belong to the cult.</b>")
+				to_chat(target, "<b>Remember, you only serve the one who summoned you.</b>")
 
 /datum/ghosttrap/cult/shade
 	object = "soul stone"

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -18,6 +18,13 @@
 	set hidden = 1
 	toggle_module(module)
 
+/mob/living/silicon/robot/hotkey_drop()
+	if (!module)
+		to_chat(src, SPAN_WARNING("You haven't selected a module yet."))
+		return
+	uneq_active()
+	hud_used.update_robot_modules_display()
+
 /mob/living/silicon/robot/proc/uneq_active()
 	if(isnull(module_active))
 		return

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -13,7 +13,8 @@
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
 
 	var/full = SOULSTONE_EMPTY
-	var/is_evil = 1
+	/// String. One of `SOULSTONE_OWNER_*`. Defines who or what 'owns' the soulstone, which affects the soul within and any created constructs.
+	var/owner_flag = SOULSTONE_OWNER_CULT
 	var/mob/living/simple_animal/shade = null
 	var/smashing = 0
 	var/soulstatus = null
@@ -65,9 +66,9 @@
 
 /obj/item/device/soulstone/attackby(var/obj/item/I, var/mob/user)
 	..()
-	if(is_evil && istype(I, /obj/item/nullrod))
+	if (owner_flag != SOULSTONE_OWNER_PURE && istype(I, /obj/item/nullrod))
 		to_chat(user, "<span class='notice'>You cleanse \the [src] of taint, purging its shackles to its creator..</span>")
-		is_evil = 0
+		owner_flag = SOULSTONE_OWNER_PURE
 		return
 	if(I.force >= 5)
 		if(full != SOULSTONE_CRACKED)
@@ -150,8 +151,13 @@
 		var/mob/living/simple_animal/construct/C = new ctype(get_turf(src))
 		C.key = S.shade.key
 		//C.cancel_camera()
-		if(S.is_evil)
+		transfer_languages(user, C, RESTRICTED | HIVEMIND)
+		if (S.owner_flag == SOULSTONE_OWNER_CULT)
 			GLOB.cult.add_antagonist(C.mind)
+		else
+			// Only cult constructs get cult languages
+			C.remove_language(LANGUAGE_CULT)
+			C.remove_language(LANGUAGE_CULT_GLOBAL)
 		qdel(S)
 		qdel(src)
 


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Robots and drones can now drop modules back into their inventory using CTRL+Q.
tweak: Constructs now know their creator's languages. Non-cultist constructs no longer have access to cult languages or hivemind.
/:cl:

- Fixes #13906
- Closes #11410