### PR TITLE
Maintenance drones can be immune to z-transfer deaths

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -59,10 +59,12 @@ var/global/list/mob_hat_cache = list()
 	var/obj/item/hat
 	var/hat_x_offset = 0
 	var/hat_y_offset = -13
+	/// Integer or null. If set, the drone will self destruct upon leaving any z-levels connected to the provided value.
+	var/z_locked = null
 
 	holder_type = /obj/item/holder/drone
 
-/mob/living/silicon/robot/drone/Initialize()
+/mob/living/silicon/robot/drone/Initialize(mapload, lock_to_current_z = TRUE)
 	. = ..()
 
 	verbs += /mob/living/proc/hide
@@ -81,6 +83,9 @@ var/global/list/mob_hat_cache = list()
 	verbs -= /mob/living/silicon/robot/verb/Namepick
 	update_icon()
 
+	if (lock_to_current_z)
+		z_locked = get_z(src)
+
 	GLOB.moved_event.register(src, src, /mob/living/silicon/robot/drone/proc/on_moved)
 
 /mob/living/silicon/robot/drone/Destroy()
@@ -91,12 +96,11 @@ var/global/list/mob_hat_cache = list()
 	. = ..()
 
 /mob/living/silicon/robot/drone/proc/on_moved(var/atom/movable/am, var/turf/old_loc, var/turf/new_loc)
-	old_loc = get_turf(old_loc)
-	new_loc = get_turf(new_loc)
-
-	if(!(old_loc && new_loc)) // Allows inventive admins to move drones between non-adjacent Z-levels by moving them to null space first I suppose
+	if (isnull(z_locked))
 		return
-	if(AreConnectedZLevels(old_loc.z, new_loc.z))
+	var/new_z = get_z(new_loc)
+
+	if (AreConnectedZLevels(z_locked, new_z))
 		return
 
 	// None of the tests passed, good bye

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -20,6 +20,8 @@
 	var/produce_drones = 1
 	var/time_last_drone = 500
 	var/drone_type = /mob/living/silicon/robot/drone
+	/// Boolean. Whether or not spawned drones should be locked to the machinery's z-level.
+	var/z_locked = TRUE
 
 	icon = 'icons/obj/machines/drone_fab.dmi'
 	icon_state = "drone_fab_idle"
@@ -77,7 +79,7 @@
 	drone_progress = 0
 	time_last_drone = world.time
 
-	var/mob/living/silicon/robot/drone/new_drone = new drone_type(get_turf(src))
+	var/mob/living/silicon/robot/drone/new_drone = new drone_type(get_turf(src), z_locked)
 	if(player)
 		announce_ghost_joinleave(player, 0, "They have taken control over a maintenance drone.")
 		if(player.mob && player.mob.mind) player.mob.mind.reset()


### PR DESCRIPTION
Should have no effect on default maint drone behavior. Added because of a funny fiasco involving adminbussed construction drones and a very very messy Charon.

:cl: SierraKomodo
admin: Maintenance and construction drones can now be made immune to z-transfer self-destruct by setting their `z_locked` var to `null`.
/:cl: