### PR TITLE
Fix excavation suit cycler breaking helmet sprites

### DIFF
--- a/code/datums/item_modifiers/space_suits.dm
+++ b/code/datums/item_modifiers/space_suits.dm
@@ -67,7 +67,7 @@
 		/obj/item/clothing/head/helmet/space = list(
 			SETUP_NAME = "excavation voidsuit helmet",
 			SETUP_ICON_STATE = "rig0-excavation",
-			SETUP_ITEM_STATE = "excavation_helm"
+			SETUP_ITEM_STATE = "excavation-helm"
 		),
 		/obj/item/clothing/suit/space/void = list(
 			SETUP_NAME = "excavation voidsuit",


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the excavation suit cycler not properly setting the item_state of helmets. 
/:cl: