### PR TITLE
slowdown rebalance

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -109,10 +109,6 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 
-/obj/item/clothing/suit/cultrobes/magusred/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
-
 /obj/item/clothing/head/helmet/space/cult
 	name = "cult helmet"
 	desc = "A space worthy helmet used by the followers of Nar-Sie."
@@ -144,7 +140,3 @@
 	)
 	siemens_coefficient = 0.2
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
-
-/obj/item/clothing/suit/space/cult/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -103,7 +103,7 @@
 	matter = list(MATERIAL_PLASTEEL = 8500)
 	max_block = 50
 	can_block_lasers = TRUE
-	slowdown_general = 1.5
+	slowdown_general = 0.5
 
 /obj/item/shield/buckler
 	name = "buckler"

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -650,7 +650,7 @@ BLIND     // can't see anything
 			return
 		user.visible_message(SPAN_ITALIC("\The [user] attaches \the [cuffs] to \the [src]."), range = 2)
 		verbs |= /obj/item/clothing/shoes/proc/remove_cuffs
-		slowdown_per_slot[slot_shoes] += cuffs.elastic ? 10 : 15
+		slowdown_per_slot[slot_shoes] += cuffs.elastic ? 5 : 10
 		attached_cuffs = cuffs
 
 /obj/item/clothing/shoes/proc/remove_cuffs(var/mob/user)
@@ -672,7 +672,7 @@ BLIND     // can't see anything
 			return
 		user.visible_message(SPAN_ITALIC("\The [user] removes \the [attached_cuffs] from \the [src]."), range = 2)
 		attached_cuffs.add_fingerprint(user)
-		slowdown_per_slot[slot_shoes] -= attached_cuffs.elastic ? 10 : 15
+		slowdown_per_slot[slot_shoes] -= attached_cuffs.elastic ? 5 : 10
 		verbs -= /obj/item/clothing/shoes/proc/remove_cuffs
 		attached_cuffs = null
 
@@ -725,7 +725,7 @@ BLIND     // can't see anything
 	if (running && attached_cuffs?.damage_health(1))
 		visible_message(SPAN_WARNING("\The [attached_cuffs] attached to \the [src] snap and fall away!"), range = 1)
 		verbs -= /obj/item/clothing/shoes/proc/remove_cuffs
-		slowdown_per_slot[slot_shoes] -= attached_cuffs.elastic ? 10 : 15
+		slowdown_per_slot[slot_shoes] -= attached_cuffs.elastic ? 5 : 10
 		QDEL_NULL(attached_cuffs)
 	return
 

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -8,7 +8,7 @@
 
 /obj/item/clothing/shoes/galoshes/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_shoes] = 1
+	slowdown_per_slot[slot_shoes] = 0.5
 
 /obj/item/clothing/shoes/jackboots
 	name = "jackboots"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -19,9 +19,6 @@
 	species_restricted = list(SPECIES_VOX, SPECIES_VOX_ARMALIS)
 	flags_inv = HIDEJUMPSUIT
 
-/obj/item/clothing/suit/space/vox/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0.75
 
 /obj/item/clothing/head/helmet/space/vox
 	icon = 'icons/obj/clothing/species/vox/obj_head_vox.dmi'

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -36,10 +36,6 @@
 	icon_state = "santa"
 	allowed = list(/obj/item) //for stuffing exta special presents
 
-/obj/item/clothing/suit/space/santa/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0
-
 //Orange emergency space suit
 /obj/item/clothing/head/helmet/space/emergency
 	name = "emergency space helmet"
@@ -55,7 +51,7 @@
 
 /obj/item/clothing/suit/space/emergency/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 3
+	slowdown_per_slot[slot_wear_suit] = 1
 
 /obj/item/clothing/head/helmet/space/fishbowl
 	name = "spacesuit helmet"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -85,7 +85,7 @@
 	var/seal_delay = SEAL_DELAY
 	var/sealing                                               // Keeps track of seal status independantly of canremove.
 	var/offline = 1                                           // Should we be applying suit maluses?
-	var/online_slowdown = 0                                   // If the suit is deployed and powered, it sets slowdown to this.
+	var/online_slowdown = 1                                   // If the suit is deployed and powered, it sets slowdown to this.
 	var/offline_slowdown = 3                                  // If the suit is deployed and unpowered, it sets slowdown to this.
 	var/vision_restriction = TINT_NONE
 	var/offline_vision_restriction = TINT_HEAVY               // tint value given to helmet

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -13,8 +13,8 @@
 		rad = ARMOR_RAD_MINOR
 		)
 	emp_protection = -20
-	online_slowdown = 6
-	offline_slowdown = 10
+	online_slowdown = 3
+	offline_slowdown = 4
 	offline_vision_restriction = TINT_BLIND
 
 	chest_type = /obj/item/clothing/suit/space/rig/unathi
@@ -35,6 +35,7 @@
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL)
+	online_slowdown = 2
 
 /obj/item/clothing/head/helmet/space/rig/unathi
 	species_restricted = list(SPECIES_UNATHI)

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -12,8 +12,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 		)
-	online_slowdown = 1
-	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/combat
@@ -100,8 +98,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	online_slowdown = 1
-	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/military

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -13,9 +13,9 @@
 		)
 	siemens_coefficient = 0.4
 	emp_protection = 10
-	online_slowdown = 0
+	online_slowdown = 0.5
+	offline_slowdown = 1
 	item_flags = ITEM_FLAG_THICKMATERIAL
-	offline_slowdown = TINT_NONE
 	offline_vision_restriction = TINT_NONE
 	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
 	min_pressure_protection = 0

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -12,8 +12,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	online_slowdown = 1
-	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/merc
@@ -97,7 +95,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	online_slowdown = 3
+	online_slowdown = 2
 	offline_slowdown = 4
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -51,8 +51,8 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 	)
-	online_slowdown = 3
-	offline_slowdown = 9
+	online_slowdown = 2
+	offline_slowdown = 4
 	vision_restriction = TINT_MODERATE
 	offline_vision_restriction = TINT_BLIND
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
@@ -114,7 +114,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	online_slowdown = 0
+	online_slowdown = 0.75
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/eva
@@ -191,7 +191,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	online_slowdown = 0
+	online_slowdown = 0.75
 	offline_vision_restriction = TINT_HEAVY
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE // this is passed to the rig suit components when deployed, including the helmet.
 
@@ -265,7 +265,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	online_slowdown = 1
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/hazmat
@@ -329,7 +328,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	online_slowdown = 0
+	online_slowdown = 0.5
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/medical
@@ -399,8 +398,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 	)
-	online_slowdown = 1
-	offline_slowdown = 3
 	offline_vision_restriction = TINT_BLIND
 
 	chest_type = /obj/item/clothing/suit/space/rig/hazard

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -162,4 +162,4 @@
 
 /obj/item/clothing/suit/space/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
+	slowdown_per_slot[slot_wear_suit] = 0.5

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -50,11 +50,13 @@
 //Black syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black
 	name = "black space helmet"
+	desc = "A black helmet sporting clean lines and durable plating."
 	icon_state = "syndicate-helm-black"
 	item_state = "syndicate-helm-black"
 
 /obj/item/clothing/suit/space/syndicate/black
 	name = "black space suit"
+	desc = "A black spacesuit sporting clean lines and durable plating."
 	icon_state = "syndicate-black"
 	item_state_slots = list(
 		slot_l_hand_str = "syndicate-black",

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -59,9 +59,6 @@
 		SPECIES_VOX = 'icons/obj/clothing/species/vox/obj_suit_vox.dmi'
 		)
 
-/obj/item/clothing/suit/space/void/merc/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
 
 /obj/item/clothing/suit/space/void/merc/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/merc

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -17,10 +17,6 @@
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0.6
 
-/obj/item/clothing/suit/space/void/swat/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
-
 //Skrell space gear. Sleek like a wetsuit.
 /obj/item/clothing/head/helmet/space/void/skrell
 	name = "Skrellian helmet"

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -41,10 +41,6 @@
 		)
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
 
-/obj/item/clothing/suit/space/void/engineering/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
-
 /obj/item/clothing/suit/space/void/engineering/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering
 	boots = /obj/item/clothing/shoes/magboots
@@ -254,7 +250,7 @@
 
 /obj/item/clothing/suit/space/void/engineering/alt/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 2
+	slowdown_per_slot[slot_wear_suit] = 1.25
 
 /obj/item/clothing/suit/space/void/engineering/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering/alt
@@ -305,7 +301,7 @@
 
 /obj/item/clothing/suit/space/void/medical/alt/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0
+	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /obj/item/clothing/suit/space/void/medical/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/medical/alt
@@ -452,6 +448,10 @@
 /obj/item/clothing/suit/space/void/pilot/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/pilot
 	boots = /obj/item/clothing/shoes/magboots
+
+/obj/item/clothing/suit/space/void/pilot/Initialize()
+	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 0.75
 
 //Retro
 /obj/item/clothing/suit/space/void/retro

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -87,6 +87,7 @@ else if(##equipment_var) {\
 
 /obj/item/clothing/suit/space/void/Initialize()
 	. = ..()
+	slowdown_per_slot[slot_wear_suit] = 1
 	VOIDSUIT_INIT_EQUIPMENT(boots,  /obj/item/clothing/shoes/magboots)
 	VOIDSUIT_INIT_EQUIPMENT(helmet, /obj/item/clothing/head/helmet)
 	VOIDSUIT_INIT_EQUIPMENT(tank,   /obj/item/tank)

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -43,10 +43,6 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS
 
-/obj/item/clothing/suit/space/void/wizard/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
-
 /obj/item/clothing/gloves/wizard
 	name = "mystical gloves"
 	desc = "Reinforced, gem-studded gloves that radiate energy. They look like they go along with a matching voidsuit."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -101,9 +101,6 @@
 	blood_overlay_type = "armor"
 	armor = null
 
-/obj/item/clothing/suit/armor/reactive/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
 
 /obj/item/clothing/suit/armor/reactive/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(prob(50))
@@ -453,10 +450,6 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0
-
-/obj/item/clothing/suit/armor/heavy/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 3
 
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/suit/bio_suit/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 1
+	slowdown_per_slot[slot_wear_suit] = 0.75
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -61,9 +61,6 @@
 	)
 	w_class = ITEM_SIZE_HUGE//bulky item
 
-/obj/item/clothing/suit/fire/heavy/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /*
  * Bomb protection
@@ -107,7 +104,7 @@
 
 /obj/item/clothing/suit/bomb_suit/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 2
+	slowdown_per_slot[slot_wear_suit] = 1.25
 
 /obj/item/clothing/head/bomb_hood/security
 	icon_state = "bombsuitsec"
@@ -160,4 +157,4 @@
 
 /obj/item/clothing/suit/radiation/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_shoes] = 1.5
+	slowdown_per_slot[slot_shoes] = 0.75

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -19,8 +19,8 @@
 	cell = /obj/item/cell/hyper
 	capacitor = /obj/item/stock_parts/capacitor/adv
 	gun_unreliable = 0
-	var/slowdown_held = 3
-	var/slowdown_worn = 2
+	var/slowdown_held = 2
+	var/slowdown_worn = 1
 
 /obj/item/gun/magnetic/railgun/Initialize()
 	slowdown_per_slot[slot_l_hand] =  slowdown_held
@@ -113,9 +113,6 @@
 	capacitor = /obj/item/stock_parts/capacitor/super
 
 	fire_delay =  8
-	slowdown_held = 4
-
-	slowdown_worn = 3
 
 	slot_flags = SLOT_BACK
 	w_class = ITEM_SIZE_NO_CONTAINER
@@ -173,7 +170,6 @@
 	one_hand_penalty = 3
 	fire_delay = 10
 	slowdown_held = 1
-	slowdown_worn = 1
 	removable_components = FALSE
 	cell = /obj/item/cell/hyper
 	capacitor = /obj/item/stock_parts/capacitor/adv

--- a/code/modules/skrell/skrell_rigs.dm
+++ b/code/modules/skrell/skrell_rigs.dm
@@ -60,8 +60,8 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	online_slowdown = 0
-	offline_slowdown = 1
+	online_slowdown = 0.75
+	offline_slowdown = 2
 	equipment_overlay_icon = null
 	air_type = /obj/item/tank/skrell
 	cell_type = /obj/item/cell/skrell

--- a/code/modules/spells/targeted/equip/dyrnwyn.dm
+++ b/code/modules/spells/targeted/equip/dyrnwyn.dm
@@ -25,8 +25,8 @@
 	W.SetName("\improper Dyrnwyn")
 	W.damtype = DAMAGE_BURN
 	W.hitsound = 'sound/items/welder2.ogg'
-	W.slowdown_per_slot[slot_l_hand] = 1
-	W.slowdown_per_slot[slot_r_hand] = 1
+	W.slowdown_per_slot[slot_l_hand] = 0.25
+	W.slowdown_per_slot[slot_r_hand] = 0.25
 	return W
 
 /spell/targeted/equip_item/dyrnwyn/empower_spell()

--- a/maps/torch/items/clothing/solgov-suit.dm
+++ b/maps/torch/items/clothing/solgov-suit.dm
@@ -586,7 +586,7 @@
 
 /obj/item/clothing/suit/space/void/command/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0
+	slowdown_per_slot[slot_wear_suit] = 0.75
 
 /obj/item/clothing/suit/space/void/command/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/command

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -20,8 +20,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	online_slowdown = 0.50
-	offline_slowdown = 2
+	online_slowdown = 0.75
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/command
@@ -331,8 +330,6 @@
 	glove_type = /obj/item/clothing/gloves/rig/command/exploration
 
 
-	online_slowdown = 0.50
-	offline_slowdown = 4
 	offline_vision_restriction = TINT_BLIND
 
 	req_access = list(access_pathfinder)


### PR DESCRIPTION
:cl:
tweak: Rebalanced all item/clothing based slowdowns to be less punishing and make a bit more relative sense for suits.
/:cl:

Changes slowdown on everything to punish less where it's
over-punishing, punish more where it's under-punishing,
make softsuits always preferable for speed, and generally
normalize the impact of wearing different stuff.

__all softsuits have a slowdown of 0.5 (from 1), except__
- emergency softsuits, at 1 (from 3)

__all voidsuits have a slowdown of 1 (from 1), except__
- streamlined medical voidsuits, at 0.5 (from 0)
- pilot voidsuits, at 0.75 (from 1)
- command voidsuits, at 0.75 (from 0)
- reinforced engineering voidsuits, at 1.25 (from 2)

__all rigs have a slowdown of **off**: 3 / **on**: 1 (from 3 / 0), except__
- the eva rig, at 3 / 0.75 (from 3 / 0)
- the CE rig, at 3 / 0.75 (from 3 / 0)
- the rescue suit, at 3 / 0.5 (from 3 / 0)
- the null suit, at 1 / 0 (unchanged)
- the internal affairs rig, at 0 / 0 (unchanged)
- the industrial rig, at 4 / 2 (from 9 / 3)
- the merc heavy rig, at 4 / 2 (from 4 / 3)
- the ninja rig, at 1 / 0 (from 0* / 0)
- other light rigs (hacker, stealth, "light"), at 1 / 0.5 (from 0* / 0)
- skrell rigs, at 2 / 0.75 (from 1 / 0)
- basic unathi rig, at 4 / 3 (from 10 / 6)
- fancy unathi rig, at 4 / 2 (from 10 / 6)

\* offline slowdown for light rigs was intended to be 3 but was set to 0 by a flub

__additionally__
- biosuits are 0.75 (from 1)
- radsuits are 0.75 (from 1.5)
- bombsuits are 1.25 (from 2)
- riot shields are 0.5 (from 1.5)
- galoshes are 0.5 (from 1)

- the wizard familiar sword is 0.25 (from 1)
- railguns are held: 2, worn: 1 (from 3/2 and 4/3)