### PR TITLE
Remove spin view verbs

### DIFF
--- a/code/modules/client/movement.dm
+++ b/code/modules/client/movement.dm
@@ -2,14 +2,3 @@
 /client/New()
 	..()
 	dir = NORTH
-
-/client/verb/spinleft()
-	set name = "Spin View CCW"
-	set category = "OOC"
-	dir = turn(dir, 90)
-
-/client/verb/spinright()
-	set name = "Spin View CW"
-	set category = "OOC"
-	dir = turn(dir, -90)
-


### PR DESCRIPTION
:cl: SierraKomodo
rscdel: The spin-view verbs have been removed due to how broken overlays and effects become after using them.
/:cl: