### PR TITLE
Fixes AI-controlled bots being unkillable

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -76,15 +76,6 @@
 		spawn(0)
 			handleAI()
 
-/mob/living/bot/updatehealth()
-	if(status_flags & GODMODE)
-		health = maxHealth
-		set_stat(CONSCIOUS)
-	else
-		health = maxHealth - getFireLoss() - getBruteLoss()
-	setOxyLoss(0)
-	setToxLoss(0)
-
 /mob/living/bot/death()
 	explode()
 


### PR DESCRIPTION
:cl: Nl208
bugfix: Bots such as Beepsky and cleanbots now take damage and die properly.
/:cl:

Removes an overriding updatehealth() proc specific to bots (Beepsky, farming, cleaning, etc.) that hasn't worked in years and prevented them from actually registering incoming damage in its current state. Bots' health-update handling now falls back on the standard updatehealth() proc, with all functions such as blowing apart properly upon death and respecting god mode still intact on testing.

fixes #18515.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->