### PR TITLE
Resets player view after exiting overmap interface

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -242,6 +242,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 /obj/machinery/computer/ship/helm/unlook(mob/user)
 	. = ..()
 	if (current_operator == user)
+		if (user.client)
+			user.client.pixel_x = 0
+			user.client.pixel_y = 0
 		set_operator(null)
 
 


### PR DESCRIPTION
:cl: Spookerton
bugfix: Fix bug where player's viewport offsets after exiting overmap interface
/:cl:

i was a stupid when trying this code out before

thanks spook for the fix