### PR TITLE
adds "set injection for all" button to RUST + style tweaks

### DIFF
--- a/code/modules/power/fusion/consoles/injector_control.dm
+++ b/code/modules/power/fusion/consoles/injector_control.dm
@@ -11,12 +11,25 @@
 	if(href_list["global_toggle"])
 		if(!lan || !fuel_injectors)
 			return TOPIC_NOACTION
-			
+
 		for(var/obj/machinery/fusion_fuel_injector/F in fuel_injectors)
 			if(F.injecting)
 				F.StopInjecting()
 			else
 				F.BeginInjecting()
+		return TOPIC_REFRESH
+
+	if(href_list["global_rate"])
+		if(!lan || !fuel_injectors)
+			return TOPIC_NOACTION
+		var/new_injection_rate = input("Enter a new injection rate between 1 and 100. This will affect all injectors!", "Modifying injection rate") as null|num
+		var/new_injection_clamped = clamp(new_injection_rate, 1, 100) / 100
+		if(!new_injection_rate)
+			return TOPIC_NOACTION
+		if(!CanInteract(user,state))
+			return TOPIC_NOACTION
+		for(var/obj/machinery/fusion_fuel_injector/F as anything in fuel_injectors)
+			F.injection_rate = new_injection_clamped
 		return TOPIC_REFRESH
 
 	if(href_list["toggle_injecting"] || href_list["injection_rate"])
@@ -31,13 +44,14 @@
 				I.BeginInjecting()
 
 		if(href_list["injection_rate"])
-			var/new_injection_rate = input("Enter a new injection rate between 0 and 100", "Modifying injection rate", I.injection_rate) as num
+			var/new_injection_rate = input("Enter a new injection rate between 1 and 100.", "Modifying injection rate", I.injection_rate) as null|num
 			if(!istype(I))
 				return TOPIC_NOACTION
 			if(!new_injection_rate)
-				to_chat(user, SPAN_WARNING("That's not a valid injection rate."))
 				return TOPIC_NOACTION
-			I.injection_rate = clamp(new_injection_rate, 0, 100) / 100
+			if(!CanInteract(user,state))
+				return TOPIC_NOACTION
+			I.injection_rate = clamp(new_injection_rate, 1, 100) / 100
 		return TOPIC_REFRESH
 
 /obj/machinery/computer/fusion/fuel_control/build_ui_data()

--- a/nano/templates/fusion_injector_control.tmpl
+++ b/nano/templates/fusion_injector_control.tmpl
@@ -6,6 +6,9 @@
 	<div class="itemContent">
 		{{:helper.link('Toggle All', null, {'global_toggle' : 1})}}
 	</div>
+	<div class="itemContent">
+		{{:helper.link('Set Injection Rates for All', null, {'global_rate' : 1})}}
+	</div>
 </div>
 {{for data.injectors}}
 	<h3>{{:value.id}}</h3>


### PR DESCRIPTION
:cl: Nl208
rscadd: Adds a "set injection rates for all" button to the RUST injector console's interface.
tweak: Adds some punctuation to the popup windows. Changed instructions to say "enter new injection rate between 1 and 100" instead of "0 and 100".
/:cl:
as per the last one, but with less leftover merge-commit crap. engineers rejoice.

I really should've gone to bed an hour ago.