### PR TITLE
Fix the 'analyze air' ghost verb

### DIFF
--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -12,5 +12,4 @@
 	return 1
 
 /proc/print_atmos_analysis(user, var/list/result)
-	for(var/line in result)
-		to_chat(user, "<span class='notice'>[line]</span>")
+	to_chat(user, SPAN_NOTICE("[result]"))


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the 'Analyze Air' ghost verb not working 
/:cl:

fixes #31830 