### PR TITLE
Make IBs lethal & buffs splints

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -258,7 +258,7 @@
 	amount = 5
 	max_amount = 5
 	animal_heal = 0
-	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
+	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT, BP_GROIN, BP_CHEST, BP_HEAD)	//List of organs you can splint, natch.
 
 /obj/item/stack/medical/splint/check_limb_state(var/mob/user, var/obj/item/organ/external/limb)
 	if(BP_IS_ROBOTIC(limb))
@@ -312,7 +312,7 @@
 	desc = "For holding your limbs in place with duct tape and scrap metal."
 	icon_state = "tape-splint"
 	amount = 1
-	splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
+	splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)
 
 // For adherent.
 /obj/item/stack/medical/resin

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -62,7 +62,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			brute /= 2
 			burn /= 2
 
-	if(status & ORGAN_BROKEN && brute)
+	if(is_broken() && brute)
 		jostle_bone(brute)
 		if(can_feel_pain() && prob(40))
 			owner.emote("scream")	//getting hit on broken hand hurts

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -153,7 +153,11 @@
 							blood_max += W.damage / 40
 
 			if(temp.status & ORGAN_ARTERY_CUT)
-				var/bleed_amount = Floor((owner.vessel.total_volume / (temp.applied_pressure || !open_wound ? 400 : 250))*temp.arterial_bleed_severity)
+				var/bleed_amount = 2 * temp.arterial_bleed_severity
+				if(temp.applied_pressure)
+					bleed_amount -= 0.5
+				if(!open_wound)
+					bleed_amount *= 0.5
 				if(bleed_amount)
 					if(open_wound)
 						blood_max += bleed_amount
@@ -171,16 +175,13 @@
 
 		if(CE_STABLE in owner.chem_effects) // inaprovaline
 			blood_max *= 0.8
-
 		if(world.time >= next_blood_squirt && istype(owner.loc, /turf) && do_spray.len)
 			var/spray_organ = pick(do_spray)
 			owner.visible_message(
 				SPAN_DANGER("Blood sprays out from \the [owner]'s [spray_organ]!"),
 				FONT_HUGE(SPAN_DANGER("Blood sprays out from your [spray_organ]!"))
 			)
-			owner.Stun(1)
 			owner.eye_blurry = 2
-
 			//AB occurs every heartbeat, this only throttles the visible effect
 			next_blood_squirt = world.time + 80
 			var/turf/sprayloc = get_turf(owner)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Imienny
tweak: Internal bleeding no longer stops bleeding after some time.
tweak: Splinting limbs now slow down internal bleeding after using bandages.
tweak: Blood sprays caused by internal bleeding no longer stun.
rscadd: Splints can now be applied to head, chest and groin.
rscadd: Makeshift splints can now be applied to hands and feet.
/:cl:

IBs are weird, they are lethal but not because of that they make you lose blood(IBs stop bleeding after some time and its quite slow) but because they stun when you get hurt.
this PR aims to fix both of these problems, by making blood loss caused by them lethal while stopping them from causing hardstuns in combat,
while also making splints less useless by letting splints actually slow down IB bleeding.