### PR TITLE
fixes uplink donk pockets option only spawning one

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -8,7 +8,7 @@
 	name = "Box of Premium Donk-Pockets"
 	desc = "A box of healthy fruit turnovers. Great for a quick meal when you're hiding from Security. Instructions included on the box."
 	item_cost = 8
-	path = /obj/item/reagent_containers/food/snacks/donkpocket/premium
+	path = /obj/item/storage/box/donkpocket_premium
 
 /datum/uplink_item/item/medical/combatstim
 	name = "Combat Stimulants"


### PR DESCRIPTION
:cl:
bugfix: Uplinks spawn a box of premium donk pockets instead of a single one. Whoops.
/:cl:
