### PR TITLE
Broken limb leaping

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -306,6 +306,8 @@
 #define BP_GROIN  "groin"
 #define BP_ALL_LIMBS list(BP_CHEST, BP_GROIN, BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_HAND, BP_R_HAND, BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
 #define BP_BY_DEPTH list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
+#define BP_LEGS_FEET list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
+#define BP_ARMS_HANDS list(BP_L_ARM, BP_R_ARM, BP_L_HAND, BP_R_HAND)
 
 // Prosthetic helpers.
 #define BP_IS_ROBOTIC(org)  ((org) && ((org).status & ORGAN_ROBOTIC))

--- a/code/modules/mob/living/carbon/human/human_maneuvers.dm
+++ b/code/modules/mob/living/carbon/human/human_maneuvers.dm
@@ -7,6 +7,12 @@
 	if(istype(aug))
 		. += aug.get_acrobatics_modifier()
 
+	// Broken limb checks
+	for (var/_limb in BP_LEGS_FEET)
+		var/obj/item/organ/external/limb = get_organ(_limb)
+		if (limb.status & ORGAN_BROKEN)
+			. -= limb.splinted ? 0.25 : 0.5
+
 
 /mob/living/carbon/human/get_jump_distance()
 	return species.standing_jump_range

--- a/code/modules/mob/living/carbon/human/human_maneuvers.dm
+++ b/code/modules/mob/living/carbon/human/human_maneuvers.dm
@@ -28,3 +28,29 @@
 			if(!silent)
 				to_chat(src, SPAN_WARNING("You are too thirsty to jump around."))
 			return FALSE
+
+
+/mob/living/carbon/human/post_maneuver()
+	..()
+
+	var/broken_limb_fail_chance = 0
+	var/list/broken_limbs = list()
+	for (var/_limb in BP_LEGS_FEET)
+		var/obj/item/organ/external/limb = get_organ(_limb)
+		if (limb.status & ORGAN_BROKEN)
+			broken_limbs += limb
+			broken_limb_fail_chance += limb.splinted ? 25 : 50
+	if (broken_limb_fail_chance)
+		var/obj/item/organ/external/limb = pick(broken_limbs)
+		if (prob(broken_limb_fail_chance))
+			visible_message(
+				SPAN_WARNING("\The [src]'s [limb.name] buckles beneath them as they land!"),
+				SPAN_DANGER("Your [limb.name] buckles beneath you as you land!")
+			)
+			apply_effect(1, EFFECT_WEAKEN)
+			limb.add_pain(30)
+			limb.take_external_damage(5)
+		else
+			to_chat(src, SPAN_DANGER("You feel a sharp pain through your [limb.name] as you land!"))
+			apply_effect(1, EFFECT_STUN)
+			limb.add_pain(15)

--- a/code/modules/mob/living/carbon/human/human_maneuvers.dm
+++ b/code/modules/mob/living/carbon/human/human_maneuvers.dm
@@ -1,12 +1,12 @@
 /mob/living/carbon/human/get_acrobatics_multiplier(var/decl/maneuver/attempting_maneuver)
-	. = 0.5 + ((get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN))
+	. = ..() * 0.5
+
+	. += ((get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN))
 	//Perhaps one day this should grab logic from organs directly
 	var/obj/item/organ/internal/augment/boost/muscle/aug = internal_organs_by_name["[BP_R_LEG]_aug"]
 	if(istype(aug))
 		. += aug.get_acrobatics_modifier()
 
-	if(skill_check(SKILL_HAULING, SKILL_BASIC))
-		. = max(..(), .)
 
 /mob/living/carbon/human/get_jump_distance()
 	return species.standing_jump_range

--- a/code/modules/mob/living/living_maneuvers.dm
+++ b/code/modules/mob/living/living_maneuvers.dm
@@ -59,3 +59,7 @@
 
 /mob/living/proc/get_jump_distance()
 	return 0
+
+
+/mob/living/proc/post_maneuver()
+	return

--- a/code/modules/mob/living/maneuvers/maneuver_leap.dm
+++ b/code/modules/mob/living/maneuvers/maneuver_leap.dm
@@ -20,6 +20,7 @@
 
 /decl/maneuver/leap/proc/end_leap(var/mob/living/user, var/atom/target, var/pass_flag)
 	user.pass_flags = pass_flag
+	user.post_maneuver()
 
 /decl/maneuver/leap/show_initial_message(var/mob/living/user, var/atom/target)
 	user.visible_message(SPAN_WARNING("\The [user] crouches, preparing for a leap!"))

--- a/code/modules/mob/living/maneuvers/maneuver_leap.dm
+++ b/code/modules/mob/living/maneuvers/maneuver_leap.dm
@@ -28,7 +28,19 @@
 	. = ..()
 	if(.)
 		var/can_leap_distance = user.get_jump_distance() * user.get_acrobatics_multiplier()
-		. = (can_leap_distance > 0 && (!target || get_dist(user, target) <= can_leap_distance))
+		if (can_leap_distance <= 0)
+			if (!silent)
+				to_chat(user, SPAN_WARNING("You can't leap in your current state."))
+			return FALSE
+		if (!istype(target))
+			if (!silent)
+				to_chat(user, SPAN_WARNING("That is not a valid leap target."))
+			return FALSE
+		if (get_dist(user, target) > can_leap_distance)
+			if (!silent)
+				to_chat(user, SPAN_WARNING("You can't leap that far."))
+			return FALSE
+		return TRUE
 
 /decl/maneuver/leap/spider
 	stamina_cost = 0

--- a/html/changelogs/sierrakomodo-broken-limb-leaping.yml
+++ b/html/changelogs/sierrakomodo-broken-limb-leaping.yml
@@ -34,4 +34,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Leaping distance is now 100% based on skill level instead of basic athletics having a weird flat skill check result, and being the only skill level with a modified result based on that check."
+  - tweak: "Leaping distance is now 100% based on skill level and mob-type specific overrides instead of relying on a flat basic athletics skill check that resulted in a flat line instead of a curve between the middle tiers of skill."
+  - tweak: "Fractured legs and feet now affect your ability to leap by reducing how far you can jump. Splinted limbs reduce this effect by half."

--- a/html/changelogs/sierrakomodo-broken-limb-leaping.yml
+++ b/html/changelogs/sierrakomodo-broken-limb-leaping.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Leaping distance is now 100% based on skill level instead of basic athletics having a weird flat skill check result, and being the only skill level with a modified result based on that check."

--- a/html/changelogs/sierrakomodo-broken-limb-leaping.yml
+++ b/html/changelogs/sierrakomodo-broken-limb-leaping.yml
@@ -36,3 +36,4 @@ delete-after: True
 changes:
   - tweak: "Leaping distance is now 100% based on skill level and mob-type specific overrides instead of relying on a flat basic athletics skill check that resulted in a flat line instead of a curve between the middle tiers of skill."
   - tweak: "Fractured legs and feet now affect your ability to leap by reducing how far you can jump. Splinted limbs reduce this effect by half."
+  - tweak: "You now receive a message indicating why you can't leap instead of silence when you attempt to leap beyond your range."

--- a/html/changelogs/sierrakomodo-broken-limb-leaping.yml
+++ b/html/changelogs/sierrakomodo-broken-limb-leaping.yml
@@ -37,3 +37,4 @@ changes:
   - tweak: "Leaping distance is now 100% based on skill level and mob-type specific overrides instead of relying on a flat basic athletics skill check that resulted in a flat line instead of a curve between the middle tiers of skill."
   - tweak: "Fractured legs and feet now affect your ability to leap by reducing how far you can jump. Splinted limbs reduce this effect by half."
   - tweak: "You now receive a message indicating why you can't leap instead of silence when you attempt to leap beyond your range."
+  - tweak: "Leaping with fractured legs or feet now causes pain on landing, and has a chance of your broken limb(s) buckling beneath you, causing you to collapse and taking more damage. 50% chance per broken limb, 25% chance if splinted."


### PR DESCRIPTION
```yml
changes:
  - tweak: "Leaping distance is now 100% based on skill level and mob-type specific overrides instead of relying on a flat basic athletics skill check that resulted in a flat line instead of a curve between the middle tiers of skill."
  - tweak: "Fractured legs and feet now affect your ability to leap by reducing how far you can jump. Splinted limbs reduce this effect by half."
  - tweak: "You now receive a message indicating why you can't leap instead of silence when you attempt to leap beyond your range."
  - tweak: "Leaping with fractured legs or feet now causes pain on landing, and has a chance of your broken limb(s) buckling beneath you, causing you to collapse and taking more damage. 50% chance per broken limb, 25% chance if splinted."
```