### PR TITLE
Medical uplink rebalancing

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -4,17 +4,17 @@
 /datum/uplink_item/item/medical
 	category = /datum/uplink_category/medical
 
-/datum/uplink_item/item/medical/sinpockets
-	name = "Box of Sin-Pockets"
-	desc = "A box of filled dough pockets. Great for a quick meal when you're hiding from Security. Instructions included on the box."
-	item_cost = 8
-	path = /obj/item/storage/box/sinpockets
+/datum/uplink_item/item/medical/combatstim
+	name = "Combat Stimulants"
+	desc = "A single use medical injector filled with performance enhancing drugs."
+	item_cost = 14
+	path = /obj/item/reagent_containers/hypospray/autoinjector/combatstim
 
 /datum/uplink_item/item/medical/stabilisation
-	name = "Stabilisation First Aid Kit"
-	desc = "Contains variety of emergency medical pouches."
+	name = "Slimline Stabilisation Kit"
+	desc = "A pocket sized medikit filled with lifesaving equipment."
 	item_cost = 16
-	path = /obj/item/storage/firstaid/stab
+	path = /obj/item/storage/firstaid/sleekstab
 
 /datum/uplink_item/item/medical/stasis
 	name = "Stasis Bag"
@@ -28,6 +28,12 @@
 	item_cost = 24
 	path = /obj/item/defibrillator/compact/combat/loaded
 
+/datum/uplink_item/item/medical/advancedmedibag
+	name = "Advanced medical toolkit"
+	desc = "A duffle bag containing a roller bed, syringes, health analyzer, health HUD, auto-compressor, auto-ressuscitator, nanoblood, an advanced fist-aid kit and a pair of nitrile gloves."
+	item_cost = 24
+	path = /obj/item/storage/backpack/dufflebag/syndie/med/full
+
 /datum/uplink_item/item/medical/surgery
 	name = "Surgery Kit"
 	desc = "Contains all the tools needed for on the spot surgery, assuming you actually know what you're doing with them. Floor sterilization not included."
@@ -39,15 +45,3 @@
 	desc = "Contains most medicines you need to recover from injuries and illnesses, all in a convenient pill form. Splints for broken bones also included!"
 	item_cost = 48
 	path = /obj/item/storage/firstaid/combat
-
-/datum/uplink_item/item/medical/scanner
-	name = "Health Scanner"
-	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
-	item_cost = 18
-	path = /obj/item/device/scanner/health
-
-/datum/uplink_item/item/medical/scanner
-	name = "Health HUD"
-	desc = "A heads-up display that scans the humans in view and provides accurate data about their health status."
-	item_cost = 18
-	path = /obj/item/clothing/glasses/hud/health

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -4,6 +4,12 @@
 /datum/uplink_item/item/medical
 	category = /datum/uplink_category/medical
 
+/datum/uplink_item/item/medical/sinpockets
+	name = "Box of Sin-Pockets"
+	desc = "A box of filled dough pockets. Great for a quick meal when you're hiding from Security. Instructions included on the box."
+	item_cost = 8
+	path = /obj/item/storage/box/sinpockets
+
 /datum/uplink_item/item/medical/combatstim
 	name = "Combat Stimulants"
 	desc = "A single use medical injector filled with performance enhancing drugs."

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -80,7 +80,7 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_compress)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_explosive)
 
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/sinpockets, reselect_propbability = 20)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/combatstim, reselect_propbability = 20)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/surgery, reselect_propbability = 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/combat, reselect_propbability = 10)
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -209,6 +209,19 @@
 	icon_state = "duffle_syndiemed"
 	item_state_slots = list(slot_l_hand_str = "duffle_syndiemed", slot_r_hand_str = "duffle_syndiemed")
 
+/obj/item/storage/backpack/dufflebag/syndie/med/full
+	startswith = list(
+		/obj/item/roller,
+		/obj/item/storage/box/syringes,
+		/obj/item/clothing/gloves/latex/nitrile,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/device/scanner/health,
+		/obj/item/auto_cpr,
+		/obj/item/defibrillator/loaded,
+		/obj/item/reagent_containers/ivbag/nanoblood,
+		/obj/item/storage/firstaid/adv
+	)
+
 /obj/item/storage/backpack/dufflebag/syndie/ammo
 	name = "ammunition dufflebag"
 	desc = "A large dufflebag for holding extra weapons ammunition and supplies."

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -133,7 +133,7 @@
 	desc = "A sleek and expensive looking medical kit."
 	icon_state = "stabfirstaid"
 	item_state = "firstaid-advanced"
-	w_class = 2
+	w_class = ITEM_SIZE_SMALL
 	storage_slots = 7
 
 	startswith = list(

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -128,6 +128,29 @@
 		/obj/item/storage/med_pouch/radiation,
 		)
 
+/obj/item/storage/firstaid/sleekstab
+	name = "Slimline stabilisation kit"
+	desc = "A sleek and expensive looking medical kit."
+	icon_state = "stabfirstaid"
+	item_state = "firstaid-advanced"
+	w_class = 2
+
+	startswith = list(
+		/obj/item/stack/medical/advanced/bruise_pack,
+		/obj/item/stack/medical/advanced/ointment,
+		/obj/item/reagent_containers/hypospray/autoinjector/coagulant, 
+		/obj/item/reagent_containers/hypospray/autoinjector/pain,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline,
+		/obj/item/reagent_containers/pill/inaprovaline,
+		/obj/item/reagent_containers/pill/dylovene,
+		/obj/item/reagent_containers/pill/dylovene,
+		/obj/item/reagent_containers/pill/hyronalin,
+		/obj/item/reagent_containers/pill/sugariron,
+		/obj/item/reagent_containers/pill/sugariron,
+		/obj/item/reagent_containers/pill/dexalin
+		)
+	
+
 /obj/item/storage/firstaid/surgery
 	name = "surgery kit"
 	desc = "Contains tools for surgery. Has precise foam fitting for safe transport and automatically sterilizes the content between uses."

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -134,18 +134,16 @@
 	icon_state = "stabfirstaid"
 	item_state = "firstaid-advanced"
 	w_class = 2
+	storage_slots = 7
 
 	startswith = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/coagulant,
-		/obj/item/reagent_containers/hypospray/autoinjector/pain,
 		/obj/item/reagent_containers/hypospray/autoinjector/pain,
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline,
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 		/obj/item/reagent_containers/hypospray/autoinjector/dexalin_plus,
-		/obj/item/reagent_containers/hypospray/autoinjector/dexalin_plus,
 		/obj/item/reagent_containers/hypospray/autoinjector/detox,
-		/obj/item/reagent_containers/hypospray/autoinjector/detox
 		)
 	
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -136,18 +136,16 @@
 	w_class = 2
 
 	startswith = list(
-		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/stack/medical/advanced/ointment,
-		/obj/item/reagent_containers/hypospray/autoinjector/coagulant, 
+		/obj/item/reagent_containers/hypospray/autoinjector/coagulant,
+		/obj/item/reagent_containers/hypospray/autoinjector/pain,
 		/obj/item/reagent_containers/hypospray/autoinjector/pain,
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline,
-		/obj/item/reagent_containers/pill/inaprovaline,
-		/obj/item/reagent_containers/pill/dylovene,
-		/obj/item/reagent_containers/pill/dylovene,
-		/obj/item/reagent_containers/pill/hyronalin,
-		/obj/item/reagent_containers/pill/sugariron,
-		/obj/item/reagent_containers/pill/sugariron,
-		/obj/item/reagent_containers/pill/dexalin
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
+		/obj/item/reagent_containers/hypospray/autoinjector/dexalin_plus,
+		/obj/item/reagent_containers/hypospray/autoinjector/dexalin_plus,
+		/obj/item/reagent_containers/hypospray/autoinjector/detox,
+		/obj/item/reagent_containers/hypospray/autoinjector/detox
 		)
 	
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1030,7 +1030,7 @@
 	color = "#bf0000"
 	metabolism = REM * 0.05
 
