### PR TITLE
Increases max_desc_len to 256 chars

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -62,7 +62,7 @@
 #define MAX_BOOK_MESSAGE_LEN  18432
 #define MAX_LNAME_LEN         64
 #define MAX_NAME_LEN          26
-#define MAX_DESC_LEN          128
+#define MAX_DESC_LEN          256
 #define MAX_TEXTFILE_LENGTH 128000		// 512GQ file
 
 // Event defines.


### PR DESCRIPTION
:cl: Ryan180602
tweak: Increases max_desc_len to 256 chars. Custom descriptions are longer.
/:cl: