### PR TITLE
Runtime batch 2022 05 30

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -875,6 +875,9 @@
 				var/reason = sanitize(input(usr,"Reason?","reason","Griefer") as text|null)
 				if(!reason)
 					return
+				if (QDELETED(M))
+					to_chat(usr, SPAN_DANGER("The mob you are banning no longer exists."))
+					return
 				var/mob_key = LAST_CKEY(M)
 				if(mob_key != given_key)
 					to_chat(usr, SPAN_DANGER("This mob's occupant has changed from [given_key] to [mob_key]. Please try again."))
@@ -899,6 +902,9 @@
 				if(!check_rights(R_BAN))   return
 				var/reason = sanitize(input(usr,"Reason?","reason","Griefer") as text|null)
 				if(!reason)
+					return
+				if (QDELETED(M))
+					to_chat(usr, SPAN_DANGER("The mob you are banning no longer exists."))
 					return
 				var/mob_key = LAST_CKEY(M)
 				if(mob_key != given_key)

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -258,7 +258,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	. = ..()
 	if (!.)
 		return FALSE
-	if (target.is_species(SPECIES_ZOMBIE))
+	if (!target || target.is_species(SPECIES_ZOMBIE))
 		to_chat(usr, SPAN_WARNING("They don't look very appetizing!"))
 		return FALSE
 	return TRUE


### PR DESCRIPTION
:cl: SierraKomodo
admin: Bans will now display an error message to the banning admin of the targeted mob ceases to exist while entering a ban reason, instead of silently (If you have runtime logs disabled) crashing.
/:cl:

- Closes #32145 
- Closes #32146
- Fixes #32148