### PR TITLE
Closet deconstruction will respect material

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -19,6 +19,7 @@
 	var/storage_types = CLOSET_STORAGE_ALL
 	var/setup = CLOSET_CAN_BE_WELDED
 	var/closet_appearance = /decl/closet_appearance
+	material = MATERIAL_STEEL
 
 	// TODO: Turn these into flags. Skipped it for now because it requires updating 100+ locations...
 	var/broken = FALSE
@@ -37,6 +38,8 @@
 			icon = app.icon
 			color = null
 			queue_icon_update()
+
+	material = SSmaterials.get_material_by_name(material)
 
 	return INITIALIZE_HINT_LATELOAD
 
@@ -318,7 +321,7 @@
 	attack_hand(user)
 
 /obj/structure/closet/proc/slice_into_parts(obj/W, mob/user)
-	new /obj/item/stack/material/steel(src.loc, 2)
+	material.place_sheet(src.loc, 2)
 	user.visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [W].</span>", \
 						 "<span class='notice'>You have cut \the [src] apart with \the [W].</span>", \
 						 "You hear welding.")

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -75,6 +75,7 @@
 	desc = "A rectangular plastic crate."
 	points_per_crate = 1
 	closet_appearance = /decl/closet_appearance/crate/plastic
+	material = MATERIAL_PLASTIC
 
 /obj/structure/closet/crate/internals
 	name = "internals crate"
@@ -278,6 +279,7 @@
 /obj/structure/closet/crate/paper_refill
 	name = "paper refill crate"
 	desc = "A rectangular plastic crate, filled up with blank papers for refilling bins and printers. A bureaucrat's favorite."
+	material = MATERIAL_PLASTIC
 
 /obj/structure/closet/crate/paper_refill/WillContain()
 	return list(/obj/item/paper = 30)


### PR DESCRIPTION
:cl: Textor
bugfix: Closets and crates made out of materials other than steel will now deconstruct to their constituent material.
/:cl:

Makes closets have a material type set up properly and use it in deconstruction code.

Fixes #31863