### PR TITLE
removed editorconfig plugin recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "gbasood.byond-dm-language-support",
     "platymuus.dm-langclient",
-    "EditorConfig.EditorConfig",
     "eamodio.gitlens"
   ]
 }


### PR DESCRIPTION
ref PolarisSS13/Polaris#8620 -- The editorconfig plugin for vscode has undesirable behaviors and recommending it is a footgun. The editorconfig file itself is retained, as other editors do not do the terrible thing.