### PR TITLE
Accessory roll down fix

### DIFF
--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -8,9 +8,6 @@
 	sprite_sheets = list(
 		SPECIES_NABBER = 'icons/mob/species/nabber/onmob_accessories_gas.dmi'
 	)
-	on_rolled = list(
-		"down" = "none"
-	)
 
 
 /obj/item/clothing/accessory/armband/cargo

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -5,6 +5,9 @@
 	slot_flags = SLOT_BELT | SLOT_TIE
 	slot = ACCESSORY_SLOT_INSIGNIA
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
+	on_rolled = list(
+		"down" = "none"
+	)
 	var/badge_string = "Detective"
 	var/stored_name
 

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -3,6 +3,9 @@
 	desc = "A simple medal."
 	icon_state = "bronze"
 	slot = ACCESSORY_SLOT_MEDAL
+	on_rolled = list(
+		"down" = "none"
+	)
 
 
 /obj/item/clothing/accessory/medal/iron

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -5,7 +5,6 @@
 	slot = ACCESSORY_SLOT_UTILITY
 	w_class = ITEM_SIZE_NORMAL
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
-	on_rolled = list("down" = "none")
 
 	var/obj/item/storage/internal/container
 	var/max_w_class = ITEM_SIZE_SMALL

--- a/maps/torch/items/clothing/ec_skillbadges.dm
+++ b/maps/torch/items/clothing/ec_skillbadges.dm
@@ -3,6 +3,7 @@
 	name = "skill badge"
 	desc = "An EC skill badge signifying that the bearer has passed the advanced training on spawning wrong types. Informally known as 'Shouldn't be seeing this'."
 	slot = ACCESSORY_SLOT_INSIGNIA
+	on_rolled = list("down" = "none")
 	var/badgecolor //for on-mob sprite cause im not putting 9000 colored pixels in dmi
 
 /obj/item/clothing/accessory/solgov/skillbadge/get_mob_overlay(mob/user_mob, slot)

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -149,7 +149,6 @@ scarves
 	icon = 'icons/obj/clothing/obj_accessories.dmi'
 	accessory_icons = list(slot_w_uniform_str = 'icons/mob/onmob/onmob_accessories.dmi', slot_wear_suit_str = 'icons/mob/onmob/onmob_accessories.dmi')
 	icon_state = "whitescarf"
-	on_rolled = list("down" = "none")
 	color = "#68a0ce"
 	check_codex_val = FACTION_EXPEDITIONARY
 

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -109,6 +109,7 @@ patches
 	name = "\improper Cultural Exchange patch"
 	desc = "A radiation-shielded shoulder patch, denoting service in the the Sol Central Government Expeditionary Corps Cultural Exchange program."
 	icon_state = "ecpatch3"
+	on_rolled = list("down" = "none")
 	slot = ACCESSORY_SLOT_INSIGNIA
 	check_codex_val = FACTION_EXPEDITIONARY
 
@@ -165,6 +166,11 @@ scarves
 /******
 ribbons
 ******/
+/obj/item/clothing/accessory/ribbon
+	on_rolled = list(
+		"down" = "none"
+	)
+
 /obj/item/clothing/accessory/ribbon/solgov
 	name = "ribbon"
 	desc = "A simple military decoration."
@@ -277,6 +283,7 @@ specialty pins
 	icon_state = "marinerank_command"
 	slot = ACCESSORY_SLOT_INSIGNIA
 	icon_state = "fleetspec"
+	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/specialty/janitor
 	name = "custodial blazes"


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Badges, medals, patches, qualification pins, etc no longer appear to be pinned to a mob's chest when their uniforms are rolled down.
tweak: Webbing vests, storage pouches, scarves, and armbands now remain visible when the uniform they're attached to is rolled down.
/:cl: