### PR TITLE
Reduce spontaneous wardrobe malfunctions

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -60,14 +60,13 @@
 	if (usr.incapacitated())
 		return
 
-	if (!usr.unEquip(src))
-		return
-
 	switch(over_object.name)
 		if("r_hand")
-			usr.put_in_r_hand(src)
+			if (usr.unEquip(src))
+				usr.put_in_r_hand(src)
 		if("l_hand")
-			usr.put_in_l_hand(src)
+			if (usr.unEquip(src))
+				usr.put_in_l_hand(src)
 	src.add_fingerprint(usr)
 
 /obj/item/clothing/examine(mob/user)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Are you sick of having your clothing and possessions suddenly explode all over the deck when you very slightly misclick on it? Because I am!

This is an artifact of the code used for unequipping clothing with storage slots. When you click-drag a clothing item (including uniforms, hats, belts, and so on) from one of your equipment slots to one of your hands, it moves the item to that hand - or, rather, it drops the item to the ground and immediately picks it back up into the target hand.

Unfortunately, if you drag it onto something that isn't one of your hands, you just drop it and don't pick it back up.

Looking at #8973, when this behaviour was introduced, it looks like the call to `unEquip` was pulled out of the switch block to reduce code duplication, while also aborting the movement if the item can't be unequipped.

My proposed change here does duplicate an if block, but it also means that nothing will happen if you click-drag your clothes onto themselves. No more explosive wardrobe malfunctions when you're trying to get something out of your pockets.

:cl: Ninetailed
bugfix: Reduce spontaneous wardrobe malfunctions
/:cl: