### PR TITLE
Remove the guaranteed flag from the mining home ruin

### DIFF
--- a/maps/away/mininghome/mininghome.dm
+++ b/maps/away/mininghome/mininghome.dm
@@ -16,7 +16,6 @@
 	description = "A chill asteroid mining station."
 	suffixes = list("mininghome/mininghome.dmm")
 	spawn_cost = 0.5
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /obj/effect/shuttle_landmark/nav_mininghome_1
 	name = "Navpoint #1"


### PR DESCRIPTION
Introduced in #32261 when the goal was to just make it spawn near the Torch, not change its spawn chance to be 100% of the time.

