### PR TITLE
Apply color coding to medical body scanner output

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -183,4 +183,23 @@
 #define COLOR_DARKMODE_DARKBACKGROUND "#171717"
 #define COLOR_DARKMODE_TEXT "#a4bad6"
 
+// Medical readout colors
+#define COLOR_MEDICAL_BRUTE "#ff0000"
+#define COLOR_MEDICAL_BURN "#ff7700"
+#define COLOR_MEDICAL_TOXIN "#00ff00"
+#define COLOR_MEDICAL_OXYLOSS "#0000ff"
+#define COLOR_MEDICAL_CRYSTAL "#0066ff"
+#define COLOR_MEDICAL_ROBOTIC "#666688"
+#define COLOR_MEDICAL_INTERNAL "#ff66ff"
+#define COLOR_MEDICAL_RADIATION "#66ff66"
+#define COLOR_MEDICAL_NECROTIC "#663333"
+#define COLOR_MEDICAL_INTERNAL_DANGER "#aa3333"
+#define COLOR_MEDICAL_DISLOCATED "#6666ff"
+#define COLOR_MEDICAL_BROKEN "#ff00aa"
+#define COLOR_MEDICAL_SPLINTED "#ff66aa"
+#define COLOR_MEDICAL_IMPLANT "#aa66ff"
+#define COLOR_MEDICAL_UNKNOWN_IMPLANT "#aa00ff"
+#define COLOR_MEDICAL_SCARRING "#aa9999"
+#define COLOR_MEDICAL_MISSING "#886666"
+
 #define COLORED_SQUARE(COLOR) "<span style='font-face: fixedsys; font-size: 14px; background-color: [COLOR]; color: [COLOR]'>___</span>"

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -310,9 +310,9 @@
 		var/row = list()
 		row += "<tr><td>[E["name"]]</td>"
 		if(E["is_stump"])
-			row += "<td><span class='bad'>Missing</span></td>"
+			row += "<td><span style='font-weight: bold; color: [COLOR_MEDICAL_MISSING]'>Missing</span></td>"
 			if(skill_level >= SKILL_ADEPT)
-				row += "<td><span class='bad'>[english_list(E["scan_results"], nothing_text = "&nbsp;")]</span></td>"
+				row += "<td><span>[english_list(E["scan_results"], nothing_text = "&nbsp;")]</span></td>"
 			else
 				row += "<td>&nbsp;</td>"
 		else
@@ -321,17 +321,17 @@
 				row += "None</td>"
 			if(skill_level < SKILL_ADEPT)
 				if(E["brute_dam"])
-					row += "<span class='bad'>Damaged</span><br>"
+					row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BRUTE]'>Damaged</span><br>"
 				if(E["burn_dam"])
-					row += "<span class='average'>Burned</span></td>"
+					row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BURN]'>Burned</span></td>"
 			else
 				if(E["brute_dam"])
-					row += "<span class='bad'>[capitalize(get_wound_severity(E["brute_ratio"], (E["limb_flags"] & ORGAN_FLAG_HEALS_OVERKILL)))] physical trauma</span><br>"
+					row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BRUTE]'>[capitalize(get_wound_severity(E["brute_ratio"], (E["limb_flags"] & ORGAN_FLAG_HEALS_OVERKILL)))] physical trauma</span><br>"
 				if(E["burn_dam"])
-					row += "<span class='average'>[capitalize(get_wound_severity(E["burn_ratio"], (E["limb_flags"] & ORGAN_FLAG_HEALS_OVERKILL)))] burns</span></td>"
+					row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BURN]'>[capitalize(get_wound_severity(E["burn_ratio"], (E["limb_flags"] & ORGAN_FLAG_HEALS_OVERKILL)))] burns</span></td>"
 			if(skill_level >= SKILL_ADEPT)
 				row += "<td>"
-				row += "<span class='bad'>[english_list(E["scan_results"], nothing_text="&nbsp;")]</span>"
+				row += "<span>[english_list(E["scan_results"], nothing_text="&nbsp;")]</span>"
 				row += "</td>"
 			else
 				row += "<td>&nbsp;</td>"

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -78,20 +78,20 @@
 
 	return english_list(flavor_text)
 
-/obj/item/organ/external/get_scan_results()
+/obj/item/organ/external/get_scan_results(tag = FALSE)
 	. = ..()
 	if(status & ORGAN_ARTERY_CUT)
-		. += "[capitalize(artery_name)] ruptured"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_INTERNAL_DANGER]'>[capitalize(artery_name)] ruptured</span>" : "[capitalize(artery_name)] ruptured"
 	if(status & ORGAN_TENDON_CUT)
-		. += "Severed [tendon_name]"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_INTERNAL]'>Severed [tendon_name]</span>" : "Severed [tendon_name]"
 	if(dislocated >= 1) // non-magical constants when
-		. += "Dislocated"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_DISLOCATED]'>Dislocated</span>" : "Dislocated"
 	if(splinted)
-		. += "Splinted"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_SPLINTED]'>Splinted</span>" : "Splinted"
 	if(status & ORGAN_BLEEDING)
-		. += "Bleeding"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_BRUTE]'>Bleeding</span>" : "Bleeding"
 	if(status & ORGAN_BROKEN)
-		. += capitalize(broken_description)
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_BROKEN]'>[capitalize(broken_description)]</span>" : capitalize(broken_description)
 	if (implants && implants.len)
 		var/unknown_body = 0
 		for(var/I in implants)
@@ -100,14 +100,14 @@
 				if(imp.hidden)
 					continue
 				if (imp.known)
-					. += "[capitalize(imp.name)] implanted"
+					. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_IMPLANT]'>[capitalize(imp.name)] implanted</span>" : "[capitalize(imp.name)] implanted"
 					continue
 			unknown_body++
 		if(unknown_body)
-			. += "Unknown body present"
+			. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_UNKNOWN_IMPLANT]'>Unknown body present</span>" : "Unknown body present"
 	for (var/obj/item/organ/internal/augment/aug in internal_organs)
 		if (aug.augment_flags & AUGMENT_SCANNABLE)
-			. += "[capitalize(aug.name)] implanted"
+			. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_IMPLANT]'>[capitalize(aug.name)] implanted</span>" : "[capitalize(aug.name)] implanted"
 
 /obj/item/organ/external/proc/inspect(mob/user)
 	if(is_stump())

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -182,11 +182,11 @@
 /obj/item/organ/internal/proc/get_scarring_level()
 	. = (initial(max_damage) - max_damage)/initial(max_damage)
 
-/obj/item/organ/internal/get_scan_results()
+/obj/item/organ/internal/get_scan_results(tag = FALSE)
 	. = ..()
 	var/scar_level = get_scarring_level()
 	if(scar_level > 0.01)
-		. += "[get_wound_severity(get_scarring_level())] scarring"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_SCARRING]'>[get_wound_severity(get_scarring_level())] scarring</span>" : "[get_wound_severity(get_scarring_level())] scarring"
 
 /obj/item/organ/internal/emp_act(severity)
 	if(!BP_IS_ROBOTIC(src))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -331,55 +331,44 @@ var/global/list/organ_cache = list()
 /obj/item/organ/proc/get_scan_results(var/tag = FALSE)
 	. = list()
 	if(BP_IS_CRYSTAL(src))
-		. += tag ? "<span class='average'>Crystalline</span>" : "Crystalline"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_CRYSTAL]'>Crystalline</span>" : "Crystalline"
 	else if(BP_IS_ASSISTED(src))
-		. += tag ? "<span class='average'>Assisted</span>" : "Assisted"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_ROBOTIC]'>Assisted</span>" : "Assisted"
 	else if(BP_IS_ROBOTIC(src))
-		. += tag ? "<span class='average'>Mechanical</span>" : "Mechanical"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_ROBOTIC]'>Mechanical</span>" : "Mechanical"
 	if(status & ORGAN_CUT_AWAY)
-		. += tag ? "<span class='bad'>Severed</span>" : "Severed"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_INTERNAL]'>Severed</span>" : "Severed"
 	if(status & ORGAN_MUTATED)
-		. += tag ? "<span class='bad'>Genetic Deformation</span>" : "Genetic Deformation"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_RADIATION]'>Genetic Deformation</span>" : "Genetic Deformation"
 	if(status & ORGAN_DEAD)
 		if(can_recover())
-			. += tag ? "<span class='bad'>Decaying</span>" : "Decaying"
+			. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_INTERNAL_DANGER]'>Decaying</span>" : "Decaying"
 		else
-			. += tag ? "<span style='color:#999999'>Necrotic</span>" : "Necrotic"
+			. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_NECROTIC]'>Necrotic</span>" : "Necrotic"
 	if(BP_IS_BRITTLE(src))
-		. += tag ? "<span class='bad'>Brittle</span>" : "Brittle"
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_CRYSTAL]'>Brittle</span>" : "Brittle"
 
+	var/germ_message
 	switch (germ_level)
 		if (INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + ((INFECTION_LEVEL_TWO - INFECTION_LEVEL_ONE) / 3))
-			. +=  "Mild Infection"
+			germ_message =  "Mild Infection"
 		if (INFECTION_LEVEL_ONE + ((INFECTION_LEVEL_TWO - INFECTION_LEVEL_ONE) / 3) to INFECTION_LEVEL_ONE + (2 * (INFECTION_LEVEL_TWO - INFECTION_LEVEL_ONE) / 3))
-			. +=  "Mild Infection+"
+			germ_message =  "Mild Infection+"
 		if (INFECTION_LEVEL_ONE + (2 * (INFECTION_LEVEL_TWO - INFECTION_LEVEL_ONE) / 3) to INFECTION_LEVEL_TWO)
-			. +=  "Mild Infection++"
+			germ_message =  "Mild Infection++"
 		if (INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + ((INFECTION_LEVEL_THREE - INFECTION_LEVEL_THREE) / 3))
-			if(tag)
-				. += "<span class='average'>Acute Infection</span>"
-			else
-				. +=  "Acute Infection"
+			germ_message =  "Acute Infection"
 		if (INFECTION_LEVEL_TWO + ((INFECTION_LEVEL_THREE - INFECTION_LEVEL_THREE) / 3) to INFECTION_LEVEL_TWO + (2 * (INFECTION_LEVEL_THREE - INFECTION_LEVEL_TWO) / 3))
-			if(tag)
-				. += "<span class='average'>Acute Infection+</span>"
-			else
-				. +=  "Acute Infection+"
+			germ_message =  "Acute Infection+"
 		if (INFECTION_LEVEL_TWO + (2 * (INFECTION_LEVEL_THREE - INFECTION_LEVEL_TWO) / 3) to INFECTION_LEVEL_THREE)
-			if(tag)
-				. += "<span class='average'>Acute Infection++</span>"
-			else
-				. +=  "Acute Infection++"
+			germ_message =  "Acute Infection++"
 		if (INFECTION_LEVEL_THREE to INFINITY)
-			if(tag)
-				. += "<span class='bad'>Septic</span>"
-			else
-				. +=  "Septic"
+			germ_message =  "Septic"
+	if (germ_message)
+		. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_TOXIN]'>[germ_message]</span>" : germ_message
 	if(rejecting)
 		if(tag)
-			. += "<span class='bad'>Genetic Rejection</span>"
-		else
-			. += "Genetic Rejection"
+			. += tag ? "<span style='font-weight: bold; color: [COLOR_MEDICAL_INTERNAL]'>Genetic Rejection</span>" : "Genetic Rejection"
 
 //used by stethoscope
 /obj/item/organ/proc/listen()


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Body scan readouts are now color-coded for different types of items. Some examples include: Implants are purple, robotic limbs are blue-gray, broken limbs are pink, etc.
/:cl:

![2022-07-14_01-06-56](https://user-images.githubusercontent.com/11140088/178904014-e0a25b3a-43a9-47ec-842a-d2fad35ed053.png)

