### PR TITLE
callproc global proc fix, add path argument

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -120,7 +120,7 @@
 			return CANCEL
 		switch(input("Type of [arguments.len+1]\th variable", "argument [arguments.len+1]") as null|anything in list(
 				"finished", "null", "text", "num", "type", "obj reference", "mob reference",
-				"area/turf reference", "icon", "file", "client", "mob's area", "marked datum", "click on atom"))
+				"area/turf reference", "icon", "file", "client", "mob's area", "path", "marked datum", "click on atom"))
 			if(null)
 				return CANCEL
 
@@ -172,6 +172,10 @@
 							; // do nothing
 						if("Cancel")
 							return CANCEL
+			if ("path")
+				current = text2path(input("Enter path for [arguments.len+1]\th argument") as null|text)
+				if (isnull(current))
+					return CANCEL
 
 			if("marked datum")
 				current = C.holder.marked_datum()
@@ -229,7 +233,9 @@
 			returnval = call(target, procname)()
 	else
 		log_and_message_admins("[key_name(C)] called [procname]() with [arguments.len ? "the arguments [list2params(arguments)]" : "no arguments"].", location = get_turf(target))
-		returnval = call(procname)(arglist(arguments))
+
+		var/P = text2path("/proc/[procname]")
+		returnval = call(P)(arglist(arguments))
 
 	to_chat(usr, "<span class='info'>[procname]() returned: [json_encode(returnval)]</span>")
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -37,7 +37,7 @@ exactly 0 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 2 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 2 ">> uses" '(?<!>)>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
-exactly 22 "text2path uses" 'text2path'
+exactly 24 "text2path uses" 'text2path'
 exactly 6 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'


### PR DESCRIPTION
:cl: Mucker
admin: Fixed 'Advanced ProcCall' verb to allow for global proc-calling
admin: Added the 'path' argument to 'Advanced ProcCall' verb
/:cl:

I can only assume it was intended for the Advanced ProcCall verb to be able to call global procs given it asks you if you have a target to call from, and that there isn't some other usage I'm breaking by doing this.