### PR TITLE
Changes to hostage shielding and grab/pulling

### DIFF
--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -10,6 +10,7 @@
 
 
 	stop_move = 1
+	force_stand = TRUE
 	reverse_facing = 1
 	can_absorb = 1
 	shield_assailant = 1
@@ -32,5 +33,13 @@
 
 	if(affecting.lying)
 		affecting.Weaken(4)
+
+	if(affecting.stat != CONSCIOUS)
+		force_stand = FALSE
+		shield_assailant = FALSE
+
+	else
+		force_stand = TRUE
+		shield_assailant = TRUE
 
 	affecting.adjustOxyLoss(1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -572,8 +572,11 @@ default behaviour is:
 	else
 		var/mob/living/M = pulling
 		if(M.grabbed_by.len)
+			var/obj/item/grab/G = pick(M.grabbed_by)
+			if (G.current_grab.shield_assailant)
+				visible_message(SPAN_WARNING("\The [G.assailant] stops \the [src] from pulling \the [G.affecting] from their grip!"), SPAN_WARNING("\The [G.assailant] is holding \the [G.affecting] too tight for you to pull them away!"))
+				return
 			if (prob(75))
-				var/obj/item/grab/G = pick(M.grabbed_by)
 				if(istype(G))
 					M.visible_message(SPAN_WARNING("[G.affecting] has been pulled from [G.assailant]'s grip by [src]!"), SPAN_WARNING("[G.affecting] has been pulled from your grip by [src]!"))
 					qdel(G)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -532,6 +532,16 @@
 	var/mob/M = AM
 	if(ismob(AM))
 
+		var/obj/item/grab/G = locate() in M
+		if(istype(G))
+			if(G.current_grab.shield_assailant) // Check that the pull target isn't holding someone hostage to prevent just yanking them away from their victim.
+				visible_message(SPAN_WARNING("\The [G.assailant] uses \the [G.affecting] to block \the [src] from getting a firm grip!"), SPAN_WARNING("Your grip is blocked by \the [G.assailant] using \the [G.affecting] as a shield!"))
+				return
+			if(prob(25))
+				visible_message(SPAN_WARNING("\The [src] fails to pull \the [G.assailant] away from \the [G.affecting]!"), SPAN_WARNING("You fail to pull \the [G.assailant] away from \the [G.affecting]!"))
+				return
+			qdel(G) // Makes sure dragging the assailant away from their victim makes them release the grab instead of holding it at long range forever.
+
 		if(!can_pull_mobs || !can_pull_size)
 			to_chat(src, "<span class='warning'>It won't budge!</span>")
 			return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -291,7 +291,7 @@
 			//if they have a neck grab on someone, that person gets hit instead
 			var/obj/item/grab/G = locate() in M
 			if(G && G.shield_assailant())
-				visible_message("<span class='danger'>\The [M] uses [G.affecting] as a shield!</span>")
+				G.affecting.visible_message(SPAN_DANGER("\The [M] uses \the [G.affecting] as a shield!"))
 				if(Bump(G.affecting, forced=1))
 					return //If Bump() returns 0 (keep going) then we continue on to attack M.
 


### PR DESCRIPTION
- Using someone as a meat shield now forces them to stand to make it obvious and prevent people shooting a hostage because they were on the ground and didn't know they were being used as a shield.
- Changes the source of the shielding `visible_message` from the projectile to the meat shield, because beams are set to be invisible and therefore did not display the message.
- You can no longer pull someone away from their hostage meat shield, when the hostage is no longer working as a shield you can pull them apart at the same odds as pulling the victim from the assailant originally.
- When an assailant is pulled away from their victim successfully it forces them to drop the grab, instead of keeping it forever at any distance as before.

:cl: Fre3bie
tweak: Hostage meat shields are forced to stand until they go unconscious/die, then stop blocking shots
tweak: Hostage/assailant can no longer be pulled away from each other while being used as a meat shield
bugfix: Pulling an assailant away from their grab target makes them properly drop the grab
/:cl: