### PR TITLE
Nerfs the marksman rifle

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -140,7 +140,7 @@ obj/item/gun/energy/retro
 	one_hand_penalty = 5 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
 	slot_flags = SLOT_BACK
 	charge_cost = 40
-	max_shots = 4
+	max_shots = 8
 	fire_delay = 35
 	force = 10
 	w_class = ITEM_SIZE_HUGE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -168,9 +168,6 @@
 	fire_sound = 'sound/weapons/marauder.ogg'
 	damage = 50
 	armor_penetration = 10
-	stun = 3
-	weaken = 3
-	stutter = 3
 
 	muzzle_type = /obj/effect/projectile/laser/xray/muzzle
 	tracer_type = /obj/effect/projectile/laser/xray/tracer


### PR DESCRIPTION
Removes the marksman rifles ability to instantly and reliably floor someone and instead doubles the ammo capacity it carries.

🆑 Kell-E
balance: Removes the marksman energy rifles ability to instantly knockdown it's victims
balance: Increases the number of shots the marksman energy rifle has from 4 to 8
/🆑 