### PR TITLE
Add GAS bioprinter to medbay

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/cloning.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/cloning.dm
@@ -28,3 +28,19 @@
 		/obj/item/stock_parts/keyboard = 1,
 		/obj/item/stock_parts/power/apc/buildable = 1
 	)
+
+/obj/item/stock_parts/circuitboard/gasbioprinter
+	name = T_BOARD("serpentid bioprinter")
+	build_path = /obj/machinery/organ_printer/flesh/gas
+	board_type = "machine"
+	origin_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
+	req_components = list(
+		/obj/item/device/scanner/health = 1,
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/stock_parts/manipulator = 2
+	)
+	additional_spawn_components = list(
+		/obj/item/stock_parts/console_screen = 1,
+		/obj/item/stock_parts/keyboard = 1,
+		/obj/item/stock_parts/power/apc/buildable = 1
+	)

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -109,6 +109,13 @@
 	build_path = /obj/item/stock_parts/circuitboard/roboprinter
 	sort_string = "FAGAM"
 
+/datum/design/circuit/gasbioprinter
+	name = "serpentid bioprinter"
+	id = "gasbioprinter"
+	req_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
+	build_path = /obj/item/stock_parts/circuitboard/gasbioprinter
+	sort_string = "FAGAN"
+
 /datum/design/circuit/teleconsole
 	name = "teleporter control console"
 	id = "teleconsole"

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -25312,6 +25312,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/device/mmi,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "qkb" = (
@@ -28271,8 +28275,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/alarm/monitor{
 	alarm_id = "xenobio3_alarm";
-	req_access = list(list("ACCESS_RESEARCH","ACCESS_ATMOS","ACCESS_ENGINE_EQUIP"));
-	dir = 8
+	dir = 8;
+	req_access = list(list("ACCESS_RESEARCH","ACCESS_ATMOS","ACCESS_ENGINE_EQUIP"))
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/cell_3)
@@ -28388,10 +28392,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/closet/crate/freezer,
-/obj/item/device/mmi,
-/obj/item/reagent_containers/ivbag/nanoblood,
-/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/machinery/organ_printer/flesh/gas/mapped,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "tCO" = (


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: Medbay's OR 2 now has a bioprinter that can print certain GAS organs. This printer can _only_ print GAS organs and cannot be used without DNA specifically from a GAS.
/:cl:

Alternative to #32494