### PR TITLE
Removed duplicate example defines include

### DIFF
--- a/maps/example/map.dm
+++ b/maps/example/map.dm
@@ -1,2 +1,1 @@
 #include "example.dm"
-#include "example_define.dm"


### PR DESCRIPTION
NUFC

It's already included in the main maps file anyway.