### PR TITLE
Fix psychokinesis hand abilities not working

### DIFF
--- a/code/modules/psionics/mob/mob_interactions.dm
+++ b/code/modules/psionics/mob/mob_interactions.dm
@@ -10,9 +10,9 @@
 					LAZYADD(holder.psi.manifested_items, result); \
 					holder.put_in_hands(result); \
 				} \
-				return return_on_invocation; \
 			} \
 		} \
+		return return_on_invocation; \
 	}
 
 /mob/living/UnarmedAttack(var/atom/A, var/proximity)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed psychokinesis in-hand abilities (tools, psyblade) not working. 
/:cl: