### PR TITLE
Fix cable hiding error

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -83,8 +83,9 @@ By design, d1 is the smallest direction and d2 is the highest
 
 	// hide the cable
 	var/turf/T = src.loc
-	if(istype(T, /turf/simulated/floor) && !T.is_plating() && src.level == 1)
-		hide(TRUE)
+	if (level == 1)
+		var/hideme = !T.is_plating() && !T.is_open()
+		hide(hideme)
 
 	GLOB.cable_list += src //add it to the global cable list
 


### PR DESCRIPTION
Fixes issue introduced in #31879

:cl: SierraKomodo
bugfix: Cables no longer appear on top of walls.
/:cl: