### PR TITLE
Fixes #21999

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -382,6 +382,7 @@ var/global/list/admin_verbs_mod = list(
 	if(!holder)	return
 	if(isghost(mob))
 		var/mob/observer/ghost/ghost = mob
+		sound_to(usr, sound(null))
 		ghost.reenter_corpse()
 
 	else if(istype(mob,/mob/new_player))
@@ -390,6 +391,8 @@ var/global/list/admin_verbs_mod = list(
 		//ghostize
 		var/mob/body = mob
 		var/mob/observer/ghost/ghost = body.ghostize(1)
+		sound_to(usr, sound(null))
+
 		if (!ghost)
 			to_chat(src, FONT_COLORED("red", "You are already admin-ghosted."))
 			return

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -557,6 +557,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	to_chat(usr, SPAN_NOTICE("<b>Make sure to play a different character, and please roleplay correctly!</b>"))
 	announce_ghost_joinleave(client, 0)
 
+	sound_to(src, sound(null))
+
 	var/mob/new_player/M = new /mob/new_player()
 	if (can_reenter_corpse != CORPSE_CAN_REENTER_AND_RESPAWN)
 		M.respawned_time = world.time


### PR DESCRIPTION
:cl: Textor
bugfix: Sounds end when you respawn, meaning you no longer have that one tune stuck in your head for the rest of the round.
/:cl:

Adds sound null calls to respawn and aghost, stopping music and other looping sounds from being stuck playing.

Fixes #21999 