### PR TITLE
Runtime batch fix

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -250,7 +250,6 @@ area/space/atmosalert()
 	for(var/mob/living/carbon/human/H in src)
 		if(H.client)
 			mysound.status = SOUND_UPDATE
-			to_chat(H, mysound)
 			if(S)
 				spawn(sound_delay)
 					sound_to(H, S)

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -14,7 +14,7 @@
 	public_variables = list(
 		/decl/public_access/public_variable/gas,
 		/decl/public_access/public_variable/pressure,
-		/decl/public_access/public_variable/temperature		
+		/decl/public_access/public_variable/temperature
 	)
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/meter = 1)
 
@@ -37,7 +37,7 @@
 /obj/machinery/meter/proc/clear_target()
 	if(target)
 		GLOB.destroyed_event.unregister(target, src)
-		target = null	
+		target = null
 
 /obj/machinery/meter/return_air()
 	if(target)
@@ -99,6 +99,10 @@
 
 
 /obj/machinery/meter/interface_interact(mob/user)
+	if (!target)
+		log_debug(append_admin_tools("\A [src] interacted with by \the [user] had no target.", user, get_turf(src)))
+		to_chat(user, SPAN_WARNING("\The [src] has no target! This might be a bug. Please report it."))
+		return TRUE
 	var/datum/gas_mixture/environment = target.return_air()
 	to_chat(user, "The pressure gauge reads [round(environment.return_pressure(), 0.01)] kPa; [round(environment.temperature,0.01)]K ([round(environment.temperature-T0C,0.01)]&deg;C)")
 	return TRUE

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -328,8 +328,8 @@
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer
 /obj/machinery/cryopod/proc/despawn_occupant()
-	if (!occupant)
-		log_and_message_admins("A mob was deleted while in a cryopod. This may cause errors!")
+	if (QDELETED(occupant))
+		log_and_message_admins("A mob was deleted while in a cryopod, or the cryopod double-processed. This may cause errors!")
 		return
 
 	//Drop all items into the pod.

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -59,7 +59,7 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 			var/atom/movable/AM = atom_movable
 			if(AM && AM.simulated && !T.protects_atom(AM))
 				AM.ex_act(severity)
-				if(!AM.anchored)
+				if(AM && !AM.anchored)
 					addtimer(CALLBACK(AM, /atom/movable/.proc/throw_at, throw_target, 9/severity, 9/severity), 0)
 
 	explosion_turfs.Cut()

--- a/code/modules/clothing/under/accessories/bowtie.dm
+++ b/code/modules/clothing/under/accessories/bowtie.dm
@@ -24,7 +24,7 @@
 		if (!B)
 			return
 	B.untied = !B.untied
-	to_chat(usr, "You [untied ? "untie" : "tie"] your [B.name].")
+	to_chat(usr, "You [B.untied ? "untie" : "tie"] your [B.name].")
 	B.queue_icon_update()
 
 

--- a/code/modules/clothing/under/accessories/flannel_shirt.dm
+++ b/code/modules/clothing/under/accessories/flannel_shirt.dm
@@ -61,7 +61,7 @@
 		if (!F)
 			return
 	F.rolled = !F.rolled
-	to_chat(usr, "You roll [rolled ? "up" : "down"] the sleeves of your [F.name].")
+	to_chat(usr, "You roll [F.rolled ? "up" : "down"] the sleeves of your [F.name].")
 	F.queue_icon_update()
 
 

--- a/code/modules/merchant/merchant_guns.dm
+++ b/code/modules/merchant/merchant_guns.dm
@@ -5,7 +5,7 @@
 /obj/item/gun/projectile/heavysniper/ant
 	name = "anti-material rifle"
 	desc = "A portable anti-armour rifle fitted with a scope, the HI PTR-7 Rifle was originally designed to used against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease. Fires armor piercing 14.5mm shells. This replica however fires pistol rounds."
-	ammo_type = /obj/item/ammo_magazine/pistol/small
+	ammo_type = /obj/item/ammo_casing/pistol/small
 	caliber = CALIBER_PISTOL_SMALL
 
 /obj/item/gun/energy/laser/dogan

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -189,7 +189,7 @@
 	else if(eyeobj)
 		if(eyeobj.owner != src)
 			reset_view(null)
-	else if(!client.adminobs)
+	else if(!client?.adminobs)
 		reset_view(null)
 
 /mob/living/proc/update_sight()


### PR DESCRIPTION
:cl: SierraKomodo
refactor: Various fixes for recent server runtimes. User facing changes include:
bugfix: Toggling bowties and flannel shirts should now display the correct messages based on toggle state.
bugfix: Cryopods should hopefully stop double-announcing flushing some people. Admin/error logs will still occur though as the root issue hasn't been found and fixed yet.
bugfix: The replica anti-material rifle now properly accepts pistol bullets instead of demanding pistol magazines that don't work with this rifle.
admin: Additional debug logs have been added for certain runtimes to help troubleshoot them when they occur.
/:cl:

- Fixes #31057
- Fixes #31295
- Fixes #31241
- Fixes #31609
- Fixes #20215
- Fixes #30916
- Fixes #29381

Implements additional debug logs to help troublshoot the following runtimes they happen:
- #29362