### PR TITLE
Make cyborg upload less hyper-secure

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -4267,8 +4267,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/engineering{
-	name = "Drone Bay";
-	secured_wires = 1
+	name = "Drone Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13845,7 +13844,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	dir = 8;
 	id_tag = "borg";
 	name = "Cyborg Upload"
@@ -13854,6 +13853,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Cyborg Upload Chamber";
+	secured_wires = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/synth/borg_upload)


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: Cyborg Upload is no longer protected by an impenetrable blast door and is easier to hack into.
/:cl:

Specific changes:
- Drone Bay door is no longer secure.
- Cyborg Upload blast door is now open by default and has a secure door underneath it.

This is to try to incentivize usage of the upload room as antags again, which has not been touched at all in a while, likely due to how impenetrable a room surrounded by r_walls and an unhackable blast door is. Now you can emag or hack your way in.