### PR TITLE
Fax overhaul

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1563,7 +1563,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 			rcvdcopy = destination.copy(P)
 			rcvdcopy.forceMove(null) //hopefully this shouldn't cause trouble
 			GLOB.adminfaxes += rcvdcopy
-		if (destination.recievefax(P))
+		if (destination.recievefax(P, P.origin))
 			success = TRUE
 
 	if (success)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1524,8 +1524,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 /datum/admins/proc/faxCallback(obj/item/paper/admin/P)
 	var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
 
-	P.SetName("[P.origin] - [customname]")
-	P.desc = "This is a paper titled '" + P.name + "'."
+	P.SetName("[customname]")
 
 	var/shouldStamp = 1
 	if(!P.sender) // admin initiated

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1493,9 +1493,23 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 		to_chat(usr, "Error: you are not an admin!")
 		return
 
-	var/replyorigin = input(src.owner, "Please specify who the fax is coming from", "Origin") as text|null
-	var/department = input("Choose a fax", "Fax") as null|anything in GLOB.alldepartments
+	// Origin
+	var/list/option_list = GLOB.admin_departments.Copy() + GLOB.alldepartments.Copy() + "(Custom)" + "(Cancel)"
+	var/replyorigin = input(owner, "Please specify who the fax is coming from. Choose '(Custom)' to enter a custom department or '(Cancel) to cancel.", "Fax Origin") as null|anything in option_list
+	if (!replyorigin || replyorigin == "(Cancel)")
+		return
+	if (replyorigin == "(Custom)")
+		replyorigin = input(owner, "Please specify who the fax is coming from.", "Fax Machine Department Tag") as text|null
+		if (!replyorigin)
+			return
+	if (replyorigin == "Unknown" || replyorigin == "(Custom)" || replyorigin == "(Cancel)")
+		to_chat(owner, SPAN_WARNING("Invalid origin selected."))
+		return
 
+	// Destination
+	var/department = input("Choose a destination fax", "Fax Target") as null|anything in GLOB.alldepartments
+
+	// Generate the fax
 	var/obj/item/paper/admin/P = new /obj/item/paper/admin( null ) //hopefully the null loc won't cause trouble for us
 	faxreply = P
 	P.admindatum = src

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1570,14 +1570,11 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 		P.overlays += stampoverlay
 
 	var/obj/item/rcvdcopy
-	var/success = FALSE
-	for (var/obj/machinery/photocopier/faxmachine/destination in P.destinations)
-		if (!rcvdcopy)
-			rcvdcopy = destination.copy(P)
-			rcvdcopy.forceMove(null) //hopefully this shouldn't cause trouble
-			GLOB.adminfaxes += rcvdcopy
-		if (destination.recievefax(P, P.origin))
-			success = TRUE
+	var/obj/machinery/photocopier/faxmachine/destination = P.destinations[1]
+	rcvdcopy = destination.copy(P, FALSE)
+	rcvdcopy.forceMove(null) //hopefully this shouldn't cause trouble
+	GLOB.adminfaxes += rcvdcopy
+	var/success = send_fax_loop(P, P.department, P.origin)
 
 	if (success)
 		to_chat(src.owner, "<span class='notice'>Message reply to transmitted successfully.</span>")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1573,7 +1573,8 @@
 
 		P.admindatum = src
 		P.origin = replyorigin
-		P.destination = fax
+
+		P.destinations = get_fax_machines_by_department(fax.department)
 		P.sender = sender
 
 		P.adminbrowse()

--- a/code/modules/paperwork/adminpaper.dm
+++ b/code/modules/paperwork/adminpaper.dm
@@ -8,7 +8,10 @@
 	var/isCrayon = 0
 	var/origin = null
 	var/mob/sender = null
-	var/obj/machinery/photocopier/faxmachine/destination
+	/// List (`/obj/machinery/photocopier/faxmachine`). List of fax machines matching the paper's target department.
+	var/list/destinations = list()
+	/// String. The paper's target department.
+	var/department = null
 
 	var/header = null
 	var/headerOn = TRUE
@@ -124,7 +127,7 @@
 					info += footer
 				updateinfolinks()
 				close_browser(usr, "window=[name]")
-				admindatum.faxCallback(src, destination)
+				admindatum.faxCallback(src)
 		return
 
 	if(href_list["penmode"])

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -227,11 +227,14 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 	sleep(20)
 
 	if (istype(incoming, /obj/item/paper))
-		copy(incoming)
-	else if (istype(incoming, /obj/item/photo))
-		photocopy(incoming)
+		var/obj/item/paper/newcopy = copy(incoming)
+		newcopy.SetName("[origin_department] - [newcopy.name]")
+	else if (istype(incoming, /obj/item/paper))
+		var/obj/item/paper/newcopy = photocopy(incoming)
+		newcopy.SetName("[origin_department] - [newcopy.name]")
 	else if (istype(incoming, /obj/item/paper_bundle))
-		bundlecopy(incoming)
+		var/obj/item/paper_bundle/newcopy = bundlecopy(incoming)
+		newcopy.SetName("[origin_department] - [newcopy.name]")
 	else
 		return 0
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -16,7 +16,6 @@ GLOBAL_LIST_EMPTY(admin_departments)
 
 	var/obj/item/card/id/scan = null // identification
 	var/authenticated = 0
-	var/sendcooldown = 0 // to avoid spamming fax messages
 	var/department = null // our department
 	var/destination = null // the department we're sending to
 
@@ -120,22 +119,12 @@ GLOBAL_LIST_EMPTY(admin_departments)
 
 		if(copyitem)
 			dat += "<a href='byond://?src=\ref[src];remove=1'>Remove Item</a><br><br>"
-
-			if(sendcooldown)
-				dat += "<b>Transmitter arrays realigning. Please stand by.</b><br>"
-
-			else
-
-				dat += "<a href='byond://?src=\ref[src];send=1'>Send</a><br>"
-				dat += "<b>Currently sending:</b> [copyitem.name]<br>"
-				dat += "<b>Sending to:</b> <a href='byond://?src=\ref[src];dept=1'>[destination ? destination : "Nobody"]</a><br>"
+			dat += "<a href='byond://?src=\ref[src];send=1'>Send</a><br>"
+			dat += "<b>Currently sending:</b> [copyitem.name]<br>"
+			dat += "<b>Sending to:</b> <a href='byond://?src=\ref[src];dept=1'>[destination ? destination : "Nobody"]</a><br>"
 
 		else
-			if(sendcooldown)
-				dat += "Please insert paper to send via secure connection.<br><br>"
-				dat += "<b>Transmitter arrays realigning. Please stand by.</b><br>"
-			else
-				dat += "Please insert paper to send via secure connection.<br><br>"
+			dat += "Please insert paper to send via secure connection.<br><br>"
 
 	else
 		dat += "Proper authentication is required to use this device.<br><br>"
@@ -154,10 +143,6 @@ GLOBAL_LIST_EMPTY(admin_departments)
 				send_admin_fax(user, destination)
 			else
 				sendfax(destination)
-
-			if (sendcooldown)
-				spawn(sendcooldown) // cooldown time
-					sendcooldown = 0
 		return TOPIC_REFRESH
 
 	if(href_list["remove"])
@@ -267,8 +252,6 @@ GLOBAL_LIST_EMPTY(admin_departments)
 
 	message_admins(sender, "[uppertext(destination)] FAX[intercepted ? "(Intercepted by [intercepted])" : null]", rcvdcopy, destination ? destination : "UNKNOWN")
 	send_fax_loop(copyitem, destination, department) // Forward to any listening fax machines
-
-	sendcooldown = 1800
 	visible_message("[src] beeps, \"Message transmitted successfully.\"")
 
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -205,14 +205,14 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 	if (destination)
 		for (var/obj/machinery/photocopier/faxmachine/F in GLOB.allfaxes)
 			if (F.department == destination)
-				success = F.recievefax(copyitem)
+				success = F.recievefax(copyitem, department)
 
 	if (success)
 		visible_message("[src] beeps, \"Message transmitted successfully.\"")
 	else
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 
-/obj/machinery/photocopier/faxmachine/proc/recievefax(var/obj/item/incoming)
+/obj/machinery/photocopier/faxmachine/proc/recievefax(obj/item/incoming, origin_department = "Unknown")
 	if(stat & (BROKEN|NOPOWER))
 		return 0
 
@@ -221,6 +221,7 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 
 	flick("faxreceive", src)
 	playsound(loc, "sound/machines/dotprinter.ogg", 50, 1)
+	visible_message(SPAN_NOTICE("\The [src] pings, \"New fax received from [origin_department].\""))
 
 	// give the sprite some time to flick
 	sleep(20)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -276,3 +276,14 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 		if(check_rights((R_ADMIN|R_MOD),0,C))
 			to_chat(C, msg)
 			sound_to(C, 'sound/machines/dotprinter.ogg')
+
+
+/// Retrieves a list of all fax machines matching the given department tag.
+/proc/get_fax_machines_by_department(department)
+	if (!department)
+		department = "Unknown"
+	var/list/faxes = list()
+	for (var/obj/machinery/photocopier/faxmachine/fax in GLOB.allfaxes)
+		if (fax.department == department)
+			faxes += fax
+	return faxes

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -222,13 +222,13 @@ GLOBAL_LIST_EMPTY(admin_departments)
 	sleep(20)
 
 	if (istype(incoming, /obj/item/paper))
-		var/obj/item/paper/newcopy = copy(incoming)
+		var/obj/item/paper/newcopy = copy(incoming, FALSE)
 		newcopy.SetName("[origin_department] - [newcopy.name]")
 	else if (istype(incoming, /obj/item/paper))
-		var/obj/item/paper/newcopy = photocopy(incoming)
+		var/obj/item/paper/newcopy = photocopy(incoming, FALSE)
 		newcopy.SetName("[origin_department] - [newcopy.name]")
 	else if (istype(incoming, /obj/item/paper_bundle))
-		var/obj/item/paper_bundle/newcopy = bundlecopy(incoming)
+		var/obj/item/paper_bundle/newcopy = bundlecopy(incoming, FALSE)
 		newcopy.SetName("[origin_department] - [newcopy.name]")
 	else
 		return 0
@@ -245,11 +245,11 @@ GLOBAL_LIST_EMPTY(admin_departments)
 	//recieved copies should not use toner since it's being used by admins only.
 	var/obj/item/rcvdcopy
 	if (istype(copyitem, /obj/item/paper))
-		rcvdcopy = copy(copyitem, 0)
+		rcvdcopy = copy(copyitem, FALSE)
 	else if (istype(copyitem, /obj/item/photo))
-		rcvdcopy = photocopy(copyitem, 0)
+		rcvdcopy = photocopy(copyitem, FALSE)
 	else if (istype(copyitem, /obj/item/paper_bundle))
-		rcvdcopy = bundlecopy(copyitem, 0)
+		rcvdcopy = bundlecopy(copyitem, FALSE)
 	else
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -52,8 +52,45 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 			return
 		scan = O
 		to_chat(user, "<span class='notice'>You insert \the [O] into \the [src].</span>")
