### PR TITLE
play_ambience is probably no longer area size dependent for performance

### DIFF
--- a/code/datums/repositories/sound_channels.dm
+++ b/code/datums/repositories/sound_channels.dm
@@ -1,8 +1,11 @@
 GLOBAL_DATUM_INIT(sound_channels, /repository/sound_channels, new)
 GLOBAL_VAR_INIT(lobby_sound_channel, GLOB.sound_channels.RequestChannel("LOBBY"))
 GLOBAL_VAR_INIT(vote_sound_channel, GLOB.sound_channels.RequestChannel("VOTE"))
-GLOBAL_VAR_INIT(ambience_sound_channel, GLOB.sound_channels.RequestChannel("AMBIENCE"))
 GLOBAL_VAR_INIT(admin_sound_channel, GLOB.sound_channels.RequestChannel("ADMIN_FUN"))
+
+GLOBAL_VAR_INIT(ambience_channel_vents, GLOB.sound_channels.RequestChannel("AMBIENCE_VENTS"))
+GLOBAL_VAR_INIT(ambience_channel_forced, GLOB.sound_channels.RequestChannel("AMBIENCE_FORCED"))
+GLOBAL_VAR_INIT(ambience_channel_common, GLOB.sound_channels.RequestChannel("AMBIENCE_COMMON"))
 
 /repository/sound_channels
 	var/datum/stack/available_channels

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -97,15 +97,19 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/Initialize()
 	. = ..()
+	var/area/area = get_area(src)
+	if (area)
+		LAZYADD(area.vent_pumps, src)
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP
 	icon = null
 
 /obj/machinery/atmospherics/unary/vent_pump/Destroy()
-	var/area/A = get_area(src)
-	if(A)
-		A.air_vent_info -= id_tag
-		A.air_vent_names -= id_tag
-	. = ..()
+	var/area/area = get_area(src)
+	if(area)
+		area.air_vent_info -= id_tag
+		area.air_vent_names -= id_tag
+		LAZYREMOVE(area.vent_pumps, src)
+	return ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume
 	name = "Large Air Vent"

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -22,8 +22,13 @@
 		///////////////
 		//SOUND STUFF//
 		///////////////
-	var/ambience_playing= null
-	var/played			= 0
+
+	/// Whether or not the client is currently playing the "ship hum" ambience sound.
+	var/playing_vent_ambience = FALSE
+
+	/// The next threshold time for the client to be able to play basic ambience sounds.
+	var/next_ambience_time = 0
+
 
 		////////////
 		//SECURITY//

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -112,8 +112,9 @@ var/global/list/_client_preferences_by_type
 
 /datum/client_preference/play_ambiance/changed(var/mob/preference_mob, var/new_value)
 	if(new_value == GLOB.PREF_NO)
-		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 0, channel = GLOB.lobby_sound_channel))
-		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 0, channel = GLOB.ambience_sound_channel))
+		sound_to(preference_mob, sound(null, channel = GLOB.ambience_channel_vents))
+		sound_to(preference_mob, sound(null, channel = GLOB.ambience_channel_forced))
+		sound_to(preference_mob, sound(null, channel = GLOB.ambience_channel_common))
 
 /datum/client_preference/play_announcement_sfx
 	description = "Play announcement sound effects"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -879,7 +879,7 @@
 			playsound_local(src,pick(GLOB.scarySounds),50, 1, -1)
 
 	var/area/A = get_area(src)
-	if(client && world.time >= client.played + 600)
+	if(client && world.time >= client.next_ambience_time + 5 MINUTES)
 		A.play_ambience(src)
 	if(stat == UNCONSCIOUS && world.time - l_move_time < 5 && prob(10))
 		to_chat(src,"<span class='notice'>You feel like you're [pick("moving","flying","floating","falling","hovering")].</span>")

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -53,12 +53,10 @@
 /area/exoplanet/grass
 	base_turf = /turf/simulated/floor/exoplanet/grass
 	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/ambience/eeriejungle2.ogg','sound/ambience/eeriejungle1.ogg')
+	forced_ambience = list(
+		'sound/ambience/jungle.ogg'
+	)
 
-/area/exoplanet/grass/play_ambience(var/mob/living/L)
-	..()
-	if(!L.ear_deaf && L.client && !L.client.ambience_playing)
-		L.client.ambience_playing = TRUE
-		L.playsound_local(get_turf(L),sound('sound/ambience/jungle.ogg', repeat = 1, wait = 0, volume = 25, channel = GLOB.ambience_sound_channel))
 
 /datum/random_map/noise/exoplanet/grass
 	descriptor = "grass exoplanet"


### PR DESCRIPTION
Tentatively attempts to prevent area/play_ambience from destroying performance in large areas by having vent_pump instances add/remove themselves on a list per area.

Also splits up ambience into its own channels (instead of two kinds reusing the lobby channel) and makes grass exoplanets use the forced ambience list instead of rolling their own.

might resolve #32223