### PR TITLE
Update gas scanner UI/UX

### DIFF
--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -42,7 +42,11 @@
 	if(!can_use(user))
 		return
 	if(is_valid_scan_target(A))
-		user.visible_message("<span class='notice'>[user] runs \the [src] over \the [A].</span>", range = 2)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] runs \the [src] over \the [A]."),
+			SPAN_NOTICE("You run \the [src] over \the [A]."),
+			range = 2
+		)
 		if(scan_sound)
 			playsound(src, scan_sound, 30)
 		if(use_delay && !do_after(user, use_delay, A))

--- a/code/game/objects/items/devices/scanners/gas.dm
+++ b/code/game/objects/items/devices/scanners/gas.dm
@@ -1,7 +1,3 @@
-#define DEFAULT_MODE 0
-#define MV_MODE 1 //moles and volume
-#define GAS_TRAIT_MODE 2 //gas traits and constants
-
 /obj/item/device/scanner/gas
 	name = "gas analyzer"
 	desc = "A hand-held environmental scanner which reports current gas levels. Has a button to cycle modes."
@@ -12,24 +8,6 @@
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 	window_width = 350
 	window_height = 400
-	var/mode = DEFAULT_MODE
-
-/obj/item/device/scanner/gas/get_header()
-	return "[..()]<a href='?src=\ref[src];switchmode=1'>Switch Mode</a>"
-
-/obj/item/device/scanner/gas/OnTopic(var/user, var/list/href_list)
-	..()
-	if(href_list["switchmode"])
-		++mode
-		switch(mode)
-			if(MV_MODE)
-				to_chat(user, "You set the gas analyzer to Moles and volume.")
-			if(GAS_TRAIT_MODE)
-				to_chat(user, "You set the gas analyzer to Gas traits and data.")
-			else
-				to_chat(user, "You set the gas analyzer to Default.")
-				mode = DEFAULT_MODE
-		playsound(src.loc, 'sound/machines/button4.ogg', 30, 0)
 
 /obj/item/device/scanner/gas/is_valid_scan_target(atom/O)
 	return istype(O)
@@ -37,56 +15,61 @@
 /obj/item/device/scanner/gas/scan(atom/A, mob/user)
 	var/air_contents = A.return_air()
 	if(!air_contents)
-		to_chat(user, "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>")
+		to_chat(user, SPAN_WARNING("Your [name] flashes a red light as it fails to analyze \the [A]."))
 		return
-	scan_data = atmosanalyzer_scan(A, air_contents, mode)
-	scan_data = jointext(scan_data, "<br>")
-	user.show_message(SPAN_NOTICE(scan_data))
+	scan_data = atmosanalyzer_scan(A, air_contents)
+	show_menu(user)
 
-/proc/atmosanalyzer_scan(var/atom/target, var/datum/gas_mixture/mixture, mode)
-	. = list()
-	. += "Results of the analysis of \the [target]:"
-	if(!mixture)
+/proc/atmosanalyzer_scan(atom/target, datum/gas_mixture/mixture)
+	var/text_summary = ""
+	var/text_details = ""
+	. = ""
+	. += "<h1>Results of the analysis of \the [target]:</h1>"
+	if (!mixture)
 		mixture = target.return_air()
 
-	if(mixture)
+	if (mixture)
 		var/pressure = mixture.return_pressure()
 		var/total_moles = mixture.total_moles
 
-		if (total_moles>0)
-			if(abs(pressure - ONE_ATMOSPHERE) < 10)
-				. += "<span class='notice'>Pressure: [round(pressure,0.01)] kPa</span>"
-			else
-				. += "<span class='warning'>Pressure: [round(pressure,0.01)] kPa</span>"
+		text_summary += "<h2>Summary:</h2><ul>"
+		text_summary += "<li>Pressure: [round(pressure, 0.01)] kPa</li>"
+		text_summary += "<li>Total Moles: [round(total_moles, 0.01)]</li>"
+		text_summary += "<li>Volume: [mixture.volume]L</li>"
+		text_summary += "<li>Temperature: [round(mixture.temperature-T0C)]&deg;C ([round(mixture.temperature)]K)</li>"
 
-			var/perGas_add_string = ""
+		var/list/summary_gasses = list()
+
+		if (total_moles > 0 && length(mixture.gas))
+			text_details += "<h2>Gas Details:</h2><dl>"
 			for(var/mix in mixture.gas)
 				var/percentage = round(mixture.gas[mix]/total_moles * 100, 0.01)
 				if(!percentage)
 					continue
-				switch(mode)
-					if(MV_MODE)
-						perGas_add_string = ", Moles: [round(mixture.gas[mix], 0.01)]"
-					if(GAS_TRAIT_MODE)
-						var/list/traits = list()
-						if(gas_data.flags[mix] & XGM_GAS_FUEL)
-							traits += "can be used as combustion fuel"
-						if(gas_data.flags[mix] & XGM_GAS_OXIDIZER)
-							traits += "can be used as oxidizer"
-						if(gas_data.flags[mix] & XGM_GAS_CONTAMINANT)
-							traits += "contaminates clothing with toxic residue"
-						if(gas_data.flags[mix] & XGM_GAS_FUSION_FUEL)
-							traits += "can be used to fuel fusion reaction"
-						perGas_add_string = "\n\tSpecific heat: [gas_data.specific_heat[mix]] J/(mol*K), Molar mass: [gas_data.molar_mass[mix]] kg/mol.[traits.len ? "\n\tThis gas [english_list(traits)]" : ""]"
-				. += "[gas_data.name[mix]]: [percentage]%[perGas_add_string]"
-			var/totalGas_add_string = ""
-			if(mode == MV_MODE)
-				totalGas_add_string = ", Total moles: [round(mixture.total_moles, 0.01)], Volume: [mixture.volume]L"
-			. += "Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K[totalGas_add_string]"
+				summary_gasses += "[percentage]% [gas_data.name[mix]]"
+				text_details += "<dt>[gas_data.name[mix]]</dt><dd><ul>"
+				text_details += "<li>Percentage: [percentage]%</li>"
+				text_details += "<li>Moles: [round(mixture.gas[mix], 0.01)]</li>"
+				text_details += "<li>Specific Heat: [gas_data.specific_heat[mix]] J/(mol*K)</li>"
+				text_details += "<li>Molar Mass: [gas_data.molar_mass[mix]] kg/mol</li>"
+				var/list/traits = list()
+				if(gas_data.flags[mix] & XGM_GAS_FUEL)
+					traits += "can be used as combustion fuel"
+				if(gas_data.flags[mix] & XGM_GAS_OXIDIZER)
+					traits += "can be used as oxidizer"
+				if(gas_data.flags[mix] & XGM_GAS_CONTAMINANT)
+					traits += "contaminates clothing with toxic residue"
+				if(gas_data.flags[mix] & XGM_GAS_FUSION_FUEL)
+					traits += "can be used to fuel fusion reaction"
+				if (traits.len)
+					text_details += "<li>This gas [english_list(traits)]</li>"
+				text_details += "</ul></dd>"
+			text_details += "</dl>"
 
-			return
-	. += "<span class='warning'>\The [target] has no gases!</span>"
+		if (summary_gasses.len)
+			text_summary += "<li>Composition: [english_list(summary_gasses)]</li>"
+		text_summary += "</ul>"
+		. += "[text_summary][text_details]"
 
-#undef DEFAULT_MODE
-#undef MV_MODE
-#undef GAS_TRAIT_MODE
+	else
+		. += SPAN_DANGER("\The [target] has no gases!")

--- a/code/modules/modular_computers/hardware/scanners/scanner_atmos.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_atmos.dm
@@ -14,15 +14,19 @@
 	program.data_buffer = html2pencode(scan_data(user, user.loc)) || program.data_buffer
 
 /obj/item/stock_parts/computer/scanner/atmos/do_on_afterattack(mob/user, atom/target, proximity)
-	if(!isobj(target))
+	if (!can_use_scanner(user, target, proximity))
 		return
+	user.visible_message(
+		SPAN_NOTICE("\The [user] runs \the [src] over \the [target]."),
+		SPAN_NOTICE("You run \the [src] over \the [target]."),
+		range = 2
+	)
 	var/data = scan_data(user, target, proximity)
-	if(!data)
+	if (!data)
 		return
-	if(driver && driver.using_scanner)
+	if (driver?.using_scanner)
 		driver.data_buffer = html2pencode(data)
 		SSnano.update_uis(driver.NM)
-	to_chat(user, data)
 
 /obj/item/stock_parts/computer/scanner/atmos/proc/scan_data(mob/user, atom/target, proximity = TRUE)
 	if(!can_use_scanner(user, target, proximity))
@@ -30,5 +34,9 @@
 	var/air_contents = target.return_air()
 	if(!air_contents)
 		return 0
-	var/list/raw = atmosanalyzer_scan(target, air_contents)
-	return jointext(raw, "<br>")
+	return atmosanalyzer_scan(target, air_contents)
+
+/obj/item/stock_parts/computer/scanner/atmos/can_use_scanner(mob/user, atom/target, proximity)
+	if (!isobj(target) && !isturf(target))
+		return FALSE
+	return ..()


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Gas scanner UI for both the scanner device and PDA module has been tweaked. Results no longer appear in chat and instead appear in the scanner's display, which will automatically open/update every time a scan is run. The display will also now display all information instead of being divided between 3 different 'Modes'. NOTE: The PDA module will not automatically open the program if it is not already open, but will update the UI if the window is already open.
bugfix: Gas scanner PDA modules now work on turfs.
/:cl:

![2022-03-30_18-01-31](https://user-images.githubusercontent.com/11140088/160955591-933389f3-e4e1-4853-a264-ef0287bd65dc.png)

![2022-03-30_18-01-33](https://user-images.githubusercontent.com/11140088/160955601-8fe13ad6-01d7-429b-8ac8-e8f3eff9d17d.png)

![2022-03-30_18-16-26](https://user-images.githubusercontent.com/11140088/160957049-1d2518c1-bc1e-436d-890d-ab9db855e3a7.png)
