### PR TITLE
[EVENT][DNM] Revert Supply Points Event Changes

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(supply)
 	name = "Supply"
-	wait = 60 SECONDS
+	wait = 20 SECONDS
 	priority = SS_PRIORITY_SUPPLY
 	//Initializes at default time
 	flags = SS_NO_TICK_CHECK
@@ -31,7 +31,6 @@ SUBSYSTEM_DEF(supply)
 
 /datum/controller/subsystem/supply/Initialize(start_uptime)
 	ordernum = rand(1,9000)
-	points = rand(40, 80)
 
 	//Build master supply list
 	var/decl/hierarchy/supply_pack/root = decls_repository.get_decl(/decl/hierarchy/supply_pack)


### PR DESCRIPTION
DO NOT MERGE UNTIL APPROVED BY THE EVENT MANAGER.

Putting it up now, so it's available for whatever dev(s) are on to revert when it's time.

This one reverts the change that reduces the number of supply points gained over time.