### PR TITLE
changes isatom again

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -33,7 +33,7 @@ var/const/NEGATIVE_INFINITY = -1#INF // win: -1.#INF, lin: -inf
 
 #define isairlock(A) istype(A, /obj/machinery/door/airlock)
 
-#define isatom(A) (ismovable(A) || isturf(A))
+#define isatom(A) (isloc(A) && !isarea(A))
 
 #define isbrain(A) istype(A, /mob/living/carbon/brain)
 


### PR DESCRIPTION
I did not initially benchmark -- now I have, exclusion seems preferable:

![https://i.imgur.com/wJ5QrPf.png](https://i.imgur.com/wJ5QrPf.png)

