### PR TITLE
Reverts industrial mech speed back to 4

### DIFF
--- a/code/modules/mechs/components/legs.dm
+++ b/code/modules/mechs/components/legs.dm
@@ -67,7 +67,7 @@
 	exosuit_desc_string = "reinforced hydraulic legs"
 	desc = "Wide and stable but not particularly fast."
 	max_damage = 70
-	move_delay = 3
+	move_delay = 4
 	turn_delay = 4
 	power_use = 10
 


### PR DESCRIPTION
Simple as, no need for a fancy description.
Having the same speed as the research-locked variant for less material cost and power usage is bad.

:cl:
tweak: Powerloader motivators had their speed dropped to regular again.
/:cl: