### PR TITLE
Dangerous uplink tweaks & Shuriken changes

### DIFF
--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -4,23 +4,17 @@
 /datum/uplink_item/item/visible_weapons
 	category = /datum/uplink_category/visible_weapons
 
-/datum/uplink_item/item/visible_weapons/zipgun
-	name = "Zip Gun"
-	desc = "A pipe attached to crude wooden stock with firing mechanism, holds one round."
-	item_cost = 8
-	path = /obj/item/gun/projectile/pirate
-
 /datum/uplink_item/item/visible_weapons/smallenergy_gun
 	name = "Small Energy Gun"
 	desc = "A pocket-sized energy based sidearm with three different lethality settings."
 	item_cost = 16
 	path = /obj/item/gun/energy/gun/small
 
-/datum/uplink_item/item/visible_weapons/ancient
-	name = "Replica Pistol"
-	desc = "A cheap replica of an earth handgun. To reload, buy another."
-	item_cost = 16
-	path = /obj/item/gun/projectile/pistol/throwback
+/datum/uplink_item/item/visible_weapons/shuriken
+	name = "Box of shurikens"
+	desc = "A small box with six shuriken, notably dangerous."
+	item_cost = 18
+	path = /obj/item/storage/box/syndie_kit/shuriken
 
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
@@ -38,8 +32,14 @@
 /datum/uplink_item/item/visible_weapons/pikecube
 	name = "Pike Cube"
 	desc = "While it looks like a normal monkey cube, the animal produced is, instead, a space pike. \ Note: The space pike does not like you."
-	item_cost = 70
+	item_cost = 44
 	path = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/pikecube
+
+/datum/uplink_item/item/visible_weapons/katana
+	name = "Katana"
+	desc = "A large sharpened steel blade capable of cutting through anything but the thickest armor."
+	item_cost = 24
+	path = /obj/item/material/sword/katana
 
 /datum/uplink_item/item/visible_weapons/energy_sword
 	name = "Energy Sword"
@@ -198,7 +198,7 @@
 	name = "Railgun"
 	desc = "An anti-armour magnetic launching system fed by a high-capacity matter cartridge, \
 			capable of firing slugs at intense speeds."
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT - (DEFAULT_TELECRYSTAL_AMOUNT % 6)) / 6
+	item_cost = 65
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/gun/magnetic/railgun
 
@@ -207,7 +207,7 @@
 	desc = "A modified prototype of the original railgun implement, this time boring slugs out of steel rods loaded into the chamber, \
 			now with even MORE stopping power."
 	antag_roles = list(MODE_MERCENARY)
-	item_cost = DEFAULT_TELECRYSTAL_AMOUNT
+	item_cost = 75
 	path = /obj/item/gun/magnetic/railgun/tcc
 
 /datum/uplink_item/item/visible_weapons/harpoonbomb

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -6,11 +6,12 @@
 	randpixel = 12
 	max_force = 10
 	force_multiplier = 0.1 // 6 with hardness 60 (steel)
-	thrown_force_multiplier = 0.75 // 15 with weight 20 (steel)
-	throw_speed = 10
+	thrown_force_multiplier = 1 // 20 with weight 20 (steel)
+	throw_speed = 8
 	throw_range = 15
 	sharp = TRUE
 	edge =  TRUE
+	w_class = ITEM_SIZE_TINY
 
 /obj/item/material/star/New()
 	..()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -196,7 +196,6 @@
 /obj/item/storage/box/ammo/sniperammo/apds
 	name = "box of sniper APDS shells"
 	startswith = list(/obj/item/ammo_casing/shell/apds = 3)
-
 /obj/item/storage/box/flashbangs
 	name = "box of flashbangs"
 	desc = "A box containing 7 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness from repeated use."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -36,6 +36,16 @@
 		/obj/item/reagent_containers/hypospray/autoinjector/mindbreaker
 		)
 
+/obj/item/storage/box/syndie_kit/shuriken
+	startswith = list(
+		/obj/item/material/star/ninja,
+		/obj/item/material/star/ninja,
+		/obj/item/material/star/ninja,
+		/obj/item/material/star/ninja,
+		/obj/item/material/star/ninja,
+		/obj/item/material/star/ninja,
+	)
+
 // Space suit uplink kit
 /obj/item/storage/backpack/satchel/syndie_kit/space
 	//name = "\improper EVA gear pack"


### PR DESCRIPTION
Adds a box of six shuriken to the uplink for 18 TC

Reduces the throw speed of shuriken from 10 to 8 (Prevents wall splat / impalement)
Increases the throw force from 15 to 20 to make up for the lost damage via speed
Reduces the size of shuriken from pistol size to syringe size (Medium to tiny, 3 -> 1)

Adds a katana to the uplink for 24 TC 
Reduces the cost of the pike cube from 70 to 44, 70 was excessive while at a price point of 44 it's only possible to purchase two, or three with a radio. 

Removes the zipgun and replica pistol from the uplink
The zipgun wasn't ever used and the replica pistol was roughly equal in strength to a 40 TC weapon without any notable downsides.

Modifies the cost of merc railguns to 65/75 respectively, both were never used because of their significant price compared to what they actually offered in return. They *might* end up being pretty strong but I'd rather they got used and we made adjustments later than have them soft removed via excessive prices.

🆑 Kell-E
rscadd: Adds a box of shurikens to the uplink for 18TC.
balance: reduces the size of shurikens from medium to tiny (Pistol -> syringe size), removes shurikens ability to gib limbs and wall splat but increased their throw force from 15 to 20.
rscadd: Adds a katana to the uplink for 24 TC.
balance: reduces the cost of the pike cube from 70 to 44.
rscdel: Removes the replica pistol and zipgun from the uplink.
balance: Reduces the cost of the two merc railguns from 109/130 to 65/75 respectively.
/🆑 