### PR TITLE
Fix runtimes and broken timers when creating runes

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -103,7 +103,7 @@
 			timer = 8 SECONDS
 			damage = 2
 	visible_message("<span class='warning'>\The [src] slices open a finger and begins to chant and paint symbols on the floor.</span>", "<span class='notice'>[self]</span>", "You hear chanting.")
-	if(do_after(src, timer, rune, DO_PUBLIC_UNIQUE))
+	if(do_after(src, timer, T, DO_PUBLIC_UNIQUE))
 		remove_blood_simple(cost * damage)
 		if(locate(/obj/effect/rune) in T)
 			return

--- a/html/changelogs/sierrakomodo-rune-runtime-fix.yml
+++ b/html/changelogs/sierrakomodo-rune-runtime-fix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Creating cult runes now have timers associated with them once more. Creating runes also now displays a public progress bar and requires unique action checks for both the user and the target tile, as was intended in #32010."


### PR DESCRIPTION
I made a changelog file for this one. Idk why.

- Fixes #32070 (At least the version of it caused by creating runes)

changes:
  - bugfix: "Creating cult runes now have timers associated with them once more. Creating runes also now displays a public progress bar and requires unique action checks for both the user and the target tile, as was intended in #32010."