### PR TITLE
removes the global pass proc

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1118,8 +1118,6 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 /proc/crash_at(msg, file, line)
 	CRASH("%% [file],[line] %% [msg]")
 
-/proc/pass()
-	return
 
 //clicking to move pulled objects onto assignee's turf/loc
 /proc/do_pull_click(mob/user, atom/A)


### PR DESCRIPTION
`/proc/pass()` and `/datum/unit_test/proc/pass()` shared a simple ambiguous name. The global proc is unused.