### PR TITLE
Minor tweaks to melee accuracy penalties

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1742,12 +1742,12 @@
 
 /mob/living/carbon/human/melee_accuracy_mods()
 	. = ..()
-	if(get_shock() > 50)
-		. += 15
+	if(get_shock() > 100)
+		. += 10
 	if(shock_stage > 10)
-		. += 15
+		. += 10
 	if(shock_stage > 30)
-		. += 15
+		. += 20
 
 /mob/living/carbon/human/ranged_accuracy_mods()
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -820,11 +820,11 @@ default behaviour is:
 	if(incapacitated(INCAPACITATION_UNRESISTING))
 		. += 100
 	if(confused)
-		. += 15
+		. += 10
 	if(weakened)
 		. += 15
 	if(eye_blurry)
-		. += 15
+		. += 5
 	if(eye_blind)
 		. += 60
 	if(MUTATION_CLUMSY in mutations)


### PR DESCRIPTION
I don't know what to say, it's really not all as bad as people make out.

I've slightly reduced the penalties on pain so that it takes generally two (lethal) shots to give someone penalties to melee accuracy (50 shock is basically one shot from any laser).
I've also slightly tweaked the effect of some of the debuffs so they don't stack up so quickly and render someone unable to land any hits.

🆑 Kell-E
balance: Slightly reduced melee accuracy penalties (By about 33%) and slightly upped the threshold of sustained damage before the penalties begin to kick in.
/🆑 