### PR TITLE
Stuns & painkillers rebalancing

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -14,7 +14,7 @@
 	base_parry_chance = 30
 	attack_ignore_harm_check = TRUE
 	var/stunforce = 0
-	var/agonyforce = 30
+	var/agonyforce = 40
 	var/status = 0		//whether the thing is on or not
 	var/obj/item/cell/bcell
 	var/hitcost = 7

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -26,7 +26,7 @@
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
 	if(can_feel_pain())
-		if(get_shock() >= 10) tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
+		if(get_shock() >= 10) tally += (get_shock() / 25) //pain shouldn't slow you down if you can't even feel it
 
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -280,7 +280,7 @@
 
 /obj/item/organ/external/proc/stun_act(var/stun_amount, var/agony_amount)
 	if(agony_amount && owner && can_feel_pain())
-		agony_amount -= (owner.chem_effects[CE_PAINKILLER]/2)//painkillers does wonders!
+		agony_amount -= (owner.chem_effects[CE_PAINKILLER]/4)//painkillers does wonders!
 		agony_amount += get_pain()
 		if(agony_amount < 5) return
 
@@ -294,14 +294,9 @@
 				owner.stance_damage_prone(src)
 				return 1
 
-		else if(agony_amount > 0.5 * max_damage)
+		else if(agony_amount >= max_damage)
 			owner.visible_message("<span class='warning'>[owner] reels in pain!</span>")
-			if(agony_amount > max_damage)
-				owner.Weaken(4)
-			else
-				owner.Stun(4)
-				owner.drop_l_hand()
-				owner.drop_r_hand()
+			owner.Weaken(4)
 			return 1
 
 /obj/item/organ/external/proc/get_agony_multiplier()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -331,6 +331,9 @@
 	pain_power = 200
 	effective_dose = 2
 
+/datum/reagent/oxycodone/affect_blood(mob/living/carbon/M, alien, removed)
+	M.add_chemical_effect(CE_SLOWDOWN, 1)
+
 /datum/reagent/deletrathol
 	name = "Deletrathol"
 	description = "An effective painkiller that causes confusion."


### PR DESCRIPTION
I feel like this has been a long time coming but I'll try to outline the changes I've made and the why, but in general I felt like security were stuck as the punching bags for any competent antagonist but hopefully this'll change that.

First up I've removed the stun / object dropping that you had at 50% damage, this could could trigger as often as on the first hit with some of the larger stun weapons, or in two hits even with the mini-perun. You're now reliant on stunning people to 100% damage which will still floor them for 4 seconds.
Secondly I've reduced the slowdown from agony, it was stacking so quickly that one shot could realistically make it impossible to dodge any more incoming attacks. 

The trade off to both of these changes is that the effectiveness of painkillers has been dropped significantly for the purposes of mitigating incoming stun effects. It's been reduced from 50% of the value to 25% of the value, in addition Oxycodone has an inbuilt slowdown effect to make it less appealing for use during combat.

Additionally the stun baton has had it's agony value increased from 30 to 40 so that it's now an appealing first option rather than a last resort.

In theory this should mean that there's always a solution available to the security team, but I'll likely have to shuffle the values a little more.

🆑 Kell-E
balance: 50% stun threshold removed.
balance: Slowdown from stuns reduced
balance: Painkillers are now less effective at mitigating stuns
balance: Oxycodone now slows for it's duration
balance: The stun baton is now more effective at stunning it's targets
/🆑 