### PR TITLE
Fix runtime errors with accessory buttoning

### DIFF
--- a/code/modules/clothing/under/accessories/flannel_shirt.dm
+++ b/code/modules/clothing/under/accessories/flannel_shirt.dm
@@ -45,7 +45,7 @@
 		if (!F)
 			return
 	F.buttoned = !F.buttoned
-	to_chat(usr, "You [buttoned ? "button up" : "unbutton"] your [F.name].")
+	to_chat(usr, "You [F.buttoned ? "button up" : "unbutton"] your [F.name].")
 	F.queue_icon_update()
 
 
@@ -77,5 +77,5 @@
 		if (!F)
 			return
 	F.tucked = !F.tucked
-	to_chat(usr, "You [tucked ? "tuck in" : "untuck"] your [F.name].")
+	to_chat(usr, "You [F.tucked ? "tuck in" : "untuck"] your [F.name].")
 	F.queue_icon_update()


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Buttoning/rolling/etc accessories (I.e. flannel shirts) should now properly display the current rolled/buttoned/etc status when using the relevant verbs.
/:cl:

- closes #31236
- closes #31293