### PR TITLE
game does not pass the lobby without ready players

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -90,6 +90,9 @@
 	/// Length of time before round start when autogamemode vote is called (in seconds, default 100).
 	var/static/vote_autogamemode_timeleft = 100
 
+	/// Length of time before round start (in seconds)
+	var/static/pre_game_time = 180
+
 	/// vote does not default to nochange/norestart (tbi)
 	var/static/vote_no_default = FALSE
 
@@ -569,6 +572,8 @@
 					log_misc("Invalid vote_autotransfer_interval: [value]")
 			if ("vote_autogamemode_timeleft")
 				vote_autogamemode_timeleft = text2num(value)
+			if ("pre_game_time")
+				pre_game_time = text2num(value)
 			if ("ert_admin_only")
 				ert_admin_call_only = TRUE
 			if ("respawn_delay")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -143,8 +143,13 @@ VOTE_AUTOTRANSFER_INITIAL 120
 # using seven semicolon (;) separated values allows for different weekday-based values
 VOTE_AUTOTRANSFER_INTERVAL 30
 
+
 ## Time left (seconds) before round start when automatic gamemote vote is called (default 160).
 VOTE_AUTOGAMEMODE_TIMELEFT 160
+
+## Time (seconds) before the server will attempt to start a round.
+# Should be bigger than VOTE_AUTOGAMEMODE_TIMELEFT + VOTE_PERIOD.
+PRE_GAME_TIME 180
 
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -30,7 +30,7 @@ exactly 2 "/datum text paths" '"/datum'
 exactly 2 "/mob text paths" '"/mob'
 exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
-exactly 117 "to_world uses" '\sto_world\('
+exactly 118 "to_world uses" '\sto_world\('
 exactly 0 "globals with leading /" '^/var' -P
 exactly 0 "globals without global sugar" '^var/(?!global/)' -P
 exactly 0 "apparent paths with trailing /" '\w/[,\)\n]' -P


### PR DESCRIPTION
When nobody is connected, the game resets to vote length + 60 seconds when it would normally do a vote. When nobody is ready, the game resets to vote length + 30 seconds and re-does the vote. Adjusted other return to lobby conditions to be a bit shorter too. Adds configuration for pre game time. Default's the same as live.