### PR TITLE
Fixes bug with floor attackby code

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -199,7 +199,7 @@
 
 /turf/simulated/floor/tiled/white/monotile
 	name = "floor"
-	icon_state = "monotile"
+	icon_state = "monotile_light"
 	initial_flooring = /decl/flooring/tiling/mono/white
 
 /turf/simulated/floor/tiled/monofloor

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -118,7 +118,7 @@
 				var/decl/flooring/F = decls[flooring_type]
 				if(!F.build_type)
 					continue
-				if(ispath(S.type, F.build_type) || ispath(S.build_type, F.build_type))
+				if(S.type == F.build_type || S.build_type == F.build_type)
 					use_flooring = F
 					break
 			if(!use_flooring)


### PR DESCRIPTION
:cl: Textor
bugfix: Placed tiles should now always be the correct type.
/:cl:

The attackby function for floors was running a for loop through flooring decls. Upon first match, it would set the variable then break the loop. If the first match was a parent object, the child object that should have been selected would not be iterated on, resulting in the wrong tile being placed down.

Changes ispath comparison to a hard comparison operator so it matches exact type instead of type/subtypes.

Also changes the white monotile turf icon_state to match the appropriate icon_state for the tile.

Fixes #31828 