### PR TITLE
say things

### DIFF
--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -140,6 +140,7 @@
 	#define EYE_GLOW_LAYER         1
 	#define BEAM_PROJECTILE_LAYER  2
 	#define SUPERMATTER_WALL_LAYER 3
+	#define SPEECH_INDICATOR_LAYER 4
 
 #define FULLSCREEN_PLANE                5 // for fullscreen overlays that do not cover the hud.
 

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -129,14 +129,18 @@ var/global/list/_client_preferences_by_type
 	options = list(GLOB.PREF_ALL_CHATTER, GLOB.PREF_NEARBY)
 
 /datum/client_preference/language_display
-	description = "Display Language Names"
+	description = "Show Language Names"
 	key = "LANGUAGE_DISPLAY"
 	options = list(GLOB.PREF_SHORTHAND, GLOB.PREF_FULL, GLOB.PREF_OFF)
+
+/datum/client_preference/ghost_language_hide
+	description = "Hide Language Names As Ghost"
+	key = "LANGUAGE_DISPLAY_GHOST"
 
 /datum/client_preference/ghost_follow_link_length
 	description = "Ghost Follow Links"
 	key = "CHAT_GHOSTFOLLOWLINKLENGTH"
-	options = list(GLOB.PREF_SHORT, GLOB.PREF_LONG)
+	options = list(GLOB.PREF_SHORT, GLOB.PREF_LONG, GLOB.PREF_OFF)
 
 /datum/client_preference/chat_tags
 	description = "Chat tags"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -1,94 +1,115 @@
-// At minimum every mob has a hear_say proc.
-
-/mob/proc/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
-	if(!client)
+/mob/proc/hear_say(message, verb = "says", datum/language/language, alt_name, italics, mob/speaker, sound/speech_sound, sound_vol)
+	if (!client)
 		return
 
-	if(speaker && !speaker.client && isghost(src) && get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH && !(speaker in view(src)))
-			//Does the speaker have a client?  It's either random stuff that observers won't care about (Experiment 97B says, 'EHEHEHEHEHEHEHE')
-			//Or someone snoring.  So we make it where they won't hear it.
-		return
+	var/is_ghost = isghost(src)
+	var/in_view = (speaker in view(src))
 
-	if(language && (language.flags & (NONVERBAL|SIGNLANG)))
-		sound_vol = 0
-		speech_sound = null
-
-	//make sure the air can transmit speech - hearer's side
-	var/turf/T = get_turf(src)
-	if ((T) && (!(isghost(src)))) //Ghosts can hear even in vacuum.
-		var/datum/gas_mixture/environment = T.return_air()
-		var/pressure = (environment)? environment.return_pressure() : 0
-		if(pressure < SOUND_MINIMUM_PRESSURE && get_dist(speaker, src) > 1)
+	if (is_ghost)
+		if (!in_view && !speaker?.client)
 			return
 
-		if (pressure < ONE_ATMOSPHERE*0.4) //sound distortion pressure, to help clue people in that the air is thin, even if it isn't a vacuum yet
-			italics = 1
-			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
+	var/pressure = 0
+	var/turf/turf = get_turf(src)
 
-	if(sleeping || stat == UNCONSCIOUS)
-		hear_sleep(message)
+	if (turf)
+		var/datum/gas_mixture/air = turf.return_air()
+		if (air)
+			pressure = air.return_pressure()
+
+	var/distance = get_dist(speaker, turf)
+
+	if (pressure < ONE_ATMOSPHERE * 0.5)
+		if (pressure < SOUND_MINIMUM_PRESSURE)
+			if (distance > 1 && !is_ghost)
+				return
+			speech_sound = null
+		else
+			sound_vol *= 0.5
+		italics = TRUE
+
+	var/non_verbal = language?.flags & (NONVERBAL | SIGNLANG)
+	var/do_stars
+
+	var/display_name = "Unknown"
+	if (ishuman(speaker))
+		var/mob/living/carbon/human/human = speaker
+		display_name = human.GetVoice()
+	else if (speaker)
+		display_name = speaker.name
+
+	if (non_verbal)
+		if (!speaker || (sdisabilities & BLINDED) || blinded || !in_view)
+			do_stars = TRUE
+		speech_sound = null
+	else if (is_deaf() || get_sound_volume_multiplier() < 0.2)
+		if (!(language?.flags & INNATE))
+			if (speaker == src)
+				to_chat(src, SPAN_WARNING("You cannot hear yourself speak!"))
+			else if (!is_blind())
+				to_chat(src, {"<span class="name">[display_name]</span>[alt_name] says something you cannot hear."})
+			return
+		speech_sound = null
+
+	if (speech_sound && in_view)
+		var/turf/sound_turf = speaker ? get_turf(speaker) : turf
+		if (sound_turf)
+			playsound_local(sound_turf, speech_sound, sound_vol, TRUE)
+
+	var/display_message = message
+
+	if (!(language?.flags & INNATE) && !say_understands(speaker, language))
+		if (!istype(speaker, /mob/living/simple_animal))
+			if (language)
+				display_message = language.scramble(display_message, languages)
+			else
+				do_stars = TRUE
+
+	if (do_stars)
+		display_message = stars(display_message)
+
+	if ((sleeping || stat == UNCONSCIOUS) && !non_verbal)
+		hear_sleep(display_message)
 		return
 
-	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
-	if (language && (language.flags & NONVERBAL))
-		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
-			message = stars(message)
+	if (italics)
+		display_message = "<i>[display_message]</i>"
 
-	if(!(language && (language.flags & INNATE))) // skip understanding checks for INNATE languages
-		if(!say_understands(speaker,language))
-			if(!istype(speaker,/mob/living/simple_animal))
-				if(language)
-					message = language.scramble(message, languages)
-				else
-					message = stars(message)
+	var/display_controls
+	if (is_ghost)
+		if (display_name != speaker.real_name && speaker.real_name)
+			display_name = "[speaker.real_name] ([display_name])"
+		if (in_view && get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
+			display_message = "<b>[display_message]</b>"
+		var/control_preference = get_preference_value(/datum/client_preference/ghost_follow_link_length)
+		switch (control_preference)
+			if (GLOB.PREF_SHORT)
+				display_controls = "([ghost_follow_link(speaker, src)])"
+			if (GLOB.PREF_LONG)
+				display_controls = "([ghost_follow_link(speaker, src, short_links = FALSE)])"
 
-	var/speaker_name = "Unknown"
-	if(speaker)
-		speaker_name = speaker.name
-
-	if(istype(speaker, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = speaker
-		speaker_name = H.GetVoice()
-
-	if(italics)
-		message = "<i>[message]</i>"
-
-	var/track = null
-	if(isghost(src))
-		if(speaker_name != speaker.real_name && speaker.real_name)
-			speaker_name = "[speaker.real_name] ([speaker_name])"
-		track = "([ghost_follow_link(speaker, src)]) "
-		if(get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH && (speaker in view(src)))
-			message = "<b>[message]</b>"
-
-	if(is_deaf() || get_sound_volume_multiplier() < 0.2)
-		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
-			if(speaker == src)
-				to_chat(src, "<span class='warning'>You cannot hear yourself speak!</span>")
-			else if(!is_blind())
-				to_chat(src, "<span class='name'>[speaker_name]</span>[alt_name] talks but you cannot hear \him.")
+	var/display_verb = verb
+	if (!language)
+		display_message = {"[display_verb], <span class="message"><span class="body">"[display_message]"</span></span>"}
 	else
-		if (language)
-			var/nverb = verb
-			if (say_understands(speaker, language))
-				var/skip = FALSE
-				if (isliving(src))
-					var/mob/living/L = src
-					skip = L.default_language == language
-				if (!skip)
-					switch(src.get_preference_value(/datum/client_preference/language_display))
-						if(GLOB.PREF_FULL) // Full language name
-							nverb = "[verb] in [language.name]"
-						if(GLOB.PREF_SHORTHAND) //Shorthand codes
-							nverb = "[verb] ([language.shorthand])"
-						if(GLOB.PREF_OFF)//Regular output
-							nverb = verb
-			on_hear_say("<span class='game say'>[track]<span class='name'>[speaker_name]</span>[alt_name] [language.format_message(message, nverb)]</span>")
-		else
-			on_hear_say("<span class='game say'>[track]<span class='name'>[speaker_name]</span>[alt_name] [verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
-		if (speech_sound && (get_dist(speaker, src) <= world.view && src.z == speaker.z))
-			var/turf/source = speaker? get_turf(speaker) : get_turf(src)
-			src.playsound_local(source, speech_sound, sound_vol, 1)
+		var/hint_preference = get_preference_value(/datum/client_preference/language_display)
+		if (is_ghost)
+			if (hint_preference != GLOB.PREF_OFF)
+				if (get_preference_value(/datum/client_preference/ghost_language_hide) == GLOB.PREF_YES)
+					hint_preference = GLOB.PREF_OFF
+		else if (say_understands(speaker, language) && isliving(src))
+			var/mob/living/living = src
+			if (living.default_language == language)
+				hint_preference = GLOB.PREF_OFF
+		switch (hint_preference)
+			if (GLOB.PREF_FULL)
+				display_verb = "[verb] in [language.name]"
+			if (GLOB.PREF_SHORTHAND)
+				display_verb = "[verb] ([language.shorthand])"
+		display_message = language.format_message(display_message, display_verb)
+
+	on_hear_say({"<span class="game say">[display_controls]<span class="name">[display_name]</span>[alt_name] [display_message]</span>"})
+
 
 /mob/proc/on_hear_say(var/message)
 	to_chat(src, message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -277,22 +277,6 @@ var/global/list/channel_to_radio_key = new
 
 		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj, /datum/client_preference/ghost_ears)
 
-
-	var/speech_bubble_test = say_test(message)
-	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"h[speech_bubble_test]")
-	speech_bubble.layer = layer
-	speech_bubble.plane = plane
-	speech_bubble.alpha = 0
-	// VOREStation Port - Attempt Multi-Z Talking
-	// for (var/atom/movable/AM in get_above_oo())
-	// 	var/turf/ST = get_turf(AM)
-	// 	if(ST)
-	// 		get_mobs_and_objs_in_view_fast(ST, world.view, listening, listening_obj, /datum/client_preference/ghost_ears)
-	// 		var/image/z_speech_bubble = image('icons/mob/talk.dmi', AM, "h[speech_bubble_test]")
-	// 		QDEL_IN(z_speech_bubble, 30)
-
-	// VOREStation Port End
-
 	var/list/speech_bubble_recipients = list()
 	for(var/mob/M in listening)
 		if(M)
@@ -329,12 +313,19 @@ var/global/list/channel_to_radio_key = new
 	else
 		log_say("[name]/[key] : [message]")
 
-	flick_overlay(speech_bubble, speech_bubble_recipients, 50)
-	animate(speech_bubble, alpha = 255, time = 10, easing = CIRCULAR_EASING)
-	animate(time = 20)
-	animate(alpha = 0, pixel_y = 12, time = 20, easing = CIRCULAR_EASING)
-
+	if (length(speech_bubble_recipients))
+		var/speech_intent = say_test(message)
+		var/image/speech_bubble = image('icons/mob/talk.dmi', src, "h[speech_intent]")
+		speech_bubble.blend_mode = BLEND_OVERLAY
+		speech_bubble.layer = SPEECH_INDICATOR_LAYER
+		speech_bubble.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+		speech_bubble.alpha = 0
+		flick_overlay(speech_bubble, speech_bubble_recipients, 3 SECONDS)
+		animate(speech_bubble, alpha = 255, time = 1 SECOND, easing = QUAD_EASING)
+		animate(time = 1 SECOND)
+		animate(alpha = 0, pixel_y = 8, time = 1 SECOND, easing = QUAD_EASING)
 	return 1
+
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)
 	for (var/mob/O in viewers(src, null))

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -10,6 +10,8 @@ I IS TYPIN'!'
 	follow_proc = /atom/movable/proc/move_to_turf_or_null
 	icon = 'icons/mob/talk.dmi'
 	icon_state = "typing"
+	plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	layer = SPEECH_INDICATOR_LAYER
 
 /atom/movable/overlay/typing_indicator/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl:
tweak: Typing indicators and speech bubbles appear over lighting.
tweak: There is a preference for seeing language names as a ghost.
/:cl:

Refactors hear_say a bit. Should avoid some stuff like multi-starring.