### PR TITLE
Removes the bio-printer from medical.

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -108,3 +108,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// Droppers. END
 ////////////////////////////////////////////////////////////////////////////////
+
+/obj/item/reagent_containers/dropper/peridaxon
+	name = "Dropper (Peridaxon)"
+	desc = "Contains peridaxon - used to rescue failing organs."
+	amount_per_transfer_from_this = 1
+
+/obj/item/reagent_containers/dropper/peridaxon/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/peridaxon, 5)
+	update_icon()
+

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -19277,7 +19277,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/organ_printer/flesh/mapped,
+/obj/structure/closet/crate/secure/biohazard/alt,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "iHb" = (
@@ -22816,6 +22816,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
+/obj/item/reagent_containers/dropper/peridaxon,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "njj" = (
@@ -26186,6 +26187,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
+/obj/item/reagent_containers/dropper/peridaxon,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "rpB" = (
@@ -29946,7 +29948,6 @@
 	c_tag = "Infirmary - Operating Theatre 1";
 	dir = 1
 	},
-/obj/structure/closet/crate/secure/biohazard/alt,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "xxl" = (


### PR DESCRIPTION
Kills the bio-printer and places a 5u dropper of peridaxon into both of the OR's. 

Also moves a waste disposal cart from OR one slightly to the left because the fact that they weren't symmetrical was bothering me immensely.

https://ibb.co/R4F8pqj

🆑 Kell-E
rscdel: Removes the organ printer (Bio-printer) from OR one.
rscadd: Adds a 5u dropper with peridaxon preset to 1u increments to both OR one and two.
/🆑 