### PR TITLE
Locks some non-uniform items to civ

### DIFF
--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -81,6 +81,10 @@
 	allowed_roles = FORMAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
 
+/datum/gear/suit/custom_suit_jacket_double
+	allowed_roles = FORMAL_ROLES
+	allowed_branches = CIVILIAN_BRANCHES
+
 /datum/gear/suit/hoodie
 	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
@@ -89,6 +93,13 @@
 	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
 
+/datum/gear/suit/pullover
+	allowed_roles = CASUAL_ROLES
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/suit/zipper
+	allowed_roles = CASUAL_ROLES
+	allowed_branches = CIVILIAN_BRANCHES
 /datum/gear/suit/labcoat
 	allowed_roles = DOCTOR_ROLES
 


### PR DESCRIPTION
🆑 Jux
tweak: Zipper Sweater and Pullover Sweater have been restricted to casual civilian in the loadout system.
bugfix: Double-Breasted Suit Jacket has been restricted to formal civilian in the loadout system.
/🆑 