### PR TITLE
reagent drinking volume is species & intent based

### DIFF
--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -121,6 +121,8 @@
 		/decl/emote/exertion/synthetic/creak
 	)
 
+	ingest_amount = 20
+
 /datum/species/vox/equip_survival_gear(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vox(H), slot_wear_mask)
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -267,6 +267,9 @@
 	var/list/exertion_emotes_biological = null
 	var/list/exertion_emotes_synthetic = null
 
+	/// When being fed a reagent item, the amount this species eats per bite on help intent.
+	var/ingest_amount = 10
+
 /*
 These are all the things that can be adjusted for equipping stuff and
 each one can be in the NORTH, SOUTH, EAST, and WEST direction. Specify

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -152,6 +152,8 @@
 		/decl/emote/exertion/biological/pant
 	)
 
+	ingest_amount = 20
+
 /datum/species/unathi/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -45,6 +45,8 @@
 		BP_HEAD =   /obj/item/organ/external/head/yeosa
 	)
 
+	ingest_amount = 15
+
 
 /datum/species/unathi/yeosa/can_float(mob/living/carbon/human/H)
 	if(!H.is_physically_disabled())

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -54,6 +54,8 @@
 		TAG_FACTION =   FACTION_TEST_SUBJECTS
 	)
 
+	ingest_amount = 6
+
 	var/list/no_touchie = list(/obj/item/mirror,
 							   /obj/item/storage/mirror)
 

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -154,6 +154,8 @@
 		/decl/emote/exertion/biological/pant
 	)
 
+	ingest_amount = 6
+
 /datum/species/nabber/New()
 	equip_adjust = list(
 		slot_head_str =    list("[NORTH]" = list("x" = 0, "y" = 7),  "[EAST]" = list("x" = 0, "y" = 8),  "[SOUTH]" = list("x" = 0, "y" = 8),  "[WEST]" = list("x" = 0, "y" = 8)),

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -243,6 +243,8 @@
 		/decl/emote/exertion/synthetic/creak
 	)
 
+	ingest_amount = 15
+
 
 /datum/species/skrell/proc/handle_protein(mob/living/carbon/human/M, datum/reagent/protein)
 	var/effective_dose = M.chem_doses[protein.type] * protein.protein_amount


### PR DESCRIPTION
:cl:
tweak: Drinking from containers is based on species and intent. Different species drink different amounts per sip, with monkeys drinking the least and vox the most. Disarm halves the amount, Grab increases by half again. See #32353 for initial specifics.
/:cl:

That is, feeding a reagent container to self/other is species dependent for a base value (ingest_amount), then applies a 0.5 multiplier if on disarm or a 1.5 if on grab.

This prevents feeding someone a bucket.

```
default: 5 / 10 / 15
others:
  monkey types: 3 / 6 / 9
  gas: 3 / 6 / 9
  skrell: 8 / 15 / 23
  yeosa: 8 / 15 / 23
  sinta: 10 / 20 / 30
  vox: 10 / 20 / 30
```
