### PR TITLE
Officer's lounge map tweaks

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -516,6 +516,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "bX" = (
@@ -651,6 +655,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "co" = (
@@ -663,7 +668,7 @@
 	pixel_y = 32
 	},
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "cr" = (
 /obj/structure/adherent_bath,
@@ -759,16 +764,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
 "cE" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "cF" = (
 /obj/machinery/door/firedoor,
@@ -1177,7 +1181,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "dS" = (
 /turf/simulated/floor/carpet/blue2,
@@ -1302,8 +1311,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "em" = (
-/obj/structure/bed/chair/wood/wings/mahogany{
-	dir = 8
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
@@ -1391,26 +1401,33 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
 "eA" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 4
-	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Mess Hall - Officer's Mess";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "eB" = (
 /obj/structure/bed/chair/wood/wings/mahogany{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "eC" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/glass2/carafe,
 /obj/item/reagent_containers/food/drinks/pitcher,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "eE" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1956,32 +1973,22 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "gr" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "gs" = (
-/obj/item/storage/box/donut,
 /obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "gu" = (
 /obj/structure/table/marble,
 /obj/item/storage/box/glasses/pint,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "gw" = (
 /obj/structure/table/marble,
@@ -1991,7 +1998,7 @@
 	pixel_x = 22;
 	pixel_y = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2227,27 +2234,18 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/captainmess)
 "hm" = (
 /obj/item/tableflag,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -2257,34 +2255,26 @@
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "hn" = (
-/obj/structure/bed/chair/wood/wings/mahogany{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "ho" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/chair/wood/wings/mahogany{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "hp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -2296,12 +2286,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/command/captainmess)
@@ -2312,6 +2298,10 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/lino,
 /area/command/captainmess)
@@ -2588,7 +2578,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "in" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -2838,7 +2828,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "jr" = (
 /obj/machinery/firealarm{
@@ -4582,20 +4572,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "pW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
 "pX" = (
@@ -7367,7 +7343,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "yC" = (
@@ -10724,7 +10699,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "KW" = (
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "KZ" = (
 /obj/machinery/door/airlock/mining{
@@ -10873,6 +10856,9 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "Lw" = (
@@ -10987,9 +10973,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "LQ" = (
-/obj/structure/table/marble,
-/obj/item/reagent_containers/food/drinks/teapot,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "LS" = (
 /obj/structure/catwalk,
@@ -11386,7 +11375,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "MX" = (
-/turf/simulated/wall/r_wall/prepainted,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "MY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -11875,13 +11867,8 @@
 	pixel_x = 4;
 	pixel_y = -24
 	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "Om" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11980,6 +11967,9 @@
 	pixel_x = -3
 	},
 /obj/structure/table/woodentable/walnut,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "OJ" = (
@@ -12096,7 +12086,7 @@
 /obj/structure/flora/pottedplant/deskferntrim{
 	pixel_y = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "Pa" = (
 /obj/machinery/door/blast/shutters{
@@ -12632,7 +12622,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "QA" = (
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "QB" = (
 /obj/machinery/access_button{
@@ -12994,7 +12989,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "RD" = (
 /obj/machinery/alarm{
@@ -13057,7 +13052,8 @@
 /area/hallway/primary/fourthdeck/aft)
 "RL" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/item/reagent_containers/food/drinks/teapot,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "RM" = (
 /obj/effect/floor_decal/corner/brown{
@@ -13132,8 +13128,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "RT" = (
-/obj/effect/floor_decal/corner/blue/three_quarters,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/chair/wood/wings/mahogany{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "RU" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -13859,7 +13860,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "TA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -14100,24 +14101,7 @@
 /turf/simulated/floor/lino,
 /area/command/captainmess)
 "Uo" = (
-/obj/effect/floor_decal/corner/blue/three_quarters{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "Up" = (
 /obj/effect/floor_decal/corner/red{
@@ -14877,14 +14861,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "Wx" = (
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/structure/bed/chair/wood/wings/mahogany{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/lino,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "Wy" = (
 /obj/structure/cable/green{
@@ -15085,7 +15067,7 @@
 "WU" = (
 /obj/structure/table/marble,
 /obj/item/storage/box/glasses/wine,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/lino,
 /area/command/captainmess)
 "WW" = (
 /obj/machinery/door/airlock/mining{
@@ -15130,39 +15112,29 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/starboard)
 "Xg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/bed/chair/wood/wings/mahogany{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
 "Xh" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
@@ -15200,16 +15172,25 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "Xm" = (
@@ -15224,10 +15205,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
@@ -15376,17 +15353,10 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "XG" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/forestarboard)
+/obj/structure/table/woodentable/walnut,
+/obj/item/storage/box/donut,
+/turf/simulated/floor/carpet/blue2,
+/area/command/captainmess)
 "XH" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 8
@@ -15407,7 +15377,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "XL" = (
@@ -15669,26 +15638,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fourthdeck)
 "Yu" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+/obj/structure/bed/chair/wood/wings/mahogany{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/blue2,
 /area/command/captainmess)
-"Yv" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/forestarboard)
 "Yw" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external/escapepod{
@@ -15952,7 +15906,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/wood,
 /area/command/captainmess)
 "Ze" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16308,7 +16262,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/lino,
 /area/command/captainmess)
 "ZS" = (
@@ -16351,7 +16307,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -33019,8 +32975,8 @@ ak
 Va
 Po
 bV
-Yv
-Yv
+bI
+bI
 cn
 ZX
 yB
@@ -33220,7 +33176,7 @@ ak
 ak
 Rs
 Mt
-XG
+uY
 af
 af
 af
@@ -33422,7 +33378,7 @@ ak
 ak
 Os
 ep
-XG
+uY
 af
 ao
 ao
@@ -33624,16 +33580,16 @@ ak
 ak
 NU
 bu
-XG
-Mp
-ap
-Mp
-Mp
-Mp
+uY
 fd
-hl
-Mp
-Mp
+ap
+fd
+fd
+fd
+fd
+fd
+fd
+fd
 Mp
 Pt
 vH
@@ -34029,12 +33985,12 @@ ak
 er
 er
 Xl
-fd
-QA
-dS
+hl
+KW
+MX
 eB
-eB
-eB
+Wx
+Wx
 Xg
 dS
 jn
@@ -34437,8 +34393,8 @@ fd
 Rq
 dS
 em
-em
-em
+gs
+XG
 hn
 dS
 jn
@@ -34637,12 +34593,12 @@ er
 VR
 fd
 py
-KW
+dS
 RT
 Yu
 Yu
 ho
-KW
+dS
 jn
 WI
 WI
@@ -34837,16 +34793,16 @@ ak
 cw
 er
 bY
-Mp
-Mp
+fd
+fd
 dT
 ZR
-Wx
-Wx
+XM
+XM
 hp
 Ol
-MX
-Mp
+fd
+fd
 Pt
 vH
 aY
@@ -35048,7 +35004,7 @@ gu
 hq
 LQ
 jq
-Mp
+fd
 hh
 oW
 Ga
@@ -35248,9 +35204,9 @@ XM
 XM
 XM
 uy
-QA
+Uo
 Zd
-Mp
+fd
 hh
 TM
 Rg
@@ -35450,9 +35406,9 @@ cq
 gw
 RL
 in
-QA
+Uo
 RC
-Mp
+fd
 hh
 hh
 hh
@@ -35646,15 +35602,15 @@ er
 er
 cK
 er
-Mp
-Mp
-Mp
-Mp
-Mp
-Mp
-Mp
-Mp
-Mp
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
 VW
 VW
 Pt


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: Tweaks the Officer's Lounge - Wider table, moves maintenance access, and makes everything wood.
/:cl:

- Makes the officer's lounge table wider
- Replaces the flooring
- Moves the maintenance access door
- Replaces the walls with wood walls