### PR TITLE
Document atom

### DIFF
--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -187,6 +187,7 @@
 #define MOUSE_OPACITY_PRIORITY 2
 
 
+/// Integer (One of `*_PLANE`). The atom's rendering plane. See `code\__defines\__renderer.dm` for a list of valid planes. Also see the DM Reference for `plane var (atom)`.
 /atom/plane = DEFAULT_PLANE
 
 #define DEFAULT_APPEARANCE_FLAGS (PIXEL_SCALE)

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -305,3 +305,8 @@
 #define EX_ACT_DEVASTATING 1 // Within devastation range - Destructive/deadly, unlikely to survive.
 #define EX_ACT_HEAVY 2 // Within heavy range - Heavy damage, very dangerous
 #define EX_ACT_LIGHT 3 // Within light range - Minor damage.
+
+
+// Atom layering/visibility levels on turfs. See `/atom/var/level`.
+#define ATOM_LEVEL_UNDER_TILE 1 // Hidden under floor tiles, visible on plating
+#define ATOM_LEVEL_OVER_TILE 2 // Visible on all turf tiles

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -310,3 +310,9 @@
 // Atom layering/visibility levels on turfs. See `/atom/var/level`.
 #define ATOM_LEVEL_UNDER_TILE 1 // Hidden under floor tiles, visible on plating
 #define ATOM_LEVEL_OVER_TILE 2 // Visible on all turf tiles
+
+
+// Atom flourescence
+#define ATOM_FLOURESCENCE_NONE 0 // Not flourescent
+#define ATOM_FLOURESCENCE_INACTIVE 1 // Flourescent but not actively lit
+#define ATOM_FLOURESCENCE_ACTVE 2 // Flourescent and actively lit. Helps prevent repeated processing on a flourescent atom by multiple UV lights

--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -1,3 +1,10 @@
+/**
+ * Performs a spin/rotation animation on the atom's sprite.
+ *
+ * **Parameters**:
+ * - `speed` (int) - How quickly the atom should rotate.
+ * - `loops` (int) - How many times the spin animation should occur. Set to `-1` for infinite looping.
+ */
 /atom/proc/SpinAnimation(speed = 10, loops = -1)
 	var/matrix/m120 = matrix(transform).Update(rotation = 120)
 	var/matrix/m240 = matrix(transform).Update(rotation = 240)
@@ -6,6 +13,12 @@
 	animate(transform = m240, time = speed / 3)
 	animate(transform = m360, time = speed / 3)
 
+/**
+ * Performs a shaking animation on the atom's sprite.
+ *
+ * **Parameters**:
+ * - `intensity` integer - The intensity of the shaking.
+ */
 /atom/proc/shake_animation(intensity = 8)
 	var/init_px = pixel_x
 	var/shake_dir = pick(-1, 1)

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -107,7 +107,9 @@
 	return pick(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_CHEST, BP_GROIN)
 
 
+/// Integer. Unique sequential ID from the `do_after` proc used to validate `DO_USER_UNIQUE_ACT` flag checks.
 /mob/var/do_unique_user_handle = 0
+/// The mob currently interacting with the atom during a `do_after` timer. Used to validate `DO_TARGET_UNIQUE_ACT` flag checks.
 /atom/var/do_unique_target_user
 
 /proc/do_after(mob/user, delay, atom/target, do_flags = DO_DEFAULT, incapacitation_flags = INCAPACITATION_DEFAULT)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -528,7 +528,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/GaussRandRound(sigma,roundto)
 	return round(GaussRand(sigma),roundto)
 
-//Will return the contents of an atom recursivly to a depth of 'searchDepth'
+/**
+ * Retrieves the contents of this atom and all atoms contained within, recursively.
+ *
+ * **Parameters**:
+ * - `searchDepth` (int) - The depth to recursively retrieve contents for.
+ *
+ * Returns a list of atoms.
+ */
 /atom/proc/GetAllContents(searchDepth = 5)
 	var/list/toReturn = list()
 
@@ -1115,6 +1122,14 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	crash_with("Prevented attempt to delete dview mob: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE // Prevents destruction
 
+/**
+ * Sets the atom's color and light values to those of `origin`.
+ *
+ * TODO: Update this to use `set_color()` and `get_color()`.
+ *
+ * **Parameters**:
+ * - `origin` - The atom to copy light and color values from.
+ */
 /atom/proc/get_light_and_color(atom/origin)
 	if(origin)
 		color = origin.color

--- a/code/_onclick/MouseDrag.dm
+++ b/code/_onclick/MouseDrag.dm
@@ -1,4 +1,19 @@
 //If we intercept it return true else return false
+/**
+ * Called by `/mob/proc/OnMouseDrag()` when a mob within this atom's contents performs a mouse drag operation. Used to provide alternative handling to mouse dragging within certain atoms.
+ *
+ * **Parameters**:
+ * - `src_object` - The atom being dragged.
+ * - `over_object` - The atom under the mouse pointer.
+ * - `src_location` - The turf, stat panel, grid cell, etc from where `src_object` was dragged.
+ * - `over_location` - The turf, stat panel, grid cell, etc. containing the object under the mouse pointer.
+ * - `src_control` - The id of the skin control the object was dragged from
+ * - `over_control` - The id of the skin control the object was dragged over
+ * - `params` - Click and keyboard parameters.
+ * - `user` - The mob performing the mouse drag operation.
+ *
+ * Returns boolean. TRUE if the mouse drag operation was intercepted, FALSE otherwise.
+ */
 /atom/proc/RelayMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, mob/user)
 	return FALSE
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -29,6 +29,17 @@
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
 	click_handler.OnDblClick(src, params)
 
+
+/**
+ * Whether or not the atom should allow a mob to click things while inside it's contents.
+ *
+ * **Parameters**:
+ * - `A` - The atom being clicked on.
+ * - `params` (list) - The click parameters
+ * - `user` - The mob performing the click action.
+ *
+ * Returns boolean.
+ */
 /atom/proc/allow_click_through(atom/A, params, mob/user)
 	return FALSE
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -176,6 +176,12 @@
 	A.attack_robot(src)
 	return TRUE
 
+/**
+ * Called when a silicon robot mob clicks on an atom.
+ *
+ * **Parameters**:
+ * - `user` - The mob clicking on the atom.
+ */
 /atom/proc/attack_robot(mob/user as mob)
 	attack_ai(user)
 	return

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,6 +6,16 @@
 	almost anything into a trash can.
 */
 
+/**
+ * Whether or not an atom can be dropped onto this atom. Called when a user click+drag's `src` onto `over`.
+ *
+ * **Parameters**:
+ * - `over` - The atom that `src` was dropped onto.
+ * - `user` - The mob click+dragging `src`.
+ * - `incapacitation_flags` (Bitflag - Any of `INCAPACITATION_*`) - Additional incapacitation flags that should be checked. Used to verify `user` can perform the action. Passed directly to `user.incapacitated()`.
+ *
+ * Returns boolean.
+ */
 /atom/proc/CanMouseDrop(atom/over, mob/user = usr, incapacitation_flags)
 	if(!user || !over)
 		return FALSE
@@ -23,7 +33,14 @@
 		over.MouseDrop_T(src,usr)
 	return
 
-// Receive a mouse drop
+
+/**
+ * Called by `MouseDrop()` after adjacency checks are performed. Generally, you should be using this for any mouse dragging operations.
+ *
+ * **Parameters**:
+ * - `dropping` - The atom being dragged.
+ * - `user` - The mob performing the mouse drag operation.
+ */
 /atom/proc/MouseDrop_T(atom/dropping, mob/user)
 	// Mitigation for some user's mouses click+dragging for a split second when clicking on moving sprites.
 	if (src == dropping && user.canClick())

--- a/code/controllers/subsystems/processing/icon_updates.dm
+++ b/code/controllers/subsystems/processing/icon_updates.dm
@@ -33,6 +33,10 @@ PROCESSING_SUBSYSTEM_DEF(icon_update)
 		else if (MC_TICK_CHECK)
 			return
 
+/**
+ * Adds the atom to the icon_update subsystem to be queued for icon updates. Use this if you're going to be pushing a
+ * lot of icon updates at once.
+ */
 /atom/proc/queue_icon_update(...)
 	SSicon_update.queue[src] = args.len ? args : TRUE
 	SSicon_update.wake()

--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -96,6 +96,9 @@
 		add_chameleon_choice(choices, path)
 	return sortAssoc(choices)
 
+/**
+ * Verb to handle changing the appearance of atoms that have the chameleon extension.
+ */
 /atom/proc/chameleon_appearance()
 	set name = "Change Appearance"
 	set desc = "Activate the holographic appearance changing module."

--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -108,6 +108,10 @@
 	if(holstered.loc != storage)
 		clear_holster()
 
+/**
+ * Verb to handle quick-holstering an item in the mob's active hand, or retrieving an item from this atom's holster
+ * extension.
+ */
 /atom/proc/holster_verb(holster_name in get_holsters())
 	set name = "Holster"
 	set category = "Object"
@@ -129,6 +133,12 @@
 	else
 		H.unholster(usr, 1)
 
+/**
+ * Retrieves all holsters contained within the atom, including itself. Generally, this is any atom that has the
+ * `/datum/extension/holster` extension.
+ *
+ * Returns associative list (name = instance of `/datum/extension/holster`)
+ */
 /atom/proc/get_holsters()
 	. = list()
 	if(has_extension(src, /datum/extension/holster))

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -82,6 +82,13 @@
 			return L.labels.Copy()
 		return list()
 
+
+/**
+ * Removes a labeller label from the atom.
+ *
+ * **Parameters**:
+ * - `label` - The label to remove.
+ */
 /atom/proc/RemoveLabel(label in get_attached_labels(src))
 	set name = "Remove Label"
 	set desc = "Used to remove labels"

--- a/code/datums/observation/helpers.dm
+++ b/code/datums/observation/helpers.dm
@@ -16,6 +16,14 @@
 	if(new_loc != loc)
 		forceMove(new_loc)
 
+/**
+ * Handler for setting an atom's dir when mimicking movements. Calls `set_dir()`.
+ *
+ * **Parameters**:
+ * - `a` - The atom triggering the event.
+ * - `old_dir` - The atom's prior `dir`.
+ * - `new_dir` - The new `dir` to set.
+ */
 /atom/proc/recursive_dir_set(atom/a, old_dir, new_dir)
 	set_dir(new_dir)
 

--- a/code/datums/observation/name_set.dm
+++ b/code/datums/observation/name_set.dm
@@ -18,6 +18,14 @@ GLOBAL_DATUM_INIT(name_set_event, /singleton/observ/name_set, new)
 * Name Set Handling *
 *********************/
 
+/**
+ * Sets the atom's name to the provided value, allowing for any additional processing required that `name = new_value` alone cannot perform. It is preferred to use this over modifying the `name` var directly.
+ *
+ * This proc will also raise `name_set_event`.
+ *
+ * **Parameters**:
+ * - `new_name` (string) - The new name to set.
+ */
 /atom/proc/SetName(new_name)
 	var/old_name = name
 	if(old_name != new_name)

--- a/code/datums/observation/opacity_set.dm
+++ b/code/datums/observation/opacity_set.dm
@@ -17,6 +17,12 @@ GLOBAL_DATUM_INIT(opacity_set_event, /singleton/observ/opacity_set, new)
 /*******************
 * Opacity Handling *
 *******************/
+/**
+ * Sets the atom's opacity, calls the opacity set event, and update's the atom's turf's opacity information.
+ *
+ * **Parameters**:
+ * - `new_opacity` boolean - The new opacity value.
+ */
 /atom/proc/set_opacity(new_opacity)
 	if(new_opacity != opacity)
 		var/old_opacity = opacity

--- a/code/datums/observation/set_invisibility.dm
+++ b/code/datums/observation/set_invisibility.dm
@@ -18,6 +18,12 @@ GLOBAL_DATUM_INIT(invisibility_set_event, /singleton/observ/invisibility_set, ne
 * Invisibility Set Handling *
 *****************************/
 
+/**
+ * Sets the atom's invisibility and raises the invisibility set event.
+ *
+ * **Parameters**:
+ * - `new_invisibility` integer (Default `0`) - The new invisibility to set.
+ */
 /atom/proc/set_invisibility(new_invisibility = 0)
 	var/old_invisibility = invisibility
 	if(old_invisibility != new_invisibility)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -19,8 +19,8 @@
 	var/germ_level = GERM_LEVEL_AMBIENT
 	/// Boolean. Whether or not the atom is considered simulated. If `FALSE`, blocks a majority of interactions, processes, etc.
 	var/simulated = TRUE
-	/// Integer. Whether or not the atom is visible under a UV light. If set to `2`, the atom is actively highlighted by a light,
-	var/fluorescent = 0
+	/// Integer (One of `ATOM_FLOURESCENCE_*`). Whether or not the atom is visible under a UV light. If set to `2`, the atom is actively highlighted by a light. See `code\__defines\misc.dm`.
+	var/fluorescent = ATOM_FLOURESCENCE_NONE
 	/// The reagents contained within the atom. Handles all reagent interactions and processing.
 	var/datum/reagents/reagents
 	/// LAZYLIST of mobs currently climbing the atom.
@@ -518,7 +518,7 @@
 /atom/proc/clean_blood()
 	if(!simulated)
 		return
-	fluorescent = 0
+	fluorescent = ATOM_FLOURESCENCE_NONE
 	germ_level = 0
 	blood_color = null
 	gunshot_residue = null

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1,6 +1,6 @@
 /atom
 	/// Integer. The atom's layering level. Primarily used for determining whether the atom is visible or not on certain tile/flooring types/layers (I.e. plating and non-plating).
-	var/level = 2
+	var/level = ATOM_LEVEL_OVER_TILE
 	/// Bitflag (Any of `ATOM_FLAG_*`). General atom level flags. See `code\__defines\flags.dm`.
 	var/atom_flags = ATOM_FLAG_NO_TEMP_CHANGE
 	/// LAZYLIST of all DNA strings present on the atom from blood. Do not modify directly. See `add_blood()` and `clean_blood()`.

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -1,18 +1,53 @@
 /atom/proc/is_flooded(lying_mob, absolute)
 	return
 
+/**
+ * Called when fluids affect the atom.
+ *
+ * **Parameters**:
+ * - `depth` integer - The depth of the fluid effect calling this proc.
+ */
 /atom/proc/water_act(depth)
 	clean_blood()
 
+/**
+ * Retrieves the atom's fluid effect, if present. Generally, this only returns a value for turfs, and for said turfs,
+ * the fluid effect present in the turf's contents.
+ *
+ * Returns instance of `/obj/effect/fluid`.
+ */
 /atom/proc/return_fluid()
 	return null
 
+/**
+ * Determines whether the atom's current fluid depth meets the provided value or not. Generally used by turfs.
+ *
+ * See `/atom/proc/get_fluid_fepth()`.
+ *
+ * **Parameters**:
+ * - `min` (integer) - The minimum fluid depth value to meet or exceed.
+ *
+ * Returns boolean.
+ */
 /atom/proc/check_fluid_depth(min)
 	return 0
 
+/**
+ * Determines the atom's current fluid depth. Currently only used by turfs.
+ *
+ * Returns integer.
+ */
 /atom/proc/get_fluid_depth()
 	return 0
 
+/**
+ * Whether or not fluids can pass through this atom.
+ *
+ * **Parameters**:
+ * - `coming_from` (Bitflag/direction) - The direction the fluid is attempting to pass from.
+ *
+ * Returns boolean.
+ */
 /atom/proc/CanFluidPass(coming_from)
 	return TRUE
 
@@ -23,6 +58,14 @@
 	var/turf/T = get_turf(src)
 	return T.is_flooded(lying_mob)
 
+/**
+ * Whether or not the atom is considered submerged in fluid.
+ *
+ * **Parameters**:
+ * - `depth` integer - The depth level used for the check. If not set, fetches the turf's `get_fluid_depth()`.
+ *
+ * Returns boolean.
+ */
 /atom/proc/submerged(depth)
 	if(isnull(depth))
 		var/turf/T = get_turf(src)
@@ -40,6 +83,9 @@
 		depth = get_fluid_depth()
 	return depth >= FLUID_OVER_MOB_HEAD
 
+/**
+ * Handler for fluid updates. Mirrors to the atom's turf.
+ */
 /atom/proc/fluid_update()
 	var/turf/T = get_turf(src)
 	if(istype(T))

--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -1,7 +1,9 @@
 #define MIN_TEMPERATURE_COEFFICIENT 1
 #define MAX_TEMPERATURE_COEFFICIENT 10
 
+/// Float. The atom's current temperature.
 /atom/var/temperature = T20C
+/// Float. Multiplier used to determine how much temperature can change/transfer to this atom when a temperature change proc is called. See `ProcessAtomTemperature()` and `/obj/proc/HandleObjectHeating()`. Should be a value between `MIN_TEMPERATURE_COEFFICIENT` and `MAX_TEMPERATURE_COEFFICIENT`.
 /atom/var/temperature_coefficient = MAX_TEMPERATURE_COEFFICIENT
 
 /atom/movable/Entered(atom/movable/atom, atom/old_loc)
@@ -30,6 +32,11 @@
 	. = ..()
 	temperature_coefficient = isnull(temperature_coefficient) ? clamp(MAX_TEMPERATURE_COEFFICIENT - Floor(mob_size/4), MIN_TEMPERATURE_COEFFICIENT, MAX_TEMPERATURE_COEFFICIENT) : temperature_coefficient
 
+/**
+ * Temperature subsystem process.
+ *
+ * Returns void or `PROCESS_KILL`.
+ */
 /atom/proc/ProcessAtomTemperature()
 
 	// Get our location temperature if possible.

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -344,6 +344,10 @@
 		see = hear(view_range, pos)
 	return see
 
+
+/**
+ * Automatically sets the atom's direction based on nearby walls. Used for atoms that should appear 'attached' to walls.
+ */
 /atom/proc/auto_turn()
 	//Automatically turns based on nearby walls.
 	var/turf/simulated/wall/T = null

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -379,7 +379,11 @@
 /obj/machinery/atmospherics/unary/cryo_cell/return_air()
 	return air_contents
 
-//This proc literally only exists for cryo cells.
+/**
+ * Alternative to `return_air()` used for internal organ and lung checks.
+ *
+ * Returns instance of `/datum/gas_mixture`.
+ */
 /atom/proc/return_air_for_internal_lifeform()
 	return return_air()
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -5,7 +5,7 @@ var/global/list/navbeacons = list()
 	icon_state = "navbeacon0-f"
 	name = "navigation beacon"
 	desc = "A radio beacon used for bot navigation."
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	layer = ABOVE_WIRE_LAYER
 	anchored = TRUE
 

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -14,7 +14,6 @@ Buildable meters
 	randpixel = 5
 	item_state = "buildpipe"
 	w_class = ITEM_SIZE_NORMAL
-	level = 2
 	obj_flags = OBJ_FLAG_ROTATABLE
 	dir = SOUTH
 	var/constructed_path = /obj/machinery/atmospherics/pipe/simple/hidden

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -12,7 +12,7 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 	idle_power_usage = 10
 	active_power_usage = 50
 	anchored = TRUE
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	machine_name = "teleporter beacon"
 	machine_desc = "Teleporter beacons allow teleporter systems to target them, for accurate, instantaneous transport of objects and people."
@@ -64,7 +64,7 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 				return TRUE
 
 			anchored = !anchored
-			level = anchored ? 1 : 2
+			level = anchored ? ATOM_LEVEL_UNDER_TILE : ATOM_LEVEL_OVER_TILE
 			user.visible_message(
 				SPAN_NOTICE("\The [user] [anchored ? "connects" : "disconnects"] \the [src] [anchored ? "to" : "from"] \the [T] with \the [I]."),
 				SPAN_NOTICE("You [anchored ? "connect" : "disconnect"] \the [src] [anchored ? "to" : "from"] \the [T] with \the [I].")

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -30,12 +30,12 @@ var/global/list/image/splatter_cache=list()
 
 /obj/effect/decal/cleanable/blood/reveal_blood()
 	if(!fluorescent)
-		fluorescent = 1
+		fluorescent = ATOM_FLOURESCENCE_INACTIVE
 		basecolor = COLOR_LUMINOL
 		update_icon()
 
 /obj/effect/decal/cleanable/blood/clean_blood()
-	fluorescent = 0
+	fluorescent = ATOM_FLOURESCENCE_NONE
 	if(invisibility != 100)
 		set_invisibility(100)
 		amount = 0

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -105,7 +105,12 @@ var/global/explosion_in_progress = 0
 /turf/unsimulated/explosion_spread(power)
 	return //So it doesn't get to the parent proc, which simulates explosions
 
-/atom/var/explosion_resistance
+/// Float. The atom's explosion resistance value. Used to calculate how much of an explosion is 'absorbed' and not passed on to tiles on the other side of the atom's turf. See `/proc/explosion_rec()`.
+/atom/var/explosion_resistance = 0
+
+/**
+ * Retrieves the atom's explosion resistance. Generally, this is `explosion_resistance` for simulated atoms.
+ */
 /atom/proc/get_explosion_resistance()
 	if(simulated)
 		return explosion_resistance

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -630,7 +630,7 @@ var/global/list/slot_flags_enumeration = list(
 
 /obj/item/reveal_blood()
 	if(was_bloodied && !fluorescent)
-		fluorescent = 1
+		fluorescent = ATOM_FLOURESCENCE_INACTIVE
 		blood_color = COLOR_LUMINOL
 		blood_overlay.color = COLOR_LUMINOL
 		update_icon()

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -142,7 +142,7 @@
 			continue
 
 		for(var/obj/O in T.contents)
-			if(O.level != 1)
+			if(O.level != ATOM_LEVEL_UNDER_TILE)
 				continue
 			if(!O.invisibility)
 				continue //if it's already visible don't need an overlay for it

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -445,7 +445,7 @@
 	desc = "A very slim satchel, that can easily fit into tight spaces."
 	icon_state = "satchel-flat"
 	item_state = "satchel-norm"
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	w_class = ITEM_SIZE_NORMAL //Can fit in backpacks itself.
 	storage_slots = 5
 	max_w_class = ITEM_SIZE_NORMAL

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -458,8 +458,16 @@
 		max_w_class = max(I.w_class, max_w_class)
 		max_storage_space += I.get_storage_cost()
 
-//Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
-//Returns -1 if the atom was not found on container.
+/**
+ * Determines the storage depth of an atom. This is the number of storage items (`/obj/item/storage`) the atom is
+ * contained in before reaching `container`.
+ *
+ * **Parameters**:
+ * - `container` - The top level container to stop at. If this is never encountered during the loop, the proc will
+ * return `-1`.
+ *
+ * Returns integer or `-1` if the atom was not found in the container.
+ */
 /atom/proc/storage_depth(atom/container)
 	var/depth = 0
 	var/atom/cur_atom = src
@@ -476,8 +484,12 @@
 
 	return depth
 
-//Like storage depth, but returns the depth to the nearest turf
-//Returns -1 if no top level turf (a loc was null somewhere, or a non-turf atom's loc was an area somehow).
+/**
+ * Determines the storage depth of an atom. This is the number of storage items (`/obj/item/storage`) the atom is
+ * contained in before reaching the turf.
+ *
+ * Returns integer or `-1` if the atom was not found in a turf.
+ */
 /atom/proc/storage_depth_turf()
 	var/depth = 0
 	var/atom/cur_atom = src

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -96,7 +96,7 @@
 	set_invisibility(hide ? INVISIBILITY_MAXIMUM : initial(invisibility))
 
 /obj/proc/hides_under_flooring()
-	return level == 1
+	return level == ATOM_LEVEL_UNDER_TILE
 
 /obj/proc/hear_talk(mob/M as mob, text, verb, datum/language/speaking)
 	if(talking_atom)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -164,7 +164,7 @@ FLOOR SAFES
 	name = "floor safe"
 	icon_state = "floorsafe"
 	density = FALSE
-	level = 1	//underfloor
+	level = ATOM_LEVEL_UNDER_TILE
 	layer = BELOW_OBJ_LAYER
 
 /obj/structure/safe/floor/Initialize()

--- a/code/game/objects/topic.dm
+++ b/code/game/objects/topic.dm
@@ -1,3 +1,8 @@
+/**
+ * The atom's default topic state. Used in various Topic related proc calls and defines to validate interactions.
+ *
+ * Returns `GLOB.default_state` by default, or a subtype of `/datum/topic_state`.
+ */
 /atom/proc/DefaultTopicState()
 	return GLOB.default_state
 
@@ -11,6 +16,16 @@
 	CouldNotUseTopic(usr)
 	return TRUE
 
+/**
+ * Called when a user successfully interacts with a topic interaction window.
+ *
+ * **Parameters**:
+ * - `user` - The mob interacting with the atom.
+ * - `href_list` - An associative list of parameters passed by the topic call.
+ * - `state` - The topic chain's state.
+ *
+ * Returns int (One of `TOPIC_*`). The return value determines what happens to the topic UI window upon completion of the interaction. See `code\__defines\topic.dm`.
+ */
 /atom/proc/OnTopic(mob/user, href_list, datum/topic_state/state)
 	return TOPIC_NOACTION
 
@@ -29,6 +44,12 @@
 /mob/proc/CanUseObjTopic()
 	return STATUS_INTERACTIVE
 
+/**
+ * Called if the `CanUseTopic()` call succeeds in `Topic()`.
+ *
+ * **Parameters**:
+ * - `user` - The Topic chain's user.
+ */
 /atom/proc/CouldUseTopic(mob/user)
 	user.AddTopicPrint(src)
 
@@ -50,4 +71,10 @@
 		return
 	target.add_hiddenprint(src)
 
+/**
+ * Called if the `CanUseTopic()` call fails in `Topic()`.
+ *
+ * **Parameters**:
+ * - `user` - The Topic chain's user.
+ */
 /atom/proc/CouldNotUseTopic(mob/user)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -31,7 +31,7 @@
 	return !flooring
 
 /turf/simulated/floor/protects_atom(atom/A)
-	return (A.level <= 1 && !is_plating()) || ..()
+	return (A.level == ATOM_LEVEL_UNDER_TILE && !is_plating()) || ..()
 
 /turf/simulated/floor/New(newloc, floortype)
 	..(newloc)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1,6 +1,6 @@
 /turf
 	icon = 'icons/turf/floors.dmi'
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	layer = TURF_LAYER
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -205,9 +205,9 @@ var/global/const/enterloopsanity = 100
 			objects++
 			spawn(0)
 				if(A)
-					A.HasProximity(thing, 1)
+					A.HasProximity(thing)
 					if ((thing && A) && (thing.movable_flags & MOVABLE_FLAG_PROXMOVE))
-						thing.HasProximity(A, 1)
+						thing.HasProximity(A)
 	return
 
 /turf/proc/adjacent_fire_act(turf/simulated/floor/source, exposed_temperature, exposed_volume)

--- a/code/modules/ZAS/Atom.dm
+++ b/code/modules/ZAS/Atom.dm
@@ -1,4 +1,16 @@
-
+/**
+ * Whether or not an atom can move through or onto the same tile as this atom.
+ *
+ * Generally called by movement and airflow procs.
+ *
+ * **Parameters**:
+ * - `mover` - The atom attempting to move onto `target`.
+ * - `target` - The originally targeted turf that `src `may be blocking.
+ * - `height` (float) -
+ * - `air_group` (boolean) - Intended use unknown - No references to this proc actually set this.
+ *
+ * Returns boolean.
+ */
 /atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	//Purpose: Determines if the object (or airflow) can pass this atom.
 	//Called by: Movement, airflow.

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -10,10 +10,6 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 
 /turf/var/obj/hotspot/hotspot = null
 
-//Some legacy definitions so fires can be started.
-/atom/proc/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	return null
-
 /atom/movable/proc/is_burnable()
 	return FALSE
 

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -107,7 +107,7 @@
 * Assisting procs *
 ******************/
 /**
- * Determine's the alarm's z-level.
+ * Determines the alarm's z-level.
  *
  * TODO: Possibly redundant. Check how areas respond to `get_z()` and potentially just replace this call with that.
  *

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -106,18 +106,38 @@
 /******************
 * Assisting procs *
 ******************/
+/**
+ * Determine's the alarm's z-level.
+ *
+ * TODO: Possibly redundant. Check how areas respond to `get_z()` and potentially just replace this call with that.
+ *
+ * Returns integer.
+ */
 /atom/proc/get_alarm_z()
 	return get_z(src)
 
 /area/get_alarm_z()
 	return contents.len ? get_z(contents[1]) : 0
 
+/**
+ * Retrieves the atom's area for alarms.
+ *
+ * TODO: Redundant. Replace with `get_area()`.
+ *
+ * Returns instance of `/area`.
+ */
 /atom/proc/get_alarm_area()
 	return get_area(src)
 
 /area/get_alarm_area()
 	return src
 
+/**
+ * Retrieves the name to use for alarms. For mobs, this is the mob's name. For everything else, this is the arom's
+ * area's name.
+ *
+ * Returns string.
+ */
 /atom/proc/get_alarm_name()
 	var/area/A = get_area(src)
 	return A.name
@@ -128,12 +148,24 @@
 /mob/get_alarm_name()
 	return name
 
+/**
+ * Retrieves an alarm's origin name. Generally this is the atom's name or, for cameras, `c_tag`.
+ *
+ * Returns string.
+ */
 /atom/proc/get_source_name()
 	return name
 
 /obj/machinery/camera/get_source_name()
 	return c_tag
 
+/**
+ * Retrieves a list of cameras from the atom's area.
+ *
+ * TODO: Redundant. Replace with `get_area()` and `get_cameras()`.
+ *
+ * Returns list (Instances of `/obj/machinery/camera`). All cameras in the atom's area.
+ */
 /atom/proc/get_alarm_cameras()
 	var/area/A = get_area(src)
 	return A.get_cameras()

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -100,6 +100,12 @@
 
 	return existing.max_severity()
 
+/**
+ * Retrieves the 'origin' point for any alarms the atom declares. For turfs, this will be the area. For any other
+ * atom, this is itself.
+ *
+ * Returns instance of `/atom`.
+ */
 /atom/proc/get_alarm_origin()
 	return src
 

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -57,7 +57,7 @@ Pipelines + Other Objects -> Pipe network
 	atmos_initalized = TRUE
 
 /obj/machinery/atmospherics/hide(do_hide)
-	if(do_hide && level == 1)
+	if(do_hide && level == ATOM_LEVEL_UNDER_TILE)
 		layer = PIPE_LAYER
 	else
 		reset_plane_and_layer()
@@ -69,7 +69,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/proc/add_underlay(turf/T, obj/machinery/atmospherics/node, direction, icon_connect_type)
 	if(node)
-		if(!T.is_plating() && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
+		if(!T.is_plating() && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
 		else
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
@@ -169,4 +169,4 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/proc/set_initial_level()
 	var/turf/T = get_turf(src)
 	if(T)
-		level = (!T.is_plating() ? 2 : 1)
+		level = (!T.is_plating() ? ATOM_LEVEL_OVER_TILE : ATOM_LEVEL_UNDER_TILE)

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -3,7 +3,7 @@
 	desc = "A machine for breaking bonds in carbon dioxide and releasing pure oxygen."
 	icon = 'icons/atmos/oxyregenerator.dmi'
 	icon_state = "off"
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	density = TRUE
 	use_power = POWER_USE_OFF
 	idle_power_usage = 200		//internal circuitry, friction losses and stuff

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -5,7 +5,7 @@
 /obj/machinery/atmospherics/binary/passive_gate
 	icon = 'icons/atmos/passive_gate.dmi'
 	icon_state = "map_off"
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	name = "pressure regulator"
 	desc = "A one-way air valve that can be used to regulate input or output pressure, and flow rate. Does not require power."

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -15,7 +15,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump
 	icon = 'icons/atmos/pump.dmi'
 	icon_state = "map_off"
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	name = "gas pump"
 	desc = "A pump."

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -1,7 +1,6 @@
 /obj/machinery/atmospherics/binary/pump/high_power
 	icon = 'icons/atmos/volume_pump.dmi'
 	icon_state = "map_off"
-	level = 1
 
 	name = "high power gas pump"
 	desc = "A pump. Has double the power rating of the standard gas pump."

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/atmos/omni_devices.dmi'
 	icon_state = "base"
 	initialize_directions = 0
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	layer = ABOVE_CATWALK_LAYER
 
 	var/configuring = 0
@@ -183,7 +183,7 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		if(!T.is_plating() && istype(P.node, /obj/machinery/atmospherics/pipe) && P.node.level == 1 )
+		if(!T.is_plating() && istype(P.node, /obj/machinery/atmospherics/pipe) && P.node.level == ATOM_LEVEL_UNDER_TILE )
 			//pipe_state = icon_manager.get_atmos_icon("underlay_down", P.dir, color_cache_name(P.node))
 			pipe_state = icon_manager.get_atmos_icon("underlay", P.dir, color_cache_name(P.node), "down")
 		else

--- a/code/modules/atmospherics/components/pipesparker.dm
+++ b/code/modules/atmospherics/components/pipesparker.dm
@@ -1,7 +1,6 @@
 /obj/machinery/atmospherics/pipe/cap/sparker
 	name = "pipe sparker"
 	desc = "A pipe sparker. Useful for starting pipe fires."
-	level = 2
 	icon = 'icons/atmos/pipe-sparker.dmi'
 	icon_state = "pipe-sparker"
 	volume = ATMOS_DEFAULT_VOLUME_PIPE / 2
@@ -37,11 +36,10 @@
 	receive_and_call = list("button_active" = /singleton/public_access/public_method/pipe_sparker_spark)
 
 /obj/machinery/atmospherics/pipe/cap/sparker/visible
-	level = 2
 	icon_state = "pipe-sparker"
 
 /obj/machinery/atmospherics/pipe/cap/sparker/hidden
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	icon_state = "pipe-sparker"
 	alpha = 128
 

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -17,7 +17,7 @@
 	var/on = 0
 	use_power = POWER_USE_OFF
 	uncreated_component_parts = null
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "connector"

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -11,7 +11,6 @@
 	clickvol = 20
 	var/close_on_leaks = TRUE	// If false it will be always open
 	var/shutoff_state = 0
-	level = 1
 	connect_types = CONNECT_TYPE_REGULAR
 	build_icon_state = "svalve"
 

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -5,7 +5,7 @@
 	name = "manual switching valve"
 	desc = "A pipe valve."
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|WEST
 

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -72,7 +72,7 @@
 	if(!isWrench(W))
 		return ..()
 	var/turf/T = src.loc
-	if (level==1 && isturf(T) && !T.is_plating())
+	if (level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
 		to_chat(user, SPAN_WARNING("You must remove the plating first."))
 		return 1
 	var/datum/gas_mixture/int_air = return_air()

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -22,7 +22,7 @@
 	var/datum/radio_frequency/radio_connection
 
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 
@@ -58,7 +58,7 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		if(!T.is_plating() && node && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
+		if(!T.is_plating() && node && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))
 			return
 		else
 			if(node)

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -9,7 +9,7 @@
 	var/start_pressure = 25*ONE_ATMOSPHERE
 	var/filling // list of gas ratios to use.
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	dir = 2
 	initialize_directions = 2
 	density = TRUE
@@ -37,7 +37,7 @@
 		update_icon()
 
 /obj/machinery/atmospherics/unary/tank/set_initial_level()
-	level = 1 // Always on top, apparently.
+	level = ATOM_LEVEL_UNDER_TILE // Always on top, apparently.
 
 // required for paint sprayers to work due to an override in pipes.dm
 /obj/machinery/atmospherics/unary/tank/set_color(new_color)
@@ -116,7 +116,7 @@
 	color =  PIPE_COLOR_WHITE
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	w_class = ITEM_SIZE_HUGE
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	dir = SOUTH
 	constructed_path = /obj/machinery/atmospherics/unary/tank
 	pipe_class = PIPE_CLASS_UNARY

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -18,7 +18,7 @@
 	power_rating = 30000			// 30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_FUEL //connects to regular, supply pipes, and fuel pipes
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	identifier = "AVP"
 
 	var/hibernate = 0 //Do we even process?
@@ -135,7 +135,7 @@
 	if(!istype(T))
 		return
 
-	if(!T.is_plating() && node && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
+	if(!T.is_plating() && node && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))
 		vent_icon += "h"
 
 	if(welded)
@@ -153,7 +153,7 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		if(!T.is_plating() && node && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
+		if(!T.is_plating() && node && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))
 			return
 		else
 			if(node)
@@ -315,7 +315,7 @@
 			to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], turn it off first."))
 			return 1
 		var/turf/T = src.loc
-		if (node && node.level==1 && isturf(T) && !T.is_plating())
+		if (node && node.level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
 			to_chat(user, SPAN_WARNING("You must remove the plating first."))
 			return 1
 		var/datum/gas_mixture/int_air = return_air()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -11,7 +11,7 @@
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER //connects to regular and scrubber pipes
 	identifier = "AScr"
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	var/hibernate = 0 //Do we even process?
 	var/scrubbing = SCRUBBER_EXCHANGE
@@ -91,7 +91,7 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		if(!T.is_plating() && node && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
+		if(!T.is_plating() && node && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))
 			return
 		else
 			if(node)
@@ -195,7 +195,7 @@
 		if (is_powered() && use_power)
 			return SPAN_WARNING("You cannot take this [src] apart, turn it off first.")
 		var/turf/T = get_turf(src)
-		if (node && node.level==1 && isturf(T) && !T.is_plating())
+		if (node && node.level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
 			return SPAN_WARNING("You must remove the plating first.")
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -5,7 +5,7 @@
 	name = "manual valve"
 	desc = "A pipe valve."
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
 	layer = ABOVE_CATWALK_LAYER

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -4,7 +4,7 @@
 	icon_state = "intact"
 	pipe_icon = "hepipe"
 	color = "#404040"
-	level = 2
+	level = ATOM_LEVEL_OVER_TILE
 	connect_types = CONNECT_TYPE_HE
 	var/initialize_directions_he
 	var/surface = 2	//surface area in m^2
@@ -111,7 +111,6 @@
 	icon = 'icons/atmos/junction.dmi'
 	icon_state = "intact"
 	pipe_icon = "hejunction"
-	level = 2
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_HE|CONNECT_TYPE_FUEL
 	build_icon_state = "junction"
 

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -31,10 +31,10 @@
 /obj/machinery/atmospherics/pipe/Initialize()
 	. = ..()
 	if(istype(get_turf(src), /turf/simulated/wall) || istype(get_turf(src), /turf/simulated/shuttle/wall) || istype(get_turf(src), /turf/unsimulated/wall))
-		level = 1
+		level = ATOM_LEVEL_UNDER_TILE
 
 /obj/machinery/atmospherics/pipe/hides_under_flooring()
-	return level != 2
+	return level != ATOM_LEVEL_OVER_TILE
 
 /obj/machinery/atmospherics/pipe/proc/set_leaking(new_leaking)
 	if(new_leaking && !leaking)
@@ -114,7 +114,7 @@
 
 	if(isWrench(W))
 		var/turf/T = src.loc
-		if (level==1 && isturf(T) && !T.is_plating())
+		if (level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
 			to_chat(user, SPAN_WARNING("You must remove the plating first."))
 			return 1
 
@@ -183,7 +183,7 @@
 	var/minimum_temperature_difference = 300
 	var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	rotate_class = PIPE_ROTATE_TWODIR
 	connect_dir_type = SOUTH | NORTH // Overridden if dir is not a cardinal for bent pipes. For straight pipes this is correct.
@@ -317,7 +317,7 @@
 		return
 
 	var/turf/T = loc
-	if(level == 1 && !T.is_plating()) hide(1)
+	if(level == ATOM_LEVEL_UNDER_TILE && !T.is_plating()) hide(1)
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/simple/disconnect(obj/machinery/atmospherics/reference)
@@ -337,7 +337,7 @@
 
 /obj/machinery/atmospherics/pipe/simple/visible
 	icon_state = "intact"
-	level = 2
+	level = ATOM_LEVEL_OVER_TILE
 
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers
 	name = "Scrubbers pipe"
@@ -383,7 +383,6 @@
 
 /obj/machinery/atmospherics/pipe/simple/hidden
 	icon_state = "intact"
-	level = 1
 	alpha = 128		//set for the benefit of mapping - this is reset to opaque when the pipe is spawned in game
 
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers
@@ -440,7 +439,7 @@
 
 	var/obj/machinery/atmospherics/node3
 	build_icon_state = "manifold"
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	pipe_class = PIPE_CLASS_TRINARY
 	connect_dir_type = NORTH | EAST | WEST
@@ -593,12 +592,12 @@
 		return
 
 	var/turf/T = get_turf(src)
-	if(level == 1 && !T.is_plating()) hide(1)
+	if(level == ATOM_LEVEL_UNDER_TILE && !T.is_plating()) hide(1)
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/manifold/visible
 	icon_state = "map"
-	level = 2
+	level = ATOM_LEVEL_OVER_TILE
 
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers
 	name="Scrubbers pipe manifold"
@@ -641,7 +640,6 @@
 
 /obj/machinery/atmospherics/pipe/manifold/hidden
 	icon_state = "map"
-	level = 1
 	alpha = 128		//set for the benefit of mapping - this is reset to opaque when the pipe is spawned in game
 
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers
@@ -696,7 +694,7 @@
 	var/obj/machinery/atmospherics/node3
 	var/obj/machinery/atmospherics/node4
 	build_icon_state = "manifold4w"
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	pipe_class = PIPE_CLASS_QUATERNARY
 	rotate_class = PIPE_ROTATE_ONEDIR
@@ -862,12 +860,12 @@
 		return
 
 	var/turf/T = get_turf(src)
-	if(level == 1 && !T.is_plating()) hide(1)
+	if(level == ATOM_LEVEL_UNDER_TILE && !T.is_plating()) hide(1)
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/manifold4w/visible
 	icon_state = "map_4way"
-	level = 2
+	level = ATOM_LEVEL_OVER_TILE
 
 /obj/machinery/atmospherics/pipe/manifold4w/visible/scrubbers
 	name="4-way scrubbers pipe manifold"
@@ -910,7 +908,6 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w/hidden
 	icon_state = "map_4way"
-	level = 1
 	alpha = 128		//set for the benefit of mapping - this is reset to opaque when the pipe is spawned in game
 
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers
@@ -957,7 +954,6 @@
 	desc = "An endcap for pipes."
 	icon = 'icons/atmos/pipes.dmi'
 	icon_state = ""
-	level = 2
 	volume = 35
 
 	pipe_class = PIPE_CLASS_UNARY
@@ -1020,11 +1016,10 @@
 				break
 
 	var/turf/T = src.loc			// hide if turf is not intact
-	if(level == 1 && !T.is_plating()) hide(1)
+	if(level == ATOM_LEVEL_UNDER_TILE && !T.is_plating()) hide(1)
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/cap/visible
-	level = 2
 	icon_state = "cap"
 
 /obj/machinery/atmospherics/pipe/cap/visible/scrubbers
@@ -1050,7 +1045,7 @@
 	connect_types = CONNECT_TYPE_FUEL
 
 /obj/machinery/atmospherics/pipe/cap/hidden
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	icon_state = "cap"
 	alpha = 128
 
@@ -1083,7 +1078,7 @@
 	name = "Vent"
 	desc = "A large air vent."
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 	volume = 250
 
@@ -1250,7 +1245,7 @@
 
 /obj/machinery/atmospherics/proc/add_underlay_adapter(turf/T, obj/machinery/atmospherics/node, direction, icon_connect_type) //modified from add_underlay, does not make exposed underlays
 	if(node)
-		if(!T.is_plating() && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
+		if(!T.is_plating() && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
 		else
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -997,7 +997,11 @@
 	cell.use(aimove_power_usage * CELLRATE)
 	wearer.DoMove(direction, user)
 
-// This returns the rig if you are contained inside one, but not if you are wearing it
+/**
+ * Retrieves the rig the atom is located inside of, recursively checking parent locs until it find one.
+ *
+ * Returns instead of `/obj/item/rig`.
+ */
 /atom/proc/get_rig()
 	if(loc)
 		return loc.get_rig()

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -1,6 +1,17 @@
+/**
+ * The codex entry name to use for this atom. By default, itself. Used for items that should direct to a codex entry
+ * other than itself, such as Fleet lore.
+ *
+ * Returns instance of `/atom` or string.
+ */
 /atom/proc/get_codex_value()
 	return src
 
+/**
+ * Retrieves the atom's codex entry, generating a new one if not already cached.
+ *
+ * Returns instance of `/datum/codex_entry` or `FALSE` if there's no codex data to generate.
+ */
 /atom/proc/get_specific_codex_entry()
 	if(SScodex.entries_by_path[type])
 		return SScodex.entries_by_path[type]
@@ -14,12 +25,27 @@
 	var/datum/codex_entry/entry = new(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
 	return entry
 
+/**
+ * Handler for displaying information in the Mechanics section of the atom's codex entry.
+ *
+ * Returns string.
+ */
 /atom/proc/get_mechanics_info()
 	return
 
+/**
+ * Handler for displaying information in the Antagonist section of the atom's codex entry.
+ *
+ * Returns string.
+ */
 /atom/proc/get_antag_info()
 	return
 
+/**
+ * Handler for displaying information in the Lore section of the atom's codex entry.
+ *
+ * Returns string.
+ */
 /atom/proc/get_lore_info()
 	return
 

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -8,14 +8,27 @@ var/global/const/FINGERPRINT_COMPLETE = 6
 /proc/is_complete_print(print)
 	return stringpercent(print) <= FINGERPRINT_COMPLETE
 
+/// LAZYLIST of mobs that have touched/used the atom. Used for staff investigation. Each entry includes a timestamp and name of the mob that generated the fingerprint. Do not modify directly. See `add_hiddenprint()`.
 /atom/var/list/fingerprintshidden
+/// String. The last ckey to generate fingerprints on this atom. Used to reduce the number of duplicate `fingerprintshidden` entries.
 /atom/var/fingerprintslast
 
+/// LAZYLIST of clothing fibers persent on the atom. Do not modify directly. See `add_fibers()` and `transfer_fingerprints_to()`.
 /atom/var/list/suit_fibers
+/// LAZYLIST of fingerprints present on the atom. Index is the full print, value is either the full print or a starred version of the full print as a partial. Do not modify directly. See `add_fingerprint()`, `add_partial_print()`, and `transfer_fingerprints_to()`.
 /atom/var/list/fingerprints
+/// LAZYLIST of gunshot residue present on the atom. Each entry contains the caliber of ammunition that generated the residue. Updated by `/obj/item/ammo_casing/proc/put_residue_on()`.
 /atom/var/list/gunshot_residue
 /obj/item/var/list/trace_DNA
 
+/**
+ * Adds fingerprint logs to the atom's hidden prints.
+ *
+ * **Parameters**:
+ * - `M` - The mob to add fingerprints from.
+ *
+ * Returns boolean.
+ */
 /atom/proc/add_hiddenprint(mob/M)
 	if(!M || !M.key)
 		return
@@ -33,6 +46,17 @@ var/global/const/FINGERPRINT_COMPLETE = 6
 	src.fingerprintshidden += "\[[time_stamp()]\] Real name: [M.real_name], Key: [M.key]"
 	return 1
 
+
+/**
+ * Adds fingerprints to an atom from a mob.
+ *
+ * **Parameters**:
+ * - `M` - The mob to add fingerprints from.
+ * - `ignoregloves` (boolean) - Whether or not the proc should ignore the presence of gloves on the mob.
+ * - `tool` - The tool in the mob's active hand. Used to check if the tool should prevent fingerprints.
+ *
+ * Returns boolean. `TRUE` if fingerprints were added, `FALSE` otherwise.
+ */
 /atom/proc/add_fingerprint(mob/M, ignoregloves, obj/item/tool)
 	if(isnull(M)) return
 	if(isAI(M)) return
@@ -75,6 +99,14 @@ var/global/const/FINGERPRINT_COMPLETE = 6
 	add_partial_print(full_print, additional_chance)
 	return 1
 
+
+/**
+ * Adds a partial print to the atom's fingerprints list.
+ *
+ * **Parameters**:
+ * - `full_print` (string) - The full fingerprint to be converted to a partial.
+ * - `bonus` (int) - Additional bonus to the chance of a more complete print.
+ */
 /atom/proc/add_partial_print(full_print, bonus)
 	LAZYINITLIST(fingerprints)
 	if(!fingerprints[full_print])
@@ -111,6 +143,12 @@ var/global/const/FINGERPRINT_COMPLETE = 6
 				else
 					fingerprints[full_print] = full_print
 
+/**
+ * Transfers this atom's fingerprints, fibres, DNA, etc to the target atom.
+ *
+ * **Parameters**:
+ * - `A` - The atom to transfer data to.
+ */
 /atom/proc/transfer_fingerprints_to(atom/A)
 	if(fingerprints)
 		LAZYDISTINCTADD(A.fingerprints, fingerprints)
@@ -131,6 +169,13 @@ var/global/const/FINGERPRINT_COMPLETE = 6
 		var/obj/item/I = A
 		LAZYDISTINCTADD(I.trace_DNA, trace_DNA)
 
+
+/**
+ * Adds forensics fibers to the atom from clothing worn by a mob.
+ *
+ * **Parameters**:
+ * - `M` - The mob to pull fibers from.
+ */
 /atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(!istype(M))
 		return

--- a/code/modules/detectivework/tools/uvlight.dm
+++ b/code/modules/detectivework/tools/uvlight.dm
@@ -34,17 +34,20 @@
 	if(scanned.len)
 		for(var/atom/O in scanned)
 			O.set_invisibility(scanned[O])
-			if(O.fluorescent == 2) O.fluorescent = 1
+			if(O.fluorescent == ATOM_FLOURESCENCE_ACTVE)
+				O.fluorescent = ATOM_FLOURESCENCE_INACTIVE
 		scanned.Cut()
 	if(stored_alpha.len)
 		for(var/atom/O in stored_alpha)
 			O.alpha = stored_alpha[O]
-			if(O.fluorescent == 2) O.fluorescent = 1
+			if(O.fluorescent == ATOM_FLOURESCENCE_ACTVE)
+				O.fluorescent = ATOM_FLOURESCENCE_INACTIVE
 		stored_alpha.Cut()
 	if(reset_objects.len)
 		for(var/obj/item/I in reset_objects)
 			I.overlays -= I.blood_overlay
-			if(I.fluorescent == 2) I.fluorescent = 1
+			if(I.fluorescent == ATOM_FLOURESCENCE_ACTVE)
+				I.fluorescent = ATOM_FLOURESCENCE_INACTIVE
 		reset_objects.Cut()
 
 /obj/item/device/uv_light/Process()
@@ -57,8 +60,8 @@
 		for(var/turf/T in range(range, origin))
 			var/use_alpha = 255 - (step_alpha * get_dist(origin, T))
 			for(var/atom/A in T.contents)
-				if(A.fluorescent == 1)
-					A.fluorescent = 2 //To prevent light crosstalk.
+				if(A.fluorescent == ATOM_FLOURESCENCE_INACTIVE)
+					A.fluorescent = ATOM_FLOURESCENCE_ACTVE
 					if(A.invisibility)
 						scanned[A] = A.invisibility
 						A.set_invisibility(0)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -1,16 +1,35 @@
-/atom
-	var/light_max_bright = 1  // intensity of the light within the full brightness range. Value between 0 and 1
-	var/light_inner_range = 1 // range, in tiles, the light is at full brightness
-	var/light_outer_range = 0 // range, in tiles, where the light becomes darkness
-	var/light_falloff_curve = 2 // adjusts curve for falloff gradient. Must be greater than 0.
-	var/light_color		// Hexadecimal RGB string representing the colour of the light
+/// Float. Intensity of the light within the full brightness range. Value between 0 and 1. Do not modify directly. See `set_light()`.
+/atom/var/light_max_bright = 1.0
+/// Integer. Range, in tiles, the light is at full brightness. Do not modify directly. See `set_light()`.
+/atom/var/light_inner_range = 1
+/// Integer. Range, in tiles, where the light becomes darkness. Do not modify directly. See `set_light()`.
+/atom/var/light_outer_range = 0
+/// Integer. Adjusts curve for falloff gradient. Must be greater than 0. Do not modify directly. See `set_light()`.
+/atom/var/light_falloff_curve = 2
+/// String (Hexadecimal color code). The color of the light. Do not modify directly. See `set_light()`.
+/atom/var/light_color
 
-	var/datum/light_source/light
-	var/list/light_sources
+/// The light source datum handling rendering of the light defined in the `light_*` vars on this atom. See `set_light()` and `update_light()`.
+/atom/var/datum/light_source/light
+/// LAZYLIST of all light sources contained within the atom and its contents. Used to propagate updates whenever somehting, i.e. position, changes.
+/atom/var/list/light_sources
 
 // Nonsensical value for l_color default, so we can detect if it gets set to null.
 #define NONSENSICAL_VALUE -99999
 #define DEFAULT_FALLOFF_CURVE (2)
+
+/**
+ * Sets the atom's light values and color. Calls `update_light()`.
+ *
+ * **Parameters**:
+ * - `l_max_bright` float (0 to 1) - Intensity of the light within the full brightness range. Value between 0 and 1. Applied to `light_max_bright`.
+ * - `l_inner_range` integer - Range, in tiles, the light is at full brightness. Applied to `light_inner_range`.
+ * - `l_outer_range` integer - Range, in tiles, where the light becomes darkness. Do not modify directly. Applied to `light_outer_range`.
+ * - `l_falloff_curbe` integer (Default `NONSENSICAL_VALUE`) - Adjusts curve for falloff gradient. Must be greater than 0. Do not modify directly. Applied to `light_falloff_curve`.
+ * - `l_color` color (Default `NONSENSICAL_VALUE`) - The color of the light. Applied to `light_color`.
+ *
+ * Returns boolean. Whether or not the light was actually changed.
+ */
 /atom/proc/set_light(l_max_bright, l_inner_range, l_outer_range, l_falloff_curve = NONSENSICAL_VALUE, l_color = NONSENSICAL_VALUE)
 	. = 0 //make it less costly if nothing's changed
 
@@ -41,6 +60,9 @@
 #undef NONSENSICAL_VALUE
 #undef DEFAULT_FALLOFF_CURVE
 
+/**
+ * Updates the atom's light source datum. This is automatically called by `set_light()`.
+ */
 /atom/proc/update_light()
 	set waitfor = FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -895,6 +895,11 @@
 		remoteview_target = null
 		reset_view(0)
 
+/**
+ * Retrieves the atom's visible gender. Generally this is just `gender` but some factors may mask or change this.
+ *
+ * Returns a valid gender value. See DM documentation for `/mob/var/gender`.
+ */
 /atom/proc/get_visible_gender()
 	return gender
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -183,10 +183,16 @@
 			return TRUE
 	return FALSE
 
-// Returns an amount of power drawn from the object (-1 if it's not viable).
-// If drain_check is set it will not actually drain power, just return a value.
-// If surge is set, it will destroy/damage the recipient and not return any power.
-// Not sure where to define this, so it can sit here for the rest of time.
+/**
+ * Returns an amount of power drawn from the atom or `-1` if it's not viable.
+ *
+ * **Parameters**:
+ * - `drain_check` Boolean - If set, does not actually drain power, only returns an amount.
+ * - `surge` Boolean - If set, this will damage the recipient and not return any power.
+ * - `amount` - The amount of power to attempt to drain.
+ *
+ * Returns integer.
+ */
 /atom/proc/drain_power(drain_check,surge, amount = 0)
 	return -1
 

--- a/code/modules/mob/observer/freelook/ai/eye.dm
+++ b/code/modules/mob/observer/freelook/ai/eye.dm
@@ -73,6 +73,9 @@
 	destroy_eyeobj()
 	. = ..()
 
+/**
+ * Handles moving an AI's 'eye' to a location on click.
+ */
 /atom/proc/move_camera_by_click()
 	if(istype(usr, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = usr

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -63,10 +63,20 @@
 	pulling.forceMove(destination)
 	return 1
 
+/**
+ * Whether or not an atom can move through or onto the same tile as this atom. Primarily used for z-level transitioning in multi-z areas.
+ *
+ * By default, passes directly to `CanPass()` and also checks upward movement with climbable atoms.
+ *
+ * **Parameters**:
+ * - `mover` - The atom attempting to move onto `target`.
+ * - `target` - The originally targeted turf that `src `may be blocking.
+ * - `height` (float) -
+ * - `direction` (bitflag/direction) - The direction of movement. This should only ever be `DOWN` or `UP`.
+ *
+ * Returns boolean.
+ */
 /atom/proc/CanMoveOnto(atom/movable/mover, turf/target, height=1.5, direction = 0)
-	//Purpose: Determines if the object can move through this
-	//Uses regular limitations plus whatever we think is an exception for the purpose of
-	//moving up and down z levles
 	return CanPass(mover, target, height, 0) || (direction == DOWN && (atom_flags & ATOM_FLAG_CLIMBABLE))
 
 /mob/proc/can_overcome_gravity()

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -16,7 +16,7 @@
 	var/minimum_temperature_difference = 300
 	var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
 
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 
 /obj/machinery/atmospherics/pipe/zpipe/hide(i)
 	if(istype(loc, /turf/simulated))

--- a/code/modules/multiz/zmimic/mimic_common.dm
+++ b/code/modules/multiz/zmimic/mimic_common.dm
@@ -1,4 +1,8 @@
-// Updates whatever openspace components may be mimicing us. On turfs this queues an openturf update on the above openturf, on movables this updates their bound movable (if present). Meaningless on any type other than `/turf` or `/atom/movable` (incl. children).
+/**
+ * Updates whatever openspace components may be mimicing us. On turfs this queues an openturf update on the above
+ * openturf, on movables this updates their bound movable (if present). Meaningless on any type other than `/turf` or
+ * `/atom/movable` (incl. children).
+ */
 /atom/proc/update_above()
 	return
 

--- a/code/modules/nano/interaction/contained.dm
+++ b/code/modules/nano/interaction/contained.dm
@@ -9,6 +9,14 @@ GLOBAL_DATUM_INIT(contained_state, /datum/topic_state/contained_state, new)
 
 	return user.shared_nano_interaction()
 
+/**
+ * Recursively checks if this atom contains another atom in its contents, or contents of its contents.
+ *
+ * **Parameters**:
+ * - `location` - The atom to check for in contents.
+ *
+ * Returns boolean.
+ */
 /atom/proc/contains(atom/location)
 	if(!location)
 		return 0

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -59,7 +59,16 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 
 	return STATUS_CLOSE
 
-//Some atoms such as vehicles might have special rules for how mobs inside them interact with NanoUI.
+/**
+ * Handles additional special checks for whether or not NanoUI interactions are valid. Some atoms such as vehicles might
+ * have special rules for how mobs inside them interact with NanoUI.
+ *
+ * **Parameters**:
+ * - `src_object` - The original object being interacted with.
+ * - `user` - The mob attempting the interaction.
+ *
+ * Returns int (One of `STATUS_*`).
+ */
 /atom/proc/contents_nano_distance(src_object, mob/living/user)
 	return user.shared_living_nano_distance(src_object)
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -264,7 +264,7 @@
 		else
 			B.blood_DNA[source.data["blood_DNA"]] = "O+"
 
-	B.fluorescent  = 0
+	B.fluorescent  = ATOM_FLOURESCENCE_NONE
 	B.set_invisibility(0)
 	return B
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -31,6 +31,15 @@
 			return
 	A.attach_label(user, src, label)
 
+
+/**
+ * Handles attaching a labeller label to the atom.
+ *
+ * **Parameters**:
+ * - `user` - The mob attaching the label.
+ * - `labeler` - The labeler being used to attach the label.
+ * - `label_text` (string) - The text to be added as a label.
+ */
 /atom/proc/attach_label(user, atom/labeler, label_text)
 	to_chat(user, SPAN_NOTICE("The label refuses to stick to [name]."))
 

--- a/code/modules/power/cable_structure.dm
+++ b/code/modules/power/cable_structure.dm
@@ -23,7 +23,7 @@ By design, d1 is the smallest direction and d2 is the highest
 */
 
 /obj/structure/cable
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	anchored = TRUE
 	name = "power cable"
 	desc = "A flexible superconducting cable for heavy-duty power transfer."
@@ -54,7 +54,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/turf/turf = loc
 	if (!isturf(turf))
 		return INITIALIZE_HINT_QDEL
-	if (level == 1)
+	if (level == ATOM_LEVEL_UNDER_TILE)
 		hide(!turf.is_plating() && !turf.is_open())
 	GLOB.cable_list += src
 

--- a/code/modules/power/sensors/powernet_sensor.dm
+++ b/code/modules/power/sensors/powernet_sensor.dm
@@ -12,7 +12,7 @@
 	desc = "Small machine which transmits data about specific powernet."
 	anchored = TRUE
 	density = FALSE
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "floor_beacon" // If anyone wants to make better sprite, feel free to do so without asking me.
 

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -85,7 +85,7 @@
 /turf/singularity_act(S, current_size)
 	if(!is_plating())
 		for(var/obj/O in contents)
-			if(O.level != 1)
+			if(O.level != ATOM_LEVEL_UNDER_TILE)
 				continue
 			if(O.invisibility == 101)
 				O.singularity_act(src, current_size)

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -1,8 +1,14 @@
 #define I_SINGULO "singulo"
 
+/**
+ * Called when a singularity interacts with the atom.
+ */
 /atom/proc/singularity_act()
 	return
 
+/**
+ * Called when a singularity attempts to pull the atom toward it.
+ */
 /atom/proc/singularity_pull(S, current_size)
 	return
 
@@ -92,6 +98,11 @@
 /*******************
 * Nar-Sie Act/Pull *
 *******************/
+/**
+ * Whether or not a singularity can consume the atom.
+ *
+ *  Returns boolean.
+ */
 /atom/proc/singuloCanEat()
 	return 1
 

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -7,7 +7,7 @@
 	name = "terminal"
 	icon_state = "term"
 	desc = "It's an underfloor wiring terminal for power equipment."
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	layer = EXPOSED_WIRE_TERMINAL_LAYER
 	var/obj/item/stock_parts/power/terminal/master
 	anchored = TRUE
@@ -15,7 +15,7 @@
 /obj/machinery/power/terminal/New()
 	..()
 	var/turf/T = src.loc
-	if(level==1) hide(!T.is_plating())
+	if(level==ATOM_LEVEL_UNDER_TILE) hide(!T.is_plating())
 	return
 
 /obj/machinery/power/terminal/proc/master_machine()
@@ -24,7 +24,7 @@
 		return machine
 
 /obj/machinery/power/terminal/hide(do_hide)
-	if(do_hide && level == 1)
+	if(do_hide && level == ATOM_LEVEL_UNDER_TILE)
 		layer = WIRE_TERMINAL_LAYER
 	else
 		reset_plane_and_layer()

--- a/code/modules/psionics/null/_null.dm
+++ b/code/modules/psionics/null/_null.dm
@@ -1,3 +1,9 @@
+/**
+ * Whether or not this atom or its contents will disrupt psionics. Top-level proc recursively checks all contents.
+ *
+ * Returns instance of `/atom/movable` or `FALSE`. Either the atom that can disrupt psionics, or `FALSE` if nothing will
+ * disrupt.
+ */
 /atom/proc/disrupts_psionics()
 	for(var/thing in contents)
 		var/atom/movable/AM = thing

--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -49,6 +49,11 @@
 /obj
 	var/rad_resistance_modifier = 1  // Allow overriding rad resistance
 
+/**
+ * Retrieves the atom's current radiation level. By default, this will return `loc.get_rads()`.
+ *
+ * Returns integer.
+ */
 /atom/proc/get_rads()
 	if(loc)
 		return loc.get_rads()
@@ -57,7 +62,14 @@
 /turf/get_rads()
 	return SSradiation.get_rads_at_turf(src)
 
-// If people expand the system, this may be useful. Here as a placeholder until then
+/**
+ * Called when radiation affects the atom.
+ *
+ * **Parameters**:
+ * - `severity` - The amount of radiation being applied. Also see `RAD_LEVEL_*`.
+ *
+ * Returns boolean
+ */
 /atom/proc/rad_act(severity)
 	return 1
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -490,8 +490,17 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 			return TRUE
 	return FALSE
 
-/* Atom reagent creation - use it all the time */
-
+/**
+ * Creates a reagent holder for the atom. This shouldn't be used if a reagents holder already exists, but it will
+ * partially function by increasing the existing holder's maximum volume instead of creating a new one. If the existing
+ * holder's maximum already exceeded the given value, however, this will not reduce the volume.
+ *
+ * **Parameters**:
+ * - `max_vol` integer - The maximum volume of the new reagents holder.
+ *
+ * Returns instance of `/datum/reagents`. The newly created reagents holder or, if the atom already had a holder, the
+ * pre-existing holder.
+ */
 /atom/proc/create_reagents(max_vol)
 	if(reagents)
 		log_debug("Attempted to create a new reagents holder when already referencing one: [log_info_line(src)]")

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -9,7 +9,6 @@
 	anchored = FALSE
 	density = FALSE
 	matter = list(MATERIAL_STEEL = 1850)
-	level = 2
 	obj_flags = OBJ_FLAG_ROTATABLE
 	var/sort_type = ""
 	var/dpdir = 0	// directions as disposalpipe
@@ -67,7 +66,7 @@
 // hide called by levelupdate if turf intact status changes
 // change visibility status and force update of icon
 /obj/structure/disposalconstruct/hide(intact)
-	set_invisibility((intact && level==1) ? 101: 0)	// hide if floor is intact
+	set_invisibility((intact && level==ATOM_LEVEL_UNDER_TILE) ? 101: 0)	// hide if floor is intact
 	update()
 
 /obj/structure/disposalconstruct/proc/flip()
@@ -181,11 +180,11 @@
 /obj/structure/disposalconstruct/proc/wrench_down(anchor)
 	if(anchor)
 		anchored = TRUE
-		level = 1 // We don't want disposal bins to disappear under the floors
+		level = ATOM_LEVEL_UNDER_TILE // We don't want disposal bins to disappear under the floors
 		set_density(0)
 	else
 		anchored = FALSE
-		level = 2
+		level = ATOM_LEVEL_OVER_TILE
 		set_density(1)
 
 /obj/structure/disposalconstruct/machine/check_buildability(obj/structure/disposalpipe/CP, mob/user)

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	density = FALSE
 
-	level = 1			// underfloor only
+	level = ATOM_LEVEL_UNDER_TILE
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes
 	health_max = 10

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -8,7 +8,7 @@
 	active_power_usage = 2000
 	anchored = TRUE
 	density = FALSE
-	level = 1
+	level = ATOM_LEVEL_UNDER_TILE
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0


### PR DESCRIPTION
NUFC

- Adds documentation to `/atom` vars
- Converts some magic numbers/hardcoded values to defines
- Removes unused parameter from `HaxProximity()`
- Repaths certain procs defined as verbs to `/verb`
- Removes unused `temperature_expose()` proc
- Adds some TODOs to some documentation blocks to be dealt with in a separate PR