### PR TITLE
Fixes #31257

### DIFF
--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -30,7 +30,7 @@
 			return
 		do_insert_ai(user, W)
 		return TRUE
-	if(isScrewdriver(W))
+	if(isScrewdriver(W) && stored_card)
 		to_chat(user, "You manually remove \the [stored_card] from \the [src].")
 		do_eject_ai(user)
 		return TRUE


### PR DESCRIPTION
:cl: Textor
bugfix: Engineers no longer try to pry out intellicards from empty intellicard slots instead of opening the maintenance hatch on multifunctional computers.
/:cl:

Fixes #31257

Checks to see if a card is in the slot or not. If it is in the slot, remove the card, if it is not, have the MFC do its normal attackby thing with the screwdriver.