### PR TITLE
Prevent dismantling snowflake shuttle consoles

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/default.dm
+++ b/code/game/machinery/_machines_base/machine_construction/default.dm
@@ -22,6 +22,9 @@
 /decl/machine_construction/default/panel_closed/attackby(obj/item/I, mob/user, obj/machinery/machine)
 	if((. = ..()))
 		return
+	if (!machine.can_use_tools)
+		to_chat(user, SPAN_WARNING("\The [src] cannot be modified!"))
+		return TRUE
 	if(isScrewdriver(I))
 		TRANSFER_STATE(down_state)
 		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -135,6 +135,8 @@ Class Procs:
 	var/id_tag
 	/// What is created when the machine is dismantled.
 	var/frame_type = /obj/machinery/constructable_frame/machine_frame/deconstruct
+	/// Whether or not the machine is allowed to be dismantled/modified. Used for snowflake consoles that would break permanently if dismantled. Also prevents damage, since the machine would be irreparable in this state. Has to be defined here because machinery datums.
+	var/can_use_tools = TRUE
 
 	/// Component parts queued for processing by the machine. Expected type: `/obj/item/stock_parts`
 	var/list/processing_parts

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -73,7 +73,7 @@
 	..()
 
 /obj/machinery/computer/proc/take_damage(var/damage)
-	if (health <= 0)
+	if (health <= 0 || !can_use_tools)
 		return
 
 	health -= damage

--- a/code/modules/shuttles/shuttle_console_multi.dm
+++ b/code/modules/shuttles/shuttle_console_multi.dm
@@ -1,5 +1,6 @@
 /obj/machinery/computer/shuttle_control/multi
 	ui_template = "shuttle_control_console_multi.tmpl"
+	can_use_tools = FALSE
 
 /obj/machinery/computer/shuttle_control/multi/get_ui_data(var/datum/shuttle/autodock/multi/shuttle)
 	. = ..()


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Unique shuttle control consoles can no longer be broken or dismantled because this places them in an unfixable state.
/:cl: