### PR TITLE
Gives the charon thrusters gas pumps so fuel doesn't get stuck

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -5474,7 +5474,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "port thrust pump"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/exploration_shuttle/atmos)
 "mB" = (
@@ -8545,7 +8547,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "starboard thrust pump"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/exploration_shuttle/fuel)
 "sC" = (


### PR DESCRIPTION
🆑 Jux
maptweak: Each charon thruster group now has an individual gas pump to provide fuel.
/🆑

because fuel was getting stuck in the pressure tanks 