### PR TITLE
Lower most spiders health

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
@@ -17,8 +17,8 @@
 	// has_eye_glow = TRUE
 
 	faction = "spiders"
-	maxHealth = 125
-	health = 125
+	maxHealth = 110
+	health = 110
 	natural_weapon = /obj/item/natural_weapon/bite/spider
 	pass_flags = PASS_FLAG_TABLE
 	poison_resist = 0.5

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/electric.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/electric.dm
@@ -7,8 +7,8 @@
 	icon_living = "spark"
 	icon_dead = "spark_dead"
 
-	maxHealth = 210
-	health = 210
+	maxHealth = 120
+	health = 120
 
 
 	base_attack_cooldown = 15

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/frost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/frost.dm
@@ -7,8 +7,8 @@
 	icon_living = "frost"
 	icon_dead = "frost_dead"
 
-	maxHealth = 175
-	health = 175
+	maxHealth = 115
+	health = 115
 
 	poison_per_bite = 5
 	poison_type = /datum/reagent/toxin/cryotoxin

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
@@ -9,8 +9,8 @@
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
 
-	maxHealth = 120
-	health = 120
+	maxHealth = 100
+	health = 100
 
 	poison_per_bite = 5
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/lurker.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/lurker.dm
@@ -10,8 +10,8 @@
 	icon_living = "lurker"
 	icon_dead = "lurker_dead"
 
-	maxHealth = 100
-	health = 100
+	maxHealth = 90
+	health = 90
 
 	poison_per_bite = 5
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/pepper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/pepper.dm
@@ -7,8 +7,8 @@
 	icon_living = "pepper"
 	icon_dead = "pepper_dead"
 
-	maxHealth = 210
-	health = 210
+	maxHealth = 130
+	health = 130
 
 	poison_chance = 20
 	poison_per_bite = 5

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/thermic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/thermic.dm
@@ -7,8 +7,8 @@
 	icon_living = "pit"
 	icon_dead = "pit_dead"
 
-	maxHealth = 175
-	health = 175
+	maxHealth = 115
+	health = 115
 
 	heat_resist = 0.75
 	cold_resist = -0.50

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/tunneler.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/tunneler.dm
@@ -11,8 +11,8 @@
 	icon_living = "tunneler"
 	icon_dead = "tunneler_dead"
 
-	maxHealth = 120
-	health = 120
+	maxHealth = 100
+	health = 100
 
 	poison_chance = 15
 	poison_per_bite = 3


### PR DESCRIPTION
:cl: Mucker
tweak: Lowered the health of most giant spider variants.
/:cl:

Should make them less spongey to fight until the wonders of standardized health can be added to simple mobs.