### PR TITLE
Prebuilt floor_light fix

### DIFF
--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -19,8 +19,22 @@ var/list/floor_light_cache = list()
 	var/default_light_outer_range = 3
 	var/default_light_colour = "#ffffff"
 
-/obj/machinery/floor_light/prebuilt
+
+/obj/machinery/floor_light/Initialize()
+	. = ..()
+	update_use_power(use_power)
+	queue_icon_update()
+
+
+/obj/machinery/floor_light/mapped_off
 	anchored = TRUE
+	use_power = POWER_USE_OFF
+
+
+/obj/machinery/floor_light/mapped_on
+	anchored = TRUE
+	use_power = POWER_USE_ACTIVE
+
 
 /obj/machinery/floor_light/attackby(var/obj/item/W, var/mob/user)
 	if(isScrewdriver(W))
@@ -77,15 +91,17 @@ var/list/floor_light_cache = list()
 	queue_icon_update()
 	return TRUE
 
+
 /obj/machinery/floor_light/set_broken(new_state)
 	. = ..()
 	if(. && (stat & BROKEN))
 		update_use_power(POWER_USE_OFF)
 
+
 /obj/machinery/floor_light/power_change(new_state)
 	. = ..()
-	if(. && (stat & NOPOWER))
-		update_use_power(POWER_USE_OFF)
+	queue_icon_update()
+
 
 /obj/machinery/floor_light/proc/update_brightness()
 	if((use_power == POWER_USE_ACTIVE) && !(stat & (NOPOWER | BROKEN)))


### PR DESCRIPTION
floor_light/prebuilt would consider itself to be on (in that it was using power and clicking it says it turns off) but not visually appear to be on. This makes the existing floor_light/prebuilt start in the off state. It adds a floor_light/prebuilt/on that is logically and visually on.

I don't think floor lights are used anywhere except the map I'm making, but maybe if they work then there will be more uses.

(No changelog included for a change that isn't player-facing)