### PR TITLE
Fixes the pocket knife, adds max_pen

### DIFF
--- a/code/game/objects/items/weapons/material/folding.dm
+++ b/code/game/objects/items/weapons/material/folding.dm
@@ -8,6 +8,7 @@
 	item_state = null
 	force = 0.2 //force of folded obj
 	max_force = 10
+	max_pen = 0
 	force_multiplier = 0.2
 	applies_material_colour = FALSE
 	applies_material_name = FALSE
@@ -98,6 +99,7 @@
 	name = "the concept of a fighting knife in which the blade can be stowed in its own handle"
 	desc = "This is a master item - berate the admin or mapper who spawned this!"
 	max_force = 15
+	max_pen = 30
 	force_multiplier = 0.25
 	thrown_force_multiplier = 0.25
 	takes_colour = FALSE

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -17,6 +17,7 @@
 	var/furniture_icon  //icon states for non-material colorable overlay, i.e. handles
 
 	var/max_force = 40	 //any damage above this is added to armor penetration value
+	var/max_pen = 100 //any penetration above this value is ignored
 	var/force_multiplier = 0.5	// multiplier to material's generic damage value for this specific type of weapon
 	var/thrown_force_multiplier = 0.5
 
@@ -57,6 +58,7 @@
 	if(new_force > max_force)
 		armor_penetration = initial(armor_penetration) + new_force - max_force
 	armor_penetration += 2*max(0, material.brute_armor - 2)
+	armor_penetration = min(max_pen, armor_penetration)
 
 	throwforce = round(material.get_blunt_damage()*thrown_force_multiplier)
 	attack_cooldown = material.get_attack_cooldown() + attack_cooldown_modifier


### PR DESCRIPTION
The pocket knife at some point started using the penetration values from steel as if it were an actual weapon leading to it suddenly having 10 force 12 pen which made it fully capable of stabbing through a knife proof vest. 
Pocket knives now use the correct amount of penetration (0).

max_pen has been added as a variable that allows more direct control over how much penetration a material weapon can/will have.

🆑 Kell-E
rscadd: Adds a new variable for controlling weapon penetration values
balance: The pocket knife is no longer sharp enough to penetrate armor
/🆑 