### PR TITLE
Ranks, patches, and awards from the uniform vendor

### DIFF
--- a/maps/torch/datums/uniforms.dm
+++ b/maps/torch/datums/uniforms.dm
@@ -29,6 +29,10 @@
 	var/dress_gloves = null
 	var/dress_extra = null
 
+	var/list/spawns_with_ranks
+	var/list/spawns_with_patches
+	var/list/spawns_with_awards
+
 /decl/hierarchy/mil_uniform/ec
 	name = "Master EC outfit"
 	hierarchy_type = /decl/hierarchy/mil_uniform/ec
@@ -53,6 +57,13 @@
 	dress_gloves = /obj/item/clothing/gloves/white
 
 	dress_extra = list(/obj/item/clothing/accessory/solgov/ec_scarf)
+
+/decl/hierarchy/mil_uniform/ec/Initialize()
+	. = ..()
+
+	LAZYADD(spawns_with_ranks, list(utility_under, service_over, dress_over))
+	LAZYADD(spawns_with_patches, list(utility_under, service_over))
+	LAZYADD(spawns_with_awards, list(service_over, dress_over))
 
 /decl/hierarchy/mil_uniform/fleet
 	name = "Master fleet outfit"
@@ -79,6 +90,13 @@
 	dress_shoes = /obj/item/clothing/shoes/dress
 	dress_hat = /obj/item/clothing/head/solgov/dress/fleet/garrison
 	dress_gloves = /obj/item/clothing/gloves/white
+
+/decl/hierarchy/mil_uniform/ec/Initialize()
+	. = ..()
+
+	LAZYADD(spawns_with_ranks, list(utility_under, service_over, dress_over))
+	LAZYADD(spawns_with_patches, list(utility_under))
+	LAZYADD(spawns_with_awards, list(service_over, dress_over))
 
 /decl/hierarchy/mil_uniform/civilian
 	name = "Master civilian outfit"		//Basically just here for the rent-a-tux, ahem, I mean... dress uniform.


### PR DESCRIPTION
- [X] Adds a whitelists for which components should have ranks, patches, and awards to the military uniform decl
- [X] Makes vendors spawn and attach ranks to the appropriate uniform pieces
- [ ] Adds functionality for setting awards and assigned section (patch) to the background page in character setup, outside of the loadout
  - [ ] Makes vendors spawn and attach patches to the appropriate uniform pieces
  - [ ] Makes vendors spawn and attach awards to the appropriate uniform pieces

Maybe (depending on scope or whether it's a good idea):
- [ ] Allows players to set awards and assigned section (patch) per job
- [ ] Adds awards and assigned section (patch) to in game records
  - [ ] Allows players to modify awards and assigned section (patch) in game from the records manager, which updates the vendor
- [ ] Allows players to select which uniform type they want to spawn in, per job