### PR TITLE
Fixes a bad var

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -214,7 +214,7 @@
 
 /obj/item/stack/tile/stone
 	name = "stone slabs"
-	singular name = "stone slab"
+	singular_name = "stone slab"
 	desc = "A smooth, flat slab of some kind of stone."
 	icon_state = "tile_stone"
 


### PR DESCRIPTION
why does this compile
w̶h̵y̵ ̸d̶o̸e̵s̶ ̵t̵h̶i̷s̷ ̶c̸o̸m̴p̷i̷l̴e̸
̵w̶͔͉͛͐h̸͖̼͖͊ỳ̵̢͐͠ ̷̢͔̼͍́̅͋d̷̠̼̺͕̄͑̋o̸̦͚͒̌̍̚ę̵͚͈͔̒ş̶̛̲̹̟͒̋͒ ̴̢̩͋͘ͅͅt̵͖̣̋͑͐h̷̛͎̘̜͛̓̐ì̸̧̪͐͆s̶̼̺̞̈́̂̈͠ͅ ̶͈̞̀̌̽̏c̶͈̈̋͠o̷̲͕̚̚m̷̤̗͇̍̓̂͝p̸̡̩͓͎̎i̴͇͎̽̎́̿ḷ̶̥̍͋̆̂e̶͙̜̤͐͊͝
̴̯̌̽w̵̨̰̩͉̚h̸͈̞͚̒̏͒̈́͒y̸̥̺̏̃͋̾̇̈̾͘ ̴̖̾͊̐̚̕͠͝d̷̨̪̝̭̳̹̪̭̾ő̷͈͍̹̟̺̥̂̇́e̵͎̗̼͂͑ͅs̶̛̳̈́́̾̀͂͘̚ ̴̨͈̤͕̬͈͛t̴̺̱̺̂͋̈́̇̓h̸̤̫̭̤̍̐͆͌̀͆̈̌i̸̡͔͓͇̥̫̳͌̂͊̊͛s̶̼͒̈͆ͅ ̸̘͔̯̫͎͌̇c̸̡̳̜̰͆̒̀̔̋̇̅̌͜ở̴̟͍̬̣̥̓̄͋̈͑͝m̷̢͈̻̹̌̈̅̈́̽͌͋ͅp̸̛̙̃̇͋́̈́̌ȉ̴͈͠l̵̪̝͈̦̓̉́ę̶̠͊́͊͗
̶̗̗̈͂ŵ̷̡̤͎̗̣̽̆̽͗͗̏̿͘͘ḧ̴̡̞̜̝͔̭̮͖͎͙͎͍̺̥̌̄̋̾̂y̴̧͓̮̖̺̳̫̙͓̯͇͒̒̈́͝ ̵̧̢̩̥͉̪͉͓̦͈̩̏̽̆̀̃͒̋̐̂͒͆͘͘͘͜d̷̰͈͚̻̼͚͕̻̝̅̆̀̉̀̎͛͌͘͘͘͝o̵̢͕͇͈̱͎̣̬͑̔̎͋̉́͜ȅ̴̛̲̹͗̎́̄͑̋̓͛͌͠s̵̼̱̯̙̺̟̍͌̔͂̍̏̚͜͝ ̴͚͖̤̗̼̝͑̄̌̿̈́̎̂̔̀̏̊̕t̵̻̘̖̠̲͚̻̗̃͒͋͜ͅh̴̗̫̦̳̱̳̞̭̼͉͕̓͒͜ͅî̶̡̜͎̞̞̞͉͇̥̦͉̺͓̫͝ş̵̰͎̼̲̠͇̂̉̊̌̇́̀̄̍̑̚͝͠ ̵̬̯̤̆̓̇̀̌͜͠c̵̬̹̘̜̟̑o̶͇̬͙͆̍̍̽͒̈́ṁ̵̢̬͇̗̞̜͉̣̥̺̓͑̒̓p̵̠̩̞̳͚͙͖̠͆̓̕į̸̧̠̥͍̗͕͘͠l̷̳̬̗̝̮̯͉̼͔̯͍̒̅̋̀͋̎̆̑̋̏̋́ͅe̸̛̪̼̱̭̠̬̬͚͈͗̒͌̂̔̄̊̏̂͌̃͘͜

̴̧̛̛̟̗̪̝̺̹͊̇̂̇͛̓̀̈́̎̂̇́̒̅̃̚̚͜͝




More seriously, changes this var override to match its actual var name of `singular_name`. Found this by attempting to get bay to compile in OpenDream.