### PR TITLE
Hypospray Timer

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -83,7 +83,7 @@
 	possible_transfer_amounts = "1;2;5;10;15;20;30"
 	amount_per_transfer_from_this = 5
 	volume = 0
-	time = 0 // hyposprays are instant for conscious people
+	time = 7
 	single_use = FALSE
 
 /obj/item/reagent_containers/hypospray/vial/New()


### PR DESCRIPTION
Recently there has apparently been an increase in CMO's wanting to get their valids with loaded hypo's of chloral hydrate for that sweet instant knockout. To combat this, a small delay has been added to the hypo injection to give a fighting chance to someone on the receiving end of an unwanted injection while still being a useful tool for the proper purpose of treating patients.

:cl: Fre3bie
tweak: Small delay added to hypospray injection to deter their use as insta-KO weapons.
/:cl: