### PR TITLE
A tiny armor tweak

### DIFF
--- a/code/datums/extensions/armor/armor.dm
+++ b/code/datums/extensions/armor/armor.dm
@@ -10,7 +10,7 @@
 	var/armor_range_mult = 2
 	// [under_armor_mult] multiplies how strongly damage that is <= armor value is blocked.
 	//  E.g. setting it to 0 will flat out block all damage below armor
-	var/under_armor_mult = 0.7
+	var/under_armor_mult = 1
 	// [over_armor_mult] multiplies how strongly damage that is > armor value is blocked.
 	//  E.g. setting it to more than 1 will make mitigation drop off faster, effectively reducing the range of damage mitigation
 	var/over_armor_mult = 1


### PR DESCRIPTION
under_armor_mult = 0.7 -> 1

This means that weapons below the armor value will less rapidly lose effectiveness.
With this change a pistol (10mm, military) will deal roughly 22 damage instead of 14 on a hit versus a medium plate (50 armor versus ballistics versus 40 force).

I still think armor as a whole needs a pass to bring it all to a similar level but for now this should somewhat increase the viability of ballistic and improvised melee weapons as they were underperforming in cases where they should have at least been moderately effective.

🆑 Kell-E
balance: Armor is somewhat less effective at blocking weapons below their protection values
/🆑 