### PR TITLE
Tweaks Charon and GUP to make them faster

### DIFF
--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -81,7 +81,7 @@
 	shuttle = "Charon"
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 1 SECONDS
-	vessel_mass = 5000
+	vessel_mass = 3000
 	fore_dir = NORTH
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_SMALL
@@ -102,7 +102,7 @@
 	shuttle = "Guppy"
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
-	vessel_mass = 3000 //very inefficient pod
+	vessel_mass = 1800
 	fore_dir = SOUTH
 	skill_needed = SKILL_BASIC
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -348,7 +348,7 @@ TORCH_ESCAPE_POD(17)
 
 /datum/shuttle/autodock/overmap/exploration_shuttle
 	name = "Charon"
-	move_time = 90
+	move_time = 60
 	shuttle_area = list(/area/exploration_shuttle/cockpit, /area/exploration_shuttle/atmos, /area/exploration_shuttle/power, /area/exploration_shuttle/crew, /area/exploration_shuttle/cargo, /area/exploration_shuttle/airlock, /area/exploration_shuttle/medical, /area/exploration_shuttle/fuel)
 	dock_target = "charon_shuttle"
 	current_location = "nav_hangar_charon"
@@ -392,7 +392,7 @@ TORCH_ESCAPE_POD(17)
 /datum/shuttle/autodock/overmap/guppy
 	name = "Guppy"
 	warmup_time = 5
-	move_time = 30
+	move_time = 20
 	shuttle_area = /area/guppy_hangar/start
 	dock_target ="guppy_shuttle"
 	current_location = "nav_hangar_guppy"
@@ -437,7 +437,7 @@ TORCH_ESCAPE_POD(17)
 
 /datum/shuttle/autodock/overmap/aquila
 	name = "Aquila"
-	move_time = 60
+	move_time = 50
 	shuttle_area = list(/area/aquila/cockpit, /area/aquila/power, /area/aquila/storage, /area/aquila/suits, /area/aquila/air, /area/aquila/crew, /area/aquila/medical, /area/aquila/airlock)
 	current_location = "nav_hangar_aquila"
 	landmark_transition = "nav_transit_aquila"


### PR DESCRIPTION
:cl: Mucker
tweak: Charon and GUP will both take off and land faster, and be faster with overmap travel. 
/:cl:

Reduced the travel time for the GUP and Charon as there's little point in keeping people waiting during those periods, and should help better fit the exploration loop into the standard 2-hour round.
