### PR TITLE
Wall explosion tweaks

### DIFF
--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -296,8 +296,8 @@
 /atom/ex_act(severity)
 	..()
 	// No hitsound here to avoid noise spam.
-	// Generalized - 75-125 damage at max, 38-63 at medium, 25-42 at minimum severities.
-	damage_health(rand(75, 125) / severity, DAMAGE_EXPLODE, severity = severity)
+	// Generalized - 250-350 damage at max, 125-175 at medium, 83-117 at minimum severities.
+	damage_health(rand(250, 350) / severity, DAMAGE_EXPLODE, severity = severity)
 
 
 /atom/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -13,6 +13,8 @@
 		explosion_resistance = material.explosion_resistance
 	if(reinf_material && reinf_material.explosion_resistance > explosion_resistance)
 		explosion_resistance = reinf_material.explosion_resistance
+	// Base material `explosion_resistance` is `5`, so a value of `5 `should result in a wall resist value of `1`.
+	set_damage_resistance(DAMAGE_EXPLODE, explosion_resistance ? 5 / explosion_resistance : 1)
 
 	if(reinf_material)
 		SetName("reinforced [material.display_name] [material.wall_name]")

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -9,7 +9,7 @@
 	icon_state = "r_generic"
 
 /turf/simulated/wall/r_wall/New(var/newloc)
-	..(newloc, MATERIAL_PLASTEEL,MATERIAL_PLASTEEL) //3strong
+	..(newloc, MATERIAL_STEEL,MATERIAL_PLASTEEL) //3strong
 
 /turf/simulated/wall/r_wall/hull
 	name = "hull"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -216,8 +216,6 @@
 	ChangeTurf(floor_type)
 
 /turf/simulated/wall/ex_act(severity)
-	if (prob(explosion_resistance))
-		return
 	if (severity == 1)
 		ChangeTurf(get_base_turf(src.z))
 		return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -215,12 +215,6 @@
 
 	ChangeTurf(floor_type)
 
-/turf/simulated/wall/ex_act(severity)
-	if (severity == 1)
-		ChangeTurf(get_base_turf(src.z))
-		return
-	..()
-
 // Wall-rot effect, a nasty fungus that destroys walls.
 /turf/simulated/wall/proc/rot()
 	if(locate(/obj/effect/overlay/wallrot) in src)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Walls now take more damage from explosions.
tweak: Pre-mapped reinforced walls are now a steel/plasteel mix instead of 100% plasteel.
/:cl:

May need more tweaking after seeing how things play out on server.

BEFORE:
- Default standard walls have 150 health.
- Default reinforced walls are plasteel reinforced with plasteel and have 600 health.
- Standard walls had a flat 5% chance to completely negate all explosion damage regardless of severity. Reinforced walls had a 25% chance.
- All walls that failed the above probability check were outright deleted at explosion severity 1 (Devastation).
- Explosion severity 2 dealt 38-63 points of damage, before applying health resistances.
- Explosion severity 3 dealt 25-42 points of damage, before applying health resistances.
- Standard walls would effectively always survive any explosions that occured if they weren't in the devastation range.
- Reinforced walls were basically unscratched.
- Walls had no resistance values against explosions.

AFTER:
- Default standard walls have 150 health (Unchanged)
- Default reinforced walls are steel reinforced with plasteel and have 350 health.
- Probability to negate all damage was fully removed.
- Explosion severity 1 deals 250-350 points of damage, before applying health resistances.
- Explosion severity 2 deals 125-175 points of damage, before applying health resistances (Essentially a 50% change of destroying a standard wall or severely damaging it).
- Explosion severity 3 deals 83-117 points of damage, before applying health resistances.
- Reinforced walls now take more damage but can still withstand multiple explosions if not in devastation range.
- Walls now have resistance values against explosions, based on their material explosion_resistance var. Standard metal has no resistance or weakness with current values and serves as a baseline. Plasteel provides a base 60% resistance to explosions.