### PR TITLE
Flechette availability changes

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -69,8 +69,9 @@
 /datum/uplink_item/item/ammo/flechette_shells
 	name = "Ammobox of Flechette Shells"
 	desc = "An ammobox with 2 sets of shell holders. Contains 8 extra accurate flechette shells."
-	item_cost = 8
+	item_cost = 12
 	path = /obj/item/storage/box/ammo/flechetteshells
+	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/shotgun_slugs
 	name = "Ammobox of Shotgun Slugs"

--- a/code/modules/fabrication/designs/general/designs_arms_ammo.dm
+++ b/code/modules/fabrication/designs/general/designs_arms_ammo.dm
@@ -96,10 +96,6 @@
 	name = "ammunition (shell, shotgun)"
 	path = /obj/item/ammo_casing/shotgun/pellet
 
-/datum/fabricator_recipe/arms_ammo/hidden/shotgun_flechette
-	name = "ammunition (flechette, shotgun)"
-	path = /obj/item/ammo_casing/shotgun/flechette
-
 /datum/fabricator_recipe/arms_ammo/hidden/tacknife
 	path = /obj/item/material/knife/combat
 


### PR DESCRIPTION
Flechette shells are now only available to mercenaries.
The cost of flechette shells has been increased by 50%.
You can no longer print flechette shells.

They out perform buckshot in all important metrics and almost entirely ignore the available armor without pulling out specialized ballistic equipment. 

🆑 Kell-E
balance: Flechette shells cost: 8 -> 12. 
balance: Flechette shells availability: Everyone -> Mercenaries only.
tweak: You can no longer print flechette shells at a lathe.
/🆑 