### PR TITLE
Fixes invalid audible_message call in thrusters

### DIFF
--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -69,7 +69,7 @@
 	use_power = POWER_USE_OFF
 	power_channel = EQUIP
 	idle_power_usage = 21600 //6 Wh per tick for default 2 capacitor. Gives them a reason to turn it off, really to nerf backup battery
-	
+
 	machine_name = "gas thruster"
 	machine_desc = "A heavy-duty spaceship thruster that throws gas out of its nozzle to allow propulsion."
 
@@ -163,7 +163,7 @@
 	if(!is_on())
 		return 0
 	if(!check_fuel() || (0 < use_power_oneoff(charge_per_burn)) || check_blockage())
-		audible_message(src,"<span class='warning'>[src] coughs once and goes silent!</span>")
+		audible_message("<span class='warning'>[src] coughs once and goes silent!</span>")
 		update_use_power(POWER_USE_OFF)
 		return 0
 


### PR DESCRIPTION
Fixes #31848 

:cl: SierraKomodo
bugfix: The audible message displayed from thrusters that fail and shut down should now appear properly again.
/:cl: