### PR TITLE
Removes heat gas

### DIFF
--- a/code/modules/xgm/gases.dm
+++ b/code/modules/xgm/gases.dm
@@ -253,8 +253,3 @@
 	breathed_product = /datum/reagent/toxin/boron
 	symbol_html = "B"
 	symbol = "B"
-
-/decl/xgm_gas/heat
-	id = GAS_HEAT
-	name = "heat"
-	tile_color = COLOR_WHITE


### PR DESCRIPTION
I am 99% sure this doesn't break anything and prevents random systems from spawning it.

the ID exists simply so I could reuse current gas rendering setup for purposes of adding the effect, but entire handling is bespoke so there should be nothing to worry about...probably.