### PR TITLE
[EVENT][DNM] Revert Event Mapped Vendors

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -3462,6 +3462,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
 "iq" = (
@@ -5013,6 +5016,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/vending/snack{
+	dir = 8
 	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 8
@@ -6731,11 +6737,17 @@
 	dir = 8;
 	pixel_x = 40
 	},
+/obj/machinery/vending/cigarette{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "oR" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
+	},
+/obj/machinery/vending/cola{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -7676,6 +7676,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"qt" = (
+/obj/effect/floor_decal/corner/lime/three_quarters{
+	dir = 1
+	},
+/obj/machinery/vending/cola{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aft)
 "qu" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/recreation)
@@ -10044,6 +10053,9 @@
 	c_tag = "Cryogenic Storage - Fore Starboard";
 	dir = 4
 	},
+/obj/machinery/vending/cola{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "xb" = (
@@ -11215,6 +11227,7 @@
 /area/storage/tools)
 "AL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/monotile,
 /area/storage/tools)
 "AM" = (
@@ -12530,6 +12543,9 @@
 	c_tag = "Cryogenic Storage - Fore Port";
 	dir = 4
 	},
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "Ew" = (
@@ -12712,6 +12728,9 @@
 	},
 /obj/structure/sign/ecplaque{
 	pixel_y = -30
+	},
+/obj/machinery/vending/cigarette{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
@@ -16755,6 +16774,9 @@
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 4
 	},
+/obj/machinery/vending/coffee{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "PV" = (
@@ -17371,6 +17393,9 @@
 "RW" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/vending/fitness{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
@@ -19951,6 +19976,9 @@
 /area/maintenance/thirddeck/port)
 "Zn" = (
 /obj/effect/floor_decal/corner/green/half,
+/obj/machinery/vending/fitness{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "Zo" = (
@@ -46578,7 +46606,7 @@ aT
 aT
 MM
 Su
-rB
+qt
 ux
 tA
 Kt

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -6848,6 +6848,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "atB" = (
+/obj/machinery/lapvend,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -8615,6 +8616,15 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/firstdeck/center)
+"aBy" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/crew_quarters/sleep/cryo/aux)
 "aBz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -9118,6 +9128,9 @@
 /obj/item/device/radio/intercom/entertainment{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/machinery/vending/fitness{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
@@ -11098,6 +11111,9 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
+/obj/machinery/vending/cigarette{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
 "aNy" = (
@@ -11231,6 +11247,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/vending/cola{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo/aux)
 "aOb" = (
@@ -11278,6 +11297,9 @@
 /area/crew_quarters/sleep/cryo/aux)
 "aOg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/vending/snack{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
@@ -17370,6 +17392,9 @@
 "fVw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
+	},
+/obj/machinery/vending/fitness{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/teleporter/firstdeck)
@@ -46517,7 +46542,7 @@ rsV
 ayg
 ure
 aAs
-aOa
+aBy
 aCP
 aDX
 aFg


### PR DESCRIPTION
DO NOT MERGE UNTIL APPROVED BY THE EVENT MANAGER.

Putting it up now, so it's available for whatever dev(s) are on to revert when it's time.

This one returns all the vending machines to the Torch map.