### PR TITLE
Makes tilt not illegal

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -746,7 +746,7 @@
 
 /datum/reagent/tilt
 	name = "Tilt"
-	description = "A potent, illegal downer made from mixing cough medicine and Space-Up."
+	description = "A potent downer made from mixing cough medicine and Space-Up."
 	taste_description = "purple sweetness"
 	reagent_state = LIQUID
 	color = "#800080"


### PR DESCRIPTION
At Spook's request.

:cl: SierraKomodo
tweak: Tilt no longer claims to be illegal in its description.
/:cl:

No wiki update needed - This PR is to reflect what Spook put on the wiki.