### PR TITLE
jackets can have accessories

### DIFF
--- a/code/modules/clothing/buttons.dm
+++ b/code/modules/clothing/buttons.dm
@@ -22,8 +22,6 @@
 
 
 /obj/item/clothing/suit/storage/toggle/buttons_suffix = "_open"
-/obj/item/clothing/suit/storage/toggle/valid_accessory_slots = ACCESSORY_SLOT_INSIGNIA
-
 
 
 /obj/item/clothing/suit/storage/toggle/inherit_custom_item_data(datum/custom_item/citem)

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/suit/storage
 	var/obj/item/storage/internal/pockets/pockets
 	var/slots = 2
+	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_RANK, ACCESSORY_SLOT_MEDAL)
 
 /obj/item/clothing/suit/storage/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl:
tweak: Storage overwear can attach insignia, ranks, and medal accessories.
/:cl:

Also fixes by consequence an oops where toggle jackets had a string instead of a list for valid accessories.

Might need a second pass to disable these accessories on stuff that makes no sense, but suit/storage is a big tree so I'm not doing it ahead of time.