### PR TITLE
uses generic shields svg for license button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Baystation [![GitHub](https://img.shields.io/github/license/baystation12/baystation12)](https://opensource.org/licenses/AGPL-3.0) [![CI Status](https://github.com/Baystation12/Baystation12/workflows/Run%20Tests/badge.svg)](https://github.com/baystation12/baystation12/actions) [![codebeat badge](https://codebeat.co/badges/8ecb9a34-1bab-4d80-b34d-b16e8b216a03)](https://codebeat.co/projects/github-com-baystation12-baystation12-dev)
+# Baystation [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3.0-orange.svg)](https://opensource.org/licenses/AGPL-3.0) [![CI Status](https://github.com/Baystation12/Baystation12/workflows/Run%20Tests/badge.svg)](https://github.com/baystation12/baystation12/actions) [![codebeat badge](https://codebeat.co/badges/8ecb9a34-1bab-4d80-b34d-b16e8b216a03)](https://codebeat.co/projects/github-com-baystation12-baystation12-dev)
 
 [Website](https://bay.ss13.me) - [Discord](https://bay.ss13.me/discord) - [Code](https://github.com/baystation12/baystation12) - [DMDoc](https://doc.ss13.me)
 


### PR DESCRIPTION
I forget why it had the snowflake link, but this one encodes the presentation into the url instead.

Usage: <https://github.com/Spookerton/baystation12/tree/spkrtn/sys/unweird-license-button#readme>