### PR TITLE
Runtime batch 2022-5-29

### DIFF
--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -161,7 +161,7 @@
 			var/list/mutations = GetMutations()
 			for(var/i = 1 to 4)
 				var/t = colour
-				if(prob(mutation_chance))
+				if (mutations && prob(mutation_chance))
 					t = pick(mutations)
 				var/mob/living/carbon/slime/M = new /mob/living/carbon/slime(loc, t)
 				if(i != 1)

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -27,7 +27,11 @@
 			"fuel_span" = fuel_span
 		)
 
-/obj/machinery/computer/shuttle_control/explore/handle_topic_href(var/datum/shuttle/autodock/overmap/shuttle, var/list/href_list)	
+/obj/machinery/computer/shuttle_control/explore/handle_topic_href(var/datum/shuttle/autodock/overmap/shuttle, var/list/href_list)
+	if (!shuttle)
+		crash_with("Shuttle controller tried to handle topic with no shuttle provided.")
+		to_chat(usr, SPAN_DEBUG("Shuttle controller tried to handle topic with no shuttle provided. This is a bug and should be reported immediately, something's probably horribly broken."))
+		return TOPIC_HANDLED
 	if(ismob(usr))
 		var/mob/user = usr
 		shuttle.operator_skill = user.get_skill_value(SKILL_PILOT)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Shuttle control consoles will now send a message to users if they horribly break in a certain way. If this happens, please help and have a dev look at it. I've been trying to figure out these shuttle controller crashes for a week now.
/:cl:

- Fixes #31843 - `GetMutations()` returning an empty list is valid for certain slime types and colors.
- Does not fix but should help address #32138 when it happens on server