### PR TITLE
update editorconfig, vscode settings, extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,17 @@
 root = true
 
 [*]
-insert_final_newline = false
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.dm]
+[*.{dme,dmf,dmm,dm}]
 end_of_line = crlf
 indent_style = tab
-indent_size = 4
 
-[*.dmm]
-end_of_line = crlf
+[*.md]
+trim_trailing_whitespace = false
 
 [*.py]
 indent_style = space
@@ -19,4 +20,3 @@ indent_size = 4
 [*.yml]
 indent_style = space
 indent_size = 2
-

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "gbasood.byond-dm-language-support",
+    "platymuus.dm-langclient",
+    "EditorConfig.EditorConfig",
+    "eamodio.gitlens"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,45 @@
 {
-	"editor.detectIndentation": false,
-	"editor.insertSpaces": false,
-	"editor.tabSize": 4,
-	"files.eol": "\r\n",
-	"files.insertFinalNewline": true,
-	"files.trimFinalNewlines": true,
-	"files.trimTrailingWhitespace": true,
-	"gitblame.commitUrl": "https://github.com/baystation12/baystation12/commit/${hash}",
-	"gitlens.advanced.blame.customArguments": [
-		"--ignore-revs-file",
-		".git-blame-ignore-revs"
-	]
+  "files.eol": "\n",
+  "files.encoding": "utf8",
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+
+  "files.associations": {
+    "*.{dme,dmf,dmm,dm}": "dm",
+  },
+  "[dm]": {
+    "files.eol": "\r\n",
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": false
+  },
+
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+
+  "[python]": {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4
+  },
+
+  "[yaml]": {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
+  },
+
+  "workbench.editorAssociations": {
+    "*.dmi": "imagePreview.previewEditor"
+  },
+
+  "debug.onTaskErrors": "abort",
+  "dreammaker.objectTreePane": true,
+  "dreammaker.autoUpdate": true,
+  "dreammaker.tickOnCreate": true,
+
+  "gitlens.advanced.blame.customArguments": [
+    "--ignore-revs-file", ".git-blame-ignore-revs"
+  ]
 }


### PR DESCRIPTION
Updates .editorconfig to be mostly in line with new VSC settings, and vice versa.

Updates workspace-level VSC settings to:
- Sandbox DM formatting expectations to DM sources (.dme, .dmf, .dmm, .dm).
- Prefer `\n` on files that are not DM sources.
- Make suite auto-update and auto-include explicitly true.
- Make suite build the object tree [1] for non-file project navigation.
- Show DMI previews inside VSC [2].
- Skip the Abort modal on failed F5 compiles.
- No longer have an opinion about tab display width.
- Remove gitblame config.


Adds workspace-level VSC extension recommendations:
- [gbasood.byond-dm-language-support](https://marketplace.visualstudio.com/items?itemName=gbasood.byond-dm-language-support)
- [platymuus.dm-langclient](https://marketplace.visualstudio.com/items?itemName=platymuus.dm-langclient)
- [EditorConfig.EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
- [eamodio.gitlens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)

EditorConfig is included simply because we theoretically use it, even though we actually haven't been. The file is mostly aimed at other (that is, not VSC) editing suites.

Noting here for the sake of it - I don't like the intrusive behavior of gitlens or the gitlens+ pushing, but gitblame's maintainer won't add an `--ignore-revs-file` option *or* permit custom params. The ability to ignore huge whitespace and line-ending change passes is important to us. 🤷


[1]
![https://i.imgur.com/lsTjYI8.png](https://i.imgur.com/lsTjYI8.png)


[2]
![https://i.imgur.com/e5zD4j7.png](https://i.imgur.com/e5zD4j7.png)