### PR TITLE
Fix some issues with the 'Rename Ship' verb

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1013,6 +1013,13 @@ Ccomp's first proc.
 			shuttle.name = name
 			break
 
+	for (var/obj/effect/shuttle_landmark/ship/S in landmarks_list)
+		if (S.name == original_name)
+			S.shuttle_name = name
+		if (istype(S, /obj/effect/overmap/visitable/ship/landable))
+			var/obj/effect/overmap/visitable/ship/landable/SL = S
+			SL.landmark.landmark_tag = "ship_[name]"
+			SL.landmark.shuttle_name = name
 	//rename waypoints based on the origin ship name
 	for (var/obj/effect/overmap/visitable/ship/S in SSshuttle.ships)
 		for (var/key in S.restricted_waypoints)
@@ -1023,6 +1030,7 @@ Ccomp's first proc.
 					var/obj/effect/overmap/visitable/ship/landable/SL = S
 					SL.landmark.landmark_tag = "ship_[name]"
 					SL.landmark.shuttle_name = name
+					SL.shuttle = name
 
 	for (var/obj/machinery/computer/shuttle_control/S in SSmachines.machinery)
 		if (S.shuttle_tag == original_name)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1037,5 +1037,4 @@ Ccomp's first proc.
 			S.shuttle_tag = name
 			S.name = "[name] Control Console"
 
-	var/client/user = resolve_client()
-	log_and_message_admins("[key_name_admin(user)] renamed \the [original_name] ship to [name].", )
+	log_and_message_admins("renamed \the [original_name] ship to [name].", )

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -993,7 +993,7 @@ Ccomp's first proc.
 	set name = "Rename Ship"
 	set desc = "Rename a ship (Does not rename areas on the ship)"
 
-	var/obj/effect/overmap/visitable/ship/ship = input("What ship?", "Rename Ship") as anything in SSshuttle.ships | null
+	var/obj/effect/overmap/visitable/ship/ship = input("What ship?", "Rename Ship") as null | anything in SSshuttle.ships
 	if (!ship)
 		return
 


### PR DESCRIPTION
:cl: Mucker
admin: Gave the 'Rename Ship' verb a cancel button on the initial popup window.
bugfix: Fixed the 'Rename Ship' verb outputting the admin name twice in the log.
bugfix: (Hopefully) fixed the issues with taking off/landing renamed ships/shuttles.
/:cl:

Please do any weird or wacky tests you can on this so we avoid me breaking the live server again.