### PR TITLE
Reduces the speed/strength of gibber gibs

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -10,7 +10,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	
+
 	machine_name = "meat grinder"
 	machine_desc = "Messily turns animals - living or dead - into edible meat. Installed safety mechanisms prevent use on humans."
 
@@ -67,12 +67,12 @@
 	return 1
 
 /obj/machinery/gibber/components_are_accessible(path)
-	return !operating && ..()	
+	return !operating && ..()
 
 /obj/machinery/gibber/cannot_transition_to(state_path, mob/user)
 	if(operating)
 		return SPAN_NOTICE("You must wait for \the [src] to finish operating first!")
-	return ..()	
+	return ..()
 
 /obj/machinery/gibber/attackby(var/obj/item/W, var/mob/user)
 	if(!operating)
@@ -82,8 +82,8 @@
 		if(!G.force_danger())
 			to_chat(user, "<span class='danger'>You need a better grip to do that!</span>")
 			return
-		qdel(G)
 		move_into_gibber(user,G.affecting)
+		qdel(G)
 	else if(istype(W, /obj/item/organ))
 		if(!user.unEquip(W))
 			return
@@ -218,5 +218,5 @@
 			qdel(thing)
 			continue
 		thing.dropInto(loc) // Attempts to drop it onto the turf for throwing.
-		thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(0,3),emagged ? 100 : 50) // Being pelted with bits of meat and bone would hurt.
+		thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(0,3),emagged ? 30 : 15) // Being pelted with bits of meat and bone would hurt.
 	update_icon()


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: The meat grinder no longer ejects gibs at speeds strong enough to destroy walls.
/:cl:

New speed values are:
- If emagged, equivalent to the result of the `gib()` proc.
- If not emagged, equivalent to 1/2 the result of the `gib()` proc.

Issue report stuff:
- Fixes #31761 