### PR TITLE
implements handling of abstract_type on decls

### DIFF
--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -13,8 +13,10 @@ var/global/repository/decls/decls_repository = new()
 
 /repository/decls/proc/get_decl(var/decl_type)
 	. = fetched_decls[decl_type]
-	if(!.)
-		. = new decl_type()
+	if (!.)
+		if (is_abstract(decl_type))
+			return
+		. = new decl_type
 		fetched_decls[decl_type] = .
 
 		var/decl/decl = .
@@ -23,13 +25,20 @@ var/global/repository/decls/decls_repository = new()
 
 /repository/decls/proc/get_decls(var/list/decl_types)
 	. = list()
-	for(var/decl_type in decl_types)
-		.[decl_type] = get_decl(decl_type)
+	for (var/decl_type in decl_types)
+		var/decl = get_decl(decl_type)
+		if (!decl)
+			continue
+		.[decl_type] = decl
+
 
 /repository/decls/proc/get_decls_unassociated(var/list/decl_types)
 	. = list()
-	for(var/decl_type in decl_types)
-		. += get_decl(decl_type)
+	for (var/decl_type in decl_types)
+		var/decl = get_decl(decl_type)
+		if (!decl)
+			continue
+		. += decl
 
 /repository/decls/proc/get_decls_of_type(var/decl_prototype)
 	. = fetched_decl_types[decl_prototype]
@@ -42,6 +51,11 @@ var/global/repository/decls/decls_repository = new()
 	if(!.)
 		. = get_decls(subtypesof(decl_prototype))
 		fetched_decl_subtypes[decl_prototype] = .
+
+
+/decl
+	abstract_type = /decl
+
 
 /decl/proc/Initialize()
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
base /decl is abstract
get_decl returns null for abstract decl types
get_decls and get_decls_unassociated skip nulls
other decl handling relies on these three procs
