### PR TITLE
remove bluespace residue

### DIFF
--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -120,15 +120,3 @@
 	name = "guppy control console"
 	shuttle_tag = "Guppy"
 	req_access = list(access_guppy_helm)
-
-/obj/effect/overmap/visitable/ship/torch/Initialize()
-	. = ..()
-	var/obj/effect/overmap/visitable/sector/residue/R = new
-	var/turf/home = locate(x, y, z)
-	R.forceMove(home)
-
-
-/obj/effect/overmap/visitable/sector/residue
-	name = "Bluespace Residue"
-	desc = "Trace radiation emanating from this sector is consistent with the aftermath of a bluespace jump."
-	icon_state = "event"


### PR DESCRIPTION
:cl: Mucker
rscdel: Removed bluespace residue from the overmap. 
/:cl:

The purpose of this was so the merc ship could easily find the Torch from wherever it spawned, but now that they always spawn in close proximity this is useless. Also, the actual coordinates on the overmap don't line up with the start point of the Torch anymore, which makes it misleading.