### PR TITLE
Makes dragging people with open incisions more dangerous

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -483,7 +483,13 @@
 	return 0
 
 /mob/living/carbon/human/pull_damage()
-	if(!lying || getBruteLoss() + getFireLoss() < 100)
+	if(!lying)
+		return 0
+	for (var/obj/item/organ/external/e in organs)
+		var/incision_state = e.how_open()
+		if(incision_state == SURGERY_RETRACTED || incision_state == SURGERY_ENCASED)
+			return 1
+	if(getBruteLoss() + getFireLoss() < 100)
 		return 0
 	for(var/thing in organs)
 		var/obj/item/organ/external/e = thing


### PR DESCRIPTION
### Changelog
:cl: karljohansson
tweak: Changes dragging to also deal damage to people with open surgical incisions.
/:cl:

### Description
As above, adds a check in `code/modules/mob/mob.dm` that checks for open surgical incisions on limbs. This trumps the already established rule on having to have a certain amount of damage being done, because I think that being dragged around with an open chest cavity is gonna cause some problems even if it hasn't technically dealt enough damage.

### Testing 
![image](https://user-images.githubusercontent.com/77447558/183218997-69fae744-a0e3-4715-bccc-a59f94b12915.png) 
![image](https://user-images.githubusercontent.com/77447558/183219036-2e01b9b7-0b93-4466-acd9-4c5abe91dfdd.png) 
![image](https://user-images.githubusercontent.com/77447558/183219120-87befda1-e97d-41fb-bc26-bf0d9616670f.png)
![image](https://user-images.githubusercontent.com/77447558/183219197-fee52b9f-8c2d-480a-bb32-6ca7fe3065d4.png)
![image](https://user-images.githubusercontent.com/77447558/183219283-ae761dfa-c2ba-4cec-9b20-aeed4a9c56ca.png)
![image](https://user-images.githubusercontent.com/77447558/183219504-c6fb7461-a7fe-4c21-b140-12d19fcb8376.png)
![image](https://user-images.githubusercontent.com/77447558/183219386-3fd3ba29-2756-45e0-b2cb-7b6bfece3d2d.png)

