### PR TITLE
Add extra specialised armour set to SecArm

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -11634,6 +11634,8 @@
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aOI" = (
@@ -20118,6 +20120,11 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/ballistic,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "jhq" = (
@@ -21692,6 +21699,11 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
+/obj/item/clothing/suit/armor/laserproof{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/ablative,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "lcL" = (


### PR DESCRIPTION
:cl:
maptweak: Add an extra special armour set to SecArm
/:cl:

multiple opinions later, SecArm now has two sets of riot, ballistic and ablative armour sets.