### PR TITLE
Condiment-Bottle Label refactor

### DIFF
--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -34,22 +34,9 @@
 /obj/item/reagent_containers/food/condiment/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	if(istype(W, /obj/item/pen) || istype(W, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
-		if(tmp_label == label_text)
-			return
-		if(length(tmp_label) > 10)
-			to_chat(user, "<span class='notice'>The label can be at most 10 characters long.</span>")
-		else
-			if(length(tmp_label))
-				to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
-				label_text = tmp_label
-				name = addtext(name," ([label_text])")
-			else
-				to_chat(user, "<span class='notice'>You remove the label.</span>")
-				label_text = null
-				on_reagent_change()
+		var/datum/extension/labels/L = get_or_create_extension(src, /datum/extension/labels)
+		L.AttachLabel(user, tmp_label)
 		return
-
-
 
 /obj/item/reagent_containers/food/condiment/attack_self(var/mob/user as mob)
 	return
@@ -96,20 +83,18 @@
 	var/reagent = reagents.get_master_reagent_type()
 	if(reagent in special_bottles)
 		var/obj/item/reagent_containers/food/condiment/special_bottle = special_bottles[reagent]
-		name = initial(special_bottle.name)
+		SetName(initial(special_bottle.name))
 		desc = initial(special_bottle.desc)
 		icon_state = initial(special_bottle.icon_state)
 		center_of_mass = initial(special_bottle.center_of_mass)
 	else
-		name = initial(name)
+		SetName(initial(name))
 		desc = initial(desc)
 		center_of_mass = initial(center_of_mass)
 		if(reagents.reagent_list.len > 0)
 			icon_state = "mixedcondiments"
 		else
 			icon_state = "emptycondiment"
-	if(label_text)
-		name = addtext(name," ([label_text])")
 
 /obj/item/reagent_containers/food/condiment/enzyme
 	name = "universal enzyme"


### PR DESCRIPTION
🆑 Andischa
bugfix: Hand labeler labels on condiment containers no longer disappear
/🆑


closes:  #29187

Changed the way pen-labels on condiment bottles were handled to using the extention/lable.dm
Changed Special-Bottle behavior to use the Setname function accordingly.

(first contribution, feel free to notify me if I breached any contributing-ettiquette) 