### PR TITLE
Fix missing timer bar for equipping items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -906,7 +906,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 
 /// Flags to use for do_after when equip_delay is set
-/obj/item/var/equip_delay_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS
+/obj/item/var/equip_delay_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS | DO_BAR_OVER_USER
 
 
 /// Virtual for behavior to do before do_after if equip_delay is set


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Equip actions with timers now display the timer bar.
/:cl: