### PR TITLE
Fixed walking intent flags

### DIFF
--- a/code/datums/move_intent/move_intent.dm
+++ b/code/datums/move_intent/move_intent.dm
@@ -25,7 +25,6 @@
 
 /decl/move_intent/walk
 	name = "Walk"
-	flags = MOVE_INTENT_DELIBERATE
 	hud_icon_state = "walking"
 
 /decl/move_intent/walk/Initialize()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -103,7 +103,7 @@
 
 		if(src.wet)
 
-			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(wet/10))) ) )
+			if(M.buckled || (!MOVING_QUICKLY(M) && prob(min(100, 100/(wet/10))) ) )
 				return
 
 			// skillcheck for slipping


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixed walking intent flags to make it work like it used to before running was added.

:cl: Imienny
bugfix: Fixed bug with walking not making floors dirty, Janitors rejoyce!
tweak: Walking will now make you trigger beartraps and snap pops.
/:cl: