### PR TITLE
Laser damage falloff & Laser/Pulse tweaks

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -44,14 +44,14 @@
 	desc = "A smaller model of the versatile LAEP90 Perun, the LAEP90-C packs considerable utility in a smaller package. Best used in situations where full-sized sidearms are inappropriate."
 	icon = 'icons/obj/guns/small_egun.dmi'
 	icon_state = "smallgunstun"
-	max_shots = 5
+	max_shots = 6
 	w_class = ITEM_SIZE_SMALL
 	force = 2 //it's the size of a car key, what did you expect?
 	modifystate = "smallgunstun"
 
 	firemodes = list(
-		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="smallgunstun"),
-		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, modifystate="smallgunshock"),
+		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun/smalllaser, modifystate="smallgunstun"),
+		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock/smalllaser, modifystate="smallgunshock"),
 		list(mode_name="kill", projectile_type=/obj/item/projectile/beam/smalllaser, modifystate="smallgunkill"),
 		)
 

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -14,7 +14,7 @@
 	burst_delay = 3
 	burst = 3
 	move_delay = 4
-	accuracy = -1
+	accuracy = 1
 	wielded_item_state = "gun_wielded"
 	bulk = GUN_BULK_RIFLE
 
@@ -32,6 +32,7 @@
 	burst_delay = 2
 	move_delay = 2
 	bulk = GUN_BULK_RIFLE - 3
+	accuracy = 0
 
 /obj/item/gun/energy/pulse_rifle/pistol
 	name = "pulse pistol"
@@ -48,6 +49,7 @@
 	move_delay = 1
 	wielded_item_state = null
 	bulk = 0
+	accuracy = 0
 
 /obj/item/gun/energy/pulse_rifle/mounted
 	self_recharge = 1

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -29,6 +29,13 @@
 	var/hitchance_mod = 0
 	var/dispersion = 0.0
 	var/distance_falloff = 2  //multiplier, higher value means accuracy drops faster with distance
+	var/damage_falloff = FALSE 
+	/// List(Distance, Multiplier), intended to represent short / medium / long ranges. Uses default of 1 for anything lower than the first value.
+	var/damage_falloff_list = list(
+		list(4, 0.9),
+		list(6, 0.8),
+		list(8, 0.7)
+	) 
 
 	var/damage = 10
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE, ELECTROCUTE are the only things that should be in here, Try not to use PAIN as it doesn't go through stun_effect_act
@@ -200,11 +207,27 @@
 /obj/item/projectile/proc/attack_mob(var/mob/living/target_mob, var/distance, var/special_miss_modifier=0)
 	if(!istype(target_mob))
 		return
-
+		
 	//roll to-hit
 	var/miss_modifier = max(distance_falloff*(distance)*(distance) - hitchance_mod + special_miss_modifier, -30)
 	//makes moving targets harder to hit, and stationary easier to hit
 	var/movment_mod = min(5, (world.time - target_mob.l_move_time) - 5)
+
+	if (damage_falloff)
+		var/damage_mod = 1
+		for (var/list/entry as anything in damage_falloff_list)
+			if (entry[1] > distance)
+				break
+			damage_mod = entry[2]
+		damage = damage * damage_mod
+		armor_penetration = armor_penetration * damage_mod
+		agony = agony * damage_mod
+	//running in a straight line isnt as helpful tho
+	if(movment_mod < 0)
+		if(target_mob.last_move == get_dir(firer, target_mob))
+			movment_mod *= 0.25
+		else if(target_mob.last_move == get_dir(target_mob,firer))
+			movment_mod *= 0.5
 	miss_modifier -= movment_mod
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,7 +13,13 @@
 	hitscan = TRUE
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
 	penetration_modifier = 0.3
-	distance_falloff = 2.5
+	distance_falloff = 1.5
+	damage_falloff = TRUE
+	damage_falloff_list = list(
+		list(3, 0.95),
+		list(5, 0.90),
+		list(7, 0.80),
+	)
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer
@@ -25,13 +31,23 @@
 	eyeblur = 2
 
 /obj/item/projectile/beam/smalllaser
-	damage = 25
-	armor_penetration = 10
+	damage = 35
+	distance_falloff = 2
+	damage_falloff_list = list(
+		list(3, 0.90),
+		list(5, 0.80),
+		list(7, 0.60),
+	)
 
 /obj/item/projectile/beam/midlaser
 	damage = 40
 	armor_penetration = 10
 	distance_falloff = 1
+	damage_falloff_list = list(
+		list(4, 0.96),
+		list(6, 0.92),
+		list(8, 0.86),
+	)
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
@@ -40,6 +56,11 @@
 	damage = 60
 	armor_penetration = 30
 	distance_falloff = 0.5
+	damage_falloff_list = list(
+		list(6, 0.97),
+		list(9, 0.94),
+		list(11, 0.88),
+	)
 
 	muzzle_type = /obj/effect/projectile/laser/heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser/heavy/tracer
@@ -52,6 +73,12 @@
 	damage = 30
 	armor_penetration = 30
 	penetration_modifier = 0.8
+	distance_falloff = 1.5
+	damage_falloff_list = list(
+		list(3, 0.95),
+		list(5, 0.90),
+		list(7, 0.80),
+	)
 
 	muzzle_type = /obj/effect/projectile/laser/xray/muzzle
 	tracer_type = /obj/effect/projectile/laser/xray/tracer
@@ -60,12 +87,25 @@
 /obj/item/projectile/beam/xray/midlaser
 	damage = 30
 	armor_penetration = 50
+	distance_falloff = 1
+	damage_falloff_list = list(
+		list(4, 0.96),
+		list(6, 0.92),
+		list(8, 0.84),
+	)
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
 	fire_sound='sound/weapons/pulse.ogg'
 	damage = 15 //lower damage, but fires in bursts
+	armor_penetration = 25
+	distance_falloff = 1.5
+	damage_falloff_list = list(
+		list(3, 0.95),
+		list(5, 0.90),
+		list(7, 0.80),
+	)
 
 	muzzle_type = /obj/effect/projectile/laser/pulse/muzzle
 	tracer_type = /obj/effect/projectile/laser/pulse/tracer
@@ -73,14 +113,33 @@
 
 /obj/item/projectile/beam/pulse/mid
 	damage = 20
+	armor_penetration = 30
+	distance_falloff = 1
+	damage_falloff_list = list(
+		list(4, 0.96),
+		list(6, 0.92),
+		list(8, 0.84),
+	)
 
 /obj/item/projectile/beam/pulse/heavy
 	damage = 25
+	armor_penetration = 35
+	distance_falloff = 0.5
+	damage_falloff_list = list(
+		list(6, 0.97),
+		list(9, 0.94),
+		list(11, 0.88),
+	)
 
 /obj/item/projectile/beam/pulse/destroy
 	name = "destroyer pulse"
 	damage = 100 //badmins be badmins I don't give a fuck
 	armor_penetration = 100
+	damage_falloff_list = list(
+		list(6, 0.99),
+		list(9, 0.98),
+		list(11, 0.97),
+	)
 
 /obj/item/projectile/beam/pulse/destroy/on_hit(var/atom/target, var/blocked = 0)
 	if(isturf(target))
@@ -168,6 +227,11 @@
 	fire_sound = 'sound/weapons/marauder.ogg'
 	damage = 50
 	armor_penetration = 10
+	damage_falloff_list = list(
+		list(8, 0.97),
+		list(12, 0.94),
+		list(16, 0.88),
+	)
 
 	muzzle_type = /obj/effect/projectile/laser/xray/muzzle
 	tracer_type = /obj/effect/projectile/laser/xray/tracer
@@ -183,15 +247,35 @@
 	damage_type = BURN
 	eyeblur = 1//Some feedback that you've been hit
 	agony = 40
+	distance_falloff = 1.5
+	damage_falloff_list = list(
+		list(3, 0.95),
+		list(5, 0.90),
+		list(7, 0.80),
+	)
 
 	muzzle_type = /obj/effect/projectile/stun/muzzle
 	tracer_type = /obj/effect/projectile/stun/tracer
 	impact_type = /obj/effect/projectile/stun/impact
 
+/obj/item/projectile/beam/stun/smalllaser
+	distance_falloff = 2
+	damage_falloff_list = list(
+		list(3, 0.90),
+		list(5, 0.80),
+		list(7, 0.60),
+	)
+
 /obj/item/projectile/beam/stun/heavy
 	name = "heavy stun beam"
 	damage = 2
 	agony = 60
+	distance_falloff = 1
+	damage_falloff_list = list(
+		list(5, 0.97),
+		list(7, 0.94),
+		list(9, 0.88),
+	)
 
 /obj/item/projectile/beam/stun/shock
 	name = "shock beam"
