### PR TITLE
Transfer run_empty_levels to config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -438,6 +438,8 @@
 
 	var/static/hub_entry = "<b>$SERVER</b> by <b>$HOST</b> &#8212; $ACTIVES of $PLAYERS alive"
 
+	var/static/run_empty_levels = FALSE
+
 
 /configuration/New()
 	build_mode_cache()
@@ -859,6 +861,8 @@
 				warn_autoban_threshold = max(0, text2num(value))
 			if ("warn_autoban_duration")
 				warn_autoban_duration = max(1, text2num(value))
+			if ("run_empty_levels")
+				run_empty_levels = TRUE
 			else
 				log_misc("Unknown setting in config/config.txt: '[name]'")
 

--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -15,7 +15,6 @@ SUBSYSTEM_DEF(ai)
 	wait = 2 SECONDS
 	var/static/tmp/list/active = list()
 	var/static/tmp/list/queue = list()
-	var/static/tmp/run_empty_levels
 
 
 /datum/controller/subsystem/ai/stat_entry(text, force)
@@ -24,7 +23,7 @@ SUBSYSTEM_DEF(ai)
 		text = {"\
 			[text] | \
 			Active AI: [active.len] \
-			Run Empty Levels: [run_empty_levels ? "Y" : "N"]\
+			Run Empty Levels: [config.run_empty_levels ? "Y" : "N"]\
 		"}
 	..(text, force)
 
@@ -39,7 +38,7 @@ SUBSYSTEM_DEF(ai)
 			continue
 		if (!ai.holder)
 			continue
-		if (!run_empty_levels && !SSpresence.population(get_z(ai.holder)))
+		if (!config.run_empty_levels && !SSpresence.population(get_z(ai.holder)))
 			continue
 		ai.handle_strategicals()
 		if (no_mc_tick)
@@ -58,7 +57,6 @@ SUBSYSTEM_DEF(aifast)
 	wait = 0.25 SECONDS
 	var/static/tmp/list/active = list()
 	var/static/tmp/list/queue = list()
-	var/static/tmp/run_empty_levels
 
 
 /datum/controller/subsystem/aifast/stat_entry(text, force)
@@ -67,7 +65,7 @@ SUBSYSTEM_DEF(aifast)
 		text = {"\
 			[text] | \
 			Active AI: [active.len] \
-			Run Empty Levels: [run_empty_levels ? "Y" : "N"]\
+			Run Empty Levels: [config.run_empty_levels ? "Y" : "N"]\
 		"}
 	..(text, force)
 
@@ -82,7 +80,7 @@ SUBSYSTEM_DEF(aifast)
 			continue
 		if (!ai.holder)
 			continue
-		if (!run_empty_levels && !SSpresence.population(get_z(ai.holder)))
+		if (!config.run_empty_levels && !SSpresence.population(get_z(ai.holder)))
 			continue
 		ai.handle_tactics()
 		if (no_mc_tick)

--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -6,7 +6,6 @@ SUBSYSTEM_DEF(mobs)
 	wait = 2 SECONDS
 	var/static/tmp/list/mob_list = list()
 	var/static/tmp/list/queue = list()
-	var/static/tmp/run_empty_levels
 
 
 /datum/controller/subsystem/mobs/stat_entry(text, force)
@@ -15,7 +14,7 @@ SUBSYSTEM_DEF(mobs)
 		text = {"\
 			[text] | \
 			Mobs: [mob_list.len] \
-			Run Empty Levels: [run_empty_levels ? "Y" : "N"]\
+			Run Empty Levels: [config.run_empty_levels ? "Y" : "N"]\
 		"}
 	..(text, force)
 
@@ -32,7 +31,7 @@ SUBSYSTEM_DEF(mobs)
 		mob = queue[i]
 		if (QDELETED(mob))
 			continue
-		if (!run_empty_levels && !SSpresence.population(get_z(mob)))
+		if (!config.run_empty_levels && !SSpresence.population(get_z(mob)))
 			continue
 		mob.Life()
 		if (no_mc_tick)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -452,3 +452,7 @@ RADIATION_LOWER_LIMIT 0.15
 
 ## The length in minutes of an automatic ban created by passing the warning threshold.
 # WARN_AUTOBAN_DURATION 30
+
+## Uncomment this to bypass empty z-level checks in certain subsystems. For testing and development purposes only.
+## Not recommended for live use.
+#RUN_EMPTY_LEVELS


### PR DESCRIPTION
NUFC

I was originally going to make this set the local var for each subsystem on init, but it turns out config doesn't init until after subsystems. RIP.

This is for local testing QOL.