### PR TITLE
Don't display hear_sleep to deaf people

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -281,6 +281,8 @@
 	src.show_message(message)
 
 /mob/proc/hear_sleep(var/message)
+	if (is_deaf())
+		return
 	var/heard = ""
 	if(prob(15))
 		var/list/punctuation = list(",", "!", ".", ";", "?")


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Deaf mobs no longer see 'You hear something about' messages while asleep.
/:cl: