### PR TITLE
Removes alarm notifications from borg chat logs

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -40,7 +40,6 @@
 	handle_confused()
 	update_sight()
 
-	process_queued_alarms()
 	handle_regular_hud_updates()
 	switch(src.sensor_mode)
 		if (SEC_HUD)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -17,7 +17,6 @@
 		update_items()
 	if (src.stat != DEAD) //still using power
 		use_power()
-		process_queued_alarms()
 	UpdateLyingBuckledAndVerbStatus()
 
 /mob/living/silicon/robot/proc/clamp_values()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -29,9 +29,6 @@
 
 	var/sensor_mode = 0 //Determines the current HUD.
 
-	var/next_alarm_notice
-	var/list/datum/alarm/queued_alarms = new()
-
 	var/list/access_rights
 	var/obj/item/card/id/idcard = /obj/item/card/id/synthetic
 
@@ -277,57 +274,6 @@
 
 	apply_damage(brute, DAMAGE_BRUTE, damage_flags = DAMAGE_FLAG_EXPLODE)
 	apply_damage(burn, DAMAGE_BURN, damage_flags = DAMAGE_FLAG_EXPLODE)
-
-/mob/living/silicon/proc/receive_alarm(var/datum/alarm_handler/alarm_handler, var/datum/alarm/alarm, was_raised)
-	if(!(alarm.alarm_z() in GetConnectedZlevels(get_z(src))))
-		return // Didn't actually hear it as far as we're concerned.
-	if(!next_alarm_notice)
-		next_alarm_notice = world.time + SecondsToTicks(10)
-
-	var/list/alarms = queued_alarms[alarm_handler]
-	if(was_raised)
-		// Raised alarms are always set
-		alarms[alarm] = 1
-	else
-		// Alarms that were raised but then cleared before the next notice are instead removed
-		if(alarm in alarms)
-			alarms -= alarm
-		// And alarms that have only been cleared thus far are set as such
-		else
-			alarms[alarm] = -1
-
-/mob/living/silicon/proc/process_queued_alarms()
-	if(next_alarm_notice && (world.time > next_alarm_notice))
-		next_alarm_notice = 0
-
-		var/alarm_raised = 0
-		for(var/datum/alarm_handler/AH in queued_alarms)
-			var/list/alarms = queued_alarms[AH]
-			var/reported = 0
-			for(var/datum/alarm/A in alarms)
-				if(alarms[A] == 1)
-					alarm_raised = 1
-					if(!reported)
-						reported = 1
-						to_chat(src, "<span class='warning'>--- [AH.category] Detected ---</span>")
-					raised_alarm(A)
-
-		for(var/datum/alarm_handler/AH in queued_alarms)
-			var/list/alarms = queued_alarms[AH]
-			var/reported = 0
-			for(var/datum/alarm/A in alarms)
-				if(alarms[A] == -1)
-					if(!reported)
-						reported = 1
-						to_chat(src, "<span class='notice'>--- [AH.category] Cleared ---</span>")
-					to_chat(src, "\The [A.alarm_name()].")
-
-		if(alarm_raised)
-			to_chat(src, "<A HREF=?src=\ref[src];showalerts=1>\[Show Alerts\]</A>")
-
-		for(var/datum/alarm_handler/AH in queued_alarms)
-			var/list/alarms = queued_alarms[AH]
-			alarms.Cut()
 
 /mob/living/silicon/proc/raised_alarm(var/datum/alarm/A)
 	to_chat(src, "[A.alarm_name()]!")

--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -31,11 +31,6 @@
 	for(var/subsystem_type in silicon_subsystems)
 		init_subsystem(subsystem_type)
 
-	if(/datum/nano_module/alarm_monitor/all in silicon_subsystems)
-		for(var/datum/alarm_handler/AH as anything in SSalarm.handlers)
-			AH.register_alarm(src, /mob/living/silicon/proc/receive_alarm)
-			queued_alarms[AH] = list()	// Makes sure alarms remain listed in consistent order
-
 /mob/living/silicon/proc/init_subsystem(var/subsystem_type)
 	var/existing_entry = silicon_subsystems[subsystem_type]
 	if(existing_entry && !ispath(existing_entry))


### PR DESCRIPTION
:cl: SierraKomodo
rscdel: Borgs no longer receive alarm notifications in chat. Alarms can still be monitored using the subsystem if desired by borgs.
/:cl:

It's incredibly spammy when things are happening, and encourages the behaviour of announcing every. Single. Alarm. The moment it happens.