### PR TITLE
Fix spider counts being low in infestation event

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -12,7 +12,7 @@
 		spawncount = 3 * severity
 	else
 		spawncount = 5 * severity
-	guaranteed_to_grow = round(rand(spawncount / 2, spawncount / 3))
+	guaranteed_to_grow = round(rand(spawncount / 3, spawncount / 2))
 	sent_spiders_to_station = 0
 
 /datum/event/spider_infestation/announce()


### PR DESCRIPTION
nufc

This doesn't actually really change counts by much, testing only showed 1-3 more per event that probably won't even be noticed.