### PR TITLE
Fix incorrect visible message use

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -119,7 +119,7 @@
 
 	var/area/A = get_area(user)
 	if (!A.can_modify_area())
-		visible_message("You can't seem to make anything with \the [src] here.")
+		to_chat(user, SPAN_WARNING("You can't seem to make anything with \the [src] here."))
 		return
 
 	if (!can_use(required))


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Failing to craft something in the holodeck no longer displays a message to everyone.
/:cl: