### PR TITLE
Block robots from resting

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -78,8 +78,8 @@
 		Paralyse(3)
 		src.sleeping--
 
-	if(src.resting)
-		Weaken(5)
+	if (resting) // Just in case. This breaks things so never allow robots to rest.
+		resting = FALSE
 
 	if(health < config.health_threshold_dead && src.stat != 2) //die only once
 		death()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1104,3 +1104,7 @@
 	var/obj/item/robot_parts/robot_suit/C = new dismantle_type(loc)
 	C.dismantled_from(src)
 	qdel(src)
+
+// Resting as a robot breaks things. Block it from happening.
+/mob/living/silicon/robot/lay_down()
+	return


### PR DESCRIPTION
:cl: SierraKomodo
rscdel: Borgs can no longer use the `rest` verb since it's not handled properly, gives no feedback, and causes confusion when you inevitably discover you can no longer interact with anything or move and don't know why.
/:cl: