### PR TITLE
Increase pikecube uplink cost

### DIFF
--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -38,7 +38,7 @@
 /datum/uplink_item/item/visible_weapons/pikecube
 	name = "Pike Cube"
 	desc = "While it looks like a normal monkey cube, the animal produced is, instead, a space pike. \ Note: The space pike does not like you."
-	item_cost = 30
+	item_cost = 70
 	path = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/pikecube
 
 /datum/uplink_item/item/visible_weapons/energy_sword


### PR DESCRIPTION
:cl: Mucker
tweak: The pikecube traitor uplink cost has been drastically increased to counteract it as an extremely deadly kill-everything weapon.
/:cl: