### PR TITLE
Fix missing death handler for rubble

### DIFF
--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -80,6 +80,10 @@
 
 	..()
 
+/obj/structure/rubble/on_death()
+	visible_message(SPAN_WARNING("\The [src] breaks apart!"))
+	qdel(src)
+
 /obj/structure/rubble/house
 	loot = list(/obj/item/archaeological_find/bowl,
 	/obj/item/archaeological_find/remains,


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Rubble now properly dies when hit enough times. It still won't drop loot unless you use the right tools, however.
/:cl: