### PR TITLE
copy mc change from tgstation/tgstation#64500

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -94,7 +94,7 @@
 		queue_node_priority = queue_node.queued_priority
 		queue_node_flags = queue_node.flags
 
-		if (queue_node_flags & SS_TICKER)
+		if (queue_node_flags & (SS_TICKER|SS_BACKGROUND) == SS_TICKER)
 			if (!(SS_flags & SS_TICKER))
 				continue
 			if (queue_node_priority < SS_priority)


### PR DESCRIPTION
resolves invisible MC scheduling issue that allows background SSs to eat up all available scheduling time if any are ever restarted

https://github.com/tgstation/tgstation/pull/64500
