### PR TITLE
Toys are now ambiguous

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1308,8 +1308,8 @@
 	base_type = /obj/machinery/vending/games
 	products = list(/obj/item/toy/blink = 5, /obj/item/toy/eightball = 8, /obj/item/deck/cards = 5, /obj/item/deck/tarot = 5, /obj/item/pack/cardemon = 6, /obj/item/pack/spaceball = 6, /obj/item/storage/pill_bottle/dice_nerd = 5, /obj/item/storage/pill_bottle/dice = 5, /obj/item/storage/box/checkers = 2, /obj/item/storage/box/checkers/chess/red = 2, /obj/item/storage/box/checkers/chess = 2, /obj/item/board = 2, /obj/item/storage/fancy/crayons = 3)
 	prices = list(/obj/item/toy/blink = 3, /obj/item/toy/eightball = 10, /obj/item/deck/tarot = 3, /obj/item/deck/cards = 3, /obj/item/pack/cardemon = 5, /obj/item/pack/spaceball = 5, /obj/item/storage/pill_bottle/dice_nerd = 6, /obj/item/storage/pill_bottle/dice = 6, /obj/item/storage/box/checkers = 10, /obj/item/storage/box/checkers/chess/red = 10, /obj/item/storage/box/checkers/chess = 10, /obj/item/board = 2, /obj/item/storage/fancy/crayons = 3)
-	premium = list(/obj/item/spirit_board = 1, /obj/item/gun/projectile/revolver/capgun = 1, /obj/item/ammo_magazine/caps = 4)
-	contraband = list(/obj/item/reagent_containers/spray/waterflower = 2, /obj/item/storage/box/snappops = 3, /obj/item/toy/sword = 3, /obj/item/toy/katana = 3)
+	premium = list(/obj/item/spirit_board = 1)
+	contraband = list(/obj/item/reagent_containers/spray/waterflower = 2, /obj/item/storage/box/snappops = 3, /obj/item/toy/sword = 3, /obj/item/toy/katana = 3, /obj/item/gun/projectile/revolver/capgun = 1, /obj/item/ammo_magazine/caps = 4)
 
 //Cajoes/Kyos/BloodyMan's Lavatory Articles Dispensiary
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -289,7 +289,7 @@
 		return
 
 /obj/item/toy/katana
-	name = "replica katana"
+	name = "katana"
 	desc = "Woefully underpowered in D20."
 	icon = 'icons/obj/weapons/melee_physical.dmi'
 	icon_state = "katana"


### PR DESCRIPTION
The replica katana now reads as a normal katana on examine.

I've also made sure that the cap gun is always available from the toy vendor by moving it to contraband, this weapon already could be used as a fake revolver by cutting off the orange band.

🆑 Kell-E
tweak: the replica katana is more difficult to identify on an examine
tweak: the toy vendors contraband now includes the cap gun and ammo.
/🆑 