### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -5,8 +5,13 @@ on:
       - dev
 
 # NB: We can discover workflow IDs for this job at https://api.github.com/repos/ORG/REPO/actions/workflows
+permissions:
+  contents: read
+
 jobs:
   cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: 'Cancel Redundant Builds'
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -5,8 +5,13 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   CompileCL:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     if: github.repository == 'Baystation12/Baystation12' # to prevent this running on forks
     steps:

--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -4,8 +4,14 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -9,8 +9,13 @@ on:
 env:
   SPACEMAN_DMM_VERSION: suite-1.7.2
 
+permissions:
+  contents: read
+
 jobs:
   generate_documentation:
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
     concurrency: gen-docs

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - dev
 
+permissions:
+  contents: read
+
 jobs:
   MakeCL:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ env:
   BYOND_MINOR: "1583"
   SPACEMAN_DMM_VERSION: suite-1.7.2
 
+permissions:
+  contents: read
+
 jobs:
   DreamChecker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
