### PR TITLE
heck you, un-magics your hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -149,18 +149,13 @@
 		air_supply = new air_type(src)
 	if(glove_type)
 		gloves = new glove_type(src)
-		verbs |= /obj/item/rig/proc/toggle_gauntlets
 	if(helm_type)
 		helmet = new helm_type(src)
 		verbs |= /obj/item/rig/proc/toggle_helmet
 	if(boot_type)
 		boots = new boot_type(src)
-		verbs |= /obj/item/rig/proc/toggle_boots
 	if(chest_type)
 		chest = new chest_type(src)
-		if(allowed)
-			chest.allowed = allowed
-		verbs |= /obj/item/rig/proc/toggle_chest
 
 	for(var/obj/item/piece in list(gloves,helmet,boots,chest))
 		if(!istype(piece))

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -55,50 +55,6 @@
 
 	toggle_piece("helmet",wearer)
 
-/obj/item/rig/proc/toggle_chest()
-
-	set name = "Toggle Chestpiece"
-	set desc = "Deploys or retracts your chestpiece."
-	set category = "Hardsuit"
-	set src = usr.contents
-
-	if(!check_suit_access(usr))
-		return
-
-	toggle_piece("chest",wearer)
-
-/obj/item/rig/proc/toggle_gauntlets()
-
-	set name = "Toggle Gauntlets"
-	set desc = "Deploys or retracts your gauntlets."
-	set category = "Hardsuit"
-	set src = usr.contents
-
-	if(!istype(wearer) || !wearer.back == src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
-		return
-
-	if(!check_suit_access(usr))
-		return
-
-	toggle_piece("gauntlets",wearer)
-
-/obj/item/rig/proc/toggle_boots()
-
-	set name = "Toggle Boots"
-	set desc = "Deploys or retracts your boots."
-	set category = "Hardsuit"
-	set src = usr.contents
-
-	if(!istype(wearer) || !wearer.back == src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
-		return
-
-	if(!check_suit_access(usr))
-		return
-
-	toggle_piece("boots",wearer)
-
 /obj/item/rig/verb/deploy_suit()
 
 	set name = "Deploy Hardsuit"

--- a/nano/templates/hardsuit.tmpl
+++ b/nano/templates/hardsuit.tmpl
@@ -136,11 +136,6 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.gauntlets)}}
 				</div>
-				{{if data.sealing != 1}}
-					<div class='fixedLeft'>
-						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'gauntlets'}, null)}}
-					</div>
-				{{/if}}
 			</div>
 			<div class='inlineBlock'>
 				<div class='fixedLeft boldText'>
@@ -149,11 +144,6 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.boots)}}
 				</div>
-				{{if data.sealing != 1}}
-					<div class='fixedLeft'>
-						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'boots'}, null)}}
-					</div>
-				{{/if}}
 			</div>
 			<div class='inlineBlock'>
 				<div class='fixedLeft boldText'>
@@ -162,11 +152,6 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.chest)}}
 				</div>
-				{{if data.sealing != 1}}
-					<div class='fixedLeft'>
-						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'chest'}, null)}}
-					</div>
-				{{/if}}
 			</div>
 		</div>
 


### PR DESCRIPTION
🆑 Jux
tweak: Hardsuit gloves, boots and chestpieces can no longer be toggled.
/🆑

What this is means is that, once you deploy the suit, even if you don't seal it, the only way those pieces come off is by removing the suit. 
The helmet can still be toggled. 