### PR TITLE
Add timers to powdered chemical interactions

### DIFF
--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -80,17 +80,25 @@
 		if(!user.check_has_mouth()) // We dont want dionae or adherents doing lines of cocaine. Probably.
 			to_chat(SPAN_WARNING("Without a nose, you seem unable to snort from \the [src]."))
 			return TRUE
-		else
-			user.visible_message(
-				SPAN_WARNING("\The [user] snorts some of \the [src] with \a [W]!"),
-				SPAN_NOTICE("You snort \the [src] with \the [W]!")
-			)
-			playsound(loc, 'sound/effects/snort.ogg', 50, 1)
 
-			if(reagents)
-				reagents.trans_to_mob(user, amount_per_transfer_from_this, CHEM_BLOOD)
+		user.visible_message(
+			SPAN_WARNING("\The [user] starts to snort some of \the [src] with \a [W]!"),
+			SPAN_NOTICE("You start to snort some of \the [src] with \the [W]!")
+		)
+		playsound(loc, 'sound/effects/snort.ogg', 50, 1)
+		if (!do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))
+			return TRUE
 
-			if(!reagents.total_volume)
-				qdel(src)
+		user.visible_message(
+			SPAN_WARNING("\The [user] snorts some of \the [src] with \a [W]!"),
+			SPAN_NOTICE("You snort \the [src] with \the [W]!")
+		)
+		playsound(loc, 'sound/effects/snort.ogg', 50, 1)
+
+		if(reagents)
+			reagents.trans_to_mob(user, amount_per_transfer_from_this, CHEM_BLOOD)
+
+		if(!reagents.total_volume)
+			qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -400,11 +400,19 @@
 
 /obj/item/reagent_containers/pill/attackby(obj/item/W, mob/user)
 	if(is_sharp(W) || istype(W, /obj/item/card/id))
+		user.visible_message(
+			SPAN_WARNING("\The [user] starts to gently cut up \the [src] with \a [W]!"),
+			SPAN_NOTICE("You start to gently cut up \the [src] with \the [W]."),
+			SPAN_WARNING("You hear quiet grinding.")
+		)
+		playsound(loc, 'sound/effects/chop.ogg', 50, 1)
+		if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE))
+			return TRUE
+
 		var/obj/item/reagent_containers/powder/J = new /obj/item/reagent_containers/powder(loc)
 		user.visible_message(
 			SPAN_WARNING("\The [user] gently cuts up \the [src] with \a [W]!"),
-			SPAN_NOTICE("You gently cut up \the [src] with \the [W]."),
-			SPAN_WARNING("You hear quiet grinding.")
+			SPAN_NOTICE("You gently cut up \the [src] with \the [W].")
 		)
 		playsound(loc, 'sound/effects/chop.ogg', 50, 1)
 


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Cutting up pills to make powders now has a 5-second unique timer.
tweak: Snorting powders now have a 2-second unique timer. This is 1 second faster than self-injecting.
/:cl: