### PR TITLE
Adds check to see if you replaced eyes to organ attachment end step

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -372,6 +372,14 @@
 		affected.implants -= I
 		I.replaced(target, affected)
 
+	if(istype(I, /obj/item/organ/internal/eyes))
+		var/obj/item/organ/internal/eyes/E = I
+		if(!E.is_broken())
+			I.owner.eye_blind = 0
+			target.disabilities &= ~BLINDED
+		if(!E.is_bruised())
+			I.owner.eye_blurry = 0
+
 /decl/surgery_step/internal/attach_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!</span>", \


### PR DESCRIPTION
:cl: Textor
bugfix: Replacing blinded eyes with undamaged new eyes or undamaged optical sensors now gives you the gift of sight.
/:cl:

Adds a check to the end step of organ attachment in surgery to check if the organ attached was eyes. If it is not in a "broken" state it resets eye_blind value and removes the BLINDED disabled flag. If not in a "bruised" state it will remove the eye_blurry value. This was put in to make sure people can't just take out broken organs and reinstall them to "fix" the blindness/blurriness issue.

Fixes #31908 