### PR TITLE
Removes the ability to casually dodge bullets

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -204,13 +204,7 @@
 	//roll to-hit
 	var/miss_modifier = max(distance_falloff*(distance)*(distance) - hitchance_mod + special_miss_modifier, -30)
 	//makes moving targets harder to hit, and stationary easier to hit
-	var/movment_mod = min(5, (world.time - target_mob.l_move_time) - 20)
-	//running in a straight line isnt as helpful tho
-	if(movment_mod < 0)
-		if(target_mob.last_move == get_dir(firer, target_mob))
-			movment_mod *= 0.25
-		else if(target_mob.last_move == get_dir(target_mob,firer))
-			movment_mod *= 0.5
+	var/movment_mod = min(5, (world.time - target_mob.l_move_time) - 5)
 	miss_modifier -= movment_mod
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 


### PR DESCRIPTION
Currently if you move a single tile you get a flat 20% reduction in the chance for a projectile to hit you for a short duration (Even if you run into it!), this chance is reduced if you moved in the same cardinal direction but this really only served to punish people attempting to disengage and flee while it generally advantaged people actively standing to fight. 

Why was this particularly bad?
If a shot had a 100% chance to hit you it'd have an 80% chance to hit if the target had been moving. (a 20% decrease)
If the shot only had a 50/50 to hit (Medium distance, side arm shot) you'd now only have a 30% to be hit, which is a 40% reduction in chance to be hit.

Without going into extremes a slight movement mid combat could make a respectable shot unlikely to strike and make poor shots literally impossible.

I've removed some of the extra calculations from movement, even if moving into a projectile still benefits your ability to dodge it, the chance to evade it is now significantly lower.
The 20% flat evasion has been reduced to 5%.

🆑 Kell-e
balance: Characters are now 75% less likely to cha-cha slide through projectiles using their extreme speed. 
/🆑 