### PR TITLE
git ignores changes to maps/using.dm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ lib/*.so
 *.pyc
 __pycache__
 
-# flyway config
-flyway.conf
+# ignore local selected map
+maps/using.dm


### PR DESCRIPTION
convenience to prevent committing the use of example map / etc without really intending it

also removes flyaway ignore; unused
