### PR TITLE
Adds MeatCubes to the SweatMAX

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -797,6 +797,7 @@
 					/obj/item/reagent_containers/food/drinks/glass2/fitnessflask/proteinshake = 8,
 					/obj/item/reagent_containers/food/drinks/glass2/fitnessflask = 8,
 					/obj/item/reagent_containers/food/snacks/proteinbar = 8,
+					/obj/item/reagent_containers/food/snacks/meatcube = 8,
 					/obj/item/reagent_containers/pill/diet = 8,
 					/obj/item/towel/random = 8)
 
@@ -806,6 +807,7 @@
 					/obj/item/reagent_containers/food/drinks/glass2/fitnessflask/proteinshake = 20,
 					/obj/item/reagent_containers/food/drinks/glass2/fitnessflask = 5,
 					/obj/item/reagent_containers/food/snacks/proteinbar = 5,
+					/obj/item/reagent_containers/food/snacks/meatcube = 10,
 					/obj/item/reagent_containers/pill/diet = 25,
 					/obj/item/towel/random = 40)
 


### PR DESCRIPTION
I feel like for an item that looks this cool, it's a shame it hasn't been utilized in game much at all since the removal of the MRE vendors.

Meatcubes are nowhere near as powerful as proteinshakes anyhow, so this is mostly just a style thing for those people that want to chomp down on a cube of meat.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->