### PR TITLE
Runtime batch 2022-06-19

### DIFF
--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -300,6 +300,9 @@ Standard helpers for users interacting with machinery parts.
 		return istype(part) // If it's not a stock part, we don't block further interactions; presumably the user meant to do something else.
 	if(isstack(part))
 		var/obj/item/stack/stack = part
+		if (!stack.can_use(number))
+			to_chat(user, SPAN_WARNING("You need at least [number] [stack.plural_name] to install into \the [src]."))
+			return FALSE
 		install_component(stack.split(number, TRUE))
 	else
 		user.unEquip(part, src)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -388,7 +388,7 @@
 		if(occupant.mind.assigned_job)
 			occupant.mind.assigned_job.clear_slot()
 
-		if(occupant.mind.objectives.len)
+		if(LAZYLEN(occupant.mind.objectives))
 			occupant.mind.objectives = null
 			occupant.mind.special_role = null
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -252,7 +252,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	var/message
 	if(isanimal(M) && !M.universal_speak)
 		var/datum/say_list/SA = M.say_list
-		if (SA?.speak)
+		if (SA && length(SA.speak))
 			message = get_hear_message(name_used, pick(SA.speak), verb, speaking)
 	else
 		message = get_hear_message(name_used, text, verb, speaking)

--- a/code/game/machinery/mech_recharger.dm
+++ b/code/game/machinery/mech_recharger.dm
@@ -12,7 +12,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	
+
 	machine_name = "exosuit dock"
 	machine_desc = "An industrial recharger built into the floor. Exosuits standing on top of the dock will have their power cell recharged."
 
@@ -58,8 +58,8 @@
 		return
 
 	if(stat & (BROKEN|NOPOWER))
-		stop_charging()
 		charging.show_message(SPAN_WARNING("Internal system Error - Charging aborted."))
+		stop_charging()
 		return
 
 	// Cell could have been removed.

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -154,8 +154,9 @@
 	else if(href_list["lock"])
 		toggle()
 		SSnano.close_user_uis(user, src, "main")
-		program.authenticated = FALSE
-		program.computer.kill_program(program)
+		if (program)
+			program.authenticated = FALSE
+			program.computer.kill_program(program)
 		. = TOPIC_HANDLED
 	else if(href_list["return"])
 		nanoui_menu = round(nanoui_menu/10)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -167,7 +167,7 @@
 /proc/spawn_money(var/sum, spawnloc, mob/living/carbon/human/human_user as mob)
 	if(sum in list(1000,500,200,100,50,20,10,1))
 		var/cash_type = text2path("/obj/item/spacecash/bundle/c[sum]")
-		var/obj/cash = new cash_type (usr.loc)
+		var/obj/cash = new cash_type (spawnloc)
 		if(ishuman(human_user) && !human_user.get_active_hand())
 			human_user.put_in_hands(cash)
 	else

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -161,6 +161,7 @@
 		for(var/obj/item/clothing/C in list(target.head, target.wear_mask, target.wear_suit, target.w_uniform, target.gloves, target.shoes))
 			if(C && (C.body_parts_covered & affecting.body_part) && (C.item_flags & ITEM_FLAG_THICKMATERIAL))
 				affecting = null
+				break
 
 		if(!(target.species && target.species.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT)))
 			affecting = null

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -48,6 +48,8 @@
 	accuracy = 2
 
 /obj/item/gun/energy/get_hardpoint_maptext()
+	if (charge_cost <= 0)
+		return "INF"
 	return "[round(power_supply.charge / charge_cost)]/[max_shots]"
 
 /obj/item/gun/energy/get_hardpoint_status_value()

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -214,6 +214,10 @@
 /mob/living/exosuit/proc/check_enter(mob/user, silent = FALSE, check_incap = TRUE)
 	if(!user || (check_incap && user.incapacitated()))
 		return FALSE
+	if (user.buckled)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("You are currently buckled to \the [user.buckled]."))
+		return FALSE
 	if(!(user.mob_size >= body.min_pilot_size && user.mob_size <= body.max_pilot_size))
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You cannot pilot an exosuit of this size."))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1339,7 +1339,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(internal_organs.len && prob(brute_dam + force))
 		owner.custom_pain("A piece of bone in your [encased ? encased : name] moves painfully!", 50, affecting = src)
 		var/obj/item/organ/internal/I = pick(internal_organs)
-		I.take_internal_damage(rand(3,5))
+		if (I)
+			I.take_internal_damage(rand(3,5))
 
 /obj/item/organ/external/proc/jointlock(mob/attacker)
 	if(!can_feel_pain())

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -43,7 +43,7 @@
 			animation.set_density(FALSE)
 			animation.anchored = TRUE
 			animation.icon = 'icons/mob/mob.dmi'
-			animation.layer = FLY_LAYER 
+			animation.layer = FLY_LAYER
 			target.ExtinguishMob()
 			if(target.buckled)
 				target.buckled = null
@@ -114,7 +114,9 @@
 /obj/effect/dummy/spell_jaunt/relaymove(var/mob/user, direction)
 	if (!canmove || reappearing) return
 	var/turf/newLoc = get_step(src, direction)
-	if(!(newLoc.turf_flags & TURF_FLAG_NOJAUNT))
+	if (!newLoc)
+		to_chat(user, SPAN_WARNING("You cannot go that way."))
+	else if (!(newLoc.turf_flags & TURF_FLAG_NOJAUNT))
 		forceMove(newLoc)
 		var/turf/T = get_turf(loc)
 		if(!T.contains_dense_objects())


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Mech weapons with no charge cost now display an ammo count of `INF` instead of whatever outputted when it runtimed from dividing by zero.
/:cl:

- Fixes #32176
- Fixes #32191
- Fixes #32187
- Fixes #32188 - Displays `INF` now for 0 charge cost weapons ![dreamseeker_2022-06-19_12-14-24](https://user-images.githubusercontent.com/11140088/174491173-91a1b4d0-0cd4-4376-9af0-511c10934d90.png)
- Fixes #31140
- Fixes #30793 - Fixes the runtime, but does not resolve the numerous simple mobs that lack a say_list datum.
- Fixes #32036
- Fixes #32193 - External organs with no internal organs seems perfectly valid - Legs, arms, etc.
- Fixes #32194
- Fixes #31188 - Empty stacks are valid in the case of borgs with no cable or other material charge left.
- Fixes #29536
