### PR TITLE
Cult talisman refactor

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -576,6 +576,8 @@
 #include "code\game\gamemodes\cult\cultify\de-cultify.dm"
 #include "code\game\gamemodes\cult\cultify\mob.dm"
 #include "code\game\gamemodes\cult\cultify\turf.dm"
+#include "code\game\gamemodes\cult\talisman\emp.dm"
+#include "code\game\gamemodes\cult\talisman\stun.dm"
 #include "code\game\gamemodes\endgame\endgame.dm"
 #include "code\game\gamemodes\endgame\bluespace_jump\bluespace_jump.dm"
 #include "code\game\gamemodes\endgame\nuclear_explosion\nuclear_explosion.dm"

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -2,6 +2,21 @@
 	icon_state = "paper_talisman"
 	info = "<center><img src='talisman.png'></center><br/><br/>"
 	language = LANGUAGE_CULT
+	abstract_type = /obj/item/paper/talisman
+	/// String. The true name of the talisman exposed to cultists on examine.
+	var/talisman_name = "default"
+	/// String. The description of the talisman effect exposed to cultists on examine.
+	var/talisman_desc
+	/// Type or list of types. The type(s) that this talisman can be used on.
+	var/valid_target_type = /atom
+
+
+/obj/item/paper/talisman/examine(mob/user, distance)
+	. = ..()
+	if (iscultist(user))
+		to_chat(user, SPAN_OCCULT("This is \a [talisman_name] talisman."))
+		if (talisman_desc)
+			to_chat(user, SPAN_OCCULT("Effect: [talisman_desc]."))
 
 
 /obj/item/paper/talisman/attack_self(mob/living/user)
@@ -11,5 +26,73 @@
 		to_chat(user, "You see strange symbols on the paper. Are they supposed to mean something?")
 
 
-/obj/item/paper/talisman/attack(mob/living/M, mob/living/user)
+/obj/item/paper/talisman/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if (!can_invoke(target, user))
+		return
+
+	// Null rods block the talisman's effect but still consume it
+	var/obj/item/nullrod/nullrod = locate() in target
+	if (nullrod)
+		user.visible_message(
+			SPAN_DANGER("\The [user] invokes \the [src] at \the [target]!"),
+			SPAN_DANGER("You invoke \the [talisman_name] talisman at \the [target], but it fails and falls to dust!"),
+		)
+	else
+		user.visible_message(
+			SPAN_DANGER("\The [user] invokes \the [src] at \the [target]!"),
+			SPAN_DANGER("You invoke \the [talisman_name] talisman at \the [target]!")
+		)
+		admin_attack_log(user, target, "Used a talisman ([type]).", "Was victim of a talisman ([type]).", "used a talisman ([type]) on")
+		invoke(target, user)
+	user.say("Talisman {talisman_name}!", all_languages[LANGUAGE_CULT])
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.do_attack_animation(target)
+	qdel(src)
+
+
+/**
+ * Whether or not this talisman can be invoked on the target by the user.
+ *
+ * **Parameters**:
+ * - `target` - The targeted atom.
+ * - `user` - The mob attempting to invoke the talisman.
+ * - `silent` (boolean) - If set, `user` will not be given any feedback messages on why they cannot invoke the talisman.
+ *
+ * Returns boolean. Whether or not the talisman can be invoked.
+ */
+/obj/item/paper/talisman/proc/can_invoke(atom/target, mob/user)
+	if (!iscultist(user))
+		// No message here even if not silent for non-cultists.
+		return FALSE
+
+	if (valid_target_type)
+		if (islist(valid_target_type))
+			var/isvalid = FALSE
+			for (var/type in valid_target_type)
+				if (istype(target, type))
+					isvalid = TRUE
+					break
+			if (!isvalid)
+				to_chat(user, SPAN_WARNING("\The [talisman_name] talisman cannot be used on \the [target]."))
+				return FALSE
+		else if (!istype(target, valid_target_type))
+			to_chat(user, SPAN_WARNING("\The [talisman_name] talisman cannot be used on \the [target]."))
+			return FALSE
+
+
+	if (!target.Adjacent(user))
+		to_chat(user, SPAN_WARNING("You must be next to \the [target] to use \the [talisman_name] talisman on them."))
+		return FALSE
+
+	return TRUE
+
+
+/**
+ * Called when a user invokes the talisman against a target. Overrides should contain the code handling the talisman's actual effects. `can_invoke()` is already checked before this is called.
+ *
+ * **Parameters**:
+ * - `target` - The targeted atom.
+ * - `user` - The mob attempting to invoke the talisman.
+ */
+/obj/item/paper/talisman/proc/invoke(atom/target, mob/user)
 	return

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -11,6 +11,31 @@
 	var/valid_target_type = /atom
 
 
+/obj/item/paper/talisman/get_antag_info()
+	. = ..()
+	. += {"
+		<p>This is a [talisman_name] talisman. It [talisman_desc].</p>
+		<p>Talismans have a single use, and are deleted when used.</p>
+		<p>If used on a mob carrying a null rod, the talisman's effect will be blocked, but the talisman will still be consumed.</p>
+		<p>Only cultists can read or use a talisman. To any non-cultist mob, the talisman appears as a paper written in gibberish.</p>
+		<p>Talismans can be created by drawing and using an Imbue rune.</p>
+		<p>It can be used on the following types of atoms:</p>
+		<ul>
+	"}
+	if (islist(valid_target_type))
+		for (var/type in valid_target_type)
+			. += {"
+				<li>[type]</li>
+			"}
+	else
+		. += {"
+			<li>[valid_target_type]</li>
+		"}
+	. += {"
+		</ul>
+	"}
+
+
 /obj/item/paper/talisman/examine(mob/user, distance)
 	. = ..()
 	if (iscultist(user))

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -1,6 +1,5 @@
 /obj/item/paper/talisman
 	icon_state = "paper_talisman"
-	var/imbue = null
 	info = "<center><img src='talisman.png'></center><br/><br/>"
 	language = LANGUAGE_CULT
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -7,6 +7,8 @@
 	var/talisman_name = "default"
 	/// String. The description of the talisman effect exposed to cultists on examine.
 	var/talisman_desc
+	/// Sound file. The sound to play when the talisman is invoked.
+	var/talisman_sound
 	/// Type or list of types. The type(s) that this talisman can be used on.
 	var/valid_target_type = /atom
 
@@ -72,6 +74,8 @@
 	user.say("Talisman {talisman_name}!", all_languages[LANGUAGE_CULT])
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(target)
+	if (talisman_sound)
+		playsound(src, talisman_sound, 100, 1)
 	qdel(src)
 
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -4,55 +4,13 @@
 	info = "<center><img src='talisman.png'></center><br/><br/>"
 	language = LANGUAGE_CULT
 
+
 /obj/item/paper/talisman/attack_self(mob/living/user)
 	if(iscultist(user))
 		to_chat(user, "Attack your target to use this talisman.")
 	else
 		to_chat(user, "You see strange symbols on the paper. Are they supposed to mean something?")
 
+
 /obj/item/paper/talisman/attack(mob/living/M, mob/living/user)
 	return
-
-/obj/item/paper/talisman/stun/attack_self(mob/living/user)
-	if(iscultist(user))
-		to_chat(user, "This is a stun talisman.")
-	..()
-
-/obj/item/paper/talisman/stun/attack(mob/living/M, mob/living/user)
-	if(!iscultist(user))
-		return
-	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
-	var/obj/item/nullrod/nrod = locate() in M
-	if(nrod)
-		user.visible_message("<span class='danger'>\The [user] invokes \the [src] at [M], but they are unaffected.</span>", "<span class='danger'>You invoke \the [src] at [M], but they are unaffected.</span>")
-		return
-	else
-		user.visible_message("<span class='danger'>\The [user] invokes \the [src] at [M].</span>", "<span class='danger'>You invoke \the [src] at [M].</span>")
-
-	if(issilicon(M))
-		M.Weaken(15)
-		M.silent += 15
-	else if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.silent += 15
-		C.Weaken(20)
-		C.Stun(20)
-	admin_attack_log(user, M, "Used a stun talisman.", "Was victim of a stun talisman.", "used a stun talisman on")
-	user.unEquip(src)
-	qdel(src)
-
-/obj/item/paper/talisman/emp/attack_self(mob/living/user)
-	if(iscultist(user))
-		to_chat(user, "This is an emp talisman.")
-	..()
-
-/obj/item/paper/talisman/emp/afterattack(atom/target, mob/user, proximity)
-	if(!iscultist(user))
-		return
-	if(!proximity)
-		return
-	user.say("Ta'gh fara[pick("'","`")]qha fel d'amar det!")
-	user.visible_message("<span class='danger'>\The [user] invokes \the [src] at [target].</span>", "<span class='danger'>You invoke \the [src] at [target].</span>")
-	target.emp_act(1)
-	user.unEquip(src)
-	qdel(src)

--- a/code/game/gamemodes/cult/talisman/emp.dm
+++ b/code/game/gamemodes/cult/talisman/emp.dm
@@ -1,0 +1,19 @@
+/obj/item/paper/talisman/emp/attack_self(mob/living/user)
+	if(iscultist(user))
+		to_chat(user, "This is an emp talisman.")
+	..()
+
+
+/obj/item/paper/talisman/emp/afterattack(atom/target, mob/user, proximity)
+	if(!iscultist(user))
+		return
+	if(!proximity)
+		return
+	user.say("Ta'gh fara[pick("'","`")]qha fel d'amar det!")
+	user.visible_message(
+		SPAN_DANGER("\The [user] invokes \the [src] at [target]."),
+		SPAN_DANGER("You invoke \the [src] at [target].")
+	)
+	target.emp_act(1)
+	user.unEquip(src)
+	qdel(src)

--- a/code/game/gamemodes/cult/talisman/emp.dm
+++ b/code/game/gamemodes/cult/talisman/emp.dm
@@ -1,19 +1,11 @@
-/obj/item/paper/talisman/emp/attack_self(mob/living/user)
-	if(iscultist(user))
-		to_chat(user, "This is an emp talisman.")
-	..()
-
-
-/obj/item/paper/talisman/emp/afterattack(atom/target, mob/user, proximity)
-	if(!iscultist(user))
-		return
-	if(!proximity)
-		return
-	user.say("Ta'gh fara[pick("'","`")]qha fel d'amar det!")
-	user.visible_message(
-		SPAN_DANGER("\The [user] invokes \the [src] at [target]."),
-		SPAN_DANGER("You invoke \the [src] at [target].")
+/obj/item/paper/talisman/emp
+	talisman_name = "emp"
+	talisman_desc = "invokes a localized EMP effect on the target. Can be used on machinery or mobs"
+	valid_target_type = list(
+		/mob,
+		/obj/machinery
 	)
+
+
+/obj/item/paper/talisman/emp/invoke(atom/target, mob/user)
 	target.emp_act(1)
-	user.unEquip(src)
-	qdel(src)

--- a/code/game/gamemodes/cult/talisman/emp.dm
+++ b/code/game/gamemodes/cult/talisman/emp.dm
@@ -1,6 +1,7 @@
 /obj/item/paper/talisman/emp
 	talisman_name = "emp"
 	talisman_desc = "invokes a localized EMP effect on the target. Can be used on machinery or mobs"
+	talisman_sound = 'sound/effects/EMPulse.ogg'
 	valid_target_type = list(
 		/mob,
 		/obj/machinery

--- a/code/game/gamemodes/cult/talisman/stun.dm
+++ b/code/game/gamemodes/cult/talisman/stun.dm
@@ -1,34 +1,18 @@
-/obj/item/paper/talisman/stun/attack_self(mob/living/user)
-	if(iscultist(user))
-		to_chat(user, "This is a stun talisman.")
-	..()
+/obj/item/paper/talisman/stun
+	talisman_name = "stun"
+	talisman_desc = "temporarily stuns a targeted mob"
+	valid_target_type = list(
+		/mob/living/carbon,
+		/mob/living/silicon
+	)
 
 
-/obj/item/paper/talisman/stun/attack(mob/living/M, mob/living/user)
-	if(!iscultist(user))
-		return
-	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
-	var/obj/item/nullrod/nrod = locate() in M
-	if(nrod)
-		user.visible_message(
-			SPAN_DANGER("\The [user] invokes \the [src] at [M], but they are unaffected."),
-			SPAN_DANGER("You invoke \the [src] at [M], but they are unaffected.")
-		)
-		return
-	else
-		user.visible_message(
-			SPAN_DANGER("\The [user] invokes \the [src] at [M]."),
-			SPAN_DANGER("You invoke \the [src] at [M].")
-		)
-
-	if(issilicon(M))
-		M.Weaken(15)
-		M.silent += 15
-	else if(iscarbon(M))
-		var/mob/living/carbon/C = M
+/obj/item/paper/talisman/stun/invoke(mob/living/target, mob/user)
+	if(issilicon(target))
+		target.Weaken(15)
+		target.silent += 15
+	else if(iscarbon(target))
+		var/mob/living/carbon/C = target
 		C.silent += 15
 		C.Weaken(20)
 		C.Stun(20)
-	admin_attack_log(user, M, "Used a stun talisman.", "Was victim of a stun talisman.", "used a stun talisman on")
-	user.unEquip(src)
-	qdel(src)

--- a/code/game/gamemodes/cult/talisman/stun.dm
+++ b/code/game/gamemodes/cult/talisman/stun.dm
@@ -1,6 +1,7 @@
 /obj/item/paper/talisman/stun
 	talisman_name = "stun"
 	talisman_desc = "temporarily stuns a targeted mob"
+	talisman_sound = 'sound/weapons/flash.ogg'
 	valid_target_type = list(
 		/mob/living/carbon,
 		/mob/living/silicon

--- a/code/game/gamemodes/cult/talisman/stun.dm
+++ b/code/game/gamemodes/cult/talisman/stun.dm
@@ -1,0 +1,34 @@
+/obj/item/paper/talisman/stun/attack_self(mob/living/user)
+	if(iscultist(user))
+		to_chat(user, "This is a stun talisman.")
+	..()
+
+
+/obj/item/paper/talisman/stun/attack(mob/living/M, mob/living/user)
+	if(!iscultist(user))
+		return
+	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
+	var/obj/item/nullrod/nrod = locate() in M
+	if(nrod)
+		user.visible_message(
+			SPAN_DANGER("\The [user] invokes \the [src] at [M], but they are unaffected."),
+			SPAN_DANGER("You invoke \the [src] at [M], but they are unaffected.")
+		)
+		return
+	else
+		user.visible_message(
+			SPAN_DANGER("\The [user] invokes \the [src] at [M]."),
+			SPAN_DANGER("You invoke \the [src] at [M].")
+		)
+
+	if(issilicon(M))
+		M.Weaken(15)
+		M.silent += 15
+	else if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.silent += 15
+		C.Weaken(20)
+		C.Stun(20)
+	admin_attack_log(user, M, "Used a stun talisman.", "Was victim of a stun talisman.", "used a stun talisman on")
+	user.unEquip(src)
+	qdel(src)


### PR DESCRIPTION
Primarily refactoring which includes some user-facing tweaks/additions.


:cl: SierraKomodo
tweak: Using a cult talisman on a mob carrying a null rod now also deletes the talisman alongside the pre-existing behaviour of blocking the effects.
tweak: Cult Talismans can now only be invoked on certain types of atoms, depending on their effect. EMP talismans can be used on mobs or machinery, while stun talismans can only be used on carbon or silicon mobs. This also prevents accidentally burning a talisman on a turfor object when trying to click a moving target.
rscadd: Cult Talismans can now be examined to see the type of talisman and their effects, if you're a cultist.
rscadd: Cult talismans now have codex entries.
rscadd: Cult talismans now have a sound effect that plays when used. Stun talismans make the flash sound effect, EMP talismans make the EMP sound effect.
admin: All cult talismans now properly generate attack logs when used.
/:cl:


NUFC:
- Divided cult talismans into individual files.
- Moved talisman logic into `can_invoke()` and `invoke()` procs for override usage while maintaining common behaviour.
- Added a valid target type var to talismans so prevent accidentally proccing the talisman on a turf while trying to use it on a moving mob.