### PR TITLE
Adds ability to place cables on space/open space tiles if there is a lattice to support them

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -50,8 +50,14 @@
 		qdel(src)
 
 /obj/structure/lattice/proc/deconstruct(var/mob/user)
-	to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
+	to_chat(user, SPAN_NOTICE("Slicing lattice joints ..."))
 	new /obj/item/stack/material/rods(loc, 1, material.name)
+	var/turf/source = get_turf(src)
+	if(locate(/obj/structure/cable, source))
+		for(var/obj/structure/cable/C in source)
+			C.visible_message(SPAN_WARNING("\The [C] snaps!"))
+			new/obj/item/stack/cable_coil(source, (C.d1 ? 2 : 1), C.color)
+			qdel(C)
 	qdel(src)
 
 /obj/structure/lattice/attackby(obj/item/C as obj, mob/user as mob)
@@ -60,17 +66,25 @@
 		var/turf/T = get_turf(src)
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
 		return
+
+	if (isCoil(C))
+		var/turf/T = get_turf(src)
+		T.attackby(C, user) //Also handing this off to turf, the checks should confirm the lattice exists
+		return
+
 	if(isWelder(C))
 		var/obj/item/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
 			deconstruct(user)
 		return
+
 	if(istype(C, /obj/item/gun/energy/plasmacutter))
 		var/obj/item/gun/energy/plasmacutter/cutter = C
 		if(!cutter.slice(user))
 			return
 		deconstruct(user)
 		return
+
 	if (istype(C, /obj/item/stack/material/rods))
 		var/obj/item/stack/material/rods/R = C
 		if(R.use(2))
@@ -80,7 +94,7 @@
 			qdel(src)
 			return
 		else
-			to_chat(user, "<span class='notice'>You require at least two rods to complete the catwalk.</span>")
+			to_chat(user, SPAN_NOTICE("You require at least two rods to complete the catwalk."))
 
 /obj/structure/lattice/on_update_icon()
 	var/dir_sum = 0

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -199,7 +199,7 @@
 
 /turf/simulated/floor/can_build_cable(var/mob/user)
 	if(!is_plating() || flooring)
-		to_chat(user, "<span class='warning'>Removing the tiling first.</span>")
+		to_chat(user, "<span class='warning'>Remove the tiling first.</span>")
 		return 0
 	if(broken || burnt)
 		to_chat(user, "<span class='warning'>This section is too damaged to support anything. Use a welder to fix the damage.</span>")

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -69,7 +69,7 @@
 			return L.attackby(C, user)
 		var/obj/item/stack/material/rods/R = C
 		if (R.use(1))
-			to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")
+			to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ReplaceWithLattice(R.material.name)
 		return
@@ -85,7 +85,19 @@
 			ChangeTurf(/turf/simulated/floor/airless, keep_air = TRUE)
 			return
 		else
-			to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
+			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
+
+	//Checking if the user attacked with a cable coil
+	if(isCoil(C))
+		var/obj/item/stack/cable_coil/coil = C
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+		if(L)
+			coil.turf_place(src, user)
+			return
+		else
+			to_chat(user, SPAN_WARNING("The cable needs something to be secured to."))
+			return
+
 	return
 
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -81,8 +81,11 @@ By design, d1 is the smallest direction and d2 is the highest
 
 	d2 = text2num( copytext( icon_state, dash+1 ) )
 
-	var/turf/T = src.loc			// hide if turf is not intact
-	if(level==1) hide(!T.is_plating())
+	// hide the cable
+	var/turf/T = src.loc
+	if(istype(T, /turf/simulated/floor) && !T.is_plating() && src.level == 1)
+		hide(TRUE)
+
 	GLOB.cable_list += src //add it to the global cable list
 
 
@@ -99,9 +102,9 @@ By design, d1 is the smallest direction and d2 is the highest
 		user.examinate(src)
 		// following code taken from attackby (multitool)
 		if(powernet && (powernet.avail > 0))
-			to_chat(user, "<span class='warning'>[get_wattage()] in power network.</span>")
+			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))
 		else
-			to_chat(user, "<span class='warning'>The cable is not powered.</span>")
+			to_chat(user, SPAN_WARNING("The cable is not powered."))
 	return
 
 ///////////////////////////////////
@@ -139,6 +142,28 @@ By design, d1 is the smallest direction and d2 is the highest
 //
 
 /obj/structure/cable/attackby(obj/item/W, mob/user)
+	var/turf/T = get_turf(src)
+	//sanity checking
+	if(!isturf(T))
+		return
+
+	if(istype(T, /turf/simulated/floor) && !T.is_plating())
+		return
+
+	if(get_dist(T, user) > 1) // make sure it's close enough
+		to_chat(user, SPAN_WARNING("You can't lay cable at a place that far away."))
+		return
+
+	// handle catwalks and plated catwalks
+	var/obj/structure/catwalk/cwalk = locate(/obj/structure/catwalk, T)
+	if(cwalk)
+		if(cwalk.plated_tile && !cwalk.hatch_open)
+			to_chat(user, SPAN_WARNING("Open the catwalk hatch first."))
+			return
+		else if(!cwalk.plated_tile)
+			to_chat(user, SPAN_WARNING("The catwalk is blocking the cable."))
+			return
+
 	if(isWirecutter(W))
 		cut_wire(W, user)
 
@@ -152,10 +177,10 @@ By design, d1 is the smallest direction and d2 is the highest
 	else if(isMultitool(W))
 
 		if(powernet && (powernet.avail > 0))		// is it powered?
-			to_chat(user, "<span class='warning'>[get_wattage()] in power network.</span>")
+			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))
 
 		else
-			to_chat(user, "<span class='warning'>The cable is not powered.</span>")
+			to_chat(user, SPAN_WARNING("The cable is not powered."))
 
 		shock(user, 5, 0.2)
 
@@ -165,10 +190,10 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/delay_holder
 
 		if(W.force < 5)
-			visible_message("<span class='warning'>[user] starts sawing away roughly at the cable with \the [W].</span>")
+			visible_message(SPAN_WARNING("[user] starts sawing away roughly at the cable with \the [W]."))
 			delay_holder = 8 SECONDS
 		else
-			visible_message("<span class='warning'>[user] begins to cut through the cable with \the [W].</span>")
+			visible_message(SPAN_WARNING("[user] begins to cut through the cable with \the [W]."))
 			delay_holder = 3 SECONDS
 
 		if(user.do_skilled(delay_holder, SKILL_ELECTRICAL, src))
@@ -176,21 +201,19 @@ By design, d1 is the smallest direction and d2 is the highest
 			if(W.obj_flags & OBJ_FLAG_CONDUCTIBLE)
 				shock(user, 66, 0.7)
 		else
-			visible_message("<span class='warning'>[user] stops cutting before any damage is done.</span>")
+			visible_message(SPAN_WARNING("[user] stops cutting before any damage is done."))
 
 	src.add_fingerprint(user)
 
 /obj/structure/cable/proc/cut_wire(obj/item/W, mob/user)
 	var/turf/T = get_turf(src)
-	if(!T || !T.is_plating())
-		return
 
 	if(d1 == UP || d2 == UP)
-		to_chat(user, "<span class='warning'>You must cut this cable from above.</span>")
+		to_chat(user, SPAN_WARNING("You must cut this cable from above."))
 		return
 
 	if(breaker_box)
-		to_chat(user, "<span class='warning'>This cable is connected to a nearby breaker box. Use the breaker box to interact with it.</span>")
+		to_chat(user, SPAN_WARNING("This cable is connected to a nearby breaker box. Use the breaker box to interact with it."))
 		return
 
 	if (shock(user, 50))
@@ -198,7 +221,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 	new/obj/item/stack/cable_coil(T, (src.d1 ? 2 : 1), color)
 
-	visible_message("<span class='warning'>[user] cuts the cable.</span>")
+	visible_message(SPAN_WARNING("[user] cuts the cable."))
 
 	if(HasBelow(z))
 		for(var/turf/turf in GetBelow(src))
@@ -526,7 +549,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 			return ..()
 
 		if(BP_IS_BRITTLE(S))
-			to_chat(user, "<span class='warning'>\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
+			to_chat(user, SPAN_WARNING("\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
 			return 1
 
 		var/use_amt = min(src.amount, Ceil(S.burn_dam/3), 5)
@@ -562,7 +585,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		selected_color = "Red"
 		final_color = GLOB.possible_cable_colours[selected_color]
 	color = final_color
-	to_chat(user, "<span class='notice'>You change \the [src]'s color to [lowertext(selected_color)].</span>")
+	to_chat(user, SPAN_NOTICE("You change \the [src]'s color to [lowertext(selected_color)]."))
 
 /obj/item/stack/cable_coil/proc/update_wclass()
 	if(amount == 1)
@@ -578,13 +601,13 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	if(ishuman(M) && !M.incapacitated())
 		if(!istype(usr.loc,/turf)) return
 		if(!src.use(15))
-			to_chat(usr, "<span class='warning'>You need at least 15 lengths to make restraints!</span>")
+			to_chat(usr, SPAN_WARNING("You need at least 15 lengths to make restraints!"))
 			return
 		var/obj/item/handcuffs/cable/B = new /obj/item/handcuffs/cable(usr.loc)
 		B.color = color
-		to_chat(usr, "<span class='notice'>You wind some cable together to make some restraints.</span>")
+		to_chat(usr, SPAN_NOTICE("You wind some cable together to make some restraints."))
 	else
-		to_chat(usr, "<span class='notice'>You cannot do that.</span>")
+		to_chat(usr, SPAN_NOTICE("You cannot do that."))
 
 /obj/item/stack/cable_coil/cyborg/verb/set_colour()
 	set name = "Change Colour"
@@ -614,39 +637,52 @@ obj/structure/cable/proc/cableColor(var/colorC)
 // Cable laying procedures
 //////////////////////////////////////////////
 
-// called when cable_coil is clicked on a turf/simulated/floor
-/obj/item/stack/cable_coil/proc/turf_place(turf/simulated/F, mob/user)
+// called when cable_coil is clicked on a turf (special exception made for space & open space)
+/obj/item/stack/cable_coil/proc/turf_place(turf/F, mob/user)
+	// all four of these checks should already be handeled by the attackby behavior and behavior of the cable coil object, but just in case I kept them here
 	if(!isturf(user.loc))
 		return
 
-	if(get_amount() < 1) // Out of cable
-		to_chat(user, "There is no cable left.")
+	if(get_amount() < 1) // Out of cable (should never happen)
+		to_chat(user, SPAN_WARNING("There is no cable left."))
 		return
 
-	if(get_dist(F,user) > 1) // Too far
-		to_chat(user, "You can't lay cable at a place that far away.")
+	if(get_dist(F,user) > 1) // Too far (also should never happen unless fuckery)
+		to_chat(user, SPAN_WARNING("You can't lay cable at a place that far away."))
 		return
 
-	if(!F.is_plating())		// Ff floor is intact, complain
-		to_chat(user, "You can't lay cable there unless the floor tiles are removed.")
+	if(istype(F, /turf/simulated/floor) && !F.is_plating()) // Making sure it's not a floor tile
+		to_chat(user, SPAN_WARNING("Remove the tiling first."))
 		return
+	// end of hopefully unnecessary checks
 
-	var/dirn
-	if(user.loc == F)
-		dirn = user.dir			// if laying on the tile we're on, lay in the direction we're facing
-	else
-		dirn = get_dir(F, user)
+	// catwalk handling
+	var/obj/structure/catwalk/cwalk = locate(/obj/structure/catwalk, F)
+	if(cwalk)
+		if(cwalk.plated_tile && !cwalk.hatch_open)
+			to_chat(user, SPAN_WARNING("Open the catwalk hatch first."))
+			return
+		else if(!cwalk.plated_tile)
+			to_chat(user, SPAN_WARNING("You can't reach underneath the catwalk."))
+			return
 
+	// Check if the player is clicking an open space
 	var/end_dir = 0
-	if(istype(F, /turf/simulated/open))
+	if(istype(F, /turf/simulated/open) && !locate(/obj/structure/lattice, F))
 		if(!can_use(2))
-			to_chat(user, "You don't have enough cable to do this!")
+			to_chat(user, SPAN_WARNING("You don't have enough cable to hang a wire down."))
 			return
 		end_dir = DOWN
 
+	var/dirn
+	if(user.loc == F)
+		dirn = user.dir	// if laying on the tile we're on, lay in the direction we're facing
+	else
+		dirn = get_dir(F, user)
+
 	for(var/obj/structure/cable/LC in F)
 		if((LC.d1 == dirn && LC.d2 == end_dir ) || ( LC.d2 == dirn && LC.d1 == end_dir))
-			to_chat(user, "<span class='warning'>There's already a cable at that position.</span>")
+			to_chat(user, SPAN_WARNING("There's already a cable at that position."))
 			return
 
 	put_cable(F, user, end_dir, dirn)
@@ -657,16 +693,9 @@ obj/structure/cable/proc/cableColor(var/colorC)
 // or click on a turf that already contains a "node" cable
 /obj/item/stack/cable_coil/proc/cable_join(obj/structure/cable/C, mob/user)
 	var/turf/U = user.loc
-	if(!isturf(U))
-		return
-
 	var/turf/T = C.loc
-
-	if(!isturf(T) || !T.is_plating())		// sanity checks, also stop use interacting with T-scanner revealed cable
-		return
-
-	if(get_dist(C, user) > 1)		// make sure it's close enough
-		to_chat(user, "You can't lay cable at a place that far away.")
+	// making sure the player is not in an invalid place
+	if(!isturf(U))
 		return
 
 	if(U == T) //if clicked on the turf we're standing on, try to put a cable in the direction we're facing
@@ -677,18 +706,21 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 	// one end of the clicked cable is pointing towards us
 	if(C.d1 == dirn || C.d2 == dirn)
-		if(!U.is_plating())						// can't place a cable if the floor is complete
-			to_chat(user, "You can't lay cable there unless the floor tiles are removed.")
+		if(istype(U, /turf/simulated/floor) && !U.is_plating()) // make sure we aren't placing cable connections under floors
+			to_chat(user, SPAN_WARNING("Remove the tiling first."))
+			return
+		// make sure we aren't placing cable connections in open space (both kinds) with no support
+		else if((istype(U, /turf/space) || istype(U, /turf/simulated/open)) && !locate(/obj/structure/lattice, U))
+			to_chat(user, SPAN_WARNING("The cable connection needs something to be secured to."))
 			return
 		else
 			// cable is pointing at us, we're standing on an open tile
 			// so create a stub pointing at the clicked cable on our tile
+			var/fdirn = turn(dirn, 180)	// the opposite direction
 
-			var/fdirn = turn(dirn, 180)		// the opposite direction
-
-			for(var/obj/structure/cable/LC in U)		// check to make sure there's not a cable there already
+			for(var/obj/structure/cable/LC in U) // check to make sure there's not a cable there already
 				if(LC.d1 == fdirn || LC.d2 == fdirn)
-					to_chat(user, "There's already a cable at that position.")
+					to_chat(user, SPAN_WARNING("There's already a cable at that position."))
 					return
 			put_cable(U,user,0,fdirn)
 			return
@@ -709,7 +741,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 			if(LC == C)			// skip the cable we're interacting with
 				continue
 			if((LC.d1 == nd1 && LC.d2 == nd2) || (LC.d1 == nd2 && LC.d2 == nd1) )	// make sure no cable matches either direction
-				to_chat(user, "There's already a cable at that position.")
+				to_chat(user, SPAN_WARNING("There's already a cable at that position."))
 				return
 
 
@@ -743,7 +775,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		C.denode()// this call may have disconnected some cables that terminated on the centre of the turf, if so split the powernets.
 		return
 
-/obj/item/stack/cable_coil/proc/put_cable(turf/simulated/F, mob/user, d1, d2)
+/obj/item/stack/cable_coil/proc/put_cable(turf/F, mob/user, d1, d2)
 	if(!istype(F))
 		return
 


### PR DESCRIPTION
Allows the player to place cables on space turfs and open space turfs (the turfs between levels on the Torch, for example) so long as they have a lattice to support them.

Previously, there were select areas in the Torch's maintenance that had cables laid over lattices on top of open space. If these cables were damaged, they could not be repaired unless the entire region was replaced with plating, which is a little bit silly. This change makes cables more intuitive to players and allows map makers to configure more complicated wiring systems involving open space or the vacuum of space without having to add plating or rely on the players knowing they have to replace the damaged areas with plating to repair them.

This pull request also cleans up some of the messaging to the player in regards to whether or not they are able to place cables, and for what reason. Previously the messages could be different because they terminated in different procs despite the logical reason for the termination being the same.

:cl: ComradeCheekiBreeki
rscadd: Adds ability to place cables from a cable coil on lattices in open space (space between levels on a multi-level map) or space (the vacuum)
bugfix: Fixes cables underneath catwalks being able to be manipulated by opening the Turf menu.
tweak: Tweaks messages to players about why they can't place cables in certain places
/:cl: