### PR TITLE
remove /mask subtype from loadout, fixes related oddness

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -145,11 +145,6 @@
 	path = /obj/item/haircomb
 	flags = GEAR_HAS_COLOR_SELECTION
 
-/datum/gear/mask
-	display_name = "sterile mask"
-	path = /obj/item/clothing/mask/surgical
-	cost = 2
-
 /datum/gear/smokingpipe
 	display_name = "pipe, smoking"
 	path = /obj/item/clothing/mask/smokable/pipe

--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -86,7 +86,7 @@
 	sort_category = "Xenowear"
 
 // IPC clothing
-/datum/gear/mask/ipc_monitor
+/datum/gear/ipc_monitor
 	display_name = "display monitor (IPC)"
 	path = /obj/item/clothing/mask/monitor
 	sort_category = "Xenowear"
@@ -162,7 +162,7 @@
 	whitelisted = list(SPECIES_UNATHI, SPECIES_YEOSA)
 
 // Vox clothing
-/datum/gear/mask/gas/vox
+/datum/gear/vox_mask
 	display_name = "vox breathing mask"
 	path = /obj/item/clothing/mask/gas/vox
 	sort_category = "Xenowear"

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -63,8 +63,9 @@
 /datum/gear/head/beret
 	allowed_branches = CIVILIAN_BRANCHES
 
-/datum/gear/mask/bandana
-	allowed_branches = CIVILIAN_BRANCHES
+/datum/gear/sterile_mask
+	display_name = "sterile mask"
+	path = /obj/item/clothing/mask/surgical
 
 /datum/gear/head/bandana
 	allowed_branches = CIVILIAN_BRANCHES


### PR DESCRIPTION
:cl:
bugfix: Fleet can have surgical masks.
:cl:
