### PR TITLE
Fixes Traitor Uplink Issue

### DIFF
--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_INIT(default_uplink_source_priority, list(
 		return SETUP_FAILED	//Not enough space or other issues.
 	to_chat(M, "<span class='notice'>A portable object teleportation relay has been installed in your [P.name]. Simply enter the code \"[pda_pass]\" in TaxQuickly program to unlock its hidden features.</span>")
 	M.StoreMemory("<B>Uplink passcode:</B> [pda_pass] ([P.name]).", /decl/memory_options/system)
+	T.program = program
 
 /decl/uplink_source/radio
 	name = "Radio"

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -31,6 +31,7 @@
 	var/next_offer_time					//The time a discount will next be offered
 	var/datum/uplink_item/discount_item	//The item to be discounted
 	var/discount_amount					//The amount as a percent the item will be discounted by
+	var/datum/computer_file/program/uplink/program
 
 /obj/item/device/uplink/nano_host()
 	return loc
@@ -153,6 +154,8 @@
 	else if(href_list["lock"])
 		toggle()
 		SSnano.close_user_uis(user, src, "main")
+		program.authenticated = 0
+		program.computer.kill_program(program)
 		. = TOPIC_HANDLED
 	else if(href_list["return"])
 		nanoui_menu = round(nanoui_menu/10)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -154,7 +154,7 @@
 	else if(href_list["lock"])
 		toggle()
 		SSnano.close_user_uis(user, src, "main")
-		program.authenticated = 0
+		program.authenticated = FALSE
 		program.computer.kill_program(program)
 		. = TOPIC_HANDLED
 	else if(href_list["return"])

--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -30,6 +30,7 @@
 				return
 			else
 				holder.hidden_uplink.toggle()
+				SSnano.close_user_uis(user, holder.hidden_uplink, "main")
 				//No return here. We want the proc to run the last two lines.
 		else if(holder.hidden_uplink.check_trigger(user, input(user, "Please enter your unique tax ID:", "Authentication"), prog.password))
 			prog.authenticated = 1

--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -28,6 +28,9 @@
 			if(alert(user, "Resume or close and secure?", name, "Resume", "Close") == "Resume")
 				holder.hidden_uplink.trigger(user)
 				return
+			else
+				holder.hidden_uplink.toggle()
+				//No return here. We want the proc to run the last two lines.
 		else if(holder.hidden_uplink.check_trigger(user, input(user, "Please enter your unique tax ID:", "Authentication"), prog.password))
 			prog.authenticated = 1
 			return


### PR DESCRIPTION
:cl: Textor
bugfix: Traitor uplinks now quit the program when you use the close button on the popup or in the UI. Closing the window leaves the program running, still.
/:cl:

Adds a program `var` to `/obj/item/device/uplink` that references the program set up in `/decl/uplink_source/pda/setup_uplink_source()` so that when the "lock" topic is selected with the close button it was able to use `kill_program()` to shut the program down.

Added logic to the close/resume dialog so that when the player chooses "close" it will toggle the active variable and then permit the code to run the kill_program line that ended the proc.

Fixes #31326 