-/datum/reagent/coagulant/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/coagulant/affect_blood(var/mob/living/carbon/M, alien, removed)
 	if(alien == IS_DIONA)
 		return
 	if(ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1021,3 +1021,24 @@
 	..()
 	M.add_chemical_effect(CE_TOXIN, 1)
 	M.immunity -= 0.5 //inverse effects when abused
+	
+/datum/reagent/coagulant
+	name = "Coagulant"
+	description = "An experimental coagulant capable of staunching both internal and external bleeding."
+	taste_description = "iron"
+	reagent_state = LIQUID
+	color = "#bf0000"
+	metabolism = REM * 0.05
+
+/datum/reagent/coagulant/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	if(ishuman(M))
+		for(var/obj/item/organ/external/E in M.organs)
+			if(E.status & ORGAN_ARTERY_CUT && prob(10))
+				E.status &= ~ORGAN_ARTERY_CUT
+			for(var/datum/wound/W in E.wounds)
+				if(W.bleeding() && prob(20))
+					W.bleed_timer = 0
+					W.clamped = TRUE
+					E.status &= ~ORGAN_BLEEDING

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -223,6 +223,18 @@
 	band_color = COLOR_DARK_GRAY
 	starts_with = list(/datum/reagent/mindbreaker = 5)
 
+/obj/item/reagent_containers/hypospray/autoinjector/combatstim
+	name ="autoinjector (combat Stimulants)"
+	band_color = COLOR_RED
+	volume = 15
+	amount_per_transfer_from_this = 15
+	starts_with = list(/datum/reagent/inaprovaline = 10, /datum/reagent/hyperzine = 3, /datum/reagent/synaptizine = 1)
+
+/obj/item/reagent_containers/hypospray/autoinjector/coagulant
+	name ="autoinjector (coagulant)"
+	band_color = COLOR_RED
+	starts_with = list(/datum/reagent/coagulant = 1, /datum/reagent/nanoblood = 4)
+
 /obj/item/reagent_containers/hypospray/autoinjector/empty
 	name = "autoinjector"
 	band_color = COLOR_WHITE


### PR DESCRIPTION
The medical uplink had a large number of items that had little to no realistic use cases and lacked many of the important tools required to be able to actually perform the role of medical technician while playing as part of a group.

The goal was to squish the number of available items but increase the usability of the ones that remained and in some cases (sinpockets) replace them with a less fiddly alternative.

First in the list of changes I removed sin pockets and replaced them with a single use injector filled with hyperzine (3u), synaptizine (1u) and inaprovaline (10u).  The injector doesn't facilitate pain immunity alone and instead serves to enhance an antagonists options when it comes to fight or flight, but by no means will it provide them with the ability to ignore incoming fire.

Edit: Some people have pointed out that sinpockets are the only reliable method of healing organ damage as an antagonist, I'm not super huge on how well they perform but it'd be potentially a bit much to remove them without an alternative.

Next up I replaced the stabilization kit with an upgraded slimline version, the slimline can fit into a pocket and takes up much less room in a bag.
The slimline stabilization kit also has an upgraded selection of tools with a focus on allowing an unskilled character to perform emergency first aid in any number of potential situations. It contains
- 1x Advanced trauma kit
- 1x Advanced burn kit
- 1x Coagulant*
- 1x Autoinjector (Painkiller) 
- 1x Autoinjector (Adrenaline)
- 1x Inaprovaline pill (30u)
- 2x Dylovene pill (15u)
- 1x Hyronalin pill (7u)
- 2x Sugar iron pill (10u)
- 1x Dexalin pill (15u)
Cost: 16 TC (Unchanged)

*The coagulant injector contains 1u of coagulant and 4u of nanoblood, the coagulant will have a reasonably high chance to heal any internal and external bleeding. Coagulant has no method of creation outside of appearing inside of these autoinjectors.

Lastly I removed the health HUD and scanner from the uplink, the individual items cost more than they really should have been valued at and largely bloated the list of objects.

In their place I've added a new "Advanced medical toolkit" which contains the following
- 1x Roller bed
- 1s Box of syringes
- 1x Health HUD
- 1x Health Scanner
- 1x Auto-resuscitator
- 1x Auto-compressor
- 1x Nanoblood IV Bag
- 1x Advanced first-aid kit
- 1x Nitrile Gloves
Cost: 24 TC

Overall my goal was to improve the quality of available tools without merely making them more powerful, providing options to antagonists so that they can fulfill various roles without resorting to stealing to obtain some of the more basic (and often required) tools.

🆑 Kell-E
rscadd: Added a stimulant autoinjector to the uplink (Cost: 14)
rscadd: Added coagulant (Cannot be created at this time, but does appear in coagulant autoinjectors). Coagulant can staunch internal and external bleeding.
balance: Improved the stabilization kit available in the uplink, it now takes up much less space, fits into a pocket and has had the quality of it's contents improved. Includes one coagulant autoinjector.
rscdel: Removed the medical HUD from the uplink
rscdel: Removed the medical scanner from the uplink
rscadd: Added an advanced medical toolkit to the uplink, contains a large number of medical tools including a HUD, scanner, rollerbed, auto-resuscitator, auto-compressor, nanoblood IV bag, advanced first-aid kit, nitrile gloves and a box of syringes. (Cost: 24)
/🆑 