+	if (isMultitool(O))
+		to_chat(user, SPAN_NOTICE("\The [src]'s department tag is set to [department]."))
+		if (!emagged)
+			to_chat(user, SPAN_WARNING("\The [src]'s department configuration is vendor locked."))
+			return
+		var/list/option_list = GLOB.alldepartments.Copy() + admin_departments + "(Custom)" + "(Cancel)"
+		var/new_department = input(user, "Which department do you want to tag this fax machine as? Choose '(Custom)' to enter a custom department or '(Cancel) to cancel.", "Fax Machine Department Tag") as null|anything in option_list
+		if (!new_department || new_department == department || new_department == "(Cancel)" || !CanUseTopic(user) || !Adjacent(user))
+			return
+		if (new_department == "(Custom)")
+			new_department = input(user, "Which department do you want to tag this fax machine as?", "Fax Machine Department Tag", department) as text|null
+			if (!new_department || new_department == department || !CanUseTopic(user) || !Adjacent(user))
+				return
+		if (new_department == "Unknown" || new_department == "(Custom)" || new_department == "(Cancel)")
+			to_chat(user, SPAN_WARNING("Invalid department tag selected."))
+			return
+		department = new_department
+		to_chat(user, SPAN_NOTICE("You reconfigure \the [src]'s department tag to [department]."))
 	else
 		..()
+
+/obj/machinery/photocopier/faxmachine/get_mechanics_info()
+	. = "<p>The fax machine can be used to transmit paper faxes to other fax machines on the map, or to off-ship organizations handled by server administration. To use the fax machine, you'll need to insert both a paper and your ID card, authenticate, select a destination, the transmit the fax.</p>"
+	. += "<p>You can also fax paper bundles, including photos, using this machine.</p>"
+	. += "<p>You can check the machine's department origin tag using a multitool.</p>"
+	. += ..()
+
+/obj/machinery/photocopier/faxmachine/get_antag_info()
+	. = "<p>If emagged with a cryptographic sequencer, the fax machine can then have it's origin department tag changed using a multitool. This allows you to send faxes pretending to be from somewhere else on the ship, or even an off-ship origin like EXCOMM.</p>"
+	. += "<p><strong>NOTE</strong>: Any new department tags created in this way that do not already exist in the list of targets cannot receive faxes, as this does not add new departments to the list of valid fax targets.</p>"
+	. += ..()
+
+/obj/machinery/photocopier/faxmachine/emag_act(remaining_charges, mob/user, emag_source)
+	if (emagged)
+		to_chat(user, SPAN_WARNING("\The [src]'s systems have already been hacked."))
+		return
+	to_chat(user, SPAN_NOTICE("You unlock \the [src]'s department tagger. You can now modify it's department tag to disguise faxes as being from another department or even off-ship using a multitool."))
+	emagged = TRUE
+	return TRUE
 
 /obj/machinery/photocopier/faxmachine/interface_interact(mob/user)
 	interact(user)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -98,7 +98,7 @@ GLOBAL_LIST_EMPTY(admin_departments)
 /obj/machinery/photocopier/faxmachine/interact(mob/user)
 	user.set_machine(src)
 
-	var/dat = "Fax Machine<BR>"
+	var/dat = "Fax Machine ([department])<BR>"
 
 	var/scan_name
 	if(scan)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 	var/obj/item/card/id/scan = null // identification
 	var/authenticated = 0
 	var/sendcooldown = 0 // to avoid spamming fax messages
-	var/department = "Unknown" // our department
+	var/department = null // our department
 	var/destination = null // the department we're sending to
 
 	var/static/list/admin_departments
@@ -24,22 +24,22 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 /obj/machinery/photocopier/faxmachine/Initialize()
 	. = ..()
 
-	GLOB.allfaxes += src
-
 	if (!admin_departments)
 		if (length(GLOB.using_map?.map_admin_faxes))
 			admin_departments = GLOB.using_map.map_admin_faxes.Copy()
 		else
 			admin_departments = list("[station_name()] Head Office", "[station_name()] Supply")
 
-	if ( !(("[department]" in GLOB.alldepartments) || ("[department]" in admin_departments)))
-		GLOB.alldepartments |= department
-
 	if (!destination)
 		if (length(admin_departments))
 			destination = admin_departments[1]
 		else if (length(GLOB.alldepartments))
 			destination = pick(GLOB.alldepartments)
+
+	GLOB.allfaxes += src
+
+	if (department && !(("[department]" in GLOB.alldepartments) || ("[department]" in admin_departments)))
+		GLOB.alldepartments |= department
 
 /obj/machinery/photocopier/faxmachine/attackby(obj/item/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/paper))

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Faxes tagged 'Unknown' no longer appear on the list of targetable fax machines."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -38,3 +38,5 @@ changes:
   - rscadd: "Fax machines can now be emagged, which in turn allows you to use multitools to change the fax machine's department tag, so that you can pretend your faxes came from somewhere else. Paperwork antags rejoice."
   - bugfix: "Sending faxes to destination tags that have multiple matching fax machines no longer does weird loopy things and then break."
   - tweak: "Fax machines now display a visible message indicating a fax has been received and which department the fax came from."
+  - tweak: "All papers printed by a fax machine now display the origin department in the paper's title, regardless of if they were an admin fax or a player fax. No more using fax titles to metagame antag faxes."
+  - bugfix: "The redundant 'The paper is titled XYZ' line from fax descriptions has been removed."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -40,6 +40,7 @@ changes:
   - bugfix: "Sending faxes to destination tags that have multiple matching fax machines no longer does weird loopy things and then break."
   - tweak: "Fax machines now display a visible message indicating a fax has been received and which department the fax came from."
   - tweak: "All papers printed by a fax machine now display the origin department in the paper's title, regardless of if they were an admin fax or a player fax. No more using fax titles to metagame antag faxes."
+  - tweak: "A fax machine's configured department now appears in the UI when using the fax machine as `Fax Machine (Department Name)`."
   - bugfix: "The redundant 'The paper is titled XYZ' line from fax descriptions has been removed."
   - admin: "send-fax now includes the same list of pre-made origin departments as the emag+multitool options for consistency and further reduction of potential metagame."
   - bugfix: "Fax machines and send-fax no longer have a perceived delay in processing when sending faxes."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -44,3 +44,4 @@ changes:
   - bugfix: "The redundant 'The paper is titled XYZ' line from fax descriptions has been removed."
   - admin: "send-fax now includes the same list of pre-made origin departments as the emag+multitool options for consistency and further reduction of potential metagame."
   - bugfix: "Fax machines and send-fax no longer have a perceived delay in processing when sending faxes."
+  - tweak: "Fax machines no longer lock themselves whenever sending a fax to off-ship places, i.e. Expeditionary Command."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -42,3 +42,4 @@ changes:
   - tweak: "All papers printed by a fax machine now display the origin department in the paper's title, regardless of if they were an admin fax or a player fax. No more using fax titles to metagame antag faxes."
   - bugfix: "The redundant 'The paper is titled XYZ' line from fax descriptions has been removed."
   - admin: "send-fax now includes the same list of pre-made origin departments as the emag+multitool options for consistency and further reduction of potential metagame."
+  - bugfix: "Fax machines and send-fax no longer have a perceived delay in processing when sending faxes."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -37,3 +37,4 @@ changes:
   - tweak: "Faxes tagged 'Unknown' no longer appear on the list of targetable fax machines."
   - rscadd: "Fax machines can now be emagged, which in turn allows you to use multitools to change the fax machine's department tag, so that you can pretend your faxes came from somewhere else. Paperwork antags rejoice."
   - bugfix: "Sending faxes to destination tags that have multiple matching fax machines no longer does weird loopy things and then break."
+  - tweak: "Fax machines now display a visible message indicating a fax has been received and which department the fax came from."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -35,3 +35,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Faxes tagged 'Unknown' no longer appear on the list of targetable fax machines."
+  - rscadd: "Fax machines can now be emagged, which in turn allows you to use multitools to change the fax machine's department tag, so that you can pretend your faxes came from somewhere else. Paperwork antags rejoice."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -36,3 +36,4 @@ delete-after: True
 changes:
   - tweak: "Faxes tagged 'Unknown' no longer appear on the list of targetable fax machines."
   - rscadd: "Fax machines can now be emagged, which in turn allows you to use multitools to change the fax machine's department tag, so that you can pretend your faxes came from somewhere else. Paperwork antags rejoice."
+  - bugfix: "Sending faxes to destination tags that have multiple matching fax machines no longer does weird loopy things and then break."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -36,6 +36,7 @@ delete-after: True
 changes:
   - tweak: "Faxes tagged 'Unknown' no longer appear on the list of targetable fax machines."
   - rscadd: "Fax machines can now be emagged, which in turn allows you to use multitools to change the fax machine's department tag, so that you can pretend your faxes came from somewhere else. Paperwork antags rejoice."
+  - rscadd: "Fax machines with department tags set to off-ship places, i.e. Expeditionary Command, can now intercept faxes sent off-ship. Now you can reply to people replying to your fake faxes!"
   - bugfix: "Sending faxes to destination tags that have multiple matching fax machines no longer does weird loopy things and then break."
   - tweak: "Fax machines now display a visible message indicating a fax has been received and which department the fax came from."
   - tweak: "All papers printed by a fax machine now display the origin department in the paper's title, regardless of if they were an admin fax or a player fax. No more using fax titles to metagame antag faxes."

--- a/html/changelogs/sierrakomodo-more-fax-tweaks.yml
+++ b/html/changelogs/sierrakomodo-more-fax-tweaks.yml
@@ -40,3 +40,4 @@ changes:
   - tweak: "Fax machines now display a visible message indicating a fax has been received and which department the fax came from."
   - tweak: "All papers printed by a fax machine now display the origin department in the paper's title, regardless of if they were an admin fax or a player fax. No more using fax titles to metagame antag faxes."
   - bugfix: "The redundant 'The paper is titled XYZ' line from fax descriptions has been removed."
+  - admin: "send-fax now includes the same list of pre-made origin departments as the emag+multitool options for consistency and further reduction of potential metagame."

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -223,9 +223,22 @@
 /obj/machinery/tele_beacon,
 /turf/simulated/floor/tiled,
 /area/constructionsite)
+"O" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "Test Fax 1"
+	},
+/turf/simulated/floor/tiled,
+/area/constructionsite)
 "P" = (
 /obj/machinery/light,
 /obj/machinery/telecomms/processor/map_preset/example,
+/turf/simulated/floor/tiled,
+/area/constructionsite)
+"Q" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "Test Fax 2";
+	send_access = list()
+	},
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "R" = (
@@ -1020,7 +1033,7 @@ c
 t
 t
 t
-c
+O
 b
 a
 a
@@ -1088,7 +1101,7 @@ c
 c
 c
 c
-c
+Q
 b
 a
 a


### PR DESCRIPTION
Ready to go. Changelog is in a .YAML file this time because separated commits.

  - tweak: "Faxes tagged 'Unknown' no longer appear on the list of targetable fax machines."
  - rscadd: "Fax machines can now be emagged, which in turn allows you to use multitools to change the fax machine's department tag, so that you can pretend your faxes came from somewhere else. Paperwork antags rejoice."
  - rscadd: "Fax machines with department tags set to off-ship places, i.e. Expeditionary Command, can now intercept faxes sent off-ship. Now you can reply to people replying to your fake faxes!"
  - bugfix: "Sending faxes to destination tags that have multiple matching fax machines no longer does weird loopy things and then break."
  - tweak: "Fax machines now display a visible message indicating a fax has been received and which department the fax came from."
  - tweak: "All papers printed by a fax machine now display the origin department in the paper's title, regardless of if they were an admin fax or a player fax. No more using fax titles to metagame antag faxes."
  - tweak: "A fax machine's configured department now appears in the UI when using the fax machine as `Fax Machine (Department Name)`."
  - bugfix: "The redundant 'The paper is titled XYZ' line from fax descriptions has been removed."
  - admin: "send-fax now includes the same list of pre-made origin departments as the emag+multitool options for consistency and further reduction of potential metagame."
  - bugfix: "Fax machines and send-fax no longer have a perceived delay in processing when sending faxes."
  - tweak: "Fax machines no longer lock themselves whenever sending a fax to off-ship places, i.e. Expeditionary Command."