### PR TITLE
Add mousetraps to gantry

### DIFF
--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -3280,6 +3280,7 @@
 "zR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/glasses/pint,
+/obj/item/storage/box/mousetraps,
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
 "zU" = (


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: The Salvage Gantry now has a box of mousetraps. They can be found on the table in the kitchen/break area near the microwave.
/:cl: