### PR TITLE
Remove tourettes disability

### DIFF
--- a/code/__defines/dna.dm
+++ b/code/__defines/dna.dm
@@ -32,8 +32,7 @@
 #define NEARSIGHTED    FLAG(0)
 #define EPILEPSY       FLAG(1)
 #define COUGHING       FLAG(2)
-#define TOURETTES      FLAG(3)
-#define NERVOUS        FLAG(4)
+#define NERVOUS        FLAG(3)
 
 // sdisabilities
 #define BLINDED     FLAG(0)

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -84,14 +84,6 @@
 /datum/dna/gene/disability/clumsy/New()
 	block=GLOB.CLUMSYBLOCK
 
-/datum/dna/gene/disability/tourettes
-	name="Tourettes"
-	activation_message="You twitch."
-	disability=TOURETTES
-
-/datum/dna/gene/disability/tourettes/New()
-	block=GLOB.TWITCHBLOCK
-
 /datum/dna/gene/disability/nervousness
 	name="Nervousness"
 	activation_message="You feel nervous."

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -228,14 +228,6 @@
 		return
 	if((owner.disabilities & EPILEPSY) && prob(1))
 		owner.seizure()
-	else if((owner.disabilities & TOURETTES) && prob(10))
-		owner.Stun(10)
-		switch(rand(1, 3))
-			if(1)
-				owner.emote("twitch")
-			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
-		owner.make_jittery(100)
 	else if((owner.disabilities & NERVOUS) && prob(10))
 		owner.stuttering = max(10, owner.stuttering)
 

--- a/code/modules/psionics/events/mini_spasm.dm
+++ b/code/modules/psionics/events/mini_spasm.dm
@@ -34,7 +34,7 @@
 	set waitfor = 0
 
 	if(iscarbon(victim) && !victim.isSynthetic())
-		var/list/disabilities = list(NEARSIGHTED, EPILEPSY, TOURETTES, NERVOUS)
+		var/list/disabilities = list(NEARSIGHTED, EPILEPSY, NERVOUS)
 		for(var/disability in disabilities)
 			if(victim.disabilities & disability)
 				disabilities -= disability


### PR DESCRIPTION
nufc

Not really user-facing since this comes up only in the psionics event, which isn't in the event pool and is done very rarely by admins anyway.