### PR TITLE
ZAS CSRFZ Heuristic improvement

### DIFF
--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -74,6 +74,11 @@
 	var/check_dirs
 	GET_ZONE_NEIGHBOURS(src, check_dirs)
 	. = check_dirs
+
+	//src is only connected to the zone by a single direction, this is a safe removal.
+	if (!(. & (. - 1)))
+		return TRUE
+
 	for(var/dir in GLOB.csrfz_check)
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
 		if((dir & check_dirs) == dir)


### PR DESCRIPTION
Webedit port of https://github.com/UPTherac/Gameserver/pull/5

Basically, ZAS has had this problem for quite a long time, where turfs that are connected to the parent zone by only a single neighbor were considered unsafe removals. This caused incredibly minor actions like closing an airlock to destroy it's parent zone and force it to rebuild, which is the most expensive action ZAS can perform.

This fixes it by checking if there's only 1 bit toggled in the neighboring directions bitfield during CSRFZ, returning true if so.

Credit to Lohikar for the very simply alternative to the logarithm