### PR TITLE
Fix surgical robots being unable to implant organs

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -201,6 +201,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 		if(S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src, zone)))
 			S = pick(possible_surgeries)
 
+	var/obj/item/gripper/gripper = user.get_active_hand()
 	// We didn't find a surgery, or decided not to perform one.
 	if(!istype(S))
 		// If we're on an optable, we are protected from some surgery fails. Bypass this for some items (like health analyzers).
@@ -216,7 +217,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			return TRUE
 
 	// Otherwise we can make a start on surgery!
-	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
+	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && (user.get_active_hand() == src || (istype(gripper) && gripper.wrapped == src)))
 		// Double-check this in case it changed between initial check and now.
 		if(zone in M.surgeries_in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))


### PR DESCRIPTION
Surgical robots were previously unable to implant anything, including organs, into patients as part of surgery. This was caused by the `do_surgery` proc checking that the object to be implanted was being directly held, with no awareness of the weirdness that is robot grippers.

Fixed by adding an extra check for whether the held object is a gripper and that it is holding the target object.

Local testing done: manually checked surgical robot can now re-implant a removed organ on test station, checked human surgeon can still do same

:cl: Ninetailed
bugfix: Surgical robots are now able to implant organs with the organ gripper
/:cl:

Fixes #25693