### PR TITLE
Handle short click-drag issues when clicking moving sprites

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -25,4 +25,7 @@
 
 // Receive a mouse drop
 /atom/proc/MouseDrop_T(atom/dropping, mob/user)
+	// Mitigation for some user's mouses click+dragging for a split second when clicking on moving sprites.
+	if (src == dropping && user.canClick())
+		user.ClickOn(src)
 	return


### PR DESCRIPTION
:cl: SierraKomodo
tweak: It should now be a lot easier to trigger click actions on moving sprites or while you yourself are moving. This will be most noticeable in combat. Report any weirdness with click or click+drag interactions.
/:cl:

Did a lot of local side testing of spam-clicking things while running around and had a lot more consistency in the server registering a _click_ versus not doing anything with these changes. Didn't see any weirdness happening with interactions, either.

Also for PSD since he mentioned concern over this: It does _not_ pass a click if you click and drag something onto any atom or turf that is not itself.