### PR TITLE
west hangar exit does not open catwalks on deck 4

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2946,7 +2946,6 @@
 "jY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
-	id_tag = "hangarexit";
 	name = "Hangar Catwalk Access"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
@@ -14836,7 +14835,6 @@
 "Wo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
-	id_tag = "hangarexit";
 	name = "Hangar Catwalk Access"
 	},
 /turf/simulated/floor/tiled/steel_ridged,


### PR DESCRIPTION
:cl: Green Macready
bugfix: The west hangar exit button no longer opens the east catwalk doors on deck 4.
/:cl: