### PR TITLE
Allow AltClick to remove ID from wallets

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -91,6 +91,20 @@
 	else
 		return ..()
 
+
+/obj/item/storage/wallet/AltClick(mob/user)
+	if (user != loc || user.incapacitated() || !ishuman(user))
+		return ..()
+
+	var/obj/item/card/id/id = GetIdCard()
+	if (istype(id))
+		remove_from_storage(id)
+		user.put_in_hands(id)
+		return
+
+	return ..()
+
+
 /obj/item/storage/wallet/random/New()
 	..()
 	var/item1_type = pick( /obj/item/spacecash/bundle/c10,/obj/item/spacecash/bundle/c100,/obj/item/spacecash/bundle/c1000,/obj/item/spacecash/bundle/c20,/obj/item/spacecash/bundle/c200,/obj/item/spacecash/bundle/c50, /obj/item/spacecash/bundle/c500)


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: You can now remove ID cards from wallets with AltClick. This only works for human mobs, and only if you're holding or wearing the wallet.
/:cl: