### PR TITLE
Frag grenade buffs

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -1,17 +1,18 @@
 /obj/item/projectile/bullet/pellet/fragment
-	damage = 7
+	damage = 30
 	range_step = 2 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
-	spread_step = 20
+	spread_step = 40
 
 	silenced = TRUE
 	fire_sound = null
 	no_attack_log = TRUE
 	muzzle_type = null
+	embed = TRUE
 
 /obj/item/projectile/bullet/pellet/fragment/strong
-	damage = 15
+	damage = 60
 
 /obj/item/grenade/frag
 	name = "fragmentation grenade"
@@ -50,6 +51,7 @@
 		var/obj/item/projectile/bullet/pellet/fragment/P = new fragment_type(T)
 		P.pellets = fragments_per_projectile
 		P.shot_from = src.name
+		P.hitchance_mod = 50
 
 		P.launch(O)
 
@@ -73,9 +75,7 @@
 				P.attack_mob(M, 0, 5)
 			else
 				P.attack_mob(M, 0, 50)
-
-
-
+		
 /obj/item/grenade/frag/proc/on_explosion(var/turf/O)
 	if(explosion_size)
 		explosion(O, -1, -1, explosion_size, round(explosion_size/2), 0)
@@ -97,7 +97,7 @@
 	throw_range = 5 //heavy, can't be thrown as far
 
 	fragment_types = list(/obj/item/projectile/bullet/pellet/fragment=1,/obj/item/projectile/bullet/pellet/fragment/strong=4)
-	num_fragments = 200  //total number of fragments produced by the grenade
+	num_fragments = 144  //total number of fragments produced by the grenade
 	explosion_size = 3
 
 /obj/item/grenade/frag/high_yield/on_explosion(var/turf/O)


### PR DESCRIPTION
Currently frag grenades suffer from multiple issues, they very unreliably are capable of hitting anyone and even when they do hit their low damage means they are almost never going to be able to pierce even thick clothing.

With these changes all types of fragmentation grenades now fill their intended purpose, being within a tile of an exploding grenade is likely to put you instantly into critical condition but with armor and distance you'll likely only take a few grazing hits.

The shrapnel was given some penetration so that it can challenge basic armor without shredding unarmored targets more than it already does. 
The values remain low enough that a medium plate will catch basically all of the incoming damage while the ballistic armor will make you more or less immune to (most) of a grenades effects (the explosion is still likely to knock you out for a few seconds)

Lastly, I gave shrapnel the ability to embed into targets so that targets in specialized armor still have to worry about embedded shrapnel into their exposed hands / feet. 

It's worth noting that if this is accepted, I'll PR an increase to the cost of fragmentation grenades and likely remove the free box that spawns in the merc base.

:cl: Kell-E
balance: All kinds of fragmentation grenades are now significantly more lethal
/:cl: