### PR TITLE
Knockout Changes/Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -222,19 +222,10 @@ meteor_act
 		radio_interrupt_cooldown = world.time + (RADIO_INTERRUPT_DEFAULT * 0.8) //getting beat on can briefly prevent radio use
 	if((I.damtype == BRUTE || I.damtype == PAIN) && prob(25 + (unimpeded_force * 2)))
 		if(!stat)
-			if(headcheck(hit_zone))
-				//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(unimpeded_force))
-					apply_effect(20, PARALYZE, 100 * blocked)
-					if(lying)
-						visible_message("<span class='danger'>[src] [species.knockout_message]</span>")
-			else
-				//Easier to score a stun but lasts less time
+			if(!headcheck(hit_zone))
 				if(prob(unimpeded_force + 5))
 					apply_effect(3, WEAKEN, 100 * blocked)
-					if(lying)
-						visible_message("<span class='danger'>[src] has been knocked down!</span>")
-
+					visible_message("<span class='danger'>[src] has been knocked down!</span>")
 		//Apply blood
 		attack_bloody(I, user, effective_force, hit_zone)
 

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -202,17 +202,17 @@
 						take_internal_damage(1)
 	..()
 
-/obj/item/organ/internal/brain/take_internal_damage(var/damage, var/silent)
+/obj/item/organ/internal/brain/take_internal_damage(var/damageTaken, var/silent)
 	set waitfor = 0
 	..()
-	if(damage >= 20) //This probably won't be triggered by oxyloss or mercury. Probably.
-		var/damage_secondary = damage * 0.20
+	if(damageTaken >= 20 && damage >= (max_damage * 0.5)) //This probably won't be triggered by oxyloss or mercury. Probably.
+		var/damage_secondary = damageTaken * 0.20
 		if (owner)
 			owner.flash_eyes()
 			owner.eye_blurry += damage_secondary
 			owner.confused += damage_secondary * 2
 			owner.Paralyse(damage_secondary)
-			owner.Weaken(round(damage, 1))
+			owner.Weaken(round(damageTaken, 1))
 			if (prob(30))
 				addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
 


### PR DESCRIPTION
Knocking people out now requires their brain health to be below half (After damage is applied) meaning that it'll generally only be useful on creatures that are already in a massively losing position and no longer an unsatisfying way to instantly end any engagement. 

Also fixes the double application of knockout (Both brain health AND force were used separately, allowing a 10-40% chance to KO someone before damage was even applied to the brain)

:cl: Kell-E
balance: Knockouts now require severe brain damage to occur.
bugfix: Knockout is now only checked once instead of two separate times by different metrics
/:cl: