### PR TITLE
Bullet Scatter, take two

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -168,20 +168,18 @@ var/list/global/organ_rel_size = list(
 		for(var/obj/item/grab/G in target.grabbed_by)
 			if(G.stop_move())
 				return zone
-
+				
 	var/miss_chance = 10
-	var/scatter_chance
 	if (zone in base_miss_chance)
 		miss_chance = base_miss_chance[zone]
 	miss_chance = max(miss_chance + miss_chance_mod, 0)
-	scatter_chance = min(95, miss_chance + 60)
 	if(prob(miss_chance))
-		if(ranged_attack && prob(scatter_chance))
-			return null
-		else if(prob(70))
-			return null
-		return (ran_zone())
-	return zone
+		return null
+	else 
+		if (prob(miss_chance))
+			return (ran_zone())
+		else
+			return zone
 
 //Replaces some of the characters with *, used in whispers. pr = probability of no star.
 //Will try to preserve HTML formatting. re_encode controls whether the returned text is HTML encoded outside tags.


### PR DESCRIPTION
Prior to this change bullets could scatter and strike the target in a random location in theory but in order for that to happen the following conditions had to be met

You had to miss your attack
You had to fail to scatter (Usually a 5% chance to avoid this roll)
You had to fail to roll a 70% random probability
This gives us 30% of 5% chance for a bullet that missed to hit a target but not in the chosen location for the shot. I'd imagine the actual odds of this happening are sub 1% once you factor in the hit/miss chance.

With this change in order for a bullet to scatter the following conditions must be met

Your attack must hit your target
Your attack must then roll a miss on a second roll, the attack will continue to strike the target but now it'll be in a random location.
This means that inaccurate fire is more likely to strike the target in random locations but accurate shots remain accurate.

Why? Because guns as they currently exist are essentially binary, there's little point wearing any armor on your limbs because hitting those locations is quite unlikely.
This change makes it so that limb armor is far more useful and it's no longer an easy choice to remove it (especially in cases where it added slowdown)

🆑 Kell-E
balance: Inaccurate shots are more likely to scatter and hit random locations upon their victim rather than their intended target.
/🆑