### PR TITLE
Makes walls more susceptible to explosions

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -221,6 +221,8 @@
 	if (severity == 1)
 		ChangeTurf(get_base_turf(src.z))
 		return
+
+	severity = min(1, severity * 0.2)
 	..()
 
 // Wall-rot effect, a nasty fungus that destroys walls.


### PR DESCRIPTION
:cl: Mucker
tweak: Walls are now more susceptible to explosions.
/:cl:

Walls should now actually get blown up by most major explosions, and have a similar feel to what they were before the last round of health changes.