### PR TITLE
Fixes In-Game Manuals

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -243,7 +243,7 @@
 				<head>
 				</head>
 				<body>
-					<iframe width='100%' height='100%' src="[url]&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+					<iframe width='100%' height='100%' src="[url]" frameborder="0" id="main_frame"></iframe>
 				</body>
 			</html>
 			"}

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -99,7 +99,6 @@
 
 /obj/structure/bookcase/manuals/medical/New()
 	..()
-	new /obj/item/book/manual/medical_cloning(src)
 	new /obj/item/book/manual/medical_diagnostics_manual(src)
 	new /obj/item/book/manual/medical_diagnostics_manual(src)
 	new /obj/item/book/manual/medical_diagnostics_manual(src)
@@ -234,21 +233,11 @@
 /obj/item/book/manual
 	icon = 'icons/obj/library.dmi'
 	unique = 1   // 0 - Normal book, 1 - Should not be treated as normal book, unable to be copied, unable to be modified
-	var/url // Using full url or just tittle, example - Standard_Operating_Procedure (https://wiki.baystation12.net/index.php?title=Standard_Operating_Procedure)
+	var/url // Using full url or just title, example - Standard_Operating_Procedure (https://wiki.baystation12.net/index.php?title=Standard_Operating_Procedure)
 
 /obj/item/book/manual/New()
 	..()
 	if(url)		// URL provided for this manual
-		// If we haven't wikiurl or it included in url - just use url
-		if(config.wiki_url && !findtextEx(url, config.wiki_url, 1, length(config.wiki_url)+1))
-			// If we have wikiurl, but it hasn't "index.php" then add it and making full link in url
-			if(config.wiki_url && !findtextEx(config.wiki_url, "/index.php", -10))
-				if(findtextEx(config.wiki_url, "/", -1))
-					url = config.wiki_url + "index.php?title=" + url
-				else
-					url = config.wiki_url + "/index.php?title=" + url
-			else	//Or just making full link in url
-				url = config.wiki_url + "?title=" + url
 		dat = {"
 			<html>
 				<head>

--- a/code/modules/library/manuals/engineering.dm
+++ b/code/modules/library/manuals/engineering.dm
@@ -3,7 +3,7 @@
 	icon_state ="bookEngineering2"
 	author = "Engineering Encyclopedia"
 	title = "Engineering Textbook"
-	url = "Engineering"
+	url = "https://bay.ss13.me/Roles/Engineer"
 
 /obj/item/book/manual/robotics_cyborgs
 	name = "Cyborgs for Dummies"
@@ -292,7 +292,7 @@
 	icon_state ="bookEngineering"
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Repairs and Construction"
-	url = "Guide_to_Construction"
+	url = "https://bay.ss13.me/Guides/Construction"
 
 /obj/item/book/manual/engineering_particle_accelerator
 	name = "Particle Accelerator User's Guide"
@@ -346,21 +346,21 @@
 	icon_state = "bookSupermatter"
 	author = "Central Engineering Division"
 	title = "Supermatter Engine Operating Manual"
-	url = "Supermatter_Engine"
+	url = "https://bay.ss13.me/Guides/Supermatter"
 
 /obj/item/book/manual/rust_engine
 	name = "R-UST Operating Manual"
 	icon_state = "bookMagazine"
 	author = "Cindy Crawfish"
 	title = "R-UST Operating Manual"
-	url = "R-UST"
+	url = "https://bay.ss13.me/Guides/RUST"
 
 /obj/item/book/manual/engineering_hacking
 	name = "Hacking"
 	icon_state ="bookHacking"
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Hacking"
-	url = "Hacking"
+	url = "https://bay.ss13.me/Guides/Hacking"
 
 /obj/item/book/manual/engineering_singularity_safety
 	name = "Singularity Safety in Special Circumstances"

--- a/code/modules/library/manuals/manuals.dm
+++ b/code/modules/library/manuals/manuals.dm
@@ -3,58 +3,7 @@
 	icon_state = "cooked_book"
 	author = "Victoria Ponsonby"
 	title = "Chef Recipes"
-
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				h3 {font-size: 13px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				body {font-size: 13px; font-family: Verdana;}
-				</style>
-				</head>
-				<body>
-
-				<h1>Food for Dummies</h1>
-				Here is a guide on basic food recipes and also how to not poison your customers accidentally.
-
-				<h3>Basics:</h3>
-				Knead an egg and some flour along with some water to make dough. Bake that to make a bun or flatten and cut it.
-
-				<h3>Burger:</h3>
-				Put a bun and some meat into the microwave and turn it on. Then wait.
-
-				<h3>Bread:</h3>
-				Put some dough and an egg into the microwave and then wait.
-
-				<h3>Waffles:</h3>
-				Add two lumps of dough and 10 units of sugar to the microwave and then wait.
-
-				<h3>Popcorn:</h3>
-				Add 1 corn to the microwave and wait.
-
-				<h3>Meat Steak:</h3>
-				Put a slice of meat, 1 unit of salt, and 1 unit of pepper into the microwave and wait.
-
-				<h3>Meat Pie:</h3>
-				Put a flattened piece of dough and some meat into the microwave and wait.
-
-				<h3>Boiled Spaghetti:</h3>
-				Put the spaghetti (processed flour) and 5 units of water into the microwave and wait.
-
-				<h3>Donuts:</h3>
-				Add some dough and 5 units of sugar to the microwave and wait.
-
-				<h3>Fries:</h3>
-				Add one potato to the processor, then bake them in the microwave.
-
-
-				</body>
-			</html>
-			"}
+	url = "https://bay.ss13.me/Guides/Cooking#list-of-cooking-recipes"
 
 
 /obj/item/book/manual/barman_recipes
@@ -62,55 +11,13 @@
 	icon_state = "barbook"
 	author = "Sir John Rose"
 	title = "Barman Recipes"
+	url = "https://bay.ss13.me/Guides/Drinks"
 
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				h3 {font-size: 13px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				body {font-size: 13px; font-family: Verdana;}
-				</style>
-				</head>
-				<body>
-
-				<h1>Drinks for Dummies</h1>
-				Here's a guide for some basic drinks.
-
-				<h3>Black Russian:</h3>
-				Mix vodka and Kahlua into a glass.
-
-				<h3>Cafe Latte:</h3>
-				Mix milk and coffee into a glass.
-
-				<h3>Classic Martini:</h3>
-				Mix vermouth and gin into a glass.
-
-				<h3>Gin Tonic:</h3>
-				Mix gin and tonic into a glass.
-
-				<h3>Grog:</h3>
-				Mix rum and water into a glass.
-
-				<h3>Irish Cream:</h3>
-				Mix cream and whiskey into a glass.
-
-				<h3>The Manly Dorf:</h3>
-				Mix ale and beer into a glass.
-
-				<h3>Mead:</h3>
-				Mix enzyme, water, and sugar into a glass.
-
-				<h3>Screwdriver:</h3>
-				Mix vodka and orange juice into a glass.
-
-				</body>
-			</html>
-			"}
-
+/obj/item/book/manual/ci_guidebook
+	name = "Criminal Investigations and Forensic Science"
+	icon_state = "bookDetective"
+	author = "Sol Federal Police "
+	url = "https://bay.ss13.me/Guides/Forensics"
 
 /obj/item/book/manual/detective
 	name = "The Film Noir: Proper Procedures for Investigations"

--- a/code/modules/library/manuals/medical.dm
+++ b/code/modules/library/manuals/medical.dm
@@ -1,102 +1,10 @@
-/obj/item/book/manual/medical_cloning
-	name = "Cloning Techniques of the 26th Century"
-	icon_state ="bookCloning"
-	author = "Medical Journal, volume 3"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
-	title = "Cloning Techniques of the 26th Century"
-
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 21px; margin: 15px 0px 5px;}
-				h2 {font-size: 18px; margin: 15px 0px 5px;}
-				h3 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				body {font-size: 13px; font-family: Verdana;}
-				</style>
-				</head>
-				<body>
-
-				<H1>How to Clone People</H1>
-				So there are 50 dead people lying on the floor, chairs are spinning like no tomorrow and you haven't the foggiest idea of what to do? Not to worry!
-				This guide is intended to teach you how to clone people and how to do it right, in a simple, step-by-step process! If at any point of the guide you have a mental meltdown,
-				genetics probably isn't for you and you should get a job-change as soon as possible before you're sued for malpractice.
-
-				<ol>
-					<li><a href='#1'>Acquire body</a></li>
-					<li><a href='#2'>Strip body</a></li>
-					<li><a href='#3'>Put body in cloning machine</a></li>
-					<li><a href='#4'>Scan body</a></li>
-					<li><a href='#5'>Clone body</a></li>
-					<li><a href='#6'>Get clean Structural Enzymes for the body</a></li>
-					<li><a href='#7'>Put body in morgue</a></li>
-					<li><a href='#8'>Await cloned body</a></li>
-					<li><a href='#9'>Cryo and use the clean SE injector</a></li>
-					<li><a href='#10'>Give person clothes back</a></li>
-					<li><a href='#11'>Send person on their way</a></li>
-				</ol>
-
-				<a name='1'><H3>Step 1: Acquire body</H3>
-				This is pretty much vital for the process because without a body, you cannot clone it. Usually, bodies will be brought to you, so you do not need to worry so much about this step. If you already have a body, great! Move on to the next step.
-
-				<a name='2'><H3>Step 2: Strip body</H3>
-				The cloning machine does not like abiotic items. What this means is you can't clone anyone if they're wearing clothes or holding things, so take all of it off. If it's just one person, it's courteous to put their possessions in the closet.
-				If you have about seven people awaiting cloning, just leave the piles where they are, but don't mix them around and for God's sake don't let people in to steal them.
-
-				<a name='3'><h3>Step 3: Put body in cloning machine</h3>
-				Grab the body and then put it inside the DNA modifier. If you cannot do this, then you messed up at Step 2. Go back and check you took EVERYTHING off - a commonly missed item is their headset.
-
-				<a name='4'><h3>Step 4: Scan body</h3>
-				Go onto the computer and scan the body by pressing 'Scan - &lt;Subject Name Here&gt;.' If you're successful, they will be added to the records (note that this can be done at any time, even with living people,
-				so that they can be cloned without a body in the event that they are lying dead on port solars and didn't turn on their suit sensors)!
-				If not, and it says "Error: Mental interface failure.", then they have left their bodily confines and are one with the spirits. If this happens, just shout at them to get back in their body,
-				click 'Refresh' and try scanning them again. If there's no success, threaten them with gibbing.
-				Still no success? Skip over to Step 7 and don't continue after it, as you have an unresponsive body and it cannot be cloned.
-				If you got "Error: Unable to locate valid genetic data.", you are trying to clone a monkey - start over.
-
-				<a name='5'><h3>Step 5: Clone body</h3>
-				Now that the body has a record, click 'View Records,' click the subject's name, and then click 'Clone' to start the cloning process. Congratulations! You're halfway there.
-				Remember not to 'Eject' the cloning pod as this will kill the developing clone and you'll have to start the process again.
-
-				<a name='6'><h3>Step 6: Get clean SEs for body</h3>
-				Cloning is a finicky and unreliable process. Whilst it will most certainly bring someone back from the dead, they can have any number of nasty disabilities given to them during the cloning process!
-				For this reason, you need to prepare a clean, defect-free Structural Enzyme (SE) injection for when they're done. If you're a competent Geneticist, you will already have one ready on your working computer.
-				If, for any reason, you do not, then eject the body from the DNA modifier (NOT THE CLONING POD) and take it next door to the Genetics research room. Put the body in one of those DNA modifiers and then go onto the console.
-				Go into View/Edit/Transfer Buffer, find an open slot and click "SE" to save it. Then click 'Injector' to get the SEs in syringe form. Put this in your pocket or something for when the body is done.
-
-				<a name='7'><h3>Step 7: Put body in morgue</h3>
-				Now that the cloning process has been initiated and you have some clean Structural Enzymes, you no longer need the body! Drag it to the morgue and tell the Chef over the radio that they have some fresh meat waiting for them in there.
-				To put a body in a morgue bed, simply open the tray, grab the body, put it on the open tray, then close the tray again. Use one of the nearby pens to label the bed "CHEF MEAT" in order to avoid confusion.
-
-				<a name='8'><h3>Step 8: Await cloned body</h3>
-				Now go back to the lab and wait for your patient to be cloned. It won't be long now, I promise.
-
-				<a name='9'><h3>Step 9: Cryo and clean SE injector on person</h3>
-				Has your body been cloned yet? Great! As soon as the guy pops out, grab them and stick them in cryo. Clonexadone and Cryoxadone help rebuild their genetic material. Then grab your clean SE injector and jab it in them. Once you've injected them,
-				they now have clean Structural Enzymes and their defects, if any, will disappear in a short while.
-
-				<a name='10'><h3>Step 10: Give person clothes back</h3>
-				Obviously the person will be naked after they have been cloned. Provided you weren't an irresponsible little shit, you should have protected their possessions from thieves and should be able to give them back to the patient.
-				No matter how cruel you are, it's simply against protocol to force your patients to walk outside naked.
-
-				<a name='11'><h3>Step 11: Send person on their way</h3>
-				Give the patient one last check-over - make sure they don't still have any defects and that they have all their possessions. Ask them how they died, if they know, so that you can report any foul play over the radio.
-				Once you're done, your patient is ready to go back to work! Chances are they do not have Medbay access, so you should let them out of Genetics and the Medbay main entrance.
-
-				<p>If you've gotten this far, congratulations! You have mastered the art of cloning. Now, the real problem is how to resurrect yourself after that traitor had his way with you for cloning his target.
-
-				</body>
-				</html>
-				"}
-
 /obj/item/book/manual/medical_diagnostics_manual
 	name = "Medical Diagnostics Manual"
 	desc = "First, do no harm. A detailed medical practitioner's guide."
 	icon_state = "bookMedical"
 	author = "Medical Department"
 	title = "Medical Diagnostics Manual"
-	url = "Guide_to_Medicine"
+	url = "https://bay.ss13.me/Guides/Medicine"
 
 /obj/item/book/manual/medical_diagnostics_manual/New()
 	..()
@@ -132,7 +40,7 @@
 
 				<HR COLOR="steelblue" WIDTH="60%" ALIGN="LEFT">
 
-				<iframe width='100%' height='100%' src="[url]&printable=yes&removelinks=1" frameborder="0" id="main_frame"></iframe>
+				<iframe width='100%' height='100%' src="[url]" frameborder="0" id="main_frame"></iframe>
 				</body>
 			</html>
 
@@ -144,4 +52,4 @@
 	icon_state = "bookChemistry"
 	author = "Zeng-Hu Pharmaceuticals"
 	title = "Guide to Medicines & Drugs"
-	url = "List_of_Medical_Chemicals"
+	url = "https://bay.ss13.me/Guides/Chemistry"

--- a/code/modules/library/manuals/nanotrasen.dm
+++ b/code/modules/library/manuals/nanotrasen.dm
@@ -1,11 +1,3 @@
-/obj/item/book/manual/nt_regs
-	name = "Corporate Regulations"
-	desc = "A set of corporate guidelines for employees of a megacorporation."
-	icon_state = "booknanoregs"
-	author = "Employee Materials"
-	title = "Corporate Regulations"
-	url = "Corporate_Regulations"
-
 /obj/item/book/manual/hydroponics_pod_people
 	name = "The Diona Harvest - From Seed to Market"
 	icon_state ="bookHydroponicsPodPeople"

--- a/maps/torch/items/manuals.dm
+++ b/maps/torch/items/manuals.dm
@@ -4,44 +4,15 @@
 	icon_state = "bookSolGovLaw"
 	author = "The Sol Central Government"
 	title = "Sol Central Government Law"
-
-/obj/item/book/manual/solgov_law/Initialize()
-	. = ..()
-	dat = {"
-
-		<html><head>
-		</head>
-
-		<body>
-		<iframe width='100%' height='97%' src="[config.wiki_url]Sol_Central_Government_Law&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-		</body>
-
-		</html>
-
-		"}
-
+	url = "https://bay.ss13.me/Rules&Regulations/SolCentralGovernmentLaw"
 
 /obj/item/book/manual/military_law
-	name = "The Sol Code of Military Justice"
+	name = "The Sol Code of Uniform Justice"
 	desc = "A brief overview of military law."
 	icon_state = "bookSolGovLaw"
 	author = "The Sol Central Government"
-	title = "The Sol Code of Military Justice"
-
-/obj/item/book/manual/military_law/Initialize()
-	. = ..()
-	dat = {"
-
-		<html><head>
-		</head>
-
-		<body>
-		<iframe width='100%' height='97%' src="[config.wiki_url]Sol_Gov_Military_Justice&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-		</body>
-
-		</html>
-
-		"}
+	title = "The Sol Code of Uniform Justice"
+	url = "https://bay.ss13.me/Rules&Regulations/SolCodeUniformJustice"
 
 /obj/item/book/manual/sol_sop
 	name = "Standard Operating Procedure"
@@ -49,21 +20,7 @@
 	icon_state = "booksolregs"
 	author = "The Sol Central Government"
 	title = "Standard Operating Procedure"
-
-/obj/item/book/manual/sol_sop/Initialize()
-	. = ..()
-	dat = {"
-
-		<html><head>
-		</head>
-
-		<body>
-		<iframe width='100%' height='97%' src="[config.wiki_url]Standard_Operating_Procedure&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-		</body>
-
-		</html>
-
-		"}
+	url = "https://bay.ss13.me/Rules&Regulations/StandardOperatingProcedure"
 
 /obj/item/folder/nt/rd
 

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11205,7 +11205,6 @@
 "AS" = (
 /obj/structure/table/glass,
 /obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
 "AT" = (
@@ -17358,7 +17357,6 @@
 /area/shuttle/petrov/isolation)
 "Yg" = (
 /obj/structure/table/steel,
-/obj/item/book/manual/nt_regs,
 /obj/item/folder/nt,
 /obj/structure/cable/cyan{
 	d1 = 2;

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1516,7 +1516,6 @@
 /obj/item/book/manual/solgov_law,
 /obj/item/book/manual/sol_sop,
 /obj/item/book/manual/military_law,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge)
 "fd" = (
@@ -4418,7 +4417,6 @@
 /obj/item/book/manual/solgov_law,
 /obj/item/book/manual/sol_sop,
 /obj/item/book/manual/military_law,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/wood,
 /area/command/captainmess)
 "pD" = (
@@ -10831,7 +10829,6 @@
 /area/command/pathfinder)
 "Li" = (
 /obj/structure/bookcase,
-/obj/item/book/manual/medical_cloning,
 /obj/item/book/manual/medical_diagnostics_manual,
 /obj/item/book/manual/nuclear,
 /obj/item/book/manual/detective,

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -16638,7 +16638,6 @@
 /obj/item/book/manual/sol_sop,
 /obj/item/book/manual/solgov_law,
 /obj/item/book/manual/military_law,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "OC" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -77,6 +77,12 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/fuelbay/aux)
+"aal" = (
+/obj/structure/table/steel,
+/obj/item/book/manual/solgov_law,
+/obj/item/book/manual/ci_guidebook,
+/turf/simulated/floor/tiled,
+/area/security/detectives_office)
 "aam" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -22449,11 +22455,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/storage)
-"mgb" = (
-/obj/structure/table/steel,
-/obj/item/book/manual/solgov_law,
-/turf/simulated/floor/tiled,
-/area/security/detectives_office)
 "mhb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39265,7 +39266,7 @@ pVv
 nOO
 nOO
 yeI
-mgb
+aal
 iVM
 uZY
 oDg

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -10061,7 +10061,6 @@
 "yU" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/sticky_pad/random,
-/obj/item/book/manual/nt_regs,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl)
 "yV" = (
@@ -13037,7 +13036,6 @@
 /area/maintenance/bridge/foreport)
 "Lv" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/nt_regs,
 /obj/item/stamp/rd,
 /obj/effect/floor_decal/corner/research{
 	dir = 5;


### PR DESCRIPTION
:cl: Textor
tweak: In-game manuals now link to the new wiki pages.
tweak: The food and drink recipe books now link to the wiki pages.
tweak: "Military Justice" books have been renamed to "Uniform Justice" to conform with wiki usage.
rscadd: Sol Federal Police have published a new forensics guidebook, and a copy delivered to the forensics office.
rscdel: Removes corporate regulations and cloning manuals.
/:cl:

**Important: This should not be merged unless the configuration on the wiki.js website has been changed.**
Due to the security settings of the new wiki, we can't inject webpages into frames, effectively nullifying the entire point of this PR. If the change cannot or will not be made, this PR should be abandoned and a discussion about how to address the broken book issue should be held.

Change required: 
file: 
security.js
line:
res.set('X-Frame-Options', 'allow')

-Removes cloning book.
-Modifies URLs for in-game manuals to point to new wiki pages.
-Removes old wiki URL syntax, as it no longer works
-Fixes a comment so that the word "title" is spelled correctly
-Links recipe book to wiki page
-Links drink book to wiki page
-Removes corporate regulations since those don't exist anymore (no equivalent wiki page).
-Adds forensic tech book written by SFP linking to forensics guide.
-Added ftech guide to ftech's desk.
-Changed SCG law/regulations/SOP book code to match how other manuals handle linking to external pages.