### PR TITLE
Default Unathi health regeneration aura to off

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -118,6 +118,7 @@
 	grow_chance = 2
 	grow_threshold = 150
 	ignore_tag = BP_HEAD
+	innate_heal = FALSE
 	var/toggle_blocked_until = 0 // A time
 
 /obj/aura/regenerating/human/unathi/toggle()


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Unathi health regeneration is now toggled off by default.
/:cl: