### PR TITLE
Add dressup outfit templates for SCGEC

### DIFF
--- a/maps/torch/datums/uniforms_expedition.dm
+++ b/maps/torch/datums/uniforms_expedition.dm
@@ -10,7 +10,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/cmd)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/command
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command
@@ -88,7 +88,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/eng)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/engineering/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/engineering
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/engineering
@@ -139,7 +139,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/sec)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/security/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/security
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/security
@@ -190,7 +190,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/med)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/medical/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/medical
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/medical
@@ -241,7 +241,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/sup)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/service/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/service
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/supply
@@ -288,7 +288,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/svc)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/service/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/service
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/service
@@ -335,7 +335,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/exp)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/exploration/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/exploration
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/exploration
@@ -354,7 +354,7 @@
 						 /obj/item/clothing/shoes/jackboots/unathi,
 						 /obj/item/clothing/gloves/thick/duty/solgov/cmd)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command
 	dress_skirt = /obj/item/clothing/under/solgov/dress/expeditionary/command/skirt
@@ -377,7 +377,7 @@
 
 	utility_under= /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/command
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command
@@ -421,7 +421,7 @@
 						 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov,
 						 /obj/item/clothing/suit/storage/toggle/labcoat/science/ec)
 
-	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/research/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command/research
 	service_hat = /obj/item/clothing/head/solgov/service/expedition/command
 
 	dress_under = /obj/item/clothing/under/solgov/dress/expeditionary/command/research

--- a/maps/torch/items/clothing/solgov-suit.dm
+++ b/maps/torch/items/clothing/solgov-suit.dm
@@ -45,54 +45,53 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'
 	)
 
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	icon_state = "ecservice_officer"
+	item_state = "ecservice_officer"
+
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/medical
 	accessories = list(/obj/item/clothing/accessory/solgov/department/medical/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/medical/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/medical
+	accessories = list(/obj/item/clothing/accessory/solgov/department/medical/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/engineering
 	accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/engineering/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/engineering
+	accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/supply
+	accessories = list(/obj/item/clothing/accessory/solgov/department/supply/service)
+
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/supply
 	accessories = list(/obj/item/clothing/accessory/solgov/department/supply/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/security
 	accessories = list(/obj/item/clothing/accessory/solgov/department/security/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/security/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/security
+	accessories = list(/obj/item/clothing/accessory/solgov/department/security/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/service
 	accessories = list(/obj/item/clothing/accessory/solgov/department/service/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/service/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/service
+	accessories = list(/obj/item/clothing/accessory/solgov/department/service/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/exploration
 	accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/exploration/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/exploration
+	accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/service)
 
 /obj/item/clothing/suit/storage/solgov/service/expeditionary/research
 	accessories = list(/obj/item/clothing/accessory/solgov/department/research/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/research/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/research
+	accessories = list(/obj/item/clothing/accessory/solgov/department/research/service)
 
-/obj/item/clothing/suit/storage/solgov/service/expeditionary/command
-	icon_state = "ecservice_officer"
-	item_state = "ecservice_officer"
+/obj/item/clothing/suit/storage/solgov/service/expeditionary/command/command
 	accessories = list(/obj/item/clothing/accessory/solgov/department/command/service)
 
 /obj/item/clothing/suit/storage/solgov/service/fleet

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -61,21 +61,6 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_under_unathi.dmi'
 		)
 
-/obj/item/clothing/under/solgov/utility/expeditionary_skirt
-	name = "expeditionary skirt"
-	desc = "A black turtleneck and skirt, the elusive ladies' uniform of the Expeditionary Corps."
-	icon_state = "blackservicefem"
-	worn_state = "blackservicefem"
-	sprite_sheets = list(
-		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_under_unathi.dmi'
-		)
-
-/obj/item/clothing/under/solgov/utility/expeditionary_skirt/officer
-	name = "expeditionary officer skirt"
-	desc = "A black turtleneck and skirt, the elusive ladies' uniform of the Expeditionary Corps. This one has gold trim."
-	icon_state = "blackservicefem_com"
-	worn_state = "blackservicefem_com"
-
 /obj/item/clothing/under/solgov/utility/expeditionary/command
 	accessories = list(/obj/item/clothing/accessory/solgov/department/command)
 

--- a/maps/torch/outfits/scgec.dm
+++ b/maps/torch/outfits/scgec.dm
@@ -1,0 +1,355 @@
+/decl/hierarchy/outfit/scgec
+	hierarchy_type = /decl/hierarchy/outfit/scgec
+	flags = OUTFIT_RESET_EQUIPMENT | OUTFIT_ADJUSTMENT_ALL_SKIPS
+	l_ear = /obj/item/device/radio/headset
+	l_hand = /obj/item/storage/backpack/dufflebag/scgec_accessories
+	back = /obj/item/storage/backpack/satchel/grey
+
+
+// Utility
+/decl/hierarchy/outfit/scgec/utility_enlisted
+	name = "SCGEC - Enlisted Utility"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/soft/solgov/expedition
+
+
+/decl/hierarchy/outfit/scgec/utility_command
+	name = "SCGEC - Command Utility"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/soft/solgov/expedition
+
+
+/decl/hierarchy/outfit/scgec/utility_senior_command
+	name = "SCGEC - Senior Command Utility"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/soft/solgov/expedition
+
+
+/decl/hierarchy/outfit/scgec/utility_captain
+	name = "SCGEC - Captain Utility"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/soft/solgov/expedition/co
+
+
+/decl/hierarchy/outfit/scgec/utility_admiral
+	name = "SCGEC - Admiral Utility"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/soft/solgov/expedition/co
+
+
+// Service
+/decl/hierarchy/outfit/scgec/service
+	name = "SCGEC - Enlisted Service"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/service/expeditionary
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/solgov/service/expedition
+
+
+/decl/hierarchy/outfit/scgec/service_command
+	name = "SCGEC - Command Service"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/solgov/service/expedition/command
+
+
+/decl/hierarchy/outfit/scgec/service_senior_command
+	name = "SCGEC - Senior Command Service"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/solgov/service/expedition/senior_command
+
+
+/decl/hierarchy/outfit/scgec/service_captain
+	name = "SCGEC - Captain Service"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/solgov/service/expedition/captain
+
+
+/decl/hierarchy/outfit/scgec/service_admiral
+	name = "SCGEC - Admiral Service"
+	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/expeditionary/command
+	shoes = /obj/item/clothing/shoes/dutyboots
+	head = /obj/item/clothing/head/solgov/service/expedition/captain
+
+
+// Dress
+/decl/hierarchy/outfit/scgec/dress_enlisted
+	name = "SCGEC - Enlisted Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_enlisted
+	name = "SCGEC - Enlisted Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_senior_enlisted
+	name = "SCGEC - Senior Enlisted Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_senior_enlisted
+	name = "SCGEC - Senior Enlisted Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_chief_enlisted
+	name = "SCGEC - Chief Enlisted Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/chief
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_chief_enlisted
+	name = "SCGEC - Chief Enlisted Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/senior
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_command
+	name = "SCGEC - Command Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/command
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_command
+	name = "SCGEC - Command Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/command
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_senior_command
+	name = "SCGEC - Senior Command Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/cdr
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/senior_command
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_senior_command
+	name = "SCGEC - Senior Command Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/cdr
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/senior_command
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_captain
+	name = "SCGEC - Captain Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/capt
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/captain
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_captain
+	name = "SCGEC - Captain Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/capt
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/captain
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_admiral
+	name = "SCGEC - Admiral Dress"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/adm
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/captain
+	gloves = /obj/item/clothing/gloves/white
+
+
+/decl/hierarchy/outfit/scgec/dress_skirt_admiral
+	name = "SCGEC - Admiral Dress (Skirt)"
+	uniform = /obj/item/clothing/under/solgov/dress/expeditionary/skirt
+	suit = /obj/item/clothing/suit/storage/solgov/dress/expedition/command/adm
+	shoes = /obj/item/clothing/shoes/dress
+	head = /obj/item/clothing/head/solgov/service/expedition/captain
+	gloves = /obj/item/clothing/gloves/white
+
+
+// PT
+/decl/hierarchy/outfit/scgec/pt
+	name = "SCGEC - PT"
+	uniform = /obj/item/clothing/under/solgov/pt/expeditionary
+	shoes = /obj/item/clothing/shoes/black
+
+
+// Accessory boxes
+/obj/item/storage/backpack/dufflebag/scgec_accessories
+	name = "dressup accessories, SCGEC"
+	startswith = list(
+		/obj/item/storage/box/large/scgec_ranks,
+		/obj/item/storage/box/scgec_patches,
+		/obj/item/storage/box/scgec_badges,
+		/obj/item/storage/box/scgec_scarves,
+		/obj/item/storage/box/large/scgec_berets,
+		/obj/item/storage/box/scgec_gloves,
+		/obj/item/storage/box/scgec_department,
+		/obj/item/storage/box/scgec_department_service
+	)
+	max_storage_space = 40 // Special snowflake for tests and UI scaling sanity. 40 is the exact size taken up by the contained boxes.
+
+
+/obj/item/storage/box/large/scgec_ranks
+	name = "rank box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7,
+		/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o3,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o3,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o5,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o5,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o6,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o6,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o8,
+		/obj/item/clothing/accessory/solgov/rank/ec/officer/o8
+	)
+
+
+/obj/item/storage/box/scgec_patches
+	name = "patch box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/accessory/solgov/torch_patch,
+		/obj/item/clothing/accessory/solgov/torch_patch,
+		/obj/item/clothing/accessory/solgov/ec_patch,
+		/obj/item/clothing/accessory/solgov/ec_patch,
+		/obj/item/clothing/accessory/solgov/ec_patch/fieldops,
+		/obj/item/clothing/accessory/solgov/ec_patch/fieldops,
+		/obj/item/clothing/accessory/solgov/cultex_patch,
+		/obj/item/clothing/accessory/solgov/cultex_patch
+	)
+
+
+/obj/item/storage/box/scgec_badges
+	name = "badge box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/accessory/solgov/skillbadge/botany,
+		/obj/item/clothing/accessory/solgov/skillbadge/netgun,
+		/obj/item/clothing/accessory/solgov/skillbadge/eva,
+		/obj/item/clothing/accessory/solgov/skillbadge/medical,
+		/obj/item/clothing/accessory/solgov/skillbadge/mech,
+		/obj/item/clothing/accessory/solgov/skillbadge/electric,
+		/obj/item/clothing/accessory/solgov/skillbadge/science,
+		/obj/item/clothing/accessory/solgov/skillstripe/botany,
+		/obj/item/clothing/accessory/solgov/skillstripe/netgun,
+		/obj/item/clothing/accessory/solgov/skillstripe/eva,
+		/obj/item/clothing/accessory/solgov/skillstripe/medical,
+		/obj/item/clothing/accessory/solgov/skillstripe/electric
+	)
+
+
+/obj/item/storage/box/scgec_scarves
+	name = "scarf box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/accessory/solgov/ec_scarf,
+		/obj/item/clothing/accessory/solgov/ec_scarf/observatory,
+		/obj/item/clothing/accessory/solgov/ec_scarf/fieldops
+	)
+
+
+/obj/item/storage/box/large/scgec_berets
+	name = "berets box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/head/beret/solgov/expedition,
+		/obj/item/clothing/head/beret/solgov/expedition/security,
+		/obj/item/clothing/head/beret/solgov/expedition/medical,
+		/obj/item/clothing/head/beret/solgov/expedition/engineering,
+		/obj/item/clothing/head/beret/solgov/expedition/supply,
+		/obj/item/clothing/head/beret/solgov/expedition/service,
+		/obj/item/clothing/head/beret/solgov/expedition/exploration,
+		/obj/item/clothing/head/beret/solgov/expedition/command,
+		/obj/item/clothing/head/beret/solgov/expedition/branch,
+		/obj/item/clothing/head/beret/solgov/expedition/branch/observatory,
+	)
+
+
+/obj/item/storage/box/scgec_gloves
+	name = "gloves box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/gloves/thick/duty/solgov/eng,
+		/obj/item/clothing/gloves/thick/duty/solgov/cmd,
+		/obj/item/clothing/gloves/thick/duty/solgov/exp,
+		/obj/item/clothing/gloves/thick/duty/solgov/med,
+		/obj/item/clothing/gloves/thick/duty/solgov/sec,
+		/obj/item/clothing/gloves/thick/duty/solgov/svc,
+		/obj/item/clothing/gloves/thick/duty/solgov/sup
+	)
+
+
+/obj/item/storage/box/scgec_department
+	name = "department utility accessories box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/accessory/solgov/department/command,
+		/obj/item/clothing/accessory/solgov/department/engineering,
+		/obj/item/clothing/accessory/solgov/department/security,
+		/obj/item/clothing/accessory/solgov/department/medical,
+		/obj/item/clothing/accessory/solgov/department/supply,
+		/obj/item/clothing/accessory/solgov/department/service,
+		/obj/item/clothing/accessory/solgov/department/exploration,
+		/obj/item/clothing/accessory/solgov/department/research
+	)
+
+
+/obj/item/storage/box/scgec_department_service
+	name = "department service accessories box, SCGEC"
+	startswith = list(
+		/obj/item/clothing/accessory/solgov/department/command/service,
+		/obj/item/clothing/accessory/solgov/department/engineering/service,
+		/obj/item/clothing/accessory/solgov/department/security/service,
+		/obj/item/clothing/accessory/solgov/department/medical/service,
+		/obj/item/clothing/accessory/solgov/department/supply/service,
+		/obj/item/clothing/accessory/solgov/department/service/service,
+		/obj/item/clothing/accessory/solgov/department/exploration/service,
+		/obj/item/clothing/accessory/solgov/department/research/service
+	)

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -110,6 +110,8 @@
 	#include "machinery/keycard authentication.dm"
 	#include "machinery/suit_storage.dm"
 
+	#include "outfits/scgec.dm"
+
 	#include "robot/module_flying_surveyor.dm"
 
 	#include "structures/signs.dm"


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Added dress-up categories for the various EC uniforms and tiers of uniforms.
/:cl:

The new dress-up options are prefixed by SCGEC and organized by uniform type (Utility, service, dress) and rank group (enlisted, senior, chief, command, captain, admiral, etc.)

The dress-ups also spawn with boxes containing additional accessories such as ranks, patches, etc., for customization of the outfit once spawned.

Also, re-pathed the service jackets so the dress-up outfits could have a general-purpose jacket.

I will do the same for fleet, army, and other factions, and redo the outfits for ICCGN to include the boxes for accessories once this is approved and fits the standards of the other maintainers.