### PR TITLE
Don't ignore whitespace diffs in VSC config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,5 +41,6 @@
 
   "gitlens.advanced.blame.customArguments": [
     "--ignore-revs-file", ".git-blame-ignore-revs"
-  ]
+],
+"diffEditor.ignoreTrimWhitespace": false
 }


### PR DESCRIPTION
NUFC.

Whitespace is very important to DM parsing.