### PR TITLE
Allow public do_after bars to appear over actor

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -464,6 +464,7 @@
 #define DO_PUBLIC_PROGRESS   FLAG(9)
 #define DO_MOVE_CHECKS_TURFS FLAG(10)
 #define DO_FAIL_FEEDBACK     FLAG(11)
+#define DO_BAR_OVER_USER     FLAG(12) // Forces the progress bar to appear over the user instead of the target
 
 #define DO_BOTH_CAN_MOVE     (DO_USER_CAN_MOVE | DO_TARGET_CAN_MOVE)
 #define DO_BOTH_CAN_TURN     (DO_USER_CAN_TURN | DO_TARGET_CAN_TURN)

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -154,9 +154,9 @@
 	var/datum/progressbar/bar
 	if (do_flags & DO_SHOW_PROGRESS)
 		if (do_flags & DO_PUBLIC_PROGRESS)
-			bar = new /datum/progressbar/public(user, delay, target)
+			bar = new /datum/progressbar/public(user, delay, target, !!(do_flags & DO_BAR_OVER_USER))
 		else
-			bar = new /datum/progressbar/private(user, delay, target)
+			bar = new /datum/progressbar/private(user, delay, target, !!(do_flags & DO_BAR_OVER_USER))
 
 	var/start_time = world.time
 	var/end_time = start_time + delay

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -18,7 +18,7 @@
 	qdel(bar)
 	. = ..()
 
-/datum/progressbar/private/New(mob/actor, max_progress, atom/actee)
+/datum/progressbar/private/New(mob/actor, max_progress, atom/actee, display_on_actor = FALSE)
 	actee = actee || actor
 	if (!istype(actee))
 		EXCEPTION("Invalid progressbar/private instance")
@@ -28,7 +28,7 @@
 	visible = actor.get_preference_value(/datum/client_preference/show_progress_bar) == GLOB.PREF_SHOW
 	if (!visible)
 		return
-	bar = image('icons/effects/progessbar.dmi', actee, "prog_bar_0", HUD_ABOVE_ITEM_LAYER)
+	bar = image('icons/effects/progessbar.dmi', display_on_actor ? actor : actee, "prog_bar_0", HUD_ABOVE_ITEM_LAYER)
 	bar.appearance_flags = DEFAULT_APPEARANCE_FLAGS | APPEARANCE_UI_IGNORE_ALPHA
 	bar.pixel_y = WORLD_ICON_SIZE
 	bar.plane = HUD_PLANE
@@ -53,6 +53,7 @@
 	var/atom/movable/actor
 	var/atom/movable/actee
 	var/atom/movable/bar
+	var/display_on_actor = FALSE
 
 /datum/progressbar/public/Destroy()
 	if (actor && bar)
@@ -60,19 +61,19 @@
 	qdel(bar)
 	. = ..()
 
-/datum/progressbar/public/New(atom/movable/actor, max_progress, atom/movable/actee)
+/datum/progressbar/public/New(atom/movable/actor, max_progress, atom/movable/actee, display_on_actor = FALSE)
 	actee = actee || actor
 	if (!istype(actee))
 		EXCEPTION("Invalid progressbar/public instance")
 	src.actor = actor
 	src.max_progress = max_progress
 	src.actee = actee
+	src.display_on_actor = display_on_actor
 	bar = new()
 	bar.mouse_opacity = 0
 	bar.icon = 'icons/effects/progessbar.dmi'
 	bar.icon_state = "prog_bar_0"
-	bar.pixel_x = (actee.x - actor.x) * WORLD_ICON_SIZE
-	bar.pixel_y = (actee.y - actor.y) * WORLD_ICON_SIZE + WORLD_ICON_SIZE
+	calculate_position()
 	bar.layer = ABOVE_HUMAN_LAYER
 	actor.vis_contents += bar
 
@@ -81,5 +82,16 @@
 		return
 	progress = clamp(progress, 0, max_progress)
 	bar.icon_state = "prog_bar_[round(progress * 100 / max_progress, 5)]"
-	bar.pixel_x = (actee.x - actor.x) * WORLD_ICON_SIZE
-	bar.pixel_y = (actee.y - actor.y) * WORLD_ICON_SIZE + WORLD_ICON_SIZE
+	calculate_position()
+
+
+/// Calculates and sets `bar`'s `pixel_x` and `pixel_y` positions based on the positions of `actor` and `actee`. If `display_on_actor` is set, the bar will be tracked over `actor` instead of `actee`.
+/datum/progressbar/public/proc/calculate_position()
+	if (display_on_actor)
+		bar.pixel_x = actor.x - actee.x
+		bar.pixel_y = actor.y - actee.y
+	else
+		bar.pixel_x = actee.x - actor.x
+		bar.pixel_y = actee.y - actor.y
+	bar.pixel_x *= WORLD_ICON_SIZE
+	bar.pixel_y *= WORLD_ICON_SIZE + WORLD_ICON_SIZE

--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -41,7 +41,7 @@
 	if(can_be_used_by(user, target))
 		var/do_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT
 		if(!reflexively)
-			do_flags |= DO_PUBLIC_PROGRESS
+			do_flags |= DO_PUBLIC_PROGRESS | DO_BAR_OVER_USER
 			show_initial_message(user, target)
 		user.face_atom(target)
 		. = (!delay || reflexively || (do_after(user, delay, target, do_flags) && can_be_used_by(user, target)))


### PR DESCRIPTION
Needs testing.

:cl: SierraKomodo
tweak: Certain public timed actions with progress bars now display the progress bar over the user instead of their target, where this would make sense. I.e., leaping.
/:cl: