### PR TITLE
Adds Hangar Ops Warning Beacons

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -776,6 +776,7 @@
 #include "code\game\machinery\pipe\pipe_datums\disposal_pipe_datums.dm"
 #include "code\game\machinery\pipe\pipe_datums\pipe_datum_base.dm"
 #include "code\game\machinery\pipe\pipe_datums\pipe_datums.dm"
+#include "code\game\machinery\rotating_alarm\hangar_warning_beacon.dm"
 #include "code\game\machinery\rotating_alarm\station_alerts.dm"
 #include "code\game\machinery\telecomms\broadcaster.dm"
 #include "code\game\machinery\telecomms\logbrowser.dm"

--- a/code/game/machinery/rotating_alarm/hangar_warning_beacon.dm
+++ b/code/game/machinery/rotating_alarm/hangar_warning_beacon.dm
@@ -1,0 +1,27 @@
+/obj/machinery/rotating_alarm/hangar_warning_beacon
+	name = "hangar docking operations warning beacon"
+	desc = "A rotating alarm light that indicates hangar launch and landing operations are in progress."
+	icon_state = "alarm"
+	alarm_light_color = COLOR_AMBER
+	var/shuttle_tags = list()
+	var/waiting = 0
+
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar
+	name = "Torch hangar docking operations warning beacon"
+	shuttle_tags = list("supplydrone", "charon", "guppy")
+
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_petrov
+	name = "Petrov docking operations warning beacon"
+	shuttle_tags = list("petrov")
+
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_aquilla
+	name = "Aquilla docking operations warning beacon"
+	shuttle_tags = list("aquilla")
+
+/obj/machinery/rotating_alarm/hangar_warning_beacon/proc/set_alert(beacon_state, operating_shuttle_tag)
+	if(operating_shuttle_tag in shuttle_tags)
+		switch (beacon_state)
+			if ("off")
+				set_off()
+			if ("on")
+				set_on()

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -201,6 +201,7 @@
 				to_chat(usr, "<span class='warning'>For safety reasons the automated supply shuttle cannot transport live organisms, classified nuclear weaponry or homing beacons.</span>")
 			else
 				shuttle.launch(user)
+
 		else
 			shuttle.launch(user)
 			var/datum/radio_frequency/frequency = radio_controller.return_frequency(1435)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -29,6 +29,8 @@
 	var/mothershuttle //tag of mothershuttle
 	var/motherdock    //tag of mothershuttle landmark, defaults to starting location
 
+	var/shuttle_tag = "none" //shuttle tag used for warning beacons
+
 /datum/shuttle/New(_name, var/obj/effect/shuttle_landmark/initial_location)
 	..()
 	if(_name)
@@ -78,6 +80,11 @@
 	if(moving_status != SHUTTLE_IDLE) return
 
 	moving_status = SHUTTLE_WARMUP
+
+	for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+		if (HB.z in GLOB.using_map.contact_levels)
+			HB.set_alert("on", shuttle_tag)
+
 	if(sound_takeoff)
 		playsound(current_location, sound_takeoff, 100, 20, 0.2)
 	spawn(warmup_time*10)
@@ -93,6 +100,9 @@
 		moving_status = SHUTTLE_INTRANSIT //shouldn't matter but just to be safe
 		attempt_move(destination)
 		moving_status = SHUTTLE_IDLE
+		for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+			if (HB.z in GLOB.using_map.contact_levels)
+				HB.set_alert("off", shuttle_tag)
 
 /datum/shuttle/proc/long_jump(var/obj/effect/shuttle_landmark/destination, var/obj/effect/shuttle_landmark/interim, var/travel_time)
 	if(moving_status != SHUTTLE_IDLE) return
@@ -100,6 +110,11 @@
 	var/obj/effect/shuttle_landmark/start_location = current_location
 
 	moving_status = SHUTTLE_WARMUP
+
+	for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+		if (HB.z in GLOB.using_map.contact_levels)
+			HB.set_alert("on", shuttle_tag)
+
 	if(sound_takeoff)
 		playsound(current_location, sound_takeoff, 100, 20, 0.2)
 		if (!istype(start_location.base_area, /area/space))
@@ -121,6 +136,7 @@
 
 		arrive_time = world.time + travel_time*10
 		moving_status = SHUTTLE_INTRANSIT
+
 		if(attempt_move(interim))
 			var/fwooshed = 0
 			while (world.time < arrive_time)
@@ -139,6 +155,9 @@
 				attempt_move(start_location) //try to go back to where we started. If that fails, I guess we're stuck in the interim location
 
 		moving_status = SHUTTLE_IDLE
+		for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+			if (HB.z in GLOB.using_map.contact_levels)
+				HB.set_alert("off", shuttle_tag)
 
 /datum/shuttle/proc/fuel_check()
 	return 1 //fuel check should always pass in non-overmap shuttles (they have magic engines)

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -13,6 +13,11 @@
 	if(isnull(location))
 		return
 
+	if(at_station())
+		for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+			if (HB.z in GLOB.using_map.contact_levels)
+				HB.set_alert("on", SSsupply.shuttle.shuttle_tag)
+
 	//it would be cool to play a sound here
 	moving_status = SHUTTLE_WARMUP
 	spawn(warmup_time*10)
@@ -33,6 +38,9 @@
 
 		//If we are at the away_landmark then we are just pretending to move, otherwise actually do the move
 		if (next_location == away_waypoint)
+			for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery) //shuts off any beacons that were turned on when leaving station
+				if (HB.z in GLOB.using_map.contact_levels)
+					HB.set_alert("off", SSsupply.shuttle.shuttle_tag)
 			attempt_move(away_waypoint)
 
 		//wait ETA here.
@@ -41,6 +49,10 @@
 			sleep(5)
 
 		if (next_location != away_waypoint)
+			if(!at_station())
+				for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+					if (HB.z in GLOB.using_map.contact_levels)
+						HB.set_alert("on", SSsupply.shuttle.shuttle_tag)
 			//late
 			if (prob(late_chance))
 				sleep(rand(0,max_late_time))
@@ -51,6 +63,10 @@
 
 		if (!at_station())	//at centcom
 			SSsupply.sell()
+
+		for (var/obj/machinery/rotating_alarm/hangar_warning_beacon/HB in SSmachines.machinery)
+			if (HB.z in GLOB.using_map.contact_levels)
+				HB.set_alert("off", SSsupply.shuttle.shuttle_tag)
 
 // returns 1 if the supply shuttle should be prevented from moving because it contains forbidden atoms
 /datum/shuttle/autodock/ferry/supply/proc/forbidden_atoms_check()

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -2932,6 +2932,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/fuel)
+"gA" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "gB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6119,6 +6126,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "nL" = (
@@ -7548,6 +7558,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_petrov{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
@@ -13489,6 +13502,11 @@
 /obj/effect/paint/silver,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/isolation)
+"JQ" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "JS" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -14704,6 +14722,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
+"OI" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "OM" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -14751,6 +14776,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/maint)
+"OT" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/hangar)
 "OU" = (
 /obj/machinery/light{
 	dir = 4
@@ -32902,12 +32934,12 @@ jt
 jB
 aX
 kU
-aX
+OI
 Jn
 aX
 tO
 zf
-aX
+OI
 aX
 aX
 aX
@@ -32921,7 +32953,7 @@ kU
 aX
 aX
 aX
-aX
+OI
 lQ
 lM
 jZ
@@ -33906,7 +33938,7 @@ wr
 tV
 Hm
 lY
-hY
+OT
 ih
 ee
 aA
@@ -36532,7 +36564,7 @@ aW
 hi
 hb
 aJ
-aX
+JQ
 cy
 Ho
 Ho
@@ -38156,7 +38188,7 @@ aX
 kT
 aX
 aX
-aX
+gA
 fj
 kV
 oL
@@ -38166,7 +38198,7 @@ ih
 pb
 IO
 il
-aX
+gA
 aX
 aX
 kT

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -4443,6 +4443,9 @@
 	c_tag = "Fourth Deck - Hangar Bridge";
 	dir = 1
 	},
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_hangar{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "pD" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -5575,6 +5575,9 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_aquilla{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "nf" = (
@@ -11239,6 +11242,12 @@
 "Fp" = (
 /turf/simulated/wall/r_wall/hull,
 /area/bridge/storage)
+"Fr" = (
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_aquilla{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "Fy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11947,6 +11956,12 @@
 /obj/effect/paint/hull,
 /turf/simulated/floor/plating,
 /area/aquila/cockpit)
+"Ic" = (
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_aquilla{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "Id" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13484,6 +13499,9 @@
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Solar Control - Bridge";
+	dir = 4
+	},
+/obj/machinery/rotating_alarm/hangar_warning_beacon/torch_aquilla{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -32385,7 +32403,7 @@ bD
 ad
 ad
 Oc
-ad
+Fr
 gX
 hK
 is
@@ -32808,7 +32826,7 @@ CO
 CO
 CO
 dV
-ad
+Ic
 wt
 aH
 Rg
@@ -33193,7 +33211,7 @@ ad
 ad
 ad
 ad
-ad
+Ic
 fj
 eb
 eb

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -60,6 +60,7 @@ TORCH_ESCAPE_POD(17)
 	logging_home_tag = "nav_petrov_start"
 	logging_access = access_petrov_helm
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling
+	shuttle_tag = "petrov"
 
 /datum/shuttle/autodock/ferry/petrov/New(_name, var/obj/effect/shuttle_landmark/initial_location)
 	shuttle_area = subtypesof(/area/shuttle/petrov)
@@ -335,6 +336,7 @@ TORCH_ESCAPE_POD(17)
 	shuttle_area = /area/supply/dock
 	waypoint_offsite = "nav_cargo_start"
 	waypoint_station = "nav_cargo_station"
+	shuttle_tag = "supplydrone"
 
 /obj/effect/shuttle_landmark/supply/centcom
 	name = "Offsite"
@@ -358,6 +360,7 @@ TORCH_ESCAPE_POD(17)
 	logging_home_tag = "nav_hangar_charon"
 	logging_access = access_expedition_shuttle_helm
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/torch
+	shuttle_tag = "charon"
 
 /obj/effect/shuttle_landmark/torch/hangar/exploration_shuttle
 	name = "Charon Hangar"
@@ -404,6 +407,7 @@ TORCH_ESCAPE_POD(17)
 	logging_access = access_guppy_helm
 	skill_needed = SKILL_NONE
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/torch
+	shuttle_tag = "guppy"
 
 /obj/effect/shuttle_landmark/torch/hangar/guppy
 	name = "Guppy Hangar"
@@ -446,6 +450,7 @@ TORCH_ESCAPE_POD(17)
 	logging_home_tag = "nav_hangar_aquila"
 	logging_access = access_aquila_helm
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/torch
+	shuttle_tag = "aquilla"
 
 /obj/effect/shuttle_landmark/torch/hangar/aquila
 	name = "Aquila Hangar"


### PR DESCRIPTION
:cl: Textor
rscadd: Warning beacons have been added to the hangar, Petrov, and Aquilla docks to inform crew of active docking and undocking operations.
/:cl:

Adds hangar warning beacons. It is designed to be generic enough so that a map maker can get it to work on any map as long as they set up the shuttle correctly and tag the beacon appropriately with the list of shuttles they want to set it off.

Presets are already in place:

- torch_hangar for charon, gup, and supply drone
- torch_aquilla for the aquilla
- torch_petrov for the petrov

Adds beacon lights to the hangar, the halls outside petrov and aquilla, and the EVA area outside the aquilla, and the hallway crossing the hangar on deck 4.

![image](https://user-images.githubusercontent.com/12721324/163699071-efc9d12e-1f67-4119-bc34-219a54a46336.png)
![image](https://user-images.githubusercontent.com/12721324/163699077-799d9459-5883-4b53-963a-9dadb6d046df.png)
![image](https://user-images.githubusercontent.com/12721324/163699148-3903b07b-0fc5-40b3-9d60-354262bd674f.png)
![image](https://user-images.githubusercontent.com/12721324/163699159-b6bc097d-74d5-47b3-82c7-4727356ec6f2.png)
![image](https://user-images.githubusercontent.com/12721324/164130162-336d6b77-fbda-4189-8b74-942f38ed4e3c.png)
