### PR TITLE
Restructures the command uniform datums to conform to other departments

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -5,6 +5,48 @@
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 	utility_extra = list(
 				/obj/item/clothing/under/solgov/utility/fleet/combat/command,
+				/obj/item/clothing/head/ushanka/solgov/fleet,
+				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+				/obj/item/clothing/head/soft/solgov/fleet,
+				/obj/item/clothing/gloves/thick
+			)
+
+	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
+	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/officer
+
+	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/officer
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/command
+	dress_extra = list(
+		/obj/item/clothing/head/beret/solgov/fleet/dress/command
+	)
+/decl/hierarchy/mil_uniform/fleet/com/noncom
+	name = "Fleet command NCO"
+	min_rank = 4
+	service_hat = /obj/item/clothing/head/solgov/dress/fleet
+	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
+
+	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+
+/decl/hierarchy/mil_uniform/fleet/com/snco
+	name = "Fleet command SNCO"
+	min_rank = 7
+
+	service_hat = /obj/item/clothing/head/solgov/dress/fleet
+	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/snco
+
+	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/snco
+	dress_hat = /obj/item/clothing/head/solgov/dress/fleet
+	dress_extra = list(
+		/obj/item/material/sword/replica/officersword/pettyofficer,
+		/obj/item/clothing/head/beret/solgov/fleet/dress
+	)
+
+/decl/hierarchy/mil_uniform/fleet/com/officer
+	name = "Fleet command CO"
+	min_rank = 11
+
+	utility_extra = list(
+				/obj/item/clothing/under/solgov/utility/fleet/combat/engineering,
 				/obj/item/clothing/head/beret/solgov/fleet/command,
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
@@ -22,14 +64,14 @@
 		/obj/item/clothing/head/beret/solgov/fleet/dress/command
 	)
 
-/decl/hierarchy/mil_uniform/fleet/com/seniorofficer
+/decl/hierarchy/mil_uniform/fleet/com/officer/com/seniorofficer
 	name = "Fleet senior command"
 	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
 
-/decl/hierarchy/mil_uniform/fleet/com/flagofficer
+/decl/hierarchy/mil_uniform/fleet/com/officer/com/flagofficer
 	name = "Fleet flag command"
 	min_rank = 17
 
@@ -469,7 +511,6 @@
 	utility_under = /obj/item/clothing/under/solgov/utility/fleet/command
 	utility_extra = list(
 				/obj/item/clothing/under/solgov/utility/fleet/combat/command,
-				/obj/item/clothing/head/beret/solgov/fleet/command,
 				/obj/item/clothing/head/ushanka/solgov/fleet,
 				/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 				/obj/item/clothing/head/soft/solgov/fleet,

--- a/maps/torch/items/uniform_vendor.dm
+++ b/maps/torch/items/uniform_vendor.dm
@@ -131,13 +131,6 @@
 		return null //Return no uniforms, which will cause the machine to spit out an error.
 
 	// we have found a branch.
-	if(department == COM) //Command only has one variant and they have to be an officer
-		for(var/decl/hierarchy/mil_uniform/child in user_outfit.children)
-			if(child.departments & COM)
-				user_outfit = child
-				for(var/decl/hierarchy/mil_uniform/seniorchild in user_outfit.children) //Check for variants of command outfits
-					if(user_rank.sort_order >= seniorchild.min_rank && user_outfit.min_rank < seniorchild.min_rank)
-						user_outfit = seniorchild
 	else
 		var/tmp_department = department
 		tmp_department &= ~COM //Parse departments, with complete disconsideration to the command flag (so we don't flag 2 outfit trees)


### PR DESCRIPTION
:cl: Textor
bugfix: Removes the SEA's ability to be issued a commissioned officer's beret when they are not a commissioned officer.
/:cl:

Restructures the fleet command uniforms to conform to other fleet uniforms, since the "command can only be officers" didn't really take into account that you can be an NCO/SNCO so some equipment might not be appropriate for the rank.

Removed the exception from the uniform vendor code for command.

Tested EC and Fleet command members and received no runtimes or other indications of issues with the uniform vendor after excising that code.

Fixes #31175 