### PR TITLE
EMP weapon splash radius nerf

### DIFF
--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -6,7 +6,7 @@
 
 /obj/item/grenade/empgrenade/detonate()
 	..()
-	if(empulse(src, 4, 10))
+	if(empulse(src, 2, 5))
 		qdel(src)
 	return
 
@@ -19,6 +19,6 @@
 
 /obj/item/grenade/empgrenade/low_yield/detonate()
 	..()
-	if(empulse(src, 4, 1))
+	if(empulse(src, 1, 3))
 		qdel(src)
 	return

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -7,7 +7,7 @@
 	damage_flags = 0
 	nodamage = TRUE
 	var/heavy_effect_range = 1
-	var/light_effect_range = 2
+	var/light_effect_range = 1
 
 /obj/item/projectile/ion/on_impact(var/atom/A)
 	empulse(A, heavy_effect_range, light_effect_range)


### PR DESCRIPTION
:cl: SierraKomodo
balance: Effective range of EMP grenades reduced from 10 tiles to 5.
balance: Heavy severity range of EMP grenades reduced from 4 tiles to 2.
bugfix: Fixed low yield EMP grenade range being limited to 1 tile; Low-yield grenades now have an effective range of 3 tiles and a heavy severity range of 1 tile.
balance: Ion projectile effective splash range reduced from 2 to 1. To be effective, ion rifles now must hit their target or hit the target's turf. This change now makes the difference between ion rifles and ion pistols solely the strength of the EMP effect and no longer the additional splash radius.
/:cl: