### PR TITLE
add abstract to datum

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -237,6 +237,7 @@
 #include "code\controllers\subsystems\processing\turf.dm"
 #include "code\controllers\subsystems\processing\vines.dm"
 #include "code\core\atom\Transform.dm"
+#include "code\core\datum\IsAbstract.dm"
 #include "code\core\image\Transform.dm"
 #include "code\core\matrix\Transform.dm"
 #include "code\datums\ai_law_sets.dm"

--- a/code/__defines/__initialization.dm
+++ b/code/__defines/__initialization.dm
@@ -17,13 +17,3 @@
 		SSatoms.InitAtom(src, args);\
 	}\
 }
-
-#define INIT_SKIP_QDELETED if (. == INITIALIZE_HINT_QDEL) {\
-return;\
-}
-
-#define INIT_DISALLOW_TYPE(path) if (type == path) {\
-. = INITIALIZE_HINT_QDEL;\
-crash_with("disallowed type [type] created");\
-return;\
-}

--- a/code/__defines/_renderer.dm
+++ b/code/__defines/_renderer.dm
@@ -9,6 +9,7 @@
 
 /// The base /renderer definition and defaults.
 /atom/movable/renderer
+	abstract_type = /atom/movable/renderer
 	appearance_flags = PLANE_MASTER
 	screen_loc = "CENTER"
 	plane = LOWEST_PLANE
@@ -40,8 +41,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 
 /atom/movable/renderer/Initialize(mapload, mob/owner)
 	. = ..()
+	if (. == INITIALIZE_HINT_QDEL)
+		return
 	src.owner = owner
-	INIT_DISALLOW_TYPE(/atom/movable/renderer)
 	if (isnull(group))
 		if (istext(render_target_name))
 			render_target = render_target_name

--- a/code/core/datum/IsAbstract.dm
+++ b/code/core/datum/IsAbstract.dm
@@ -1,0 +1,23 @@
+/**
+* Abstract-ness is a meta-property of a class that is used to indicate
+* that the class is intended to be used as a base class for others, and
+* should not (or cannot) be instantiated.
+* We have no such language concept in DM, and so we provide a datum member
+* that can be used to hint at abstractness for circumstances where we would
+* like that to be the case, such as base behavior providers.
+*/
+
+/// If set, a path at/above this one that expects not to be instantiated.
+/datum/var/abstract_type
+
+/// If true, this datum is an instance of an abstract type. Oops.
+/datum/proc/IsAbstract()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return type == abstract_type
+
+/// Passed a path or instance, returns whether it is abstract. Otherwise null.
+/proc/is_abstract(datum/thing)
+	if (ispath(thing))
+		return thing == initial(thing.abstract_type)
+	if (istype(thing))
+		return thing.IsAbstract()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -52,6 +52,10 @@
 		crash_with("Warning: [src]([type]) initialized multiple times!")
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
+	if (IsAbstract())
+		log_debug("Abstract atom [type] created!")
+		return INITIALIZE_HINT_QDEL
+
 	if(light_max_bright && light_outer_range)
 		update_light()
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -682,6 +682,7 @@
  */
 
 /obj/structure/plushie
+	abstract_type = /obj/structure/plushie
 	name = "generic plush"
 	desc = "A very generic plushie. It seems to not want to exist."
 	icon = 'icons/obj/toy.dmi'
@@ -690,11 +691,6 @@
 	anchored = FALSE
 	density = TRUE
 	var/phrase = "I don't want to exist anymore!"
-
-
-/obj/structure/plushie/Initialize()
-	. = ..()
-	INIT_DISALLOW_TYPE(/obj/structure/plushie)
 
 
 /obj/structure/plushie/attack_hand(mob/living/user)
@@ -745,16 +741,12 @@
 
 
 /obj/item/toy/plushie
+	abstract_type = /obj/item/toy/plushie
 	name = "generic small plush"
 	desc = "A very generic small plushie. It seems to not want to exist."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "nymphplushie"
 	w_class = ITEM_SIZE_SMALL
-
-
-/obj/item/toy/plushie/Initialize()
-	. = ..()
-	INIT_DISALLOW_TYPE(/obj/item/toy/plushie)
 
 
 /obj/item/toy/plushie/attack_self(mob/living/user)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -20,7 +20,6 @@
 
 /obj/item/clothing/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	var/list/init_accessories = accessories
 	accessories = list()
 	for (var/path in init_accessories)

--- a/code/modules/clothing/buttons.dm
+++ b/code/modules/clothing/buttons.dm
@@ -17,7 +17,6 @@
 
 /obj/item/clothing/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	if (buttons_suffix)
 		verbs |= /obj/item/clothing/proc/toggle_buttons
 

--- a/code/modules/clothing/under/accessories/chaplain.dm
+++ b/code/modules/clothing/under/accessories/chaplain.dm
@@ -1,14 +1,9 @@
 /obj/item/clothing/accessory/chaplain
+	abstract_type = /obj/item/clothing/accessory/chaplain
 	name = "base chaplain insignia"
 	item_state = "chaplaininsignia"
 	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_INSIGNIA
-
-
-/obj/item/clothing/accessory/chaplain/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/chaplain)
 
 
 /obj/item/clothing/accessory/chaplain/christianity

--- a/code/modules/clothing/under/accessories/hawaii.dm
+++ b/code/modules/clothing/under/accessories/hawaii.dm
@@ -17,7 +17,6 @@
 
 /obj/item/clothing/accessory/toggleable/hawaii/random/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	if (prob(50))
 		icon_state = "hawaii2"
 		icon_closed = "hawaii2"

--- a/code/modules/clothing/under/accessories/helmet_decor.dm
+++ b/code/modules/clothing/under/accessories/helmet_decor.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/accessory/helmet_decor
+	abstract_type = /obj/item/clothing/accessory/helmet_decor
 	name = "base helmet decor"
 	desc = "You should not see this."
 	icon = 'icons/obj/clothing/helmet_decor.dmi'
@@ -12,12 +13,6 @@
 	slot = ACCESSORY_SLOT_HELM_D
 	body_location = HEAD
 	gender = PLURAL
-
-
-/obj/item/clothing/accessory/helmet_decor/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/helmet_decor)
 
 
 /obj/item/clothing/accessory/helmet_decor/get_fibers()

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -12,7 +12,6 @@
 
 /obj/item/clothing/accessory/storage/holster/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	container.virtual = TRUE
 	set_extension(src, /datum/extension/holster, container, sound_in, sound_out, can_holster)
 

--- a/code/modules/clothing/under/accessories/pride_pin.dm
+++ b/code/modules/clothing/under/accessories/pride_pin.dm
@@ -1,14 +1,9 @@
 /obj/item/clothing/accessory/pride_pin
+	abstract_type = /obj/item/clothing/accessory/pride_pin
 	name = "base pride pin"
 	item_state = "pridepins"
 	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_INSIGNIA
-
-
-/obj/item/clothing/accessory/pride_pin/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/pride_pin)
 
 
 /obj/item/clothing/accessory/pride_pin/transgender

--- a/code/modules/clothing/under/accessories/pronouns.dm
+++ b/code/modules/clothing/under/accessories/pronouns.dm
@@ -1,16 +1,11 @@
 /obj/item/clothing/accessory/pronouns
+	abstract_type = /obj/item/clothing/accessory/pronouns
 	name = "base pronouns badge"
 	icon_state = "pronounpin"
 	item_state = "pronouns"
 	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_INSIGNIA
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
-
-
-/obj/item/clothing/accessory/pronouns/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/pronouns)
 
 
 /obj/item/clothing/accessory/pronouns/they

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/accessory/storage
+	abstract_type = /obj/item/clothing/accessory/storage
 	name = "base storage accessory"
 	icon_state = "webbing"
 	slot = ACCESSORY_SLOT_UTILITY
@@ -13,8 +14,8 @@
 
 /obj/item/clothing/accessory/storage/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/storage)
+	if (. == INITIALIZE_HINT_QDEL)
+		return
 	if (!slots)
 		. = INITIALIZE_HINT_QDEL
 		crash_with("[type] created with no slots")
@@ -147,7 +148,6 @@
 
 /obj/item/clothing/accessory/storage/knifeharness/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	if (container)
 		container.can_hold = list(
 			/obj/item/material/hatchet,
@@ -167,7 +167,6 @@
 
 /obj/item/clothing/accessory/storage/bandolier/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	if (container)
 		container.can_hold = list(
 			/obj/item/ammo_casing,
@@ -198,7 +197,6 @@
 
 /obj/item/clothing/accessory/storage/bandolier/safari/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	if (container)
 		for(var/i = 1 to abs(slots))
 			new /obj/item/net_shell (container)

--- a/code/modules/clothing/under/accessories/suit_jacket.dm
+++ b/code/modules/clothing/under/accessories/suit_jacket.dm
@@ -30,5 +30,4 @@
 
 /obj/item/clothing/accessory/toggleable/tan_jacket/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	do_toggle()

--- a/code/modules/reagents/reagent_containers/food/fish.dm
+++ b/code/modules/reagents/reagent_containers/food/fish.dm
@@ -1,4 +1,5 @@
 /obj/item/reagent_containers/food/snacks/fish
+	abstract_type = /obj/item/reagent_containers/food/snacks/fish
 	name = "base fish fillet"
 	desc = "A fillet of fish."
 	icon_state = "fishfillet"
@@ -11,8 +12,8 @@
 
 /obj/item/reagent_containers/food/snacks/fish/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/reagent_containers/food/snacks/fish)
+	if (. == INITIALIZE_HINT_QDEL)
+		return
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 6)
 	name = "[fish_type] fillet"
 
@@ -41,7 +42,6 @@
 /// fish/generated permits arbitrary fish type and contents setting through new (loc, "type", list(/type = amount), 1/0)
 /obj/item/reagent_containers/food/snacks/fish/generated/Initialize(_mapload, _fish_type, list/_reagents, _replace_reagents)
 	. = ..()
-	INIT_SKIP_QDELETED
 	if (_fish_type)
 		fish_type = _fish_type
 		name = "[fish_type] fillet"
@@ -59,7 +59,6 @@
 
 /obj/item/reagent_containers/food/snacks/fish/space_carp/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	reagents.add_reagent(/datum/reagent/toxin/carpotoxin, 6)
 
 
@@ -71,7 +70,6 @@
 
 /obj/item/reagent_containers/food/snacks/fish/space_pike/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	reagents.add_reagent(/datum/reagent/toxin/carpotoxin, 6)
 
 
@@ -83,7 +81,6 @@
 
 /obj/item/reagent_containers/food/snacks/fish/space_shark/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 5)
 	reagents.add_reagent(/datum/reagent/space_drugs, 1)
 	reagents.add_reagent(/datum/reagent/toxin/phoron, 1)

--- a/code/modules/reagents/reagent_containers/food/snacks/donkpocket.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/donkpocket.dm
@@ -5,42 +5,43 @@
 * become more useful.
 */
 
-/obj/item/reagent_containers/food/snacks/donkpocket/name = "donk-pocket"
+/obj/item/reagent_containers/food/snacks/donkpocket
+	abstract_type = /obj/item/reagent_containers/food/snacks/donkpocket
+	name = "donk-pocket"
+	icon_state = "donkpocket"
+	filling_color = "#dedeab"
+	center_of_mass = "x=16;y=10"
+	bitesize = 3
+	nutriment_amt = 2
+	nutriment_desc = list(
+		"heartiness" = 1,
+		"dough" = 2
+	)
 
-/obj/item/reagent_containers/food/snacks/donkpocket/icon_state = "donkpocket"
+	/// Whether the donk pocket is currently hot. Hot donk pockets have additional reagents
+	var/is_hot = FALSE
 
-/obj/item/reagent_containers/food/snacks/donkpocket/filling_color = "#dedeab"
+	/// Whether the donk pocket is able to be made hot without a microwave by using it in-hand
+	var/can_self_heat = FALSE
 
-/obj/item/reagent_containers/food/snacks/donkpocket/center_of_mass = "x=16;y=10"
+	/// Whether the donk pocket was heated up already. Reheating does not re-add the extra reagents.
+	var/was_heated = FALSE
 
-/obj/item/reagent_containers/food/snacks/donkpocket/bitesize = 3
+	/// The reagents to be added to the donk pocket when it is made hot (and removed when made cold)
+	var/list/hot_reagents = list(
+		/datum/reagent/tricordrazine = 5
+	)
 
-/obj/item/reagent_containers/food/snacks/donkpocket/nutriment_amt = 2
-
-/obj/item/reagent_containers/food/snacks/donkpocket/nutriment_desc = list(
-	"heartiness" = 1,
-	"dough" = 2
-)
-
-/// Whether the donk pocket is currently hot. Hot donk pockets have additional reagents
-/obj/item/reagent_containers/food/snacks/donkpocket/var/is_hot = FALSE
-
-/// Whether the donk pocket is able to be made hot without a microwave by using it in-hand
-/obj/item/reagent_containers/food/snacks/donkpocket/var/can_self_heat = FALSE
-
-/// Whether the donk pocket was heated up already. Reheating does not re-add the extra reagents.
-/obj/item/reagent_containers/food/snacks/donkpocket/var/was_heated = FALSE
-
-/// The reagents to be added to the donk pocket when it is made hot (and removed when made cold)
-/obj/item/reagent_containers/food/snacks/donkpocket/var/list/hot_reagents = list(
-	/datum/reagent/tricordrazine = 5
-)
+	/// The reagents to be added to the donk pocket when it is initialized
+	var/list/filling_options
 
 
 /obj/item/reagent_containers/food/snacks/donkpocket/Initialize()
 	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/reagent_containers/food/snacks/donkpocket)
+	if (. == INITIALIZE_HINT_QDEL)
+		return
+	if (filling_options)
+		SetInitialReagents(filling_options)
 
 
 /obj/item/reagent_containers/food/snacks/donkpocket/OnConsume(mob/living/consumer)
@@ -109,30 +110,19 @@
 
 
 
