### PR TITLE
Gives deuterium and tritium independent mass and capacity

### DIFF
--- a/code/modules/xgm/gases.dm
+++ b/code/modules/xgm/gases.dm
@@ -113,12 +113,16 @@
 /decl/xgm_gas/hydrogen/deuterium
 	id = GAS_DEUTERIUM
 	name = "Deuterium"
+	specific_heat = 80
+	molar_mass = 0.004
 	symbol_html = "D"
 	symbol = "D"
 
 /decl/xgm_gas/hydrogen/tritium
 	id = GAS_TRITIUM
 	name = "Tritium"
+	molar_mass = 0.006
+	specific_heat = 60
 	symbol_html = "T"
 	symbol = "T"
 


### PR DESCRIPTION
### Description
As stated above, this pull request gives deuterium and tritium gas their own mass and heat capacity because I felt that it didn't make sense that they inherited their mass and heat capacity from hydrogen. Admittedly, this is based on my own (limited) research, so the figures or concept may not even be correct.

🆑  karljohansson
tweak: Deuterium gas has a molar mass of 0.004
tweak: Deuterium gas has a heat capacity of 80
tweak: Tritium gas has a molar mass of 0.006
tweak: Tritium gas has a heat capacity of 60
tweak: The R-UST engine is slightly less energy efficient, more so using tritium based setups
/:cl:

