### PR TITLE
fix overmap effects being mouse transparent

### DIFF
--- a/code/__defines/_renderer.dm
+++ b/code/__defines/_renderer.dm
@@ -13,7 +13,6 @@
 	screen_loc = "CENTER"
 	plane = LOWEST_PLANE
 	blend_mode = BLEND_OVERLAY
-	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
 	/// The compositing renderer this renderer belongs to.
 	var/group = RENDER_GROUP_FINAL
@@ -114,6 +113,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR
 	blend_mode = BLEND_MULTIPLY
 	color = list(null, null, null, "#0000", "#000f")
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
 
 // Draws the game world; live mobs, items, turfs, etc.
@@ -121,7 +121,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Game"
 	group = RENDER_GROUP_SCENE
 	plane = DEFAULT_PLANE
-	mouse_opacity = MOUSE_OPACITY_NORMAL
 
 
 /// Draws observers; ghosts, camera eyes, etc.
@@ -129,7 +128,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Observers"
 	group = RENDER_GROUP_SCENE
 	plane = OBSERVER_PLANE
-	mouse_opacity = MOUSE_OPACITY_NORMAL
 
 
 /// Draws darkness effects.
@@ -146,6 +144,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 		 0,  0,  0,  0, // A
 		 1,  1,  1,  1  // Mapping
 	)
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
 
 /// Draws visuals that should not be affected by darkness.
@@ -160,6 +159,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Screen Effects"
 	group = RENDER_GROUP_SCENE
 	plane = FULLSCREEN_PLANE
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
 
 /// Draws user interface elements.
@@ -167,7 +167,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Interface"
 	group = RENDER_GROUP_SCREEN
 	plane = HUD_PLANE
-	mouse_opacity = MOUSE_OPACITY_NORMAL
 
 
 /* *
@@ -185,7 +184,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Scene Group"
 	group = RENDER_GROUP_FINAL
 	plane = RENDER_GROUP_SCENE
-	mouse_opacity = MOUSE_OPACITY_NORMAL
 
 
 /// Render group for stuff OUTSIDE the typical game context - UI, full screen effects, etc.
@@ -193,7 +191,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Screen Group"
 	group = RENDER_GROUP_FINAL
 	plane = RENDER_GROUP_SCREEN
-	mouse_opacity = MOUSE_OPACITY_NORMAL
 
 
 /// Render group for final compositing before user display.
@@ -201,7 +198,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name = "Final Group"
 	group = RENDER_GROUP_NONE
 	plane = RENDER_GROUP_FINAL
-	mouse_opacity = MOUSE_OPACITY_NORMAL
 
 
 /* *
@@ -220,6 +216,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	group = RENDER_GROUP_NONE
 	plane = WARP_EFFECT_PLANE
 	render_target_name = "*warp"
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
 
 /// Adds the warp effect to the game rendering group


### PR DESCRIPTION
also inverts the original default of mouse transparent to mouse opaque again since we only want letterbox, lighting, fullscreen effects, and effect helpers to be transparent for now