### PR TITLE
Smoke fixes

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -28,11 +28,6 @@
 	if(destination)
 		walk_to(src, destination)
 
-/obj/effect/effect/smoke/chem/Destroy()
-	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
-	fadeOut()
-	return ..()
-
 /obj/effect/effect/smoke/chem/Move()
 	var/list/oldlocs = view(1, src)
 	. = ..()
@@ -55,17 +50,6 @@
 		for(var/atom/movable/AM in T)
 			if(!istype(AM, /obj/effect/effect/smoke/chem))
 				reagents.splash(AM, splash_amount, copy = 1)
-
-// Fades out the smoke smoothly using it's alpha variable.
-/obj/effect/effect/smoke/chem/proc/fadeOut(var/frames = 16)
-	set waitfor = FALSE
-	if(!alpha) return //already transparent
-
-	frames = max(frames, 1) //We will just assume that by 0 frames, the coder meant "during one frame".
-	var/alpha_step = round(alpha / frames)
-	while(alpha > 0)
-		alpha = max(0, alpha - alpha_step)
-		sleep(world.tick_lag)
 
 /////////////////////////////////////////////
 // Chem Smoke Effect System

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -3,7 +3,6 @@
 /////////////////////////////////////////////
 /obj/effect/effect/smoke/chem
 	icon = 'icons/effects/chemsmoke.dmi'
-	opacity = 0
 	layer = ABOVE_PROJECTILE_LAYER
 	time_to_live = 300
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
@@ -24,17 +23,12 @@
 	pixel_x = -32 + rand(-8, 8)
 	pixel_y = -32 + rand(-8, 8)
 
-	//switching opacity on after the smoke has spawned, and then turning it off before it is deleted results in cleaner
-	//lighting and view range updates (Is this still true with the new lighting system?)
-	set_opacity(1)
-
 	//float over to our destination, if we have one
 	destination = dest_turf
 	if(destination)
 		walk_to(src, destination)
 
 /obj/effect/effect/smoke/chem/Destroy()
-	set_opacity(0)
 	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
 	fadeOut()
 	return ..()

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -20,8 +20,6 @@
 		icon = cached_icon
 
 	set_dir(pick(GLOB.cardinal))
-	pixel_x = -32 + rand(-8, 8)
-	pixel_y = -32 + rand(-8, 8)
 
 	//float over to our destination, if we have one
 	destination = dest_turf
@@ -36,9 +34,6 @@
 			for(var/atom/movable/AM in T)
 				if(!istype(AM, /obj/effect/effect/smoke/chem))
 					reagents.splash(AM, splash_amount, copy = 1)
-		if(loc == destination)
-			bound_width = 96
-			bound_height = 96
 
 /obj/effect/effect/smoke/chem/Crossed(atom/movable/AM)
 	..()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -183,14 +183,24 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	pixel_x = -32
 	pixel_y = -32
 
-/obj/effect/effect/smoke/New()
-	..()
-	QDEL_IN(src, time_to_live)
+/obj/effect/effect/smoke/Initialize()
+	. = ..()
+	addtimer(CALLBACK(src, .proc/fade_out), time_to_live)
 
 /obj/effect/effect/smoke/Crossed(mob/living/carbon/M as mob )
 	..()
 	if(istype(M))
 		affect(M)
+
+/// Fades out the smoke smoothly using it's alpha variable.
+/obj/effect/effect/smoke/proc/fade_out(frames = 16)
+	set_opacity(FALSE)
+	frames = max(frames, 1) //We will just assume that by 0 frames, the coder meant "during one frame".
+	var/alpha_step = round(alpha / frames)
+	while(alpha > 0)
+		alpha = max(0, alpha - alpha_step)
+		sleep(world.tick_lag)
+	qdel(src)
 
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
 	if (!istype(M))


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Did you know smoke was supposed to have a fade out effect when it goes away? Me either! That feature works now.
bugfix: Smoke will no longer affect mobs through walls and windows.
bugfix: Smoke no longer leaves behind broken turfs shadows.
/:cl:

Shadow and through-object fixes done by removing the increased smoke bounds. The sprites still overlay things, and any mobs covered by the sprites will still be affected, but this resolves the two bugs associated with smoke grenades

Also does the following:
- Removes the smoke opacity toggling during init and destroy.
- Removes the randomization of chemical smoke pixel offsets to avoid ambiguity on smoke coverage.

Does not fix #32320 but does prevent smoke grenades from causing it.