### PR TITLE
Add vv handlers for standardized health vars

### DIFF
--- a/code/_helpers/functional.dm
+++ b/code/_helpers/functional.dm
@@ -52,6 +52,11 @@
 	if(!. && feedback_receiver)
 		to_chat(feedback_receiver, "<span class='warning'>Value must be a direction.</span>")
 
+/proc/is_strict_bool_predicate(value, feedback_receiver)
+	. = (value == TRUE || value == FALSE)
+	if (!. && feedback_receiver)
+		to_chat(feedback_receiver, SPAN_WARNING("Value must be a boolean (Strict)."))
+
 /proc/can_locate(var/atom/container, var/container_thing)
 	return (locate(container_thing) in container)
 

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -132,3 +132,25 @@
 	var/new_falloff = variable == "light_falloff_curve" ? var_value : A.light_falloff_curve
 
 	A.set_light(new_max, new_inner, new_outer, new_falloff)
+
+/decl/vv_set_handler/health_value_handler
+	handled_type = /atom
+	handled_vars = list(
+		"health_max" = /atom/proc/set_max_health,
+		"health_current" = /atom/proc/set_health
+	)
+	predicates = list(/proc/is_num_predicate)
+
+/decl/vv_set_handler/health_dead_handler
+	handled_type = /atom
+	handled_vars = list("health_dead")
+	predicates = list(/proc/is_strict_bool_predicate)
+
+/decl/vv_set_handler/health_dead_handler/handle_set_var(atom/target, variable, var_value, client)
+	if (var_value == target.health_dead)
+		return
+	switch (var_value)
+		if (TRUE)
+			target.kill_health()
+		if (FALSE)
+			target.revive_health()


### PR DESCRIPTION
:cl: SierraKomodo
admin: Var-editing the `health_max`, `health_current`, and `health_dead` vars is now properly sanitized and will call the relevant proc calls automagically. Beware setting health to 0 on anything that qdels itself when dead.
/:cl: