### PR TITLE
Let's the specialised arm/legguards be removed as well

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -354,6 +354,8 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 		)
+	flags_inv = CLOTHING_BULKY
+	slowdown_general = 1
 	siemens_coefficient = 0.5
 	accessories = list(/obj/item/clothing/accessory/arm_guards/riot, /obj/item/clothing/accessory/leg_guards/riot)
 
@@ -373,6 +375,8 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 		)
+	flags_inv = CLOTHING_BULKY
+	slowdown_general = 1
 	siemens_coefficient = 0.7
 	accessories = list(/obj/item/clothing/accessory/arm_guards/ballistic, /obj/item/clothing/accessory/leg_guards/ballistic)
 
@@ -394,6 +398,8 @@
 		laser = ARMOR_LASER_RIFLES,
 		energy = ARMOR_ENERGY_RESISTANT
 		)
+	flags_inv = CLOTHING_BULKY
+	slowdown_general = 1
 	siemens_coefficient = 0
 	accessories = list(/obj/item/clothing/accessory/arm_guards/ablative, /obj/item/clothing/accessory/leg_guards/ablative)
 

--- a/code/modules/clothing/under/accessories/arm_guards.dm
+++ b/code/modules/clothing/under/accessories/arm_guards.dm
@@ -67,7 +67,6 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 	siemens_coefficient = 0.5
-	accessory_flags = EMPTY_BITFIELD
 
 
 /obj/item/clothing/accessory/arm_guards/ballistic
@@ -82,7 +81,6 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 	siemens_coefficient = 0.7
-	accessory_flags = EMPTY_BITFIELD
 
 
 /obj/item/clothing/accessory/arm_guards/ablative
@@ -97,4 +95,3 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 	siemens_coefficient = 0
-	accessory_flags = EMPTY_BITFIELD

--- a/code/modules/clothing/under/accessories/leg_guards.dm
+++ b/code/modules/clothing/under/accessories/leg_guards.dm
@@ -64,8 +64,6 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 	siemens_coefficient = 0.5
-	slowdown = 1
-	accessory_flags = EMPTY_BITFIELD
 
 
 /obj/item/clothing/accessory/leg_guards/ballistic
@@ -80,8 +78,6 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 	siemens_coefficient = 0.7
-	slowdown = 1
-	accessory_flags = EMPTY_BITFIELD
 
 
 /obj/item/clothing/accessory/leg_guards/ablative
@@ -96,5 +92,3 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 	siemens_coefficient = 0
-	slowdown = 1
-	accessory_flags = EMPTY_BITFIELD


### PR DESCRIPTION
:cl: 
tweak: Allows the specialised arm/legguards to be removed and attached at will.
tweak: Removes slowdown from legguards, add slowdown to specialised plate carriers only.
/:cl:

For some reason, while the normal arm/leg guards could be attached and detached; the riot/ballistic/ablative ones could not be.
This lets them be attached and detached at will, as well.