### PR TITLE
purges some locker contents

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -232,6 +232,14 @@
 		/obj/item/material/knife/folding/
 		)
 
+/obj/item/storage/belt/holster/security/full/Initialize()
+	. = ..()
+	new /obj/item/device/flash (src)
+	new /obj/item/reagent_containers/spray/pepper (src)
+	new /obj/item/melee/baton/loaded (src)
+	new /obj/item/device/holowarrant (src)
+	queue_icon_update()
+
 /obj/item/storage/belt/security
 	name = "security belt"
 	desc = "Can hold security gear like handcuffs and flashes."

--- a/maps/torch/structures/closets/command.dm
+++ b/maps/torch/structures/closets/command.dm
@@ -103,8 +103,7 @@
 		/obj/item/device/holowarrant,
 		/obj/item/folder/blue,
 		/obj/item/material/knife/folding/swiss/officer,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger))
+		/obj/item/storage/backpack/dufflebag
 	)
 
 /obj/structure/closet/secure_closet/bridgeofficer
@@ -127,7 +126,6 @@
 		/obj/item/device/radio/headset/bridgeofficer/alt,
 		/obj/item/storage/belt/general,
 		/obj/item/material/knife/folding/swiss/officer,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger)),
-		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))
+		/obj/item/storage/backpack/dufflebag,
+		/obj/item/device/flashlight
 	)

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -45,7 +45,6 @@
 		/obj/item/device/radio/headset/heads/ce,
 		/obj/item/device/radio/headset/heads/ce/alt,
 		/obj/item/storage/belt/utility/full,
-		/obj/item/storage/belt/general,
 		/obj/item/clothing/suit/storage/hazardvest,
 		/obj/item/clothing/mask/gas,
 		/obj/item/device/multitool,
@@ -63,9 +62,7 @@
 		/obj/item/storage/box/armband/engine,
 		/obj/item/storage/box/secret_project_disks,
 		/obj/item/material/knife/folding/swiss/officer,
-		/obj/item/clothing/head/hardhat/damage_control/White,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+		/obj/item/storage/backpack/dufflebag/eng
 	)
 
 /obj/structure/closet/secure_closet/engineering_torch
@@ -75,7 +72,6 @@
 
 /obj/structure/closet/secure_closet/engineering_torch/WillContain()
 	return list(
-		/obj/item/clothing/under/hazard,
 		/obj/item/clothing/accessory/storage/brown_vest,
 		/obj/item/storage/belt/utility/full,
 		/obj/item/device/radio/headset/headset_eng,
@@ -85,12 +81,9 @@
 		/obj/item/clothing/glasses/meson,
 		/obj/item/taperoll/engineering,
 		/obj/item/device/flashlight,
-		/obj/item/taperoll/atmos,
 		/obj/item/clothing/gloves/insulated,
 		/obj/item/material/knife/folding/swiss/engineer,
-		/obj/item/clothing/head/hardhat/damage_control,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+		/obj/item/storage/backpack/dufflebag/eng
 	)
 
 /obj/structure/closet/secure_closet/engineering_senior
@@ -100,7 +93,6 @@
 
 /obj/structure/closet/secure_closet/engineering_senior/WillContain()
 	return list(
-		/obj/item/clothing/under/hazard,
 		/obj/item/clothing/accessory/storage/brown_vest,
 		/obj/item/device/radio/headset/headset_eng,
 		/obj/item/device/radio/headset/headset_eng/alt,
@@ -109,16 +101,13 @@
 		/obj/item/storage/belt/utility/full,
 		/obj/item/clothing/glasses/meson,
 		/obj/item/taperoll/engineering,
-		/obj/item/taperoll/atmos,
 		/obj/item/clothing/glasses/welding/superior,
 		/obj/item/device/flash,
 		/obj/item/device/flashlight,
 		/obj/item/device/megaphone,
 		/obj/item/clothing/gloves/insulated,
 		/obj/item/material/knife/folding/swiss/engineer,
-		/obj/item/clothing/head/hardhat/damage_control/Yellow,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+		/obj/item/storage/backpack/dufflebag/eng
 	)
 
 /obj/structure/closet/secure_closet/atmos_torch
@@ -128,7 +117,6 @@
 
 /obj/structure/closet/secure_closet/atmos_torch/WillContain()
 	return list(
-		/obj/item/clothing/under/hazard,
 		/obj/item/storage/backpack/dufflebag/firefighter,
 		/obj/item/clothing/head/hardhat/red,
 		/obj/item/device/flashlight,

--- a/maps/torch/structures/closets/exploration.dm
+++ b/maps/torch/structures/closets/exploration.dm
@@ -51,9 +51,8 @@
 		/obj/item/material/knife/folding/swiss/explorer,
 		/obj/item/clothing/accessory/buddy_tag,
 		/obj/item/storage/firstaid/light,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger)),
-		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))
+		/obj/item/storage/backpack/dufflebag,
+		/obj/item/device/flashlight/flare
 	)
 
 /obj/structure/closet/secure_closet/explorer
@@ -77,9 +76,8 @@
 		/obj/item/storage/firstaid/light,
 		/obj/item/material/knife/folding/swiss/explorer,
 		/obj/item/device/camera,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/explorer, /obj/item/storage/backpack/satchel/explorer)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger/explorer)),
-		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))
+		/obj/item/storage/backpack/dufflebag,
+		/obj/item/device/flashlight/flare
 	)
 
 /obj/structure/closet/secure_closet/pilot
@@ -105,7 +103,6 @@
 		/obj/item/clothing/head/helmet/nt/pilot,
 		/obj/item/storage/firstaid/light,
 		/obj/item/material/knife/folding/swiss/explorer,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger)),
-		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))
+		/obj/item/storage/backpack/dufflebag,
+		/obj/item/device/flashlight/flare
 	)

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -34,9 +34,7 @@
 	return list(
 		/obj/item/clothing/suit/bio_suit/cmo,
 		/obj/item/clothing/head/bio_hood/cmo,
-		/obj/item/clothing/shoes/white,
 		/obj/item/clothing/suit/storage/toggle/labcoat/cmo,
-		/obj/item/clothing/suit/storage/toggle/labcoat/cmoalt,
 		/obj/item/device/radio/headset/heads/cmo,
 		/obj/item/device/radio/headset/heads/cmo/alt,
 		/obj/item/device/flash,
@@ -53,10 +51,8 @@
 		/obj/item/device/holowarrant,
 		/obj/item/storage/firstaid/adv,
 		/obj/item/storage/box/armband/med,
-		/obj/item/storage/belt/general,
 		/obj/item/material/knife/folding/swiss/officer,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/medic, /obj/item/storage/backpack/satchel/med)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/med, /obj/item/storage/backpack/messenger/med)),
+		/obj/item/storage/backpack/dufflebag/med,
 		RANDOM_SCRUBS
 	)
 
@@ -67,10 +63,8 @@
 
 /obj/structure/closet/secure_closet/medical_torchsenior/WillContain()
 	return list(
-		/obj/item/clothing/under/sterile,
 		/obj/item/clothing/suit/storage/toggle/labcoat,
 		/obj/item/clothing/suit/surgicalapron,
-		/obj/item/clothing/shoes/white,
 		/obj/item/device/radio/headset/headset_med,
 		/obj/item/device/radio/headset/headset_med/alt,
 		/obj/item/taperoll/medical,
@@ -83,8 +77,7 @@
 		/obj/item/device/megaphone,
 		/obj/item/storage/firstaid/adv,
 		/obj/item/material/knife/folding/swiss/medic,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/medic, /obj/item/storage/backpack/satchel/med)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/med, /obj/item/storage/backpack/messenger/med)),
