### PR TITLE
Traitor skill re-mastery

### DIFF
--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -228,7 +228,7 @@ The generic antag version.
 Similar, but for station antags that have jobs.
 */
 /datum/nano_module/skill_ui/antag/station
-	max_choices = list(0, 0, 3, 1, 0)
+	max_choices = list(0, 0, 2, 1, 1)
 /*
 Similar, but for off-station jobs (Bearcat, Verne, survivor etc.).
 */


### PR DESCRIPTION
Traitors were gifted a change of one extra master skill at the cost of one less trained skill in #30756, it was later reverted in #30940 because master CQC was awfully balanced and a terrible experience for everyone involved.

Now that master CQC is far more in line with other skills now seems a fair time to give traitors a chance to try out more things. (Dear god surgery takes a huge investment)

🆑 Kell-E
balance: Traitors now have one additional master skill at the cost of one less trained skill.
/🆑 