-/obj/item/reagent_containers/food/snacks/donkpocket/protein/name = "protein donk-pocket"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/protein/desc = "A mass produced shelf-stable turnover. Allegedly contains mixed meat product."
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/protein/Initialize()
-	. = ..()
-	var/static/list/options = list(
+/obj/item/reagent_containers/food/snacks/donkpocket/protein
+	name = "protein donk-pocket"
+	desc = "A mass produced shelf-stable turnover. Allegedly contains mixed meat product."
+	filling_options = list(
 		/datum/reagent/nutriment/protein,
 		/datum/reagent/drink/porksoda
 	)
-	SetInitialReagents(options)
 
 
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/vegetable/name = "vegetable donk-pocket"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/vegetable/desc = "A mass produced shelf-stable turnover. Allegedly contains plant based nutrients."
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/vegetable/Initialize()
-	. = ..()
-	var/static/list/options = list(
+/obj/item/reagent_containers/food/snacks/donkpocket/vegetable
+	name = "vegetable donk-pocket"
+	desc = "A mass produced shelf-stable turnover. Allegedly contains plant based nutrients."
+	filling_options = list(
 		list(
 			/datum/reagent/drink/juice/potato,
 			/datum/reagent/drink/juice/onion,
@@ -143,38 +133,24 @@
 		/datum/reagent/drink/juice/cabbage,
 		/datum/reagent/drink/milk/soymilk
 	)
-	SetInitialReagents(options)
 
 
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/fruit/name = "fruit donk-pocket"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/fruit/desc = "A mass produced shelf-stable turnover. Allegedly contains fruit derivatives."
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/fruit/Initialize()
-	. = ..()
-	var/static/list/options = list(
+/obj/item/reagent_containers/food/snacks/donkpocket/fruit
+	name = "fruit donk-pocket"
+	desc = "A mass produced shelf-stable turnover. Allegedly contains fruit derivatives."
+	filling_options = list(
 		/datum/reagent/drink/juice/apple,
 		/datum/reagent/drink/juice/berry,
 		/datum/reagent/drink/juice/melon,
 		/datum/reagent/drink/juice/orange,
 		/datum/reagent/drink/coconut
 	)
-	SetInitialReagents(options)
 
 
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/dessert/name = "dessert donk-pocket"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/dessert/desc = "A mass produced shelf-stable turnover. Allegedly contains unnatural delights."
-
-
-/obj/item/reagent_containers/food/snacks/donkpocket/dessert/Initialize()
-	. = ..()
-	var/static/list/options = list(
+/obj/item/reagent_containers/food/snacks/donkpocket/dessert
+	name = "dessert donk-pocket"
+	desc = "A mass produced shelf-stable turnover. Allegedly contains unnatural delights."
+	filling_options = list(
 		/datum/reagent/drink/milk/chocolate,
 		/datum/reagent/drink/milk/cream,
 		/datum/reagent/drink/coffee/soy_latte/mocha,
@@ -185,42 +161,32 @@
 		/datum/reagent/cinnamon,
 		/datum/reagent/drink/kefir
 	)
-	SetInitialReagents(options)
+
+
+/obj/item/reagent_containers/food/snacks/donkpocket/premium
+	name = "premium donk-pocket"
+	desc = "A \"premium\" shelf-stable turnover. Possibly contains \"real\" fruit paste. Crush the packaging to cook it on the go!"
+	filling_color = "#6d6d00"
+	can_self_heat = TRUE
+	nutriment_amt = 4
+	nutriment_desc = list(
+		"nutritious goodness" = 1,
+		"flaky pastry" = 2
+	)
+	hot_reagents = list(
+		/datum/reagent/drink/doctor_delight = 4,
+		/datum/reagent/hyperzine = 0.5,
+		/datum/reagent/synaptizine = 0.1
+	)
 
 
 
 
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/name = "premium donk-pocket"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/desc = "A \"premium\" shelf-stable turnover. Possibly contains \"real\" fruit paste. Crush the packaging to cook it on the go!"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/filling_color = "#6d6d00"
-
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/nutriment_amt = 4
-
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/nutriment_desc = list(
-	"nutritious goodness" = 1,
-	"flaky pastry" = 2
-)
-
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/can_self_heat = TRUE
-
-/obj/item/reagent_containers/food/snacks/donkpocket/premium/hot_reagents = list(
-	/datum/reagent/drink/doctor_delight = 4,
-	/datum/reagent/hyperzine = 0.5,
-	/datum/reagent/synaptizine = 0.1
-)
-
-
-
-
-/obj/random/donkpocket/name = "random donk-pocket"
-
-/obj/random/donkpocket/desc = "This is a random donk-pocket."
-
-/obj/random/donkpocket/icon = 'icons/obj/food.dmi'
-
-/obj/random/donkpocket/icon_state = "donkpocket"
+/obj/random/donkpocket
+	name = "random donk-pocket"
+	desc = "This is a random donk-pocket."
+	icon = 'icons/obj/food.dmi'
+	icon_state = "donkpocket"
 
 
 /obj/random/donkpocket/spawn_choices()
@@ -235,92 +201,68 @@
 
 
 
-/obj/item/storage/box/donkpocket_protein/name = "box of protein donk-pockets"
-
-/obj/item/storage/box/donkpocket_protein/desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Contains meat."
-
-/obj/item/storage/box/donkpocket_protein/icon_state = "donk_kit"
-
-/obj/item/storage/box/donkpocket_protein/startswith = list(
-	/obj/item/reagent_containers/food/snacks/donkpocket/protein = 4
-)
+/obj/item/storage/box/donkpocket_protein
+	name = "box of protein donk-pockets"
+	desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Contains meat."
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/item/reagent_containers/food/snacks/donkpocket/protein = 4
+	)
 
 
+/obj/item/storage/box/donkpocket_vegetable
+	name = "box of vegetable donk-pockets"
+	desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Suitable for vegetarians."
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/item/reagent_containers/food/snacks/donkpocket/vegetable = 4
+	)
 
 
-/obj/item/storage/box/donkpocket_vegetable/name = "box of vegetable donk-pockets"
-
-/obj/item/storage/box/donkpocket_vegetable/desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Suitable for vegetarians."
-
-/obj/item/storage/box/donkpocket_vegetable/icon_state = "donk_kit"
-
-/obj/item/storage/box/donkpocket_vegetable/startswith = list(
-	/obj/item/reagent_containers/food/snacks/donkpocket/vegetable = 4
-)
+/obj/item/storage/box/donkpocket_fruit
+	name = "box of fruit donk-pockets"
+	desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Contains plant sugars."
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/item/reagent_containers/food/snacks/donkpocket/fruit = 4
+	)
 
 
+/obj/item/storage/box/donkpocket_dessert
+	name = "box of dessert donk-pockets"
+	desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Contains animal products."
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/item/reagent_containers/food/snacks/donkpocket/dessert = 4
+	)
 
 
-/obj/item/storage/box/donkpocket_fruit/name = "box of fruit donk-pockets"
-
-/obj/item/storage/box/donkpocket_fruit/desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Contains plant sugars."
-
-/obj/item/storage/box/donkpocket_fruit/icon_state = "donk_kit"
-
-/obj/item/storage/box/donkpocket_fruit/startswith = list(
-	/obj/item/reagent_containers/food/snacks/donkpocket/fruit = 4
-)
-
-
-
-
-/obj/item/storage/box/donkpocket_dessert/name = "box of dessert donk-pockets"
-
-/obj/item/storage/box/donkpocket_dessert/desc = "Heat in microwave. Product will cool if not eaten within seven minutes. Contains animal products."
-
-/obj/item/storage/box/donkpocket_dessert/icon_state = "donk_kit"
-
-/obj/item/storage/box/donkpocket_dessert/startswith = list(
-	/obj/item/reagent_containers/food/snacks/donkpocket/dessert = 4
-)
-
-
-
-
-/obj/item/storage/box/donkpocket_premium/name = "box of premium donk-pockets"
-
-/obj/item/storage/box/donkpocket_premium/desc = "Heat in microwave or crush packaging in hand. Product will cool if not eaten within seven minutes. Suitable for vegetarians. Contains plant sugars."
-
-/obj/item/storage/box/donkpocket_premium/icon_state = "donk_kit"
-
-/obj/item/storage/box/donkpocket_premium/startswith = list(
-	/obj/item/reagent_containers/food/snacks/donkpocket/premium = 4
-)
-
-
+/obj/item/storage/box/donkpocket_premium
+	name = "box of premium donk-pockets"
+	desc = "Heat in microwave or crush packaging in hand. Product will cool if not eaten within seven minutes. Suitable for vegetarians. Contains plant sugars."
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/item/reagent_containers/food/snacks/donkpocket/premium = 4
+	)
 
 
 // Mixed donk pocket boxes gives you a couple of extras for taking a chance
-/obj/item/storage/box/donkpocket_mixed/name = "box of mixed donk-pockets"
-
-/obj/item/storage/box/donkpocket_mixed/desc = "Heat in microwave or crush packaging in hand. Product will cool if not eaten within seven minutes. Check packaged products for individual safety."
-
-/obj/item/storage/box/donkpocket_mixed/icon_state = "donk_kit"
-
-/obj/item/storage/box/donkpocket_mixed/startswith = list(
-	/obj/random/donkpocket = 6
-)
+/obj/item/storage/box/donkpocket_mixed
+	name = "box of mixed donk-pockets"
+	desc = "Heat in microwave or crush packaging in hand. Product will cool if not eaten within seven minutes. Check packaged products for individual safety."
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/random/donkpocket = 6
+	)
 
 
 
 
-/obj/random/donkpocket_box/name = "random box of donk-pockets"
-
-/obj/random/donkpocket_box/desc = "This is a random box of donk-pockets."
-
-/obj/random/donkpocket_box/icon = 'icons/obj/storage.dmi'
-
-/obj/random/donkpocket_box/icon_state = "donk_kit"
+/obj/random/donkpocket_box
+	name = "random box of donk-pockets"
+	desc = "This is a random box of donk-pockets."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "donk_kit"
 
 
 /obj/random/donkpocket_box/spawn_choices()

--- a/packs/faction_iccgn/badges.dm
+++ b/packs/faction_iccgn/badges.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/accessory/iccgn_badge
+	abstract_type = /obj/item/clothing/accessory/iccgn_badge
 	name = "base badge, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/badges.dmi'
@@ -11,12 +12,6 @@
 	)
 	w_class = ITEM_SIZE_TINY
 	slot = ACCESSORY_SLOT_INSIGNIA
-
-
-/obj/item/clothing/accessory/iccgn_badge/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/iccgn_badge)
 
 
 /obj/item/clothing/accessory/iccgn_badge/get_fibers()

--- a/packs/faction_iccgn/clothing.dm
+++ b/packs/faction_iccgn/clothing.dm
@@ -1,6 +1,7 @@
 
 //Main Clothing
 /obj/item/clothing/under/iccgn
+	abstract_type = /obj/item/clothing/under/iccgn
 	name = "base uniform, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/clothing.dmi'
@@ -15,12 +16,6 @@
 		melee = ARMOR_MELEE_MINOR,
 		energy = ARMOR_ENERGY_MINOR
 	)
-
-
-/obj/item/clothing/under/iccgn/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/under/iccgn)
 
 
 /obj/item/clothing/under/iccgn/get_gender_suffix(suffix)
@@ -77,6 +72,7 @@
 
 //Over Clothing
 /obj/item/clothing/suit/iccgn
+	abstract_type = /obj/item/clothing/suit/iccgn
 	name = "base jacket, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/clothing.dmi'
@@ -93,12 +89,6 @@
 		ACCESSORY_SLOT_MEDAL
 	)
 	allowed = list()
-
-
-/obj/item/clothing/suit/iccgn/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/suit/iccgn)
 
 
 /obj/item/clothing/suit/iccgn/utility
@@ -207,6 +197,7 @@
 
 //Gloves
 /obj/item/clothing/gloves/iccgn
+	abstract_type = /obj/item/clothing/gloves/iccgn
 	name = "base gloves, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/clothing.dmi'
@@ -215,12 +206,6 @@
 	)
 	sprite_sheets = list()
 	icon_state = "error"
-
-
-/obj/item/clothing/gloves/iccgn/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/gloves/iccgn)
 
 
 /obj/item/clothing/gloves/iccgn/duty
@@ -236,6 +221,7 @@
 
 //Shoes
 /obj/item/clothing/shoes/iccgn
+	abstract_type = /obj/item/clothing/shoes/iccgn
 	name = "base shoes, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/clothing.dmi'
@@ -244,12 +230,6 @@
 	)
 	sprite_sheets = list()
 	icon_state = "error"
-
-
-/obj/item/clothing/shoes/iccgn/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/shoes/iccgn)
 
 
 /obj/item/clothing/shoes/iccgn/utility
@@ -276,6 +256,7 @@
 
 //Hats
 /obj/item/clothing/head/iccgn
+	abstract_type = /obj/item/clothing/head/iccgn
 	name = "base hat, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/clothing.dmi'
@@ -284,12 +265,6 @@
 	)
 	sprite_sheets = list()
 	icon_state = "error"
-
-
-/obj/item/clothing/head/iccgn/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/head/iccgn)
 
 
 /obj/item/clothing/head/iccgn/beret

--- a/packs/faction_iccgn/patches.dm
+++ b/packs/faction_iccgn/patches.dm
@@ -9,6 +9,7 @@
 
 
 /obj/item/clothing/accessory/iccgn_patch
+	abstract_type = /obj/item/clothing/accessory/iccgn_patch
 	name = "base uniform patch, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/patches.dmi'
@@ -23,12 +24,6 @@
 	w_class = ITEM_SIZE_TINY
 	slot = ACCESSORY_SLOT_INSIGNIA
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
-
-
-/obj/item/clothing/accessory/iccgn_patch/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/iccgn_patch)
 
 
 /obj/item/clothing/accessory/iccgn_patch/get_fibers()

--- a/packs/faction_iccgn/ranks.dm
+++ b/packs/faction_iccgn/ranks.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/accessory/iccgn_rank
+	abstract_type = /obj/item/clothing/accessory/iccgn_rank
 	name = "base rank insignia, ICCGN"
 	desc = "You should not see this."
 	icon = 'packs/faction_iccgn/ranks.dmi'
@@ -14,12 +15,6 @@
 	slot = ACCESSORY_SLOT_RANK
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
 	gender = PLURAL
-
-
-/obj/item/clothing/accessory/iccgn_rank/Initialize()
-	. = ..()
-	INIT_SKIP_QDELETED
-	INIT_DISALLOW_TYPE(/obj/item/clothing/accessory/iccgn_rank)
 
 
 /obj/item/clothing/accessory/iccgn_rank/get_fibers()


### PR DESCRIPTION
Adds a handy dandy soft-abstract concept to datums.
Setting abstract_type on one allows:
datums getting an IsAbstract() proc to hide `return type == abstract_type`
a global proc is_abstract that takes a datum or a path and checks it for abstractness.

Actual usage is left down to implementation. It is used in the second commit to replace INIT_DISALLOW_TYPE and INIT_SKIP_QDELETED by checking IsAbstract in base atom/Initialize and returning INITIALIZE_HINT_QDEL (with a log) if the atom should not have been created.
```
. = ..()
if (. == INITIALIZE_HINT_QDEL)
  return
```
is added to abstract behavior providers that Initialize to skip work they may do. While it could be added lower, fixing bad behavior is preferable to tolerating it better (and we do not have existing cases of base atoms being spawned except through shenanigans).
