### PR TITLE
Robotic bones, asystole MMIs, and microbattery tweaks

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -260,12 +260,6 @@
 	animal_heal = 0
 	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
 
-/obj/item/stack/medical/splint/check_limb_state(var/mob/user, var/obj/item/organ/external/limb)
-	if(BP_IS_ROBOTIC(limb))
-		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a robotic limb."))
-		return FALSE
-	return TRUE
-
 /obj/item/stack/medical/splint/attack(var/mob/living/carbon/M, var/mob/user)
 	if(..())
 		return 1

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -177,7 +177,7 @@
 	for (var/obj/item/organ/external/E in organs)
 		if(!E || !(E.limb_flags & ORGAN_FLAG_CAN_GRASP))
 			continue
-		if(((E.is_broken() || E.is_dislocated()) && !E.splinted) || E.is_malfunctioning())
+		if(((E.is_broken() || E.is_dislocated()) && !E.splinted))
 			grasp_damage_disarm(E)
 
 /mob/living/carbon/human/proc/stance_damage_prone(var/obj/item/organ/external/affected)

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -75,16 +75,31 @@
 				to_chat(user, SPAN_NOTICE("Cell charge: [C.percent()] %"))
 			else
 				to_chat(user, SPAN_NOTICE("Cell charge: ERROR - Cell not present"))
+
+			to_chat(user, "<hr>")
+
+			to_chat(user, "<span class='notice'>Internal brain activity:</span>")
+			var/obj/item/organ/internal/B = H.internal_organs_by_name[BP_BRAIN]
+			if(B)
+				to_chat(user, "[B.name]: <font color='red'>[(B.status & ORGAN_DEAD) ? "NO ACTIVITY DETECTED - DAMAGED PAST POINT OF NO RETURN" : B.damage]</font>")
+			else
+				to_chat(user, "<font color='red'>ERROR - Brain not present</font>")
+
+			to_chat(user, "<hr>")
+
 			to_chat(user, "<span class='notice'>External prosthetics:</span>")
+
 			var/organ_found
 			for(var/obj/item/organ/external/E in H.organs)
 				if(!BP_IS_ROBOTIC(E))
 					continue
 				organ_found = 1
-				to_chat(user, "[E.name]: <font color='red'>[E.brute_dam]</font> <font color='#ffa500'>[E.burn_dam]</font>")
+				to_chat(user, "[E.name]: <font color='red'>[E.brute_dam]</font> <font color='#ffa500'>[E.burn_dam]</font><font color='red'>[(E.status & ORGAN_BROKEN) ? "- INTERNAL STRUCTURE FRACTURED" : ""]</font>")
 			if(!organ_found)
 				to_chat(user, "No prosthetics located.")
+
 			to_chat(user, "<hr>")
+
 			to_chat(user, "<span class='notice'>Internal prosthetics:</span>")
 			organ_found = null
 			for(var/obj/item/organ/O in H.internal_organs)
@@ -94,6 +109,8 @@
 				to_chat(user, "[O.name]: <font color='red'>[(O.status & ORGAN_DEAD) ? "DESTROYED" : O.damage]</font>")
 			if(!organ_found)
 				to_chat(user, "No prosthetics located.")
+
+	playsound(user,'sound/effects/scanbeep.ogg', 30)
 	return
 
 /obj/item/device/robotanalyzer/attack(mob/living/M, mob/living/user)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -164,7 +164,7 @@
 	var/mult = 1 + !!(BP_IS_ASSISTED(src)) // This macro returns (large) bitflags.
 	burn_damage *= mult/species.get_burn_mod(owner) //ignore burn mod for EMP damage
 
-	var/power = 3 - severity //stupid reverse severity
+	var/power = (3 - severity)/5 //stupid reverse severity
 	for(var/obj/item/I in implants)
 		if(I.obj_flags & OBJ_FLAG_CONDUCTIBLE)
 			burn_damage += I.w_class * rand(power, 3*power)
@@ -1029,8 +1029,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/fracture()
 	if(!config.bones_can_break)
 		return
-	if(BP_IS_ROBOTIC(src))
-		return	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if((status & ORGAN_BROKEN) || !(limb_flags & ORGAN_FLAG_CAN_BREAK))
 		return
 
@@ -1045,7 +1043,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	playsound(src.loc, "fracture", 100, 1, -2)
 	status |= ORGAN_BROKEN
-	broken_description = pick("broken","fracture","hairline fracture")
+	if(BP_IS_ROBOTIC(src) || BP_IS_CRYSTAL(src))
+		broken_description = pick("broken","shattered","structural rupture")
+	else
+		broken_description = pick("broken","fracture","hairline fracture")
 
 	// Fractures have a chance of getting you out of restraints
 	if (prob(25))
@@ -1059,8 +1060,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		suit.handle_fracture(owner, src)
 
 /obj/item/organ/external/proc/mend_fracture()
-	if(BP_IS_ROBOTIC(src))
-		return 0	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if(brute_dam > min_broken_damage * config.organ_health_multiplier)
 		return 0	//will just immediately fracture again
 

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -8,9 +8,9 @@
 	status = ORGAN_ROBOTIC
 	vital = 1
 	var/open
-	var/obj/item/cell/cell = /obj/item/cell/hyper
-	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
-	var/servo_cost = 0.8
+	var/obj/item/cell/cell = /obj/item/cell/high
+	//at 0.26 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
+	var/servo_cost = 0.26
 
 /obj/item/organ/internal/cell/New()
 	robotize()
@@ -57,6 +57,8 @@
 		if(!owner.lying && !owner.buckled)
 			to_chat(owner, "<span class='warning'>You don't have enough energy to function!</span>")
 		owner.Paralyse(3)
+	if(percent() < 10 && prob(1))
+		to_chat(owner, SPAN_WARNING("Your internal battery beeps an alert code, it is low on charge!"))
 
 /obj/item/organ/internal/cell/emp_act(severity)
 	..()
@@ -121,6 +123,17 @@
 	update_from_mmi()
 	persistantMind = owner.mind
 	ownerckey = owner.ckey
+
+/obj/item/organ/internal/mmi_holder/Process()
+	..()
+	if(owner.is_asystole())
+		take_internal_damage(0.5)
+
+/obj/item/organ/internal/mmi_holder/handle_regeneration() // MMI will regenerate from small amounts of damage, e.g. damage that might occur when swapping a power cell
+	if(!damage || !owner || owner.is_asystole())
+		return
+	if(damage < 0.1*max_damage)
+		heal_damage(0.1)
 
 /obj/item/organ/internal/mmi_holder/proc/update_from_mmi()
 


### PR DESCRIPTION
With the makeshift parts PR done, i can safely move to this second required part for expanding prosthetics and robots.
Proof of concept and slow addition of more complex repair systems similar to humans, done gradually to prevent overwhelming players with new info (also smaller PRs)

Broken heatsinks and ruptured coolant lines, similar to IB and arterial bleeding respectively, will come on later PRs.

The surgery steps and some of the code comes from #26724 , Which attempted to do the same a few years back, but was closed by the author to work on other projects, allegedly. Might revisit some of the ideas they had as well, such as radiation susceptibility.

Robotic scanners have been adjusted accordingly to show all of this damage.

What does this mean, essentially? less random malfunctions and hassle when dealing with robotic bodyparts, and "makeshift" ways of keeping them running in case of no engineers/physicians/roboticists , such as splinting the limb, like an organic one.

MMI damage will be expanded upon as well, this is a first step on widening the gap between FBP and IPC, to make each distinct (and prevent people playing them like diet IPC)

Crystal bodyparts will get a face-lift with some overlays and custom sounds too. Eventually. Not on the near future, though.

:cl: AzlanonPC
rscadd: prosthetic organs now have bone-adjacent structures; Broken in similar ways, and repaired through robotic surgery.
rscadd: Robotic hands and arms will no longer deal grasp damage when mildly damaged (Read: dropping objects), Instead, this will be affected by structural damage. Legs remain the same
rscadd: When their battery drops to critical, MMIs will start taking damage. Put your fellows in a charger. Positronic brains unchanged. MMIs will regenerate very minor amounts of damage like normal brains, as well.
rscadd: Robot analyzers now show damage to robot brains and MMIs. Also do sound.
rscadd: Robotic and crystalline parts now have custom broken names.
rscadd: microbatteries now have 1000w cell, instead of 3000w. The cost of moving and power damage received by EMPs adjusted accordingly. 
/:cl: