### PR TITLE
Gives crisis borgs adrenaline

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -22,7 +22,7 @@
 	reagent_ids = list(/datum/reagent/bicaridine, /datum/reagent/dexalin, /datum/reagent/tramadol)
 
 /obj/item/reagent_containers/borghypo/crisis
-	reagent_ids = list(/datum/reagent/tricordrazine, /datum/reagent/inaprovaline, /datum/reagent/tramadol)
+	reagent_ids = list(/datum/reagent/tricordrazine, /datum/reagent/inaprovaline, /datum/reagent/tramadol, /datum/reagent/adrenaline)
 
 /obj/item/reagent_containers/borghypo/Initialize()
 	. = ..()


### PR DESCRIPTION
They should have this. It's a chemical which is really important for stabilization, which is what these borgs are suppose to do. Everyone else has access to adrenaline - it's in every low oxy pouch. 
:cl: Jeff
rscadd: Crisis borgs can now synthesize adrenaline
/:cl: