### PR TITLE
use regex for trim, improves file reading behaviors

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -104,6 +104,7 @@
 #include "code\_helpers\builtin_proc_callers.dm"
 #include "code\_helpers\client.dm"
 #include "code\_helpers\cmp.dm"
+#include "code\_helpers\files.dm"
 #include "code\_helpers\functional.dm"
 #include "code\_helpers\game.dm"
 #include "code\_helpers\global_lists.dm"

--- a/code/_global_vars/lists/names.dm
+++ b/code/_global_vars/lists/names.dm
@@ -1,16 +1,16 @@
-GLOBAL_LIST_INIT(ai_names, world.file2list("config/names/ai.txt"))
-GLOBAL_LIST_INIT(wizard_first, world.file2list("config/names/wizardfirst.txt"))
-GLOBAL_LIST_INIT(wizard_second, world.file2list("config/names/wizardsecond.txt"))
-GLOBAL_LIST_INIT(ninja_titles, world.file2list("config/names/ninjatitle.txt"))
-GLOBAL_LIST_INIT(ninja_names, world.file2list("config/names/ninjaname.txt"))
-GLOBAL_LIST_INIT(commando_names, world.file2list("config/names/death_commando.txt"))
-GLOBAL_LIST_INIT(first_names_male, world.file2list("config/names/first_male.txt"))
-GLOBAL_LIST_INIT(first_names_female, world.file2list("config/names/first_female.txt"))
-GLOBAL_LIST_INIT(last_names, world.file2list("config/names/last.txt"))
-GLOBAL_LIST_INIT(clown_names, world.file2list("config/names/clown.txt"))
+GLOBAL_LIST_INIT(ai_names, read_lines("config/names/ai.txt"))
+GLOBAL_LIST_INIT(wizard_first, read_lines("config/names/wizardfirst.txt"))
+GLOBAL_LIST_INIT(wizard_second, read_lines("config/names/wizardsecond.txt"))
+GLOBAL_LIST_INIT(ninja_titles, read_lines("config/names/ninjatitle.txt"))
+GLOBAL_LIST_INIT(ninja_names, read_lines("config/names/ninjaname.txt"))
+GLOBAL_LIST_INIT(commando_names, read_lines("config/names/death_commando.txt"))
+GLOBAL_LIST_INIT(first_names_male, read_lines("config/names/first_male.txt"))
+GLOBAL_LIST_INIT(first_names_female, read_lines("config/names/first_female.txt"))
+GLOBAL_LIST_INIT(last_names, read_lines("config/names/last.txt"))
+GLOBAL_LIST_INIT(clown_names, read_lines("config/names/clown.txt"))
 
 
-GLOBAL_LIST_INIT(verbs, world.file2list("config/names/verbs.txt"))
-GLOBAL_LIST_INIT(adjectives, world.file2list("config/names/adjectives.txt"))
+GLOBAL_LIST_INIT(verbs, read_lines("config/names/verbs.txt"))
+GLOBAL_LIST_INIT(adjectives, read_lines("config/names/adjectives.txt"))
 //loaded on startup because of "
 //would include in rsc if ' was used

--- a/code/_helpers/files.dm
+++ b/code/_helpers/files.dm
@@ -1,0 +1,56 @@
+/// Reads path as a text file, splitting it on delimiter matches.
+/proc/read_lines(path)
+	var/static/regex/pattern
+	if (!pattern)
+		pattern = regex(@"\r?\n")
+	return splittext_char(file2text(path) || "", pattern)
+
+
+/// Read path as a text file to a list, stripping empty space and comments.
+/proc/read_commentable(path)
+	var/static/regex/pattern
+	if (!pattern)
+		pattern = regex(@"^([^#]+)")
+	to_world_log("PATTERN: [pattern] [istype(pattern)]")
+	var/list/result = list()
+	for (var/line in read_lines(path))
+		if (!pattern.Find_char(line))
+			continue
+		line = trim(pattern.group[1])
+		if (!line)
+			continue
+		result += line
+	return result
+
+
+/// Read path as a text file to a map of key value or key list pairs.
+/proc/read_config(path, lowercase_keys = TRUE)
+	var/static/regex/pattern
+	if (!pattern)
+		pattern = regex(@"\s+")
+	var/list/result = list()
+	for (var/line in read_commentable(path))
+		if (!pattern.Find_char(line))
+			if (lowercase_keys)
+				line = lowertext(line)
+			if (!result[line])
+				result[line] = TRUE
+			else if (result[line] != TRUE)
+				log_error({"Mixed-type key "[line]" discovered in config file "[path]"!"})
+			else
+				log_debug({"Duplicate key "[line]" discovered in config file "[path]"!"})
+			continue
+		var/key = copytext_char(line, 1, pattern.index)
+		if (lowercase_keys)
+			key = lowertext(key)
+		var/value = copytext_char(line, pattern.index + 1)
+		if (!result[key])
+			result[key] = value
+			continue
+		if (!islist(result[key]))
+			if (result[key] == TRUE)
+				log_error({"Mixed-type key "[key]" discovered in config file "[path]"!"})
+				continue
+			result[key] = list(result[key])
+		result[key] += value
+	return result

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -255,23 +255,42 @@
 	return copytext_char(result, 1, -length_difference)
 
 
-//Returns a string with reserved characters and spaces before the first letter removed
+///Returns a string with leading whitespace removed.
 /proc/trim_left(text)
-	for (var/i = 1 to length(text))
-		if (text2ascii(text, i) > 32)
-			return copytext(text, i)
-	return ""
+	var/static/regex/pattern = regex(@"^\s*(.+)$")
+	if (!pattern.Find_char(text))
+		return ""
+	return pattern.group[1]
 
-//Returns a string with reserved characters and spaces after the last letter removed
+
+///Returns a string with trailing whitespace removed.
 /proc/trim_right(text)
-	for (var/i = length(text) to 1 step -1)
-		if (text2ascii(text, i) > 32)
-			return copytext(text, 1, i + 1)
-	return ""
+	var/static/regex/pattern = regex(@"^(.+?)\s*$")
+	if (!pattern.Find_char(text))
+		return ""
+	return pattern.group[1]
 
-//Returns a string with reserved characters and spaces before the first word and after the last word removed.
+
+/// Returns a string with leading and trailing whitespace removed.
 /proc/trim(text)
-	return trim_left(trim_right(text))
+	var/static/regex/pattern = regex(@"^\s*(.+?)\s*$")
+	if (!pattern.Find_char(text))
+		return ""
+	return pattern.group[1]
+
+
+/// Strips all symbols from text except printable basic latin, not including < and >. Adds cyrillic if mode is "ru" on first run.
+/proc/cleantext(text, mode = "en")
+	var/static/regex/pattern
+	if (!isnull(pattern))
+		return pattern.Replace_char(text, "")
+	switch (mode)
+		if ("ru")
+			pattern = regex(@"[^\x20-\x3b\x3d\x3f-\x7e\n\u0400-\u04ff]", "g")
+		else //en
+			pattern = regex(@"[^\x20-\x3b\x3d\x3f-\x7e\n]", "g")
+	return pattern.Replace_char(text, "")
+
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(text)

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -1,22 +1,8 @@
-/*
- * Holds procs designed to change one type of value, into another.
- * Contains:
- *			text2list & list2text
- *			file2list
- *			angle2dir
- *			angle2text
- *			worldtime2text
- */
-
 /proc/text2numlist(text, delimiter="\n")
 	var/list/num_list = list()
 	for(var/x in splittext(text, delimiter))
 		num_list += text2num(x)
 	return num_list
-
-// Splits the text of a file at seperator and returns them in a list.
-/proc/file2list(filename, seperator="\n")
-	return splittext(file2text(filename) || "", seperator)
 
 // Turns a direction into text
 /proc/num2dir(direction)
@@ -190,7 +176,3 @@
 
 /proc/atomtype2nameassoclist(atom_type)
 	return atomtypes2nameassoclist(typesof(atom_type))
-
-//Splits the text of a file at seperator and returns them in a list.
-/world/proc/file2list(filename, seperator="\n")
-	return splittext(file2text(filename), seperator)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -447,38 +447,6 @@
 	event = file2text("config/event.txt") || ""
 
 
-/// Read a text file, stripping lines starting with # and empties
-/datum/configuration/proc/read_commentable(filename)
-	var/list/result = list()
-	var/list/lines = file2list(filename)
-	for (var/line in lines)
-		if (!line)
-			continue
-		line = trim(line)
-		if (!line || line[1] == "#")
-			continue
-		result += line
-	return result
-
-
-/datum/configuration/proc/read_config(filename)
-	var/list/result = list()
-	var/lines = read_commentable(filename)
-	for (var/line in lines)
-		var/index = findtext(line, " ")
-		var/name = index ? lowertext(copytext(line, 1, index)) : lowertext(line)
-		if (!name)
-			continue
-		var/value = index ? copytext(line, index + 1) : TRUE
-		if (!result[name])
-			result[name] = value
-			continue
-		if (!islist(result[name]))
-			result[name] = list(result[name])
-		result[name] += value
-	return result
-
-
 /datum/configuration/proc/load_config()
 	var/list/file = read_config("config/config.txt")
 	for (var/name in file)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -75,7 +75,7 @@ SUBSYSTEM_DEF(mapping)
 
 /proc/generateMapList(filename)
 	var/list/potentialMaps = list()
-	var/list/Lines = world.file2list(filename)
+	var/list/Lines = read_lines(filename)
 	if(!Lines.len)
 		return
 	for (var/t in Lines)

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -7,11 +7,11 @@ var/global/datum/getrev/revdata = new()
 	var/showinfo
 
 /datum/getrev/New()
-	var/list/head_branch = file2list(".git/HEAD", "\n")
+	var/list/head_branch = read_lines(".git/HEAD")
 	if(head_branch.len)
 		branch = copytext(head_branch[1], 17)
 
-	var/list/head_log = file2list(".git/logs/HEAD", "\n")
+	var/list/head_log = read_lines(".git/logs/HEAD")
 	for(var/line=head_log.len, line>=1, line--)
 		if(head_log[line])
 			var/list/last_entry = splittext(head_log[line], " ")

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -8,7 +8,7 @@ var/global/list/whitelist = list()
 	return 1
 
 /proc/load_whitelist()
-	whitelist = file2list(WHITELISTFILE)
+	whitelist = read_lines(WHITELISTFILE)
 	if(!whitelist.len)	whitelist = null
 
 /proc/check_whitelist(mob/M /*, rank*/)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -492,7 +492,7 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 	if(!fexists("data/mode.txt"))
 		return
 
-	var/list/Lines = file2list("data/mode.txt")
+	var/list/Lines = read_lines("data/mode.txt")
 	if(Lines.len)
 		if(Lines[1])
 			SSticker.master_mode = Lines[1]

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -7,7 +7,7 @@ var/global/list/admin_ranks = list()								//list of all ranks with associated 
 	var/previous_rights = 0
 
 	//load text from file
-	var/list/Lines = file2list("config/admin_ranks.txt")
+	var/list/Lines = read_lines("config/admin_ranks.txt")
 
 	//process each line seperately
 	for(var/line in Lines)
@@ -72,7 +72,7 @@ var/global/list/admin_ranks = list()								//list of all ranks with associated 
 		load_admin_ranks()
 
 		//load text from file
-		var/list/Lines = file2list("config/admins.txt")
+		var/list/Lines = read_lines("config/admins.txt")
 
 		//process each line seperately
 		for(var/line in Lines)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,7 +34,7 @@ exactly 117 "to_world uses" '\sto_world\('
 exactly 0 "globals with leading /" '^/var' -P
 exactly 0 "globals without global sugar" '^var/(?!global/)' -P
 exactly 0 "apparent paths with trailing /" '\w/[,\)\n]' -P
-exactly 51 "to_world_log uses" '\sto_world_log\('
+exactly 52 "to_world_log uses" '\sto_world_log\('
 exactly 0 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 0 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 2 "<< uses" '(?<!<)<<(?!<)' -P


### PR DESCRIPTION
trim_left, trim_right, and trim use regular expressions instead of symbol index loops
- no longer cares about low ascii, but that's not what trim should do anyway

added but does not use cleantext; cleantext is a harsh regex based sanitizer that only permits basic latin printables *excluding* < and >. Passed the "ru" mode, it extends permission to cyrillic codepoints as well.

file2list => read_lines
- handles carriage returns, should they be somehow present
- removed a duplicate definition of file2list on /world for some reason

pulled read_commentable and read_config off /datum/configuration
- allows comments to start after line content
- allows config keys to not be lowercase if desired
- handles whitespace more gracefully in general
