### PR TITLE
Fix wormhole proc spawning WAY too many wormholes

### DIFF
--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -1,4 +1,8 @@
-/proc/wormhole_event(var/list/zlevels = GLOB.using_map.station_levels)
+/*
+* Wormhole event that spawns wormholes over time on the station that teleport people to random locations on the station.
+* Default run time is 3000 deciseconds, which is 5 minutes total.
+*/
+/proc/wormhole_event(list/zlevels = GLOB.using_map.station_levels, event_duration = 3000)
 	spawn()
 		var/list/pick_turfs = list()
 		for(var/z in zlevels)
@@ -9,23 +13,20 @@
 		if(pick_turfs.len)
 			//All ready. Announce that bad juju is afoot.
 			GLOB.using_map.space_time_anomaly_detected_annoncement()
-			var/event_duration = 3000	//~5 minutes in ticks
-			var/number_of_selections = (pick_turfs.len/5)+1	//+1 to avoid division by zero!
-			var/sleep_duration = round( event_duration / number_of_selections )
+			var/number_of_selections = (pick_turfs.len / 15) + 1	//+1 to avoid division by zero!
+			var/sleep_duration = round(event_duration / number_of_selections)
 			var/end_time = world.time + event_duration	//the time by which the event should have ended
 
-			var/increment =	max(1,round(number_of_selections/50))
+			var/increment =	max(1, round(number_of_selections / 50))
 
 
 			var/i = 1
-			while( 1 )
+			while(TRUE)
 
 				//we've run into overtime. End the event
-				if( end_time < world.time )
-
+				if (end_time < world.time)
 					return
-				if( !pick_turfs.len )
-
+				if (!pick_turfs.len)
 					return
 
 				//loop it round
@@ -36,11 +37,11 @@
 				//get our enter and exit locations
 				var/turf/simulated/floor/enter = pick_turfs[i]
 				pick_turfs -= enter							//remove it from pickable turfs list
-				if( !enter || !istype(enter) )	continue	//sanity
+				if (!enter || !istype(enter))	continue	//sanity
 
 				var/turf/simulated/floor/exit = pick(pick_turfs)
 				pick_turfs -= exit
-				if( !exit || !istype(exit) )	continue	//sanity
+				if (!exit || !istype(exit))	continue	//sanity
 
 				create_wormhole(enter,exit)
 
@@ -48,8 +49,8 @@
 
 
 //maybe this proc can even be used as an admin tool for teleporting players without ruining immulsions?
-/proc/create_wormhole(var/turf/enter as turf, var/turf/exit as turf)
-	var/obj/effect/portal/P = new /obj/effect/portal( enter )
+/proc/create_wormhole(turf/enter as turf, turf/exit as turf)
+	var/obj/effect/portal/P = new /obj/effect/portal(enter)
 	P.target = exit
 	P.creator = null
 	P.icon = 'icons/obj/objects.dmi'

--- a/maps/~mapsystem/maps_announcements.dm
+++ b/maps/~mapsystem/maps_announcements.dm
@@ -52,7 +52,7 @@
 	command_announcement.Announce(replacetext(radiation_detected_message, "%STATION_NAME%", station_name()), "Anomaly Alert", new_sound = radiation_detected_sound)
 
 /datum/map/proc/space_time_anomaly_detected_annoncement()
-	command_announcement.Announce("Space-time anomalies have been detected on the [station_name()].", "Anomaly Alert", new_sound = space_time_anomaly_sound)
+	command_announcement.Announce("Space-time anomalies have been detected on the [station_name()]. Internals and voidsuits recommended.", "Anomaly Alert", new_sound = space_time_anomaly_sound)
 
 /datum/map/proc/unidentified_lifesigns_announcement()
 	command_announcement.Announce(replacetext(unidentified_lifesigns_message, "%STATION_NAME%", station_name()), "Lifesign Alert", new_sound = unidentified_lifesigns_sound)


### PR DESCRIPTION
NUFC since this isn't used as an event for the moment.

Just fixes the proc up a bit so it can be used for shenanigans, doesn't actually re-implement it as an event. May do that later though.