### PR TITLE
Restrict maintenance tunnel access to maintenance personnel

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -119,7 +119,7 @@
 		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_rd,
 		access_petrov_control, access_petrov_maint, access_pathfinder, access_explorer, access_eva, access_solgov_crew,
-		access_expedition_shuttle, access_expedition_shuttle_helm, access_maint_tunnels, access_torch_fax, access_radio_comm,
+		access_expedition_shuttle, access_expedition_shuttle_helm, access_torch_fax, access_radio_comm,
 		access_radio_sci, access_radio_exp, access_research_storage
 	)
 
@@ -160,7 +160,7 @@
 	skill_points = 26
 
 	access = list(
-		access_medical, access_morgue, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_medical, access_morgue, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_bridge, access_heads,
 		access_chapel_office, access_crematorium, access_chemistry, access_virology, access_aquila,
 		access_cmo, access_surgery, access_RC_announce, access_keycard_auth, access_psychiatrist,
@@ -260,7 +260,7 @@
 
 	access = list(
 		access_security, access_brig, access_armory, access_forensics_lockers,
-		access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_bridge, access_heads, access_aquila,
 		access_hos, access_RC_announce, access_keycard_auth, access_sec_doors,
 		access_solgov_crew, access_gun, access_emergency_armory, access_hangar, access_torch_fax,
@@ -340,7 +340,7 @@
 
 
 	access = list(
-		access_security, access_medical, access_engine, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_security, access_medical, access_engine, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_janitor,
 		access_kitchen, access_cargo, access_RC_announce, access_keycard_auth, access_aquila, access_guppy_helm,
 		access_solgov_crew, access_gun, access_expedition_shuttle, access_guppy, access_senadv, access_hangar, access_torch_fax,
@@ -382,7 +382,7 @@
 
 
 	access = list(
-		access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+		access_security, access_medical, access_engine, access_emergency_storage,
 		access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
 		access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
 		access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -27,7 +27,7 @@
 	skill_points = 22
 
 	access = list(
-		access_pathfinder, access_explorer, access_eva, access_maint_tunnels, access_bridge, access_emergency_storage,
+		access_pathfinder, access_explorer, access_eva, access_bridge, access_emergency_storage,
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
 		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
 		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
@@ -69,7 +69,7 @@
 		access_mining_office, access_petrov, access_petrov_helm, access_petrov_maint, access_mining_station,
 		access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm,
 		access_mining, access_pilot, access_solgov_crew, access_eva, access_explorer, access_research,
-		access_radio_exp, access_radio_sci, access_radio_sup, access_maint_tunnels, access_emergency_storage
+		access_radio_exp, access_radio_sci, access_radio_sup, access_emergency_storage
 	)
 	min_skill = list(	SKILL_EVA   = SKILL_BASIC,
 						SKILL_PILOT = SKILL_ADEPT)
@@ -102,7 +102,7 @@
 	                    SKILL_WEAPONS     = SKILL_EXPERT)
 
 	access = list(
-		access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
+		access_explorer, access_eva, access_emergency_storage,
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
 		access_petrov, access_petrov_maint, access_research, access_radio_exp
 	)

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -36,7 +36,7 @@
 	skill_points = 20
 
 	access = list(
-		access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
+		access_medical, access_morgue, access_virology, access_emergency_storage,
 		access_crematorium, access_chemistry, access_surgery,
 		access_medical_equip, access_solgov_crew, access_senmed, access_radio_med
 	)
@@ -79,7 +79,7 @@
 	skill_points = 16
 
 	access = list(
-		access_medical, access_morgue, access_virology, access_maint_tunnels, access_emergency_storage,
+		access_medical, access_morgue, access_virology, access_emergency_storage,
 		access_crematorium, access_chemistry, access_surgery,
 		access_medical_equip, access_solgov_crew, access_senmed, access_radio_med
 	)
@@ -122,7 +122,7 @@
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
 
 	access = list(
-		access_medical, access_morgue, access_maint_tunnels,
+		access_medical, access_morgue,
 		access_external_airlocks, access_emergency_storage,
 		access_eva, access_surgery, access_medical_equip,
 		access_solgov_crew, access_hangar, access_radio_med
@@ -168,7 +168,7 @@
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
 
 	access = list(
-		access_medical, access_morgue, access_maint_tunnels,
+		access_medical, access_morgue,
 		access_external_airlocks, access_emergency_storage,
 		access_surgery, access_medical_equip, access_solgov_crew,
 		access_radio_med
@@ -207,7 +207,7 @@
 	skill_points = 16
 
 	access = list(
-		access_medical, access_maint_tunnels, access_emergency_storage,
+		access_medical, access_emergency_storage,
 		access_medical_equip, access_solgov_crew, access_chemistry,
 	 	access_virology, access_morgue, access_crematorium, access_radio_med
 	)

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -22,7 +22,7 @@
 	)
 
 	access = list(
-		access_tox, access_tox_storage, access_maint_tunnels, access_research, access_mining_office,
+		access_tox, access_tox_storage, access_research, access_mining_office,
 		access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen, access_solgov_crew,
 		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_control,

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -31,7 +31,7 @@
 
 	access = list(
 		access_security, access_brig, access_armory, access_forensics_lockers,
-		access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_external_airlocks, access_emergency_storage,
 		access_eva, access_sec_doors, access_solgov_crew, access_gun, access_torch_fax,
 		access_radio_sec
 	)
@@ -82,7 +82,7 @@
 
 	access = list(
 		access_security, access_brig, access_forensics_lockers,
-		access_maint_tunnels, access_emergency_storage,
+		access_emergency_storage,
 		access_sec_doors, access_solgov_crew, access_morgue,
 		access_torch_fax, access_network, access_radio_sec
 	)
@@ -122,7 +122,7 @@
 	                    SKILL_FORENSICS   = SKILL_EXPERT)
 
 	access = list(
-		access_security, access_brig, access_maint_tunnels,
+		access_security, access_brig,
 		access_external_airlocks, access_emergency_storage,
 		access_eva, access_sec_doors, access_solgov_crew,
 		access_radio_sec

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -122,6 +122,6 @@
 	)
 
 	access = list(
-		access_maint_tunnels, access_emergency_storage,
+		access_emergency_storage,
 		access_solgov_crew, access_radio_serv
 	)

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -31,7 +31,7 @@
 	skill_points = 18
 
 	access = list(
-		access_maint_tunnels, access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
+		access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
 		access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
 		access_mining, access_mining_office, access_mining_station, access_commissary, access_teleporter, access_eva, access_torch_fax,
 		access_radio_sup, access_radio_exp, access_radio_comm
@@ -71,7 +71,7 @@
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
 
 	access = list(
-		access_maint_tunnels, access_emergency_storage, access_cargo, access_guppy_helm,
+		access_emergency_storage, access_cargo, access_guppy_helm,
 		access_cargo_bot, access_mailsorting, access_solgov_crew, access_expedition_shuttle,
 		access_guppy, access_hangar, access_commissary, access_radio_sup
 	)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Maintenance access is now restricted to personnel expected to be in maintenance. This means only engineers and janitors (Due to their office being in maint) have access. For antagonists, the Agent ID card comes with maint access built it.
/:cl:

Inspired by another server that's been running with this access setup for a while now.