### PR TITLE
Restrict hangar access to roles that normally use shuttles

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -164,7 +164,7 @@
 		access_teleporter, access_eva, access_bridge, access_heads,
 		access_chapel_office, access_crematorium, access_chemistry, access_virology, access_aquila,
 		access_cmo, access_surgery, access_RC_announce, access_keycard_auth, access_psychiatrist,
-		access_medical_equip, access_solgov_crew, access_senmed, access_hangar, access_torch_fax, access_radio_comm,
+		access_medical_equip, access_solgov_crew, access_senmed, access_torch_fax, access_radio_comm,
 		access_radio_med
 	)
 
@@ -212,7 +212,7 @@
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 		access_tech_storage, access_robotics, access_atmospherics, access_janitor, access_construction,
 		access_network, access_network_admin, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
-		access_solgov_crew, access_aquila, access_seneng, access_hangar, access_torch_fax, access_torch_helm, access_radio_comm,
+		access_solgov_crew, access_aquila, access_seneng, access_torch_fax, access_torch_helm, access_radio_comm,
 		access_radio_eng
 		)
 
@@ -263,7 +263,7 @@
 		access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_bridge, access_heads, access_aquila,
 		access_hos, access_RC_announce, access_keycard_auth, access_sec_doors,
-		access_solgov_crew, access_gun, access_emergency_armory, access_hangar, access_torch_fax,
+		access_solgov_crew, access_gun, access_emergency_armory, access_torch_fax,
 		access_radio_comm, access_radio_sec
 	)
 
@@ -343,7 +343,7 @@
 		access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_janitor,
 		access_kitchen, access_cargo, access_RC_announce, access_keycard_auth, access_aquila, access_guppy_helm,
-		access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_torch_fax,
+		access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_torch_fax,
 		access_radio_comm, access_radio_eng, access_radio_med, access_radio_sec, access_radio_serv, access_radio_sup, access_radio_exp
 		)
 

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -37,7 +37,7 @@
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-		access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network, access_network_admin, access_radio_eng
+		access_tcomsat, access_solgov_crew, access_seneng, access_network, access_network_admin, access_radio_eng
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
@@ -96,7 +96,7 @@
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-		access_solgov_crew, access_hangar, access_network, access_radio_eng
+		access_solgov_crew, access_network, access_radio_eng
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
@@ -150,7 +150,7 @@
 	access = list(
 		access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_eva, access_tech_storage, access_janitor, access_construction,
-		access_solgov_crew, access_hangar, access_radio_eng
+		access_solgov_crew, access_radio_eng
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -125,7 +125,7 @@
 		access_medical, access_morgue, access_maint_tunnels,
 		access_external_airlocks, access_emergency_storage,
 		access_eva, access_surgery, access_medical_equip,
-		access_solgov_crew, access_hangar, access_radio_med
+		access_solgov_crew, access_radio_med
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Hangar access is now restricted to only personnel that would be expected to use the shuttles. This means only bridge officers, supply, research, and exploration can access the hangar without assistance.
/:cl: