### PR TITLE
Runtime batch 2022 06 05

### DIFF
--- a/code/datums/repositories/attack_logs.dm
+++ b/code/datums/repositories/attack_logs.dm
@@ -34,7 +34,7 @@ var/global/repository/attack_logs/attack_log_repository = new()
 		message = "[victim.name] [action_message]"
 
 	intent = mob_attacker ? uppertext(mob_attacker.a_intent) : "N/A"
-	zone_sel = mob_attacker.zone_sel?.selecting ? uppertext(mob_attacker.zone_sel.selecting) : "N/A"
+	zone_sel = mob_attacker?.zone_sel?.selecting ? uppertext(mob_attacker.zone_sel.selecting) : "N/A"
 
 	if(mob_attacker)
 		location = get_turf(mob_attacker)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -134,7 +134,7 @@
 /obj/effect/energy_net/Process()
 	if(temporary)
 		countdown--
-	if(captured.buckled != src)
+	if(!captured || captured.buckled != src)
 		health = 0
 	if(get_turf(src) != get_turf(captured))  //just in case they somehow teleport around or
 		countdown = 0

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -37,7 +37,10 @@
 		else
 			params["type"] = "adminpm"
 			params["trg_key"] = target.key
-			params["trg_char"] = target.mob.real_name || target.mob.name
+			if (target.mob)
+				params["trg_char"] = target.mob.real_name || target.mob.name
+			else
+				params["trg_char"] = "\[NO CHARACTER\]"
 
 		export2irc(params)
 

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -75,6 +75,7 @@
 	owned_core = new_owned_core
 	if(!owned_core)
 		qdel(src)
+		return
 
 	particles.spawning = 0 //Turn off particles until something calls for it
 

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -160,7 +160,7 @@
 	if(prob(25))
 		new_item = new /obj/item/vampiric(loc)
 	else
-		new_item = new(loc)
+		new_item = ..()
 	new_item.SetName("statuette")
 	new_item.icon = 'icons/obj/xenoarchaeology.dmi'
 	new_item.icon_state = "statuette"
@@ -304,7 +304,7 @@
 	if(prob(25))
 		new_item = new /obj/item/device/soulstone(loc)
 	else
-		new_item = new(loc)
+		new_item = ..()
 	apply_image_decorations = 1
 	additional_desc = pick("It shines faintly as it catches the light.","It appears to have a faint inner glow.","It seems to draw you inward as you look it at.","Something twinkles faintly as you look at it.","It's mesmerizing to behold.")
 
@@ -318,6 +318,7 @@
 	else
 		item_type = "rough red crystal"
 		new_item.icon_state = "changerock"
+	return new_item
 
 /obj/item/archaeological_find/blade
 	item_type = "blade"


### PR DESCRIPTION
NUFC

- Fixes #30677 - `mob_attacker` being `null` is valid - See `/proc/admin_victim_log()`
- Fixes #22609 - Ensures all implementations of `archaeological_find/proc/spawn_item()` return a valid object. Replaces cases of `new null()` with `..()`.
- Fixes #19240
- Fixes #19247
- Fixes #32173