### PR TITLE
Fixes cremation attack log being reversed

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -359,7 +359,7 @@
 					else
 						playsound(src, 'sound/effects/ghost2.ogg', 10, 5)
 
-				admin_attack_log(M, A, "Cremated their victim.", "Was cremated.", "cremated alive")
+				admin_attack_log(A, M, "Cremated their victim.", "Was cremated.", "cremated alive")
 				M.audible_message("[M]'s screams cease, as does any movement within the [src]. All that remains is a dull, empty silence.")
 				M.dust()
 


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Attack logs for cremation now longer make the victim appear as the attacker.
/:cl: