### PR TITLE
Lets the AMS be beside the Torch whenever spawns

### DIFF
--- a/maps/away/mininghome/mininghome.dm
+++ b/maps/away/mininghome/mininghome.dm
@@ -2,6 +2,7 @@
 	name = "Asteroid Mining Station"
 	desc = "A small mining station. No active lifesigns found on the station. Sensors indicate an abundance of valuable ore."
 	icon_state = "object"
+	place_near_main = list(1, 1)
 	initial_generic_waypoints = list(
 		"nav_mininghome_1",
 		"nav_mininghome_2",
@@ -15,6 +16,7 @@
 	description = "A chill asteroid mining station."
 	suffixes = list("mininghome/mininghome.dmm")
 	spawn_cost = 0.5
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /obj/effect/shuttle_landmark/nav_mininghome_1
 	name = "Navpoint #1"


### PR DESCRIPTION
:cl: Ryan180602
tweak: Makes the asteroid mining station spawn beside the Torch whenever it does spawn.
/:cl:

Does not change spawn chance. Whenever it *does* spawn, it will spawn only a sector away from the Torch.

This lets prospectors/xenoarchaeologists/even explorers to actually go there quickly without having to hassle with piloting, which is unfun for some people, considering the wait/time required.

Does not change anything else.