### PR TITLE
workflow permissions limits, tools is core review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 SpacemanDMM.toml @Baystation12/Core
 
 /docs/ @Baystation12/Core
+/tools/ @Baystation12/Core
 
 /LICENSE @Baystation12/Core
 /README.md @Baystation12/Core

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,4 +1,8 @@
 name: Cancel
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -8,6 +12,8 @@ on:
 jobs:
   cancel:
     name: 'Cancel Redundant Builds'
+    permissions:
+      actions: write # required to cancel other actions
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -1,12 +1,17 @@
 name: Compile changelogs
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
+  workflow_dispatch: # allows this workflow to be manually triggered
 
 jobs:
   CompileCL:
+    permissions:
+      contents: write # required to push the updated changelog commit
     runs-on: ubuntu-latest
     if: github.repository == 'Baystation12/Baystation12' # to prevent this running on forks
     steps:

--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -1,4 +1,8 @@
 name: 'Close stale issues and PRs'
+
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -6,6 +10,8 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write # required to close stale issues
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -1,16 +1,21 @@
 name: Generate Documentation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
     - dev
-  workflow_dispatch:
+  workflow_dispatch: # allows this workflow to be manually triggered
 
 env:
   SPACEMAN_DMM_VERSION: suite-1.7.2
 
 jobs:
   generate_documentation:
+    permissions:
+      contents: write # required to push the doc commit
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
     concurrency: gen-docs

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,8 @@
 name: "Pull Request Labeler"
+
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     branches:
@@ -6,6 +10,9 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read # may be required due to overwrite/add ambiguity
+      pull-requests: write # required to apply labels to PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -1,5 +1,8 @@
 name: Make changelogs
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -7,6 +10,8 @@ on:
 
 jobs:
   MakeCL:
+    permissions:
+      contents: write # required to push the changelog chunk yml commit
     runs-on: ubuntu-latest
     if: github.repository == 'Baystation12/Baystation12' # to prevent this running on forks
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Alternate version of #31935. Differences:
- adds write on the changelog chunk runner, required to commit the automatic cl.yml files
- adds /tools/ to codeowners for core since we should probably care about those files

ed: also noted that `workflow_dispatch` is present to allow manual runs on workflows that have it