### PR TITLE
Janiborgs no longer clean all overlay effects

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -874,7 +874,7 @@
 					S.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
-						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
+						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
 							qdel(A)
 					else if(istype(A, /obj/item))
 						var/obj/item/cleaned_item = A


### PR DESCRIPTION
There are no subtypes of `/obj/effect/overlay` that should even be valid for a janitor to delete. Easy fix.

:cl: SierraKomodo
bugfix: Janitor borgs can no longer delete holograms and other things that use effects overlays.
/:cl:

- Fixes #32305