+		/obj/item/storage/backpack/dufflebag/med,
 		RANDOM_SCRUBS = 2
 	)
 
@@ -95,10 +88,8 @@
 
 /obj/structure/closet/secure_closet/medical_torch/WillContain()
 	return list(
-		/obj/item/clothing/under/sterile,
 		/obj/item/clothing/accessory/storage/white_vest,
 		/obj/item/clothing/suit/storage/toggle/fr_jacket,
-		/obj/item/clothing/shoes/white,
 		/obj/item/device/radio/headset/headset_med,
 		/obj/item/device/radio/headset/headset_corpsman/alt,
 		/obj/item/taperoll/medical,
@@ -112,8 +103,7 @@
 		/obj/item/clothing/suit/storage/medical_chest_rig,
 		/obj/item/clothing/head/hardhat/EMS,
 		/obj/item/material/knife/folding/swiss/medic,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/medic, /obj/item/storage/backpack/satchel/med)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/med, /obj/item/storage/backpack/messenger/med))
+		/obj/item/storage/backpack/dufflebag/med
 	)
 
 /obj/structure/closet/wardrobe/medic_torch

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -41,8 +41,7 @@
 		/obj/item/clothing/suit/storage/toggle/suit/black,
 		/obj/item/clothing/glasses/sunglasses/big,
 		/obj/item/storage/belt/general,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/messenger, 50),
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel, /obj/item/storage/backpack/messenger)),
 		/obj/item/device/radio/headset/heads/torchntcommand,
 		/obj/item/device/radio/headset/heads/torchntcommand/alt
 	)
@@ -66,8 +65,7 @@
 		/obj/item/clothing/suit/storage/toggle/suit/black,
 		/obj/item/clothing/glasses/sunglasses/big,
 		/obj/item/storage/belt/general,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/messenger, 50)
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel, /obj/item/storage/backpack/messenger)),
 	)
 
 //equipment closets that everyone on the crew or in research can access, for storing things securely

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -27,8 +27,6 @@
 
 /obj/structure/closet/secure_closet/RD_torch/WillContain()
 	return list(
-		/obj/item/clothing/suit/storage/toggle/labcoat,
-		/obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
 		/obj/item/clothing/suit/storage/toggle/labcoat/rd/ec,
 		/obj/item/clothing/gloves/latex,
 		/obj/item/clothing/glasses/science,
@@ -50,8 +48,7 @@
 		/obj/item/storage/box/secret_project_disks/science,
 		/obj/item/storage/belt/general,
 		/obj/item/device/holowarrant,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/toxins, /obj/item/storage/backpack/satchel/tox)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/messenger/tox, 50)
+		/obj/item/storage/backpack/dufflebag
 	)
 
 /obj/structure/closet/secure_closet/secure_closet/xenoarchaeologist_torch
@@ -63,9 +60,6 @@
 	return list(
 		/obj/item/clothing/under/rank/scientist,
 		/obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
-		/obj/item/clothing/suit/storage/toggle/labcoat/science,
-		/obj/item/clothing/suit/storage/toggle/labcoat,
-		/obj/item/clothing/shoes/white,
 		/obj/item/device/radio/headset/torchnanotrasen,
 		/obj/item/clothing/mask/gas,
 		/obj/item/material/clipboard,
@@ -80,8 +74,7 @@
 		/obj/item/clothing/glasses/meson,
 		/obj/item/device/radio,
 		/obj/item/device/flashlight/lantern,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/toxins, /obj/item/storage/backpack/satchel/tox)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/dufflebag, 50)
+		/obj/item/storage/backpack/dufflebag
 	)
 
 /obj/structure/closet/secure_closet/scientist_torch
