### PR TITLE
Allow CnC programme to be authorised once and used without ID

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -11,7 +11,6 @@
 	program_menu_icon = "flag"
 	nanomodule_path = /datum/nano_module/program/comm
 	extended_desc = "Used to command and control. Can relay long-range communications. This program can not be run on tablet computers."
-	required_access = access_bridge
 	requires_ntnet = TRUE
 	size = 12
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
@@ -36,6 +35,7 @@
 	var/datum/announcement/priority/crew_announcement = new
 	var/current_viewing_message_id = 0
 	var/current_viewing_message = null
+	var/admin_access = list(access_bridge)
 
 /datum/nano_module/program/comm/New()
 	..()
@@ -44,6 +44,7 @@
 /datum/nano_module/program/comm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 
 	var/list/data = host.initial_data()
+	var/authenticated = check_access(user, admin_access)
 
 	if(program && program.computer)
 		data["net_comms"] = program.computer.get_ntnet_capability(NTNET_COMMUNICATION)
@@ -63,8 +64,8 @@
 	data["message_line2"] = msg_line2
 	data["state"] = current_status
 	data["isAI"] = issilicon(usr)
-	data["authenticated"] = is_autenthicated(user)
 	data["boss_short"] = GLOB.using_map.boss_short
+	data["authenticated"] = authenticated
 
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 	data["current_security_level_ref"] = any2ref(security_state.current_security_level)
@@ -107,7 +108,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/program/comm/proc/is_autenthicated(var/mob/user)
+/datum/nano_module/program/comm/proc/is_authenticated(authenticated, var/mob/user)
 	if(program)
 		return program.can_run(user)
 	return TRUE
@@ -131,7 +132,7 @@
 			current_status = text2num(href_list["target"])
 		if("announce")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && !issilicon(usr) && ntn_comm)
+			if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 				if(user)
 					var/obj/item/card/id/id_card = user.GetIdCard()
 					crew_announcement.announcer = GetNameAndAssignmentFromId(id_card)
@@ -152,7 +153,7 @@
 			. = TOPIC_HANDLED
 			if(href_list["target"] == "emagged")
 				if(program)
-					if(is_autenthicated(user) && program.computer.emagged() && !issilicon(usr) && ntn_comm)
+					if(is_authenticated(user) && program.computer.emagged() && !issilicon(usr) && ntn_comm)
 						if(centcomm_message_cooldown)
 							to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 							SSnano.update_uis(src)
@@ -167,7 +168,7 @@
 						spawn(300)//30 second cooldown
 							centcomm_message_cooldown = 0
 			else if(href_list["target"] == "regular")
-				if(is_autenthicated(user) && !issilicon(usr) && ntn_comm)
+				if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 					if(centcomm_message_cooldown)
 						to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 						SSnano.update_uis(src)
@@ -186,7 +187,7 @@
 						centcomm_message_cooldown = 0
 		if("evac")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user))
+			if(is_authenticated(user))
 				var/datum/evacuation_option/selected_evac_option = evacuation_controller.evacuation_options[href_list["target"]]
 				if (isnull(selected_evac_option) || !istype(selected_evac_option))
 					return
@@ -199,7 +200,7 @@
 					evacuation_controller.handle_evac_option(selected_evac_option.option_target, user)
 		if("setstatus")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && ntn_cont)
+			if(is_authenticated(user) && ntn_cont)
 				switch(href_list["target"])
 					if("line1")
 						var/linput = reject_bad_text(sanitize(input("Line 1", "Enter Message Text", msg_line1) as text|null, 40), 40)
@@ -217,7 +218,7 @@
 						post_status(href_list["target"])
 		if("setalert")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
+			if(is_authenticated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
 				var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 				var/decl/security_level/target_level = locate(href_list["target"]) in security_state.comm_console_security_levels
 				if(target_level && security_state.can_switch_to(target_level))
@@ -230,7 +231,7 @@
 			current_status = STATE_DEFAULT
 		if("viewmessage")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				current_viewing_message_id = text2num(href_list["target"])
 				for(var/list/m in l.messages)
 					if(m["id"] == current_viewing_message_id)
@@ -238,12 +239,12 @@
 				current_status = STATE_VIEWMESSAGE
 		if("delmessage")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && ntn_comm && l != global_message_listener)
+			if(is_authenticated(user) && ntn_comm && l != global_message_listener)
 				l.Remove(current_viewing_message)
 			current_status = STATE_MESSAGELIST
 		if("printmessage")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				if(!program.computer.print_paper(current_viewing_message["contents"],current_viewing_message["title"]))
 					to_chat(usr, "<span class='notice'>Hardware Error: Printer was unable to print the selected file.</span>")
 		if("unbolt_doors")
@@ -254,7 +255,7 @@
 			to_chat(usr, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms bolted.</span>")
 		if("toggle_alert_border")
 			. = TOPIC_HANDLED
-			if(is_autenthicated(user) && ntn_comm)
+			if(is_authenticated(user) && ntn_comm)
 				post_status("toggle_alert_border")
 
 #undef STATE_DEFAULT

--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -95,7 +95,11 @@ datum/announcement/proc/NewsCast(message as text, message_title as text, zlevels
 
 /proc/GetNameAndAssignmentFromId(var/obj/item/card/id/I)
 	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
-	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name
+	if (!I)
+		return "Unknown"
+	if (I.assignment)
+		return "[I.registered_name] ([I.assignment])"
+	return "[I.registered_name]"
 
 /proc/level_seven_announcement()
 	GLOB.using_map.level_x_biohazard_announcement(7)


### PR DESCRIPTION
:cl:
tweak: Command n Comms programme now only needs to be authorised once when opening.
/:cl:

So now you can open the program once with the necessary access ID, and after that anyone else can use it.

Remember to close your highly secure command applications, bridge.