### PR TITLE
Adds prosthetic groin to the prosthetic organ fabricator

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -121,6 +121,7 @@
 		BP_R_FOOT   = list(/obj/item/organ/external/foot/right, 40),
 		BP_L_HAND   = list(/obj/item/organ/external/hand,       40),
 		BP_R_HAND   = list(/obj/item/organ/external/hand/right, 40),
+		BP_GROIN    = list(/obj/item/organ/external/groin,      75),
 		BP_CELL		= list(/obj/item/organ/internal/cell, 25)
 		)
 


### PR DESCRIPTION
:cl: Rootoo807
tweak: Prosthetic organ fabricator can print lower bodies. 
/:cl:

Lower bodies were previously only available in the bioprinter, so currently they can't be replaced (without some ugly workaround like printing a whole FBP and stealing it's lower body, anyways). 