### PR TITLE
Fix empty readable times at 0 seconds

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -86,7 +86,7 @@
 	// Seconds
 	if (round)
 		seconds = round(seconds)
-	if (seconds > 0 || !result) // Empty result should just say 0 seconds
+	if (seconds > 0 || !result.len) // Empty result should just say 0 seconds
 		result += "[seconds] second\s"
 
 	return jointext(result, ", ")


### PR DESCRIPTION
:cl: SierraKomodo
admin: Fixes the inactivity timer saying 'Logged out' when it should be '0 seconds'.
/:cl: