### PR TITLE
adds "fun" -> "simulate distant explosion"

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -123,6 +123,7 @@ var/list/admin_verbs_fun = list(
 	/datum/admins/proc/call_supply_drop,
 	/datum/admins/proc/call_drop_pod,
 	/client/proc/create_dungeon,
+	/client/proc/cmd_admin_simulate_distant_explosion,
 	/datum/admins/proc/ai_hologram_set
 	)
 
@@ -250,6 +251,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_admin_add_random_ai_law,
 	/client/proc/cmd_admin_create_centcom_report,
 	/client/proc/toggle_random_events,
+	/client/proc/cmd_admin_simulate_distant_explosion,
 	/client/proc/cmd_admin_add_random_ai_law,
 	/datum/admins/proc/startnow,
 	/datum/admins/proc/restart,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -809,3 +809,67 @@ Ccomp's first proc.
 		config.allow_random_events = 0
 		to_chat(usr, "Random events disabled")
 		message_admins("Admin [key_name_admin(usr)] has disabled random events.", 1)
+
+
+/client/proc/cmd_admin_simulate_distant_explosion()
+	set category = "Fun"
+	set name = "Simulate Distant Explosion"
+	set desc = "Plays distant explosion audio and optionally causes players to fall over"
+	var/client/user = resolve_client()
+	if (!check_rights(R_ADMIN, TRUE, user))
+		return
+	var/mob/mob = user.mob
+	if (!mob || !isliving(mob) && !isobserver(mob))
+		to_chat(user, SPAN_WARNING("You must be in the game world to use this command."))
+		return
+	var/turf/turf = get_turf(mob)
+	if (!turf)
+		to_chat(user, SPAN_WARNING("You must be in the game world to use this command."))
+		return
+	var/list/levels = GetConnectedZlevels(turf.z)
+	if (!length(levels))
+		to_chat(user, SPAN_WARNING("No levels connected to this z-group."))
+		return
+	levels = sortList(levels)
+	var/mode
+	var/response = alert(user, "Players on levels [levels.Join(", ")] will be affected.\nShould they be knocked over?", "Simulate Distant Explosion", "Yes", "No", "Cancel")
+	if (!response || response == "Cancel")
+		return
+	if (response == "Yes")
+		response = alert(user, "Should all players be knocked down, or only unstable ones?", "Simulate Distant Explosion", "Unstable", "All", "Cancel")
+		if (!response || response == "Cancel")
+			return
+		if (response == "All")
+			mode = 2
+		else
+			mode = 1
+	var/affected = 0
+	var/floored = 0
+	for (mob as anything in GLOB.player_list)
+		var/living = isliving(mob)
+		if (!living && !isobserver(mob))
+			continue
+		turf = get_turf(mob)
+		if (!(turf?.z in levels))
+			continue
+		++affected
+		mob.playsound_local(mob, 'sound/effects/explosionfar.ogg', 15)
+		if (!mode)
+			continue
+		if (!living || !mob.can_be_floored())
+			continue
+		var/fall = mode
+		if (fall == 1)
+			var/since_move = world.time - mob.l_move_time
+			if (since_move > 5 SECONDS)
+				fall = prob(20)
+			else if (since_move > 3 SECONDS)
+				fall = MOVING_QUICKLY(mob) ? prob(75) : prob(20)
+			else
+				fall = MOVING_QUICKLY(mob) ? prob(75) : prob(50)
+		if (fall)
+			to_chat(mob, SPAN_DANGER("You stumble onto the floor from the shaking!"))
+			mob.AdjustWeakened(2)
+			mob.AdjustStunned(2)
+			++floored
+	log_and_message_admins("[key_name_admin(user)] simulated a distant explosion, affecting [affected] players and flooring [floored] on levels [levels.Join(", ")].")


### PR DESCRIPTION
:cl:
admin: Added Simulate Distant Explosion to the Fun tab. Plays the distant explosion sound for players in the admin's z group and optionally knocks them over.
/:cl:
