### PR TITLE
Petrov refurbish

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -12,40 +12,44 @@
 /turf/simulated/floor/lino,
 /area/command/pilot)
 "ad" = (
+/obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/toxins)
 "ae" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Heat Exchanger Input"
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/toxins)
 "af" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Exterior Vent"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
-"ah" = (
-/obj/machinery/computer/modular/preset/supply_public,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"ag" = (
 /obj/effect/floor_decal/corner/purple/half{
 	dir = 1
 	},
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 2;
+	icon_state = "console"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/control)
+"ah" = (
+/obj/effect/floor_decal/corner/purple/half{
+	dir = 1
+	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/control)
 "ai" = (
@@ -66,13 +70,29 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "aj" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Heat Exchanger Output"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/cell1)
+"ak" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/purple/half{
+	dir = 8
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/control)
 "al" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -100,25 +120,24 @@
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
 "ap" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Chamber Output"
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 2;
+	icon_state = "freezer"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/toxins)
 "aq" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/obj/machinery/light/spot{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/toxins)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -191,32 +210,22 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "ax" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/atmospherics/binary/passive_gate,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/petrov/toxins)
 "ay" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/table/standard,
-/obj/random/tool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/atmospherics/binary/passive_gate,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/petrov/toxins)
 "az" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/air_sensor{
-	id_tag = "toxins_sensor"
-	},
-/turf/simulated/floor/reinforced/airless,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/shuttle/petrov/toxins)
 "aA" = (
 /obj/effect/floor_decal/corner/green{
@@ -283,21 +292,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
 "aG" = (
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 8;
-	icon_state = "console"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/machinery/button/windowtint{
-	id = "rcheckinner_windows";
-	pixel_x = 10;
-	pixel_y = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/control)
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -454,7 +451,6 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/meter,
 /obj/effect/paint/silver,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -559,21 +555,13 @@
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/crew)
 "bl" = (
-/obj/machinery/atmospherics/omni/mixer{
-	tag_east = 2;
-	tag_north = 1;
-	tag_north_con = 0.33;
-	tag_south = 1;
-	tag_south_con = 0.33;
-	tag_west = 1;
-	tag_west_con = 0.34
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/button/ignition{
-	id_tag = "toxlab";
-	pixel_w = 6;
-	pixel_z = -23
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/machinery/atmospherics/unary/heater,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/toxins)
 "bm" = (
 /obj/effect/floor_decal/industrial/loading{
@@ -589,23 +577,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "bn" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Chamber Input"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "toxin_exhaust";
-	name = "Chamber Vent";
-	pixel_w = 8;
-	pixel_y = -24
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "toxins_shutters";
-	name = "Chamber Protective Shutters";
-	pixel_w = -5;
-	pixel_z = -24
-	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
 /area/shuttle/petrov/toxins)
 "bo" = (
 /obj/machinery/light/spot{
@@ -651,22 +627,11 @@
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "bs" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	frequency = 1441;
-	id = "toxins_in"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/sparker{
-	id_tag = "toxlab";
-	pixel_w = 1;
-	pixel_z = -23
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
+/area/shuttle/petrov/eva)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -761,6 +726,12 @@
 /obj/structure/bed/chair/shuttle/blue,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
+"bD" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/artifact_scanpad,
+/obj/random_multi/single_item/boombox,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "bE" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger{
@@ -782,6 +753,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/crew)
+"bF" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/control)
 "bG" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -894,6 +881,13 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"bO" = (
+/obj/structure/table/steel,
+/obj/machinery/photocopier/faxmachine/torch{
+	department = "Petrov - Chief Science Officer"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/control)
 "bP" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -914,6 +908,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/maint)
+"bR" = (
+/obj/effect/paint/silver,
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovBiohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/equipment)
 "bS" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -994,6 +998,11 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/cockpit)
+"bX" = (
+/obj/effect/paint/silver,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/equipment)
 "bY" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -1118,6 +1127,16 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/guppy_hangar/start)
+"ck" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "heater"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/deep_storage)
 "cl" = (
 /obj/item/device/radio,
 /obj/machinery/computer/ship/engines{
@@ -1157,6 +1176,30 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
+"co" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	alarm_id = "petrov3";
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"cp" = (
+/obj/machinery/sparker{
+	dir = 2;
+	id_tag = "Isocell1";
+	pixel_x = -18
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 2
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "cq" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10;
@@ -1266,10 +1309,31 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/airlock)
+"cx" = (
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - Chief Science Officer";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/suspension_gen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "cy" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"cz" = (
+/obj/structure/stasis_cage,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "cA" = (
 /obj/effect/overmap/visitable/ship/landable/guppy,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -1297,6 +1361,25 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
+"cC" = (
+/obj/machinery/disposal,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "cD" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crew Area"
@@ -1594,6 +1677,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
+"cX" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "cY" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -1798,6 +1893,40 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
+"dq" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"dr" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"ds" = (
+/obj/structure/table/standard,
+/obj/item/flame/lighter/random,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/analysis)
+"dt" = (
+/obj/machinery/suit_cycler/science,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "du" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -1919,6 +2048,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/airlock)
+"dC" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Petrov Expedition Equipment";
+	departmentType = 2;
+	name = "Petrov Request Console";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/structure/closet/secure_closet/xenoarchaeologist,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "dD" = (
 /obj/structure/table/rack,
 /obj/item/storage/belt/utility/full,
@@ -1985,6 +2127,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
+"dH" = (
+/obj/structure/closet/secure_closet/xenobio,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"dI" = (
+/obj/structure/closet/secure_closet/hydroponics_torch,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"dJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "dK" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
@@ -2049,9 +2205,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"dQ" = (
+/obj/structure/closet/toolcloset/excavation,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "dR" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
+"dS" = (
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov1";
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 2;
+	icon_state = "map_scrubber_off"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "dT" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -2107,6 +2280,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
+"dX" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell1)
 "dY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2213,7 +2390,7 @@
 "eg" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup{
-	start_pressure = 7498.00
+	start_pressure = 7498
 	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2248,6 +2425,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
+"ej" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/rnd)
 "ek" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -2346,6 +2527,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
+"ep" = (
+/obj/machinery/psi_meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "eq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -2401,6 +2586,14 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/atmos)
+"ex" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/assist,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "ey" = (
 /obj/structure/handrail{
 	dir = 1;
@@ -2468,6 +2661,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/airlock)
+"eD" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "eE" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2477,12 +2683,42 @@
 /obj/effect/paint/hull,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/power)
+"eG" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/deep_storage)
 "eH" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"eI" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"eJ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/techfloor,
+/area/rnd/canister)
+"eK" = (
+/obj/structure/anomaly_container,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"eL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/closet/crate/radiation,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "eM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
@@ -2500,6 +2736,15 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"eO" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/techfloor,
+/area/rnd/canister)
+"eP" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/deep_storage)
 "eQ" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2512,6 +2757,18 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/cargo)
+"eR" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "eS" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -2541,12 +2798,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "eW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/shuttle/engine/heater{
 	dir = 4;
-	level = 2
+	icon_state = "heater"
 	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/custodial)
 "eX" = (
 /obj/machinery/camera/network/exploration_shuttle{
 	dir = 4;
@@ -2611,6 +2871,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fc" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "fd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -2651,6 +2918,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fg" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/l3closet/scientist/multi,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
+"fh" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "fi" = (
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/plating,
@@ -2668,6 +2948,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"fk" = (
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "fl" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/fore)
@@ -2719,6 +3003,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fs" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"ft" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/industrial/warning,
+/obj/item/device/integrated_electronics/analyzer{
+	pixel_x = 6
+	},
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_electronics/debugger{
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "fu" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2734,6 +3038,16 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/power)
+"fv" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"fw" = (
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "fx" = (
 /obj/machinery/power/apc/shuttle/charon{
 	dir = 4;
@@ -2774,6 +3088,12 @@
 "fz" = (
 /turf/simulated/wall/walnut,
 /area/vacant/bar)
+"fA" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "fB" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2786,40 +3106,66 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"fD" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 1;
-	icon_state = "map"
+"fC" = (
+/obj/structure/table/rack,
+/obj/item/storage/excavation,
+/obj/item/stack/flag/red,
+/obj/item/device/measuring_tape,
+/obj/item/pickaxe{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"fD" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
+/area/shuttle/petrov/hallwaya)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/shuttle/petrov/hallwaya)
 "fF" = (
-/obj/effect/paint/red,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/isolation)
+/obj/machinery/artifact_analyser,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "fG" = (
-/obj/machinery/atmospherics/binary/pump,
-/obj/structure/handrail{
-	dir = 8;
-	icon_state = "handrail"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "fH" = (
 /obj/item/stool,
 /turf/simulated/floor/tiled,
@@ -2882,6 +3228,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"fO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/science,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "fP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -2933,6 +3286,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
+"fV" = (
+/obj/machinery/suit_storage_unit/science,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "fW" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 4;
@@ -2978,6 +3335,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"ga" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"gb" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 21
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
 "gc" = (
 /obj/effect/shuttle_landmark/supply/station,
 /turf/simulated/floor/plating,
@@ -2990,13 +3364,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
 "ge" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "PetrovShield";
+	name = "Petrov Blast Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
+/obj/effect/paint/silver,
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/equipment)
+"gf" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/terrarium)
 "gg" = (
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
@@ -3007,6 +3389,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"gh" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/equipment)
 "gi" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -3067,6 +3453,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
+"gn" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/reagentgrinder,
+/obj/item/stack/material/phoron,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "go" = (
 /obj/structure/fuel_port,
 /obj/effect/paint/red,
@@ -3115,6 +3512,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/rnd)
+"gu" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/device/scanner/reagent,
+/obj/item/device/scanner/spectrometer/adv,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "gv" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 4;
@@ -3144,6 +3548,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
+"gA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Suit Storage"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "gB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3213,11 +3635,24 @@
 "gI" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
+"gJ" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/observation)
 "gK" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
+"gL" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "gM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -3233,6 +3668,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/expedition/atmos)
+"gN" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "gO" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/shuttlefuel)
@@ -3248,6 +3693,38 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
+"gQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"gR" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"gS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell1)
 "gT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/floodlight,
@@ -3265,22 +3742,72 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"gV" = (
+/obj/structure/table/standard,
+/obj/item/anodevice{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/anodevice,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
+"gW" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"gX" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"gY" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "gZ" = (
 /obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
+"ha" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"ha" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
 /obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell1)
 "hb" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -3320,6 +3847,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"he" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "hf" = (
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 8;
@@ -3405,6 +3938,26 @@
 "hq" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
+"hr" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/analysis)
+"hs" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/omni/mixer{
+	tag_east = 1;
+	tag_east_con = 0.8;
+	tag_north = 1;
+	tag_north_con = 0.2;
+	tag_south = 2;
+	tag_south_con = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "ht" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -3462,6 +4015,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"hB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"hC" = (
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/deep_storage)
+"hD" = (
+/obj/structure/table/standard,
+/obj/item/remains/robot,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/analysis)
 "hE" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -3490,6 +4064,65 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
+"hH" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"hI" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/shieldwallgen{
+	anchored = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
+"hJ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
+"hK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "hL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -3546,6 +4179,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"hQ" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/observation)
 "hR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
@@ -3577,6 +4217,46 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"hU" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/catwalk,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
+"hV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/cell1)
+"hW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"hX" = (
+/obj/machinery/button/ignition{
+	id_tag = "Isocell1";
+	pixel_x = -25;
+	pixel_y = -25
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/tvalve/mirrored{
+	dir = 2;
+	state = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "hY" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -3592,6 +4272,50 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
+"ia" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"ib" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/tvalve/mirrored{
+	dir = 2;
+	state = 0
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"ic" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell1";
+	name = "Test Chamber Vent";
+	pixel_x = 0;
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"id" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "ie" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -3603,6 +4327,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"ig" = (
+/obj/random/date_based/christmas/tree,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/deep_storage)
 "ih" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/cyan{
@@ -3619,6 +4347,36 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
+"ij" = (
+/obj/structure/table/steel,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/item/folder/nt,
+/obj/random_multi/single_item/memo_research,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/control)
+"ik" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/cockpit)
+"il" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "im" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3637,6 +4395,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"in" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"io" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "ip" = (
 /obj/machinery/light{
 	dir = 8
@@ -3663,6 +4450,26 @@
 /obj/machinery/camera/network/hangar,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"is" = (
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - Equipment";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/table/standard,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("petrov1");
+	req_access = list("ACCESS_TORCH_PETROV")
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"it" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/observation)
 "iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3866,6 +4673,32 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/storage)
+"iM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/rack,
+/obj/item/spirit_board,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/deep_storage)
+"iN" = (
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Custodial Closet"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/deep_storage)
 "iO" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin{
@@ -3995,6 +4828,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"jb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/observation)
 "jc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -4057,6 +4898,30 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
+"jh" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "ji" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4180,6 +5045,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/hangar)
+"jv" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "jw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -4359,6 +5232,14 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fifthdeck/fore)
+"jN" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	name = "isolation return regulator";
+	regulate_mode = 0
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "jO" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -4539,10 +5420,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"ka" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "kb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"kc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "kd" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light/spot{
@@ -4550,6 +5441,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"ke" = (
+/obj/machinery/atmospherics/unary/vent_pump/tank{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	id_tag = "toxins_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/toxins)
 "kf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -4604,6 +5512,12 @@
 "kl" = (
 /turf/unsimulated/mask,
 /area/hallway/primary/fifthdeck/fore)
+"km" = (
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/toxins)
 "kn" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -4659,6 +5573,20 @@
 /obj/item/gun/projectile/flare,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
+"ks" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/deep_storage)
 "kt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/science{
@@ -4832,6 +5760,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
+"kH" = (
+/obj/machinery/air_sensor{
+	id_tag = "toxins_sensor"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/toxins)
 "kI" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4854,6 +5788,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/exploration)
+"kK" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/toxins)
 "kL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -4876,6 +5813,27 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
+"kN" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/space,
+/area/shuttle/petrov/hallwaya)
+"kO" = (
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
 "kP" = (
 /obj/machinery/suit_storage_unit/explorer,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5073,6 +6031,15 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/hangar)
+"ll" = (
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 2;
+	tag_north = 1;
+	tag_south = 3;
+	tag_west = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/toxins)
 "lm" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/cable/cyan{
@@ -5115,6 +6082,11 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/storage)
+"lp" = (
+/obj/structure/table/standard,
+/obj/machinery/reagent_temperature/cooler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "lq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
@@ -5145,6 +6117,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
+"ls" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1441;
+	id = "toxins_in"
+	},
+/obj/machinery/sparker{
+	id_tag = "toxlab";
+	pixel_w = 1;
+	pixel_z = -23
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/toxins)
 "lt" = (
 /obj/machinery/computer/modular/preset/civilian,
 /obj/machinery/computer/guestpass{
@@ -5223,6 +6208,11 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
+"lB" = (
+/obj/structure/table/standard,
+/obj/item/device/integrated_circuit_printer,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "lC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5284,6 +6274,17 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"lI" = (
+/obj/random_multi/single_item/punitelly,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/control)
+"lJ" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/random/tool,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
 "lK" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -5316,6 +6317,29 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"lO" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/table/standard,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/rnd)
+"lP" = (
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - Toxins";
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("petrov1","petrov2","petrov3","petrov_terrarium","petrov_terrarium_access");
+	req_access = list("ACCESS_TORCH_PETROV")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/toxins)
 "lQ" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1;
@@ -5336,6 +6360,15 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/prepainted,
 /area/quartermaster/hangar)
+"lU" = (
+/obj/machinery/meter,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "lV" = (
 /obj/machinery/light/spot,
 /turf/simulated/floor/tiled/monotile,
@@ -5363,6 +6396,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
+"ma" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/toxins)
+"mb" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/tvalve{
+	dir = 8;
+	state = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "mc" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
@@ -5385,6 +6435,23 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"me" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "mf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5429,6 +6496,32 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"mi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
+"mj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "mk" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -5438,19 +6531,44 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"mm" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/spectrometer/adv,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+"ml" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"mm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Chamber Output"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "mn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5475,6 +6593,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"mo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "mp" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -5505,6 +6630,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"mr" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "ms" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5529,6 +6661,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"mu" = (
+/obj/machinery/atmospherics/tvalve/mirrored{
+	dir = 1;
+	name = "main supply switching valve";
+	state = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "mv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
@@ -5568,6 +6708,52 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
+"my" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/observation)
+"mz" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/table/standard,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("petrov2","petrov3","petrov_terrarium","petrov_terrarium_access");
+	req_access = list("ACCESS_TORCH_PETROV")
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"mA" = (
+/obj/machinery/shieldwallgen{
+	anchored = 1
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/eva)
 "mB" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/cyan{
@@ -5624,6 +6810,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"mG" = (
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - Anomaly Fore";
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/open,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "mH" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -5720,6 +6919,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
+"mO" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/control)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5773,6 +6984,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"mT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "mU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5782,6 +7000,27 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"mV" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"mW" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/table/standard,
+/obj/item/device/camera,
+/obj/item/device/taperecorder,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "mX" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/structure/railing/mapped{
@@ -5799,6 +7038,13 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"mZ" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "na" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5826,6 +7072,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"nc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/deep_storage)
 "nd" = (
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/plating,
@@ -5900,6 +7153,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"nj" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/deep_storage)
 "nk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5974,6 +7234,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"np" = (
+/obj/structure/table/standard,
+/obj/item/device/geiger,
+/obj/item/rig_module/device/anomaly_scanner,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "nq" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6069,6 +7335,19 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"nx" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/capacitor,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/stack/nanopaste,
+/obj/item/device/t_scanner,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "ny" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -6144,6 +7423,25 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"nE" = (
+/obj/machinery/disposal,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -6298,6 +7596,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"nS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 9
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
+"nT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/table/standard,
+/obj/item/storage/box/monkeycubes/farwacubes{
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/item/reagent_containers/food/snacks/xenomeat{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "nU" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6344,6 +7664,24 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"nX" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "nY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -6414,6 +7752,32 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"oc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"od" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"oe" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "of" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6578,6 +7942,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"op" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "oq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -6675,6 +8046,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"oz" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/isolation)
+"oA" = (
+/obj/structure/table/standard,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/machinery/reagent_temperature,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/analysis)
 "oB" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -6688,6 +8073,30 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
+"oC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
 "oD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6744,6 +8153,25 @@
 /obj/structure/closet/crate/radiation,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"oH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
+/obj/machinery/atmospherics/pipe/cap/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/toxins)
 "oI" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/camera/network/hangar,
@@ -6753,6 +8181,20 @@
 /obj/turbolift_map_holder/torch,
 /turf/unsimulated/mask,
 /area/hallway/primary/fifthdeck/fore)
+"oK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/computer/air_control{
+	dir = 8;
+	input_tag = "toxins_in";
+	name = "Toxins Gas Monitor";
+	output_tag = "toxins_out";
+	sensor_name = "Toxins Test Chamber";
+	sensor_tag = "toxins_sensor"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/toxins)
 "oL" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/camera/network/hangar{
@@ -6795,6 +8237,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
+"oP" = (
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	icon_state = "nosmoking";
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "oQ" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4;
@@ -6841,6 +8302,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
+"oT" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/isolation)
 "oU" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10;
@@ -6848,6 +8314,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
+"oV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	dir = 8;
+	frequency = 1439;
+	pixel_x = 23;
+	pixel_y = 0;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/observation)
 "oW" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 8;
@@ -6921,6 +8402,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"pd" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/observation)
 "pe" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -6954,6 +8442,10 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/fifthdeck)
+"pg" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/space,
+/area/shuttle/petrov/hallwaya)
 "ph" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/fifthdeck)
@@ -6962,6 +8454,15 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/fifthdeck/fore)
+"pj" = (
+/obj/structure/handrail{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "pk" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4;
@@ -7005,6 +8506,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"pn" = (
+/obj/structure/table/standard,
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/random_multi/single_item/memo_research,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "po" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/brown{
@@ -7125,6 +8635,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"pB" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/item/seeds/random,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "pC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -7148,6 +8674,19 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"pE" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
 "pF" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
@@ -7192,6 +8731,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"pJ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/shuttle/petrov/deep_storage)
 "pK" = (
 /obj/structure/table/steel,
 /obj/machinery/alarm{
@@ -7226,6 +8777,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition)
+"pL" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "pM" = (
 /obj/structure/iv_drip,
 /obj/structure/hygiene/sink/kitchen{
@@ -7353,6 +8909,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vacant/infirmary)
+"pX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	name = "vent isolation scrubbers to space";
+	regulate_mode = 1;
+	target_pressure = 506.5
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "pY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -7364,6 +8932,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"pZ" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/sign/warning/airlock{
+	dir = 8;
+	icon_state = "doors";
+	name = "\improper EXTERNAL VENT"
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "qa" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -7452,6 +9030,13 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
+"qk" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
 "ql" = (
 /obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/firedoor,
@@ -7509,6 +9094,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
+"qs" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/obj/item/device/scanner/xenobio,
+/obj/item/device/scanner/gas,
+/obj/item/device/scanner/xenobio,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"qt" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "qu" = (
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -7541,6 +9148,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
+"qw" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"qx" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "qy" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -7642,6 +9274,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
+"qG" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "qH" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/machinery/firealarm{
@@ -7931,6 +9577,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
+"rd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "re" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -7943,6 +9601,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/substation/fifthdeck)
+"rf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "rg" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7952,6 +9617,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"rh" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/table/standard,
+/obj/item/device/scanner/health,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "ri" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8072,6 +9752,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"rs" = (
+/obj/machinery/button/ignition{
+	id_tag = "Isocell3";
+	pixel_x = -6;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "rt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8097,6 +9785,28 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"rv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/microscope,
+/obj/machinery/alarm{
+	alarm_id = "petrov2";
+	frequency = 1439;
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "rw" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8235,6 +9945,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"rJ" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/hallwaya)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8391,6 +10106,10 @@
 /obj/item/storage/box/autoinjectors,
 /turf/simulated/floor/tiled/white,
 /area/vacant/infirmary)
+"rX" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/hallwaya)
 "rY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -8458,6 +10177,17 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"sd" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "se" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -8591,6 +10321,9 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/storage)
+"st" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell1)
 "su" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8603,6 +10336,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"sv" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "sw" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -8612,6 +10357,16 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
+"sy" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "sz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -8627,6 +10382,21 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
+"sB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
 "sC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8641,6 +10411,62 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"sD" = (
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell3";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"sE" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/valve/open,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"sF" = (
+/mob/living/simple_animal/yithian,
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
+"sG" = (
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - Desublimation";
+	dir = 4
+	},
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
+"sH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 0
+	},
+/turf/simulated/floor/steel_dirty,
+/area/shuttle/petrov/terrarium)
 "sI" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -8670,11 +10496,49 @@
 /obj/machinery/shipsensors/weak,
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
+"sL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
+"sM" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "sN" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/tiled/white,
 /area/vacant/infirmary)
+"sO" = (
+/obj/machinery/button/blast_door{
+	id_tag = "petrovcell2";
+	name = "Test Chamber Vent";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/valve/open,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "sP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/green{
@@ -8715,15 +10579,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/infirmary)
+"sV" = (
+/obj/machinery/atmospherics/valve/open,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "sW" = (
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/prepainted,
 /area/rnd/canister)
 "sX" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/canister)
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -21
+	},
+/obj/machinery/button/windowtint{
+	id = "rcheckinner_windows";
+	pixel_x = 10;
+	pixel_y = -21
+	},
+/obj/machinery/computer/modular/preset/security{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/petrov/control)
 "sY" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -8747,6 +10626,20 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/canister)
+"ta" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "tb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8762,10 +10655,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/canister)
 "td" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/canister)
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/isolation)
 "te" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -8907,6 +10803,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/expedition/eva)
+"tq" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "tr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -8977,6 +10886,20 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"tw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "tx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -8996,6 +10919,13 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"tB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/steel_dirty,
+/area/shuttle/petrov/terrarium)
 "tC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9068,6 +10998,15 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fifthdeck/aft)
+"tI" = (
+/obj/machinery/atmospherics/valve/open,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "tJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9079,6 +11018,75 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
+"tK" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
+"tL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
+"tM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"tN" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/terrarium_access)
+"tO" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"tP" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "tQ" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -9108,6 +11116,21 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/analysis)
+"tS" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 23
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/dnaforensics,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
 "tT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -9165,6 +11188,31 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"tZ" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"ua" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
 "ub" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9218,6 +11266,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"uf" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing/mapped{
@@ -9512,6 +11582,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"uG" = (
+/obj/effect/paint/silver,
+/turf/simulated/wall/ocp_wall,
+/area/shuttle/petrov/terrarium_access)
 "uH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -9529,6 +11603,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"uJ" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "terrarium"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "uK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9568,6 +11648,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"uN" = (
+/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "uO" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -9615,6 +11701,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"uR" = (
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Test Chamber"
+	},
+/obj/machinery/door/window/southright{
+	name = "Test Chamber"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
 "uS" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -9694,6 +11797,43 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/fore)
+"va" = (
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Experimental Atmospherics"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/toxins)
+"vb" = (
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Petrov Fabrication"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/rnd)
 "vc" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9701,6 +11841,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/rnd)
+"vd" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Expedition Supply"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/equipment)
 "ve" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor{
@@ -9725,12 +11880,75 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"vg" = (
+/obj/effect/wallframe_spawn/reinforced/polarized{
+	id = "terrarium"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"vh" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Terrarium Access"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"vi" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"vk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"vl" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	on = 0;
+	pixel_x = 23;
+	pixel_y = 0
+	},
+/obj/structure/handrail{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "vm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9749,6 +11967,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"vn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "vo" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -9775,15 +12000,9 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
 "vq" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/structure/handrail{
-	dir = 4;
-	icon_state = "handrail"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/structure/bed,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "vr" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -9795,16 +12014,89 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/maint)
-"vt" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
+"vs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/button/windowtint{
+	id = "terrarium";
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"vt" = (
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"vu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov_terrarium";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/grass{
+	base_desc = "Gritty and unpleasant.";
+	base_icon_state = "asteroid";
+	base_name = "sand";
+	footstep_type = /decl/footsteps/asteroid;
+	icon = 'icons/turf/flooring/asteroid.dmi';
+	icon_state = "asteroid";
+	initial_flooring = /decl/flooring/asteroid;
+	name = "sand"
+	},
+/area/shuttle/petrov/terrarium)
+"vv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - Anomaly Aft";
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/obj/structure/table/standard,
+/obj/item/storage/plants,
+/obj/item/device/scanner/plant,
+/obj/item/material/minihoe,
+/turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
+"vw" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"vx" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/isolation)
+"vy" = (
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"vz" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/custodial)
 "vA" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -9818,23 +12110,33 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"vC" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
+"vB" = (
+/obj/machinery/light,
+/obj/machinery/button/ignition{
+	id_tag = "Isocell2";
+	pixel_x = -6;
+	pixel_y = -25
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
+/area/shuttle/petrov/isolation)
+"vC" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/valve/open,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "vD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -9851,13 +12153,20 @@
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fifthdeck/aft)
 "vG" = (
-/obj/structure/dispenser/oxygen,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "vH" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -9910,6 +12219,24 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"vQ" = (
+/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov2";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"vR" = (
+/obj/structure/closet/crate/secure/biohazard,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/custodial)
 "vS" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9927,10 +12254,24 @@
 /obj/item/light/tube,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"vV" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/custodial)
 "vW" = (
 /obj/item/material/minihoe,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"vX" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/table/standard,
+/obj/item/device/scanner/xenobio,
+/obj/item/scalpel,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "vY" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9944,6 +12285,12 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"wb" = (
+/obj/machinery/optable{
+	name = "Xenobiology Operating Table"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "wc" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -9973,6 +12320,18 @@
 /obj/random/trash,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
+"wh" = (
+/obj/machinery/seed_storage,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"wi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "wj" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
@@ -9991,23 +12350,70 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
 "wm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
+/area/shuttle/petrov/isolation)
 "wn" = (
-/obj/structure/table/standard,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light{
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"wo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"wp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
+/area/shuttle/petrov/isolation)
+"wq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "wr" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -10032,35 +12438,77 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "wu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/hologram/holopad/longrange,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"wx" = (
-/obj/structure/table/standard,
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/debugger{
-	pixel_x = -5
-	},
-/obj/item/device/integrated_electronics/analyzer{
-	pixel_x = 6
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"wv" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
+/area/shuttle/petrov/isolation)
+"ww" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
+"wx" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	icon_state = "map_scrubber_off"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"wy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "petrov_terrarium_access";
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "wz" = (
 /obj/machinery/door/airlock/research{
 	id_tag = null;
@@ -10090,6 +12538,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"wB" = (
+/obj/machinery/computer/operating{
+	dir = 1;
+	name = "Xenobiology Operating Computer"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"wC" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "wD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
@@ -10100,12 +12570,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "wE" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/effect/paint/silver,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/observation)
 "wF" = (
 /turf/simulated/wall/prepainted,
 /area/command/pilot)
+"wG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "wH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10115,6 +12592,22 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
+"wI" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"wJ" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/syringes,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"wK" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/table/standard,
+/obj/item/retractor,
+/obj/item/autopsy_scanner,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
 "wL" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -10144,6 +12637,94 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
+"wM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"wN" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell2";
+	pixel_x = -18
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/obj/structure/stasis_cage,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"wO" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/custodial)
+"wP" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"wQ" = (
+/obj/structure/bed,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"wR" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell1";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/terrarium_access)
+"wS" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/vitals_monitor,
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
+"wT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 12
+	},
+/obj/machinery/camera/network/petrov{
+	c_tag = "Petrov - EVA";
+	dir = 4
+	},
+/obj/structure/anomaly_container,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/eva)
 "wU" = (
 /obj/machinery/door/blast/regular{
 	density = 1;
@@ -10155,6 +12736,17 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/toxins)
+"wV" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 1;
+	icon_state = "pdoor1";
+	id_tag = "petrovcell2";
+	name = "Test Chamber Blast Doors";
+	opacity = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "wW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10193,17 +12785,11 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
 "wY" = (
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/turf/simulated/floor/reinforced/airless,
+/area/shuttle/petrov/custodial)
 "wZ" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -10214,6 +12800,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"xa" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/deep_storage)
+"xb" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/deep_storage)
+"xc" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/isolation)
 "xd" = (
 /obj/structure/bed/chair/office/comfy/red{
 	dir = 4;
@@ -10226,6 +12840,36 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/control)
+"xe" = (
+/obj/machinery/light,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"xf" = (
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/custodial)
 "xg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10244,6 +12888,36 @@
 /obj/effect/paint/silver,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/cockpit)
+"xi" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"xj" = (
+/obj/machinery/sparker{
+	id_tag = "Isocell3";
+	pixel_x = -18
+	},
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"xk" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell2)
 "xl" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -10256,28 +12930,99 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
+"xm" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 4;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"xn" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 8;
+	icon_state = "handrail"
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/petrov/cell3)
+"xo" = (
+/obj/random_multi/single_item/skelestand,
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/isolation)
+"xp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
+"xq" = (
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 8;
+	icon_state = "nosmoking";
+	pixel_x = 32
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/shuttle/petrov/hallwaya)
 "xr" = (
-/obj/structure/table/standard,
-/obj/item/anodevice{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/button/blast_door{
+	id_tag = "toxins_shutters";
+	name = "Chamber Protective Shutters";
+	pixel_w = -5;
+	pixel_z = -24
 	},
-/obj/item/anodevice,
-/obj/item/device/scanner/health,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
+/obj/machinery/button/ignition{
+	id_tag = "toxlab";
+	pixel_w = 6;
+	pixel_z = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
 "xs" = (
-/obj/structure/closet/secure_closet/crew/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/item/folder/nt,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Chamber Input"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "toxin_exhaust";
+	name = "Chamber Vent";
+	pixel_w = 8;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/toxins)
+"xt" = (
+/obj/effect/paint/silver,
+/obj/structure/sign/xenobio_1{
+	name = "\improper XENO STUDIES"
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/analysis)
 "xu" = (
 /obj/machinery/floodlight,
 /obj/structure/handrail{
@@ -10294,14 +13039,52 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"xy" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/structure/handrail{
-	dir = 8;
-	icon_state = "handrail"
+"xw" = (
+/obj/effect/paint/silver,
+/obj/structure/sign/warning/deathsposal{
+	icon_state = "space";
+	pixel_y = 7
 	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/equipment)
+"xx" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/observation)
+"xy" = (
+/obj/machinery/door/airlock/research{
+	id_tag = null;
+	name = "Anomaly Isolation"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
+/area/shuttle/petrov/observation)
+"xz" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/custodial)
 "xA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -10312,13 +13095,12 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
 "xB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/protolathe,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/custodial)
 "xC" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -10329,14 +13111,74 @@
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
+"xD" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"xE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/structure/cable/cyan,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
+"xF" = (
+/obj/effect/paint/silver,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/wall/titanium,
+/area/shuttle/petrov/toxins)
+"xG" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/table/standard,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/shuttle/petrov/toxins)
+"xH" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/lino,
+/area/shuttle/petrov/equipment)
+"xI" = (
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 1;
+	tag_north = 9;
+	tag_south = 6;
+	tag_west = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/petrov/toxins)
 "xJ" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
-"xK" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "xL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10365,12 +13207,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/control)
-"xO" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "xP" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -10401,17 +13237,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"xV" = (
-/obj/structure/closet/crate/secure/biohazard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
 "xX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -10424,11 +13249,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/analysis)
-"xY" = (
-/obj/structure/closet/toolcloset/excavation,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "ya" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10460,10 +13280,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10592,13 +13408,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"yy" = (
-/obj/structure/table/standard,
-/obj/item/crowbar,
-/obj/item/flame/lighter/random,
-/obj/item/storage/box/evidence,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/analysis)
 "yz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -10689,13 +13498,6 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"yO" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "yP" = (
 /obj/machinery/door/airlock/research{
 	id_tag = null;
@@ -10734,23 +13536,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"yR" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
-"yU" = (
-/obj/machinery/atmospherics/unary/heater,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "yW" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -10768,15 +13553,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"za" = (
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"zd" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "zf" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light/spot{
@@ -10790,53 +13566,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"zi" = (
-/obj/structure/bed,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"zk" = (
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "zl" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/silver,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/rnd)
-"zm" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/random/tool,
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell1";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/button/ignition{
-	id_tag = "Isocell1";
-	pixel_x = -36;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "zn" = (
 /obj/random/tech_supply,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -10856,26 +13590,12 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/cockpit)
-"zp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"zs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "zv" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/button/blast_door{
@@ -10929,16 +13649,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/cockpit)
-"zC" = (
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/control)
-"zH" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "zK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -10952,19 +13662,6 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"zO" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"zP" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "zS" = (
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
@@ -10997,29 +13694,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/maint)
-"Ae" = (
-/obj/machinery/suit_cycler/science,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
 "Ag" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -11041,20 +13715,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"Ak" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Al" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -11089,13 +13749,6 @@
 /obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
-"Aq" = (
-/obj/item/stool/padded,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Ar" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4;
@@ -11125,22 +13778,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"At" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell2";
-	pixel_x = -18
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"Ax" = (
-/obj/random/trash,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
 "Ay" = (
 /obj/structure/catwalk,
 /obj/machinery/power/apc{
@@ -11184,30 +13821,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/rnd)
-"AM" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 4;
-	icon_state = "console"
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"AP" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell3";
-	pixel_x = -18
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"AS" = (
-/obj/structure/table/glass,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/book/manual/nt_regs,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "AT" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -11246,14 +13859,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ba" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/computer/rdconsole/petrov{
-	dir = 4;
-	icon_state = "computer"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/rnd)
 "Bf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -11263,18 +13868,6 @@
 	name = "Petrov Interior Access"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/petrov/hallwaya)
-"Bg" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
 "Bi" = (
 /obj/machinery/door/blast/regular{
@@ -11311,30 +13904,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Bn" = (
-/obj/machinery/artifact_analyser,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Bo" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Br" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11346,27 +13915,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Bs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Bu" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"Bx" = (
-/obj/structure/closet/l3closet/scientist/multi,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "By" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/techfloor,
@@ -11403,14 +13951,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"BH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"BJ" = (
-/obj/item/stool/padded,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "BL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -11450,11 +13990,6 @@
 /obj/item/stack/material/plastic/ten,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/rnd)
-"BR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "BS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -11462,16 +13997,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"BT" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/custodial)
 "BX" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
@@ -11493,12 +14018,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"BY" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Cf" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
@@ -11515,18 +14034,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Ch" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/stack/material/phoron,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "Cm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/guppy{
 	dir = 4;
@@ -11595,16 +14102,6 @@
 /obj/random_multi/single_item/piano,
 /turf/simulated/floor/plating,
 /area/vacant/bar)
-"Cy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "CA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -11626,22 +14123,6 @@
 /obj/random/trash,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"CC" = (
-/obj/structure/closet/secure_closet/crew/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/item/folder/nt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "CE" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11666,28 +14147,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"CG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"CH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/research{
-	id_tag = "";
-	name = "Sublimation Chamber"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"CJ" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 1;
-	icon_state = "comfyofficechair_preview"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "CL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11722,35 +14181,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/custodial)
-"CT" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/rd)
-"CV" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/health,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"CW" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Research Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "CX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11824,23 +14254,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Dh" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"Di" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/paint/silver,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
 "Dl" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -11888,10 +14301,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"Dq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Dr" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -11923,22 +14332,6 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/fore)
-"Dt" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
-"Du" = (
-/obj/structure/table/glass,
-/obj/item/device/paicard,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Dv" = (
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Dw" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11953,24 +14346,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/cockpit)
-"Dy" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Dz" = (
 /obj/machinery/door/airlock/multi_tile/glass/research{
 	dir = 8;
@@ -11980,25 +14355,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
-"DE" = (
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - EVA";
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/structure/table/rack,
-/obj/item/stack/flag/red,
-/obj/item/stack/flag/red,
-/obj/item/stack/flag/red,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
 "DF" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -12011,65 +14367,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/button/ignition{
-	id_tag = "Isocell3";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"DK" = (
-/obj/effect/paint/silver,
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rd)
-"DN" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Anomaly Aft";
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"DO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/button/ignition{
-	id_tag = "Isocell2";
-	pixel_x = -6;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "DQ" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/titanium,
@@ -12091,12 +14388,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"DX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/equipment)
 "DY" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -12121,48 +14412,6 @@
 "Ea" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"Ec" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
-"Ed" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Equipment Storage"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Ee" = (
-/obj/machinery/atmospherics/tvalve/digital{
-	dir = 1;
-	icon_state = "map_tvalve0";
-	id_tag = "fuelmode"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	dir = 1;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Eg" = (
 /obj/structure/closet/secure_closet/prospector,
 /obj/effect/floor_decal/corner/brown/mono,
@@ -12187,29 +14436,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fifthdeck/aftstarboard)
-"El" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "Em" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/storage)
-"En" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Ep" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -12252,27 +14481,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Ex" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 12
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Toxins";
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/vending/phoronresearch{
-	dir = 4;
-	icon_state = "generic"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Ey" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12310,19 +14518,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"EE" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"EH" = (
-/obj/machinery/suit_storage_unit/science,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "EI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12334,22 +14529,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"EJ" = (
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Desublimation";
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "EK" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -12375,19 +14554,6 @@
 	},
 /turf/space,
 /area/space)
-"ER" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	alarm_id = "petrov3";
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "ET" = (
 /obj/structure/closet/medical_wall{
 	pixel_x = 0;
@@ -12404,19 +14570,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Fd" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"Ff" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "Fg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -12466,10 +14619,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/analysis)
-"Fu" = (
-/obj/structure/bed,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "Fw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
@@ -12478,31 +14627,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/cockpit)
-"Fy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"FD" = (
-/obj/structure/table/standard,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov2";
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "FR" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
@@ -12552,38 +14676,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Gb" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
-"Gc" = (
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine/torch{
-	department = "Petrov - Chief Science Officer"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Science Officer's Desk";
-	departmentType = 5;
-	name = "Chief Science Officer RC";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "Ge" = (
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/tiled/techfloor,
@@ -12623,18 +14715,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"Gr" = (
-/obj/structure/table/standard,
-/obj/random/tool,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Gv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12681,40 +14761,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
-"GB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"GG" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"GI" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"GK" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "GL" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular{
@@ -12805,58 +14851,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"GX" = (
-/obj/structure/bed/chair/padded/red,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Ha" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Hb" = (
-/obj/machinery/disposal,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "rd_windows";
-	pixel_x = 6;
-	pixel_y = 24;
-	range = 11
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "Hc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/emitter{
@@ -12928,19 +14922,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"Ht" = (
-/obj/machinery/air_sensor{
-	id_tag = "phoron_sensor"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Hu" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Hv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -12955,21 +14936,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Hw" = (
-/obj/structure/table/standard,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/scanning_module,
-/obj/item/device/paicard,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "Hy" = (
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Petrov"
@@ -12977,11 +14943,6 @@
 /obj/structure/cable/cyan,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"Hz" = (
-/obj/structure/table/glass,
-/obj/item/pen,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "HB" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/rnd)
@@ -13126,24 +15087,6 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"HV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"HX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "HY" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -13153,49 +15096,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"HZ" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Suit Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Ia" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/vacant/bar)
-"Ib" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ic" = (
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/acid{
-	density = 0;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "Id" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -13216,20 +15120,6 @@
 /obj/machinery/artifact_harvester,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
-"Ik" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "In" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13257,26 +15147,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"It" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/cell1)
 "Iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Iv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"IA" = (
-/obj/machinery/lapvend,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "IB" = (
 /obj/machinery/disposal,
 /obj/machinery/camera/network/petrov{
@@ -13298,11 +15174,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/rnd)
-"IC" = (
-/obj/machinery/suspension_gen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "IF" = (
 /obj/machinery/computer/shuttle_control{
 	dir = 4;
@@ -13354,19 +15225,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"IR" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "IU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13402,14 +15260,6 @@
 	},
 /turf/space,
 /area/space)
-"IY" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "Ja" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -13446,25 +15296,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell3)
-"Jj" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
 "Jk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cockpit)
-"Jl" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/cell1)
 "Jn" = (
 /obj/effect/catwalk_plated,
 /obj/structure/closet/hydrant{
@@ -13545,38 +15382,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/analysis)
-"Jz" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"JA" = (
-/obj/structure/closet/crate/secure/biohazard,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
-"JB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "JD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -13601,36 +15406,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"JH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell3";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"JK" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
 "JL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13650,16 +15425,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/cockpit)
-"JO" = (
-/obj/structure/closet/bombcloset,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"JP" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
 "JS" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -13702,37 +15467,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Kb" = (
-/obj/machinery/sparker{
-	id_tag = "Isocell1";
-	pixel_x = -18
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Kc" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rd)
-"Kh" = (
-/obj/structure/table/standard,
-/obj/item/folder/nt,
-/obj/item/stack/nanopaste,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "Ki" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/camera/network/petrov{
@@ -13746,28 +15480,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"Kj" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Kk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
 "Ko" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/port_gen/pacman{
@@ -13779,20 +15491,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
-"Kr" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Kt" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/custodial)
 "Ku" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -13807,10 +15505,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Kw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "Ky" = (
 /obj/machinery/power/smes/buildable/preset/torch/shuttle{
 	RCon_tag = "Shuttle - Charon"
@@ -13850,18 +15544,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"KD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "KI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -13896,26 +15578,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"KN" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"KQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "KU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13926,14 +15588,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"KV" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "KW" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -13947,15 +15601,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
-"KY" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14026,12 +15671,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"Li" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/effect/paint/silver,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/phoron)
 "Lj" = (
 /turf/simulated/floor/wood/walnut{
 	icon_state = "walnut_broken5"
@@ -14110,13 +15749,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/rnd)
-"Lu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Lv" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light/small{
@@ -14130,31 +15762,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell3)
-"LA" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/rd)
 "LB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"LC" = (
-/obj/structure/table/rack,
-/obj/item/device/flashlight,
-/obj/item/device/radio,
-/obj/item/crowbar,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/control)
 "LE" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -14170,27 +15783,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/analysis)
-"LF" = (
-/obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
-"LG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
-"LI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14203,12 +15795,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"LM" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/isolation)
 "LN" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -14217,14 +15803,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/cockpit)
-"LQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "LT" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -14239,20 +15817,6 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"LU" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"LW" = (
-/obj/effect/wallframe_spawn/reinforced/polarized{
-	id = "rd_windows"
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/rd)
 "LX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14271,11 +15835,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Mb" = (
-/obj/structure/table/steel,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/control)
 "Mc" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
 /obj/structure/railing/mapped{
@@ -14285,11 +15844,6 @@
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Mg" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/scientist_torch,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "Mj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14310,23 +15864,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Ml" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"Mm" = (
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/analysis)
 "Mn" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -14346,21 +15883,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/cockpit)
-"Mo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	icon_state = "map_scrubber_off"
-	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "petrov1";
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "Mr" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -14390,33 +15912,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Mv" = (
-/obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/device/megaphone,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/control)
-"Mx" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "My" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14424,15 +15919,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Mz" = (
-/obj/structure/stasis_cage,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Equipment";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "MB" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -14521,11 +16007,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"MQ" = (
-/obj/structure/table/standard,
-/obj/machinery/reagent_temperature,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/analysis)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/primary/fifthdeck/fore)
@@ -14541,12 +16022,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"MX" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Na" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
@@ -14568,18 +16043,6 @@
 "Ne" = (
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
-"Nf" = (
-/obj/structure/table/standard,
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
-"Ng" = (
-/obj/effect/wallframe_spawn/reinforced_phoron/titanium,
-/obj/machinery/door/firedoor,
-/obj/effect/paint/silver,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -14635,28 +16098,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Nq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
-"Nu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 4;
-	icon_state = "cap"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Nv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14680,25 +16121,6 @@
 /obj/structure/sign/solgov,
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftport)
-"Ny" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
 "NC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14737,10 +16159,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"NG" = (
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "NI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14777,14 +16195,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/control)
-"NP" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "NS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14797,14 +16207,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/toxins)
-"NX" = (
-/obj/machinery/atmospherics/omni/filter{
-	tag_east = 2;
-	tag_south = 3;
-	tag_west = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "NY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14815,17 +16217,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/rnd)
-"NZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/toxins)
 "Od" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -14840,24 +16231,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Of" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Custodial Closet"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/custodial)
 "Og" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -14887,10 +16260,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/toxins)
-"Oi" = (
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Ol" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable{
@@ -14952,17 +16321,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
-"OC" = (
-/obj/structure/table/standard,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "OD" = (
 /obj/machinery/door/airlock/research{
 	id_tag = null;
@@ -14996,15 +16354,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"OM" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "ON" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -15021,20 +16370,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/cockpit)
-"OO" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
 "OR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/door/airlock/external{
@@ -15093,13 +16428,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"Pa" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital{
-	dir = 1;
-	icon_state = "map_tvalvem0"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Pd" = (
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/tiled,
@@ -15110,23 +16438,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/analysis)
-"Pm" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "Pn" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -15145,28 +16456,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
-"Pr" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/item/folder/nt,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Anomaly Fore";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Pt" = (
 /obj/structure/sign/warning/airlock{
 	dir = 8;
@@ -15239,17 +16528,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/toxins)
-"PK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "PM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -15269,40 +16547,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"PR" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovShield";
-	name = "Blast Shutter Control";
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "PetrovBiohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "Qd" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/bar)
-"Qe" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Qg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15319,11 +16566,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Qi" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/toxins)
 "Qj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -15331,17 +16573,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Qk" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Qm" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -15403,18 +16634,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
-"Qr" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "PetrovShield";
-	name = "Petrov Blast Shutters";
-	opacity = 0
-	},
-/obj/effect/paint/silver,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/equipment)
 "Qz" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -15438,29 +16657,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"QB" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "QE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -15478,38 +16674,11 @@
 /obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/rnd)
-"QH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"QI" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Phoron Sublimation Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "QJ" = (
 /obj/effect/paint/hull,
 /obj/structure/sign/solgov,
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
-"QK" = (
-/obj/structure/table/standard,
-/obj/item/device/scanner/reagent,
-/obj/item/device/scanner/spectrometer/adv,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "QL" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/blast/regular{
@@ -15525,14 +16694,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"QR" = (
-/obj/structure/closet/crate/secure/biohazard,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/custodial)
 "QV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -15600,10 +16761,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Rc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
 "Rd" = (
 /obj/machinery/light{
 	dir = 8
@@ -15614,7 +16771,7 @@
 	icon_state = "map_connector"
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup{
-	start_pressure = 7498.00
+	start_pressure = 7498
 	},
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
@@ -15666,38 +16823,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/petrov/rnd)
-"Rp" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
-"Rr" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Rt" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/ocp_wall,
@@ -15747,43 +16872,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"RB" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	frequency = 1441;
-	icon_state = "map_injector";
-	id = "phoron_in";
-	use_power = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"RE" = (
-/obj/machinery/suit_storage_unit/science,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/eva)
-"RG" = (
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Test Chamber"
-	},
-/obj/machinery/door/window/southright{
-	name = "Test Chamber"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
-"RN" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "RQ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/infirmary)
@@ -15841,17 +16929,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
-"Sb" = (
-/obj/machinery/door/blast/regular{
-	density = 1;
-	dir = 1;
-	icon_state = "pdoor1";
-	id_tag = "petrovcell2";
-	name = "Test Chamber Blast Doors";
-	opacity = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell2)
 "Sc" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15875,37 +16952,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Sg" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/machinery/computer/atmoscontrol/laptop{
-	monitored_alarm_ids = list("petrov1","petrov2","petrov3");
-	req_access = list("ACCESS_TORCH_PETROV")
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "So" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/petrov/maint)
-"Sp" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	icon_state = "nosmoking";
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Sr" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -15921,17 +16973,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/analysis)
-"Su" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Sv" = (
 /obj/random/torchcloset,
 /obj/random/maintenance/solgov,
@@ -15954,11 +16995,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"Sz" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "SB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -16000,20 +17036,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell3)
-"SI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "SJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16057,40 +17079,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"SN" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/rnd)
-"SQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
-"SU" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "SV" = (
 /obj/machinery/atmospherics/valve/shutoff/supply{
 	dir = 4
@@ -16110,28 +17098,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Tc" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/binary/pump,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
-"Tg" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16168,23 +17134,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
-"Ts" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Tt" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -16197,24 +17146,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Tu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Tw" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16263,44 +17194,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
-"TF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"TG" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/purple/half{
-	dir = 8
-	},
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/control)
-"TH" = (
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/screwdriver{
-	pixel_y = 15
-	},
-/obj/item/melee/baton/loaded,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/analysis)
 "TL" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -16315,12 +17208,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)
-"TM" = (
-/obj/structure/table/glass,
-/obj/item/folder/nt,
-/obj/item/folder/nt,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "TO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -16347,23 +17234,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"TR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "TS" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -16430,35 +17300,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
-"Uq" = (
-/obj/machinery/atmospherics/unary/vent_pump/tank{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "toxins_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/toxins)
-"Ur" = (
-/obj/machinery/vending/assist,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Us" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -16469,10 +17310,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Uu" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "Uw" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -16484,22 +17321,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/analysis)
-"UA" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"UC" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/shuttle/petrov/isolation)
 "UE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -16510,11 +17331,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"UF" = (
-/obj/structure/table/standard,
-/obj/item/device/integrated_circuit_printer,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "UG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -16538,34 +17354,9 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
-"UM" = (
-/obj/machinery/door/airlock/research{
-	name = "Chief Science Officer";
-	secured_wires = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rd)
 "UO" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"UQ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "UT" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/cable/cyan{
@@ -16592,10 +17383,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"UX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "Va" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
@@ -16692,15 +17479,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/rnd)
-"Vy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell3)
 "Vz" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner/brown{
@@ -16749,38 +17527,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"VD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "petrovcell2";
-	name = "Test Chamber Vent";
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"VF" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "VG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -16802,43 +17548,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
-"VM" = (
-/obj/structure/noticeboard{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Chief Science Officer";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "VN" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"VO" = (
-/obj/structure/table/rack,
-/obj/item/storage/belt/archaeology,
-/obj/item/storage/belt/archaeology,
-/obj/item/storage/belt/archaeology,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/pickaxe{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
 "VP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -16857,26 +17572,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
-"VT" = (
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"VU" = (
-/obj/structure/table/rack,
-/obj/item/device/scanner/xenobio,
-/obj/item/device/scanner/xenobio,
-/obj/item/device/scanner/xenobio,
-/obj/item/storage/excavation,
-/obj/item/device/measuring_tape,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/eva)
-"VV" = (
-/obj/structure/closet/secure_closet/scientist_torch,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "VX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -16958,50 +17653,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Wp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
-/obj/random/cash,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/cockpit)
-"Wt" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"Wy" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/atmospherics/unary/vent_pump/tank{
-	dir = 1;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "phoron_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 0
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/phoron)
-"Wz" = (
-/obj/machinery/computer/air_control{
-	dir = 2;
-	input_tag = "phoron_in";
-	name = "Test Chamber Gas Monitor";
-	output_tag = "phoron_out";
-	sensor_name = "Test Chamber";
-	sensor_tag = "phoron_sensor"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "WD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -17033,32 +17684,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"WG" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/phoron)
 "WH" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
-"WO" = (
-/obj/structure/table/standard,
-/obj/item/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/disk/design_disk,
-/obj/item/disk/design_disk,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/rnd)
 "WR" = (
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell2)
@@ -17095,18 +17725,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/rnd)
-"Xd" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	icon_state = "nosmoking";
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/hallwaya)
 "Xe" = (
 /obj/structure/bed/chair/office/comfy/red,
 /turf/simulated/floor/tiled/dark,
@@ -17166,19 +17784,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Xq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Xs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
 "Xt" = (
 /obj/effect/paint/hull,
 /obj/structure/disposalpipe/segment{
@@ -17213,19 +17818,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
-"XB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -17245,32 +17837,6 @@
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
-"XG" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/ocp_wall,
-/area/shuttle/petrov/phoron)
-"XH" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "XI" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/bar)
@@ -17301,10 +17867,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/maint)
-"XQ" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "XT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17334,13 +17896,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"XW" = (
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
-"Yb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Yc" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 8
@@ -17350,27 +17905,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
-"Yf" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
-"Yg" = (
-/obj/structure/table/steel,
-/obj/item/book/manual/nt_regs,
-/obj/item/folder/nt,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/petrov/control)
 "Yi" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -17401,29 +17935,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Yk" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall/titanium,
-/area/shuttle/petrov/phoron)
 "Ym" = (
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
-"Yn" = (
-/obj/machinery/disposal,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -21
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/equipment)
 "Yo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17439,42 +17953,6 @@
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
-"Yp" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Yr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/shuttle/petrov/eva)
-"Ys" = (
-/obj/machinery/door/airlock/research{
-	id_tag = null;
-	name = "Toxins Lab"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Yu" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17483,20 +17961,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"Yw" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/dispenser,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/toxins)
 "Yz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -17556,9 +18020,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/bar)
-"YJ" = (
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/phoron)
 "YL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -17571,42 +18032,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftport)
-"YQ" = (
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
-"YS" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "YV" = (
 /obj/structure/hygiene/shower{
 	dir = 4;
@@ -17640,21 +18065,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"YZ" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
-	icon_state = "freezer"
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = 23
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "Za" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17700,13 +18110,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"Ze" = (
-/obj/machinery/computer/modular/preset/civilian,
-/obj/effect/floor_decal/corner/purple/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/shuttle/petrov/control)
 "Zg" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -17766,30 +18169,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
-"Zp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/computer/air_control{
-	dir = 8;
-	input_tag = "toxins_in";
-	name = "Toxins Gas Monitor";
-	output_tag = "toxins_out";
-	sensor_name = "Toxins Test Chamber";
-	sensor_tag = "toxins_sensor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/toxins)
-"Zr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "Zu" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
@@ -17813,44 +18192,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
-"Zx" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/crate/radiation,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/equipment)
-"Zy" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/shuttle/petrov/cell1)
 "ZA" = (
 /turf/simulated/wall/prepainted,
 /area/rnd/canister)
-"ZB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	icon_state = "intact"
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/alarm{
-	alarm_id = "petrov2";
-	frequency = 1439;
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
-"ZD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/hallwaya)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -17900,29 +18244,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"ZQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/petrov/isolation)
 "ZT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"ZU" = (
-/obj/structure/table/standard,
-/obj/item/device/geiger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/shuttle/petrov/isolation)
 "ZV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41659,7 +41985,7 @@ ZG
 ZG
 GQ
 ZA
-sX
+eO
 tg
 tc
 BC
@@ -42065,7 +42391,7 @@ GQ
 ZA
 sY
 tl
-td
+eJ
 BC
 BC
 aa
@@ -42083,7 +42409,7 @@ Zc
 Al
 Jk
 xh
-Wp
+ik
 JM
 LP
 xh
@@ -42274,7 +42600,7 @@ aa
 aa
 tT
 ND
-TG
+ak
 HJ
 bP
 NO
@@ -42479,7 +42805,7 @@ ND
 Vo
 zK
 Qo
-Mb
+bO
 YE
 YV
 OH
@@ -42678,22 +43004,22 @@ aa
 bP
 bP
 bP
-LC
+mO
 NI
-zC
+lI
 Xe
 Ni
 Pn
 vp
 Ao
-LA
-LA
-LA
-LA
-LA
-LA
-LA
-LA
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
 aa
 ws
 ws
@@ -42879,23 +43205,23 @@ ZG
 aa
 tT
 ND
-ah
+ag
 xd
 NI
 BN
-aG
+sX
 bP
 Al
 Qp
 Dz
-LA
-VM
-YQ
-Gc
-AM
-Wt
-Kc
-CT
+LN
+cx
+cX
+dC
+fv
+fO
+ge
+gh
 aa
 ws
 ws
@@ -43081,23 +43407,23 @@ ZG
 aa
 tT
 ND
-Ze
-Yg
-Mv
+ah
+ij
+bF
 xN
 yG
 Ub
 JS
 wL
 TS
-LW
-VT
-GX
-Hz
-CJ
-VT
-Kc
-CT
+bX
+eK
+dq
+dH
+fw
+fV
+ge
+gh
 aa
 ws
 ws
@@ -43292,14 +43618,14 @@ bu
 Lg
 Gm
 MN
-LW
-eW
-GX
-AS
-PR
-wu
-LA
-LA
+bX
+cz
+eR
+dI
+fw
+fV
+LN
+LN
 ws
 ws
 ws
@@ -43494,14 +43820,14 @@ Xa
 yx
 Yz
 GR
-UM
-Pm
-UA
-BH
-QH
-VT
-Kc
-CT
+vd
+dr
+xH
+dJ
+fA
+ga
+ge
+gh
 ws
 ws
 ws
@@ -43678,7 +44004,7 @@ aa
 ZG
 ZG
 ZG
-ER
+co
 AU
 AU
 NJ
@@ -43695,15 +44021,15 @@ Jo
 AY
 BD
 JX
-DK
-LA
-Hb
-TM
-Du
-xK
-KQ
-Kc
-CT
+bR
+xw
+cC
+dt
+dQ
+fC
+gb
+ge
+gh
 ws
 ws
 ws
@@ -43897,15 +44223,15 @@ bu
 Jh
 VB
 MB
-LA
-LA
-LA
-LW
-LW
-LW
-LA
-LA
-LA
+LN
+LN
+LN
+bX
+bX
+bX
+LN
+LN
+LN
 ws
 ws
 ws
@@ -44096,14 +44422,14 @@ Rv
 Do
 Hy
 bu
-Mg
+fg
 UT
 Ki
 Lt
 IB
 gt
-Ba
-SN
+ej
+lJ
 Xc
 QF
 GL
@@ -44298,10 +44624,10 @@ By
 BL
 PC
 bu
-ge
+fh
 YG
 tJ
-CW
+vb
 Vv
 NY
 NS
@@ -44504,10 +44830,10 @@ xA
 Qz
 yl
 zl
-WO
+lB
 AL
 vc
-xB
+ex
 HB
 yC
 GL
@@ -44706,12 +45032,12 @@ xA
 BM
 Wn
 zl
-Ic
-Kh
-Hw
-OO
+nx
+pn
+ft
+eD
 OU
-zO
+lO
 Lt
 Lt
 Lt
@@ -44899,25 +45225,25 @@ bb
 bb
 bb
 Hc
-RN
+bD
 AK
 RZ
-xr
+gV
 bb
-bb
+xt
 BM
-Wn
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
-XG
-XG
-XG
-XG
-Yk
+ka
+Al
+gf
+gf
+gf
+gf
+gf
+uG
+uG
+uG
+uG
+tN
 aa
 aa
 aa
@@ -45108,18 +45434,18 @@ ZY
 Mt
 bb
 yr
-ZD
-Yk
-IR
-Dt
-EJ
-XQ
-Ff
-Ng
-Wy
-Dv
-XG
-Yk
+MN
+pg
+oC
+pE
+sG
+pE
+ua
+uJ
+sy
+vX
+uG
+tN
 aa
 aa
 aa
@@ -45309,19 +45635,19 @@ xX
 Jx
 Gy
 yP
-YS
-Zr
-QI
-Cy
-KD
-wm
-LI
-WG
-CH
-Dv
-Dv
-XG
-Yk
+jh
+jv
+kN
+tK
+kO
+kO
+kO
+kO
+uJ
+sM
+wb
+uG
+tN
 aa
 aa
 aa
@@ -45503,27 +45829,27 @@ aa
 aa
 Pe
 ZJ
-Ib
+aG
 ZY
 ZY
-yy
+ds
 tR
 Ag
 ZV
-Mm
+bb
 As
 Wn
-Li
-Wz
-zs
-YJ
-YJ
-WG
-Rc
-Ht
-Dv
-XG
-Yk
+rJ
+pE
+sH
+sL
+tB
+tL
+vg
+ta
+wB
+uG
+tN
 aa
 aa
 aa
@@ -45705,27 +46031,27 @@ aa
 aa
 Pe
 ZJ
-Nf
+hD
 ZY
 DZ
 vo
 Fo
 Vk
-MQ
+lp
 Tx
 BM
 Wn
-Li
-wn
-El
-OC
-IY
-Tc
-Ng
-RB
-Dv
-XG
-Yk
+rJ
+kO
+sF
+kO
+pE
+kO
+vh
+tw
+wJ
+uG
+tN
 aa
 aa
 aa
@@ -45910,24 +46236,24 @@ bb
 Px
 wl
 Ap
-TH
-Ch
-LF
-mm
+gu
+gn
+gL
+oA
 Tx
 QW
 FU
-Wl
-Wl
-Wl
-Wl
-Wl
-It
-Jl
-Jl
-Jl
-Jl
-It
+rX
+sB
+pE
+kO
+pE
+vu
+uJ
+tw
+wK
+uG
+tN
 aa
 aa
 aa
@@ -46110,26 +46436,26 @@ aa
 bb
 bb
 bb
+hr
+hr
+hr
+hr
 bb
-Tx
-Tx
-Tx
 bb
 bb
-bb
-QB
-Dq
-JP
-vq
-Pr
-Sg
-zm
-xO
-Nq
-Mo
-Kb
-Zy
-Oq
+ml
+Wn
+Wl
+Wl
+td
+vx
+Wl
+tN
+tN
+vs
+wI
+wR
+vt
 aa
 aa
 aa
@@ -46309,29 +46635,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-IA
-MX
-Mx
-NP
-IC
-Mz
-wY
-yR
-Bo
-Yb
-JP
-Oi
-Ha
-JB
-Tu
-Dy
-SI
-SU
-KN
-Zy
+af
 Oq
+cp
+fc
+gQ
+gX
+hX
+is
+mW
+pd
+fD
+mo
+oT
+mz
+qt
+wi
+mG
+tO
+tM
+vk
+vw
+wR
+vt
 aa
 aa
 aa
@@ -46511,29 +46837,29 @@ aa
 aa
 aa
 aa
-DX
-Qr
-UF
-Fd
-Fd
-XW
-Xs
-Fd
-QK
-yR
-Og
-Dq
-Ec
-ZU
-TF
-Lu
-fD
-xO
-Bn
-GG
-zk
-Zy
+aj
 Oq
+st
+fk
+st
+gY
+ia
+it
+np
+wE
+Og
+od
+op
+nT
+qw
+wm
+sE
+tP
+vl
+wy
+wx
+wR
+vt
 aa
 aa
 aa
@@ -46713,29 +47039,29 @@ aa
 aa
 aa
 aa
-DX
-Qr
-Bx
-Fd
-Zx
-xs
-Iv
-Fd
-Yn
-LN
-Ts
-Hu
-Wl
-Gr
-Rr
-zd
-DO
-It
-It
-It
-It
-It
-It
+aj
+Oq
+dS
+fF
+gR
+gZ
+ib
+jb
+nE
+xx
+nX
+oe
+oz
+pB
+qG
+rf
+vB
+Qm
+tN
+tN
+tN
+tN
+tN
 aa
 aa
 aa
@@ -46915,29 +47241,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-JO
-Ak
-wx
-CC
-Jz
-En
-Tg
-Ed
+dX
+dX
+dX
+gS
+ha
+hV
+ic
+my
+me
+xy
 CE
 TY
 OD
-PK
-XH
-EE
-VD
-gZ
-Dh
-Fy
-At
-RX
-Sb
+qx
+uf
+wn
+sO
+sd
+vG
+wC
+wN
+xk
+wV
 aa
 aa
 aa
@@ -47117,29 +47443,29 @@ aa
 aa
 aa
 aa
-LN
-LN
-LN
-HZ
-LN
-LN
-GK
-Aq
-BJ
-LN
-TR
-Bg
+gJ
+gJ
+gN
+gW
+he
+hW
+in
+mT
+nS
+gJ
+xp
+xi
 Wl
-Ur
-KV
-zH
-Bs
-RG
-HV
+oc
+rd
+wo
+sV
+sv
+vn
 WR
-LQ
+wP
 RX
-Sb
+wV
 aa
 aa
 aa
@@ -47321,27 +47647,27 @@ aa
 aa
 bc
 bc
-Ae
-Ny
-DE
-LN
-VV
-Sz
-Kr
-LN
-SQ
-Xd
-Wl
-Bu
-CV
-zP
+bc
+gA
+bc
+hQ
+io
+mV
+oV
+gJ
 fE
-ha
-Fu
-FD
-zi
-RX
-Sb
+xq
+Wl
+qs
+rh
+wp
+xo
+tZ
+vq
+vQ
+wQ
+wS
+wV
 aa
 aa
 aa
@@ -47521,25 +47847,25 @@ aa
 aa
 aa
 aa
-Yr
+bs
 Tp
-xY
-GB
-VU
+eL
+hB
+wT
+mZ
 NW
 NW
 NW
 NW
-NW
-Ys
+va
+xD
 NW
 Wl
-Wl
-yU
-Uu
-DG
-Qm
-Qm
+rv
+wq
+rs
+Uw
+Uw
 Qm
 Qm
 Qm
@@ -47723,28 +48049,28 @@ aa
 aa
 aa
 aa
-Yr
+bs
 Tp
-EH
+ep
 NC
-VO
-NW
-BY
-Ee
-Yw
-Ex
-Rp
-Sp
-UQ
+eI
+mZ
+ad
+ax
+hs
+lP
+oH
+oP
+xE
 Wl
-YZ
-Yf
-JH
-zp
-Di
-Vy
-AP
-GM
+tS
+wu
+sD
+tI
+uN
+wM
+xj
+xm
 Bi
 aa
 aa
@@ -47925,25 +48251,25 @@ aa
 aa
 aa
 aa
-Yr
+bs
 Tp
-EH
-Ik
-Kw
-NW
-Qe
-BR
-yO
-UX
-vC
-CG
-bl
+hH
+hJ
+il
+mZ
+ae
+ay
+hU
+lU
+mi
+mr
+xG
 Wl
-ZB
-Qk
-Nu
-ZQ
-Gb
+tq
+wv
+vi
+vC
+uR
 TO
 Ji
 GM
@@ -48129,26 +48455,26 @@ aa
 aa
 bc
 bc
-RE
-Ml
-vG
-NW
-OM
-Pa
-Yp
-yO
-XB
-Xq
-bn
-Wl
-NX
-NG
-Yf
-GI
+hI
+hK
+mA
+mZ
+ap
+az
+id
+xI
+mj
+mu
+xr
+xF
+wh
+ww
+wG
+xc
 Gx
 Lv
 SH
-GM
+xn
 Bi
 aa
 aa
@@ -48329,24 +48655,24 @@ aa
 aa
 aa
 aa
-CS
-CS
-CS
-Of
-CS
-CS
-ad
-Su
-Kj
-KY
-ap
-Zp
-HX
-Wl
-DN
-xy
-fG
-VF
+eP
+eP
+eP
+iN
+eP
+qk
+aq
+bl
+kc
+mb
+mm
+oK
+xs
+NW
+vv
+vy
+pj
+xe
 Uw
 Uw
 Uw
@@ -48531,16 +48857,16 @@ aa
 aa
 aa
 aa
-DQ
-DQ
-xV
-Kk
-QR
-CS
-NW
-ay
-ax
-aj
+hC
+hC
+iM
+ks
+nc
+xa
+jN
+fG
+ll
+ma
 aV
 be
 aV
@@ -48548,12 +48874,12 @@ Rt
 Wl
 Wl
 Wl
-wE
-Wl
-UC
-UC
-fF
-fF
+xf
+CS
+vR
+vz
+DQ
+DQ
 aa
 aa
 aa
@@ -48734,27 +49060,27 @@ aa
 aa
 aa
 aa
-DQ
-JA
-JK
-JA
-CS
-NW
-ae
-af
-LG
-Uq
-az
-bs
+hC
+ig
+pJ
+nj
+xb
+pL
+pX
+pZ
+Rt
+ke
+kH
+ls
 Rt
 Wl
 Wl
 Wl
-za
-za
-Ax
-za
-fF
+xz
+xB
+vV
+wO
+DQ
 aa
 aa
 aa
@@ -48936,27 +49262,27 @@ aa
 aa
 aa
 aa
-DQ
-DQ
-DQ
-DQ
-DQ
-DQ
-NZ
-Jj
-Qi
-aq
-yf
-LU
+hC
+hC
+hC
+hC
+hC
+hC
+bn
+fs
+Rt
+km
+kK
+kK
 Rt
 Wl
 Wl
-fF
-fF
-fF
-fF
-fF
-fF
+DQ
+DQ
+DQ
+DQ
+DQ
+DQ
 aa
 aa
 aa
@@ -49138,12 +49464,12 @@ aa
 aa
 aa
 aa
-DQ
-BT
-BT
-BT
-BT
-DQ
+hC
+ck
+ck
+ck
+ck
+hC
 Oh
 PE
 yo
@@ -49153,12 +49479,12 @@ wU
 yo
 VP
 VP
-fF
-vt
-vt
-vt
-vt
-fF
+DQ
+eW
+eW
+eW
+eW
+DQ
 aa
 aa
 aa
@@ -49340,27 +49666,27 @@ aa
 aa
 aa
 aa
+hC
+eG
+eG
+eG
+eG
+hC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 DQ
-Kt
-Kt
-Kt
-Kt
+wY
+wY
+wY
+wY
 DQ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-fF
-LM
-LM
-LM
-LM
-fF
 aa
 aa
 aa

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -428,13 +428,20 @@
 	lighting_tone = AREA_LIGHTING_COOL
 
 /area/shuttle/petrov/cell1
-	name = "\improper SRV Petrov - Isolation Cell 1"
+	name = "\improper SRV Petrov - Anomaly Isolation Cell"
 	icon_state = "shuttle"
 /area/shuttle/petrov/cell2
-	name = "\improper SRV Petrov - Isolation Cell 2"
+	name = "\improper SRV Petrov - Xenobiology Isolation Cell 2"
 	icon_state = "shuttlegrn"
 /area/shuttle/petrov/cell3
-	name = "\improper SRV Petrov - Isolation Cell 3"
+	name = "\improper SRV Petrov - Xenobiology Isolation Cell 3"
+	icon_state = "shuttle"
+
+/area/shuttle/petrov/terrarium
+	name = "\improper SRV Petrov - Terrarium"
+	icon_state = "shuttlegrn"
+/area/shuttle/petrov/terrarium_access
+	name = "\improper SRV Petrov - Terrarium Access"
 	icon_state = "shuttle"
 
 /area/shuttle/petrov/hallwaya
@@ -446,11 +453,6 @@
 	icon_state = "checkpoint1"
 	req_access = list(access_petrov_control)
 
-/area/shuttle/petrov/rd
-	icon_state = "heads_rd"
-	name = "\improper SRV Petrov - CSO's Office"
-	icon_state = "head_quarters"
-	req_access = list(access_petrov_rd)
 
 /area/shuttle/petrov/cockpit
 	name = "\improper SRV Petrov - Cockpit"
@@ -468,8 +470,13 @@
 	icon_state = "devlab"
 	req_access = list(access_petrov_analysis)
 
+/area/shuttle/petrov/observation
+	name = "\improper SRV Petrov - Anomaly Observation"
+	icon_state = "exploration"
+	req_access = list(access_petrov_analysis)
+
 /area/shuttle/petrov/toxins
-	name = "\improper SRV Petrov - Toxins Lab"
+	name = "\improper SRV Petrov - Experimental Atmospherics"
 	icon_state = "toxstorage"
 	req_access = list(access_petrov_toxins)
 
@@ -478,13 +485,9 @@
 	icon_state = "devlab"
 
 /area/shuttle/petrov/isolation
-	name = "\improper SRV Petrov - Isolation Lab"
+	name = "\improper SRV Petrov - Xenobiology Lab"
 	icon_state = "xeno_lab"
-
-/area/shuttle/petrov/phoron
-	name = "\improper SRV Petrov - Sublimation Lab"
-	icon_state = "toxstorage"
-	req_access = list(access_petrov_phoron)
+	req_access = list(access_petrov_analysis)
 
 /area/shuttle/petrov/custodial
 	name = "\improper SRV Petrov - Custodial"
@@ -498,6 +501,11 @@
 /area/shuttle/petrov/eva
 	name = "\improper SRV Petrov - EVA Storage"
 	icon_state = "locker"
+
+/area/shuttle/petrov/deep_storage
+	name = "\improper SRV Petrov - Restricted Storage"
+	icon_state = "checkpoint1"
+	req_access = list(access_petrov_control)
 
 //Turbolift
 /area/turbolift


### PR DESCRIPTION
The motivation for this is three intersecting problems:
1. The usability the Petrov labs is not great. There are three different atmospheric systems, two of which have unclear purposes. There are no tools or supplies to support the hydroponics trays. The excavation gear is at the far end from the hangar. The anomaly isolation cell is not visible from the anomaly lab. There is no designated space for xeno animals.
2. The layout of the Petrov is a relic of an earlier cultural stage of Baystation that had NanoTrasen as a separate command and control structure on the ship. This is particularly reflected in the presence of the second CSO office and R&D console.
3. Researchers (especially anomalists) could use more Torch-based things to do when not supplied with toys by explorers.

This PR is mainly aimed at solving number 1, but also kills number 2 as a happy side effect. There are some small gestures towards number 3, though its mostly just making map space in which more activities could take place. 

The first step was eliminating the Petrov CSO office. Some office equipment moved to the control room. The CSO space is now voidsuits and lockers, as close as possible to the hangar instead of as far as possible. The fabrication room collects all the tools (including circuit tools and tool vending machines) in one place but no longer has R&D functions. Rather than being a full second science department, Petrov's identity is reinforced as a place to process things recovered from exploration.

The former locker room holds an anomaly isolation cell with window visibility from the anomaly lab. The starboard aft compartment holds some additional anomaly-related equipment. The port-side lab now has a biological focus with appropriate medical and botany equipment. The phoron room has been replaced with a terrarium for holding xeno life in a "natural" setting.

The "toxin lab" is now "experimental atmospherics", replacing the three different half-baked atmo systems with one centralized one that connects to vents and scrubbers in all the isolation cells. There's a valve to switch the isolation supply between the Petrov holding tank and the main Torch supply. 

There are several random round-start items in the labs pulled from all over the item pallette to find things that were atmospheric or could provide a few minutes of amusement. Nothing unbalancing or that would steal exploration's thunder.

Access control lists are less stingy towards engineering/security/medical/command/service jobs that could have legitimate business in the Petrov.

![petrov](https://user-images.githubusercontent.com/98623517/151836817-093f307d-3674-4d86-9814-a31e7781da64.PNG)

:cl: Sennalen
maptweak: Revised the Petrov for more functional lab space.
/:cl: