### PR TITLE
Allow placing cards on tables

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -154,12 +154,6 @@
 			update_material()
 		return 1
 
-	if(istype(W, /obj/item/hand)) //playing cards
-		var/obj/item/hand/H = W
-		if(H.cards && H.cards.len == 1)
-			usr.visible_message("\The [user] plays \the [H.cards[1].name].")
-		return
-
 	// Handle dismantling or placing things on the table from here on.
 	if(isrobot(user))
 		return


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Playing cards can now be placed on tables instead of simply displaying a "User displays their hand" message. Users can still show their hand by using the show-held-object verb.
/:cl: