### PR TITLE
Updates the colors and descriptions of the soda variants

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -945,12 +945,12 @@
 	description = "A refreshing cola in vanilla flavour."
 	taste_description = "vanilla cola"
 	reagent_state = LIQUID
-	color = "#100800"
+	color = "#55381b"
 	adj_drowsy = -3
 	adj_temp = -5
 
-	glass_name = "Space Cola"
-	glass_desc = "A glass of refreshing Space Cola"
+	glass_name = "Vanilla Cola"
+	glass_desc = "A glass of refreshing Space Cola with hints of vanilla."
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/drink/orange_cola
@@ -958,12 +958,12 @@
 	description = "A refreshing cola in orange flavour."
 	taste_description = "orange cola"
 	reagent_state = LIQUID
-	color = "#100800"
+	color = "#a86017"
 	adj_drowsy = -3
 	adj_temp = -5
 
-	glass_name = "Space Cola"
-	glass_desc = "A glass of refreshing Space Cola"
+	glass_name = "Orange Cola"
+	glass_desc = "A glass of refreshing Space Cola with orange flavoring."
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/drink/cherry_cola
@@ -971,12 +971,12 @@
 	description = "A refreshing cola in cherry flavour."
 	taste_description = "cherry cola"
 	reagent_state = LIQUID
-	color = "#100800"
+	color = "#641010"
 	adj_drowsy = -3
 	adj_temp = -5
 
-	glass_name = "Space Cola"
-	glass_desc = "A glass of refreshing Space Cola"
+	glass_name = "Cherry Cola"
+	glass_desc = "A glass of refreshing Space Cola with cherry flavoring."
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/drink/coffee/coffee_cola
@@ -984,7 +984,7 @@
 	description = "There are people in town, man, crazy people in town."
 	taste_description = "coffee and cola"
 	reagent_state = LIQUID
-	color = "#100800"
+	color = "#3b240c"
 	adj_drowsy = -3
 	adj_temp = -5
 
@@ -1001,8 +1001,8 @@
 	adj_drowsy = -3
 	adj_temp = -5
 
-	glass_name = "Space Cola"
-	glass_desc = "A glass of refreshing Space Cola"
+	glass_name = "Diet Cola"
+	glass_desc = "A glass of refreshing Space Cola. This one's calorie-free!"
 	glass_special = list(DRINK_FIZZ)
 
 /datum/reagent/drink/ionbru


### PR DESCRIPTION
:cl: Textor
tweak: The space cola variants now have adjusted descriptions and color variation.
/:cl:

Modifies the space cola variants to have color hints that indicate what flavor it might be, and also updates the names and descriptions for the glasses so they aren't all listed as "space cola" when you look at them.

![image](https://user-images.githubusercontent.com/12721324/164583003-193de507-f210-4d55-84d2-2d8e7d9c6930.png)

Fixes #31278