### PR TITLE
Fix doors potentially closing on dense things

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -455,8 +455,8 @@
 
 	close_door_at = 0
 	do_animate("closing")
-	sleep(3)
 	src.set_density(1)
+	sleep(3)
 	src.layer = closed_layer
 	update_nearby_tiles()
 	sleep(7)


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Doors should no longer allow mobs to enter their turfs while doing the close animation.
/:cl: