### PR TITLE
Add allinone tcomms to icgnv hound [#32381 Alternative]

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -116,6 +116,7 @@
 #define COMMS_COLOR_BEARCAT    "#590e2d"
 #define COMMS_COLOR_COLONY     "#ceaf3e"
 #define COMMS_COLOR_VERNE      "#738465"
+#define COMMS_COLOR_ICCG       "#790000"
 
 #define WOOD_COLOR_GENERIC     "#d5a66e"
 #define WOOD_COLOR_RICH        "#792f27"

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -109,6 +109,7 @@ var/global/const/COMM_FREQ = 1353
 var/global/const/ERT_FREQ	= 1345
 var/global/const/AI_FREQ	= 1343
 var/global/const/ENT_FREQ	= 1461 //entertainment frequency. This is not a diona exclusive frequency.
+var/global/const/ICCGN_FREQ = 1344
 
 //antagonist channels
 var/global/const/DTH_FREQ	= 1341
@@ -167,7 +168,8 @@ var/global/list/radiochannels = list(
 	"AI Private"	= AI_FREQ,
 	"Entertainment" = ENT_FREQ,
 	"Medical (I)"	= MED_I_FREQ,
-	"Security (I)"	= SEC_I_FREQ
+	"Security (I)"	= SEC_I_FREQ,
+	"ICGNV Hound"   = ICCGN_FREQ
 )
 
 var/global/list/channel_color_presets = list(

--- a/maps/event/iccgn_ship/icgnv_hound.dmm
+++ b/maps/event/iccgn_ship/icgnv_hound.dmm
@@ -22,6 +22,8 @@
 	dir = 8
 	},
 /obj/machinery/cell_charger,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "ac" = (
@@ -278,6 +280,7 @@
 /obj/item/clothing/head/iccgn/service_command,
 /obj/item/clothing/accessory/solgov/department/exploration/fleet,
 /obj/structure/table/steel_reinforced,
+/obj/item/device/radio/headset/iccgn,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "aM" = (
@@ -726,6 +729,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/telecomms/allinone/iccgn,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "bE" = (
@@ -1434,6 +1438,7 @@
 /obj/item/clothing/under/iccgn/service_command,
 /obj/item/clothing/head/iccgn/service_command,
 /obj/structure/table/steel_reinforced,
+/obj/item/device/radio/headset/iccgn,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "Vw" = (

--- a/maps/event/iccgn_ship/icgnv_hound_shuttle.dm
+++ b/maps/event/iccgn_ship/icgnv_hound_shuttle.dm
@@ -50,3 +50,29 @@
 /obj/machinery/power/apc/debug/iccgn
 	cell_type = /obj/item/cell/infinite
 	req_access = list(access_syndicate)
+
+/obj/machinery/telecomms/allinone/iccgn
+	listening_freqs = list(ICCGN_FREQ)
+	channel_color = COMMS_COLOR_CENTCOMM
+	channel_name = "ICGNV Hound"
+	circuitboard = /obj/item/stock_parts/circuitboard/telecomms/allinone/iccgn
+
+
+//Items
+/obj/item/device/radio/headset/iccgn
+	name = "iccgn headset"
+	desc = "Headset belonging to an ICCGN operative."
+	icon_state = "syndie_headset"
+	item_state = "headset"
+	ks1type = /obj/item/device/encryptionkey/iccgn
+
+/obj/item/device/radio/headset/ert/Initialize()
+	. = ..()
+	set_frequency(ERT_FREQ)
+
+/obj/item/device/encryptionkey/iccgn
+	name = "\improper ICCGN radio encryption key"
+	channels = list("ICGNV Hound" = 1)
+
+/obj/item/stock_parts/circuitboard/telecomms/allinone/iccgn
+	build_path = /obj/machinery/telecomms/allinone/iccgn


### PR DESCRIPTION
:cl: Mucker
maptweak : Added telecomms for the ICGNV Hound.
/:cl:

Alternative to the full tcomms setup in #32381. Space is already limited, and its an admin-only ship anyway so I figured it didn't need a suite of telecomms machinery.