### PR TITLE
Utensils no longer make you eat plates

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -166,6 +166,11 @@
 			else
 				reagents.trans_to_obj(U, min(reagents.total_volume,5))
 				if (reagents.total_volume <= 0)
+					if (loc && trash)
+						if (ispath(trash))
+							trash = new trash
+						trash.dropInto(loc)
+						trash = null
 					qdel(src)
 			return
 


### PR DESCRIPTION
:cl: Rootoo807
tweak: Eating food that normally produces trash with a utensil now properly spawns trash. 
/:cl:

Tiny PR, does what it says on the tin.