### PR TITLE
revert planet unsim

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -229,7 +229,7 @@
 	return "<h2>Exoplanetary outpost blueprints</h2><small>Property of [GLOB.using_map.company_name].</small><hr>"
 
 /obj/item/blueprints/outpost/check_tile_is_border(var/turf/T2,var/dir)
-	if (istype(T2, /turf/unsimulated/floor/exoplanet/))
+	if (istype(T2, /turf/simulated/floor/exoplanet/))
 		return BORDER_SPACE
 	. = ..()
 

--- a/code/game/objects/items/devices/scanners/mining.dm
+++ b/code/game/objects/items/devices/scanners/mining.dm
@@ -20,8 +20,8 @@
 	. = ..()
 	to_chat(user,"A tiny indicator on the [src] shows it holds [survey_data] good explorer points.")
 
-/obj/item/device/scanner/mining/is_valid_scan_target(atom/atom)
-	return isturf(atom)
+/obj/item/device/scanner/mining/is_valid_scan_target(turf/simulated/T)
+	return istype(T)
 
 /obj/item/device/scanner/mining/scan(turf/simulated/T, mob/user)
 	scan_title = "Mineral scan data"
@@ -90,7 +90,7 @@
 
 	for(var/turf/simulated/T in range(2, target))
 
-		if(!T.resources)
+		if(!T.has_resources)
 			continue
 
 		for(var/metal in T.resources)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -37,8 +37,8 @@
 
 /obj/structure/pit/on_update_icon()
 	icon_state = "pit[open]"
-	if(istype(loc,/turf/unsimulated/floor/exoplanet))
-		var/turf/unsimulated/floor/exoplanet/E = loc
+	if(istype(loc,/turf/simulated/floor/exoplanet))
+		var/turf/simulated/floor/exoplanet/E = loc
 		if(E.dirt_color)
 			color = E.dirt_color
 

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -367,7 +367,7 @@
 
 /turf/simulated/floor/beach/sand/desert
 	icon_state = "desert"
-	resources = TRUE
+	has_resources = 1
 
 /turf/simulated/floor/beach/sand/desert/New()
 	icon_state = "desert[rand(0,5)]"

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -3,6 +3,10 @@
 	var/wet = 0
 	var/image/wet_overlay = null
 
+	//Mining resources (for the large drills).
+	var/has_resources
+	var/list/resources
+
 	var/thermite = 0
 	initial_gas = list(GAS_OXYGEN = MOLES_O2STANDARD, GAS_NITROGEN = MOLES_N2STANDARD)
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed

--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -4,6 +4,19 @@
 		var/decl/footsteps/FS = decls_repository.get_decl(footstep_type)
 		. = pick(FS.footstep_sounds)
 
+/turf/simulated/proc/get_footstep_sound(var/mob/caller)
+	for(var/obj/structure/S in contents)
+		if(S.footstep_type)
+			return get_footstep(S.footstep_type, caller)
+
+	if(check_fluid_depth(10) && !is_flooded(TRUE))
+		return get_footstep(/decl/footsteps/water, caller)
+
+	if(footstep_type)
+		return get_footstep(footstep_type, caller)
+
+	if(is_plating())
+		return get_footstep(/decl/footsteps/plating, caller)
 
 /turf/simulated/floor/get_footstep_sound(var/mob/caller)
 	. = ..()
@@ -28,7 +41,7 @@
 
 	if(!has_organ(BP_L_FOOT) && !has_organ(BP_R_FOOT))
 		return //no feet no footsteps
-
+	
 	return TRUE
 
 /mob/living/carbon/human/proc/handle_footsteps()
@@ -38,7 +51,7 @@
 	 //every other turf makes a sound
 	if((step_count % 2) && MOVING_QUICKLY(src))
 		return
-
+	
 	// don't need to step as often when you hop around
 	if((step_count % 3) && !has_gravity(src))
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -33,7 +33,6 @@
 	var/flooded // Whether or not this turf is absolutely flooded ie. a water source.
 	var/height = 0 // Determines if fluids can overflow onto next turf
 	var/footstep_type
-	var/list/resources
 
 	var/tmp/changing_turf
 
@@ -94,19 +93,6 @@
 
 /turf/proc/is_solid_structure()
 	return 1
-
-
-/turf/proc/get_footstep_sound(mob/caller)
-	for(var/obj/structure/S in contents)
-		if(S.footstep_type)
-			return get_footstep(S.footstep_type, caller)
-	if(check_fluid_depth(10) && !is_flooded(TRUE))
-		return get_footstep(/decl/footsteps/water, caller)
-	if(footstep_type)
-		return get_footstep(footstep_type, caller)
-	if(is_plating())
-		return get_footstep(/decl/footsteps/plating, caller)
-
 
 /turf/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -76,8 +76,8 @@
 		var/turf/simulated/floor/asteroid/T = get_turf(src)
 		if(!T.dug)
 			T.gets_dug()
-	else if(istype(get_turf(src), /turf/unsimulated/floor/exoplanet))
-		var/turf/unsimulated/floor/exoplanet/T = get_turf(src)
+	else if(istype(get_turf(src), /turf/simulated/floor/exoplanet))
+		var/turf/simulated/floor/exoplanet/T = get_turf(src)
 		if(T.diggable)
 			new /obj/structure/pit(T)
 			T.diggable = 0
@@ -90,6 +90,7 @@
 		var/turf/simulated/harvesting = pick(resource_field)
 
 		while(resource_field.len && !harvesting.resources)
+			harvesting.has_resources = 0
 			harvesting.resources = null
 			resource_field -= harvesting
 			if(resource_field.len)
@@ -133,6 +134,7 @@
 					new oretype(src)
 
 		if(!found_resource)
+			harvesting.has_resources = 0
 			harvesting.resources = null
 			resource_field -= harvesting
 	else
@@ -227,7 +229,7 @@
 	need_update_field = 0
 
 	for (var/turf/simulated/T in range(2, src))
-		if (T.resources)
+		if (T.has_resources)
 			resource_field += T
 
 	if (!length(resource_field))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -218,7 +218,7 @@
 	if(use(1)) // Don't skip use() checks even if you only need one! Stacks with the amount of 0 are possible, e.g. on synthetics!
 		var/obj/item/stack/flag/newflag = new src.type(T, 1)
 		newflag.set_up()
-		if(istype(T, /turf/simulated/floor/asteroid) || istype(T, /turf/unsimulated/floor/exoplanet))
+		if(istype(T, /turf/simulated/floor/asteroid) || istype(T, /turf/simulated/floor/exoplanet))
 			user.visible_message("\The [user] plants \the [newflag.singular_name] firmly in the ground.")
 		else
 			user.visible_message("\The [user] attaches \the [newflag.singular_name] firmly to the ground.")

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -36,7 +36,8 @@ var/list/mining_floors = list()
 	var/obj/item/last_find
 	var/datum/artifact_find/artifact_find
 	var/image/ore_overlay
-	resources = TRUE
+
+	has_resources = 1
 
 /turf/simulated/mineral/Initialize()
 	. = ..()
@@ -423,7 +424,7 @@ var/list/mining_floors = list()
 	temperature = TCMB
 	var/dug = 0       //0 = has not yet been dug, 1 = has already been dug
 	var/overlay_detail
-	resources = TRUE
+	has_resources = 1
 
 /turf/simulated/floor/asteroid/Initialize()
 	. = ..()

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -176,7 +176,7 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	var/light = 0.1
 	if (!night)
 		light = lightlevel
-	for (var/turf/unsimulated/floor/exoplanet/T in block(locate(daycolumn,1,min(map_z)),locate(daycolumn,maxy,max(map_z))))
+	for (var/turf/simulated/floor/exoplanet/T in block(locate(daycolumn,1,min(map_z)),locate(daycolumn,maxy,max(map_z))))
 		T.set_light(light, 0.1, 2)
 	daycolumn++
 	if (daycolumn > maxx)

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -153,6 +153,18 @@ GLOBAL_VAR(planet_repopulation_disabled)
 		if (!atmosphere)
 			continue
 
+		var/zone/Z
+		for (var/i = 1 to maxx)
+			var/turf/simulated/T = locate(i, 2, zlevel)
+			if (istype(T) && T.zone && T.zone.contents.len > (maxx*maxy*0.25)) //if it's a zone quarter of zlevel, good enough odds it's planetary main one
+				Z = T.zone
+				break
+		if (Z && !Z.fire_tiles.len && !atmosphere.compare(Z.air)) //let fire die out first if there is one
+			var/datum/gas_mixture/daddy = new() //make a fake 'planet' zone gas
+			daddy.copy_from(atmosphere)
+			daddy.group_multiplier = Z.air.group_multiplier
+			Z.air.equalize(daddy)
+
 	if (daycycle)
 		if (tick % round(daycycle / wait) == 0)
 			night = !night
@@ -185,7 +197,7 @@ GLOBAL_VAR(planet_repopulation_disabled)
 		edges |= block(locate(1, 1, zlevel), locate(maxx, TRANSITIONEDGE, zlevel))
 		edges |= block(locate(1, maxy-TRANSITIONEDGE, zlevel),locate(maxx, maxy, zlevel))
 		for (var/turf/T in edges)
-			T.ChangeTurf(/turf/unsimulated/planet_edge)
+			T.ChangeTurf(/turf/simulated/planet_edge)
 		var/padding = TRANSITIONEDGE
 		for (var/map_type in map_generators)
 			if (ispath(map_type, /datum/random_map/noise/exoplanet))

--- a/code/modules/overmap/exoplanets/exoplanet_fauna.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_fauna.dm
@@ -42,7 +42,7 @@
 /obj/effect/overmap/visitable/sector/exoplanet/proc/handle_repopulation()
 	for (var/i = 1 to round(max_animal_count - animals.len))
 		if (prob(10))
-			var/turf/T = pick_area_turf(planetary_area, list(/proc/not_turf_contains_dense_objects))
+			var/turf/simulated/T = pick_area_turf(planetary_area, list(/proc/not_turf_contains_dense_objects))
 			var/mob_type = pick(repopulate_types)
 			var/mob/S = new mob_type(T)
 			track_animal(S)

--- a/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
@@ -22,7 +22,7 @@
 		S.range = 4
 		SSradiation.add_source(S)
 		T.set_light(0.4, 1, 2, l_color = PIPE_COLOR_GREEN)
-		for (var/turf/unsimulated/floor/exoplanet/crater in circlerangeturfs(T, 3))
+		for (var/turf/simulated/floor/exoplanet/crater in circlerangeturfs(T, 3))
 			if (prob(10))
 				new/obj/item/remains/xeno/charred(crater)
 			crater.melt()

--- a/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
@@ -14,7 +14,7 @@
 	var/radiation_power = rand(10, 37.5)
 	var/num_craters = round(min(0.04, rand()) * 0.02 * E.maxx * E.maxy)
 	for (var/i = 1 to num_craters)
-		var/turf/T = pick_area_turf(E.planetary_area, list(/proc/not_turf_contains_dense_objects))
+		var/turf/simulated/T = pick_area_turf(E.planetary_area, list(/proc/not_turf_contains_dense_objects))
 		if (!T) // ran out of space somehow
 			return
 		new/obj/structure/rubble/war(T)

--- a/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
@@ -124,13 +124,13 @@
 			return /turf/unsimulated/floor/exoplanet/concrete/reinforced
 	return ..()
 
-/datum/random_map/maze/concrete/get_additional_spawns(value, turf/floor)
-	if (!istype(floor))
+/datum/random_map/maze/concrete/get_additional_spawns(var/value, var/turf/simulated/floor/T)
+	if (!istype(T))
 		return
 	if (prob(10))
-		new /obj/item/remains/xeno/charred (floor)
-	if (prob(20))
-		new /obj/structure/rubble/house (floor)
+		new/obj/item/remains/xeno/charred(T)
+	if ((T.broken && prob(80)) || prob(10))
+		new/obj/structure/rubble/house(T)
 
 //Artifact containment lab
 /turf/simulated/wall/containment
@@ -175,7 +175,6 @@
 		entrance_y = rand(2,limit_y-1)
 	map[get_map_cell(entrance_x,entrance_y)] = DOOR_VALUE
 
-
 /datum/random_map/maze/lab/get_appropriate_path(var/value)
 	if (value == ARTIFACT_VALUE)
 		return floor_type
@@ -183,23 +182,25 @@
 		return floor_type
 	. = ..()
 
+/datum/random_map/maze/lab/get_additional_spawns(var/value, var/turf/simulated/floor/T)
+	if (!istype(T))
+		return
 
-/datum/random_map/maze/lab/get_additional_spawns(value, turf/floor)
-	if (!isturf(floor))
+	if (value == DOOR_VALUE)
+		new/obj/machinery/door/airlock/alien(T)
 		return
-	else if (value == ARTIFACT_VALUE)
-		var/datum/artifact_find/A = new
-		new A.artifact_find_type(floor)
+
+	if (value == ARTIFACT_VALUE)
+		var/datum/artifact_find/A = new()
+		new A.artifact_find_type(T)
 		qdel(A)
-	else if (floor.density)
 		return
-	else if (value == DOOR_VALUE)
-		new /obj/machinery/door/airlock/alien (floor)
-	else if (value == FLOOR_VALUE)
+
+	if (value == FLOOR_VALUE)
 		if (prob(20))
-			new /obj/structure/rubble/lab (floor)
-		else if (prob(20))
-			new /obj/item/remains/xeno/charred (floor)
+			new/obj/structure/rubble/lab(T)
+		if (prob(20))
+			new/obj/item/remains/xeno/charred(T)
 
 
 #undef TRANSLATE_COORD

--- a/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
@@ -101,7 +101,7 @@
 
 /datum/random_map/city/get_appropriate_path(var/value)
 	if (value == ROAD_VALUE)
-		return /turf/unsimulated/floor/exoplanet/concrete/reinforced/road
+		return /turf/simulated/floor/exoplanet/concrete/reinforced/road
 
 /datum/random_map/city/apply_to_map()
 	..()
@@ -113,7 +113,7 @@
 //Generic ruin
 /datum/random_map/maze/concrete
 	wall_type =  /turf/simulated/wall/concrete
