### PR TITLE
fix existing uses of sspresence to use get_z

### DIFF
--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -37,7 +37,9 @@ SUBSYSTEM_DEF(ai)
 		ai = queue[i]
 		if (QDELETED(ai) || ai.busy)
 			continue
-		if (!run_empty_levels && !SSpresence.population(ai.holder?.z))
+		if (!ai.holder)
+			continue
+		if (!run_empty_levels && !SSpresence.population(get_z(ai.holder)))
 			continue
 		ai.handle_strategicals()
 		if (no_mc_tick)
@@ -78,7 +80,9 @@ SUBSYSTEM_DEF(aifast)
 		ai = queue[i]
 		if (QDELETED(ai) || ai.busy)
 			continue
-		if (!run_empty_levels && !SSpresence.population(ai.holder?.z))
+		if (!ai.holder)
+			continue
+		if (!run_empty_levels && !SSpresence.population(get_z(ai.holder)))
 			continue
 		ai.handle_tactics()
 		if (no_mc_tick)

--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(mobs)
 		mob = queue[i]
 		if (QDELETED(mob))
 			continue
-		if (!run_empty_levels && !SSpresence.population(mob.z))
+		if (!run_empty_levels && !SSpresence.population(get_z(mob)))
 			continue
 		mob.Life()
 		if (no_mc_tick)


### PR DESCRIPTION
:cl:
bugfix: Cryopods work again.
bugfix: Being inside something in general no longer stops your life ticks.
/:cl:

should probably have .population( discover the argument type and do
this itself, but shrug for now

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->