### PR TITLE
Prevent landing shuttles from deleting landmarks

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -24,7 +24,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define MOVABLE_FLAG_PROXMOVE       FLAG(0)  // Does this object require proximity checking in Enter()?
 #define MOVABLE_FLAG_Z_INTERACT     FLAG(1)  // Should attackby and attack_hand be relayed through ladders and open spaces?
 #define MOVABLE_FLAG_EFFECTMOVE     FLAG(2)  // Is this an effect that should move?
-#define MOVABLE_FLAG_DEL_SHUTTLE    FLAG(3)  // Shuttle transistion will delete this.
 
 #define OBJ_FLAG_ANCHORABLE     FLAG(0)  // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE    FLAG(1)  // Conducts electricity. (metal etc.)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -189,16 +189,9 @@
 		var/turf/dst_turf = turf_translation[src_turf]
 		if(src_turf.is_solid_structure()) //in case someone put a hole in the shuttle and you were lucky enough to be under it
 			for(var/atom/movable/AM in dst_turf)
-				if(AM.movable_flags & MOVABLE_FLAG_DEL_SHUTTLE)
-					qdel(AM)
-					continue
 				if(!AM.simulated)
 					continue
-				if(isliving(AM))
-					var/mob/living/bug = AM
-					bug.gib()
-				else
-					qdel(AM) //it just gets atomized I guess? TODO throw it into space somewhere, prevents people from using shuttles as an atom-smasher
+				AM.shuttle_land_on()
 	var/list/powernets = list()
 	for(var/area/A in shuttle_area)
 		// if there was a zlevel above our origin, erase our ceiling now we're leaving
@@ -257,6 +250,13 @@
 				mothership.shuttle_area |= shuttle_area
 			else
 				mothership.shuttle_area -= shuttle_area
+
+/// Handler for shuttles landing on atoms. Called by `shuttle_moved()`.
+/atom/movable/proc/shuttle_land_on()
+	qdel(src)
+
+/mob/living/shuttle_land_on()
+	gib()
 
 //returns 1 if the shuttle has a valid arrive time
 /datum/shuttle/proc/has_arrive_time()


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Shuttles can no longer delete shuttle landmarks and break themselves by landing on beacons.
/:cl:

- Fixes #31886
- Closes #31890
- Closes #31889
- Closes #31888