### PR TITLE
Remove toggleable preferences for all ghost roles except pAI

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -14,8 +14,6 @@
 #define END_GAME_AWAITING_TICKETS 6
 #define END_GAME_DELAYED          7
 
-#define BE_PLANT "BE_PLANT"
-#define BE_SYNTH "BE_SYNTH"
 #define BE_PAI   "BE_PAI"
 
 // Antagonist datum flags.

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -48,38 +48,15 @@
 			. += "<a href='?src=\ref[src];add_special=[antag.id]'>High</a> <a href='?src=\ref[src];add_maybe=[antag.id]'>Low</a> <span class='linkOn'>Never</span></br>"
 
 		. += "</td></tr>"
-	. += "</table>"
-	. += "<b>Ghost Role Availability:</b>"
-	. += "<table>"
-	var/list/ghost_traps = get_ghost_traps()
-	for(var/ghost_trap_key in ghost_traps)
-		var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
-		if(!ghost_trap.list_as_special_role)
-			continue
 
-		. += "<tr><td>[(ghost_trap.ghost_trap_role)]: </td><td>"
-		if(banned_from_ghost_role(preference_mob(), ghost_trap))
-			. += "<span class='danger'>\[BANNED\]</span><br>"
-		else if (!ghost_trap.assess_whitelist(user))
-			var/datum/species/S = new ghost_trap.species_whitelist()
-			. += "[SPAN_DANGER("\[WHITELIST RESTRICTED - [S]\]")]<br />"
-		else if(ghost_trap.pref_check in pref.be_special_role)
-			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];add_maybe=[ghost_trap.pref_check]'>Low</a> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Never</a></br>"
-		else if(ghost_trap.pref_check in pref.may_be_special_role)
-			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Never</a></br>"
-		else
-			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <a href='?src=\ref[src];add_maybe=[ghost_trap.pref_check]'>Low</a> <span class='linkOn'>Never</span></br>"
-
-		. += "</td></tr>"
-	. += "<tr><td>Select All: </td><td><a href='?src=\ref[src];select_all=2'>High</a> <a href='?src=\ref[src];select_all=1'>Low</a> <a href='?src=\ref[src];select_all=0'>Never</a></td></tr>"
+	// Special handling for pAI role
+	. += "<tr></tr><tr><td>pAI:</td>"
+	if (BE_PAI in pref.be_special_role)
+		. += "<td><span class='linkOn'>Yes</span> <a href='?src=\ref[src];del_special=[BE_PAI]'>No</a></br></td></tr>"
+	else
+		. += "<td><a href='?src=\ref[src];add_special=[BE_PAI]'>Yes</a> <span class='linkOn'>No</span></br></td></tr>"
 	. += "</table>"
 	. = jointext(.,null)
-
-/datum/category_item/player_setup_item/proc/banned_from_ghost_role(var/mob, var/datum/ghosttrap/ghost_trap)
-	for(var/ban_type in ghost_trap.ban_checks)
-		if(jobban_isbanned(mob, ban_type))
-			return 1
-	return 0
 
 /datum/category_item/player_setup_item/antagonism/candidacy/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["add_special"])
@@ -131,15 +108,8 @@
 				continue
 		private_valid_special_roles += antag_type
 
-	var/list/ghost_traps = get_ghost_traps()
-	for(var/ghost_trap_key in ghost_traps)
-		var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
-		if(!ghost_trap.list_as_special_role)
-			continue
-		if(!include_bans)
-			if(banned_from_ghost_role(preference_mob(), ghost_trap))
-				continue
-		private_valid_special_roles += ghost_trap.pref_check
+	// Special handling to allow pAI selection as it is not an antagonist but does have a role pref
+	private_valid_special_roles += BE_PAI
 
 
 	return private_valid_special_roles

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -23,11 +23,9 @@ var/global/list/ghost_traps
 	var/object = "default ghost trap"
 	var/minutes_since_death = 0     // If non-zero the ghost must have been dead for this many minutes to be allowed to spawn
 	var/list/ban_checks = list()
-	var/pref_check = ""
 	var/ghost_trap_message = "They are no longer a ghost."
 	var/ghost_trap_role = "default ghost trap"
 	var/can_set_own_name = TRUE
-	var/list_as_special_role = FALSE	// If true, this entry will be listed as a special role in the character setup
 
 	var/list/request_timeouts
 	var/datum/species/species_whitelist // If defined, this is the species whitelist required to join
