### PR TITLE
Area code formatting refactor

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -76,14 +76,6 @@
 
 #define DEFAULT_JOB_TYPE /datum/job/assistant
 
-//Area flags, possibly more to come
-#define AREA_FLAG_RAD_SHIELDED         FLAG(0)  // shielded from radiation, clearly
-#define AREA_FLAG_EXTERNAL             FLAG(1)  // External as in exposed to space, not outside in a nice, green, forest
-#define AREA_FLAG_ION_SHIELDED         FLAG(2)  // shielded from ionospheric anomalies as an FBP / IPC
-#define AREA_FLAG_IS_NOT_PERSISTENT    FLAG(3)  // SSpersistence will not track values from this area.
-#define AREA_FLAG_NO_MODIFY            FLAG(4)  // turf in this area cannot be dismantled.
-#define AREA_FLAG_HIDE_FROM_HOLOMAP    FLAG(5) // if we shouldn't be drawn on station holomaps
-
 //Map template flags
 #define TEMPLATE_FLAG_ALLOW_DUPLICATES    FLAG(0)  // Lets multiple copies of the template to be spawned
 #define TEMPLATE_FLAG_SPAWN_GUARANTEED    FLAG(1)  // Makes it ignore away site budget and just spawn (only for away sites)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -631,12 +631,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 				atoms += A
 	return atoms
 
+/**
+ * Attempts to move the contents of one area to another area.
+ *
+ * **Parameters**:
+ * - `A` `/area` - The area to move the contents to.
+ */
 /area/proc/move_contents_to(var/area/A)
-	//Takes: Area.
-	//Returns: Nothing.
-	//Notes: Attempts to move the contents of one area to another area.
-	//       Movement based on lower left corner.
-
 	if(!A || !src) return
 
 	var/list/turfs_src = get_area_turfs("\ref[src]")

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -637,16 +637,18 @@ Turf and target are seperate in case you want to teleport some distance from a t
  * **Parameters**:
  * - `A` `/area` - The area to move the contents to.
  */
-/area/proc/move_contents_to(var/area/A)
-	if(!A || !src) return
+/area/proc/move_contents_to(area/A)
+	if (!A)
+		return
 
-	var/list/turfs_src = get_area_turfs("\ref[src]")
+	var/list/turfs_src = get_area_turfs(src)
 
-	if(!turfs_src.len) return
+	if (!turfs_src.len)
+		return
 
 	//figure out a suitable origin - this assumes the shuttle areas are the exact same size and shape
 	//might be worth doing this with a shuttle core object instead of areas, in the future
-	var/src_origin = locate(src.x, src.y, src.z)
+	var/src_origin = locate(x, y, z)
 	var/trg_origin = locate(A.x, A.y, A.z)
 
 	if(src_origin && trg_origin)
@@ -693,26 +695,31 @@ Turf and target are seperate in case you want to teleport some distance from a t
  *
  * Returns List (`/atom`). A list containing all atoms that were created at the target area during the process.
  */
-/area/proc/copy_contents_to(var/area/A , var/platingRequired = 0 )
-	if(!A || !src) return 0
+/area/proc/copy_contents_to(area/A, platingRequired = FALSE)
+	if (!A || !src)
+		return FALSE
 
-	var/list/turfs_src = get_area_turfs(src.type)
+	var/list/turfs_src = get_area_turfs(type)
 	var/list/turfs_trg = get_area_turfs(A.type)
 
 	var/src_min_x = 0
 	var/src_min_y = 0
-	for (var/turf/T in turfs_src)
-		if(T.x < src_min_x || !src_min_x) src_min_x	= T.x
-		if(T.y < src_min_y || !src_min_y) src_min_y	= T.y
+	for (var/turf/T as anything in turfs_src)
+		if(T.x < src_min_x || !src_min_x)
+			src_min_x	= T.x
+		if(T.y < src_min_y || !src_min_y)
+			src_min_y	= T.y
 
 	var/trg_min_x = 0
 	var/trg_min_y = 0
-	for (var/turf/T in turfs_trg)
-		if(T.x < trg_min_x || !trg_min_x) trg_min_x	= T.x
-		if(T.y < trg_min_y || !trg_min_y) trg_min_y	= T.y
+	for (var/turf/T as anything in turfs_trg)
+		if(T.x < trg_min_x || !trg_min_x)
+			trg_min_x	= T.x
+		if(T.y < trg_min_y || !trg_min_y)
+			trg_min_y	= T.y
 
 	var/list/refined_src = new/list()
-	for(var/turf/T in turfs_src)
+	for (var/turf/T as anything in turfs_src)
 		refined_src += T
 		refined_src[T] = new/datum/coords
 		var/datum/coords/C = refined_src[T]
@@ -720,7 +727,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		C.y_pos = (T.y - src_min_y)
 
 	var/list/refined_trg = new/list()
-	for(var/turf/T in turfs_trg)
+	for (var/turf/T as anything in turfs_trg)
 		refined_trg += T
 		refined_trg[T] = new/datum/coords
 		var/datum/coords/C = refined_trg[T]
@@ -733,9 +740,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 
 	moving:
-		for (var/turf/T in refined_src)
+		for (var/turf/T as anything in refined_src)
 			var/datum/coords/C_src = refined_src[T]
-			for (var/turf/B in refined_trg)
+			for (var/turf/B as anything in refined_trg)
 				var/datum/coords/C_trg = refined_trg[B]
 				if(C_src.x_pos == C_trg.x_pos && C_src.y_pos == C_trg.y_pos)
 
@@ -770,11 +777,11 @@ Turf and target are seperate in case you want to teleport some distance from a t
 						objs += O
 
 
-					for(var/obj/O in objs)
+					for (var/obj/O as anything in objs)
 						newobjs += DuplicateObject(O , 1)
 
 
-					for(var/obj/O in newobjs)
+					for (var/obj/O as anything in newobjs)
 						O.forceMove(X)
 
 					for(var/mob/M in T)
@@ -782,10 +789,10 @@ Turf and target are seperate in case you want to teleport some distance from a t
 						if(!istype(M,/mob) || !M.simulated) continue // If we need to check for more mobs, I'll add a variable
 						mobs += M
 
-					for(var/mob/M in mobs)
+					for (var/mob/M as anything in mobs)
 						newmobs += DuplicateObject(M , 1)
 
-					for(var/mob/M in newmobs)
+					for (var/mob/M as anything in newmobs)
 						M.forceMove(X)
 
 					copiedobjs += newobjs

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -14,7 +14,7 @@
 	return 0
 
 // Not a sane use of the function and (for now) indicative of an error elsewhere
-/area/Adjacent(var/atom/neighbor)
+/area/Adjacent(atom/neighbor)
 	CRASH("Call to /area/Adjacent(), unimplemented proc")
 
 

--- a/code/controllers/subsystems/holomap.dm
+++ b/code/controllers/subsystems/holomap.dm
@@ -101,7 +101,7 @@ SUBSYSTEM_DEF(minimap)
 			var/area/A
 			if(tile)
 				A = tile.loc
-				if (A.area_flags & AREA_FLAG_HIDE_FROM_HOLOMAP)
+				if (A.area_flags & GLOB.AREA_FLAG_HIDE_FROM_HOLOMAP)
 					continue
 				if(IS_ROCK(tile))
 					continue

--- a/code/controllers/subsystems/initialization/persistence.dm
+++ b/code/controllers/subsystems/initialization/persistence.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(persistence)
 		return
 
 	var/area/A = get_area(T)
-	if(!A || (A.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))
+	if(!A || (A.area_flags & GLOB.AREA_FLAG_IS_NOT_PERSISTENT))
 		return
 
 	if(!(T.z in GLOB.using_map.station_levels) || !initialized)

--- a/code/controllers/subsystems/radiation.dm
+++ b/code/controllers/subsystems/radiation.dm
@@ -78,7 +78,7 @@ SUBSYSTEM_DEF(radiation)
 			continue // Radiation is not multi-z
 		if(source.respect_maint)
 			var/area/A = T.loc
-			if(A.area_flags & AREA_FLAG_RAD_SHIELDED)
+			if(A.area_flags & GLOB.AREA_FLAG_RAD_SHIELDED)
 				continue // In shielded area
 
 		var/dist = get_dist(source.source_turf, T)

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -57,8 +57,8 @@ var/global/const/AALARM_WIRE_AALARM = 16
 
 
 		if(AALARM_WIRE_AALARM)
-			if (A.alarm_area.atmosalert(2, A))
-				A.post_alert(2)
+			if (A.alarm_area.atmosalert(GLOB.AIR_ALARM_LEVEL_DANGER, A))
+				A.post_alert(GLOB.AIR_ALARM_LEVEL_DANGER)
 			A.update_icon()
 
 /datum/wires/alarm/UpdatePulsed(var/index)
@@ -104,6 +104,6 @@ var/global/const/AALARM_WIRE_AALARM = 16
 		if(AALARM_WIRE_AALARM)
 //			log_debug("Aalarm wire pulsed")
 
-			if (A.alarm_area.atmosalert(0, A))
-				A.post_alert(0)
+			if (A.alarm_area.atmosalert(GLOB.AIR_ALARM_LEVEL_SAFE, A))
+				A.post_alert(GLOB.AIR_ALARM_LEVEL_SAFE)
 			A.update_icon()

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -28,7 +28,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	plane = DEFAULT_PLANE
 	layer = BASE_AREA_LAYER
 	luminosity = 0
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	/// Boolean. Whether or not the area's lightswitch is switched to 'On' or 'Off'. Used to synchronize lightswitch buttons. Do not modify directly; Use `./set_lightswitch()` instead.
 	var/lightswitch = TRUE
 
@@ -118,7 +118,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	secure = FALSE
 
 /area/space/atmosalert()
-	return
+	return FALSE
 
 /area/space/fire_alert()
 	return

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -17,8 +17,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area
 	/// Boolean. Whether or not the area has an active fire alarm. Do not modify directly; Use `./fire_alert()` and `./fire_reset()` instead.
 	var/fire = FALSE
-	/// Integer (`0`, `1`, or `2`). Whether or not the area has an active atmosphere alarm and the level of the atmosphere alarm. Do not modify directly; Use `./atmosalert()` instead.
-	var/atmosalm = 0
+	/// Integer (One of `GLOB.AIR_ALARM_LEVEL_*`). Whether or not the area has an active atmosphere alarm and the level of the atmosphere alarm. Do not modify directly; Use `./atmosalert()` instead.
+	var/atmosalm = GLOB.AIR_ALARM_LEVEL_SAFE
 	/// Boolean. Whether or not the area is in 'party light' mode. Do not modify directly; Use `./partyalert()` or `./partyreset()` instead.
 	var/party = FALSE
 	level = null

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -107,7 +107,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	power_equip = FALSE
 	power_environ = FALSE
 	has_gravity = FALSE
-	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_EXTERNAL | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	ambience = list(
 		'sound/ambience/ambispace1.ogg',
 		'sound/ambience/ambispace2.ogg',
@@ -175,7 +175,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	req_access = list(access_brig)
 
 /area/maintenance
-	area_flags = AREA_FLAG_RAD_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED
 	sound_env = TUNNEL_ENCLOSED
 	turf_initializer = /decl/turf_initializer/maintenance
 	forced_ambience = list('sound/ambience/maintambience.ogg')
@@ -225,7 +225,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/shuttle/specops/centcom
 	icon_state = "shuttlered"
 	req_access = list(access_cent_specops)
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/shuttle/syndicate_elite
 	req_access = list(access_syndicate)
@@ -240,7 +240,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Supply Shuttle"
 	icon_state = "shuttle3"
 	req_access = list(access_cargo)
-	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_flags = GLOB.AREA_FLAG_HIDE_FROM_HOLOMAP
 
 /area/syndicate_elite_squad
 	name = "\improper Elite Mercenary Squad"
@@ -257,7 +257,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	requires_power = FALSE
 	sound_env = SMALL_ENCLOSED
 	base_turf = /turf/space
-	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_flags = GLOB.AREA_FLAG_HIDE_FROM_HOLOMAP
 	base_turf_special_handling = TRUE
 
 /*

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -64,7 +64,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	/// Direct reference to the APC installed in the area, if it exists. Automatically updated during the APC's `Initialize()` and `Destroy()` calls.
 	var/obj/machinery/power/apc/apc = null
 	/// LAZYLIST (`/obj/machinery/door/firedoor`). Contains a list of all firedoors within and adjacent to this area. Updated during a firedoor's `Initialize()` and `Destroy()` calls. Do not modify directly.
-	var/list/all_doors = null
+	var/list/all_firedoors = null
 	/// Boolean. Whether or not the area's firedoors are activated (closed). Tied to area alarm processing. Do not modify directly; Use `air_doors_close()` or `air_doors_open()` instead.
 	var/air_doors_activated = FALSE
 	/// List (`file (sounds)`). List of sounds that can be played to mobs in the area as ambience. See `./play_ambience()`.

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -16,11 +16,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area
 	/// Boolean. Whether or not the area has an active fire alarm. Do not modify directly; Use `./fire_alert()` and `./fire_reset()` instead.
-	var/fire = null
+	var/fire = FALSE
 	/// Integer (`0`, `1`, or `2`). Whether or not the area has an active atmosphere alarm and the level of the atmosphere alarm. Do not modify directly; Use `./atmosalert()` instead.
 	var/atmosalm = 0
 	/// Boolean. Whether or not the area is in 'party light' mode. Do not modify directly; Use `./partyalert()` or `./partyreset()` instead.
-	var/party = null
+	var/party = FALSE
 	level = null
 	name = "Unknown"
 	icon = 'icons/turf/areas.dmi'
@@ -30,22 +30,22 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	luminosity = 0
 	mouse_opacity = 0
 	/// Boolean. Whether or not the area's lightswitch is switched to 'On' or 'Off'. Used to synchronize lightswitch buttons. Do not modify directly; Use `./set_lightswitch()` instead.
-	var/lightswitch = 1
+	var/lightswitch = TRUE
 
 	/// Boolean. Whether or not the area is in the 'Evacuation' alert state. Do not modify directly; Use `./readyalert()` or `./readyreset()` instead.
-	var/eject = null
+	var/eject = FALSE
 
 	/// Boolean. Whether or not the area requires power to be considered powered, bypassing all other checks if `TRUE`. This takes priority over `always_unpowered`.
-	var/requires_power = 1
+	var/requires_power = TRUE
 	/// Boolean. Whether or not the area is always considered to be unpowered, bypassing all other area checks if `TRUE`.
-	var/always_unpowered = 0
+	var/always_unpowered = FALSE
 
 	/// Boolean. Whether or not the `EQUIP` power channel is enabled for the area. Updated and used by APCs.
-	var/power_equip = 1
+	var/power_equip = TRUE
 	/// Boolean. Whether or not the `LIGHT` power channel is enabled for the area. Updated and used by APCs.
-	var/power_light = 1
+	var/power_light = TRUE
 	/// Boolean. Whether or not the `ENVIRON` power channel is enabled for the area. Updated and used by APCs.
-	var/power_environ = 1
+	var/power_environ = TRUE
 	/// Integer. Amount of constant use power drain from the `EQUIP` power channel. Do not modify; Use `./power_use_change()` instead.
 	var/used_equip = 0
 	/// Integer. Amount of constant use power drain from the `LIGHT` power channel. Do not modify; Use `./power_use_change()` instead.
@@ -60,15 +60,28 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/oneoff_environ = 0
 
 	/// Boolean. Whether or not the area has gravity. Do not set directly; Use `./gravitychange()` instead.
-	var/has_gravity = 1
+	var/has_gravity = TRUE
 	/// Direct reference to the APC installed in the area, if it exists. Automatically updated during the APC's `Initialize()` and `Destroy()` calls.
 	var/obj/machinery/power/apc/apc = null
 	/// LAZYLIST (`/obj/machinery/door/firedoor`). Contains a list of all firedoors within and adjacent to this area. Updated during a firedoor's `Initialize()` and `Destroy()` calls. Do not modify directly.
 	var/list/all_doors = null
 	/// Boolean. Whether or not the area's firedoors are activated (closed). Tied to area alarm processing. Do not modify directly; Use `air_doors_close()` or `air_doors_open()` instead.
-	var/air_doors_activated = 0
+	var/air_doors_activated = FALSE
 	/// List (`file (sounds)`). List of sounds that can be played to mobs in the area as ambience. See `./play_ambience()`.
-	var/list/ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
+	var/list/ambience = list(
+		'sound/ambience/ambigen1.ogg',
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambigen12.ogg',
+		'sound/ambience/ambigen14.ogg'
+	)
 	/// LAZYLIST (`file (sounds)`). Additional ambience files. These are always played instead of only on probability, are set to loop, and are slightly louder than `ambience` sound files. See `./play_ambience()`.
 	var/list/forced_ambience = null
 	/// Integer (One of the environments defined in `code\game\sound.dm`). Sound environment used for modification of sounds played to mobs in the area.
@@ -89,15 +102,19 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/space
 	name = "\improper Space"
 	icon_state = "space"
-	requires_power = 1
-	always_unpowered = 1
-	dynamic_lighting = 1
-	power_light = 0
-	power_equip = 0
-	power_environ = 0
-	has_gravity = 0
+	always_unpowered = TRUE
+	power_light = FALSE
+	power_equip = FALSE
+	power_environ = FALSE
+	has_gravity = FALSE
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT
-	ambience = list('sound/ambience/ambispace1.ogg','sound/ambience/ambispace2.ogg','sound/ambience/ambispace3.ogg','sound/ambience/ambispace4.ogg','sound/ambience/ambispace5.ogg')
+	ambience = list(
+		'sound/ambience/ambispace1.ogg',
+		'sound/ambience/ambispace2.ogg',
+		'sound/ambience/ambispace3.ogg',
+		'sound/ambience/ambispace4.ogg',
+		'sound/ambience/ambispace5.ogg'
+	)
 	secure = FALSE
 
 /area/space/atmosalert()
@@ -121,8 +138,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/centcom
 	name = "\improper Centcom"
 	icon_state = "centcom"
-	requires_power = 0
-	dynamic_lighting = 0
+	requires_power = FALSE
+	dynamic_lighting = FALSE
 	req_access = list(access_cent_general)
 
 /area/centcom/holding
@@ -171,27 +188,26 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/rnd/xenobiology
 	name = "\improper Xenobiology Lab"
 	icon_state = "xeno_lab"
-	req_access = list(access_xenobiology, access_research)
+	req_access = list(
+		access_xenobiology,
+		access_research
+	)
 
 /area/rnd/xenobiology/cell_1
 	name = "\improper Xenobiology Containment Cell 1"
 	icon_state = "xeno_lab_cell_1"
-	req_access = list(access_xenobiology, access_research)
 
 /area/rnd/xenobiology/cell_2
 	name = "\improper Xenobiology Containment Cell 2"
 	icon_state = "xeno_lab_cell_2"
-	req_access = list(access_xenobiology, access_research)
 
 /area/rnd/xenobiology/cell_3
 	name = "\improper Xenobiology Containment Cell 3"
 	icon_state = "xeno_lab_cell_3"
-	req_access = list(access_xenobiology, access_research)
 
 /area/rnd/xenobiology/cell_4
 	name = "\improper Xenobiology Containment Cell 4"
 	icon_state = "xeno_lab_cell_4"
-	req_access = list(access_xenobiology, access_research)
 
 /area/rnd/xenobiology/xenoflora
 	name = "\improper Xenoflora Lab"
@@ -211,13 +227,14 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	req_access = list(access_cent_specops)
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
+/area/shuttle/syndicate_elite
+	req_access = list(access_syndicate)
+
 /area/shuttle/syndicate_elite/mothership
 	icon_state = "shuttlered"
-	req_access = list(access_syndicate)
 
 /area/shuttle/syndicate_elite/station
 	icon_state = "shuttlered2"
-	req_access = list(access_syndicate)
 
 /area/supply
 	name = "Supply Shuttle"
@@ -237,7 +254,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //All shuttles should now be under shuttle since we have smooth-wall code.
 
 /area/shuttle
-	requires_power = 0
+	requires_power = FALSE
 	sound_env = SMALL_ENCLOSED
 	base_turf = /turf/space
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
@@ -250,8 +267,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Keelin's private beach"
 	icon_state = "beach"
 	luminosity = 1
-	dynamic_lighting = 0
-	requires_power = 0
+	dynamic_lighting = FALSE
+	requires_power = FALSE
 	var/sound/mysound = null
 
 /area/beach/New()

--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -5,11 +5,11 @@
 */
 
 /// Returns boolean. Whether or not the area is considered to have power for the given power channel. See `requires_power` and `always_unpowered` for some area-level overrides.
-/area/proc/powered(var/chan)
+/area/proc/powered(chan)
 	if(!requires_power)
-		return 1
+		return TRUE
 	if(always_unpowered)
-		return 0
+		return FALSE
 	switch(chan)
 		if(EQUIP)
 			return power_equip
@@ -17,10 +17,8 @@
 			return power_light
 		if(ENVIRON)
 			return power_environ
-		if(LOCAL)
-			return FALSE // if you're running on local power, don't come begging for help here.
 
-	return 0
+	return FALSE
 
 /// Called whenever the area's power or power usage state should change.
 /area/proc/power_change()
@@ -30,7 +28,7 @@
 		update_icon()
 
 /// Returns Integer. The total amount of power usage queued for the area from both `used_*` and `oneoff_*` for the given power channel, or all channels if `TOTAL` is passed instead.
-/area/proc/usage(var/chan)
+/area/proc/usage(chan)
 	switch(chan)
 		if(LIGHT)
 			return used_light + oneoff_light
@@ -56,7 +54,7 @@
  * - `amount` Integer. The amount of power to add to the given channel. Use negative numbers to subtract instead.
  * - `chan` Integer (`EQUIP`, `LIGHT`, or `ENVIRON`). The power channel to add the power to.
  */
-/area/proc/use_power(var/amount, var/chan)
+/area/proc/use_power(amount, chan)
 	switch(chan)
 		if(EQUIP)
 			used_equip += amount
@@ -87,7 +85,7 @@
  * - `amount` Integer. The amount of power to add to the given channel. Use negative numbers to subtract instead.
  * - `chan` Integer (`EQUIP`, `LIGHT`, or `ENVIRON`). The power channel to add the power to.
  */
-/area/proc/use_power_oneoff(var/amount, var/chan)
+/area/proc/use_power_oneoff(amount, chan)
 	switch(chan)
 		if(EQUIP)
 			oneoff_equip += amount

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -16,21 +16,21 @@
 	icon_state = ""
 	uid = ++global_uid
 
-	if(!requires_power)
+	if (!requires_power)
 		power_light = FALSE
 		power_equip = FALSE
 		power_environ = FALSE
 
-	if(dynamic_lighting)
-		luminosity = 0
+	if (dynamic_lighting)
+		luminosity = FALSE
 	else
-		luminosity = 1
+		luminosity = TRUE
 
-	if(!requires_power || !apc)
+	if (!requires_power || !apc)
 		power_light = FALSE
 		power_equip = FALSE
 		power_environ = FALSE
-	power_change()		// all machines set to current power level, also updates lighting icon
+	power_change() // all machines set to current power level, also updates lighting icon
 
 	if (turf_initializer)
 		for (var/turf/T in src)
@@ -77,7 +77,7 @@
  *
  * Returns boolean. `TRUE` if the atmosphere alarm level was changed, `FALSE` otherwise.
  */
-/area/proc/atmosalert(danger_level, var/alarm_source)
+/area/proc/atmosalert(danger_level, alarm_source)
 	if (danger_level == 0)
 		GLOB.atmosphere_alarm.clearAlarm(src, alarm_source)
 	else
@@ -85,10 +85,10 @@
 
 	//Check all the alarms before lowering atmosalm. Raising is perfectly fine.
 	for (var/obj/machinery/alarm/AA in src)
-		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted && AA.report_danger_level)
+		if (AA.operable() && !AA.shorted && AA.report_danger_level)
 			danger_level = max(danger_level, AA.danger_level)
 
-	if(danger_level != atmosalm)
+	if (danger_level != atmosalm)
 		if (danger_level < 1 && atmosalm >= 1)
 			//closing the doors on red and opening on green provides a bit of hysteresis that will hopefully prevent fire doors from opening and closing repeatedly due to noise
 			air_doors_open()
@@ -99,22 +99,21 @@
 		for (var/obj/machinery/alarm/AA in src)
 			AA.update_icon()
 
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /// Sets `air_doors_activated` and sets all firedoors in `all_doors` to the closed state. Does nothing if `air_doors_activated` is already set.
 /area/proc/air_doors_close()
-	if(!air_doors_activated)
+	if (!air_doors_activated)
 		air_doors_activated = TRUE
 		if (!LAZYLEN(all_doors))
 			return
 		for (var/obj/machinery/door/firedoor/E as anything in all_doors)
-			if(!E.blocked)
-				if(E.operating)
+			if (!E.blocked)
+				if (E.operating)
 					E.nextstate = FIREDOOR_CLOSED
-				else if(!E.density)
-					spawn(0)
-						E.close()
+				else if (!E.density)
+					INVOKE_ASYNC(E, /obj/machinery/door/firedoor/.proc/close)
 
 /// Clears `air_doors_activated` and sets all firedoors in `all_doors` to the open state. Does nothing if `air_doors_activated` is already cleared.
 /area/proc/air_doors_open()
@@ -127,10 +126,8 @@
 			if(!E.blocked)
 				if(E.operating)
 					E.nextstate = FIREDOOR_OPEN
-				else if(E.density)
-					spawn(0)
-						if(E.can_safely_open())
-							E.open()
+				else if(E.density && E.can_safely_open())
+					INVOKE_ASYNC(E, /obj/machinery/door/firedoor/.proc/open)
 
 
 /// Sets a fire alarm in the area, if one is not already active.
@@ -138,7 +135,6 @@
 	if(!fire)
 		fire = TRUE
 		update_icon()
-		mouse_opacity = 0
 		if (!LAZYLEN(all_doors))
 			return
 		for (var/obj/machinery/door/firedoor/D as anything in all_doors)
@@ -146,15 +142,13 @@
 				if(D.operating)
 					D.nextstate = FIREDOOR_CLOSED
 				else if(!D.density)
-					spawn()
-						D.close()
+					INVOKE_ASYNC(D, /obj/machinery/door/firedoor/.proc/close)
 
 /// Clears an active fire alarm from the area.
 /area/proc/fire_reset()
 	if (fire)
 		fire = FALSE
 		update_icon()
-		mouse_opacity = 0
 		if (!LAZYLEN(all_doors))
 			return
 		for (var/obj/machinery/door/firedoor/D as anything in all_doors)
@@ -163,45 +157,37 @@
 				if(D.operating)
 					D.nextstate = FIREDOOR_OPEN
 				else if(D.density)
-					spawn(0)
-					D.open()
+					INVOKE_ASYNC(D, /obj/machinery/door/firedoor/.proc/open)
 
 /// Sets an active evacuation alarm in the area, if one is not already active.
 /area/proc/readyalert()
 	if(!eject)
 		eject = TRUE
 		update_icon()
-	return
 
 /// Clears an active evacuation alarm from the area.
 /area/proc/readyreset()
 	if(eject)
 		eject = FALSE
 		update_icon()
-	return
 
 /// Sets a party alarm in the area, if one is not already active.
 /area/proc/partyalert()
-	if (!( party ))
+	if (!party)
 		party = TRUE
 		update_icon()
-		mouse_opacity = 0
-	return
 
 /// Clears an active party alarm from the area.
 /area/proc/partyreset()
 	if (party)
 		party = FALSE
-		mouse_opacity = 0
 		update_icon()
 		for(var/obj/machinery/door/firedoor/D in src)
 			if(!D.blocked)
 				if(D.operating)
 					D.nextstate = FIREDOOR_OPEN
 				else if(D.density)
-					spawn(0)
-					D.open()
-	return
+					INVOKE_ASYNC(D, /obj/machinery/door/firedoor/.proc/open)
 
 /area/on_update_icon()
 	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.
@@ -220,7 +206,7 @@
 		icon_state = null
 
 /// Sets the area's light switch state to on or off, in turn turning all lights in the area on or off.
-/area/proc/set_lightswitch(var/new_switch)
+/area/proc/set_lightswitch(new_switch)
 	if(lightswitch != new_switch)
 		lightswitch = new_switch
 		for(var/obj/machinery/light_switch/L in src)
@@ -229,7 +215,7 @@
 		power_change()
 
 /// Calls `set_emergency_lighting(enable)` on all `/obj/machinery/light` in src.
-/area/proc/set_emergency_lighting(var/enable)
+/area/proc/set_emergency_lighting(enable)
 	for(var/obj/machinery/light/M in src)
 		M.set_emergency_lighting(enable)
 
@@ -238,17 +224,19 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /area/Entered(A)
 	..()
-	if(!istype(A,/mob/living))	return
+	if (!isliving(A))
+		return
 
 	var/mob/living/L = A
-	if(!L.ckey)	return
+	if (!L.ckey)
+		return
 
-	if(!L.lastarea)
-		L.lastarea = get_area(L.loc)
 	var/area/newarea = get_area(L.loc)
+	if (!L.lastarea)
+		L.lastarea = newarea
 	var/area/oldarea = L.lastarea
-	if(oldarea.has_gravity != newarea.has_gravity)
-		if(newarea.has_gravity && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
+	if (oldarea.has_gravity != newarea.has_gravity)
+		if (newarea.has_gravity && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
 			thunk(L)
 		L.update_floating()
 
@@ -261,35 +249,36 @@ var/global/list/mob/living/forced_ambiance_list = new
  * **Parameters**:
  * - `L` Instance of `/mob/living`. The mob to play the sound file to.
  */
-/area/proc/play_ambience(var/mob/living/L)
+/area/proc/play_ambience(mob/living/L)
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
-	if(!(L && L.client && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))	return
+	if (!(L?.client && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))
+		return
 
 	var/turf/T = get_turf(L)
-	var/hum = 0
+	var/hum = FALSE
 	if(L.get_sound_volume_multiplier() >= 0.2 && !always_unpowered && power_environ)
 		for(var/obj/machinery/atmospherics/unary/vent_pump/vent in src)
 			if(vent.can_pump())
-				hum = 1
+				hum = TRUE
 				break
 	if(hum)
 		if(!L.client.ambience_playing)
-			L.client.ambience_playing = 1
-			L.playsound_local(T,sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 20, channel = GLOB.ambience_sound_channel))
+			L.client.ambience_playing = TRUE
+			L.playsound_local(T, sound('sound/ambience/shipambience.ogg', TRUE, FALSE, GLOB.ambience_sound_channel, 20))
 	else
 		if(L.client.ambience_playing)
-			L.client.ambience_playing = 0
+			L.client.ambience_playing = FALSE
 			sound_to(L, sound(null, channel = GLOB.ambience_sound_channel))
 
 	if(L.lastarea != src)
 		if(LAZYLEN(forced_ambience))
 			forced_ambiance_list |= L
-			L.playsound_local(T,sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = GLOB.lobby_sound_channel))
+			L.playsound_local(T, sound(pick(forced_ambience), TRUE, FALSE, GLOB.lobby_sound_channel, 25))
 		else	//stop any old area's forced ambience, and try to play our non-forced ones
 			sound_to(L, sound(null, channel = GLOB.lobby_sound_channel))
 			forced_ambiance_list -= L
 	if(ambience.len && prob(5) && (world.time >= L.client.played + 3 MINUTES))
-		L.playsound_local(T, sound(pick(ambience), repeat = 0, wait = 0, volume = 15, channel = GLOB.lobby_sound_channel))
+		L.playsound_local(T, sound(pick(ambience), FALSE, FALSE, GLOB.lobby_sound_channel, 15))
 		L.client.played = world.time
 
 /**
@@ -298,11 +287,12 @@ var/global/list/mob/living/forced_ambiance_list = new
  * **Parameters**:
  * - `gravitystate` Boolean, default `FALSE`. The new state to set `has_gravity` to.
  */
-/area/proc/gravitychange(var/gravitystate = 0)
+/area/proc/gravitychange(gravitystate = FALSE)
+	if (gravitystate == has_gravity)
+		return
 	has_gravity = gravitystate
-
-	for(var/mob/M in src)
-		if(has_gravity)
+	for (var/mob/M in src)
+		if (has_gravity)
 			thunk(M)
 		M.update_floating()
 
@@ -314,7 +304,7 @@ var/global/list/mob/living/forced_ambiance_list = new
 	if(mob.Check_Shoegrip())
 		return
 
-	if(istype(mob,/mob/living/carbon/human))
+	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
 		if(!H.buckled && prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_PROF)))
 			if(!MOVING_DELIBERATELY(H))
@@ -323,12 +313,12 @@ var/global/list/mob/living/forced_ambiance_list = new
 			else
 				H.AdjustStunned(3)
 				H.AdjustWeakened(3)
-			to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
+			to_chat(mob, SPAN_NOTICE("The sudden appearance of gravity makes you fall to the floor!"))
 
 /// Trigger for the prison break event. Causes lighting to overload and dooes to open. Has no effect if the area lacks an APC or the APC is turned off.
 /area/proc/prison_break()
 	var/obj/machinery/power/apc/theAPC = get_apc()
-	if(theAPC && theAPC.operating)
+	if(theAPC?.operating)
 		for(var/obj/machinery/power/apc/temp_apc in src)
 			temp_apc.overload_lighting(70)
 		for(var/obj/machinery/door/airlock/temp_airlock in src)
@@ -341,7 +331,7 @@ var/global/list/mob/living/forced_ambiance_list = new
 	return has_gravity
 
 /area/space/has_gravity()
-	return 0
+	return FALSE
 
 /proc/has_gravity(atom/AT, turf/T)
 	if(!T)
@@ -353,9 +343,15 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /// Returns List (axis => Integer). The width and height, in tiles, of the area, indexed by axis. Axis is `"x"` or `"y"`.
 /area/proc/get_dimensions()
-	var/list/res = list("x"=1,"y"=1)
-	var/list/min = list("x"=world.maxx,"y"=world.maxy)
-	for(var/turf/T in src)
+	var/list/res = list(
+		"x" = 1,
+		"y" = 1
+	)
+	var/list/min = list(
+		"x" = world.maxx,
+		"y" = world.maxy
+	)
+	for (var/turf/T in src)
 		res["x"] = max(T.x, res["x"])
 		res["y"] = max(T.y, res["y"])
 		min["x"] = min(T.x, min["x"])
@@ -370,6 +366,6 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /// Returns boolean. Whether or not the area can be modified by player actions.
 /area/proc/can_modify_area()
-	if (src && src.area_flags & AREA_FLAG_NO_MODIFY)
+	if (area_flags & AREA_FLAG_NO_MODIFY)
 		return FALSE
 	return TRUE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -15,6 +15,15 @@ GLOBAL_VAR_CONST(AREA_FLAG_NO_MODIFY, FLAG(4))
 GLOBAL_VAR_CONST(AREA_FLAG_HIDE_FROM_HOLOMAP, FLAG(5))
 
 
+// Alert levels for atmosphere alarms
+/// Safe air zone - Green.
+GLOBAL_VAR_CONST(AIR_ALARM_LEVEL_SAFE, 0)
+/// Warning level atmosphere alarm- Yellow.
+GLOBAL_VAR_CONST(AIR_ALARM_LEVEL_WARNING, 1)
+/// Danger level atmosphere alarm - Red
+GLOBAL_VAR_CONST(AIR_ALARM_LEVEL_DANGER, 2)
+
+
 /// Integer. Global counter for `uid` values assigned to areas. Increments by one for each new area.
 /area/var/static/global_uid = 0
 /// Integer. The area's unique ID number. set to the value of `global_uid` + 1 when the area is created.
@@ -84,13 +93,13 @@ GLOBAL_VAR_CONST(AREA_FLAG_HIDE_FROM_HOLOMAP, FLAG(5))
  * Defines the area's atmosphere alert level.
  *
  * **Parameters**:
- * - `danger_level` Integer. The new alert danger level to set.
+ * - `danger_level` Integer (One of `GLOB.AIR_ALARM_LEVEL_*`). The new alert danger level to set.
  * - `alarm_source` Atom. The source that's triggering the alert change.
  *
  * Returns boolean. `TRUE` if the atmosphere alarm level was changed, `FALSE` otherwise.
  */
 /area/proc/atmosalert(danger_level, alarm_source)
-	if (danger_level == 0)
+	if (danger_level == GLOB.AIR_ALARM_LEVEL_SAFE)
 		GLOB.atmosphere_alarm.clearAlarm(src, alarm_source)
 	else
 		GLOB.atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level)
@@ -101,10 +110,10 @@ GLOBAL_VAR_CONST(AREA_FLAG_HIDE_FROM_HOLOMAP, FLAG(5))
 			danger_level = max(danger_level, AA.danger_level)
 
 	if (danger_level != atmosalm)
-		if (danger_level < 1 && atmosalm >= 1)
+		if (danger_level < GLOB.AIR_ALARM_LEVEL_WARNING && atmosalm >= GLOB.AIR_ALARM_LEVEL_WARNING)
 			//closing the doors on red and opening on green provides a bit of hysteresis that will hopefully prevent fire doors from opening and closing repeatedly due to noise
 			air_doors_open()
-		else if (danger_level >= 2 && atmosalm < 2)
+		else if (danger_level >= GLOB.AIR_ALARM_LEVEL_DANGER && atmosalm < GLOB.AIR_ALARM_LEVEL_DANGER)
 			air_doors_close()
 
 		atmosalm = danger_level

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -1,13 +1,25 @@
 // Areas.dm
 
+//Area flags, possibly more to come
+/// Area is shielded from radiation.
+GLOBAL_VAR_CONST(AREA_FLAG_RAD_SHIELDED, FLAG(0))
+/// Area is considered external, i.e. exposed to space.
+GLOBAL_VAR_CONST(AREA_FLAG_EXTERNAL, FLAG(1))
+/// Area is shielded from ionospheric anomalies as an FBP / IPC.
+GLOBAL_VAR_CONST(AREA_FLAG_ION_SHIELDED, FLAG(2))
+/// SSpersistence will not track values from this area.
+GLOBAL_VAR_CONST(AREA_FLAG_IS_NOT_PERSISTENT, FLAG(3))
+/// Turfs in this area cannot be dismantled.
+GLOBAL_VAR_CONST(AREA_FLAG_NO_MODIFY, FLAG(4))
+/// Area is not drawn on station holomaps.
+GLOBAL_VAR_CONST(AREA_FLAG_HIDE_FROM_HOLOMAP, FLAG(5))
 
 
-// ===
 /// Integer. Global counter for `uid` values assigned to areas. Increments by one for each new area.
 /area/var/static/global_uid = 0
 /// Integer. The area's unique ID number. set to the value of `global_uid` + 1 when the area is created.
 /area/var/uid
-/// Bitflag (Any of `AREA_FLAG_*`). See `code\__defines\misc.dm`.
+/// Bitflag (Any of `GLOB.AREA_FLAG_*`). See `code\game\area\areas.dm`.
 /area/var/area_flags
 
 /area/Initialize()
@@ -366,6 +378,6 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /// Returns boolean. Whether or not the area can be modified by player actions.
 /area/proc/can_modify_area()
-	if (area_flags & AREA_FLAG_NO_MODIFY)
+	if (area_flags & GLOB.AREA_FLAG_NO_MODIFY)
 		return FALSE
 	return TRUE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -15,9 +15,9 @@
 	uid = ++global_uid
 
 	if(!requires_power)
-		power_light = 0
-		power_equip = 0
-		power_environ = 0
+		power_light = FALSE
+		power_equip = FALSE
+		power_environ = FALSE
 
 	if(dynamic_lighting)
 		luminosity = 0
@@ -29,9 +29,9 @@
 /area/Initialize()
 	. = ..()
 	if(!requires_power || !apc)
-		power_light = 0
-		power_equip = 0
-		power_environ = 0
+		power_light = FALSE
+		power_equip = FALSE
+		power_environ = FALSE
 	power_change()		// all machines set to current power level, also updates lighting icon
 
 /area/Destroy()
@@ -102,10 +102,10 @@
 /// Sets `air_doors_activated` and sets all firedoors in `all_doors` to the closed state. Does nothing if `air_doors_activated` is already set.
 /area/proc/air_doors_close()
 	if(!air_doors_activated)
-		air_doors_activated = 1
-		if(!all_doors)
+		air_doors_activated = TRUE
+		if (!LAZYLEN(all_doors))
 			return
-		for(var/obj/machinery/door/firedoor/E in all_doors)
+		for (var/obj/machinery/door/firedoor/E as anything in all_doors)
 			if(!E.blocked)
 				if(E.operating)
 					E.nextstate = FIREDOOR_CLOSED
@@ -116,10 +116,10 @@
 /// Clears `air_doors_activated` and sets all firedoors in `all_doors` to the open state. Does nothing if `air_doors_activated` is already cleared.
 /area/proc/air_doors_open()
 	if(air_doors_activated)
-		air_doors_activated = 0
-		if(!all_doors)
+		air_doors_activated = FALSE
+		if (!LAZYLEN(all_doors))
 			return
-		for(var/obj/machinery/door/firedoor/E in all_doors)
+		for (var/obj/machinery/door/firedoor/E as anything in all_doors)
 			E.locked = FALSE
 			if(!E.blocked)
 				if(E.operating)
@@ -133,12 +133,12 @@
 /// Sets a fire alarm in the area, if one is not already active.
 /area/proc/fire_alert()
 	if(!fire)
-		fire = 1	//used for firedoor checks
+		fire = TRUE
 		update_icon()
 		mouse_opacity = 0
-		if(!all_doors)
+		if (!LAZYLEN(all_doors))
 			return
-		for(var/obj/machinery/door/firedoor/D in all_doors)
+		for (var/obj/machinery/door/firedoor/D as anything in all_doors)
 			if(!D.blocked)
 				if(D.operating)
 					D.nextstate = FIREDOOR_CLOSED
@@ -149,12 +149,12 @@
 /// Clears an active fire alarm from the area.
 /area/proc/fire_reset()
 	if (fire)
-		fire = 0	//used for firedoor checks
+		fire = FALSE
 		update_icon()
 		mouse_opacity = 0
-		if(!all_doors)
+		if (!LAZYLEN(all_doors))
 			return
-		for(var/obj/machinery/door/firedoor/D in all_doors)
+		for (var/obj/machinery/door/firedoor/D as anything in all_doors)
 			D.locked = FALSE
 			if(!D.blocked)
 				if(D.operating)
@@ -166,21 +166,21 @@
 /// Sets an active evacuation alarm in the area, if one is not already active.
 /area/proc/readyalert()
 	if(!eject)
-		eject = 1
+		eject = TRUE
 		update_icon()
 	return
 
 /// Clears an active evacuation alarm from the area.
 /area/proc/readyreset()
 	if(eject)
-		eject = 0
+		eject = FALSE
 		update_icon()
 	return
 
 /// Sets a party alarm in the area, if one is not already active.
 /area/proc/partyalert()
 	if (!( party ))
-		party = 1
+		party = TRUE
 		update_icon()
 		mouse_opacity = 0
 	return
@@ -188,7 +188,7 @@
 /// Clears an active party alarm from the area.
 /area/proc/partyreset()
 	if (party)
-		party = 0
+		party = FALSE
 		mouse_opacity = 0
 		update_icon()
 		for(var/obj/machinery/door/firedoor/D in src)
@@ -245,7 +245,7 @@ var/global/list/mob/living/forced_ambiance_list = new
 	var/area/newarea = get_area(L.loc)
 	var/area/oldarea = L.lastarea
 	if(oldarea.has_gravity != newarea.has_gravity)
-		if(newarea.has_gravity == 1 && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
+		if(newarea.has_gravity && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
 			thunk(L)
 		L.update_floating()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -338,7 +338,7 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /// Trigger for the prison break event. Causes lighting to overload and dooes to open. Has no effect if the area lacks an APC or the APC is turned off.
 /area/proc/prison_break()
-	var/obj/machinery/power/apc/theAPC = get_apc()
+	var/obj/machinery/power/apc/theAPC = apc
 	if(theAPC?.operating)
 		for(var/obj/machinery/power/apc/temp_apc in src)
 			temp_apc.overload_lighting(70)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -10,7 +10,9 @@
 /// Bitflag (Any of `AREA_FLAG_*`). See `code\__defines\misc.dm`.
 /area/var/area_flags
 
-/area/New()
+/area/Initialize()
+	. = ..()
+
 	icon_state = ""
 	uid = ++global_uid
 
@@ -24,15 +26,16 @@
 	else
 		luminosity = 1
 
-	..()
-
-/area/Initialize()
-	. = ..()
 	if(!requires_power || !apc)
 		power_light = FALSE
 		power_equip = FALSE
 		power_environ = FALSE
 	power_change()		// all machines set to current power level, also updates lighting icon
+
+	if (turf_initializer)
+		for (var/turf/T in src)
+			var/decl/turf_initializer/ti = decls_repository.get_decl(turf_initializer)
+			ti.InitializeTurf(T)
 
 /area/Destroy()
 	..()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -102,26 +102,26 @@
 		return TRUE
 	return FALSE
 
-/// Sets `air_doors_activated` and sets all firedoors in `all_doors` to the closed state. Does nothing if `air_doors_activated` is already set.
+/// Sets `air_doors_activated` and sets all firedoors in `all_firedoors` to the closed state. Does nothing if `air_doors_activated` is already set.
 /area/proc/air_doors_close()
 	if (!air_doors_activated)
 		air_doors_activated = TRUE
-		if (!LAZYLEN(all_doors))
+		if (!LAZYLEN(all_firedoors))
 			return
-		for (var/obj/machinery/door/firedoor/E as anything in all_doors)
+		for (var/obj/machinery/door/firedoor/E as anything in all_firedoors)
 			if (!E.blocked)
 				if (E.operating)
 					E.nextstate = FIREDOOR_CLOSED
 				else if (!E.density)
 					INVOKE_ASYNC(E, /obj/machinery/door/firedoor/.proc/close)
 
-/// Clears `air_doors_activated` and sets all firedoors in `all_doors` to the open state. Does nothing if `air_doors_activated` is already cleared.
+/// Clears `air_doors_activated` and sets all firedoors in `all_firedoors` to the open state. Does nothing if `air_doors_activated` is already cleared.
 /area/proc/air_doors_open()
 	if(air_doors_activated)
 		air_doors_activated = FALSE
-		if (!LAZYLEN(all_doors))
+		if (!LAZYLEN(all_firedoors))
 			return
-		for (var/obj/machinery/door/firedoor/E as anything in all_doors)
+		for (var/obj/machinery/door/firedoor/E as anything in all_firedoors)
 			E.locked = FALSE
 			if(!E.blocked)
 				if(E.operating)
@@ -135,9 +135,9 @@
 	if(!fire)
 		fire = TRUE
 		update_icon()
-		if (!LAZYLEN(all_doors))
+		if (!LAZYLEN(all_firedoors))
 			return
-		for (var/obj/machinery/door/firedoor/D as anything in all_doors)
+		for (var/obj/machinery/door/firedoor/D as anything in all_firedoors)
 			if(!D.blocked)
 				if(D.operating)
 					D.nextstate = FIREDOOR_CLOSED
@@ -149,9 +149,9 @@
 	if (fire)
 		fire = FALSE
 		update_icon()
-		if (!LAZYLEN(all_doors))
+		if (!LAZYLEN(all_firedoors))
 			return
-		for (var/obj/machinery/door/firedoor/D as anything in all_doors)
+		for (var/obj/machinery/door/firedoor/D as anything in all_firedoors)
 			D.locked = FALSE
 			if(!D.blocked)
 				if(D.operating)

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -167,7 +167,7 @@
 	// Trigger a powernet alarm. Careful engineers will probably notice something is going on.
 	var/area/temp_area = get_area(M)
 	if(temp_area)
-		var/obj/machinery/power/apc/temp_apc = temp_area.get_apc()
+		var/obj/machinery/power/apc/temp_apc = temp_area.apc
 		var/obj/machinery/power/terminal/terminal = temp_apc && temp_apc.terminal()
 		if(terminal && terminal.powernet)
 			terminal.powernet.trigger_warning(50) // Long alarm

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -414,7 +414,7 @@ Class Procs:
 	if(electrocute_mob(user, get_area(src), src, 0.7))
 		var/area/temp_area = get_area(src)
 		if(temp_area)
-			var/obj/machinery/power/apc/temp_apc = temp_area.get_apc()
+			var/obj/machinery/power/apc/temp_apc = temp_area.apc
 			var/obj/machinery/power/terminal/terminal = temp_apc && temp_apc.terminal()
 
 			if(terminal && terminal.powernet)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -95,12 +95,12 @@
 	var/list/TLV = list()
 	var/list/trace_gas = list() //list of other gases that this air alarm is able to detect
 
-	var/danger_level = 0
-	var/pressure_dangerlevel = 0
-	var/oxygen_dangerlevel = 0
-	var/co2_dangerlevel = 0
-	var/temperature_dangerlevel = 0
-	var/other_dangerlevel = 0
+	var/danger_level = GLOB.AIR_ALARM_LEVEL_SAFE
+	var/pressure_dangerlevel = GLOB.AIR_ALARM_LEVEL_SAFE
+	var/oxygen_dangerlevel = GLOB.AIR_ALARM_LEVEL_SAFE
+	var/co2_dangerlevel = GLOB.AIR_ALARM_LEVEL_SAFE
+	var/temperature_dangerlevel = GLOB.AIR_ALARM_LEVEL_SAFE
+	var/other_dangerlevel = GLOB.AIR_ALARM_LEVEL_SAFE
 	var/environment_type = /decl/environment_data
 	var/report_danger_level = 1
 
@@ -197,11 +197,11 @@
 	danger_level = overall_danger_level(environment)
 
 	if (old_level != danger_level)
-		if(danger_level == 2)
+		if(danger_level == GLOB.AIR_ALARM_LEVEL_DANGER)
 			playsound(src.loc, 'sound/machines/airalarm.ogg', 25, 0, 4)
 		apply_danger_level(danger_level)
 
-	if (pressure_dangerlevel != 0)
+	if (pressure_dangerlevel != GLOB.AIR_ALARM_LEVEL_SAFE)
 		if (breach_detected())
 			mode = AALARM_MODE_OFF
 			apply_mode()
@@ -216,7 +216,7 @@
 		if(RCON_NO)
 			remote_control = 0
 		if(RCON_AUTO)
-			if(danger_level == 2)
+			if(danger_level == GLOB.AIR_ALARM_LEVEL_DANGER)
 				remote_control = 1
 			else
 				remote_control = 0
@@ -343,17 +343,17 @@
 
 	var/icon_level = danger_level
 	if (alarm_area.atmosalm)
-		icon_level = max(icon_level, 1)	//if there's an atmos alarm but everything is okay locally, no need to go past yellow
+		icon_level = max(icon_level, GLOB.AIR_ALARM_LEVEL_WARNING)	//if there's an atmos alarm but everything is okay locally, no need to go past yellow
 
 	var/new_color = null
 	switch(icon_level)
-		if (0)
+		if (GLOB.AIR_ALARM_LEVEL_SAFE)
 			icon_state = "alarm0"
 			new_color = COLOR_LIME
-		if (1)
+		if (GLOB.AIR_ALARM_LEVEL_WARNING)
 			icon_state = "alarm2" //yes, alarm2 is yellow alarm
 			new_color = COLOR_SUN
-		if (2)
+		if (GLOB.AIR_ALARM_LEVEL_DANGER)
 			icon_state = "alarm1"
 			new_color = COLOR_RED_LIGHT
 
@@ -484,11 +484,11 @@
 	alert_signal.data["zone"] = alarm_area.name
 	alert_signal.data["type"] = "Atmospheric"
 
-	if(alert_level==2)
+	if(alert_level==GLOB.AIR_ALARM_LEVEL_DANGER)
 		alert_signal.data["alert"] = "severe"
-	else if (alert_level==1)
+	else if (alert_level==GLOB.AIR_ALARM_LEVEL_WARNING)
 		alert_signal.data["alert"] = "minor"
-	else if (alert_level==0)
+	else if (alert_level==GLOB.AIR_ALARM_LEVEL_SAFE)
 		alert_signal.data["alert"] = "clear"
 
 	frequency.post_signal(src, alert_signal)
@@ -792,14 +792,14 @@
 			return TOPIC_REFRESH
 
 		if(href_list["atmos_alarm"])
-			if (alarm_area.atmosalert(2, src))
-				apply_danger_level(2)
+			if (alarm_area.atmosalert(GLOB.AIR_ALARM_LEVEL_DANGER, src))
+				apply_danger_level(GLOB.AIR_ALARM_LEVEL_DANGER)
 			update_icon()
 			return TOPIC_REFRESH
 
 		if(href_list["atmos_reset"])
-			if (alarm_area.atmosalert(0, src))
-				apply_danger_level(0)
+			if (alarm_area.atmosalert(GLOB.AIR_ALARM_LEVEL_SAFE, src))
+				apply_danger_level(GLOB.AIR_ALARM_LEVEL_SAFE)
 			update_icon()
 			return TOPIC_REFRESH
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -551,7 +551,7 @@
 	data["total_danger"] = danger_level
 	data["environment"] = environment_data
 	data["atmos_alarm"] = alarm_area.atmosalm
-	data["fire_alarm"] = alarm_area.fire != null
+	data["fire_alarm"] = alarm_area.fire
 	data["target_temperature"] = "[target_temperature - T0C]C"
 
 /obj/machinery/alarm/proc/populate_controls(var/list/data)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -73,18 +73,18 @@
 	var/area/A = get_area(src)
 	ASSERT(istype(A))
 
-	LAZYADD(A.all_doors, src)
+	LAZYADD(A.all_firedoors, src)
 	areas_added = list(A)
 
 	for(var/direction in GLOB.cardinal)
 		A = get_area(get_step(src,direction))
 		if(istype(A) && !(A in areas_added))
-			LAZYADD(A.all_doors, src)
+			LAZYADD(A.all_firedoors, src)
 			areas_added += A
 
 /obj/machinery/door/firedoor/Destroy()
 	for(var/area/A in areas_added)
-		LAZYREMOVE(A.all_doors, src)
+		LAZYREMOVE(A.all_firedoors, src)
 	. = ..()
 
 /obj/machinery/door/firedoor/get_material()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -221,7 +221,7 @@ var/global/list/turret_icons
 
 /obj/machinery/porta_turret/proc/HasController()
 	var/area/A = get_area(src)
-	return A && A.turret_controls.len > 0
+	return A && LAZYLEN(A.turret_controls) > 0
 
 /obj/machinery/porta_turret/CanUseTopic(var/mob/user)
 	if(HasController())

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -2,8 +2,8 @@
 //Turret Control Panel//
 ////////////////////////
 
-/// List (`/obj/machinery/turretid`). A list of all turret control panels in the area. Turrets use this list to see if individual power/lethal settings are allowed. Updated during `Initialize()` and `Destroy()` calls on the controllers.
-/area/var/list/turret_controls = list()
+/// Lazylist (`/obj/machinery/turretid`). A list of all turret control panels in the area. Turrets use this list to see if individual power/lethal settings are allowed. Updated during `Initialize()` and `Destroy()` calls on the controllers.
+/area/var/list/turret_controls = null
 
 /obj/machinery/turretid
 	name = "turret control panel"
@@ -41,7 +41,7 @@
 	if(control_area)
 		var/area/A = control_area
 		if(A && istype(A))
-			A.turret_controls -= src
+			LAZYREMOVE(A.turret_controls, src)
 	. = ..()
 
 /obj/machinery/turretid/Initialize()
@@ -56,7 +56,7 @@
 	if(control_area)
 		var/area/A = control_area
 		if(istype(A))
-			A.turret_controls += src
+			LAZYADD(A.turret_controls, src)
 		else
 			control_area = null
 

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -37,7 +37,7 @@
 	if (!istype(loc, /turf/simulated/floor))
 		to_chat(usr, "<span class='danger'>\The [src] cannot be placed on this spot.</span>")
 		return
-	if ((A.requires_power == 0 || A.name == "Space") && !isLightFrame())
+	if ((!A.requires_power || A.name == "Space") && !isLightFrame())
 		to_chat(usr, "<span class='danger'>\The [src] cannot be placed in this area.</span>")
 		return
 

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -27,7 +27,7 @@
 	if (!A.requires_power || istype(A, /area/space))
 		to_chat(usr, "<span class='warning'>APC cannot be placed in this area.</span>")
 		return
-	if (A.get_apc())
+	if (A.apc)
 		to_chat(usr, "<span class='warning'>This area already has an APC.</span>")
 		return //only one APC per area
 	for(var/obj/machinery/power/terminal/T in loc)

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -24,7 +24,7 @@
 	if (!istype(loc, /turf/simulated/floor))
 		to_chat(usr, "<span class='warning'>APC cannot be placed on this spot.</span>")
 		return
-	if (A.requires_power == 0 || istype(A, /area/space))
+	if (!A.requires_power || istype(A, /area/space))
 		to_chat(usr, "<span class='warning'>APC cannot be placed in this area.</span>")
 		return
 	if (A.get_apc())

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -106,13 +106,11 @@
 		return
 	var/area/A = new
 	A.SetName(str)
-	A.power_equip = 0
-	A.power_light = 0
-	A.power_environ = 0
-	A.always_unpowered = 0
+	A.power_equip = FALSE
+	A.power_light = FALSE
+	A.power_environ = FALSE
 	for(var/T in turfs)
 		ChangeArea(T, A)
-	A.always_unpowered = 0
 	interact()
 
 /obj/item/blueprints/proc/edit_area()

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -147,7 +147,7 @@
 
 		addtimer(CALLBACK(src, .proc/do_spray, target), 0)
 
-		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
+		if((istype(usr.loc, /turf/space)) || (!usr.lastarea.has_gravity))
 			user.inertia_dir = get_dir(target, user)
 			step(user, user.inertia_dir)
 	else

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -142,7 +142,7 @@
 		for(var/direction in GLOB.cardinal)
 			var/turf/T = get_step(src, direction)
 			var/area/A = get_area(T)
-			if(A && (A.area_flags & AREA_FLAG_EXTERNAL))
+			if(A && (A.area_flags & GLOB.AREA_FLAG_EXTERNAL))
 				spacefacing = TRUE
 				break
 		if(spacefacing)

--- a/code/game/turfs/initialization/init.dm
+++ b/code/game/turfs/initialization/init.dm
@@ -3,10 +3,3 @@
 
 /// Type path (Types of `/decl/turf_initializer`). If set, uses the provided decl to modify all turfs in the area during `Initialize()`.
 /area/var/turf_initializer = null
-
-/area/Initialize()
-	. = ..()
-	for(var/turf/T in src)
-		if(turf_initializer)
-			var/decl/turf_initializer/ti = decls_repository.get_decl(turf_initializer)
-			ti.InitializeTurf(T)

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -33,7 +33,7 @@
 		for(var/direction in GLOB.cardinal)
 			var/turf/T = get_step(src, direction)
 			var/area/A = get_area(T)
-			if(A && (A.area_flags & AREA_FLAG_EXTERNAL))
+			if(A && (A.area_flags & GLOB.AREA_FLAG_EXTERNAL))
 				spacefacing = TRUE
 				break
 		if(spacefacing)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -26,7 +26,7 @@
 		return
 	var/area/A = below.loc
 
-	if(!below.density && (A.area_flags & AREA_FLAG_EXTERNAL))
+	if(!below.density && (A.area_flags & GLOB.AREA_FLAG_EXTERNAL))
 		return
 
 	return INITIALIZE_HINT_LATELOAD // oh no! we need to switch to being a different kind of turf!

--- a/code/modules/admin/buildmode/areas.dm
+++ b/code/modules/admin/buildmode/areas.dm
@@ -95,10 +95,9 @@ Shift + Right Click - Select point B
 			return
 		var/area/new_area = new
 		new_area.SetName(new_name)
-		new_area.power_equip = 0
-		new_area.power_light = 0
-		new_area.power_environ = 0
-		new_area.always_unpowered = 0
+		new_area.power_equip = FALSE
+		new_area.power_light = FALSE
+		new_area.power_environ = FALSE
 		SelectArea(new_area)
 		user.client.debug_variables(selected_area)
 		to_chat(user, "Created area [new_area.name]")

--- a/code/modules/admin/verbs/fluids.dm
+++ b/code/modules/admin/verbs/fluids.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(submerged_levels, new)
 		for(var/thing in block(locate(1, 1, submerge_z), locate(world.maxx, world.maxy, submerge_z)))
 			var/turf/T = thing
 			var/area/A = get_area(T)
-			if(A && (A.area_flags & AREA_FLAG_EXTERNAL))
+			if(A && (A.area_flags & GLOB.AREA_FLAG_EXTERNAL))
 				if(A.base_turf)
 					A.base_turf = /turf/simulated/ocean/non_flooded
 				if(!istype(T, /turf/space))
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(submerged_levels, new)
 		for(var/thing in block(locate(1, 1, submerge_z), locate(world.maxx, world.maxy, submerge_z)))
 			var/turf/T = thing
 			var/area/A = get_area(T)
-			if(A && (A.area_flags & AREA_FLAG_EXTERNAL))
+			if(A && (A.area_flags & GLOB.AREA_FLAG_EXTERNAL))
 				if(A.base_turf)
 					A.base_turf = /turf/simulated/open
 				if(istype(T, /turf/space))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -25,7 +25,7 @@
 		var/area/A = get_area(S)
 		if(!A)
 			continue
-		if(A.area_flags & AREA_FLAG_ION_SHIELDED)
+		if(A.area_flags & GLOB.AREA_FLAG_ION_SHIELDED)
 			continue
 		to_chat(S, SPAN_WARNING("Your integrated sensors detect an ionospheric anomaly. Your systems will be impacted as you begin a partial restart."))
 		var/ionbug = rand(5, 15)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -46,7 +46,7 @@
 		if(areas && areas.len > 0)
 			var/obj/machinery/power/apc/theAPC = null
 			for(var/area/A in areas)
-				theAPC = A.get_apc()
+				theAPC = A.apc
 				if(theAPC && theAPC.operating)	//If the apc's off, it's a little hard to overload the lights.
 					for(var/obj/machinery/light/L in A)
 						L.flicker(10)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -52,7 +52,7 @@
 		var/area/A = get_area(C)
 		if(!A)
 			continue
-		if(A.area_flags & AREA_FLAG_RAD_SHIELDED)
+		if(A.area_flags & GLOB.AREA_FLAG_RAD_SHIELDED)
 			continue
 		if(istype(C,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = C

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -289,7 +289,7 @@
 	if(HP.ambience)
 		linkedholodeck.forced_ambience = HP.ambience
 	else
-		linkedholodeck.forced_ambience = list()
+		LAZYCLEARLIST(linkedholodeck.forced_ambience)
 
 	for(var/mob/living/M in mobs_in_area(linkedholodeck))
 		if(M.mind)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -241,7 +241,7 @@
 		loadProgram(GLOB.using_map.holodeck_programs["turnoff"], 0)
 
 		if(!linkedholodeck.has_gravity)
-			linkedholodeck.gravitychange(1)
+			linkedholodeck.gravitychange(TRUE)
 
 		active = 0
 		update_use_power(POWER_USE_IDLE)
@@ -277,7 +277,7 @@
 	for(var/obj/effect/decal/cleanable/blood/B in linkedholodeck)
 		qdel(B)
 
-	holographic_objs = A.copy_contents_to(linkedholodeck , 1)
+	holographic_objs = A.copy_contents_to(linkedholodeck, TRUE)
 	for(var/obj/holo_obj in holographic_objs)
 		holo_obj.alpha *= 0.8 //give holodeck objs a slight transparency
 		holo_obj.holographic = TRUE
@@ -332,16 +332,16 @@
 	update_use_power(POWER_USE_IDLE)
 
 	if(A.has_gravity)
-		A.gravitychange(0,A)
+		A.gravitychange(FALSE)
 	else
-		A.gravitychange(1,A)
+		A.gravitychange(TRUE)
 
 /obj/machinery/computer/HolodeckControl/proc/emergencyShutdown()
 	//Turn it back to the regular non-holographic room
 	loadProgram(GLOB.using_map.holodeck_programs["turnoff"], 0)
 
 	if(!linkedholodeck.has_gravity)
-		linkedholodeck.gravitychange(1,linkedholodeck)
+		linkedholodeck.gravitychange(TRUE)
 
 	active = 0
 	update_use_power(POWER_USE_IDLE)

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -3,8 +3,3 @@
 /area/var/dynamic_lighting = TRUE
 /// String (One of `AREA_LIGHTING_*`). The light tone selection mode used for the area. See `code\__defines\lighting.dm` for possible values.
 /area/var/lighting_tone = AREA_LIGHTING_DEFAULT
-
-/area/New()
-	..()
-	if(dynamic_lighting)
-		luminosity = FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -321,7 +321,7 @@
 
 	if(!src.lastarea)
 		src.lastarea = get_area(src.loc)
-	if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity == 0))
+	if((istype(src.loc, /turf/space)) || (!src.lastarea.has_gravity))
 		if(prob((itemsize * itemsize * 10) * MOB_MEDIUM/src.mob_size))
 			src.inertia_dir = get_dir(target, src)
 			step(src, inertia_dir)

--- a/code/modules/mob/living/silicon/ai/power.dm
+++ b/code/modules/mob/living/silicon/ai/power.dm
@@ -40,7 +40,7 @@
 			// step 3 tries to locate an APC. It tries up to three times before failing, relying on external influence to restore power only.
 			if(AI_RESTOREPOWER_CONNECTED)
 				var/area/A = get_area(src)
-				theAPC = A.get_apc()
+				theAPC = A.apc
 
 				if(!istype(theAPC))
 					to_chat(src, "<span class='notice'>Error processing connection to APC: Attempt [connection_failures+1]/[AI_POWER_RESTORE_MAX_ATTEMPTS]</span>")

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -60,9 +60,9 @@
 		if ((!monitored_alarms.len) && (!Z || !AreConnectedZLevels(Z, alarm.z)))
 			continue
 		var/danger_level = max(alarm.danger_level, alarm.alarm_area.atmosalm)
-		if(danger_level == 2)
+		if(danger_level == GLOB.AIR_ALARM_LEVEL_DANGER)
 			alarmsAlert[++alarmsAlert.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
-		else if(danger_level == 1)
+		else if(danger_level == GLOB.AIR_ALARM_LEVEL_WARNING)
 			alarmsDanger[++alarmsDanger.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
 		else
 			alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)

--- a/code/modules/overmap/_defines.dm
+++ b/code/modules/overmap/_defines.dm
@@ -6,7 +6,7 @@ var/global/list/map_sectors = list()
 /area/overmap
 	name = "System Map"
 	icon_state = "start"
-	requires_power = 0
+	requires_power = FALSE
 	base_turf = /turf/unsimulated/map
 
 /turf/unsimulated/map

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -314,5 +314,5 @@ GLOBAL_VAR(planet_repopulation_disabled)
 		'sound/effects/wind/wind_5_1.ogg'
 	)
 	always_unpowered = TRUE
-	area_flags = AREA_FLAG_EXTERNAL
+	area_flags = GLOB.AREA_FLAG_EXTERNAL
 	planetary_surface = TRUE

--- a/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
@@ -34,7 +34,7 @@
 
 /datum/exoplanet_theme/ruined_city/after_map_generation(obj/effect/overmap/visitable/sector/exoplanet/E)
 	var/area/A = E.planetary_area
-	LAZYDISTINCTADD(A.ambience, spooky_ambience)
+	A.ambience |= spooky_ambience
 
 /datum/exoplanet_theme/ruined_city/get_sensor_data()
 	return "Extensive artificial structures detected on the surface."

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -45,6 +45,4 @@
 	update_icon()
 
 /area/exoplanet/barren
-	name = "\improper Planetary surface"
-	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/effects/wind/wind_4_2.ogg','sound/effects/wind/wind_5_1.ogg')
 	base_turf = /turf/simulated/floor/exoplanet/barren

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -44,7 +44,14 @@
 	large_flora_prob = 0
 
 /area/exoplanet/chlorine
-	ambience = list('sound/effects/wind/desert0.ogg','sound/effects/wind/desert1.ogg','sound/effects/wind/desert2.ogg','sound/effects/wind/desert3.ogg','sound/effects/wind/desert4.ogg','sound/effects/wind/desert5.ogg')
+	ambience = list(
+		'sound/effects/wind/desert0.ogg',
+		'sound/effects/wind/desert1.ogg',
+		'sound/effects/wind/desert2.ogg',
+		'sound/effects/wind/desert3.ogg',
+		'sound/effects/wind/desert4.ogg',
+		'sound/effects/wind/desert5.ogg'
+	)
 	base_turf = /turf/simulated/floor/exoplanet/chlorine_sand
 
 /turf/simulated/floor/exoplanet/water/shallow/chlorine_liquid

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -57,7 +57,14 @@
 		new/obj/effect/quicksand(T)
 
 /area/exoplanet/desert
-	ambience = list('sound/effects/wind/desert0.ogg','sound/effects/wind/desert1.ogg','sound/effects/wind/desert2.ogg','sound/effects/wind/desert3.ogg','sound/effects/wind/desert4.ogg','sound/effects/wind/desert5.ogg')
+	ambience = list(
+		'sound/effects/wind/desert0.ogg',
+		'sound/effects/wind/desert1.ogg',
+		'sound/effects/wind/desert2.ogg',
+		'sound/effects/wind/desert3.ogg',
+		'sound/effects/wind/desert4.ogg',
+		'sound/effects/wind/desert5.ogg'
+	)
 	base_turf = /turf/simulated/floor/exoplanet/desert
 
 /obj/effect/quicksand

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -61,11 +61,11 @@
 		'sound/ambience/eeriejungle1.ogg'
 	)
 
-/area/exoplanet/grass/play_ambience(var/mob/living/L)
+/area/exoplanet/grass/play_ambience(mob/living/L)
 	..()
 	if(!L.ear_deaf && L.client && !L.client.ambience_playing)
 		L.client.ambience_playing = TRUE
-		L.playsound_local(get_turf(L),sound('sound/ambience/jungle.ogg', repeat = 1, wait = 0, volume = 25, channel = GLOB.ambience_sound_channel))
+		L.playsound_local(get_turf(L), sound('sound/ambience/jungle.ogg', TRUE, FALSE, GLOB.ambience_sound_channel, 25))
 
 /datum/random_map/noise/exoplanet/grass
 	descriptor = "grass exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -52,7 +52,14 @@
 
 /area/exoplanet/grass
 	base_turf = /turf/simulated/floor/exoplanet/grass
-	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/ambience/eeriejungle2.ogg','sound/ambience/eeriejungle1.ogg')
+	ambience = list(
+		'sound/effects/wind/wind_2_1.ogg',
+		'sound/effects/wind/wind_2_2.ogg',
+		'sound/effects/wind/wind_3_1.ogg',
+		'sound/effects/wind/wind_4_1.ogg',
+		'sound/ambience/eeriejungle2.ogg',
+		'sound/ambience/eeriejungle1.ogg'
+	)
 
 /area/exoplanet/grass/play_ambience(var/mob/living/L)
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -45,7 +45,10 @@
 		new/obj/structure/leech_spawner(T)
 
 /area/exoplanet/shrouded
-	forced_ambience = list("sound/ambience/spookyspace1.ogg", "sound/ambience/spookyspace2.ogg")
+	forced_ambience = list(
+		'sound/ambience/spookyspace1.ogg',
+		'sound/ambience/spookyspace2.ogg'
+	)
 	base_turf = /turf/simulated/floor/exoplanet/shrouded
 
 /turf/simulated/floor/exoplanet/water/shallow/tar

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -34,5 +34,11 @@
 	water_type = /turf/simulated/floor/exoplanet/ice
 
 /area/exoplanet/snow
-	ambience = list('sound/effects/wind/tundra0.ogg','sound/effects/wind/tundra1.ogg','sound/effects/wind/tundra2.ogg','sound/effects/wind/spooky0.ogg','sound/effects/wind/spooky1.ogg')
+	ambience = list(
+		'sound/effects/wind/tundra0.ogg',
+		'sound/effects/wind/tundra1.ogg',
+		'sound/effects/wind/tundra2.ogg',
+		'sound/effects/wind/spooky0.ogg',
+		'sound/effects/wind/spooky1.ogg'
+	)
 	base_turf = /turf/simulated/floor/exoplanet/snow

--- a/code/modules/persistence/persistence_datum.dm
+++ b/code/modules/persistence/persistence_datum.dm
@@ -75,7 +75,7 @@
 	if(!T || !(T.z in GLOB.using_map.station_levels) )
 		return FALSE
 	var/area/A = get_area(T)
-	if(!A || (A.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))
+	if(!A || (A.area_flags & GLOB.AREA_FLAG_IS_NOT_PERSISTENT))
 		return FALSE
 	return TRUE
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -195,9 +195,9 @@
 /obj/machinery/power/apc/Destroy()
 	src.update()
 	area.apc = null
-	area.power_light = 0
-	area.power_equip = 0
-	area.power_environ = 0
+	area.power_light = FALSE
+	area.power_equip = FALSE
+	area.power_environ = FALSE
 	area.power_change()
 
 	// Malf AI, removes the APC from AI's hacked APCs list.
@@ -795,9 +795,9 @@
 		area.power_equip = (equipment >= POWERCHAN_ON)
 		area.power_environ = (environ >= POWERCHAN_ON)
 	else
-		area.power_light = 0
-		area.power_equip = 0
-		area.power_environ = 0
+		area.power_light = FALSE
+		area.power_equip = FALSE
+		area.power_environ = FALSE
 
 	area.power_change()
 

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -101,10 +101,10 @@
 					if((A in G.localareas) && (G.on))
 						break
 				if(!G)
-					A.gravitychange(0)
+					A.gravitychange(FALSE)
 		else
 			for(var/area/A in gravity_generator.localareas)
 				gravity_generator.on = 1
-				A.gravitychange(1)
+				A.gravitychange(TRUE)
 
 	src.updateUsrDialog()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -314,7 +314,7 @@
 	var/drained_energy = drained_hp*20
 
 	if (source_area)
-		source_area.use_power_oneoff(drained_energy/CELLRATE)
+		source_area.use_power_oneoff(drained_energy/CELLRATE, EQUIP)
 	else if (istype(power_source,/datum/powernet))
 		var/drained_power = drained_energy/CELLRATE
 		drained_power = PN.draw_power(drained_power)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -255,7 +255,7 @@
 	var/area/source_area
 	if(istype(power_source,/area))
 		source_area = power_source
-		power_source = source_area.get_apc()
+		power_source = source_area.apc
 	if(istype(power_source,/obj/structure/cable))
 		var/obj/structure/cable/Cable = power_source
 		power_source = Cable.powernet

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -198,8 +198,3 @@
 		if(C.d1 == 0)
 			return C
 	return null
-
-
-/// Returns instance of `/obj/machinery/apc` or `null`. The area's APC, if defined and present.
-/area/proc/get_apc()
-	return apc

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -68,7 +68,7 @@
 
 	var/turf/TO = get_turf(src)
 	var/area/AO = TO.loc
-	if(AO && (AO.area_flags & AREA_FLAG_EXTERNAL))
+	if(AO && (AO.area_flags & GLOB.AREA_FLAG_EXTERNAL))
 		//Everyone saw that!
 		for(var/mob/living/mob in GLOB.living_mob_list_)
 			var/turf/T = get_turf(mob)

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -488,7 +488,7 @@
 			// Find adjacent space/shuttle tiles and cover them. Shuttles won't be blocked if shield diffuser is mapped in and turned on.
 			for(var/turf/TN in orange(1, T))
 				TA = get_area(TN)
-				if ((istype(TN, /turf/space) || (istype(TN, /turf/simulated/open) && (istype(TA, /area/space) || TA.area_flags & AREA_FLAG_EXTERNAL))))
+				if ((istype(TN, /turf/space) || (istype(TN, /turf/simulated/open) && (istype(TA, /area/space) || TA.area_flags & GLOB.AREA_FLAG_EXTERNAL))))
 					. |= TN
 					continue
 

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -177,7 +177,7 @@
 //	log_degug("area_coming_from: [origin]")
 //	log_debug("destination: [destination]")
 	if((flags & SHUTTLE_FLAGS_ZERO_G))
-		var/new_grav = 1
+		var/new_grav = TRUE
 		if(destination.flags & SLANDMARK_FLAG_ZERO_G)
 			var/area/new_area = get_area(destination)
 			new_grav = new_area.has_gravity

--- a/maps/antag_spawn/ert/ert.dm
+++ b/maps/antag_spawn/ert/ert.dm
@@ -44,7 +44,7 @@
 	name = "\improper Response Team Base"
 	icon_state = "yellow"
 	requires_power = FALSE
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/map_template/rescue_base/base
 	name = "\improper Barracks"

--- a/maps/antag_spawn/ert/ert.dm
+++ b/maps/antag_spawn/ert/ert.dm
@@ -5,7 +5,7 @@
 	apc_test_exempt_areas = list(
 		/area/map_template/rescue_base = NO_SCRUBBER|NO_VENT|NO_APC
 	)
-		
+
 
 /datum/shuttle/autodock/multi/antag/rescue
 	name = "Rescue"
@@ -43,14 +43,13 @@
 /area/map_template/rescue_base
 	name = "\improper Response Team Base"
 	icon_state = "yellow"
-	requires_power = 0
-	dynamic_lighting = 1
+	requires_power = FALSE
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/map_template/rescue_base/base
 	name = "\improper Barracks"
 	icon_state = "yellow"
-	dynamic_lighting = 0
+	dynamic_lighting = FALSE
 
 /area/map_template/rescue_base/start
 	name = "\improper Response Team Base"

--- a/maps/antag_spawn/heist/heist.dm
+++ b/maps/antag_spawn/heist/heist.dm
@@ -42,19 +42,18 @@
 /area/map_template/skipjack_station
 	name = "Raider Outpost"
 	icon_state = "yellow"
-	requires_power = 0
+	requires_power = FALSE
 	req_access = list(access_syndicate)
 
 /area/map_template/skipjack_station/start
 	name = "\improper Skipjack"
 	icon_state = "yellow"
-	req_access = list(access_syndicate)
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
 /area/map_template/syndicate_mothership/raider_base
 	name = "\improper Raider Base"
-	requires_power = 0
-	dynamic_lighting = 0
+	requires_power = FALSE
+	dynamic_lighting = FALSE
 	req_access = list(access_syndicate)
 
 /turf/simulated/floor/shuttle_ceiling/heist

--- a/maps/antag_spawn/heist/heist.dm
+++ b/maps/antag_spawn/heist/heist.dm
@@ -48,7 +48,7 @@
 /area/map_template/skipjack_station/start
 	name = "\improper Skipjack"
 	icon_state = "yellow"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/map_template/syndicate_mothership/raider_base
 	name = "\improper Raider Base"

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -84,7 +84,7 @@
 /area/map_template/merc_shuttle
 	name = "\improper Cyclopes"
 	icon_state = "yellow"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_syndicate)
 
 

--- a/maps/antag_spawn/ninja/ninja.dm
+++ b/maps/antag_spawn/ninja/ninja.dm
@@ -33,7 +33,7 @@
 	name = "\improper Ninja Base"
 	icon_state = "green"
 	requires_power = FALSE
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_syndicate)
 
 /area/map_template/ninja_dojo/dojo

--- a/maps/antag_spawn/ninja/ninja.dm
+++ b/maps/antag_spawn/ninja/ninja.dm
@@ -32,14 +32,13 @@
 /area/map_template/ninja_dojo
 	name = "\improper Ninja Base"
 	icon_state = "green"
-	requires_power = 0
-	dynamic_lighting = 1
+	requires_power = FALSE
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 	req_access = list(access_syndicate)
 
 /area/map_template/ninja_dojo/dojo
 	name = "\improper Clan Dojo"
-	dynamic_lighting = 0
+	dynamic_lighting = FALSE
 
 /area/map_template/ninja_dojo/start
 	name = "\improper Clan Dojo"

--- a/maps/antag_spawn/vox/voxraider.dm
+++ b/maps/antag_spawn/vox/voxraider.dm
@@ -81,5 +81,5 @@
 /area/map_template/vox_raider
 	name = "\improper Alien Interceptor"
 	icon_state = "syndie-ship"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_syndicate)

--- a/maps/antag_spawn/wizard/wizard.dm
+++ b/maps/antag_spawn/wizard/wizard.dm
@@ -5,6 +5,6 @@
 /area/map_template/wizard_station
 	name = "\improper Wizard's Den"
 	icon_state = "yellow"
-	requires_power = 0
-	dynamic_lighting = 0
+	requires_power = FALSE
+	dynamic_lighting = FALSE
 	req_access = list(access_syndicate)

--- a/maps/away/bearcat/bearcat_areas.dm
+++ b/maps/away/bearcat/bearcat_areas.dm
@@ -1,6 +1,17 @@
 /area/ship/scrap
 	name = "Generic Ship"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambigen12.ogg'
+	)
 
 /area/ship/scrap/crew
 	name = "Crew Compartements"
@@ -123,16 +134,49 @@
 /area/ship/scrap/maintenance/atmos
 	name = "Atmospherics Comparment"
 	icon_state = "atmos"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambiatm1.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambiatm1.ogg'
+	)
 
 /area/ship/scrap/maintenance/power
 	name = "Power Compartment"
 	icon_state = "engine_smes"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambieng1.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambieng1.ogg'
+	)
 
 /area/ship/scrap/maintenance/engine
 	icon_state = "engine"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambieng1.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambieng1.ogg'
+	)
 
 /area/ship/scrap/maintenance/engine/aft
 	name = "Main Engine Bay"
@@ -161,7 +205,12 @@
 /area/ship/scrap/comms
 	name = "Communications Relay"
 	icon_state = "tcomsatcham"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/signal.ogg','sound/ambience/sonar.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/signal.ogg',
+		'sound/ambience/sonar.ogg'
+	)
 
 /area/ship/scrap/shuttle/lift
   name = "Cargo Lift"

--- a/maps/away/blueriver/blueriver_areas.dm
+++ b/maps/away/blueriver/blueriver_areas.dm
@@ -2,14 +2,20 @@
 	name = "\improper Bluespace River Underground"
 	icon_state = "underground"
 	icon = 'blueriver.dmi'
-	ambience = list('sound/ambience/spookyspace1.ogg', 'sound/ambience/spookyspace2.ogg')
+	ambience = list(
+		'sound/ambience/spookyspace1.ogg',
+		'sound/ambience/spookyspace2.ogg'
+	)
 	sound_env = ASTEROID
 
 /area/bluespaceriver/ground
 	name = "\improper Arctic Planet Surface"
 	icon_state = "ground"
 	icon = 'blueriver.dmi'
-	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
+	ambience = list(
+		'sound/ambience/ambimine.ogg',
+		'sound/ambience/song_game.ogg'
+	)
 	sound_env = ASTEROID
 	planetary_surface = TRUE
 

--- a/maps/away/derelict/derelict_areas.dm
+++ b/maps/away/derelict/derelict_areas.dm
@@ -51,8 +51,7 @@
 	name = "\improper Construction Site Solars"
 	icon_state = "solar"
 	area_flags = AREA_FLAG_EXTERNAL
-	requires_power = 1
-	always_unpowered = 1
+	always_unpowered = TRUE
 	has_gravity = FALSE
 	base_turf = /turf/space
 

--- a/maps/away/derelict/derelict_areas.dm
+++ b/maps/away/derelict/derelict_areas.dm
@@ -50,7 +50,7 @@
 /area/constructionsite/solar
 	name = "\improper Construction Site Solars"
 	icon_state = "solar"
-	area_flags = AREA_FLAG_EXTERNAL
+	area_flags = GLOB.AREA_FLAG_EXTERNAL
 	always_unpowered = TRUE
 	has_gravity = FALSE
 	base_turf = /turf/space

--- a/maps/away/mining/mining_areas.dm
+++ b/maps/away/mining/mining_areas.dm
@@ -1,7 +1,10 @@
 // GENERIC MINING AREAS
 /area/mine
 	icon_state = "mining"
-	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
+	ambience = list(
+		'sound/ambience/ambimine.ogg',
+		'sound/ambience/song_game.ogg'
+	)
 	sound_env = ASTEROID
 	base_turf = /turf/simulated/floor/asteroid
 

--- a/maps/away/miningstation/miningstation_areas.dm
+++ b/maps/away/miningstation/miningstation_areas.dm
@@ -106,7 +106,7 @@
 	name = "crashed shuttle"
 	icon_state = "surgery"
 	always_unpowered = TRUE
-	area_flags = AREA_FLAG_EXTERNAL
+	area_flags = GLOB.AREA_FLAG_EXTERNAL
 	has_gravity = FALSE
 
 /area/miningstation/cryo

--- a/maps/away/miningstation/miningstation_areas.dm
+++ b/maps/away/miningstation/miningstation_areas.dm
@@ -105,9 +105,9 @@
 /area/miningstation/fix
 	name = "crashed shuttle"
 	icon_state = "surgery"
-	always_unpowered = 1
+	always_unpowered = TRUE
 	area_flags = AREA_FLAG_EXTERNAL
-	has_gravity = 0
+	has_gravity = FALSE
 
 /area/miningstation/cryo
 	name = "Cryogenic Storage"

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -119,7 +119,7 @@
 /area/scavver/gantry/lift
 	name = "\improper Salvage Gantry Lift"
 	icon_state = "gantry_lift"
-	requires_power = 0
+	requires_power = FALSE
 
 /area/scavver/yachtup
 	name = "\improper Private Yacht Upper Deck"

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -136,27 +136,27 @@
 /area/scavver/hab
 	name = "\improper Habitation Module"
 	icon_state = "gantry_hab"
-	area_flags = AREA_FLAG_RAD_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED
 
 /area/scavver/calypso
 	name = "\improper ITV Calypso"
 	icon_state = "gantry_calypso"
-	area_flags = AREA_FLAG_RAD_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED
 
 /area/scavver/lifepod
 	name = "\improper ITV The Reclaimer"
 	icon_state = "gantry_lifepod"
-	area_flags = AREA_FLAG_RAD_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED
 
 /area/scavver/escapepod
 	name = "\improper ITV Vulcan"
 	icon_state = "gantry_pod"
-	area_flags = AREA_FLAG_RAD_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED
 
 /area/scavver/harvestpod
 	name = "\improper ITV Spiritus"
 	icon_state = "gantry_yacht_down"
-	area_flags = AREA_FLAG_RAD_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED
 
 
 //smes

--- a/maps/away/skrellscoutship/skrellscoutship_areas.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_areas.dm
@@ -1,6 +1,6 @@
 /area/ship/skrellscoutship
 	name = "\improper Skrellian Ship"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	base_turf = /turf/space
 	req_access = list(access_skrellscoutship)
 
@@ -50,7 +50,7 @@
 	name = "\improper SSV Shuttle"
 	icon_state = "bridge"
 	base_turf = /turf/simulated/floor/plating
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_skrellscoutship)
 
 //New Ship Areas

--- a/maps/away/skrellscoutship/skrellscoutship_areas.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_areas.dm
@@ -6,7 +6,7 @@
 
 /area/ship/skrellscoutship/solars
 	name = "\improper Solar Area"
-	
+
 /area/ship/skrellscoutship/crew/hallway/d1
 	name = "\improper Hallway - Deck 1"
 
@@ -16,7 +16,7 @@
 /area/ship/skrellscoutship/crew/rec
 	name = "\improper Recreational Area"
 	icon_state = "green"
-	
+
 /area/ship/skrellscoutship/crew/fit
 	name = "\improper Exercise Area"
 	icon_state = "green"
@@ -32,7 +32,7 @@
 /area/ship/skrellscoutship/robotics
 	name = "\improper Maintenance"
 	icon_state = "green"
-	
+
 /area/ship/skrellscoutship/maintenance/power
 	name = "\improper Engineering"
 	icon_state = "engine_smes"
@@ -41,11 +41,11 @@
 /area/ship/skrellscoutship/command/bridge
 	name = "\improper SSV Helm"
 	icon_state = "bridge"
-	
+
 /area/ship/skrellscoutship/command/armory
 	name = "\improper Armory"
 	icon_state = "shuttlered"
-	
+
 /area/ship/skrellscoutshuttle
 	name = "\improper SSV Shuttle"
 	icon_state = "bridge"
@@ -102,7 +102,18 @@
 /area/ship/skrellscoutship/maintenance/power
 	name = "\improper Engineering"
 	icon_state = "engine_smes"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambieng1.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambieng1.ogg'
+	)
 
 /area/ship/skrellscoutship/hangar
 	name = "\improper Shuttle Dock"
@@ -119,4 +130,15 @@
 /area/ship/skrellscoutship/maintenance/atmos
 	name = "\improper Atmospherics"
 	icon_state = "atmos"
-	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambiatm1.ogg')
+	ambience = list(
+		'sound/ambience/ambigen3.ogg',
+		'sound/ambience/ambigen4.ogg',
+		'sound/ambience/ambigen5.ogg',
+		'sound/ambience/ambigen6.ogg',
+		'sound/ambience/ambigen7.ogg',
+		'sound/ambience/ambigen8.ogg',
+		'sound/ambience/ambigen9.ogg',
+		'sound/ambience/ambigen10.ogg',
+		'sound/ambience/ambigen11.ogg',
+		'sound/ambience/ambiatm1.ogg'
+	)

--- a/maps/away/voxship/voxship_areas.dm
+++ b/maps/away/voxship/voxship_areas.dm
@@ -1,28 +1,24 @@
 
 /area/voxship
 	icon = 'maps/away/voxship/voxship.dmi'
+	req_access = list(access_voxship)
 
 /area/voxship/scavship
 	name = "Vox Scavenger Ship"
 	icon_state = "scavship"
-	req_access = list(access_voxship)
 
 /area/voxship/fore
 	name = "Unknown Vessel Cockpit"
 	icon_state = "fore"
-	req_access = list(access_voxship)
 
 /area/voxship/engineering
 	name = "Vox Engineering"
 	icon_state = "eng"
-	req_access = list(access_voxship)
 
 /area/voxship/thrusters
 	name = "Vox Thrusters"
 	icon_state = "thrust"
-	req_access = list(access_voxship)
 
 /area/voxship/shuttle
 	name = "Vox Shuttle"
 	icon_state = "shuttle"
-	req_access = list(access_voxship)

--- a/maps/event/iccgn_ship/icgnv_hound.dm
+++ b/maps/event/iccgn_ship/icgnv_hound.dm
@@ -42,5 +42,5 @@
 /area/map_template/icgnv_hound
 	name = "\improper ICGNV Hound"
 	icon_state = "yellow"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_syndicate)

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
@@ -30,7 +30,7 @@
 /area/map_template/ecship/engine
 	name = "\improper Engine Exterior"
 	icon_state = "engine"
-	area_flags = AREA_FLAG_EXTERNAL
+	area_flags = GLOB.AREA_FLAG_EXTERNAL
 
 /area/map_template/ecship/cockpit
 	name = "\improper Cockpit"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -136,7 +136,7 @@
 	name = "Third Deck Substation"
 
 /area/crew_quarters/safe_room
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/crew_quarters/safe_room/thirddeck
 	name = "\improper Third Deck Safe Room"
@@ -293,57 +293,57 @@
 /area/shuttle/escape_pod6/station
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 	name = "Escape Pod One"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 
 /area/shuttle/escape_pod7/station
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 	name = "Escape Pod Two"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 
 /area/shuttle/escape_pod8/station
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 	name = "Escape Pod Three"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 
 /area/shuttle/escape_pod9/station
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 	name = "Escape Pod Four"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 
 /area/shuttle/escape_pod10/station
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 	name = "Escape Pod Five"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 
 /area/shuttle/escape_pod11/station
 	name = "Escape Pod Six"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 //torch small pods
 /area/shuttle/escape_pod12/station
 	name = "Escape Pod Seven"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 /area/shuttle/escape_pod13/station
 	name = "Escape Pod Eight"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 /area/shuttle/escape_pod15/station
 	name = "Escape Pod Ten"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 /area/shuttle/escape_pod16/station
 	name = "Escape Pod Eleven"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 /area/shuttle/escape_pod17/station
 	name = "Escape Pod Twelve"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 //Charon
@@ -352,7 +352,7 @@
 	name = "\improper Charon"
 	icon_state = "shuttlered"
 	base_turf = /turf/simulated/floor/plating
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_HIDE_FROM_HOLOMAP
 	base_turf_special_handling = TRUE
 
 /area/exploration_shuttle/cockpit
@@ -386,7 +386,7 @@
 	name = "\improper SEV Aquila"
 	icon_state = "shuttlered"
 	base_turf = /turf/simulated/floor/reinforced/airless
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_HIDE_FROM_HOLOMAP
 	base_turf_special_handling = TRUE
 
 /area/aquila/cockpit
@@ -424,7 +424,7 @@
 /area/guppy_hangar/start
 	name = "\improper Guppy"
 	icon_state = "shuttlered"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED | GLOB.AREA_FLAG_HIDE_FROM_HOLOMAP
 	req_access = list(access_guppy)
 	base_turf_special_handling = TRUE
 
@@ -434,7 +434,7 @@
 /area/shuttle/petrov
 	name = "\improper SRV Petrov"
 	requires_power = TRUE
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_petrov)
 	lighting_tone = AREA_LIGHTING_COOL
 
@@ -515,7 +515,7 @@
 	name = "\improper Turbolift"
 	icon_state = "shuttle"
 	requires_power = FALSE
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	req_access = list(access_maint_tunnels)
 
 /area/turbolift/start
@@ -563,7 +563,7 @@
 	name = "\improper Merchant Vessel"
 	icon_state = "shuttlegrn"
 	req_access = list(access_merchant)
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 // Elevator areas.
 /area/turbolift/torch_top
@@ -1061,19 +1061,19 @@
 	name = "\improper Safe Room"
 	icon_state = "crew_quarters"
 	sound_env = SMALL_ENCLOSED
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/crew_quarters/sleep/bunk
 	name = "\improper Bunk Room"
 	icon_state = "Sleep"
 	sound_env = SMALL_SOFTFLOOR
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 	lighting_tone = AREA_LIGHTING_WARM
 
 /area/crew_quarters/sleep/cryo/aux
 	name = "\improper First Deck Cryogenic Storage"
 	icon_state = "Sleep"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/crew_quarters/adherent
 	name = "\improper Adherent Maintenence"
@@ -1384,7 +1384,7 @@
 /area/torchexterior
 	name = "\improper Exterior Reinforcements"
 	icon_state = "maint_exterior"
-	area_flags = AREA_FLAG_EXTERNAL
+	area_flags = GLOB.AREA_FLAG_EXTERNAL
 	has_gravity = FALSE
 	turf_initializer = /decl/turf_initializer/maintenance/space
 	req_access = list(
@@ -1437,7 +1437,7 @@
 	holomap_color = HOLOMAP_AREACOLOR_AIRLOCK
 
 /area/solar
-	area_flags = AREA_FLAG_EXTERNAL
+	area_flags = GLOB.AREA_FLAG_EXTERNAL
 	always_unpowered = TRUE
 	has_gravity = FALSE
 	base_turf = /turf/space
@@ -1494,7 +1494,7 @@
 	icon_state = "Holodeck"
 	dynamic_lighting = FALSE
 	sound_env = LARGE_ENCLOSED
-	area_flags = AREA_FLAG_NO_MODIFY
+	area_flags = GLOB.AREA_FLAG_NO_MODIFY
 
 /area/holodeck/alphadeck
 	name = "\improper Holodeck Alpha"
@@ -1665,7 +1665,7 @@
 	name = "\improper Administration Shuttle"
 	icon_state = "shuttlered"
 	req_access = list(access_cent_general)
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/shuttle/escape_pod1/centcom
 	icon_state = "shuttle"
@@ -1699,7 +1699,7 @@
 /area/security/nuke_storage
 	name = "\improper Vault"
 	icon_state = "nuke_storage"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
+	area_flags = GLOB.AREA_FLAG_IS_NOT_PERSISTENT
 	req_access = list(access_heads_vault)
 
 // Crew
@@ -1707,7 +1707,7 @@
 /area/crew_quarters/sleep/cryo
 	name = "\improper Third Deck Cryogenic Storage"
 	icon_state = "Sleep"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = GLOB.AREA_FLAG_RAD_SHIELDED | GLOB.AREA_FLAG_ION_SHIELDED
 
 /area/hydroponics
 	name = "\improper Hydroponics"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -283,7 +283,6 @@
 
 /area/bridge/storage
 	name = "\improper Bridge Storage"
-	req_access = list(access_bridge)
 
 // Shuttles
 /area/shuttle/transport1/centcom
@@ -387,8 +386,6 @@
 	name = "\improper SEV Aquila"
 	icon_state = "shuttlered"
 	base_turf = /turf/simulated/floor/reinforced/airless
-	requires_power = 1
-	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 	base_turf_special_handling = TRUE
 
@@ -427,8 +424,6 @@
 /area/guppy_hangar/start
 	name = "\improper Guppy"
 	icon_state = "shuttlered"
-	requires_power = 1
-	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 	req_access = list(access_guppy)
 	base_turf_special_handling = TRUE
@@ -438,8 +433,7 @@
 
 /area/shuttle/petrov
 	name = "\improper SRV Petrov"
-	requires_power = 1
-	dynamic_lighting = 1
+	requires_power = TRUE
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 	req_access = list(access_petrov)
 	lighting_tone = AREA_LIGHTING_COOL
@@ -520,8 +514,7 @@
 /area/turbolift
 	name = "\improper Turbolift"
 	icon_state = "shuttle"
-	requires_power = 0
-	dynamic_lighting = 1
+	requires_power = FALSE
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 	req_access = list(access_maint_tunnels)
 
@@ -642,7 +635,12 @@
 /area/command/armoury
 	name = "\improper Emergency Armory"
 	icon_state = "Warden"
-	req_access = list(list(access_bridge, access_emergency_armory))
+	req_access = list(
+		list(
+			access_bridge,
+			access_emergency_armory
+		)
+	)
 
 /area/command/armoury/access
 	name = "\improper Emergency Armory - Access"
@@ -712,7 +710,6 @@
 /area/crew_quarters/heads/office/cl/backroom
 	icon_state = "heads_cl"
 	name = "\improper Command - CL's Backroom"
-	req_access = list(access_liaison)
 
 /area/crew_quarters/heads/office/sgr
 	icon_state = "heads_sr"
@@ -729,19 +726,24 @@
 /area/engineering/shieldbay
 	name = "Shield Bay"
 	icon_state = "engineering"
-	req_access = list(access_engine, access_engine_equip)
 
 /area/engineering/bluespace
 	name = "Bluespace Drive Containment"
 	icon_state = "engineering"
 	color = COLOR_BLUE_LIGHT
-	req_access = list(list(access_engine_equip, access_heads), access_engine, access_maint_tunnels)
+	req_access = list(
+		list(
+			access_engine_equip,
+			access_heads
+		),
+		access_engine,
+		access_maint_tunnels
+	)
 
 /area/engineering/atmos/aux
 	name = "\improper Auxiliary Atmospherics"
 	icon_state = "atmos"
 	sound_env = SMALL_ENCLOSED
-	req_access = list(access_atmospherics)
 
 /area/engineering/auxpower
 	name = "\improper Auxiliary Power Storage"
@@ -881,33 +883,67 @@
 /area/quartermaster/expedition
 	name = "\improper Expedition Preparation"
 	icon_state = "mining"
-	req_access = list(list(access_mining, access_nanotrasen, access_xenoarch))
+	req_access = list(
+		list(
+			access_mining,
+			access_nanotrasen,
+			access_xenoarch
+		)
+	)
 
 /area/quartermaster/expedition/eva
 	name = "\improper Expedition EVA"
 	icon_state = "mining"
-	req_access = list(list(access_mining, access_xenoarch))
+	req_access = list(
+		list(
+			access_mining,
+			access_xenoarch
+		)
+	)
 
 /area/quartermaster/expedition/storage
 	name = "\improper Hangar Expedition Storage"
 	icon_state = "mining"
-	req_access = list(list(access_mining, access_explorer, access_xenoarch))
+	req_access = list(
+		list(
+			access_mining,
+			access_explorer,
+			access_xenoarch
+		)
+	)
 
 /area/quartermaster/expedition/atmos
 	name = "\improper Hangar Atmospheric Storage"
 	icon_state = "mining"
-	req_access = list(list(access_mining, access_explorer, access_xenoarch))
+	req_access = list(
+		list(
+			access_mining,
+			access_explorer,
+			access_xenoarch
+		)
+	)
 
 /area/quartermaster/exploration
 	name = "\improper Exploration Equipment"
 	icon_state = "exploration"
-	req_access = list(list(access_explorer, access_pathfinder, access_pilot))
+	req_access = list(
+		list(
+			access_explorer,
+			access_pathfinder,
+			access_pilot
+		)
+	)
 	holomap_color = HOLOMAP_AREACOLOR_EXPLORATION
 
 /area/quartermaster/shuttlefuel
 	name = "\improper Shuttle Fuel Bay"
 	icon_state = "toxstorage"
-	req_access = list(list(access_hangar, access_cargo))
+	req_access = list(
+		list(
+			access_hangar,
+			access_cargo
+		)
+	)
 
 /area/quartermaster/hangar
 	name = "\improper Hangar Deck"
@@ -1142,7 +1178,13 @@
 /area/medical/foyer
 	name = "\improper Medical Foyer"
 	icon_state = "medbay"
-	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
+	req_access = list(
+		list(
+			access_medical,
+			access_morgue,
+			access_forensics_lockers
+		)
+	)
 
 /area/medical/foyer/storeroom
 	name = "\improper Medical Storeroom"
@@ -1156,7 +1198,6 @@
 /area/medical/medpaperworkoffice
 	name = "\improper Medical Paperwork Office"
 	icon_state = "locker"
-	req_access = list(access_medical)
 
 /area/medical/washroom
 	name = "\improper Medical Washroom"
@@ -1193,7 +1234,6 @@
 /area/medical/staging
 	name = "\improper Infirmary Staging"
 	icon_state = "patients"
-	req_access = list(access_medical)
 
 /area/medical/chemistry
 	name = "\improper Chemistry"
@@ -1207,8 +1247,17 @@
 /area/medical/morgue
 	name = "\improper Morgue"
 	icon_state = "morgue"
-	ambience = list('sound/ambience/ambimo1.ogg','sound/ambience/ambimo2.ogg','sound/music/main.ogg')
-	req_access = list(list(access_morgue,access_forensics_lockers))
+	ambience = list(
+		'sound/ambience/ambimo1.ogg',
+		'sound/ambience/ambimo2.ogg',
+		'sound/music/main.ogg'
+	)
+	req_access = list(
+		list(
+			access_morgue,
+			access_forensics_lockers
+		)
+	)
 
 /area/medical/morgue/autopsy
 	name = "\improper Autopsy"
@@ -1338,7 +1387,10 @@
 	area_flags = AREA_FLAG_EXTERNAL
 	has_gravity = FALSE
 	turf_initializer = /decl/turf_initializer/maintenance/space
-	req_access = list(access_external_airlocks, access_maint_tunnels)
+	req_access = list(
+		access_external_airlocks,
+		access_maint_tunnels
+	)
 
 // CentCom
 
@@ -1368,20 +1420,25 @@
 	name = "Solar Maintenance - Port"
 	icon_state = "SolarcontrolP"
 	sound_env = SMALL_ENCLOSED
-	req_access = list(access_engine_equip, access_maint_tunnels)
+	req_access = list(
+		access_engine_equip,
+		access_maint_tunnels
+	)
 	holomap_color = HOLOMAP_AREACOLOR_AIRLOCK
 
 /area/maintenance/auxsolarstarboard
 	name = "Solar Maintenance - Starboard"
 	icon_state = "SolarcontrolS"
 	sound_env = SMALL_ENCLOSED
-	req_access = list(access_engine_equip, access_maint_tunnels)
+	req_access = list(
+		access_engine_equip,
+		access_maint_tunnels
+	)
 	holomap_color = HOLOMAP_AREACOLOR_AIRLOCK
 
 /area/solar
 	area_flags = AREA_FLAG_EXTERNAL
-	requires_power = 1
-	always_unpowered = 1
+	always_unpowered = TRUE
 	has_gravity = FALSE
 	base_turf = /turf/space
 	req_access = list(access_engine_equip)
@@ -1403,7 +1460,13 @@
 /area/maintenance/incinerator
 	name = "\improper Incinerator"
 	icon_state = "disposal"
-	req_access = list(list(access_engine, access_medical, access_cargo))
+	req_access = list(
+		list(
+			access_engine,
+			access_medical,
+			access_cargo
+		)
+	)
 
 /area/maintenance/waterstore
 	name = "\improper Cistern"
@@ -1429,7 +1492,7 @@
 /area/holodeck
 	name = "\improper Holodeck"
 	icon_state = "Holodeck"
-	dynamic_lighting = 0
+	dynamic_lighting = FALSE
 	sound_env = LARGE_ENCLOSED
 	area_flags = AREA_FLAG_NO_MODIFY
 
@@ -1488,7 +1551,7 @@
 
 /area/holodeck/source_space
 	name = "\improper Holodeck - Space"
-	has_gravity = 0
+	has_gravity = FALSE
 	sound_env = SPACE
 
 /area/holodeck/source_cafe
@@ -1509,6 +1572,12 @@
 
 // Engineering
 
+/area/engineering
+	req_access = list(
+		access_engine,
+		access_engine_equip
+	)
+
 /area/engineering/atmos/storage
 	name = "\improper Atmospherics Storage"
 	icon_state = "atmos_storage"
@@ -1519,7 +1588,6 @@
 	name = "\improper Engine Room"
 	icon_state = "engine"
 	sound_env = LARGE_ENCLOSED
-	req_access = list(access_engine, access_engine_equip)
 
 /area/engineering/drone_fabrication
 	name = "\improper Engineering Drone Fabrication"
@@ -1530,13 +1598,11 @@
 /area/engineering/engine_monitoring
 	name = "\improper Engine Monitoring Room"
 	icon_state = "engine_monitoring"
-	req_access = list(access_engine, access_engine_equip)
 
 /area/engineering/engine_smes
 	name = "\improper Engineering SMES"
 	icon_state = "engine_smes"
 	sound_env = SMALL_ENCLOSED
-	req_access = list(access_engine, access_engine_equip)
 
 /area/engineering/foyer
 	name = "\improper Engineering Foyer"
@@ -1546,7 +1612,6 @@
 /area/engineering/engineering_bay
 	name = "\improper Engineering Bay"
 	icon_state = "engineering_locker"
-	req_access = list(access_engine)
 
 /area/engineering/storage
 	name = "\improper Engineering Storage"
@@ -1573,7 +1638,12 @@
 
 /area/assembly/robotics/laboratory
 	name = "\improper Robotics Laboratory"
-	req_access = list(list(access_medical,access_robotics))
+	req_access = list(
+		list(
+			access_medical,
+			access_robotics
+		)
+	)
 
 /area/assembly/robotics/office
 	name = "\improper Robotics Office"
@@ -1616,7 +1686,7 @@
 /area/supply/dock
 	name = "Supply Shuttle"
 	icon_state = "shuttle3"
-	requires_power = 0
+	requires_power = FALSE
 	req_access = list(access_cent_storage)
 
 // Secure
@@ -1654,7 +1724,12 @@
 
 // Tcomm
 /area/tcommsat
-	ambience = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
+	ambience = list(
+		'sound/ambience/ambisin2.ogg',
+		'sound/ambience/signal.ogg',
+		'sound/ambience/signal.ogg',
+		'sound/ambience/ambigen10.ogg'
+	)
 	req_access = list(access_tcomsat)
 
 /area/tcommsat/chamber
@@ -1670,7 +1745,13 @@
 /area/chapel/main
 	name = "\improper Chapel"
 	icon_state = "chapel"
-	ambience = list('sound/ambience/ambicha1.ogg','sound/ambience/ambicha2.ogg','sound/ambience/ambicha3.ogg','sound/ambience/ambicha4.ogg','sound/music/traitor.ogg')
+	ambience = list(
+		'sound/ambience/ambicha1.ogg',
+		'sound/ambience/ambicha2.ogg',
+		'sound/ambience/ambicha3.ogg',
+		'sound/ambience/ambicha4.ogg',
+		'sound/music/traitor.ogg'
+	)
 	sound_env = LARGE_ENCLOSED
 
 /area/chapel/office
@@ -1695,15 +1776,15 @@
 /area/acting
 	name = "\improper Centcom Acting Guild"
 	icon_state = "red"
-	dynamic_lighting = 0
-	requires_power = 0
+	dynamic_lighting = FALSE
+	requires_power = FALSE
 
 /area/acting/backstage
 	name = "\improper Backstage"
 
 /area/acting/stage
 	name = "\improper Stage"
-	dynamic_lighting = 1
+	dynamic_lighting = TRUE
 	icon_state = "yellow"
 
 // Thunderdome
@@ -1711,8 +1792,8 @@
 /area/tdome
 	name = "\improper Thunderdome"
 	icon_state = "thunder"
-	requires_power = 0
-	dynamic_lighting = 0
+	requires_power = FALSE
+	dynamic_lighting = FALSE
 	sound_env = ARENA
 	req_access = list(access_cent_thunder)
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 363 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 358 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 2 ".Replace( matches" '\.Replace(_char)?\(' -P
 exactly 3 ".Find( matches" '\.Find(_char)?\(' -P


### PR DESCRIPTION
WIP

NUFC

- Removed redundant definitions of vars
- Switched boolean values to TRUE/FALSE
- Updated lists to multi-line format if they had several entries
- Replaced `spawn(0)` calls with `INVOKE_ASYNC()`
- Converted some of the defines to constants - Specifically those benefitting from dmdoc parsing
- Added constants for accepted values used in `atmosalm`
- Removed the `get_apc()` proc as it was redundant to just directly referencing the `apc` var.