### PR TITLE
Block shield generator nanoui with open panels

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -277,6 +277,8 @@
 	return TRUE
 
 /obj/machinery/power/shield_generator/CanUseTopic(var/mob/user)
+	if (panel_open)
+		return STATUS_CLOSE
 	if(issilicon(user) && !Adjacent(user) && ai_control_disabled)
 		return STATUS_UPDATE
 	return ..()


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Shield Generator nanoUI windows are no longer usable if the panel is opened while the window was open. This prevents generators from being placed into a broken state where they are on and have an open panel, and become unable to be interacted with due to restriction checks.
/:cl: