### PR TITLE
Makes some overmap effects render as overlays

### DIFF
--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -10,7 +10,9 @@
 	var/next_meteor_upper = 20
 
 /datum/event/meteor_wave/get_skybox_image()
-	return overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	res.blend_mode = BLEND_OVERLAY
+	return res
 
 /datum/event/meteor_wave/setup()
 	waves = 0

--- a/code/modules/overmap/exoplanets/exoplanet_skybox.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_skybox.dm
@@ -56,3 +56,4 @@
 	skybox_image.pixel_x = rand(0,64)
 	skybox_image.pixel_y = rand(128,256)
 	skybox_image.appearance_flags = DEFAULT_APPEARANCE_FLAGS | RESET_COLOR
+	skybox_image.blend_mode = BLEND_OVERLAY

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -17,10 +17,13 @@
 	known = FALSE
 
 /obj/effect/overmap/visitable/sector/cluster/generate_skybox()
-	return overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	res.blend_mode = BLEND_OVERLAY
+	return res
 
 /obj/effect/overmap/visitable/sector/cluster/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	res.blend_mode = BLEND_OVERLAY
 	res.transform *= 0.5
 	return res
 
@@ -92,6 +95,7 @@
 
 /obj/effect/overmap/visitable/sector/away/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	res.blend_mode = BLEND_OVERLAY
 	res.transform *= 0.3
 	return res
 
@@ -159,6 +163,7 @@
 
 /obj/effect/overmap/visitable/sector/orb/get_skybox_representation()
 	var/image/res = overlay_image('icons/skybox/skybox_rock_128.dmi', "bigrock", COLOR_ASTEROID_ROCK, RESET_COLOR)
+	res.blend_mode = BLEND_OVERLAY
 	res.pixel_x = rand(256,512)
 	res.pixel_y = rand(256,512)
 	return res


### PR DESCRIPTION
no idea if it's bugged but it was reported to me. Some skybox overlays no longer blend multiply, making them properly visible again

Asteroids still look a bit funky. not sure why. Exoplanets seem fine however. Possible that asteroid effect is doubling up due to event and due to overmap location

Edit: Figured out asteroids. LEft as is for electric, looks cool. not sure on what intended look of rads is