### PR TITLE
[EVENT] Removes most vendors on Torch

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -3462,9 +3462,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/vending/coffee{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
 "iq" = (
@@ -5016,9 +5013,6 @@
 	},
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/vending/snack{
-	dir = 8
 	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 8
@@ -6737,17 +6731,11 @@
 	dir = 8;
 	pixel_x = 40
 	},
-/obj/machinery/vending/cigarette{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "oR" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
-	},
-/obj/machinery/vending/cola{
-	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -7675,15 +7675,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"qt" = (
-/obj/effect/floor_decal/corner/lime/three_quarters{
-	dir = 1
-	},
-/obj/machinery/vending/cola{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
 "qu" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/recreation)
@@ -10052,9 +10043,6 @@
 	c_tag = "Cryogenic Storage - Fore Starboard";
 	dir = 4
 	},
-/obj/machinery/vending/cola{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "xb" = (
@@ -11228,7 +11216,6 @@
 /area/storage/tools)
 "AL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/monotile,
 /area/storage/tools)
 "AM" = (
@@ -12546,9 +12533,6 @@
 	c_tag = "Cryogenic Storage - Fore Port";
 	dir = 4
 	},
-/obj/machinery/vending/coffee{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "Ew" = (
@@ -12731,9 +12715,6 @@
 	},
 /obj/structure/sign/ecplaque{
 	pixel_y = -30
-	},
-/obj/machinery/vending/cigarette{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
@@ -16777,9 +16758,6 @@
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 4
 	},
-/obj/machinery/vending/coffee{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "PV" = (
@@ -17396,9 +17374,6 @@
 "RW" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/vending/fitness{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
@@ -19980,9 +19955,6 @@
 /area/maintenance/thirddeck/port)
 "Zn" = (
 /obj/effect/floor_decal/corner/green/half,
-/obj/machinery/vending/fitness{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "Zo" = (
@@ -46610,7 +46582,7 @@ aT
 aT
 MM
 Su
-qt
+rB
 ux
 tA
 Kt

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -6848,7 +6848,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "atB" = (
-/obj/machinery/lapvend,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -8616,15 +8615,6 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/center)
-"aBy" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/vending/coffee{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/crew_quarters/sleep/cryo/aux)
 "aBz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -9128,9 +9118,6 @@
 /obj/item/device/radio/intercom/entertainment{
 	dir = 8;
 	pixel_x = 22
-	},
-/obj/machinery/vending/fitness{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
@@ -11111,9 +11098,6 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/obj/machinery/vending/cigarette{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
 "aNy" = (
@@ -11247,9 +11231,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/vending/cola{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
 "aOb" = (
@@ -11297,9 +11278,6 @@
 /area/crew_quarters/sleep/cryo/aux)
 "aOg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/vending/snack{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
@@ -17392,9 +17370,6 @@
 "fVw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
-	},
-/obj/machinery/vending/fitness{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/teleporter/firstdeck)
@@ -46542,7 +46517,7 @@ rsV
 ayg
 ure
 aAs
-aBy
+aOa
 aCP
 aDX
 aFg


### PR DESCRIPTION
:cl: Ryan180602
maptweak: Removes most vendors on Torch
/:cl:

Bridge vendors, sweat max in gym and cig vendor in mess left untouched.