### PR TITLE
Shuttle floors no longer can be an infinite source of tiles

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -57,6 +57,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/sound_env = STANDARD_STATION
 	var/turf/base_turf //The base turf type of the area, which can be used to override the z-level's base turf
 	var/planetary_surface = FALSE // true if the area belongs to a planet.
+	///Some base_turfs might cause issues with changing turfs, this flags it as a special case.
+	var/base_turf_special_handling = FALSE
 
 /*-----------------------------------------------------------------------------*/
 
@@ -199,6 +201,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_env = SMALL_ENCLOSED
 	base_turf = /turf/space
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
+	base_turf_special_handling = TRUE
 
 /*
 * Special Areas

--- a/code/game/base_turf.dm
+++ b/code/game/base_turf.dm
@@ -7,8 +7,10 @@
 	return GLOB.using_map.base_turf_by_z[z]
 
 /// Fetches the area's `base_turf`, if defined, or the z level's `base_turf` as a default.
-/proc/get_base_turf_by_area(turf/T)
+/proc/get_base_turf_by_area(turf/T, check_handling = FALSE)
 	var/area/A = get_area(T)
+	if(check_handling && A?.base_turf_special_handling)
+		return get_base_turf(get_z(T))
 	if (A?.base_turf)
 		return A.base_turf
 	return get_base_turf(get_z(T))

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -1,7 +1,7 @@
 /turf/proc/ReplaceWithLattice(var/material)
-	var base_turf = get_base_turf_by_area(src);
+	var base_turf = get_base_turf_by_area(src, TRUE)
 	if(type != base_turf)
-		src.ChangeTurf(get_base_turf_by_area(src))
+		src.ChangeTurf(get_base_turf_by_area(src, TRUE))
 	if(!locate(/obj/structure/lattice) in src)
 		new /obj/structure/lattice(src, material)
 

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -354,6 +354,7 @@
 	icon_state = "shuttlered"
 	base_turf = /turf/simulated/floor/plating
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	base_turf_special_handling = TRUE
 
 /area/exploration_shuttle/cockpit
 	name = "\improper Charon - Cockpit"
@@ -389,6 +390,7 @@
 	requires_power = 1
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	base_turf_special_handling = TRUE
 
 /area/aquila/cockpit
 	name = "\improper SEV Aquila - Cockpit"
@@ -432,6 +434,7 @@
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 	req_access = list(access_guppy)
+	base_turf_special_handling = TRUE
 
 
 //Petrov


### PR DESCRIPTION
:cl: Textor
bugfix: Crowbarring up the bottom tile of a shuttle will no longer yield an infinite supply of tiles.
/:cl:

Adds a new bool to areas that can be set to indicate the base turf should have special handling.

get_base_turf_by_area now returns the base turf of the Z level if special handling is enabled and get_base_turf_by_area is asked to check for special handling.

Assigned special handling bool to /area/shuttle and all the torch shuttles, which should cover most of them..

I tested landed shuttles, shuttles in space, and shuttles on exoplanets.

Fixes #29829