@@ -93,8 +86,7 @@
 	return list(
 		/obj/item/clothing/under/rank/scientist,
 		/obj/item/clothing/suit/storage/toggle/labcoat/science,
-		/obj/item/clothing/suit/storage/toggle/labcoat,
-		/obj/item/clothing/shoes/white,
+		/obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
 		/obj/item/device/radio/headset/torchnanotrasen,
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/tank/oxygen_emergency_extended,
@@ -108,8 +100,7 @@
 		/obj/item/clothing/gloves/latex,
 		/obj/item/clothing/glasses/science,
 		/obj/item/storage/belt/general,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/toxins, /obj/item/storage/backpack/satchel/tox)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/messenger/tox, 50)
+		/obj/item/storage/backpack/dufflebag
 	)
 
 /obj/structure/closet/secure_closet/guard
@@ -158,7 +149,7 @@
 
 /obj/structure/closet/secure_closet/ec_scientist/WillContain()
 	return list(
-		/obj/item/clothing/suit/storage/toggle/labcoat,
+		/obj/item/clothing/suit/storage/toggle/labcoat/science/ec,
 		/obj/item/device/radio/headset/torchnanotrasen,
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/tank/oxygen_emergency_extended,
@@ -174,6 +165,5 @@
 		/obj/item/storage/belt/general,
 		/obj/item/device/scanner/xenobio,
 		/obj/item/device/scanner/plant,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/, /obj/item/storage/backpack/satchel/grey)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/messenger/, 50)
+		/obj/item/storage/backpack/dufflebag
 	)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -40,24 +40,19 @@
 		/obj/item/clothing/head/helmet/solgov/security,
 		/obj/item/device/radio/headset/headset_sec,
 		/obj/item/device/radio/headset/headset_sec/alt,
-		/obj/item/storage/belt/holster/security,
-		/obj/item/device/flash,
-		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/storage/belt/holster/security/full,
 		/obj/item/grenade/chem_grenade/teargas,
-		/obj/item/melee/baton/loaded,
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,
 		/obj/item/taperoll/police,
 		/obj/item/device/hailer,
 		/obj/item/clothing/accessory/storage/black_vest,
-		/obj/item/gun/energy/gun/small/secure,
 		/obj/item/device/megaphone,
 		/obj/item/clothing/gloves/thick,
-		/obj/item/device/holowarrant,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/storage/belt/security,
 		/obj/item/material/knife/folding/swiss/sec,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/security, /obj/item/storage/backpack/satchel/sec)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/sec, /obj/item/storage/backpack/messenger/sec))
+		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/gun/energy/gun/small/secure
 	)
 
 
@@ -75,28 +70,21 @@
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,
 		/obj/item/taperoll/police,
 		/obj/item/handcuffs,
-		/obj/item/storage/belt/holster/security,
+		/obj/item/storage/belt/holster/security/full,
 		/obj/item/storage/belt/security,
-		/obj/item/storage/belt/holster/general,
-		/obj/item/storage/belt/general,
-		/obj/item/device/flash,
 		/obj/item/device/megaphone,
-		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/gun/secure/preauthorized,
 		/obj/item/melee/telebaton,
-		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/device/hailer,
 		/obj/item/material/clipboard,
 		/obj/item/folder/red,
-		/obj/item/device/holowarrant,
 		/obj/item/clothing/gloves/thick,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/device/taperecorder,
 		/obj/item/material/knife/folding/swiss/officer,
 		/obj/item/device/personal_shield,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/security, /obj/item/storage/backpack/satchel/sec)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/sec, /obj/item/storage/backpack/messenger/sec))
+		/obj/item/storage/backpack/dufflebag/sec
 	)
 
 /obj/structure/closet/secure_closet/brigchief
@@ -112,23 +100,18 @@
 		/obj/item/device/radio/headset/headset_sec/alt,
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,
 		/obj/item/taperoll/police,
-		/obj/item/storage/belt/holster/security,
+		/obj/item/storage/belt/holster/security/full,
 		/obj/item/storage/belt/security,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/gun/secure/preauthorized,
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/handcuffs,
 		/obj/item/device/hailer,
-		/obj/item/device/flash,
 		/obj/item/device/megaphone,
 		/obj/item/hand_labeler,
-		/obj/item/device/holowarrant,
 		/obj/item/clothing/gloves/thick,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/material/knife/folding/swiss/sec,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/security, /obj/item/storage/backpack/satchel/sec)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/sec, /obj/item/storage/backpack/messenger/sec))
+		/obj/item/storage/backpack/dufflebag/sec
 	)
 
 /obj/structure/closet/secure_closet/forensics
@@ -159,8 +142,7 @@
 		/obj/item/storage/belt/security,
 		/obj/item/clothing/gloves/thick,
 		/obj/item/material/knife/folding/swiss/sec,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/security, /obj/item/storage/backpack/satchel/sec)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/sec, /obj/item/storage/backpack/messenger/sec))
+		/obj/item/storage/backpack/dufflebag/sec
 	)
 
 /obj/structure/closet/bombclosetsecurity/WillContain()

--- a/maps/torch/structures/closets/services.dm
+++ b/maps/torch/structures/closets/services.dm
@@ -41,8 +41,7 @@
 		/obj/item/wirecutters/clippers,
 		/obj/item/reagent_containers/spray/plantbgone,
 		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/apron, /obj/item/clothing/suit/apron/overalls)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/hydroponics, /obj/item/storage/backpack/satchel/hyd)),
-		new /datum/atom_creator/simple(/obj/item/storage/backpack/messenger/hyd, 50)
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/hydroponics, /obj/item/storage/backpack/satchel/hyd))
 	)
 
 /obj/structure/closet/jcloset_torch

--- a/maps/torch/structures/closets/supply.dm
+++ b/maps/torch/structures/closets/supply.dm
@@ -44,8 +44,7 @@
 		/obj/item/storage/belt/general,
 		/obj/item/stamp/cargo,
 		/obj/item/stamp/denied,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack = 75, /obj/item/storage/backpack/satchel/grey = 25)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/messenger = 75, /obj/item/storage/backpack/dufflebag = 25))
+		/obj/item/storage/backpack/dufflebag
 	)
 
 /obj/structure/closet/secure_closet/deckofficer
@@ -73,8 +72,7 @@
 		/obj/item/clothing/suit/armor/pcarrier/light/sol,
 		/obj/item/device/binoculars,
 		/obj/item/storage/belt/general,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack = 75, /obj/item/storage/backpack/satchel/grey = 25)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/messenger = 75, /obj/item/storage/backpack/dufflebag = 25))
+		/obj/item/storage/backpack/dufflebag
 	)
 
 /obj/structure/closet/secure_closet/prospector
@@ -101,6 +99,5 @@
 		/obj/item/device/radio,
 		/obj/item/clothing/glasses/material,
 		/obj/item/clothing/glasses/meson,
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng, /obj/item/storage/backpack/messenger/engi)),
 		/obj/item/storage/backpack/dufflebag/eng
 	)


### PR DESCRIPTION
woo. hate lockers.
🆑 Jux
tweak: Lots of locker condensing.
/🆑

Proper changelog as follows, putting it all in there would've been pain.
P.much every locker touched swaps the bag glut for a set dufflebag spawn.
Department heads lose their "general" belts if they have a job specific belt.
Science and medical lockers with multiple labcoats had them cut down to one, or two at most, and have lost their.. shoes.
All exploration lockers now spawn with a flare, instead of a random light source.
Security lockers, except the FT, now spawn with the flash, baton, warrant proj. and pepperspray in the holster belt. Does NOT remove the standard belt.
Non-atmos engi lockers have lost the atmos tape. ALL Engi lockers with the hazard jumpsuit have lost it. ALL Engi lockers have lost the weird DC helmets.
Medical lockers have lost the sterile jumpsuit.

Jumpsuit removals are because uniforms are a thing. DC helmet removals are because they can be taken in loadout. Shoes are for uniform. Same with labcoats. General belts can be taken in loadout.