### PR TITLE
start now works when no players are ready

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -125,13 +125,14 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/setup_tick()
 #ifndef UNIT_TEST
-	var/list/ready = ready_players()
-	if (!length(ready))
-		pregame_timeleft = config.vote_period + 30 SECONDS
-		gamemode_vote_results = null
-		Master.SetRunLevel(RUNLEVEL_LOBBY)
-		to_world("<b>No ready players.</b> Returning to pre-game lobby.")
-		return
+	if (!start_ASAP)
+		var/list/ready = ready_players()
+		if (!length(ready))
+			pregame_timeleft = config.vote_period + 30 SECONDS
+			gamemode_vote_results = null
+			Master.SetRunLevel(RUNLEVEL_LOBBY)
+			to_world("<b>No ready players.</b> Returning to pre-game lobby.")
+			return
 #endif
 
 	switch(choose_gamemode())

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -862,6 +862,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 			to_chat(usr, FONT_LARGE(SPAN_WARNING("The game will begin as normal.")))
 			log_and_message_admins("will begin the game as normal.")
 		return 0
+	SSticker.start_ASAP = TRUE
 	if(SSticker.start_now())
 		log_and_message_admins("has started the game.")
 		return 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->