### PR TITLE
Remove borg cameras

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -47,7 +47,6 @@
 #define NETWORK_MERCENARY "MercurialNet"
 #define NETWORK_MINE "Mining"
 #define NETWORK_RESEARCH "Research"
-#define NETWORK_ROBOTS "Robots"
 #define NETWORK_SECURITY "Security"
 #define NETWORK_THUNDER "Thunderdome"
 

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -1,20 +1,18 @@
 /datum/wires/robot
 	random = 1
 	holder_type = /mob/living/silicon/robot
-	wire_count = 5
+	wire_count = 4
 	descriptions = list(
 		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module."),
 		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERT),
 		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override."),
-		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(BORG_WIRE_CAMERA,  "This wire runs to the unit's vision modules.")
+		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems.")
 	)
 
 var/global/const/BORG_WIRE_LAWCHECK = 1
 var/global/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy
 var/global/const/BORG_WIRE_LOCKED_DOWN = 4
 var/global/const/BORG_WIRE_AI_CONTROL = 8
-var/global/const/BORG_WIRE_CAMERA = 16
 
 /datum/wires/robot/GetInteractWindow(mob/user)
 
@@ -22,7 +20,6 @@ var/global/const/BORG_WIRE_CAMERA = 16
 	var/mob/living/silicon/robot/R = holder
 	. += text("<br>\n[(R.lawupdate ? "The LawSync light is on." : "The LawSync light is off.")]")
 	. += text("<br>\n[(R.connected_ai ? "The AI link light is on." : "The AI link light is off.")]")
-	. += text("<br>\n[((!isnull(R.camera) && R.camera.status == 1) ? "The Camera light is on." : "The Camera light is off.")]")
 	. += text("<br>\n[(R.lockcharge ? "The lockdown light is on." : "The lockdown light is off.")]")
 	return .
 
@@ -43,10 +40,6 @@ var/global/const/BORG_WIRE_CAMERA = 16
 			if(!mended)
 				R.disconnect_from_ai()
 
-		if (BORG_WIRE_CAMERA)
-			if(!isnull(R.camera) && !R.scrambledcodes)
-				R.camera.status = mended
-
 		if(BORG_WIRE_LOCKED_DOWN)
 			R.SetLockdown(!mended)
 
@@ -59,11 +52,6 @@ var/global/const/BORG_WIRE_CAMERA = 16
 				var/mob/living/silicon/ai/new_ai = select_active_ai(R, get_z(R))
 				R.connect_to_ai(new_ai)
 
-		if (BORG_WIRE_CAMERA)
-			if(!isnull(R.camera) && R.camera.can_use() && !R.scrambledcodes)
-				R.visible_message("[R]'s camera lense focuses loudly.")
-				to_chat(R, "Your camera lense focuses loudly.")
-
 		if(BORG_WIRE_LOCKED_DOWN)
 			R.SetLockdown(!R.lockcharge) // Toggle
 
@@ -72,9 +60,6 @@ var/global/const/BORG_WIRE_CAMERA = 16
 	if(R.wiresexposed)
 		return 1
 	return 0
-
-/datum/wires/robot/proc/IsCameraCut()
-	return wires_status & BORG_WIRE_CAMERA
 
 /datum/wires/robot/proc/LockedCut()
 	return wires_status & BORG_WIRE_LOCKED_DOWN

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -232,11 +232,6 @@
 	 // Now, are they viewable by a camera? (This is last because it's the most intensive check)
 	return near_camera() ? TRACKING_POSSIBLE : TRACKING_NO_COVERAGE
 
-/mob/living/silicon/robot/tracking_status()
-	. = ..()
-	if(. == TRACKING_NO_COVERAGE)
-		return camera && camera.can_use() ? TRACKING_POSSIBLE : TRACKING_NO_COVERAGE
-
 /mob/living/carbon/human/tracking_status()
 	if(is_cloaked())
 		. = TRACKING_TERMINATE

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -141,14 +141,4 @@
 /area/get_alarm_cameras()
 	return get_cameras()
 
-/mob/living/silicon/robot/get_alarm_cameras()
-	var/list/cameras = ..()
-	if(camera)
-		cameras += camera
-
-	return cameras
-
-/mob/living/silicon/robot/syndicate/get_alarm_cameras()
-	return list()
-
 #undef ALARM_RESET_DELAY

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -145,38 +145,6 @@
 	active_usage = 25
 	max_damage = 30
 
-
-// CAMERA
-// Enables cyborg vision. Can also be remotely accessed via consoles.
-// Uses 10J constantly
-/datum/robot_component/camera
-	name = "camera"
-	external_type = /obj/item/robot_parts/robot_component/camera
-	idle_usage = 10
-	max_damage = 40
-	var/obj/machinery/camera/camera
-
-/datum/robot_component/camera/New(mob/living/silicon/robot/R)
-	..()
-	camera = R.camera
-
-/datum/robot_component/camera/update_power_state()
-	..()
-	if (camera)
-		camera.status = powered
-
-/datum/robot_component/camera/install()
-	if (camera)
-		camera.status = 1
-
-/datum/robot_component/camera/uninstall()
-	if (camera)
-		camera.status = 0
-
-/datum/robot_component/camera/destroy()
-	if (camera)
-		camera.status = 0
-
 // SELF DIAGNOSIS MODULE
 // Analyses cyborg's modules, providing damage readouts and basic information
 // Uses 1kJ burst when analysis is done
@@ -199,7 +167,6 @@
 	components["radio"] = new/datum/robot_component/radio(src)
 	components["power cell"] = new/datum/robot_component/cell(src)
 	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
-	components["camera"] = new/datum/robot_component/camera(src)
 	components["comms"] = new/datum/robot_component/binary_communication(src)
 	components["armour"] = new/datum/robot_component/armour(src)
 

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -5,8 +5,6 @@
 	..()
 
 /mob/living/silicon/robot/death(gibbed,deathmessage, show_dead_message)
-	if(camera)
-		camera.status = 0
 	if(module)
 		for(var/obj/item/gripper/G in module.equipment)
 			G.drop_gripped_item()

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -17,7 +17,6 @@
 	components["radio"] =          new/datum/robot_component/radio(src)
 	components["power cell"] =     new/datum/robot_component/cell(src)
 	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
-	components["camera"] =         new/datum/robot_component/camera(src)
 	components["comms"] =          new/datum/robot_component/binary_communication(src)
 	components["armour"] =         new/datum/robot_component/armour/light(src)
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -65,12 +65,6 @@
 
 /mob/living/silicon/robot/handle_regular_status_updates()
 
-	if(src.camera && !scrambledcodes)
-		if(src.stat == 2 || wires.IsIndexCut(BORG_WIRE_CAMERA))
-			src.camera.set_status(0)
-		else
-			src.camera.set_status(1)
-
 	updatehealth()
 
 	if(src.sleeping)

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -61,7 +61,6 @@
 	R.module = src
 
 	grant_skills(R)
-	add_camera_networks(R)
 	add_languages(R)
 	add_subsystems(R)
 	apply_status_flags(R)
@@ -126,7 +125,6 @@
 		emag = null
 
 /obj/item/robot_module/proc/Reset(var/mob/living/silicon/robot/R)
-	remove_camera_networks(R)
 	remove_languages(R)
 	remove_subsystems(R)
 	remove_status_flags(R)
@@ -189,18 +187,6 @@
 		var/datum/language/language_datum = original_language
 		R.add_language(language_datum.name, original_languages[original_language])
 	original_languages.Cut()
-
-/obj/item/robot_module/proc/add_camera_networks(var/mob/living/silicon/robot/R)
-	if(R.camera && (NETWORK_ROBOTS in R.camera.network))
-		for(var/network in networks)
-			if(!(network in R.camera.network))
-				R.camera.add_network(network)
-				added_networks |= network
-
-/obj/item/robot_module/proc/remove_camera_networks(var/mob/living/silicon/robot/R)
-	if(R.camera)
-		R.camera.remove_networks(added_networks)
-	added_networks.Cut()
 
 /obj/item/robot_module/proc/add_subsystems(var/mob/living/silicon/robot/R)
 	for(var/subsystem_type in subsystems)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -55,7 +55,6 @@
 
 	var/mob/living/silicon/ai/connected_ai = null
 	var/obj/item/cell/cell = /obj/item/cell/high
-	var/obj/machinery/camera/camera = null
 
 	var/cell_emp_mult = 2.5
 
@@ -112,13 +111,6 @@
 	icontype = "Basic"
 	updatename(modtype)
 	update_icon()
-
-	if(!scrambledcodes && !camera)
-		camera = new /obj/machinery/camera(src)
-		camera.c_tag = real_name
-		camera.replace_networks(list(NETWORK_EXODUS,NETWORK_ROBOTS))
-		if(wires.IsIndexCut(BORG_WIRE_CAMERA))
-			camera.status = 0
 	init()
 	initialize_components()
 
@@ -319,10 +311,6 @@
 	name = real_name
 	if(mind)
 		mind.name = changed_name
-
-	//We also need to update name of internal camera.
-	if (camera)
-		camera.c_tag = changed_name
 
 	if(!custom_sprite) //Check for custom sprite
 		set_custom_sprite()
@@ -907,9 +895,6 @@
 	lawupdate = FALSE
 	lockcharge = FALSE
 	scrambledcodes = TRUE
-	//Disconnect it's camera so it's not so easily tracked.
-	if(src.camera)
-		src.camera.clear_all_networks()
 
 
 /mob/living/silicon/robot/proc/ResetSecurityCodes()

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -10,8 +10,6 @@
 	switch(network)
 		if(NETWORK_ENGINEERING, NETWORK_ALARM_ATMOS, NETWORK_ALARM_CAMERA, NETWORK_ALARM_FIRE, NETWORK_ALARM_POWER)
 			return access_engine
-		if(NETWORK_ROBOTS)
-			return access_ai_upload
 		if(NETWORK_CRESCENT, NETWORK_ERT)
 			return access_cent_specops
 		if(NETWORK_MEDICAL)

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -36,7 +36,6 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 /datum/map/torch
 	// Networks that will show up as options in the camera monitor program
 	station_networks = list(
-		NETWORK_ROBOTS,
 		NETWORK_FIRST_DECK,
 		NETWORK_SECOND_DECK,
 		NETWORK_THIRD_DECK,


### PR DESCRIPTION
:cl: SierraKomodo
rscdel: Borgs/robots/etc no longer have cameras. This means camera monitoring programs can no longer be used to track borgs, and AI cores cannot use borgs to gain vision where they otherwise can't see.
/:cl: