### PR TITLE
add join_url, fix player panel wiki links

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -596,3 +596,28 @@ proc/TextPreview(var/string,var/len=40)
 			var/regex/matcher = entry[1]
 			message = replacetext_char(message, matcher, entry[2])
 	return message
+
+
+/**
+* Connects either a list or variadic arguments with "/" and cleans up multiple joins.
+* eg:
+*   join_url("a", "b", "c") => "a/b/c"
+*   join_url(list("a", "b", "c")) => "a/b/c"
+*   join_url("https://some.tld/", "/cats", "~", "//dogs") => "https://some.tld/cats/~/dogs"
+*/
+/proc/join_url()
+	var/len = length(args)
+	if (!len)
+		return ""
+	var/list/parts
+	if (len == 1)
+		if (!islist(args[1]))
+			parts = list(args[1])
+		else
+			parts = args[1]
+	else
+		parts = args
+	var/static/regex/clean1 = regex(@"\/\/+", "g") //Squash //+ to /
+	var/static/regex/clean2 = regex(@"^([^:]+:)\/([^\/])") //Fix "blah://" if we killed it in clean1
+	parts = replacetext_char(parts.Join("/"), clean1, "/")
+	return replacetext_char(parts, clean2, "$1//$2")

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -426,8 +426,13 @@
 		popup.open()
 
 	else if(href_list["job_wiki"])
+		if (!config.wiki_url)
+			return
 		var/rank = href_list["job_wiki"]
-		send_link(user,"[config.wiki_url][rank]")
+		var/datum/job/job = SSjobs.get_by_title(rank)
+		if (!job)
+			return
+		send_link(user, join_url(config.wiki_url, "roles", ckey(rank)))
 
 	return ..()
 


### PR DESCRIPTION
:cl:
bugfix: Character setup wiki links for occupations work again, where a page exists for the role.
/:cl:

Also moved all roles pages under /roles/ on the wiki to reduce link cruft.
