### PR TITLE
Lung damage tweaks / bugfixes

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -23,18 +23,15 @@
 	var/snowflake_speak = (speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) || (vox && vox.is_usable() && vox.assists_languages[speaking])
 	if(!isSynthetic() && need_breathe() && failed_last_breath && !snowflake_speak)
 		var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species.breathing_organ]
-		if(!L || L.breath_fail_ratio > 0.9)
-			if(L && world.time < L.last_successful_breath + 2 MINUTES) //if we're in grace suffocation period, give it up for last words
-				to_chat(src, "<span class='warning'>You use your remaining air to say something!</span>")
-				L.last_successful_breath = world.time - 2 MINUTES
-				return ..(message, speaking = speaking)
-
-			to_chat(src, "<span class='warning'>You don't have enough air[L ? " in [L]" : ""] to make a sound!</span>")
-			return
-		else if(L.breath_fail_ratio > 0.7)
-			whisper_say(length(message) > 5 ? stars(message) : message, speaking)
-		else if(L.breath_fail_ratio > 0.4 && length(message) > 10)
-			whisper_say(message, speaking)
+		if (!L || L.breath_fail_ratio)
+			if (L.breath_fail_ratio >= 0.9)
+				return ..(stars(message, 5, 1), speaking = speaking, whispering = TRUE)
+			else if (L.breath_fail_ratio > 0.5)
+				return ..(stars(message, 35, 1), speaking = speaking, whispering = TRUE)
+			else if (L.breath_fail_ratio > 0.1)
+				return ..(stars(message, 65, 1), speaking = speaking, whispering = TRUE)
+			else
+				return ..(stars(message, 95, 1), speaking = speaking, whispering = TRUE)
 	else
 		return ..(message, speaking = speaking, whispering = whispering)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -168,9 +168,9 @@ proc/get_radio_key_from_channel(var/channel)
 		return
 
 	var/prefix = copytext_char(message, 1, 2)
-	if(prefix == get_prefix_key(/decl/prefix/custom_emote))
+	if(prefix == get_prefix_key(/decl/prefix/custom_emote) && !whispering)
 		return emote(copytext_char(message, 2))
-	if(prefix == get_prefix_key(/decl/prefix/visible_emote))
+	if(prefix == get_prefix_key(/decl/prefix/visible_emote) && !whispering)
 		return custom_emote(1, copytext_char(message, 2))
 
 	//parse the language code and consume it


### PR DESCRIPTION
I've removed the almost entirely broken code for speaking with lung damage and replaced it with a new system.

Instead of being unable to speak with lung damage and the resulting loss of breath you instead will be forced to whisper. The less breath you have in your lungs the higher the chance of your letters will be replaced by stars until eventually with little to no oxygen in your lungs you'll be basically unable to speak. 

The custom emote character is now ignored when whispering to facilitate this, it's not really the best way of handling it but I couldn't really see any other way to accomplish what I had in mind.

🆑 Kell-E
tweak: Lung damage forced whispering now works, whispering with lung damage is now more difficult to understand (even over the radio)
/🆑 