### PR TITLE
Fixed a Typo

### DIFF
--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -23,7 +23,7 @@
 			sandwich_limit += 4
 
 	if(src.contents.len > sandwich_limit)
-		to_chat(user, "<span class='wwarning'>If you put anything else on \the [src] it's going to collapse.</span>")
+		to_chat(user, "<span class='warning'>If you put anything else on \the [src] it's going to collapse.</span>")
 		return
 	else if(istype(W,/obj/item/material/shard))
 		if(!user.unEquip(W, src))


### PR DESCRIPTION
:cl: Andischa
bugfix: Fixed a typo in a text-tag in the sandwich-system
/:cl:

Probably prevented the message for "too large sandwiches" being shown as a warning.
