### PR TITLE
Adds the ability to eject from disposals without power

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -312,6 +312,20 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	if(. == TOPIC_REFRESH)
 		interact(user)
 
+/obj/machinery/disposal/verb/manual_eject()
+	set src in oview(1)
+	set category = "Object"
+	set name = "Eject Items From Bin"
+
+	if (!isliving(usr) || usr.incapacitated())
+		return
+	usr.visible_message(
+		SPAN_NOTICE("\The [usr] ejects \the [src]'s contents'."),
+		SPAN_NOTICE("You eject \the [initial(name)]'s contents."),
+	)
+	eject()
+	add_fingerprint(usr)
+
 // eject the contents of the disposal unit
 /obj/machinery/disposal/proc/eject()
 	for(var/atom/movable/AM in (contents - component_parts))


### PR DESCRIPTION
🆑 Textor
rscadd: The disposal bin can now be ejected by right clicking and selecting the verb, even without power.
/🆑

Adds right click ability for ejecting from a disposal, allowing for items to be removed during a power outage.

Fixes #29136