### PR TITLE
Adds both CMO labcoat to loadout

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -17,7 +17,7 @@
 	icon_state = "labcoat_cmo"
 
 /obj/item/clothing/suit/storage/toggle/labcoat/cmoalt
-	name = "chief medical officer labcoat"
+	name = "chief medical officer's labcoat"
 	desc = "A labcoat with command blue highlights."
 	icon_state = "labcoat_cmoalt"
 

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -71,6 +71,20 @@
 	allowed_roles = DOCTOR_ROLES
 	allowed_branches = list(/datum/mil_branch/expeditionary_corps)
 
+/datum/gear/suit/labcoat_cmo
+	display_name = "labcoat, chief medical officer"
+	allowed_roles = list(
+		/datum/job/cmo
+	)
+	path = /obj/item/clothing/suit/storage/toggle/labcoat
+
+/datum/gear/suit/labcoat_cmo/New()
+	..()
+	var/list/options = list()
+	options["chief medical officer's labcoat"] = /obj/item/clothing/suit/storage/toggle/labcoat/cmo
+	options["chief medical officer's command labcoat"] = /obj/item/clothing/suit/storage/toggle/labcoat/cmoalt
+	gear_tweaks += new/datum/gear_tweak/path(options)
+
 /datum/gear/suit/labcoat_ec_cso
 	display_name = "labcoat, chief science officer, Expeditionary Corps"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/rd/ec


### PR DESCRIPTION
:cl: Ryan18062
tweak: Adds both CMO labcoats `cmo` and `cmoalt` to loadout
/:cl:

For some reason even after re-adding the cmoalt to the lockers, it wasn't appearing in live.
I fiddled around with the list and now I can't get the both of them to *not* spawn in my local, even after reverting changes

So I just added them both to the loadout to be selected by CMOs, like the CSO labcoat.
Blue-trimmed is command labcoat in the list.