-	floor_type = /turf/unsimulated/floor/exoplanet/concrete/reinforced
+	floor_type = /turf/simulated/floor/exoplanet/concrete/reinforced
 	preserve_map = 0
 
 /datum/random_map/maze/concrete/get_appropriate_path(var/value)
@@ -121,7 +121,7 @@
 		if (prob(80))
 			return /turf/simulated/wall/concrete
 		else
-			return /turf/unsimulated/floor/exoplanet/concrete/reinforced
+			return /turf/simulated/floor/exoplanet/concrete/reinforced/damaged
 	return ..()
 
 /datum/random_map/maze/concrete/get_additional_spawns(var/value, var/turf/simulated/floor/T)
@@ -205,14 +205,16 @@
 
 #undef TRANSLATE_COORD
 
-/turf/unsimulated/floor/exoplanet/concrete/reinforced
+/turf/simulated/floor/exoplanet/concrete/reinforced
 	name = "reinforced concrete"
 	desc = "Stone-like artificial material. It has been reinforced with an unknown compound."
 	icon_state = "hexacrete"
 
-/turf/unsimulated/floor/exoplanet/concrete/reinforced/road
+/turf/simulated/floor/exoplanet/concrete/reinforced/road
 	icon_state = "hexacrete_dark"
 
+/turf/simulated/floor/exoplanet/concrete/reinforced/damaged
+	broken = TRUE
 
 /obj/item/remains/xeno/charred
 	color = COLOR_DARK_GRAY

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -25,26 +25,26 @@
 /datum/random_map/noise/exoplanet/barren
 	descriptor = "barren exoplanet"
 	smoothing_iterations = 4
-	land_type = /turf/unsimulated/floor/exoplanet/barren
+	land_type = /turf/simulated/floor/exoplanet/barren
 	flora_prob = 0.1
 	large_flora_prob = 0
 	fauna_prob = 0
 
-/turf/unsimulated/floor/exoplanet/barren
+/turf/simulated/floor/exoplanet/barren
 	name = "ground"
 	icon = 'icons/turf/flooring/asteroid.dmi'
 	icon_state = "asteroid"
 
-/turf/unsimulated/floor/exoplanet/barren/on_update_icon()
+/turf/simulated/floor/exoplanet/barren/on_update_icon()
 	overlays.Cut()
 	if(prob(20))
 		overlays += image('icons/turf/flooring/decals.dmi', "asteroid[rand(0,9)]")
 
-/turf/unsimulated/floor/exoplanet/barren/Initialize()
+/turf/simulated/floor/exoplanet/barren/Initialize()
 	. = ..()
 	update_icon()
 
 /area/exoplanet/barren
 	name = "\improper Planetary surface"
 	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/effects/wind/wind_4_2.ogg','sound/effects/wind/wind_5_1.ogg')
-	base_turf = /turf/unsimulated/floor/exoplanet/barren
+	base_turf = /turf/simulated/floor/exoplanet/barren

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -35,8 +35,8 @@
 /datum/random_map/noise/exoplanet/chlorine
 	descriptor = "chlorine exoplanet"
 	smoothing_iterations = 3
-	land_type = /turf/unsimulated/floor/exoplanet/chlorine_sand
-	water_type = /turf/unsimulated/floor/exoplanet/water/shallow/chlorine_liquid
+	land_type = /turf/simulated/floor/exoplanet/chlorine_sand
+	water_type = /turf/simulated/floor/exoplanet/water/shallow/chlorine_liquid
 	water_level_min = 2
 	water_level_max = 3
 	fauna_prob = 2
@@ -45,9 +45,9 @@
 
 /area/exoplanet/chlorine
 	ambience = list('sound/effects/wind/desert0.ogg','sound/effects/wind/desert1.ogg','sound/effects/wind/desert2.ogg','sound/effects/wind/desert3.ogg','sound/effects/wind/desert4.ogg','sound/effects/wind/desert5.ogg')
-	base_turf = /turf/unsimulated/floor/exoplanet/chlorine_sand
+	base_turf = /turf/simulated/floor/exoplanet/chlorine_sand
 
-/turf/unsimulated/floor/exoplanet/water/shallow/chlorine_liquid
+/turf/simulated/floor/exoplanet/water/shallow/chlorine_liquid
 	name = "chlorine marsh"
 	icon = 'icons/turf/chlorine.dmi'
 	icon_state = "chlorine_liquid"
@@ -55,7 +55,7 @@
 	dirt_color = "#d2e0b7"
 	reagent_type = /datum/reagent/toxin/chlorine
 
-/turf/unsimulated/floor/exoplanet/chlorine_sand
+/turf/simulated/floor/exoplanet/chlorine_sand
 	name = "chlorinated sand"
 	icon = 'icons/turf/chlorine.dmi'
 	icon_state = "chlorine_sand1"
@@ -63,6 +63,6 @@
 	dirt_color = "#d2e0b7"
 	footstep_type = /decl/footsteps/sand
 
-/turf/unsimulated/floor/exoplanet/chlorine_sand/New()
+/turf/simulated/floor/exoplanet/chlorine_sand/New()
 	icon_state = "chlorine_sand[rand(0,11)]"
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -45,7 +45,7 @@
 /datum/random_map/noise/exoplanet/desert
 	descriptor = "desert exoplanet"
 	smoothing_iterations = 4
-	land_type = /turf/unsimulated/floor/exoplanet/desert
+	land_type = /turf/simulated/floor/exoplanet/desert
 
 	flora_prob = 5
 	large_flora_prob = 0
@@ -58,7 +58,7 @@
 
 /area/exoplanet/desert
 	ambience = list('sound/effects/wind/desert0.ogg','sound/effects/wind/desert1.ogg','sound/effects/wind/desert2.ogg','sound/effects/wind/desert3.ogg','sound/effects/wind/desert4.ogg','sound/effects/wind/desert5.ogg')
-	base_turf = /turf/unsimulated/floor/exoplanet/desert
+	base_turf = /turf/simulated/floor/exoplanet/desert
 
 /obj/effect/quicksand
 	name = "quicksand"

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -51,7 +51,7 @@
 			S.set_trait(TRAIT_SPREAD,1)
 
 /area/exoplanet/grass
-	base_turf = /turf/unsimulated/floor/exoplanet/grass
+	base_turf = /turf/simulated/floor/exoplanet/grass
 	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/ambience/eeriejungle2.ogg','sound/ambience/eeriejungle1.ogg')
 
 /area/exoplanet/grass/play_ambience(var/mob/living/L)
@@ -63,8 +63,8 @@
 /datum/random_map/noise/exoplanet/grass
 	descriptor = "grass exoplanet"
 	smoothing_iterations = 2
-	land_type = /turf/unsimulated/floor/exoplanet/grass
-	water_type = /turf/unsimulated/floor/exoplanet/water/shallow
+	land_type = /turf/simulated/floor/exoplanet/grass
+	water_type = /turf/simulated/floor/exoplanet/water/shallow
 
 	flora_prob = 10
 	grass_prob = 50

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -35,8 +35,8 @@
 	megafauna_spawn_prob = 2 //Remember to change this if more types are added.
 	water_level_max = 3
 	water_level_min = 2
-	land_type = /turf/unsimulated/floor/exoplanet/shrouded
-	water_type = /turf/unsimulated/floor/exoplanet/water/shallow/tar
+	land_type = /turf/simulated/floor/exoplanet/shrouded
+	water_type = /turf/simulated/floor/exoplanet/water/shallow/tar
 
 /datum/random_map/noise/exoplanet/shrouded/get_additional_spawns(value, turf/T)
 	..()
@@ -46,9 +46,9 @@
 
 /area/exoplanet/shrouded
 	forced_ambience = list("sound/ambience/spookyspace1.ogg", "sound/ambience/spookyspace2.ogg")
-	base_turf = /turf/unsimulated/floor/exoplanet/shrouded
+	base_turf = /turf/simulated/floor/exoplanet/shrouded
 
-/turf/unsimulated/floor/exoplanet/water/shallow/tar
+/turf/simulated/floor/exoplanet/water/shallow/tar
 	name = "tar"
 	icon = 'icons/turf/shrouded.dmi'
 	icon_state = "shrouded_tar"
@@ -57,17 +57,17 @@
 	reagent_type = /datum/reagent/toxin/tar
 	dirt_color = "#3e3960"
 
-/turf/unsimulated/floor/exoplanet/water/shallow/tar/get_footstep_sound(mob/caller)
+/turf/simulated/floor/exoplanet/water/shallow/tar/get_footstep_sound(mob/caller)
 	return get_footstep(/decl/footsteps/water, caller)
 
 
-/turf/unsimulated/floor/exoplanet/shrouded
+/turf/simulated/floor/exoplanet/shrouded
 	name = "packed sand"
 	icon = 'icons/turf/shrouded.dmi'
 	icon_state = "shrouded"
 	desc = "Sand that has been packed in to solid earth."
 	dirt_color = "#3e3960"
 
-/turf/unsimulated/floor/exoplanet/shrouded/New()
+/turf/simulated/floor/exoplanet/shrouded/New()
 	icon_state = "shrouded[rand(0,8)]"
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -30,9 +30,9 @@
 	flora_prob = 5
 	large_flora_prob = 10
 	water_level_max = 3
-	land_type = /turf/unsimulated/floor/exoplanet/snow
-	water_type = /turf/unsimulated/floor/exoplanet/ice
+	land_type = /turf/simulated/floor/exoplanet/snow
+	water_type = /turf/simulated/floor/exoplanet/ice
 
 /area/exoplanet/snow
 	ambience = list('sound/effects/wind/tundra0.ogg','sound/effects/wind/tundra1.ogg','sound/effects/wind/tundra2.ogg','sound/effects/wind/spooky0.ogg','sound/effects/wind/spooky1.ogg')
-	base_turf = /turf/unsimulated/floor/exoplanet/snow/
+	base_turf = /turf/simulated/floor/exoplanet/snow/

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -37,8 +37,8 @@
 /datum/random_map/noise/exoplanet/volcanic
 	descriptor = "volcanic exoplanet"
 	smoothing_iterations = 5
-	land_type = /turf/unsimulated/floor/exoplanet/volcanic
-	water_type = /turf/unsimulated/floor/exoplanet/lava
+	land_type = /turf/simulated/floor/exoplanet/volcanic
+	water_type = /turf/simulated/floor/exoplanet/lava
 	water_level_min = 5
 	water_level_max = 6
 
@@ -65,9 +65,9 @@
 
 /area/exoplanet/volcanic
 	forced_ambience = list('sound/ambience/magma.ogg')
-	base_turf = /turf/unsimulated/floor/exoplanet/volcanic
+	base_turf = /turf/simulated/floor/exoplanet/volcanic
 
-/turf/unsimulated/floor/exoplanet/volcanic
+/turf/simulated/floor/exoplanet/volcanic
 	name = "volcanic floor"
 	icon = 'icons/turf/flooring/lava.dmi'
 	icon_state = "cold"
@@ -83,9 +83,9 @@
 /datum/random_map/automata/cave_system/mountains/volcanic/get_additional_spawns(value, var/turf/simulated/mineral/T)
 	..()
 	if(use_area && istype(T))
-		T.mined_turf = prob(90) ? use_area.base_turf : /turf/unsimulated/floor/exoplanet/lava
+		T.mined_turf = prob(90) ? use_area.base_turf : /turf/simulated/floor/exoplanet/lava
 
-/turf/unsimulated/floor/exoplanet/lava
+/turf/simulated/floor/exoplanet/lava
 	name = "lava"
 	icon = 'icons/turf/flooring/lava.dmi'
 	icon_state = "lava"
@@ -94,18 +94,18 @@
 	turf_flags = TURF_DISALLOW_BLOB
 	var/list/victims
 
-/turf/unsimulated/floor/exoplanet/lava/on_update_icon()
+/turf/simulated/floor/exoplanet/lava/on_update_icon()
 	return
 
-/turf/unsimulated/floor/exoplanet/lava/Initialize()
+/turf/simulated/floor/exoplanet/lava/Initialize()
 	. = ..()
 	set_light(0.95, 0.5, 2, l_color = COLOR_ORANGE)
 
-/turf/unsimulated/floor/exoplanet/lava/Destroy()
+/turf/simulated/floor/exoplanet/lava/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/turf/unsimulated/floor/exoplanet/lava/Entered(atom/movable/AM)
+/turf/simulated/floor/exoplanet/lava/Entered(atom/movable/AM)
 	..()
 	if(locate(/obj/structure/catwalk/) in src)
 		return
@@ -116,11 +116,11 @@
 		LAZYADD(victims, weakref(AM))
 		START_PROCESSING(SSobj, src)
 
-/turf/unsimulated/floor/exoplanet/lava/Exited(atom/movable/AM)
+/turf/simulated/floor/exoplanet/lava/Exited(atom/movable/AM)
 	. = ..()
 	LAZYREMOVE(victims, weakref(AM))
 
-/turf/unsimulated/floor/exoplanet/lava/Process()
+/turf/simulated/floor/exoplanet/lava/Process()
 	if(locate(/obj/structure/catwalk/) in src)
 		victims = null
 		return PROCESS_KILL
@@ -137,7 +137,7 @@
 	if(!LAZYLEN(victims))
 		return PROCESS_KILL
 
-/turf/unsimulated/floor/exoplanet/lava/get_footstep_sound(var/mob/caller)
+/turf/simulated/floor/exoplanet/lava/get_footstep_sound(var/mob/caller)
 	return get_footstep(/decl/footsteps/lava, caller)
 
 /turf/simulated/mineral/volcanic

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -7,7 +7,7 @@
 	var/water_level
 	var/water_level_min = 0
 	var/water_level_max = 5
-	var/land_type = /turf/unsimulated/floor
+	var/land_type = /turf/simulated/floor
 	var/water_type
 	var/coast_type
 

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -194,7 +194,7 @@
 
 //Special world edge turf
 
-/turf/unsimulated/planet_edge
+/turf/simulated/planet_edge
 	name = "world's edge"
 	desc = "Government didn't want you to see this!"
 	density = TRUE
@@ -203,7 +203,7 @@
 	icon = null
 	icon_state = null
 
-/turf/unsimulated/planet_edge/Initialize()
+/turf/simulated/planet_edge/Initialize()
 	. = ..()
 	var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 	if(!istype(E))
@@ -230,7 +230,7 @@
 	O.name = "distant terrain"
 	O.desc = "You need to come over there to take a better look."
 
-/turf/unsimulated/planet_edge/Bumped(atom/movable/A)
+/turf/simulated/planet_edge/Bumped(atom/movable/A)
 	. = ..()
 	var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 	if(!istype(E))

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -1,15 +1,16 @@
-/turf/unsimulated/floor/exoplanet
+/turf/simulated/floor/exoplanet
 	name = "space land"
 	icon = 'icons/turf/desert.dmi'
 	icon_state = "desert"
+	has_resources = 1
 	footstep_type = /decl/footsteps/asteroid
 	var/diggable = 1
 	var/dirt_color = "#7c5e42"
 
-/turf/unsimulated/floor/exoplanet/can_engrave()
+/turf/simulated/floor/exoplanet/can_engrave()
 	return FALSE
 
-/turf/unsimulated/floor/exoplanet/New()
+/turf/simulated/floor/exoplanet/New()
 	if(GLOB.using_map.use_overmap)
 		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E))
@@ -25,7 +26,7 @@
 				ChangeArea(src, E.planetary_area)
 	..()
 
-/turf/unsimulated/floor/exoplanet/attackby(obj/item/C, mob/user)
+/turf/simulated/floor/exoplanet/attackby(obj/item/C, mob/user)
 	if(diggable && istype(C,/obj/item/shovel))
 		visible_message("<span class='notice'>\The [user] starts digging \the [src]</span>")
 		if(do_after(user, 50))
@@ -44,7 +45,7 @@
 	else
 		..()
 
-/turf/unsimulated/floor/exoplanet/ex_act(severity)
+/turf/simulated/floor/exoplanet/ex_act(severity)
 	switch(severity)
 		if(1)
 			ChangeTurf(get_base_turf_by_area(src))
@@ -52,11 +53,11 @@
 			if(prob(40))
 				ChangeTurf(get_base_turf_by_area(src))
 
-/turf/unsimulated/floor/exoplanet/Initialize()
+/turf/simulated/floor/exoplanet/Initialize()
 	. = ..()
 	update_icon(1)
 
-/turf/unsimulated/floor/exoplanet/on_update_icon(var/update_neighbors)
+/turf/simulated/floor/exoplanet/on_update_icon(var/update_neighbors)
 	overlays.Cut()
 	if(LAZYLEN(decals))
 		overlays += decals
@@ -79,13 +80,13 @@
 			turf_to_check.update_icon()
 
 //WAter
-/turf/unsimulated/floor/exoplanet/water/on_update_icon()
+/turf/simulated/floor/exoplanet/water/on_update_icon()
 	return
 
-/turf/unsimulated/floor/exoplanet/water/is_flooded(lying_mob, absolute)
+/turf/simulated/floor/exoplanet/water/is_flooded(lying_mob, absolute)
 	. = absolute ? ..() : lying_mob
 
-/turf/unsimulated/floor/exoplanet/water/shallow
+/turf/simulated/floor/exoplanet/water/shallow
 	name = "shallow water"
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "seashallow"
@@ -93,7 +94,7 @@
 	footstep_type = /decl/footsteps/water
 	var/reagent_type = /datum/reagent/water
 
-/turf/unsimulated/floor/exoplanet/water/shallow/attackby(obj/item/O, var/mob/living/user)
+/turf/simulated/floor/exoplanet/water/shallow/attackby(obj/item/O, var/mob/living/user)
 	var/obj/item/reagent_containers/RG = O
 	if (reagent_type && istype(RG) && RG.is_open_container() && RG.reagents)
 		RG.reagents.add_reagent(reagent_type, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
@@ -101,44 +102,47 @@
 	else
 		return ..()
 
+/turf/simulated/floor/exoplanet/water/update_dirt()
+	return	// Water doesn't become dirty
+
 //Ice
-/turf/unsimulated/floor/exoplanet/ice
+/turf/simulated/floor/exoplanet/ice
 	name = "ice"
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "ice"
 
-/turf/unsimulated/floor/exoplanet/ice/on_update_icon()
+/turf/simulated/floor/exoplanet/ice/on_update_icon()
 	return
 
 //Snow
-/turf/unsimulated/floor/exoplanet/snow
+/turf/simulated/floor/exoplanet/snow
 	name = "snow"
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
 	dirt_color = "#e3e7e8"
 	footstep_type = /decl/footsteps/snow
 
-/turf/unsimulated/floor/exoplanet/snow/Initialize()
+/turf/simulated/floor/exoplanet/snow/Initialize()
 	. = ..()
 	icon_state = pick("snow[rand(1,12)]","snow0")
 
-/turf/unsimulated/floor/exoplanet/snow/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/turf/simulated/floor/exoplanet/snow/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	melt()
 
-/turf/unsimulated/floor/exoplanet/snow/melt()
+/turf/simulated/floor/exoplanet/snow/melt()
 	SetName("permafrost")
 	icon_state = "permafrost"
 	footstep_type = /decl/footsteps/asteroid
 
 //Grass
-/turf/unsimulated/floor/exoplanet/grass
+/turf/simulated/floor/exoplanet/grass
 	name = "grass"
 	icon = 'icons/turf/jungle.dmi'
 	icon_state = "greygrass"
 	color = "#799c4b"
 	footstep_type = /decl/footsteps/grass
 
-/turf/unsimulated/floor/exoplanet/grass/Initialize()
+/turf/simulated/floor/exoplanet/grass/Initialize()
 	. = ..()
 	if(GLOB.using_map.use_overmap)
 		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
@@ -153,44 +157,54 @@
 	if(prob(2))
 		resources[MATERIAL_DIAMOND] = 1
 
-/turf/unsimulated/floor/exoplanet/grass/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/turf/simulated/floor/exoplanet/grass/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if((temperature > T0C + 200 && prob(5)) || temperature > T0C + 1000)
 		melt()
 
-/turf/unsimulated/floor/exoplanet/grass/melt()
+/turf/simulated/floor/exoplanet/grass/melt()
 	SetName("scorched ground")
 	icon_state = "scorched"
 	footstep_type = /decl/footsteps/asteroid
 	color = null
 
 //Sand
-/turf/unsimulated/floor/exoplanet/desert
+/turf/simulated/floor/exoplanet/desert
 	name = "sand"
 	desc = "It's coarse and gets everywhere."
 	dirt_color = "#ae9e66"
 	footstep_type = /decl/footsteps/sand
 
-/turf/unsimulated/floor/exoplanet/desert/Initialize()
+/turf/simulated/floor/exoplanet/desert/Initialize()
 	. = ..()
 	icon_state = "desert[rand(0,5)]"
 
-/turf/unsimulated/floor/exoplanet/desert/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/turf/simulated/floor/exoplanet/desert/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if((temperature > T0C + 1700 && prob(5)) || temperature > T0C + 3000)
 		melt()
 
-/turf/unsimulated/floor/exoplanet/desert/melt()
+/turf/simulated/floor/exoplanet/desert/melt()
 	SetName("molten silica")
 	desc = "A glassed patch of sand."
 	icon_state = "sandglass"
 	diggable = 0
 
 //Concrete
-/turf/unsimulated/floor/exoplanet/concrete
+/turf/simulated/floor/exoplanet/concrete
 	name = "concrete"
 	desc = "Stone-like artificial material."
 	icon = 'icons/turf/flooring/misc.dmi'
 	icon_state = "concrete"
 
+/turf/simulated/floor/exoplanet/concrete/on_update_icon()
+	overlays.Cut()
+	if(burnt)
+		overlays |= get_damage_overlay("burned[(x + y) % 3]", BLEND_MULTIPLY)
+	if(broken)
+		overlays |= get_damage_overlay("broken[(x + y) % 5]", BLEND_MULTIPLY)
+
+/turf/simulated/floor/exoplanet/concrete/melt()
+	burnt = TRUE
+	update_icon()
 
 //Special world edge turf
 

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -50,7 +50,7 @@
 	for(var/i=0,i<chunk_size,i++)
 		for(var/j=0,j<chunk_size,j++)
 			var/turf/simulated/T = locate(tx+j, ty+i, origin_z)
-			if(!istype(T) || !T.resources)
+			if(!istype(T) || !T.has_resources)
 				continue
 			if(!priority_process)
 				CHECK_TICK

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -10,56 +10,56 @@
 	},
 /area/bluespaceriver/ground)
 "ac" = (
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "ad" = (
 /obj/structure/flora/grass/brown,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "ae" = (
 /obj/structure/flora/tree/pine,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "af" = (
 /obj/structure/flora/bush,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "ag" = (
 /obj/structure/flora/bush,
 /obj/structure/flora/grass/both,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "ah" = (
 /obj/structure/flora/grass/green,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "ai" = (
 /obj/structure/flora/grass/both,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "aj" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "ak" = (
 /obj/effect/shuttle_landmark/nav_blueriv/nav3,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
@@ -67,13 +67,13 @@
 /obj/effect/overmap/visitable/sector/arcticplanet{
 	desc = "Sensors show an arctic planet with a small vessel on the surface. The vessel is located in the western region of a trough surrounded by mineral-rich mountains on all four sides. Scans further indicate strange energy emissions from below the planet's surface. Sunrise is expected in 56 hours."
 	},
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "am" = (
 /obj/effect/shuttle_landmark/nav_blueriv/nav1,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
@@ -99,7 +99,7 @@
 /area/bluespaceriver/ship)
 "as" = (
 /obj/machinery/light,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ship)
@@ -413,7 +413,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ship)
@@ -498,7 +498,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ship)
@@ -644,7 +644,7 @@
 	dir = 8;
 	use_power = 1
 	},
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ship)
@@ -779,51 +779,51 @@
 /area/bluespaceriver/ship)
 "cv" = (
 /obj/machinery/mining/brace,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cw" = (
 /obj/machinery/mining/drill,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cx" = (
 /obj/effect/shuttle_landmark/nav_blueriv/nav4,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cy" = (
 /obj/structure/ladder,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cz" = (
 /obj/item/remains/human,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cA" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/grass/both,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cB" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)
 "cC" = (
 /obj/effect/shuttle_landmark/nav_blueriv/nav2,
-/turf/unsimulated/floor/exoplanet/snow{
+/turf/simulated/floor/exoplanet/snow{
 	temperature = 240
 	},
 /area/bluespaceriver/ground)

--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -2709,7 +2709,7 @@
 /turf/simulated/floor/airless,
 /area/space)
 "fP" = (
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "fQ" = (
 /obj/structure/window/basic{
@@ -2717,7 +2717,7 @@
 	},
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/item/seeds/weeds,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "fR" = (
 /obj/structure/window/basic{
@@ -2728,16 +2728,16 @@
 	},
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/item/seeds/weeds,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "fS" = (
 /obj/machinery/door/window/eastleft,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "fT" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/item/seeds/weeds,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "fU" = (
 /obj/structure/window/basic{
@@ -2745,7 +2745,7 @@
 	},
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/item/seeds/weeds,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "fV" = (
 /obj/structure/table/marble,
@@ -2862,7 +2862,7 @@
 /area/meatstation/hydroponics)
 "gj" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "gk" = (
 /obj/random/single/meatstation/wormscientist,
@@ -3747,7 +3747,7 @@
 /area/meatstation/bathroom)
 "im" = (
 /obj/machinery/beehive,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "in" = (
 /obj/effect/floor_decal/corner/lime/border{
@@ -8049,12 +8049,12 @@
 /area/meatstation/hydroponics)
 "tl" = (
 /obj/random/single/meatstation/low/wormguard,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "tm" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/random/single/meatstation/low/wormguard,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "tn" = (
 /obj/random/single/meatstation/meatworm,
@@ -9354,7 +9354,7 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/item/seeds/weeds,
 /obj/machinery/light,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/meatstation/hydroponics)
 "wa" = (
 /obj/machinery/biogenerator,

--- a/maps/away/mining/mining-orb.dmm
+++ b/maps/away/mining/mining-orb.dmm
@@ -56,7 +56,7 @@
 	dir = 1;
 	icon_state = "spline_fancy"
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "as" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -66,7 +66,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "au" = (
 /obj/effect/shuttle_landmark/orb/nav4,
@@ -74,26 +74,26 @@
 /area/space)
 "ax" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aB" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aD" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aF" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1;
 	icon_state = "spline_fancy"
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aI" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -113,7 +113,7 @@
 /turf/simulated/floor/airless/stone,
 /area/mine/explored)
 "aP" = (
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aQ" = (
 /obj/machinery/door/unpowered/simple/sandstone,
@@ -135,20 +135,20 @@
 	dir = 9;
 	icon_state = "spline_fancy"
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aW" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood/corner,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aX" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -157,7 +157,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -166,7 +166,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aZ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -175,7 +175,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "ba" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -184,7 +184,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "bb" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -193,20 +193,20 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "bc" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10;
 	icon_state = "spline_fancy"
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "bd" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "be" = (
 /turf/unsimulated/mask,
@@ -223,13 +223,13 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "eM" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "fA" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -237,13 +237,13 @@
 	icon_state = "spline_fancy"
 	},
 /obj/effect/floor_decal/spline/fancy/wood/corner,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "ma" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "pz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -253,7 +253,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "st" = (
 /obj/effect/shuttle_landmark/orb/nav7,
@@ -264,7 +264,7 @@
 	dir = 10;
 	icon_state = "spline_fancy"
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "wM" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -273,13 +273,13 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "yQ" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "yR" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -289,13 +289,13 @@
 /area/mine/explored)
 "Aj" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "DJ" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "EM" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -308,7 +308,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "Gl" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -317,13 +317,13 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "Le" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "LT" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -331,16 +331,16 @@
 	icon_state = "spline_fancy"
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "MX" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "NQ" = (
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "Ol" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -353,7 +353,7 @@
 /area/mine/explored)
 "Rr" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
 "SY" = (
 /obj/structure/fountain,

--- a/maps/away/mobius_rift/mobius_rift.dmm
+++ b/maps/away/mobius_rift/mobius_rift.dmm
@@ -33,7 +33,7 @@
 /turf/simulated/floor/grass,
 /area/mobius_rift)
 "k" = (
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/mobius_rift)
 "l" = (
 /obj/structure/flora/ausbushes/fullgrass,

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -2034,7 +2034,7 @@
 	dir = 4;
 	icon_state = "0-1"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "eM" = (
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -40,7 +40,7 @@
 		overlays += I
 		set_light(0.3, 0.1, 2, l_color = I.color)
 
-	var/turf/unsimulated/floor/exoplanet/T = get_turf(src)
+	var/turf/simulated/floor/exoplanet/T = get_turf(src)
 	if(istype(T))
 		var/image/I = overlay_image(icon, "dugin", T.dirt_color, RESET_COLOR)
 		overlays += I

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis.dmm
@@ -12,37 +12,37 @@
 /area/template_noop)
 "e" = (
 /obj/structure/flora/grass/green,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "f" = (
 /obj/structure/flora/grass/both,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "g" = (
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/template_noop)
 "h" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/template_noop)
 "i" = (
 /obj/structure/flora/bush,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "j" = (
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "k" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "l" = (
 /obj/structure/flora/grass/brown,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "m" = (
 /obj/structure/flora/ausbushes,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 
 (1,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis2.dmm
@@ -4,58 +4,58 @@
 /area/template_noop)
 "b" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "c" = (
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "d" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "e" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "f" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "g" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "h" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "i" = (
 /obj/structure/flora/grass/both,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "j" = (
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/template_noop)
 "k" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "l" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/template_noop)
 "m" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 "n" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/unsimulated/floor/exoplanet/grass,
+/turf/simulated/floor/exoplanet/grass,
 /area/template_noop)
 
 (1,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
@@ -15,7 +15,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "ak" = (
 /obj/structure/hygiene/toilet{
@@ -81,7 +81,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "bl" = (
 /obj/structure/cable/yellow{
@@ -129,7 +129,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "bQ" = (
 /obj/machinery/computer/crew,
@@ -151,7 +151,7 @@
 /area/map_template/oldlab/station/chem)
 "cv" = (
 /obj/effect/landmark/clear,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/southairlock)
 "cw" = (
 /obj/effect/floor_decal/techfloor{
@@ -217,7 +217,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "dz" = (
 /obj/structure/cable/yellow{
@@ -321,7 +321,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "eW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -545,7 +545,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -560,7 +560,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "iG" = (
 /obj/machinery/door/firedoor,
@@ -767,7 +767,7 @@
 "lV" = (
 /obj/effect/landmark/clear,
 /obj/machinery/light/spot,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/northairlockatmos)
 "mn" = (
 /obj/effect/floor_decal/techfloor{
@@ -1001,7 +1001,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/northairlockatmos)
 "pc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1126,7 +1126,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "rt" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -1265,7 +1265,7 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/hall)
 "uj" = (
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "uq" = (
 /obj/structure/cable/yellow{
@@ -1398,7 +1398,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "wD" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -1459,14 +1459,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "xH" = (
 /obj/effect/landmark/clear,
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/southairlock)
 "xK" = (
 /obj/structure/cable/yellow{
@@ -1477,7 +1477,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "xU" = (
 /obj/machinery/bodyscanner{
@@ -1630,7 +1630,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/southairlock)
 "AP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1860,7 +1860,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/paint/black,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "Fj" = (
 /turf/simulated/floor/tiled/white,
@@ -1904,7 +1904,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "FF" = (
 /obj/effect/floor_decal/techfloor{
@@ -1932,7 +1932,7 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/southairlock)
 "Gk" = (
 /obj/structure/table/steel,
@@ -2043,7 +2043,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "HV" = (
 /obj/effect/floor_decal/techfloor{
@@ -2074,7 +2074,7 @@
 "Is" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/black,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "IV" = (
 /obj/structure/cable/yellow{
@@ -2316,7 +2316,7 @@
 /area/map_template/oldlab/station/xenobio)
 "Ms" = (
 /obj/effect/landmark/clear,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/station/northairlockatmos)
 "Mx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2382,7 +2382,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "Nf" = (
 /obj/structure/cable/yellow{
@@ -2837,7 +2837,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "Vq" = (
 /obj/structure/cable/yellow{
@@ -2961,7 +2961,7 @@
 /area/map_template/oldlab/station/northairlockatmos)
 "Xx" = (
 /obj/structure/grille,
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "Yb" = (
 /obj/machinery/light{
@@ -3035,7 +3035,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "Ze" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3069,7 +3069,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 "ZS" = (
 /obj/machinery/door/airlock/civilian,
@@ -3085,7 +3085,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/concrete/reinforced,
+/turf/simulated/floor/exoplanet/concrete/reinforced,
 /area/map_template/oldlab/solars)
 
 (1,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -18,7 +18,7 @@
 /area/map_template/colony/tcomms)
 "af" = (
 /obj/structure/grille,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ag" = (
 /obj/structure/table/steel_reinforced,
@@ -57,7 +57,7 @@
 /area/map_template/colony/tcomms)
 "aj" = (
 /obj/structure/catwalk,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ak" = (
 /turf/simulated/wall,
@@ -278,7 +278,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "aN" = (
 /turf/simulated/wall,
@@ -380,7 +380,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ba" = (
 /turf/simulated/wall/r_wall,
@@ -422,7 +422,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "bf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -691,7 +691,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "bC" = (
 /obj/effect/floor_decal/techfloor{
@@ -782,7 +782,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -816,7 +816,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
@@ -874,7 +874,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "bS" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -898,7 +898,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "bU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1027,7 +1027,7 @@
 /obj/machinery/power/emitter/gyrotron{
 	req_lock_access = list()
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cg" = (
 /obj/structure/cable{
@@ -1061,7 +1061,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cj" = (
 /obj/structure/table/steel_reinforced,
@@ -1143,7 +1143,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cr" = (
 /obj/structure/grille,
@@ -1157,7 +1157,7 @@
 	icon_state = "0-2";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cs" = (
 /obj/structure/grille,
@@ -1171,7 +1171,7 @@
 	icon_state = "0-2";
 	pixel_y = 0
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ct" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -1310,7 +1310,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -1346,7 +1346,7 @@
 /obj/structure/sign/warning/compressed_gas{
 	pixel_y = -28
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -1566,7 +1566,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "dm" = (
 /obj/structure/catwalk,
@@ -1576,13 +1576,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/spot,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "dn" = (
 /obj/structure/catwalk,
 /obj/machinery/power/rad_collector,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1753,7 +1753,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/surgery)
 "dG" = (
 /obj/structure/cable{
@@ -2060,7 +2060,7 @@
 /obj/structure/catwalk,
 /obj/structure/closet/crate/solar_assembly,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ei" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2114,7 +2114,7 @@
 /obj/structure/sign/warning/compressed_gas{
 	pixel_y = -28
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "em" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2150,7 +2150,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ep" = (
 /obj/machinery/atmospherics/pipe/cap/hidden,
@@ -2230,7 +2230,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2317,7 +2317,7 @@
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/command)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -2416,7 +2416,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/engineering)
 "eL" = (
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "eM" = (
 /obj/structure/table/steel_reinforced,
@@ -2605,7 +2605,7 @@
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "fa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2623,7 +2623,7 @@
 "fc" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "fd" = (
 /obj/structure/table/steel_reinforced,
@@ -2673,7 +2673,7 @@
 /area/map_template/colony/atmospherics)
 "fi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/atmospherics)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4084,7 +4084,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/atmospherics)
 "hr" = (
 /turf/simulated/wall,
@@ -5551,7 +5551,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/messhall)
 "jL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6208,11 +6208,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "kL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "kM" = (
 /obj/structure/crematorium{
@@ -6220,7 +6220,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "kN" = (
 /obj/machinery/button/crematorium{
@@ -6232,7 +6232,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharger,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "kO" = (
 /obj/structure/closet/firecloset,
@@ -6260,7 +6260,7 @@
 "kR" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "kS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6349,12 +6349,12 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "la" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lb" = (
 /obj/machinery/door/window/eastright,
@@ -6412,7 +6412,7 @@
 "lg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lh" = (
 /obj/machinery/door/airlock/external{
@@ -6489,7 +6489,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lo" = (
 /mob/living/simple_animal/passive/cow,
@@ -6532,7 +6532,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lu" = (
 /obj/structure/cable{
@@ -6545,12 +6545,12 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lv" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lw" = (
 /obj/machinery/door/firedoor,
@@ -6594,7 +6594,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lA" = (
 /obj/machinery/light/spot{
@@ -6605,7 +6605,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lB" = (
 /obj/machinery/door/firedoor,
@@ -6636,7 +6636,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lD" = (
 /obj/structure/catwalk,
@@ -6646,7 +6646,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lG" = (
 /obj/machinery/door/firedoor,
@@ -6822,13 +6822,13 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lT" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lU" = (
 /obj/structure/catwalk,
@@ -6836,7 +6836,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lV" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -6844,7 +6844,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6883,7 +6883,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "lY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -6910,7 +6910,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "ma" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -6944,7 +6944,7 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/suit/space/emergency,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "mb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6963,7 +6963,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "md" = (
 /obj/structure/grille,
@@ -6976,7 +6976,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "me" = (
 /obj/machinery/fabricator/hacked,
@@ -7047,7 +7047,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ml" = (
 /obj/machinery/door/firedoor,
@@ -7088,7 +7088,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "mo" = (
 /obj/machinery/door/firedoor,
@@ -7166,7 +7166,7 @@
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "mw" = (
 /obj/machinery/door/firedoor,
@@ -7240,7 +7240,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/command)
 "mD" = (
 /obj/structure/table/rack,
@@ -7429,7 +7429,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight/lamp/floodlamp,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "mQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7439,7 +7439,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/recharge_station,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "mR" = (
 /obj/structure/bed/chair/comfy/beige{
@@ -7526,7 +7526,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "na" = (
 /obj/structure/catwalk,
@@ -7540,7 +7540,7 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nb" = (
 /obj/structure/window/reinforced{
@@ -7690,7 +7690,7 @@
 "nm" = (
 /obj/machinery/mining/drill,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "nn" = (
 /obj/effect/floor_decal/techfloor{
@@ -7721,7 +7721,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "nr" = (
 /obj/machinery/atmospherics/unary/heater{
@@ -7801,7 +7801,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nz" = (
 /obj/structure/grille,
@@ -7814,7 +7814,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nA" = (
 /obj/structure/grille,
@@ -7832,7 +7832,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8028,7 +8028,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nQ" = (
 /obj/machinery/door/firedoor,
@@ -8061,7 +8061,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "nS" = (
 /obj/structure/cable{
@@ -8216,33 +8216,33 @@
 	icon_state = "loadingarea"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oe" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "of" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "og" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oh" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oi" = (
 /obj/structure/railing/mapped,
@@ -8277,7 +8277,7 @@
 /obj/item/stack/flag/yellow,
 /obj/item/stack/flag/yellow,
 /obj/item/stack/flag/yellow,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oj" = (
 /obj/structure/railing/mapped,
@@ -8304,7 +8304,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "ok" = (
 /obj/structure/railing/mapped,
@@ -8319,7 +8319,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "ol" = (
 /obj/structure/railing/mapped{
@@ -8341,7 +8341,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "om" = (
 /obj/structure/cable{
@@ -8357,7 +8357,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "on" = (
 /obj/structure/railing/mapped{
@@ -8379,7 +8379,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oo" = (
 /obj/structure/grille,
@@ -8392,7 +8392,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "op" = (
 /obj/structure/catwalk,
@@ -8402,7 +8402,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "oq" = (
 /obj/structure/catwalk,
@@ -8412,7 +8412,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "or" = (
 /obj/structure/cable{
@@ -8425,7 +8425,7 @@
 	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "os" = (
 /obj/structure/cable{
@@ -8435,7 +8435,7 @@
 	},
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "ot" = (
 /obj/structure/catwalk,
@@ -8443,7 +8443,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/hydroponics)
 "ou" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -8477,7 +8477,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "ow" = (
 /obj/structure/cable{
@@ -8523,7 +8523,7 @@
 	dir = 1;
 	icon_state = "map"
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8531,14 +8531,14 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 5
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/catwalk,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8546,7 +8546,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8556,7 +8556,7 @@
 	icon_state = "intact"
 	},
 /obj/structure/catwalk,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "oD" = (
 /obj/machinery/alarm{
@@ -8646,7 +8646,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "tz" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -8703,7 +8703,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "vt" = (
 /mob/living/simple_animal/passive/chicken,
@@ -8833,7 +8833,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/template_noop)
 "JY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8870,7 +8870,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/hydroponics)
 "KK" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -8931,7 +8931,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
-/turf/unsimulated/floor/exoplanet/concrete,
+/turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "Ot" = (
 /turf/simulated/floor/tiled/white,

--- a/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dmm
+++ b/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dmm
@@ -12,7 +12,7 @@
 /turf/simulated/floor/fixed/alium,
 /area/template_noop)
 "y" = (
-/turf/unsimulated/floor/exoplanet/water/shallow,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/template_noop)
 "E" = (
 /obj/item/remains/xeno,

--- a/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dmm
+++ b/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/unsimulated/floor/exoplanet/water/shallow/tar,
+/turf/simulated/floor/exoplanet/water/shallow/tar,
 /area/template_noop)
 "b" = (
 /turf/template_noop,
@@ -12,7 +12,7 @@
 "d" = (
 /obj/machinery/artifact,
 /obj/effect/landmark/clear,
-/turf/unsimulated/floor/exoplanet/shrouded,
+/turf/simulated/floor/exoplanet/shrouded,
 /area/template_noop)
 "e" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -20,7 +20,7 @@
 /area/template_noop)
 "f" = (
 /obj/structure/monolith,
-/turf/unsimulated/floor/exoplanet/water/shallow/tar,
+/turf/simulated/floor/exoplanet/water/shallow/tar,
 /area/template_noop)
 
 (1,1,1) = {"


### PR DESCRIPTION
I don't really have the time or energy to fix everything wrong with unsimulated planets while leaving them live; reverts the parts of that stuff that weren't rider fixes. Might pick it up again later.