### PR TITLE
Robots can now remove shuttle H2 tanks from ports

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -256,6 +256,14 @@
 		W.dropInto(loc)
 	return FALSE
 
+/// Check if the thing being dropped is in a gripper and clear the gripper's reference to it if so
+/mob/living/silicon/robot/remove_from_mob(obj/thing, atom/target)
+	. = ..()
+	if (.)
+		for (var/obj/item/gripper/gripper in module?.equipment)
+			if (gripper.wrapped == thing)
+				gripper.wrapped = null
+
 //Robots don't use inventory slots, so we need to override this.
 /mob/living/silicon/robot/canUnEquip(obj/item/I)
 	if(!I)

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -161,6 +161,10 @@
 			user.unEquip(W, src)
 	update_icon()
 
+/obj/structure/fuel_port/attack_robot(mob/user)
+	if (Adjacent(user))
+		attack_hand(user)
+
 // Walls hide stuff inside them, but we want to be visible.
 /obj/structure/fuel_port/hide()
 	return


### PR DESCRIPTION
:cl: Ninetailed
bugfix: Robots can now remove shuttle H2 tanks from ports
/:cl:

While fixing this, I also found that grippers were retaining a reference to objects removed from them during attackby handling. This made the gripper appear to still have contents when it did not, and had potential GC implications. Fixed this problem also.