@@ -199,21 +283,47 @@
 	damage = 15
 	damage_type = ELECTROCUTE
 	fire_sound='sound/weapons/pulse.ogg'
+	distance_falloff = 1.5
+	damage_falloff_list = list(
+		list(3, 0.95),
+		list(5, 0.90),
+		list(7, 0.80),
+	)
+
+/obj/item/projectile/beam/stun/shock/smalllaser
+	distance_falloff = 2
+	damage_falloff_list = list(
+		list(3, 0.90),
+		list(5, 0.80),
+		list(7, 0.60),
+	)
 
 /obj/item/projectile/beam/stun/shock/heavy
 	name = "heavy shock beam"
 	damage = 30
+	distance_falloff = 1
+	damage_falloff_list = list(
+		list(5, 0.97),
+		list(7, 0.94),
+		list(9, 0.88),
+	)
 
 /obj/item/projectile/beam/plasmacutter
 	name = "plasma arc"
 	icon_state = "omnilaser"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	damage = 15
+	damage = 30
+	armor_penetration = 30
 	edge = TRUE
 	damage_type = BURN
 	life_span = 5
 	pass_flags = PASS_FLAG_TABLE
-	distance_falloff = 4
+	distance_falloff = 2
+	damage_falloff_list = list(
+		list(3, 0.90),
+		list(5, 0.80),
+		list(7, 0.60),
+	)
 
 	muzzle_type = /obj/effect/projectile/trilaser/muzzle
 	tracer_type = /obj/effect/projectile/trilaser/tracer
@@ -315,6 +425,11 @@
 	damage_flags = 0
 	life_span = 8
 	armor_penetration = 10
+	damage_falloff_list = list(
+		list(3, 0.95),
+		list(5, 0.90),
+		list(7, 0.80),
+	)
 
 	muzzle_type = /obj/effect/projectile/incen/muzzle
 	tracer_type = /obj/effect/projectile/incen/tracer

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -85,6 +85,11 @@
 	damage_type = BURN
 	eyeblur = 1//Some feedback that you've been hit
 	step_delay = 0.7
+	damage_falloff_list = list(
+		list(5, 0.97),
+		list(7, 0.94),
+		list(9, 0.88),
+	)
 
 /obj/item/projectile/energy/electrode/green
 	icon_state = "spark_green"


### PR DESCRIPTION
All guns may now optionally have damage falloff using the damage_falloff variable.
Lasers now suffer from damage falloff (Human weaponry only, I've not touched alien weapons. If there's a desire for it I can apply the same changes to them.)

Weapons with damage falloff deal less damage, agony and penetrate less effectively the further they have to travel towards their target. 
Updated: Weapons now use a series of range bands to decide on their final damage falloff rather than relying on math to do the heavy lifting. 

The compact smartguns lethal damage has been increased to thirty fie and the number of shots increased from five to six. The compact smartgun has the most rapid drop in effectiveness of all lasers, when used at close range this should perform as a small buff but when firing at a distance it should be much less effective.

All pulse weapons have had their accuracy tweaked slightly, in addition they've all gained a large armor penetration buff.
Pulse weapons suffer from damage falloff similarly to lasers but to a lesser effect.
I've also retweaked the plasma cutter to be significantly more dangerous, the damage increased from fifteen to thirty and it's armor penetration increased from zero to thirty. It should be able to function as a threatening weapon up close but suffer significantly once any distance is placed between it's user and target as it has a similar damage falloff to the compact smartgun.

The largest concern and the one pointed out to me is that this will promote players trying to get as absolutely close as possible when using their lasers to mitigate the distance penalties potentially ignoring danger in favor of effectiveness. 

🆑 Kell-E
rscadd: All guns may now optionally have damage falloff 
balance: All laser weapons suffer from damage falloff relative to their size
balance: Compact smartgun: Shots (5 ->6), Lethal damage (25 -> 35), Armor penetration (10 -> 0) 
balance: Pulse pistol: Armor penetration (0 -> 25), Accuracy (-1 -> 0)
balance: Pulse carbine: Armor penetration (0 ->30), Accuracy (-1 -> 0)
balance: Pulse rifle: Armor penetration (0 -> 35), Accuracy (-1 -> 1)
balance: Plasma cutter: Damage (15 -> 30), Armor penetration (0 -> 30)
/🆑 