### PR TITLE
Minor survivability update for raiders

### DIFF
--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -189,6 +189,11 @@
 	pixel_y = 32
 	},
 /obj/item/soap,
+/obj/item/storage/box/detergent{
+	desc = "A bag full of juicy, yummy detergent pods. Warranty void if swallowed."
+	},
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -730,7 +735,7 @@
 /obj/item/tray{
 	pixel_y = 5
 	},
-/obj/item/storage/backpack,
+/obj/random/backpack,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},
@@ -908,7 +913,7 @@
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "cf" = (
-/obj/item/storage/backpack,
+/obj/random/backpack,
 /turf/unsimulated/floor{
 	icon_state = "asteroid"
 	},
@@ -1363,6 +1368,7 @@
 /obj/structure/table/rack,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
+/obj/item/tape_roll,
 /obj/item/device/multitool,
 /obj/item/device/multitool,
 /obj/item/clothing/shoes/magboots,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Imienny
rscadd: Added roll of duct tape and cleaning supplies to raiders base.
tweak: Raiders now get colorful backpacks instead of ugly gray backpacks.
/:cl: