### PR TITLE
Fix months in time to readable

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -54,9 +54,9 @@
 		result += "[years] year\s"
 
 	// Months
-	if (seconds >= 259200)
-		months = round(seconds / 259200)
-		seconds -= months * 259200
+	if (seconds >= 2592000)
+		months = round(seconds / 2592000)
+		seconds -= months * 2592000
 		result += "[months] month\s"
 
 	// Weeks


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Text displaying a readable duration based on computer time/ticks no longer thinks 3 days is a month.
/:cl: