### PR TITLE
mixed fixes

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -141,7 +141,7 @@
 
 
 /// A circular random coordinate pair from 0, unit by default, scaled by radius, then rounded if round.
-/proc/Crand(radius = 1, round)
+/proc/CircularRandomCoordinate(radius = 1, round)
 	var/angle = rand(0, 359)
 	var/x = cos(angle) * radius
 	var/y = sin(angle) * radius
@@ -149,6 +149,7 @@
 		x = Round(x)
 		y = Round(y)
 	return list(x, y)
+
 
 /**
 * A circular random coordinate with radius on center_x, center_y,
@@ -160,10 +161,10 @@
 * in box constraint
 *
 * A "donut" pattern can be achieved by varying the number supplied as
-* radius outside the scope of the proc, eg as BCrand(Frand(1, 3), ...)
+* radius outside the scope of the proc, eg as BoundedCircularRandomCoordinate(Frand(1, 3), ...)
 */
-/proc/BCrand(radius, center_x, center_y, low_x, low_y, high_x, high_y, round)
-	var/list/xy = Crand(radius, round)
+/proc/BoundedCircularRandomCoordinate(radius, center_x, center_y, low_x, low_y, high_x, high_y, round)
+	var/list/xy = CircularRandomCoordinate(radius, round)
 	var/dx = xy[1]
 	var/dy = xy[2]
 	var/x = center_x + dx
@@ -177,6 +178,17 @@
 		clamp(y, low_y, high_y)
 	)
 
+
+/// Pick a random turf using BoundedCircularRandomCoordinate about x,y on level z
+/proc/CircularRandomTurf(radius, z, center_x, center_y, low_x = 1, low_y = 1, high_x = world.maxx, high_y = world.maxy)
+	var/list/xy = BoundedCircularRandomCoordinate(radius, center_x, center_y, low_x, low_y, high_x, high_y, TRUE)
+	return locate(xy[1], xy[2], z)
+
+
+/// Pick a random turf using BoundedCircularRandomCoordinate around the turf of target
+/proc/CircularRandomTurfAround(atom/target, radius, low_x = 1, low_y = 1, high_x = world.maxx, high_y = world.maxy)
+	var/turf/turf = get_turf(target)
+	return CircularRandomTurf(radius, turf.z, turf.x, turf.y, low_x, low_y, high_x, high_y)
 
 
 /// Returns the angle of the matrix according to atan2 on the b, a parts

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -33,7 +33,7 @@ var/const/NEGATIVE_INFINITY = -1#INF // win: -1.#INF, lin: -inf
 
 #define isairlock(A) istype(A, /obj/machinery/door/airlock)
 
-#define isatom(A) isloc(A)
+#define isatom(A) (ismovable(A) || isturf(A))
 
 #define isbrain(A) istype(A, /mob/living/carbon/brain)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -30,27 +30,22 @@
 /atom/movable/Destroy()
 	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
 		crash_with("Was deleted before initalization")
-
+	walk(src, 0)
 	for(var/A in src)
 		qdel(A)
-
 	forceMove(null)
 	if (pulledby)
 		if (pulledby.pulling == src)
 			pulledby.pulling = null
 		pulledby = null
-
 	if(LAZYLEN(movement_handlers) && !ispath(movement_handlers[1]))
 		QDEL_NULL_LIST(movement_handlers)
-
 	if (bound_overlay)
 		QDEL_NULL(bound_overlay)
-
 	if(virtual_mob && !ispath(virtual_mob))
 		qdel(virtual_mob)
 		virtual_mob = null
-
-	. = ..()
+	return ..()
 
 /atom/movable/Bump(var/atom/A, yes)
 	if(!QDELETED(throwing))

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -34,7 +34,6 @@
 		walk_to(src, destination)
 
 /obj/effect/effect/smoke/chem/Destroy()
-	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	set_opacity(0)
 	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
 	fadeOut()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -187,7 +187,6 @@
 	if(dormant)
 		GLOB.moved_event.unregister(src, src, /obj/effect/spider/spiderling/proc/disturbed)
 	STOP_PROCESSING(SSobj, src)
-	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	. = ..()
 
 /obj/effect/spider/spiderling/attackby(var/obj/item/W, var/mob/user)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -79,9 +79,6 @@
 		if (M.ear_damage >= 5)
 			to_chat(M, "<span class='danger'>Your ears start to ring!</span>")
 
-/obj/item/grenade/flashbang/Destroy()
-	walk(src, 0) // Because we might have called walk_away, we must stop the walk loop or BYOND keeps an internal reference to us forever.
-	return ..()
 
 /obj/item/grenade/flashbang/instant/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -91,11 +91,22 @@
 				check -= picked
 			return
 
-// Preset types - left here for the code that uses them
-/obj/item/material/shard/phoron/New(loc)
-	..(loc, MATERIAL_PHORON_GLASS)
 
-/obj/item/material/shard/shrapnel
-	name = "shrapnel"
-	default_material = MATERIAL_STEEL
-	w_class = ITEM_SIZE_TINY	//it's real small
+/obj/item/material/shard/phoron/default_material = MATERIAL_PHORON_GLASS
+
+
+/obj/item/material/shard/shrapnel/name = "shrapnel"
+/obj/item/material/shard/shrapnel/w_class = ITEM_SIZE_TINY
+/obj/item/material/shard/shrapnel/item_flags = EMPTY_BITFIELD
+
+
+/obj/item/material/shard/shrapnel/steel/default_material = MATERIAL_STEEL
+
+
+/obj/item/material/shard/shrapnel/titanium/default_material = MATERIAL_TITANIUM
+
+
+/obj/item/material/shard/shrapnel/aluminium/default_material = MATERIAL_ALUMINIUM
+
+
+/obj/item/material/shard/shrapnel/copper/default_material = MATERIAL_COPPER

--- a/code/modules/ai/say_list.dm
+++ b/code/modules/ai/say_list.dm
@@ -75,21 +75,6 @@
 	threaten_sound = 'sound/weapons/TargetOn.ogg'
 	stand_down_sound = 'sound/weapons/TargetOff.ogg'
 
-/datum/say_list/malf_drone
-	speak = list("ALERT.","Hostile-ile-ile entities dee-twhoooo-wected.","Threat parameterszzzz- szzet.","Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")
-	emote_see = list("beeps menacingly","whirrs threateningly","scans its immediate vicinity")
-
-	say_understood = list("Affirmative.", "Positive.")
-	say_cannot = list("Denied.", "Negative.")
-	say_maybe_target = list("Possible threat detected. Investigating.", "Motion detected.", "Investigating.")
-	say_got_target = list("Threat detected.", "New task: Remove threat.", "Threat removal engaged.", "Engaging target.")
-	say_threaten = list("Motion detected, judging target...")
-	say_stand_down = list("Visual lost.", "Error: Target not found.")
-	say_escalate = list("Viable target found. Removing.", "Engaging target.", "Target judgement complete. Removal required.")
-
-	threaten_sound = 'sound/effects/turret/move1.wav'
-	stand_down_sound = 'sound/effects/turret/move2.wav'
-
 /datum/say_list/crab
 	emote_hear = list("clicks")
 	emote_see = list("clacks")

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -165,9 +165,7 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 				var/turf/MT = get_turf(M)
 				if (MT)
 					if (istype(chosen_planet, /obj/effect/overmap/visitable/sector/exoplanet))
-						var/obj/effect/overmap/visitable/sector/exoplanet/E = chosen_planet
-						var/list/offset = BCrand(Frand(3, 5), MT.x, MT.y, 0, 0, E.maxx, E.maxy, TRUE)
-						T = locate(offset[1], offset[2], MT.z)
+						T = CircularRandomTurfAround(MT, Frand(3, 5))
 				else
 					T = pick(area_turfs)
 			else

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -220,7 +220,7 @@
 	var/list/shrapnel = list()
 
 	for(var/I = 3, I<3 , I++) //Toolbox shatters.
-		shrapnel += new /obj/item/material/shard/shrapnel(Tsec)
+		shrapnel += new /obj/item/material/shard/shrapnel/steel(Tsec)
 
 	for(var/Amt = amount, Amt>0, Amt--) //Why not just spit them out in a disorganized jumble?
 		shrapnel += new /obj/item/stack/tile/floor(Tsec)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -1,13 +1,10 @@
-
-//malfunctioning combat drones
 /mob/living/simple_animal/hostile/retaliate/malf_drone
 	name = "combat drone"
 	desc = "An automated combat drone armed with state of the art weaponry and shielding."
 	icon_state = "drone"
 	icon_living = "drone"
 	icon_dead = "drone_dead"
-	ranged = 1
-	rapid = 0
+	ranged = TRUE
 	turns_per_move = 3
 	response_help = "pokes"
 	response_disarm = "gently pushes aside"
@@ -21,80 +18,54 @@
 	projectiletype = /obj/item/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
 	destroy_surroundings = 0
-
-	meat_type =     null
-	meat_amount =   0
+	meat_type = null
+	meat_amount = 0
 	bone_material = null
-	bone_amount =   0
+	bone_amount = 0
 	skin_material = null
-	skin_amount =   0
-
+	skin_amount = 0
 	ai_holder = /datum/ai_holder/simple_animal/ranged/pointblank/malf_drone
-
-	var/datum/effect/effect/system/trail/ion_trail
-
-	//the drone randomly switches between these states if it's malfunctioning
-	var/malfunctioning = 1
-	var/hostile_drone = 0
-	//0 - retaliate, only attack enemies that attack it
-	//1 - hostile, attack everything that comes near
-	var/hostile_range = 10
-
-	var/turf/patrol_target
-	var/explode_chance = 1
-	var/disabled = 0
-	var/exploding = 0
-
-	//Drones aren't affected by atmos.
+	say_list_type = /datum/say_list/malf_drone
 	min_gas = null
 	max_gas = null
 	minbodytemp = 0
-
-	var/has_loot = 1
 	faction = "malf_drone"
 
-/datum/ai_holder/simple_animal/melee/malf_drone
+	var/datum/effect/effect/system/trail = /datum/effect/effect/system/trail/ion
+	var/malfunctioning = TRUE
+	var/hostile = FALSE
+	var/hostile_drone = FALSE
+	var/hostile_range = 10
+	var/explode_chance = 1
+	var/exploding = FALSE
+	var/disabled = 0
+	var/has_loot = TRUE
 
-/datum/ai_holder/simple_animal/melee/malf_drone/list_targets()
-	. = ..()
 
-	var/mob/living/simple_animal/hostile/retaliate/malf_drone/D = holder
-	if(D.hostile_drone)
-		var/list/targets = list()
-		for (var/mob/M in view(src, D.hostile_range))
-			if (M == src || istype(M, /mob/living/simple_animal/hostile/retaliate/malf_drone))
-				continue
-			targets |= M
+/mob/living/simple_animal/hostile/retaliate/malf_drone/Destroy()
+	QDEL_NULL(trail)
+	return ..()
 
-		return targets
-	else
-		return ..()
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Initialize()
 	. = ..()
-	if(prob(5))
+	if (prob(50))
 		projectiletype = /obj/item/projectile/beam/pulse/drone
 		projectilesound = 'sound/weapons/pulse2.ogg'
-	ion_trail = new /datum/effect/effect/system/trail/ion()
-	ion_trail.set_up(src)
-	ion_trail.start()
+	if (ispath(trail))
+		trail = new trail
+		trail.set_up(src)
+		trail.start()
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(var/check_drift = 0)
-	return 1
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/proc/Haywire()
-	if(prob(disabled ? 0 : 1) && malfunctioning)
-		if(hostile_drone)
-			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] retracts several targetting vanes, and dulls it's running lights.</span>")
-			hostile_drone = 0
-		else
-			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly lights up, and additional targetting vanes slide into place.</span>")
-			hostile_drone = 1
+/mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(check_drift)
+	return TRUE
 
-//self repair systems have a chance to bring the drone back to life
+
 /mob/living/simple_animal/hostile/retaliate/malf_drone/Life()
-
-	//emps and lots of damage can temporarily shut us down
+	. = ..()
+	if (!.)
+		return
 	if(disabled > 0)
 		set_stat(UNCONSCIOUS)
 		icon_state = "[initial(icon_state)]_dead"
@@ -106,198 +77,203 @@
 			icon_state = "[initial(icon_state)]0"
 			set_wander (TRUE)
 			ai_holder.speak_chance = 5
-
-	//repair a bit of damage
-	if(prob(1))
-		src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] shudders and shakes as some of it's damaged systems come back online.</span>")
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
-		health += rand(25,100)
-
-	//spark for no reason
-	if(prob(5))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
-
-	//sometimes our targetting sensors malfunction, and we attack anyone nearby
-	Haywire()
-
-	if(health / maxHealth > 0.9)
+	var/sparked = FALSE
+	if (prob(1))
+		sparked = TRUE
+		visible_message(SPAN_WARNING("\The [src] shudders and shakes."))
+		var/datum/effect/effect/system/spark_spread/sparks = new
+		sparks.set_up(3, 1, src)
+		sparks.start()
+		health += rand(25, 50)
+	if (!sparked && prob(5))
+		sparked = TRUE
+		var/datum/effect/effect/system/spark_spread/sparks = new
+		sparks.set_up(3, 1, src)
+		sparks.start()
+	if (malfunctioning && prob(disabled ? 0 : 1))
+		hostile_drone = !hostile_drone
+		if (hostile_drone)
+			visible_message(SPAN_WARNING("\The [src] suddenly lights up with activity, searching for targets."))
+		else
+			visible_message(SPAN_WARNING("\The [src] dulls its running lights, becoming passive."))
+	if (health / maxHealth > 0.9)
 		icon_state = "[initial(icon_state)]"
 		explode_chance = 0
-	else if(health / maxHealth > 0.7)
+	else if (health / maxHealth > 0.7)
 		icon_state = "[initial(icon_state)]2"
 		explode_chance = 0
-	else if(health / maxHealth > 0.5)
+	else if (health / maxHealth > 0.5)
 		icon_state = "[initial(icon_state)]1"
 		explode_chance = 0.5
-	else if(health / maxHealth > 0.3)
+	else if (health / maxHealth > 0.3)
 		icon_state = "[initial(icon_state)]0"
 		explode_chance = 5
-	else if(health > 0)
-		//if health gets too low, shut down
+	else if (health > 0)
 		icon_state = "[initial(icon_state)]_dead"
-		exploding = 0
-		if(!disabled)
-			if(prob(50))
-				src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly shuts down!</span>")
-			else
-				src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly lies still and quiet.</span>")
+		exploding = FALSE
+		if (!disabled)
+			visible_message(SPAN_WARNING("\The [src] suddenly goes still and quiet."))
 			disabled = rand(150, 600)
-			walk(src,0)
-
-	if(exploding && prob(20))
-		if(prob(50))
-			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] begins to spark and shake violenty!</span>")
-		else
-			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] sparks and shakes like it's about to explode!</span>")
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
-
-	if(!exploding && !disabled && prob(explode_chance))
-		exploding = 1
+			walk(src, 0)
+	if (exploding && prob(20))
+		visible_message(SPAN_WARNING("\The [src] begins to spark and shake violently!"))
+		if (!sparked)
+			var/datum/effect/effect/system/spark_spread/sparks = new
+			sparks.set_up(3, 1, src)
+			sparks.start()
+	if (!exploding && !disabled && prob(explode_chance))
+		exploding = TRUE
 		set_stat(UNCONSCIOUS)
 		set_wander(TRUE)
-		walk(src,0)
-		spawn(rand(50,150))
-			if(!disabled && exploding)
-				explosion(get_turf(src), 0, 1, 4, 7)
-				death()
-	..()
+		walk(src, 0)
+		if (!disabled && exploding)
+			explosion(get_turf(src), 0, 1, 4, 7)
+			death()
 
-//ion rifle!
+
 /mob/living/simple_animal/hostile/retaliate/malf_drone/emp_act(severity)
-	health -= rand(3,15) * (severity + 1)
+	health -= rand(3, 15) * (severity + 1)
 	disabled = rand(150, 600)
-	hostile_drone = 0
-	walk(src,0)
+	hostile_drone = FALSE
+	walk(src, 0)
+
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/death()
-	..(null,"suddenly breaks apart.", "You have been destroyed.")
+	..(FALSE, "suddenly breaks apart.", "You have been destroyed.")
+	if (has_loot)
+		var/turf/origin = get_turf(src)
+		if (origin)
+			var/datum/effect/effect/system/spark_spread/sparks = new
+			sparks.set_up(3, 1, origin)
+			sparks.start()
+			var/list/loot = list()
+			for (var/i = rand(1, 2) to 1 step -1)
+				loot += new /obj/item/material/shard/shrapnel/steel (origin)
+			for (var/i = rand(1, 2) to 1 step -1)
+				loot += new /obj/item/material/shard/shrapnel/aluminium (origin)
+			if (prob(50))
+				loot += new /obj/item/material/shard/shrapnel/titanium (origin)
+			if (prob(50))
+				loot += new /obj/item/material/shard/shrapnel/copper (origin)
+			for (var/i = rand(1, 3) to 1 step -1)
+				loot += new /obj/item/drone_loot_board (origin)
+			var/strength = exploding ? 1 : 0.5
+			for (var/obj/item/item as anything in loot)
+				item.throw_at(CircularRandomTurfAround(origin, Frand(2, 6) * strength), 5, 5 * strength)
 	qdel(src)
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Destroy()
-	//some random debris left behind
-	if(has_loot)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
-		var/obj/O
 
-		//shards
-		O = new /obj/item/material/shard(src.loc)
-		step_to(O, get_turf(pick(view(7, src))))
-		if(prob(75))
-			O = new /obj/item/material/shard(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(50))
-			O = new /obj/item/material/shard(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(25))
-			O = new /obj/item/material/shard(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
 
-		//rods
-		O = new /obj/item/stack/material/rods(loc)
-		step_to(O, get_turf(pick(view(7, src))))
-		if(prob(75))
-			O = new /obj/item/stack/material/rods(loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(50))
-			O = new /obj/item/stack/material/rods(loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(25))
-			O = new /obj/item/stack/material/rods(loc)
-			step_to(O, get_turf(pick(view(7, src))))
 
-		//plasteel
-		O = new /obj/item/stack/material/plasteel(src.loc)
-		step_to(O, get_turf(pick(view(7, src))))
-		if(prob(75))
-			O = new /obj/item/stack/material/plasteel(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(50))
-			O = new /obj/item/stack/material/plasteel(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(25))
-			O = new /obj/item/stack/material/plasteel(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
+/obj/item/drone_loot_board/name = "circuit board (drone systems)"
 
-		//also drop dummy circuit boards deconstructable for research (loot)
-		var/obj/item/stock_parts/circuitboard/C
+/obj/item/drone_loot_board/desc = "A damaged piece of circuitry that was once part of a combat drone."
 
-		//spawn 1-4 boards of a random type
-		var/spawnees = 0
-		var/num_boards = rand(1,4)
-		var/list/options = list(1,2,4,8,16,32,64,128,256,512)
-		for(var/i=0, i<num_boards, i++)
-			var/chosen = pick(options)
-			options.Remove(list_find(options, chosen))
-			spawnees |= chosen
+/obj/item/drone_loot_board/icon = 'icons/obj/module.dmi'
 
-		if(spawnees & 1)
-			C = new(src.loc)
-			C.SetName("Drone CPU motherboard")
-			C.origin_tech = list(TECH_DATA = rand(3, 6))
+/obj/item/drone_loot_board/icon_state = "id_mod"
 
-		if(spawnees & 2)
-			C = new(src.loc)
-			C.SetName("Drone neural interface")
-			C.origin_tech = list(TECH_BIO = rand(3,6))
+/obj/item/drone_loot_board/item_state = "electronic"
 
-		if(spawnees & 4)
-			C = new(src.loc)
-			C.SetName("Drone suspension processor")
-			C.origin_tech = list(TECH_MAGNET = rand(3,6))
+/obj/item/drone_loot_board/w_class = ITEM_SIZE_SMALL
 
-		if(spawnees & 8)
-			C = new(src.loc)
-			C.SetName("Drone shielding controller")
-			C.origin_tech = list(TECH_BLUESPACE = rand(3,6))
+/obj/item/drone_loot_board/obj_flags = OBJ_FLAG_CONDUCTIBLE
 
-		if(spawnees & 16)
-			C = new(src.loc)
-			C.SetName("Drone power capacitor")
-			C.origin_tech = list(TECH_POWER = rand(3,6))
 
-		if(spawnees & 32)
-			C = new(src.loc)
-			C.SetName("Drone hull reinforcer")
-			C.origin_tech = list(TECH_MATERIAL = rand(3,6))
+/obj/item/drone_loot_board/Initialize()
+	. = ..()
+	if (prob(33))
+		LAZYSET(origin_tech, TECH_DATA, rand(2, 4))
+	if (prob(33))
+		LAZYSET(origin_tech, TECH_POWER, rand(2, 4))
+	if (prob(33))
+		LAZYSET(origin_tech, TECH_ENGINEERING, rand(2, 4))
+	if (prob(33))
+		LAZYSET(origin_tech, TECH_COMBAT, rand(2, 4))
 
-		if(spawnees & 64)
-			C = new(src.loc)
-			C.SetName("Drone auto-repair system")
-			C.origin_tech = list(TECH_ENGINEERING = rand(3,6))
 
-		if(spawnees & 128)
-			C = new(src.loc)
-			C.SetName("Drone phoron overcharge counter")
-			C.origin_tech = list(TECH_PHORON = rand(3,6))
 
-		if(spawnees & 256)
-			C = new(src.loc)
-			C.SetName("Drone targetting circuitboard")
-			C.origin_tech = list(TECH_COMBAT = rand(3,6))
 
-		if(spawnees & 512)
-			C = new(src.loc)
-			C.SetName("Corrupted drone morality core")
-			C.origin_tech = list(TECH_ESOTERIC = rand(3,6))
+/obj/item/projectile/beam/drone/damage = 15
 
-	..()
 
-/datum/ai_holder/simple_animal/ranged/pointblank/malf_drone
-	speak_chance = 5
 
-/datum/say_list/malf_drone
-	speak = list("ALERT.","Hostile-ile-ile entities dee-twhoooo-wected.","Threat parameterszzzz- szzet.","Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")
-	emote_see = list("beeps menacingly","whirrs threateningly","scans its immediate vicinity")
-/obj/item/projectile/beam/drone
-	damage = 15
 
-/obj/item/projectile/beam/pulse/drone
-	damage = 10
+/obj/item/projectile/beam/pulse/drone/damage = 10
+
+
+
+
+/datum/ai_holder/simple_animal/ranged/pointblank/malf_drone/speak_chance = 5
+
+
+/datum/ai_holder/simple_animal/ranged/pointblank/malf_drone/list_targets()
+	var/mob/living/simple_animal/hostile/retaliate/malf_drone/D = holder
+	if (!D.hostile_drone)
+		return ..()
+	var/list/targets = list()
+	for (var/mob/living/M in oview(D.hostile_range, D))
+		if (M.stat == DEAD)
+			continue
+		if (M.type == D.type)
+			continue
+		targets += M
+	return targets
+
+
+
+
+/datum/say_list/malf_drone/speak = list(
+	"ALERT.",
+	"Hostile-ile-ile entities dee-twhoooo-wected.",
+	"Threat parameterszzzz- szzet.",
+	"Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a."
+)
+
+/datum/say_list/malf_drone/emote_see = list(
+	"beeps menacingly",
+	"whirrs threateningly",
+	"scans its immediate vicinity"
+)
+
+/datum/say_list/malf_drone/say_understood = list(
+	"Affirmative.",
+	"Positive."
+)
+
+/datum/say_list/malf_drone/say_cannot = list(
+	"Denied.",
+	"Negative."
+)
+
+/datum/say_list/malf_drone/say_maybe_target = list(
+	"Possible threat detected. Investigating.",
+	"Motion detected.",
+	"Investigating."
+)
+
+/datum/say_list/malf_drone/say_got_target = list(
+	"Threat detected.",
+	"New task: Remove threat.",
+	"Threat removal engaged.",
+	"Engaging target."
+)
+
+/datum/say_list/malf_drone/threaten_sound = 'sound/effects/turret/move1.wav'
+
+/datum/say_list/malf_drone/say_threaten = list(
+	"Motion detected, judging target..."
+)
+
+/datum/say_list/malf_drone/stand_down_sound = 'sound/effects/turret/move2.wav'
+
+/datum/say_list/malf_drone/say_stand_down = list(
+	"Visual lost.",
+	"Error: Target not found."
+)
+
+/datum/say_list/malf_drone/say_escalate = list(
+	"Viable target found. Removing.",
+	"Engaging target.",
+	"Target judgement complete. Removal required."
+)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -38,18 +38,17 @@
 
 	var/map_low = OVERMAP_EDGE
 	var/map_high = GLOB.using_map.overmap_size - OVERMAP_EDGE
+	var/turf/home
 	if (place_near_main)
+		var/obj/effect/overmap/visitable/main = map_sectors["1"]
 		if (islist(place_near_main))
 			place_near_main = Roundm(Frand(place_near_main[1], place_near_main[2]), 0.1)
-		var/obj/effect/overmap/visitable/main = map_sectors["1"]
-		var/list/offset = BCrand(abs(place_near_main), main.x, main.y, map_low, map_low, map_high, map_high, TRUE)
-		start_x = offset[1]
-		start_y = offset[2]
-		log_debug("place_near_main moving [src] near [main] ([main.x], [main.y]) with radius [place_near_main], got ([start_x], [start_y])")
+		home = CircularRandomTurfAround(main, abs(place_near_main), map_low, map_low, map_high, map_high)
+		log_debug("place_near_main moving [src] near [main] ([main.x],[main.y]) with radius [place_near_main], got ([home.x],[home.y])")
 	else
 		start_x = start_x || rand(map_low, map_high)
 		start_y = start_y || rand(map_low, map_high)
-	var/turf/home = locate(start_x, start_y, GLOB.using_map.overmap_z)
+		home = locate(start_x, start_y, GLOB.using_map.overmap_z)
 	forceMove(home)
 
 	for(var/obj/effect/overmap/event/E in loc)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -39,8 +39,8 @@
 /obj/item/arrow/rod/removed(mob/user)
 	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
 		to_chat(user, "[src] shatters into a scattering of overstressed metal shards as it leaves the crossbow.")
-		var/obj/item/material/shard/shrapnel/S = new()
-		S.dropInto(loc)
+		var/obj/item/material/shard/shrapnel/steel/shrapnel = new
+		shrapnel.dropInto(loc)
 		qdel(src)
 
 /obj/item/gun/launcher/crossbow

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -61,7 +61,7 @@
 	var/miss_sounds
 	var/ricochet_sounds
 	var/list/impact_sounds	//for different categories, IMPACT_MEAT etc
-	var/shrapnel_type = /obj/item/material/shard/shrapnel
+	var/shrapnel_type = /obj/item/material/shard/shrapnel/steel
 
 	var/vacuum_traversal = 1 //Determines if the projectile can exist in vacuum, if false, the projectile will be deleted if it enters vacuum.
 

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -77,11 +77,10 @@
 	name = "hydroponics supplies locker"
 	req_access = list()
 
-/obj/item/projectile/beam/drone/weak
-	damage = 7
+
+/obj/item/natural_weapon/hooves/strong/force = 15
 
 
-// Mobs //
 /mob/living/simple_animal/hostile/retaliate/goat/hydro
 	name = "goat"
 	desc = "An impressive goat, in size and coat. His horns look pretty serious!"
@@ -90,8 +89,9 @@
 	natural_weapon = /obj/item/natural_weapon/hooves/strong
 	faction = "farmbots"
 
-/obj/item/natural_weapon/hooves/strong
-	force = 15
+
+/obj/item/projectile/beam/drone/weak/damage = 7
+
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/hydro
 	name = "Farmbot"
@@ -103,26 +103,37 @@
 	faction = "farmbots"
 	health = 225
 	maxHealth = 225
-	malfunctioning = 0
-
-	ai_holder = /datum/ai_holder/simple_animal/passive
-
+	malfunctioning = FALSE
 	say_list_type = /datum/say_list/malf_drone/hydro
+	trail = null
+
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/hydro/Initialize()
 	. = ..()
-	if(prob(15))
+	if (prob(50))
 		projectiletype = /obj/item/projectile/beam/drone/weak
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/hydro/emp_act(severity)
-	health -= rand(5,10) * (severity + 1)
-	disabled = rand(15, 30)
-	malfunctioning = 1
-	hostile_drone = 1
-	destroy_surroundings = 1
-	projectiletype = initial(projectiletype)
-	walk(src,0)
 
-/datum/say_list/malf_drone/hydro
-	speak = list("Initiating harvesting subrout-ine-ine.", "Connection timed out.", "Connection with master AI syst-tem-tem lost.", "Core systems override enab-...")
-	emote_see = list("beeps repeatedly", "whirrs violently", "flashes its indicator lights", "emits a ping sound")
+/mob/living/simple_animal/hostile/retaliate/malf_drone/hydro/emp_act(severity)
+	health -= rand(5, 10) * (severity + 1)
+	disabled = rand(15, 30)
+	malfunctioning = TRUE
+	hostile_drone = TRUE
+	destroy_surroundings = TRUE
+	projectiletype = initial(projectiletype)
+	walk(src, 0)
+
+
+/datum/say_list/malf_drone/hydro/speak = list(
+	"Initiating harvesting subrout-ine-ine.",
+	"Connection timed out.",
+	"Connection with master AI syst-tem-tem lost.",
+	"Core systems override enab-..."
+)
+
+/datum/say_list/malf_drone/hydro/emote_see = list(
+	"beeps repeatedly",
+	"whirrs violently",
+	"flashes its indicator lights",
+	"emits a ping sound"
+)


### PR DESCRIPTION
:cl:
bugfix: You can no longer hide shrapnel in your boots.
bugfix: Malfunctioning drones no longer kill themselves (and will try to kill you instead).
bugfix: Malfunctioning drones no longer drop invalid circuit boards.
/:cl:

[correct isatom to not be true for areas](https://github.com/Baystation12/Baystation12/commit/4e63c6eeacba7a40d83e9a5822d2c9575839099e)

[movable Destroy halts walk, prevents obsure refs](https://github.com/Baystation12/Baystation12/commit/4e96d2570d3881445c4b28618aa8f0273bca5244)

[renames b/crand, adds turf & center-atom helpers](https://github.com/Baystation12/Baystation12/commit/61db602568d02abedba0facca89537351ed4ce05)
\- Renames Crand to CircularRandomCoordinate
\- Renames BCrand to BoundedCircularRandomCoordinate
\- Adds CircularRandomTurf which locate()s the result of BoundedCircularRandomCoordinate for you
\- Adds CircularRandomTurfAround which replaces source coordinates with an atom as input
\- Defaults CircularRandomTurf & CircularRandomTurfAround bounds to 1,1,world.maxx,world.maxy
\- - permits the nice easy CircularRandomTurfAround(something, distance)

[shrapnel can't go in boots, add some default types](https://github.com/Baystation12/Baystation12/commit/ddb5ee04ec001b13dbdd822720ff6ae02f12aca6)
\- also makes shard/phoron use default_material instead of New

fixes #28654
[and rewrote malf drones in the process](https://github.com/Baystation12/Baystation12/commit/72f87ad47aa9a5fc9e8613362559f3fd1927d0d9) 
\- fixed a bunch of other stuff about them at the same time, but I doubt any of it had open issues

