### PR TITLE
adds option to disable same-ip warnings for staff

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -304,6 +304,8 @@
 
 	var/static/login_export_addr
 
+	var/static/warn_if_staff_same_ip = FALSE
+
 	var/static/enter_allowed = TRUE
 
 	var/static/player_limit = FALSE
@@ -849,6 +851,8 @@
 				warn_autoban_duration = max(1, text2num(value))
 			if ("run_empty_levels")
 				run_empty_levels = TRUE
+			if ("warn_if_staff_same_ip")
+				warn_if_staff_same_ip = TRUE
 			else
 				log_misc("Unknown setting in config/config.txt: '[name]'")
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -4,26 +4,27 @@
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
 	last_ckey = ckey
-	log_access("Login: [key_name(src)] from [lastKnownIP ? lastKnownIP : "localhost"]-[computer_id] || BYOND v[client.byond_version]")
 	if(config.log_access)
+		log_access("Login: [key_name(src)] from [lastKnownIP ? lastKnownIP : "localhost"]-[computer_id] || BYOND v[client.byond_version]")
 		var/is_multikeying = 0
-		for(var/mob/M in GLOB.player_list)
-			if(M == src)	continue
-			if( M.key && (M.key != key) )
-				var/matches
-				if( (M.lastKnownIP == client.address) )
-					matches += "IP ([client.address])"
-				if( (client.connection != "web") && (M.computer_id == client.computer_id) )
-					if(matches)	matches += " and "
-					matches += "ID ([client.computer_id])"
-					is_multikeying = 1
-				if(matches)
-					if(M.client)
-						message_admins("[SPAN_DANGER("<B>Notice:</B>")] <span class='info'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as <A href='?src=\ref[usr];priv_msg=\ref[M]'>[key_name_admin(M)]</A>.</span>", 1)
-						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)].")
-					else
-						message_admins("[SPAN_DANGER("<B>Notice:</B>")] <span class='info'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in).</span>", 1)
-						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
+		if (!check_rights(R_MOD, FALSE, client) || !config.warn_if_staff_same_ip)
+			for(var/mob/M in GLOB.player_list)
+				if(M == src)	continue
+				if( M.key && (M.key != key) )
+					var/matches
+					if( (M.lastKnownIP == client.address) )
+						matches += "IP ([client.address])"
+					if( (client.connection != "web") && (M.computer_id == client.computer_id) )
+						if(matches)	matches += " and "
+						matches += "ID ([client.computer_id])"
+						is_multikeying = 1
+					if(matches)
+						if(M.client)
+							message_admins("[SPAN_DANGER("<B>Notice:</B>")] <span class='info'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as <A href='?src=\ref[usr];priv_msg=\ref[M]'>[key_name_admin(M)]</A>.</span>", 1)
+							log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)].")
+						else
+							message_admins("[SPAN_DANGER("<B>Notice:</B>")] <span class='info'><A href='?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in).</span>", 1)
+							log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
 		if(is_multikeying && !client.warned_about_multikeying)
 			client.warned_about_multikeying = 1
 			spawn(1 SECOND)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -49,6 +49,9 @@ LOG_ADMIN
 ## log client access (logon/logoff)
 LOG_ACCESS
 
+## When not set, staff with R_MOD and shared IPs do not cause warnings.
+WARN_IF_STAFF_SAME_IP
+
 ## log game actions (start of round, results, etc.)
 LOG_GAME
 


### PR DESCRIPTION
by default, staff same-ip warnings are now disabled for staff with R_MOD.
use config option to re-enable.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->