### PR TITLE
Flechette shell rebalancing

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -191,12 +191,11 @@
 	icon_state = "flechette"
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
 	damage = 30
-	armor_penetration = 25
-	pellets = 3
+	armor_penetration = 30
+	pellets = 4
 	range_step = 3
 	base_spread = 99
 	spread_step = 2
-	penetration_modifier = 0.5
 	hitchance_mod = 5
 
 /* "Rifle" rounds */


### PR DESCRIPTION
Removes the inherent 0.5 penetration modifier on flechette shells that allowed them to almost entirely ignore all available armor, the rounds were vastly out performing all other available shotgun shells in almost every scenario possible with the sole exception being buckshot into an unarmored target.

The shell is being given a slight uptick in penetration and one more pellet to make up for the loss so that it remains consistent in situations where it should work without leaving it entirely too powerful in all others.

🆑 Kell-E
balance: Flechette shells gain one more pellet while taking a large decrease to their ability to penetrate higher tier ballistic armor.
/🆑 