### PR TITLE
reimplements text padding more usefully

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -38,9 +38,8 @@
 
 /proc/group_areas_by_z_level(var/list/predicates)
 	. = list()
-	var/enough_digits_to_contain_all_zlevels = 3
 	for(var/area/A in get_filtered_areas(predicates))
-		group_by(., add_zero(num2text(A.z), enough_digits_to_contain_all_zlevels), A)
+		group_by(., pad_left(num2text(A.z), 3, "0"), A)
 
 /*
 	Pick helpers

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -220,7 +220,7 @@
 	var/padding_size = length_char(padding)
 	if (!padding_size)
 		return ""
-	var/padding_count = CEILING(size / padding_size, 1)
+	var/padding_count = Ceil(size / padding_size)
 	var/list/result = list()
 	for (var/i = padding_count to 1 step -1)
 		result += padding // pow2 strategies could be used here at the cost of complexity
@@ -253,11 +253,6 @@
 	if (!length_difference)
 		return result
 	return copytext_char(result, 1, -length_difference)
-
-
-/// Adds count number of '0' before text
-/proc/add_zero(text, count)
-	return "[generate_padding(count, "0")][text||""]"
 
 
 //Returns a string with reserved characters and spaces before the first letter removed

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -214,37 +214,51 @@
 		t = replacetext(t, char, repl_chars[char])
 	return t
 
-//Adds 'u' number of zeros ahead of the text 't'
-/proc/add_zero(t, u)
-	return pad_left(t, u, "0")
 
-//Adds 'u' number of spaces ahead of the text 't'
-/proc/add_lspace(t, u)
-	return pad_left(t, u, " ")
-
-//Adds 'u' number of spaces behind the text 't'
-/proc/add_tspace(t, u)
-	return pad_right(t, u, " ")
-
-// Adds the required amount of 'character' in front of 'text' to extend the lengh to 'desired_length', if it is shorter
-// No consideration are made for a multi-character 'character' input
-/proc/pad_left(text, desired_length, character)
-	var/padding = generate_padding(length_char(text), desired_length, character)
-	return length(padding) ? "[padding][text]" : text
-
-// Adds the required amount of 'character' after 'text' to extend the lengh to 'desired_length', if it is shorter
-// No consideration are made for a multi-character 'character' input
-/proc/pad_right(text, desired_length, character)
-	var/padding = generate_padding(length_char(text), desired_length, character)
-	return length(padding) ? "[text][padding]" : text
-
-/proc/generate_padding(current_length, desired_length, character)
-	if(current_length >= desired_length)
+/// Builds a string of padding repeated until its character count meets or exceeds size
+/proc/generate_padding(size, padding)
+	var/padding_size = length_char(padding)
+	if (!padding_size)
 		return ""
-	var/characters = list()
-	for(var/i = 1 to (desired_length - current_length))
-		characters += character
-	return JOINTEXT(characters)
+	var/padding_count = CEILING(size / padding_size, 1)
+	var/list/result = list()
+	for (var/i = padding_count to 1 step -1)
+		result += padding // pow2 strategies could be used here at the cost of complexity
+	return result.Join(null)
+
+
+/// Pads the matter of padding onto the start of text until the result length is size
+/proc/pad_left(text, size, padding)
+	var/text_length = length_char(text)
+	if (text_length >= size)
+		return text
+	if (!text_length)
+		text = ""
+	var/result = "[generate_padding(size - text_length, padding)][text]"
+	var/length_difference = length_char(result) - size
+	if (!length_difference)
+		return result
+	return copytext_char(result, length_difference + 1)
+
+
+/// Pads the matter of padding onto the start of text until the result length is size
+/proc/pad_right(text, size, padding)
+	var/text_length = length_char(text)
+	if (text_length >= size)
+		return text
+	if (!text_length)
+		text = ""
+	var/result = "[text][generate_padding(size - text_length, padding)]"
+	var/length_difference = length_char(result) - size
+	if (!length_difference)
+		return result
+	return copytext_char(result, 1, -length_difference)
+
+
+/// Adds count number of '0' before text
+/proc/add_zero(text, count)
+	return "[generate_padding(count, "0")][text||""]"
+
 
 //Returns a string with reserved characters and spaces before the first letter removed
 /proc/trim_left(text)

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -140,8 +140,8 @@ var/round_start_time = 0
 	var/mins = round((mills % 36000) / 600)
 	var/hours = round(mills / 36000)
 
-	mins = mins < 10 ? add_zero(mins, 1) : mins
-	hours = hours < 10 ? add_zero(hours, 1) : hours
+	mins = pad_left("[mins]", 2, "0")
+	hours = pad_left("[hours]", 2, "0")
 
 	last_round_duration = "[hours]:[mins]"
 	next_duration_update = world.time + 1 MINUTES

--- a/code/controllers/evacuation/evacuation_eta.dm
+++ b/code/controllers/evacuation/evacuation_eta.dm
@@ -5,7 +5,8 @@
 	var/timeleft = get_eta()
 	if(timeleft < 0)
 		return ""
-	return "[is_on_cooldown() ? "Returning" : (is_arriving() ? "ETA" : "ETD")] [add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+
+	return "[is_on_cooldown() ? "Returning" : (is_arriving() ? "ETA" : "ETD")] [pad_left(num2text((timeleft / 60) % 60), 2, "0")]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 
 /datum/evacuation_controller/proc/has_eta()
 	return (state == EVAC_PREPPING || state == EVAC_LAUNCHING || state == EVAC_IN_TRANSIT || state == EVAC_COOLDOWN)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -329,7 +329,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 
 /proc/EncodeDNABlock(var/value)
-	return add_zero2(num2hex(value & 0xF), 3)
+	return pad_left(num2hex(value & 0xF), 3, "0")
+
 
 /datum/dna/proc/UpdateUI()
 	src.uni_identity=""

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -2,15 +2,6 @@
 // Helpers for DNA2
 /////////////////////////////
 
-// Pads 0s to t until length == u
-/proc/add_zero2(t, u)
-	var/temp1
-	while (length(t) < u)
-		t = "0[t]"
-	temp1 = t
-	if (length(t) > u)
-		temp1 = copytext(t,2,u+1)
-	return temp1
 
 // DNA Gene activation boundaries, see dna2.dm.
 // Returns a list object with 4 numbers.

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -169,7 +169,7 @@
 
 	else if (href_list["issue"])
 		if (giver && accesses.len)
-			var/number = add_zero(random_id("guestpass_id_number",1000,9999), 4)
+			var/number = pad_left(random_id("guestpass_id_number", 1, 9999), 6, "0")
 			var/entry = "\[[stationtime2text()]\] Pass #[number] issued by [giver.registered_name] ([giver.assignment]) to [giv_name]. Reason: [reason]. Granted access to following areas: "
 			var/list/access_descriptors = list()
 			for (var/A in accesses)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -220,7 +220,7 @@
 	if(src.timing)
 		var/disp1 = id
 		var/timeleft = timeleft()
-		var/disp2 = "[add_zero(num2text((timeleft / 60) % 60),2)]~[add_zero(num2text(timeleft % 60), 2)]"
+		var/disp2 = "[pad_left(num2text((timeleft / 60) % 60), 2, "0")]~[pad_left(num2text(timeleft % 60), 2, "0")]"
 		if(length(disp2) > CHARS_PER_LINE)
 			disp2 = "Error"
 		update_display(disp1, disp2)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -212,7 +212,7 @@
 	var/timeleft = evacuation_controller.get_eta()
 	if(timeleft < 0)
 		return ""
-	return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+	return "[pad_left(num2text((timeleft / 60) % 60), 2, "0")]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 
 /obj/machinery/status_display/proc/get_supply_shuttle_timer()
 	var/datum/shuttle/autodock/ferry/supply/shuttle = SSsupply.shuttle
@@ -223,7 +223,7 @@
 		var/timeleft = round((shuttle.arrive_time - world.time) / 10,1)
 		if(timeleft < 0)
 			return "Late"
-		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+		return "[pad_left(num2text((timeleft / 60) % 60), 2, "0")]:[pad_left(num2text(timeleft % 60), 2, "0")]"
 	return ""
 
 /obj/machinery/status_display/proc/remove_display()

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -334,7 +334,7 @@
 		else
 			var/timeleft = evacuation_controller.get_eta()
 			if (evacuation_controller.waiting_to_leave())
-				dat += "ETA: [(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]<BR>"
+				dat += "ETA: [(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]<BR>"
 				dat += "<a href='?src=\ref[src];call_shuttle=2'>Send Back</a><br>"
 
 		dat += "<a href='?src=\ref[src];delay_round_end=1'>[SSticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -48,7 +48,7 @@
 		var/date2 = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [rand(1000,3000)]"
 		T.date = pick("", stationdate2text(), date1, date2)
 		var/time1 = rand(0, 99999999)
-		var/time2 = "[round(time1 / 36000)+12]:[(time1 / 600 % 60) < 10 ? add_zero(time1 / 600 % 60, 1) : time1 / 600 % 60]"
+		var/time2 = "[round(time1 / 36000)+12]:[pad_left(time1 / 600 % 60, 2, "0")]"
 		T.time = pick("", stationtime2text(), time2)
 		
 		T.perform()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 /mob/living/silicon/pai/proc/show_silenced()
 	if(silence_time)
 		var/timeleft = round((silence_time - world.timeofday)/10 ,1)
-		stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+		stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[pad_left(num2text(timeleft % 60), 2, "0")]")
 
 /mob/living/silicon/pai/Stat()
 	. = ..()


### PR DESCRIPTION
Previously, text padding didn't care about the result length in a particularly meaningful way. This redoes it such that https://pastebin.com/fiGSQEff passes; longer text is returned without modification, shorter text is padded to the exact requested size instead of `size as a minimum`. Changes it over to character-aware instead of just bytes too.

~~It also re-makes add_zero bad because I can't be bothered to make its uses good at the same time. TODO.~~ Did.