### PR TITLE
Explosion severity refactor

### DIFF
--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -311,11 +311,11 @@
 	var/damage = 0
 	switch (severity)
 		if (EX_ACT_DEVASTATING)
-			damage = health_max
+			damage = round(health_max * (rand(100, 200) / 100)) // So that even atoms resistant to explosions may still be heavily damaged at this severity. Effective range of 100% to 200%.
 		if (EX_ACT_HEAVY)
-			damage = round(health_max / rand(2, 3))
+			damage = round(health_max * (rand(50, 100) / 100)) // Effective range of 50% to 100%.
 		if (EX_ACT_LIGHT)
-			damage = round(health_max / rand(10, 15))
+			damage = round(health_max * (rand(10, 50) / 100)) // Effective range of 10% to 50%.
 	if (damage && can_damage_health(damage, DAMAGE_EXPLODE))
 		damage_health(damage, DAMAGE_EXPLODE, damage_flags, severity)
 

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -44,9 +44,11 @@ var/global/explosion_in_progress = 0
 		if(!T) continue
 
 		//Wow severity looks confusing to calculate... Fret not, I didn't leave you with any additional instructions or help. (just kidding, see the line under the calculation)
-		var/severity = 4 - round(max(min( 3, ((explosion_turfs[T] - T.get_explosion_resistance()) / (max(3,(power/3)))) ) ,1), 1)								//sanity			effective power on tile				divided by either 3 or one third the total explosion power
-								//															One third because there are three power levels and I
-								//															want each one to take up a third of the crater
+		var/severity = explosion_turfs[T] - T.get_explosion_resistance() // effective power on tile, factoring in the tile's explosion resistance
+		severity /= max(3, power / 3) // One third the total explosion power - One third because there are three power levels and I want each one to take up a third of the crater
+		severity = clamp(severity, 1, 3) // Sanity
+		severity = 4 - severity // Invert the value to accomodate lower numbers being a higher severity. Removing this inversion would require a lot of refactoring of math in `ex_act()` handlers.
+
 		var/x = T.x
 		var/y = T.y
 		var/z = T.z

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -120,6 +120,9 @@ var/global/explosion_in_progress = 0
 	if(is_below_sound_pressure(src))
 		. *= 3
 
+/turf/simulated/wall/get_explosion_resistance()
+	return 5 // Standardized health results in explosion_resistance being used to reduce overall damage taken, instead of changing explosion severity. 5 was the original default, so 5 is always returned here.
+
 /turf/simulated/floor/explosion_resistance = 1
 
 /turf/simulated/mineral/explosion_resistance = 2

--- a/code/modules/materials/definitions/materials_metal.dm
+++ b/code/modules/materials/definitions/materials_metal.dm
@@ -175,7 +175,7 @@
 	icon_base = "solid"
 	icon_reinf = "reinf_over"
 	icon_colour = "#a8a9b2"
-	explosion_resistance = 25
+	explosion_resistance = 7.5
 	brute_armor = 8
 	burn_armor = 10
 	hardness = MATERIAL_VERY_HARD


### PR DESCRIPTION
Testing changes

:cl: SierraKomodo
balance: Explosion damage handling for walls and other standardized health atoms has been tweaked. Overall, explosions are now more damaging in general, and walls using plasteel as a material are now far less resilient to explosions than they used to be, while still being about 1/3 - 1/2 stronger. See https://github.com/Baystation12/Baystation12/pull/32256 for specific numbers.
/:cl:

- Prevents `ex_act()` severity numbers applied to walls from being reduced by the wall's `explosion_resistance` value, as this value is already being used to affect damage output in standardized health processing. This resulted in reinforced walls being far more resilient against explosions than intended. (Oversight)
- Reworks the base damage values for each severity in standardized health `ex_act()` calculations. New base damage values are now the following range of percentages of the atom's maximum health, before applying resistance values. These changes, overall, result in higher base damage output from explosions against any atoms using standardized health.
	- DEVASTATING: 100 - 200%, from 100% - This is to allow for devastating severity to truly be devastating, even against atoms that have a resistance to explosion damage - Primarily as a response to reinforced walls.
	- HEAVY - 50 - 100%, from 33 - 50%
	- LIGHT - 10 - 50%, from 6 - 10%
- Reduces plasteel explosion resistance from 25 to 7.5. This final change allows explosions to actually be marginally useful against reinforced walls - Primarily focused around balancing against meteors.

# BEFORE:
## Base Damage Values (Standardized Health only; Before Damage Resistance)
- SEVERITY DEVASTATION: 100% of max health
- SEVERITY HEAVY: 33 - 50% of max health
- SEVERITY LIGHT: 6 - 10% of max health

## Meteors vs Reinforced Walls
- R WALL SEVERITY DAMAGE PERCENTAGES:
	- DEVASTATION: 20% of max health
	- HEAVY: 6 - 10% of max health
	- LIGHT: 1 - 2% of max health
- CHANCES WHEN IMPACTED BY METEOR:
	- CHANCE OF SEVERITY DEVASTATION: Some ridiculously small if not 0 number that it's proving too complicated to actually calculate by hand using this function in explosion handling.
	- CHANCE OF DEATH WHEN HIT: ??? Probably near zero based on testing.

# AFTER:
## Base Damage Values (Standardized Health only; Before Damage Resistance)
- SEVERITY DEVASTATION: 100 - 200% of max health
- SEVERITY HEAVY: 50 - 100% of max health
- SEVERITY LIGHT: 10 - 50% of max health

## Meteors vs Reinforced Walls
- R WALL SEVERITY DAMAGE PERCENTAGES:
	- DEVASTATION: 67 - 133% of max health
	- HEAVY: 33 - 67% of max health
	- LIGHT: 7 - 33% of max health
- CHANCES WHEN IMPACTED BY METEOR:
	- CHANCE OF SEVERITY DEVASTATION: 100%
	- CHANCE OF DEATH WHEN HIT: ~50%