@@ -39,6 +37,16 @@ var/global/list/ghost_traps
 // Check for bans, proper atom types, etc.
 /datum/ghosttrap/proc/assess_candidate(var/mob/observer/ghost/candidate, var/mob/target, var/feedback = TRUE)
 	if(!candidate.MayRespawn(feedback, minutes_since_death))
+		return FALSE
+
+	if(request_timeouts[target] && world.time > request_timeouts[target])
+		if (feedback)
+			to_chat(candidate, "This occupation request is no longer valid.")
+		return FALSE
+
+	if(target.key)
+		if (feedback)
+			to_chat(candidate, "The target is already occupied.")
 		return FALSE
 
 	if(islist(ban_checks))
@@ -73,8 +81,6 @@ var/global/list/ghost_traps
 
 	for(var/mob/observer/ghost/O in GLOB.player_list)
 		if(!assess_candidate(O, target, FALSE))
-			return
-		if(pref_check && !O.client.wishes_to_be_role(pref_check))
 			continue
 		if(O.client)
 			to_chat(O, "[request_string] <a href='?src=\ref[src];candidate=\ref[O];target=\ref[target]'>(Occupy)</a> ([ghost_follow_link(target, O)])")
@@ -86,7 +92,7 @@ var/global/list/ghost_traps
 // Handles a response to request_player().
 /datum/ghosttrap/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
 	if(href_list["candidate"] && href_list["target"])
 		var/mob/observer/ghost/candidate = locate(href_list["candidate"]) // BYOND magic.
 		var/mob/target = locate(href_list["target"])                     // So much BYOND magic.
@@ -94,20 +100,18 @@ var/global/list/ghost_traps
 			return
 		if(candidate != usr)
 			return
-		if(request_timeouts[target] && world.time > request_timeouts[target])
-			to_chat(candidate, "This occupation request is no longer valid.")
+		if(!assess_candidate(candidate, target))
 			return
-		if(target.key)
-			to_chat(candidate, "The target is already occupied.")
+		// Modal yes/no alert to guard misclicks
+		if(alert("Would you like to occupy \a [object]?", "Occupy", "Yes", "No") != "Yes")
 			return
-		if(assess_candidate(candidate, target))
-			transfer_personality(candidate,target)
-		return 1
+		transfer_personality(candidate,target)
+		return TRUE
 
 // Shunts the ckey/mind into the target mob.
 /datum/ghosttrap/proc/transfer_personality(var/mob/candidate, var/mob/target)
 	if(!assess_candidate(candidate, target))
-		return 0
+		return FALSE
 	target.ckey = candidate.ckey
 	if(target.mind)
 		target.mind.reset()
@@ -115,7 +119,7 @@ var/global/list/ghost_traps
 	announce_ghost_joinleave(candidate, 0, "[ghost_trap_message]")
 	welcome_candidate(target)
 	set_new_name(target)
-	return 1
+	return TRUE
 
 /datum/ghosttrap/proc/welcome_candidate(var/mob/target)
 	return
@@ -136,10 +140,8 @@ var/global/list/ghost_traps
 /datum/ghosttrap/positronic
 	object = "positronic brain"
 	ban_checks = list("AI","Robot")
-	pref_check = BE_SYNTH
 	ghost_trap_message = "They are occupying a positronic brain now."
 	ghost_trap_role = "Positronic Brain"
-	list_as_special_role = TRUE
 
 /datum/ghosttrap/positronic/welcome_candidate(mob/target)
 	to_chat(target, SPAN_BOLD("You are a positronic brain, activated on [station_name()]."))
@@ -167,10 +169,8 @@ var/global/list/ghost_traps
 /datum/ghosttrap/plant
 	object = "living plant"
 	ban_checks = list("Dionaea")
-	pref_check = BE_PLANT
 	ghost_trap_message = "They are occupying a living plant now."
 	ghost_trap_role = "Plant"
-	list_as_special_role = TRUE
 	species_whitelist = /datum/species/diona
 
 /datum/ghosttrap/plant/welcome_candidate(var/mob/target)
@@ -185,11 +185,9 @@ var/global/list/ghost_traps
 /datum/ghosttrap/borer
 	object = "cortical borer"
 	ban_checks = list(MODE_BORER)
-	pref_check = MODE_BORER
 	ghost_trap_message = "They are occupying a borer now."
 	ghost_trap_role = "Cortical Borer"
 	can_set_own_name = FALSE
-	list_as_special_role = FALSE
 
 /datum/ghosttrap/borer/welcome_candidate(var/mob/target)
 	to_chat(target, "<span class='notice'>You are a cortical borer!</span> You are a brain slug that worms its way \
@@ -201,11 +199,9 @@ var/global/list/ghost_traps
 *********************/
 /datum/ghosttrap/drone
 	object = "maintenance drone"
-	pref_check = BE_PAI
 	ghost_trap_message = "They are occupying a maintenance drone now."
 	ghost_trap_role = "Maintenance Drone"
 	can_set_own_name = FALSE
-	list_as_special_role = FALSE
 
 /datum/ghosttrap/drone/New()
 	minutes_since_death = DRONE_SPAWN_DELAY
@@ -214,11 +210,11 @@ var/global/list/ghost_traps
 /datum/ghosttrap/drone/assess_candidate(var/mob/observer/ghost/candidate, var/mob/target)
 	. = ..()
 	if(. && !target.can_be_possessed_by(candidate))
-		return 0
+		return FALSE
 
 /datum/ghosttrap/drone/transfer_personality(var/mob/candidate, var/mob/living/silicon/robot/drone/drone)
 	if(!assess_candidate(candidate))
-		return 0
+		return FALSE
 	drone.transfer_personality(candidate.client)
 
 /**************
@@ -226,39 +222,33 @@ var/global/list/ghost_traps
 **************/
 /datum/ghosttrap/pai
 	object = "pAI"
-	pref_check = BE_PAI
 	ghost_trap_message = "They are occupying a pAI now."
 	ghost_trap_role = "pAI"
-	list_as_special_role = TRUE
 
 /datum/ghosttrap/pai/assess_candidate(var/mob/observer/ghost/candidate, var/mob/target)
-	return 0
+	return FALSE
 
 /datum/ghosttrap/pai/transfer_personality(var/mob/candidate, var/mob/living/silicon/robot/drone/drone)
-	return 0
+	return FALSE
 
 /******************
 * Wizard Familiar *
 ******************/
 /datum/ghosttrap/familiar
 	object = "wizard familiar"
-	pref_check = MODE_WIZARD
 	ghost_trap_message = "They are occupying a familiar now."
 	ghost_trap_role = "Wizard Familiar"
 	ban_checks = list(MODE_WIZARD)
-	list_as_special_role = TRUE
 
 /datum/ghosttrap/familiar/welcome_candidate(var/mob/target)
-	return 0
+	return FALSE
 
 /datum/ghosttrap/cult
 	object = "cultist"
 	ban_checks = list("cultist")
-	pref_check = MODE_CULTIST
 	can_set_own_name = FALSE
 	ghost_trap_message = "They are occupying a cultist's body now."
 	ghost_trap_role = "Cultist"
-	list_as_special_role = TRUE
 
 /datum/ghosttrap/cult/welcome_candidate(var/mob/target)
 	var/obj/item/device/soulstone/S = target.loc
@@ -277,4 +267,3 @@ var/global/list/ghost_traps
 	object = "soul stone"
 	ghost_trap_message = "They are occupying a soul stone now."
 	ghost_trap_role = "Shade"
-	list_as_special_role = TRUE


### PR DESCRIPTION
Removes the preference settings for most ghost roles, including diona, cultist, and shade. The prompt to occupy the associated object will always show up in chat if the role is available to the player.

This does not apply to pAI, which has its own selection mechanism. This now has a special Yes/No selector on the roles page, as Low never made any difference for it anyway.

Discussed this with SierraKomodo and Gentlefood earlier and there was general agreement that this feature as it currently exists, while technically working as designed, has the unintended effect of creating a shortage of players for roles such as cult shades, and thus the perception that these roles do not work at all. (https://discord.com/channels/104289531796131840/444456478775181312/969650213381894225)

![Screenshot 2022-04-29 200652](https://user-images.githubusercontent.com/1348714/166063968-4e5770f7-1cc4-4feb-b271-bdb33bbebabe.png)
![Screenshot 2022-04-29 210110](https://user-images.githubusercontent.com/1348714/166063973-c6a140d7-5a28-4ad7-bd99-d4994ccea726.png)

🆑 Ninetailed
rscdel: Most ghost roles (except pAI) no longer require a preference to be set
rscadd: Yes/no confirmation prompt when accepting a ghost role
tweak: pAI preference now Yes/No instead of High/Low/Never
/🆑
