### PR TITLE
Event stuff - Different ICCGN rank names, agent ID rank functionality

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -23,7 +23,8 @@
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/solgov,
 		/datum/mil_branch/alien,
-		/datum/mil_branch/skrell_fleet
+		/datum/mil_branch/skrell_fleet,
+		/datum/mil_branch/iccgn
 	)
 
 	species_to_branch_blacklist = list(

--- a/packs/faction_iccgn/faction.dm
+++ b/packs/faction_iccgn/faction.dm
@@ -14,155 +14,107 @@
 	rank_types = subtypesof(/datum/mil_rank/iccgn)
 	..()
 
+	spawn_rank_types = subtypesof(/datum/mil_rank/iccgn)
+	..()
+
 
 /datum/mil_rank/iccgn/e1
-	name = "Sailor Recruit"
-	name_short = "SlrRct"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e1
-	)
+	name = "Guardian Recruit"
+	name_short = "GRDR"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e1)
 	sort_order = 10
 
-
 /datum/mil_rank/iccgn/e3
-	name = "Sailor"
-	name_short = "Slr"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e3
-	)
-	sort_order = 30
-
+	name = "Guardian"
+	name_short = "GRD"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e3)
+	sort_order = 20
 
 /datum/mil_rank/iccgn/e4
-	name = "Bosman"
-	name_short = "Bsn"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e4
-	)
-	sort_order = 40
-
+	name = "Corporal"
+	name_short = "CPL"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e4)
+	sort_order = 30
 
 /datum/mil_rank/iccgn/e5
-	name = "Starszy Bosman"
-	name_short = "SBsn"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e5
-	)
+	name = "Star Corporal"
+	name_short = "SCPL"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e5)
+	sort_order = 40
+/datum/mil_rank/iccgn/e6
+	name = "Sergeant"
+	name_short = "SGT"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e6)
 	sort_order = 50
 
-
-/datum/mil_rank/iccgn/e6
-	name = "Serzhant"
-	name_short = "Szt"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e6
-	)
+/datum/mil_rank/iccgn/e7
+	name = "Laserey Sergeant"
+	name_short = "LsSGT"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e7)
 	sort_order = 60
 
-
-/datum/mil_rank/iccgn/e7
-	name = "Glavny Serzhant"
-	name_short = "GSzt"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e7
-	)
+/datum/mil_rank/iccgn/e8
+	name = "Master Sergeant"
+	name_short = "MSG"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e8)
 	sort_order = 70
 
-
-/datum/mil_rank/iccgn/e8
-	name = "Starshina"
-	name_short = "Str"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e8
-	)
-	sort_order = 80
-
-
 /datum/mil_rank/iccgn/e9
-	name = "Michman"
-	name_short = "Mch"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/e9
-	)
-	sort_order = 90
-
+	name = "Command Master Sergeant"
+	name_short = "CMS"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/e9)
+	sort_order = 80
 
 /datum/mil_rank/iccgn/o1
 	name = "Junker"
-	name_short = "Jkr"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o1
-	)
+	name_short = "JU"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o1)
 	sort_order = 110
 
-
 /datum/mil_rank/iccgn/o2
-	name = "Leytenant"
-	name_short = "Lyt"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o2
-	)
+	name = "Leftenant"
+	name_short = "LT"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o2)
 	sort_order = 120
 
-
 /datum/mil_rank/iccgn/o3
-	name = "Starshy Leytenant"
-	name_short = "SLyt"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o3
-	)
+	name = "Star Leftenant"
+	name_short = "SLT"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o3)
 	sort_order = 130
 
-
 /datum/mil_rank/iccgn/o4
-	name = "Sub-Komandor"
-	name_short = "SKdr"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o4
-	)
+	name = "Commander"
+	name_short = "CDR"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o4)
 	sort_order = 140
 
-
 /datum/mil_rank/iccgn/o5
-	name = "Komandor"
-	name_short = "Kdr"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o5
-	)
+	name = "Star Commander"
+	name_short = "SCDR"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o5)
 	sort_order = 150
 
-
 /datum/mil_rank/iccgn/o6
-	name = "Kapitan"
-	name_short = "Kpt"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o6
-	)
+	name = "Captain"
+	name_short = "CPT"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o6)
 	sort_order = 160
 
-
 /datum/mil_rank/iccgn/o7
-	name = "Starshy Kapitan"
-	name_short = "SKpt"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o7
-	)
+	name = "Star Captain"
+	name_short = "SCPT"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o7)
 	sort_order = 170
-
 
 /datum/mil_rank/iccgn/o8
 	name = "Vice-Admiral"
-	name_short = "VAdm"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o8
-	)
+	name_short = "VADM"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o8)
 	sort_order = 180
-
 
 /datum/mil_rank/iccgn/o9
 	name = "Admiral"
-	name_short = "Adm"
-	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/o9
-	)
+	name_short = "ADM"
+	accessory = list(/obj/item/clothing/accessory/iccgn_rank/o9)
 	sort_order = 190

--- a/packs/faction_iccgn/ranks.dm
+++ b/packs/faction_iccgn/ranks.dm
@@ -27,119 +27,119 @@
 
 
 /obj/item/clothing/accessory/iccgn_rank/e1
-	name = "rank insignia, E1 Sailor Recruit"
-	desc = "Collar tabs denoting the confederation navy E1 rank of Sailor Recruit."
+	name = "rank insignia, E1 Guardian Recruit"
+	desc = "Collar tabs that denote the Confederation Navy E1 rank of Guardian Recruit."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e3
-	name = "rank insignia, E3 Sailor"
-	desc = "Collar tabs denoting the confederation navy E3 rank of Sailor."
+	name = "rank insignia, E3 Guardian"
+	desc = "Collar tabs denoting the Confederation Navy E3 rank of Guardian."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e4
-	name = "rank insignia, E4 Bosman"
-	desc = "Collar tabs denoting the confederation navy E4 rank of Bosman."
+	name = "rank insignia, E4 Corporal"
+	desc = "Collar tabs denoting the Confederation Navy E4 rank of Corporal."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e5
-	name = "rank insignia, E5 Starszy Bosman"
-	desc = "Collar tabs denoting the confederation navy E5 rank of Starszy Bosman."
+	name = "rank insignia, E5 Star Corporal"
+	desc = "Collar tabs denoting the Confederation Navy E5 rank of Star Corporal."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e6
-	name = "rank insignia, E6 Serzhant"
-	desc = "Collar tabs denoting the confederation navy E6 rank of Serzhant."
+	name = "rank insignia, E6 Sergeant"
+	desc = "Collar tabs denoting the Confederation Navy E6 rank of Sergeant."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e7
-	name = "rank insignia, E7 Glavny Serzhant"
-	desc = "Collar tabs denoting the confederation navy E7 rank of Glavny Serzhant."
+	name = "rank insignia, E7 Laserey Sergeant"
+	desc = "Collar tabs denoting the Confederation Navy E7 rank of Laserey Sergeant."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e8
-	name = "rank insignia, E8 Starshina"
-	desc = "Collar tabs denoting the confederation navy E8 rank of Starshina."
+	name = "rank insignia, E8 Master Sergeant"
+	desc = "Collar tabs denoting the Confederation Navy E8 rank of Master Sergeant."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/e9
-	name = "rank insignia, E9 Michman"
-	desc = "Collar tabs denoting the confederation navy E9 rank of Michman."
+	name = "rank insignia, E9 Command Master Sergeant"
+	desc = "Collar tabs denoting the Confederation Navy E9 rank of Command Master Sergeant."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o1
 	name = "rank insignia, O1 Junker"
-	desc = "Collar tabs denoting the confederation navy O1 rank of Junker."
+	desc = "Collar tabs denoting the Confederation Navy O1 rank of Junker."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o2
-	name = "rank insignia, O2 Leytenant"
-	desc = "Collar tabs denoting the confederation navy O2 rank of Leytenant."
+	name = "rank insignia, O2 Leftenant"
+	desc = "Collar tabs denoting the Confederation Navy O2 rank of Leftenant."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o3
-	name = "rank insignia, O3 Starszy Leytenant"
-	desc = "Collar tabs denoting the confederation navy O3 rank of Starszy Leytenant."
+	name = "rank insignia, O3 Star Leftenant"
+	desc = "Collar tabs denoting the Confederation Navy O3 rank of Star Leftenant."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o4
-	name = "rank insignia, O4 Sub-Komandor"
-	desc = "Collar tabs denoting the confederation navy O4 rank of Sub-Komandor."
+	name = "rank insignia, O4 Commander"
+	desc = "Collar tabs denoting the Confederation Navy O4 rank of Commander."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o5
-	name = "rank insignia, O5 Komandor"
-	desc = "Collar tabs denoting the confederation navy O5 rank of Komandor."
+	name = "rank insignia, O5 Star Commander"
+	desc = "Collar tabs denoting the Confederation Navy O5 rank of Star Commander."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o6
-	name = "rank insignia, O6 Kapitan"
-	desc = "Collar tabs denoting the confederation navy O6 rank of Kapitan."
+	name = "rank insignia, O6 Captain"
+	desc = "Collar tabs denoting the Confederation Navy O6 rank of Captain."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o7
-	name = "rank insignia, O7 Starszy Kapitan"
-	desc = "Collar tabs denoting the confederation navy O7 rank of Starszy Kapitan."
+	name = "rank insignia, O7 Star Captain"
+	desc = "Collar tabs denoting the Confederation Navy O7 rank of Star Captain."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o8
 	name = "rank insignia, O8 Vice-Admiral"
-	desc = "Collar tabs denoting the confederation navy O8 rank of Vice-Admiral."
+	desc = "Collar tabs denoting the Confederation Navy O8 rank of Vice-Admiral."
 	icon_state = "officer"
 	overlay_state = "officer_worn"
 
 
 /obj/item/clothing/accessory/iccgn_rank/o9
 	name = "rank insignia, O9 Admiral"
-	desc = "Collar tabs denoting the confederation navy O9 rank of Admiral."
+	desc = "Collar tabs denoting the Confederation Navy O9 rank of Admiral."
 	icon_state = "officer"
 	overlay_state = "officer_worn"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

🆑
tweak: The ICCGN has different ranks, and now you can pick them on your Agent ID.
/🆑

So I'm not sure if this entirely lore-approved, but this is what I have and it's what I'm going to put up and yell at anyone but me, thank you.

Changes the ICCGN ranks to new, different ones for some reason, and does some code magic I don't fully understand to make them work with the Agent ID. I don't know, I didn't have time to test it, this is for the event which is starting in as of now 1 hour and 14 minutes.