### PR TITLE
add initial tiny versions of Input & Text libraries

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1203,6 +1203,8 @@
 #include "code\game\verbs\who.dm"
 #include "code\js\byjax.dm"
 #include "code\js\menus.dm"
+#include "code\library\Input.dm"
+#include "code\library\Text.dm"
 #include "code\modules\acting\acting_items.dm"
 #include "code\modules\admin\admin.dm"
 #include "code\modules\admin\admin_attack_log.dm"

--- a/code/library/Input.dm
+++ b/code/library/Input.dm
@@ -1,0 +1,36 @@
+/Input/var/static/const/max_name_length = 32
+
+/Input/var/static/const/max_line_length = 128
+
+/Input/var/static/const/max_text_length = 1024
+
+/Input/var/static/const/default_confirm_accept = "Okay"
+
+/Input/var/static/const/default_confirm_cancel = "Cancel"
+
+
+//-- defaults config ends --
+
+
+/Input/proc/Confirm(user, query, accept = default_confirm_accept, cancel = default_confirm_cancel)
+	return alert(user, query, null, cancel, accept) == accept
+
+
+/Input/proc/GetLine(user, query, default, max_length = max_line_length, regex/sanitizer)
+	var/response = input(user, query, null, default) as null | text
+	if (!isnull(response))
+		return Text.Sanitize(response, max_length, sanitizer)
+
+
+/Input/proc/GetText(user, query, default, max_length = max_text_length, regex/sanitizer)
+	var/response = input(user, query, null, default) as null | message
+	if (!isnull(response))
+		return Text.Sanitize(response, max_length, sanitizer)
+
+
+/Input/Destroy(force)
+	if (force)
+		return ..()
+	return QDEL_HINT_LETMELIVE
+
+VAR_FINAL/global/Input/Input = new

--- a/code/library/Text.dm
+++ b/code/library/Text.dm
@@ -1,0 +1,47 @@
+/Text/var/static/const/default_sanitizer = "EN"
+
+
+//-- defaults config ends --
+
+
+/Text/var/static/const/sanitizer_en = "EN"
+
+/Text/var/static/const/sanitizer_ru = "RU"
+
+/Text/var/static/list/standard_sanitizers = list(
+	// "EN" - Allows printable symbols in the Basic Latin codeblock, except for > and <
+	"[sanitizer_en]" = regex(@"[^\x20-\x3b\x3d\x3f-\x7e\n]", "g"),
+	// "RU" - Allows symbols in the "EN" set, plus the Cyrillic codeblock
+	"[sanitizer_ru]" = regex(@"[^\x20-\x3b\x3d\x3f-\x7e\n\u0400-\u04ff]", "g")
+)
+
+/* *
+* Sanitize text by replacing every symbol matching sanitizers with
+* the text of replacer, then trimming the result to max_length if
+* specified.
+* sanitizers may be:
+* null - the default sanitizer is used
+* text - the Text.* const refering to a standard sanitizer
+* regex - a regex to match against
+* list - a list of either of the above
+* FALSE - no sanitization is performed
+*/
+/Text/proc/Sanitize(text, max_length, list/sanitizers = default_sanitizer, replacer = "")
+	if (sanitizers != FALSE)
+		if (!islist(sanitizers))
+			sanitizers = list(sanitizers)
+		for (var/regex/sanitizer as anything in sanitizers)
+			if (istext(sanitizer))
+				sanitizer = standard_sanitizers[sanitizer]
+			text = replacetext_char(text, sanitizer, replacer)
+	if (max_length && length(text) > max_length)
+		text = copytext_char(text, 1, max_length)
+	return text
+
+
+/Text/Destroy(force)
+	if (force)
+		return ..()
+	return QDEL_HINT_LETMELIVE
+
+VAR_FINAL/global/Text/Text = new


### PR DESCRIPTION
Opening this early for a look at the concept.

```
A Library is an Uppercased bare global (datum) that provides
constants and pure procs. They are useful for removing behaviors
from the global scope, reducing the potential for collisions and
redefinition, and adding more context to their intended uses.
```

The intention here is to replace stuff like sanitize(input()) and sanitizeSafe(input()) all through by expecting use of, for example, Input.GetLine() instead.

Adding this somewhere
```
/mob/verb/TestGetText()
    usr << Input.GetText(usr, "Test me!")
```
allows testing the sanitization behavior, etc