### PR TITLE
join/leave messages about tickets use admin ckeys

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -146,8 +146,8 @@
 			return
 
 	for (var/datum/ticket/T in tickets)
-		if (T.owner.ckey == ckey)
-			message_staff("[key_name_admin(src)] has joined the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admins)]" : SPAN_DANGER("Unassigned.")]")
+		if (T.status == TICKET_OPEN && T.owner.ckey == ckey)
+			message_staff("[key_name_admin(src)] has joined the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]")
 			break
 
 	// Change the way they should download resources.
@@ -225,8 +225,8 @@
 
 /client/Destroy()
 	for (var/datum/ticket/T in tickets)
-		if (T.owner.ckey == ckey)
-			message_staff("[key_name_admin(src)] has left the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admins)]" : SPAN_DANGER("Unassigned.")]")
+		if (T.status == TICKET_OPEN && T.owner.ckey == ckey)
+			message_staff("[key_name_admin(src)] has left the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]")
 			break
 	if (holder)
 		holder.owner = null


### PR DESCRIPTION
:cl: Mucker
admin: The join/leave messages regarding players and their tickets now use ckeys when listing admins assigned to the ticket.
admin: Fixed the join/leave ticket message triggering with closed tickets.
/:cl:

In testing I only tested a player leaving/joining from the lobby, so it never showed a character name, and I also completely forgot to actually check the ticket status.