### PR TITLE
Increase Desc Word Limit + Customisation for Fluff Augments

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -239,7 +239,7 @@ Custom Description
 /datum/gear_tweak/custom_desc/get_metadata(user, metadata, title)
 	if(valid_custom_desc)
 		return input(user, "Choose an item description.", "Character Preference", metadata) as null|anything in valid_custom_desc
-	return sanitize(input(user, "Choose the item's description. Leave it blank to use the default description.", "Item Description", metadata) as message|null, MAX_LNAME_LEN, extra = FALSE)
+	return sanitize(input(user, "Choose the item's description. Leave it blank to use the default description.", "Item Description", metadata) as message|null, MAX_DESC_LEN, extra = FALSE)
 
 /datum/gear_tweak/custom_desc/tweak_item(user, obj/item/I, metadata)
 	if(!metadata)

--- a/code/modules/client/preference_setup/loadout/lists/augments.dm
+++ b/code/modules/client/preference_setup/loadout/lists/augments.dm
@@ -2,7 +2,6 @@
 	sort_category = "Augments"
 	category = /datum/gear/augment
 	cost = 2
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/augment/armor_minor
@@ -68,6 +67,7 @@
 	display_name = "Head Augments (Vision)"
 	description = "Head augments with vision effects."
 	path = /obj/item/organ/internal/augment
+	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/augment/head_vision/New()


### PR DESCRIPTION
:cl: Ryan180602
tweak: Lets descriptions be longer (128 char limit).
tweak: Lets fluff augments (minus eye-ones) be customised.
/:cl:

how fast will i regret this.