### PR TITLE
add license and codebeat buttons to project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Baystation [![CI Status](https://github.com/Baystation12/Baystation12/workflows/Run%20Tests/badge.svg)](https://github.com/baystation12/baystation12/actions)
+# Baystation [![GitHub](https://img.shields.io/github/license/baystation12/baystation12)](https://opensource.org/licenses/AGPL-3.0) [![CI Status](https://github.com/Baystation12/Baystation12/workflows/Run%20Tests/badge.svg)](https://github.com/baystation12/baystation12/actions) [![codebeat badge](https://codebeat.co/badges/8ecb9a34-1bab-4d80-b34d-b16e8b216a03)](https://codebeat.co/projects/github-com-baystation12-baystation12-dev)
 
 [Website](https://bay.ss13.me) - [Discord](https://bay.ss13.me/discord) - [Code](https://github.com/baystation12/baystation12) - [DMDoc](https://doc.ss13.me)
 


### PR DESCRIPTION
codebeat has no dm coverage but can still look at 14kloc in the repo usefully; probably worth it.

codebeat button aims at: <https://codebeat.co/projects/github-com-baystation12-baystation12-dev>

license button aims at: <https://opensource.org/licenses/AGPL-3.0>

looks like:

![https://i.imgur.com/ghXmlmD.png](https://i.imgur.com/ghXmlmD.png)