### PR TITLE
Fixes Branch Beret Descriptions

### DIFF
--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -264,12 +264,12 @@
 
 /obj/item/clothing/head/beret/solgov/expedition/branch
 	name = "\improper Field Operations beret"
-	desc = "An SCG Expeditionary Corps beret carrying insignia of the Field Operations section. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Expeditionary Corps beret carrying the insignia of the Field Operations section. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_black_fieldOps"
 
 /obj/item/clothing/head/beret/solgov/expedition/branch/observatory
 	name = "\improper Observatory beret"
-	desc = "An SCG Expeditionary Corps beret carrying insignia of the Observatory section. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Expeditionary Corps beret carrying the insignia of the Observatory section. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_black_observatory"
 
 /obj/item/clothing/head/beret/solgov/fleet
@@ -324,27 +324,27 @@
 
 /obj/item/clothing/head/beret/solgov/fleet/branch
 	name = "first fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of First Fleet, the Sol Guard, stationed in Sol. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Fleet beret carrying the insignia of the First Fleet, the Sol Guard, stationed in Sol. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_first"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/second
 	name = "second fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Second Fleet, the Home Guard, tasked with defense of Sol territories. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Fleet beret carrying the insignia of the Second Fleet, the Home Guard, tasked with defense of Sol territories. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_second"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/third
 	name = "third fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Third Fleet, the Border Guard, guarding borders of Sol territory against Vox and pirates. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Fleet beret carrying the insignia of the Third Fleet, the Border Guard, guarding borders of Sol territory against Vox and pirates. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_third"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/fourth
 	name = "fourth fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Fourth Fleet, stationed on Skrell border. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Fleet beret carrying the insignia of the Fourth Fleet, stationed on Skrell border. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_fourth"
 
 /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
 	name = "fifth fleet beret"
-	desc = "An SCG Fleet beret carrying insignia of Fifth Fleet, the Quick Reaction Force, recently formed and outfited with last tech. For personnel that are more inclined towards style than safety."
+	desc = "An SCG Fleet beret carrying the insignia of the Fifth Fleet, the Quick Reaction Force, recently formed and outfitted with the latest tech. For personnel that are more inclined towards style than safety."
 	icon_state = "beret_navy_fifth"
 
 //ushanka


### PR DESCRIPTION
A relatively simple PR. Fixes a strange grammar mistake on the 5th Fleet beret. It now reads 'outfitted with the latest tech' instead of 'outfited with last tech.'

This PR also changes 'carrying insignia' to 'carrying the insignia' to every division beret.

:cl: BurpleBineapple
bugfix: Fixes the Fifth Fleet beret's description to be grammatically correct.
bugfix: Fixes minor grammatical issues with all division berets.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->