### PR TITLE
Vessel mass vv handler

### DIFF
--- a/code/_helpers/functional.dm
+++ b/code/_helpers/functional.dm
@@ -42,6 +42,21 @@
 	if(!. && feedback_receiver)
 		to_chat(feedback_receiver, "<span class='warning'>Value must be a numeral.</span>")
 
+/proc/is_non_zero_predicate(value, feedback_receiver)
+	. = value != 0
+	if (!. && feedback_receiver)
+		to_chat(feedback_receiver, SPAN_WARNING("Value cannot be 0."))
+
+/proc/is_non_negative_predicate(value, feedback_receiver)
+	. = value >= 0
+	if (!. && feedback_receiver)
+		to_chat(feedback_receiver, SPAN_WARNING("Value must be a positive number."))
+
+/proc/is_non_positive_predicate(value, feedback_receiver)
+	. = value <= 0
+	if (!. && feedback_receiver)
+		to_chat(feedback_receiver, SPAN_WARNING("Value must be a negative number."))
+
 /proc/is_text_predicate(var/value, var/feedback_receiver)
 	. = !value || istext(value)
 	if(!. && feedback_receiver)

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -154,3 +154,12 @@
 			target.kill_health()
 		if (FALSE)
 			target.revive_health()
+
+/decl/vv_set_handler/vessel_mass
+	handled_type = /obj/effect/overmap/visitable/ship
+	handled_vars = list("vessel_mass")
+	predicates = list(
+		/proc/is_num_predicate,
+		/proc/is_non_zero_predicate,
+		/proc/is_non_negative_predicate
+	)


### PR DESCRIPTION
:cl: SierraKomodo
admin: Var-editing a ship's vessel_mass var is restricted to positive, non-zero numbers.
/:cl:

Because setting it to zero sounds great in theory but causes the proc chain to runtime and crash.