### PR TITLE
uncolorable markings get no ui button to do so

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -197,9 +197,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	. += "<br />[BTN("marking_style", "+ Body Marking")]"
 	for (var/marking in pref.body_markings)
-		var/color = pref.body_markings[marking]
 		. += "<br />[VTBTN("marking_remove", marking, "-", marking)] "
-		. += "[VBTN("marking_color", marking, "Color")] [COLOR_PREVIEW(color)]"
+		var/datum/sprite_accessory/marking/instance = GLOB.body_marking_styles_list[marking]
+		if (instance.do_coloration == DO_COLORATION_USER)
+			var/color = pref.body_markings[marking]
+			. += "[VBTN("marking_color", marking, "Color")] [COLOR_PREVIEW(color)]"
 	if (length(pref.body_markings))
 		. += "<br />"
 


### PR DESCRIPTION
:cl:
tweak: Markings that can't be colored don't offer a button to do so.
/:cl:

breaking some stuff unrelated to the intent of #31871 out of it
