### PR TITLE
Empty autoinjectors and reagent colored tags

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -990,7 +990,7 @@
 	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
 	base_type = /obj/machinery/vending/wallmed2
 	products = list(
-		/obj/item/reagent_containers/hypospray/autoinjector = 5,
+		/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 5,
 		/obj/item/stack/medical/bruise_pack = 4,
 		/obj/item/stack/medical/ointment = 4,
 		/obj/item/storage/med_pouch/trauma,

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -398,7 +398,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	startswith = list(
 	/obj/item/clothing/gloves/latex/nitrile,
-	/obj/item/reagent_containers/hypospray/autoinjector,
+	/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 	/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/deletrathol,
 	/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin,
 	/obj/item/stack/medical/bruise_pack

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -171,7 +171,7 @@
 				/obj/item/stack/medical/advanced/bruise_pack = 2,
 				/obj/item/stack/medical/advanced/ointment = 2,
 				/obj/item/stack/medical/splint = 1,
-				/obj/item/reagent_containers/hypospray/autoinjector = 3,
+				/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 3,
 				/obj/item/storage/pill_bottle/kelotane = 2,
 				/obj/item/storage/pill_bottle/antitox = 2,
 				/obj/item/storage/med_pouch/trauma = 2,

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -176,7 +176,7 @@
 			/obj/item/rcd_ammo,
 			/obj/item/reagent_containers/syringe,
 			/obj/item/reagent_containers/hypospray,
-			/obj/item/reagent_containers/hypospray/autoinjector,
+			/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
 			/obj/item/syringe_cartridge,
 			/obj/item/plastique,
 			/obj/item/clothing/mask/smokable,

--- a/code/modules/fabrication/designs/general/designs_medical.dm
+++ b/code/modules/fabrication/designs/general/designs_medical.dm
@@ -42,4 +42,4 @@
 	path = /obj/item/storage/pill_bottle
 
 /datum/fabricator_recipe/medical/hypospray/autoinjector
-	path = /obj/item/reagent_containers/hypospray/autoinjector/empty
+	path = /obj/item/reagent_containers/hypospray/autoinjector

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -169,8 +169,9 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
 	slot_flags = SLOT_BELT | SLOT_EARS
 	w_class = ITEM_SIZE_TINY
-	var/list/starts_with = list(/datum/reagent/inaprovaline = 5)
-	var/band_color = COLOR_CYAN
+	matter = list(MATERIAL_PLASTIC = 150, MATERIAL_GLASS = 50)
+	var/list/starts_with = list()
+	var/band_color = COLOR_GRAY
 
 /obj/item/reagent_containers/hypospray/autoinjector/New()
 	..()
@@ -240,8 +241,7 @@
 	band_color = COLOR_BLUE
 	starts_with = list(/datum/reagent/dexalinp = 5)
 
-/obj/item/reagent_containers/hypospray/autoinjector/empty
-	name = "autoinjector"
-	band_color = COLOR_WHITE
-	starts_with = list()
-	matter = list(MATERIAL_PLASTIC = 150, MATERIAL_GLASS = 50)
+/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline
+	name = "autoinjector (inaprovaline)"
+	band_color = COLOR_CYAN
+	starts_with = list(/datum/reagent/inaprovaline = 5)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -171,7 +171,8 @@
 	w_class = ITEM_SIZE_TINY
 	matter = list(MATERIAL_PLASTIC = 150, MATERIAL_GLASS = 50)
 	var/list/starts_with = list()
-	var/band_color = COLOR_GRAY
+	/// Color. If set, forces the autoinjectors window color to instead be a solid band color matching the provided color. If not set, the band color instead matches the contained reagent color.
+	var/band_color
 
 /obj/item/reagent_containers/hypospray/autoinjector/New()
 	..()
@@ -184,13 +185,22 @@
 	..()
 	update_icon()
 
+/obj/item/reagent_containers/hypospray/autoinjector/on_reagent_change()
+	update_icon()
+
 /obj/item/reagent_containers/hypospray/autoinjector/on_update_icon()
 	overlays.Cut()
 	if(reagents.total_volume > 0)
 		icon_state = "[initial(icon_state)]1"
 	else
 		icon_state = "[initial(icon_state)]0"
-	overlays+= overlay_image(icon,"injector_band",band_color,RESET_COLOR)
+	var/overlay_color = band_color
+	if (isnull(overlay_color))
+		if (reagents.total_volume)
+			overlay_color = reagents.get_color()
+		else
+			overlay_color = COLOR_GRAY
+	overlays += overlay_image(icon, "injector_band", overlay_color, RESET_COLOR)
 
 /obj/item/reagent_containers/hypospray/autoinjector/examine(mob/user)
 	. = ..(user)
@@ -201,47 +211,38 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/detox
 	name = "autoinjector (antitox)"
-	band_color = COLOR_GREEN
 	starts_with = list(/datum/reagent/dylovene = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/pain
 	name = "autoinjector (painkiller)"
-	band_color = COLOR_PURPLE
 	starts_with = list(/datum/reagent/tramadol = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/combatpain
 	name = "autoinjector (oxycodone)"
-	band_color = COLOR_DARK_GRAY
 	starts_with = list(/datum/reagent/tramadol/oxycodone = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/antirad
 	name = "autoinjector (anti-rad)"
-	band_color = COLOR_AMBER
 	starts_with = list(/datum/reagent/hyronalin = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/mindbreaker
 	name = "autoinjector"
-	band_color = COLOR_DARK_GRAY
 	starts_with = list(/datum/reagent/mindbreaker = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/combatstim
 	name ="autoinjector (combat Stimulants)"
-	band_color = COLOR_RED
 	volume = 15
 	amount_per_transfer_from_this = 15
 	starts_with = list(/datum/reagent/inaprovaline = 10, /datum/reagent/hyperzine = 3, /datum/reagent/synaptizine = 1)
 
 /obj/item/reagent_containers/hypospray/autoinjector/coagulant
 	name ="autoinjector (coagulant)"
-	band_color = COLOR_RED
 	starts_with = list(/datum/reagent/coagulant = 1, /datum/reagent/nanoblood = 4)
 
 /obj/item/reagent_containers/hypospray/autoinjector/dexalin_plus
 	name ="autoinjector (dexalin plus)"
-	band_color = COLOR_BLUE
 	starts_with = list(/datum/reagent/dexalinp = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline
 	name = "autoinjector (inaprovaline)"
-	band_color = COLOR_CYAN
 	starts_with = list(/datum/reagent/inaprovaline = 5)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -29012,6 +29012,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/item/storage/box/autoinjectors,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "uVf" = (


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Autoinjector color bands now serve as a 'window' showing the color of the reagent inside. Just like syringes. Except those special autoinjectors in pouches that have snowflake colors. Rely on the labels for those.
map: Added a box of empty autoinjectors to the chemistry lab.
/:cl: