### PR TITLE
Fix heat overlay being clickable on low graphics

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -136,3 +136,4 @@
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "3"
 	render_target = HEAT_EFFECT_TARGET
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: An invisible 'HEAT' overlay no longer blocks interacting with your own tile or yourself when on the Low graphics quality preset.
/:cl: