### PR TITLE
Add empty reagent dispensers to supply

### DIFF
--- a/code/datums/supplypacks/dispcarts.dm
+++ b/code/datums/supplypacks/dispcarts.dm
@@ -2,6 +2,14 @@
 /decl/hierarchy/supply_pack/dispenser_cartridges
 	name = "Dispenser Cartridges"
 
+/decl/hierarchy/supply_pack/dispenser_cartridges/empty
+	name = "Empty dispenser cartridges"
+	contains = list(
+		/obj/item/reagent_containers/chem_disp_cartridge = 2
+	)
+	cost = 10
+	containername = "empty reagent cartridge crate"
+
 #define SEC_PACK(_tname, _type, _name, _cname, _cost, _access)\
 	decl/hierarchy/supply_pack/dispenser_cartridges{\
 		_tname {\


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Supply can now order empty dispenser cartridges. For those bartenders that want to add their juiced fruits to the dispenser machines.
/:cl: