### PR TITLE
Deck Four hallway modification

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -151,9 +151,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hangcheck)
 "aA" = (
-/obj/structure/sign/warning/pods/east,
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/center)
+/turf/simulated/floor/shuttle_ceiling/torch/air,
+/area/quartermaster/hangar/top)
 "aD" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
@@ -223,8 +222,15 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/starboard)
 "aY" = (
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/lounge)
 "bc" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -351,8 +357,9 @@
 /turf/space,
 /area/space)
 "bo" = (
-/turf/simulated/wall/prepainted,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/random/trash,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fourthdeck/forestarboard)
 "bt" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Emergency Storage"
@@ -775,9 +782,15 @@
 /turf/simulated/floor/wood,
 /area/command/captainmess)
 "cF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/brown{
+/obj/effect/floor_decal/corner/brown/half{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
@@ -1274,11 +1287,26 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/starboard)
 "ei" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "bottom-right"
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/reagent_containers/food/drinks/pitcher,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup/metal{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/button/blast_door{
+	pixel_x = 25;
+	pixel_y = 5;
+	name = "FCT Shutter Control";
+	id_tag = "Sup_Tower"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/flightcontrol)
 "ej" = (
 /turf/simulated/wall/prepainted,
 /area/storage/auxillary/starboard)
@@ -1754,11 +1782,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "fF" = (
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_y = -4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/wall/prepainted,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
 "fH" = (
 /obj/structure/cable/green{
@@ -1889,7 +1923,7 @@
 "gg" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "gh" = (
 /obj/structure/closet/crate/medical,
 /obj/random/medical,
@@ -2063,24 +2097,14 @@
 	dir = 8
 	},
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "gW" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "center-right"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/random/tech_supply,
+/obj/random/maintenance/solgov,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fourthdeck/port)
 "gX" = (
 /obj/structure/disposalpipe/down{
 	dir = 8
@@ -2206,9 +2230,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/commissary)
 "hh" = (
-/obj/structure/catwalk,
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/effect/floor_decal/corner/brown/three_quarters{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "hi" = (
 /obj/structure/disposalpipe/up,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -2541,7 +2568,22 @@
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod6/station)
 "ic" = (
-/obj/machinery/alarm,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "id" = (
@@ -2561,14 +2603,22 @@
 /area/maintenance/fourthdeck/starboard)
 "if" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "ig" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/wall/r_titanium,
 /area/shuttle/escape_pod7/station)
 "ii" = (
-/obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/brown{
 	dir = 8
 	},
@@ -2646,11 +2696,11 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 1
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "iM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2840,9 +2890,9 @@
 /area/crew_quarters/lounge)
 "js" = (
 /obj/structure/catwalk,
-/obj/machinery/light,
+/obj/machinery/light/spot,
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "ju" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -2939,7 +2989,7 @@
 	name = "Hangar Catwalk Access"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/hangar/catwalks_port)
+/area/hallway/primary/fourthdeck/center)
 "ka" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
@@ -2954,12 +3004,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "kb" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/effect/floor_decal/corner/brown/three_quarters,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "kc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera/network/command{
@@ -3036,21 +3083,32 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/commissary)
+"kk" = (
+/obj/machinery/door/airlock/mining{
+	name = "Flight Control Tower"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/quartermaster/flightcontrol)
 "kl" = (
 /turf/unsimulated/mask,
 /area/hallway/primary/fourthdeck/center)
 "ko" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_starboard)
+/turf/simulated/open,
+/area/quartermaster/hangar/top)
 "ks" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
@@ -3326,7 +3384,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "lo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/monotile,
@@ -3774,7 +3832,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "mD" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -3783,9 +3841,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "mG" = (
-/obj/structure/railing/mapped,
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "Sup_Tower";
+	name = "Control Tower Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/flightcontrol)
 "mH" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/janitor/storage)
@@ -4070,11 +4134,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
 "nG" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "top-left"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining{
+	name = "Hangar Catwalk Access"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/fourthdeck/aft)
 "nH" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -4342,12 +4407,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "oW" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/effect/floor_decal/corner/brown/three_quarters{
+	dir = 8
 	},
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "oZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
@@ -4432,12 +4496,15 @@
 /turf/simulated/floor/wood,
 /area/command/captainmess)
 "pz" = (
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Hangar Bridge";
+/obj/structure/bed/chair/office/light{
+	icon_state = "officechair_preview";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/quartermaster/flightcontrol)
 "pD" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -4459,8 +4526,9 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/lounge)
 "pI" = (
+/obj/structure/railing/mapped,
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "pJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4707,8 +4775,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "qx" = (
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/obj/machinery/space_heater,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fourthdeck/port)
 "qy" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Custodial Closet"
@@ -4724,11 +4794,9 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/janitor)
 "qz" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "bottom-left"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/obj/structure/sign/warning/pods/east,
+/turf/simulated/wall/mahogany,
+/area/command/captainmess)
 "qC" = (
 /obj/machinery/vending/tool/adherent,
 /obj/machinery/light{
@@ -4745,7 +4813,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "qM" = (
-/obj/machinery/rotating_alarm/security_alarm,
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "qQ" = (
@@ -4904,11 +4975,11 @@
 /area/hallway/primary/fourthdeck/center)
 "rm" = (
 /obj/structure/railing/mapped,
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 8
 	},
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "rn" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -4919,10 +4990,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
 "ro" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/shuttle_ceiling/torch/air,
+/area/quartermaster/hangar/top)
 "rp" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fourthdeck/center)
@@ -4980,6 +5052,13 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"rE" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "rF" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5445,23 +5524,31 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "sS" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "top-right"
+/obj/structure/catwalk,
+/obj/machinery/light/spot{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/turf/simulated/floor/shuttle_ceiling/torch/air,
+/area/quartermaster/hangar/top)
 "sZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "tc" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -6063,16 +6150,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/janitor/storage)
 "uB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Hangar Maintenance"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_starboard)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/hallway/primary/fourthdeck/center)
 "uH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6214,12 +6296,14 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/eva)
 "va" = (
-/obj/structure/catwalk,
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/effect/floor_decal/corner/brown/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "vb" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -6487,12 +6571,18 @@
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/commissary)
 "vH" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/center)
 "vJ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/no_grille,
@@ -6607,28 +6697,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "wl" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/primary/fourthdeck/aft)
 "wm" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/aft)
 "wn" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/center)
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/aft)
 "wp" = (
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced/airless,
@@ -6652,7 +6741,7 @@
 	name = "Hangar Maintenance"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "wt" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
@@ -6694,6 +6783,23 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/eva)
+"wB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "wC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6852,7 +6958,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "wT" = (
 /obj/effect/wallframe_spawn/no_grille,
 /obj/structure/disposalpipe/segment{
@@ -6959,15 +7065,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "xw" = (
-/obj/effect/floor_decal/scglogo,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
@@ -6991,10 +7099,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "xB" = (
-/obj/structure/closet/firecloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 8
+	},
+/obj/machinery/computer/ship/navigation{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/quartermaster/flightcontrol)
 "xE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/maintenance/solgov/clean,
@@ -7297,20 +7409,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "yp" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "yr" = (
 /obj/effect/shuttle_landmark/merc/dock,
 /turf/space,
@@ -7835,17 +7944,24 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "An" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "Ap" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/corner/brown{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/primary/fourthdeck/aft)
 "Aq" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -7858,12 +7974,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "Ar" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/brown/three_quarters{
 	dir = 4
 	},
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "At" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -8291,7 +8406,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "Ci" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -8302,16 +8417,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Cm" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/structure/table/standard{
+	name = "plastic table frame"
 	},
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/item/folder/yellow,
+/obj/item/device/binoculars,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/flightcontrol)
 "Cr" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -8365,8 +8480,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "CG" = (
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/flightcontrol)
 "CH" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -8804,7 +8930,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "EE" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -8913,31 +9039,40 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "EW" = (
-/obj/machinery/light/small{
+/obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Lounge Aft";
-	name = "security camera"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/center)
 "EY" = (
-/obj/item/paper_bin,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled,
+/area/quartermaster/flightcontrol)
 "EZ" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/item/device/radio/intercom/entertainment{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/random_multi/single_item/runtime,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled,
+/area/quartermaster/flightcontrol)
 "Fb" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -9181,14 +9316,8 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "FI" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/vending/snack{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
+/turf/simulated/wall/prepainted,
+/area/quartermaster/flightcontrol)
 "FK" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -9273,8 +9402,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
 "Ga" = (
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Gb" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -9375,36 +9515,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "Gq" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/obj/structure/reagent_dispensers/water_cooler{
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
+/obj/structure/largecrate,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fourthdeck/port)
 "Gr" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/closet/hydrant{
+	pixel_y = 32
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/vending/cigarette{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Gt" = (
 /obj/effect/shuttle_landmark/scavver_gantry/torch,
 /turf/space,
@@ -9565,16 +9692,14 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/item/storage/box/cups,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
-"GZ" = (
 /obj/machinery/vending/games{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
+"GZ" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/quartermaster/hangar/top)
 "Hd" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -9602,14 +9727,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "Hh" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "bottom-center"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/turf/simulated/open,
+/area/quartermaster/hangar/top)
 "Hm" = (
 /obj/structure/cable{
 	d1 = 16;
@@ -9691,21 +9810,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
-"HB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Lounge Maintenance"
+"Hy" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
+"HB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/lounge)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "HE" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/door/firedoor,
@@ -9843,11 +9963,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "Ic" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10068,12 +10183,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "II" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
 "IL" = (
 /obj/structure/catwalk,
@@ -10800,7 +10911,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "Lm" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -10920,9 +11031,11 @@
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
 "LI" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/floor_decal/corner/brown{
-	dir = 10
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
@@ -11051,26 +11164,19 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Ma" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
-"Mb" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/standard{
-	name = "plastic table frame"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_starboard)
+/area/quartermaster/hangar/top)
+"Mb" = (
+/obj/structure/table/rack,
+/obj/random/medical,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fourthdeck/port)
 "Mc" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/hull,
@@ -11138,6 +11244,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/adherent)
 "Mp" = (
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = -4
+	},
 /turf/simulated/wall/prepainted,
 /area/command/captainmess)
 "Mq" = (
@@ -11268,18 +11378,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hangcheck)
 "MF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_starboard)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "MH" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -11669,7 +11772,7 @@
 	dir = 4
 	},
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "NH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11679,13 +11782,17 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/starboard)
 "NL" = (
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/railing/mapped,
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/center)
 "NM" = (
 /obj/effect/fluid_mapped,
 /turf/simulated/floor/reinforced,
@@ -11780,6 +11887,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "NY" = (
@@ -12114,29 +12222,40 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "Pe" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
-"Pf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Hangar Maintenance"
+	name = "Lounge Maintenance"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/crew_quarters/lounge)
+"Pf" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 8
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/hailing,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/device/radio/intercom/hailing{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/flightcontrol)
 "Pg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12211,16 +12330,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "Pn" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Po" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -12251,12 +12373,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Pt" = (
-/obj/structure/catwalk,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/center)
 "Pu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12517,9 +12641,8 @@
 /area/quartermaster/storage/upper)
 "Qf" = (
 /obj/structure/catwalk,
-/obj/machinery/light,
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "Qg" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Emergency Storage"
@@ -12597,13 +12720,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "Qt" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 8
 	},
-/obj/machinery/recharger,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
+/obj/machinery/computer/modular/preset/dock{
+	dir = 4;
+	icon_state = "console"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/flightcontrol)
 "Qu" = (
 /obj/structure/table/standard,
 /obj/item/device/megaphone,
@@ -12816,12 +12944,18 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Rg" = (
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Rk" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13194,13 +13328,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "Sf" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 8;
-	icon_state = "console"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/random/torchcloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/fourthdeck/forestarboard)
 "Sg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/civilian{
@@ -13382,21 +13512,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "SA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/valve/shutoff/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
-/obj/machinery/atmospherics/valve/shutoff/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "SC" = (
 /obj/machinery/door/blast/shutters{
@@ -13763,25 +13889,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/center)
+"To" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/aft)
+"Tp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_starboard)
-"To" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/aft)
-"Tp" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Tr" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 8
@@ -13844,15 +13975,14 @@
 /turf/simulated/wall/prepainted,
 /area/storage/primary)
 "Tx" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+/obj/random/junk,
+/obj/random/trash,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "Tz" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -13934,16 +14064,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "TM" = (
-/obj/structure/railing/mapped{
-	dir = 1;
-	icon_state = "railing0-1"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/open,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "TN" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1331;
@@ -14070,13 +14203,14 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/janitor/storage)
 "Uj" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
+/obj/effect/floor_decal/corner/brown/three_quarters{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "Ul" = (
 /obj/machinery/light{
 	dir = 1
@@ -14302,7 +14436,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "UN" = (
 /turf/simulated/wall/prepainted,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "UQ" = (
 /obj/structure/catwalk,
 /obj/structure/ladder,
@@ -14371,22 +14505,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "UX" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "center-left"
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "UY" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -14670,9 +14795,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "VO" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/floor_decal/corner/brown/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "VQ" = (
 /obj/structure/lattice,
@@ -14768,7 +14894,7 @@
 "Wf" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "Wh" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -14818,11 +14944,9 @@
 /area/hallway/primary/fourthdeck/aft)
 "Wo" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Hangar Catwalk Access"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/effect/floor_decal/corner/brown/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/center)
 "Wp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -14981,9 +15105,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "WI" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/shuttle_ceiling/torch/air,
-/area/quartermaster/hangar/catwalks_starboard)
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "WJ" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -14999,8 +15125,9 @@
 /area/maintenance/fourthdeck/aft)
 "WM" = (
 /obj/structure/catwalk,
+/obj/machinery/light/spot,
 /turf/simulated/open,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "WN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15043,10 +15170,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "WQ" = (
-/obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/primary/fourthdeck/aft)
 "WR" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
@@ -15787,15 +15913,20 @@
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fourthdeck/fore)
 "YL" = (
-/obj/effect/floor_decal/scglogo{
-	icon_state = "top-center"
+/obj/machinery/light/spot{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/turf/simulated/open,
+/area/quartermaster/hangar/top)
 "YN" = (
 /turf/simulated/wall/prepainted,
 /area/janitor/storage)
+"YP" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/fourthdeck/center)
 "YQ" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -16008,17 +16139,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "Zq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -16157,8 +16284,13 @@
 /area/maintenance/fourthdeck/forestarboard)
 "ZI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/quartermaster/hangar/catwalks_port)
+/area/quartermaster/hangar/top)
 "ZJ" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -31780,12 +31912,12 @@ WR
 sH
 Yy
 rp
-pI
-pI
-pI
-pI
+Hh
+Hh
+Hh
+Hh
 rm
-WM
+Qf
 UN
 Sl
 BD
@@ -31982,12 +32114,12 @@ rl
 sI
 um
 rp
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-pI
-pI
-mG
-WM
+Qf
 UN
 Ww
 OM
@@ -32184,10 +32316,10 @@ rg
 UY
 QC
 vJ
-CG
-CG
-CG
-CG
+aA
+aA
+aA
+aA
 Wf
 gg
 ws
@@ -32386,10 +32518,10 @@ WC
 VJ
 QC
 vJ
-CG
-CG
-CG
-CG
+aA
+aA
+aA
+aA
 Wf
 gg
 UN
@@ -32588,10 +32720,10 @@ Xo
 sK
 up
 HE
-CG
-CG
-CG
-CG
+aA
+aA
+aA
+aA
 Wf
 gg
 Sd
@@ -32778,8 +32910,8 @@ uY
 YQ
 Qn
 QX
-bo
-bo
+er
+er
 fl
 TT
 TT
@@ -32981,14 +33113,14 @@ yB
 XI
 Xm
 bo
-MF
-ko
-WI
-WI
+pW
+rp
+Uj
+LI
 WI
 kb
 Wo
-za
+MF
 MW
 QC
 jY
@@ -33182,16 +33314,16 @@ af
 af
 UC
 Xh
-Pf
-Tm
+pW
+pW
 uB
-WI
+za
 Pn
 Tp
-Tp
-rp
+SA
+NL
 cF
-wl
+Tm
 ii
 rp
 EC
@@ -33384,22 +33516,22 @@ at
 af
 AD
 pW
-bo
+bN
 Sf
-Mb
-WI
-vH
-aY
-aY
-ro
-za
-Yn
-QC
-ro
-CG
-CG
-CG
-CG
+rp
+xw
+ic
+rp
+rp
+rp
+II
+II
+II
+rp
+aA
+aA
+aA
+aA
 Wf
 gg
 Yd
@@ -33590,18 +33722,18 @@ fd
 fd
 Mp
 Pt
-vH
-aY
-aY
-ro
-za
 Yn
-QC
+rp
+aA
 ro
-CG
-CG
-CG
-CG
+aA
+aA
+aA
+ro
+aA
+aA
+aA
+aA
 Wf
 gg
 Yd
@@ -33790,20 +33922,20 @@ gr
 Uo
 ij
 jn
-WI
-WI
+oW
+rE
 vH
-aY
-aY
-ro
-za
-Yn
-QC
-ro
-CG
-CG
-CG
-CG
+II
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 Wf
 gg
 Yd
@@ -33992,20 +34124,20 @@ Wx
 Xg
 dS
 jn
-WI
-Pn
-aY
-aY
-aY
-ro
 za
-sK
-QC
-ro
-CG
-CG
-CG
-CG
+NP
+Yn
+II
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 Wf
 gg
 Sd
@@ -34194,20 +34326,20 @@ gs
 hm
 dS
 jn
-WI
-vH
-aY
-aY
-rp
-fF
-rU
-Yn
-LI
+za
+NP
+MW
+II
 aA
-rp
-CG
-CG
-CG
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 Wf
 gg
 Yd
@@ -34396,21 +34528,21 @@ XG
 hn
 dS
 jn
-WI
-Cm
-aY
-aY
-rp
-An
-qx
+za
+NP
 Yn
-qx
-xB
-rp
-CG
-CG
-CG
-Wf
+II
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+wS
+Cg
 gg
 Yd
 XZ
@@ -34598,26 +34730,26 @@ Yu
 ho
 dS
 jn
-WI
-WI
-vH
-aY
-rp
-rp
+VO
 qM
-Yn
-NP
-wn
-rp
-CG
-CG
-CG
+fF
+II
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 Wf
+gg
+sS
 gg
 Yd
 ES
-TY
-Gp
+PK
+aY
 GY
 iS
 NX
@@ -34800,28 +34932,28 @@ XM
 hp
 Ol
 fd
-fd
-Pt
-vH
-aY
-aY
-ro
-nG
-UX
 qz
-ro
-CG
-CG
-CG
-CG
+rU
+EW
+rp
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 Wf
 js
-Sd
-EW
-PK
+FI
+FI
+FI
+FI
+FI
 Pe
-Qt
-iS
+Sd
+Sd
 YF
 zx
 Ss
@@ -35003,27 +35135,27 @@ hq
 LQ
 jq
 fd
-hh
-oW
-Ga
-Ga
-ro
+Hy
+MW
+rp
+rp
+rp
 YL
-xw
 Hh
-ro
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-pI
-pI
+Qf
 mG
-WM
-Yd
-Wh
-TY
+Pf
+Qt
+xB
+FI
 Gp
 Gq
-iS
+qx
 Ib
 eq
 IT
@@ -35205,26 +35337,26 @@ uy
 Uo
 Zd
 fd
-hh
+Gr
 TM
 Rg
 Ga
-ro
-sS
-gW
-ei
-ro
+rp
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-pI
-pI
+Qf
 mG
-WM
-Yd
+Cm
+pz
 EY
-FB
+FI
 Zp
-Ma
+HB
 HB
 Ic
 eq
@@ -35408,26 +35540,26 @@ Uo
 RC
 fd
 hh
-hh
-hh
-rp
-rp
-ic
+An
+YP
 Yn
-pz
-rp
-rp
+II
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-pI
-lk
-WM
-Yd
+Qf
+mG
+ei
+CG
 EZ
-TY
-Uj
+FI
+TW
 Tx
-iS
+UX
 Id
 eq
 IT
@@ -35611,25 +35743,25 @@ fd
 fd
 VW
 VW
-Pt
-rp
-II
-qx
+za
 Yn
-qx
-VO
-rp
+II
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-mG
 WM
-WM
-Sd
-Sd
 FI
-Gr
-GZ
-Sd
+FI
+kk
+FI
+FI
+GW
+GW
+GW
 Id
 Ss
 Ss
@@ -35813,25 +35945,25 @@ NM
 NM
 NM
 VW
-WI
-rp
-aA
-rU
+za
 Yn
-LI
-fF
-rp
+II
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-NL
-WM
+Qf
+Ma
 if
 yp
-Sd
-iS
-iS
-iS
-Sd
+GW
+Mb
+gW
+gW
+GW
 If
 kw
 XL
@@ -36015,18 +36147,18 @@ NM
 NM
 NM
 VW
-WI
-vH
-ro
 za
-SA
-QC
-ro
+MW
+II
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-mG
-WM
-WM
+Qf
+GZ
 ZI
 sZ
 eJ
@@ -36217,16 +36349,16 @@ Zy
 Zy
 Zy
 VW
-WI
-vH
-ro
-za
+rU
 Yn
-QC
-ro
+II
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
 pI
-pI
-mG
 Qf
 vQ
 uq
@@ -36419,17 +36551,17 @@ Lw
 Lf
 YC
 VW
-WI
-vH
-ro
 za
 Yn
-QC
-ro
+rp
+Hh
+Hh
+Hh
+ko
+Hh
+Hh
 pI
-pI
-mG
-WM
+Qf
 Cr
 Dr
 Em
@@ -36621,17 +36753,17 @@ Vh
 PZ
 oG
 mJ
-WI
-vH
-ro
 za
 Yn
-QC
-ro
+rp
+wn
+wn
+wn
+Xn
+Hh
+Hh
 pI
-pI
-mG
-WM
+Qf
 Cr
 Vw
 yy
@@ -36823,13 +36955,13 @@ QZ
 lt
 SE
 VW
-hh
-TM
-rp
+za
+wB
+NL
 Ap
 wl
 WQ
-rp
+Xn
 Lk
 Lk
 lk
@@ -37031,11 +37163,11 @@ Wo
 ru
 xJ
 RW
-jY
-WM
+nG
+Qf
 ND
 gU
-WM
+Qf
 vQ
 jB
 IF

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -915,15 +915,14 @@
 	sound_env = LARGE_ENCLOSED
 	req_access = list(access_hangar)
 
-/area/quartermaster/hangar/catwalks_port
-	name = "\improper Hangar Port Upper Walkway"
+/area/quartermaster/hangar/top
+	name = "\improper Hangar Upper Walkway"
 	req_access = list()
-	icon_state = "hangar_catwalk_p"
 
-/area/quartermaster/hangar/catwalks_starboard
-	name = "\improper Hangar Starboard Upper Walkway"
-	req_access = list()
-	icon_state = "hangar_catwalk_s"
+/area/quartermaster/flightcontrol
+	name = "\improper Flight Control Tower"
+	icon_state = "hangar"
+	req_access = list(access_hangar)
 
 // Research
 /area/rnd/canister


### PR DESCRIPTION
🆑 JoeyNosegay
tweak: Redirects deck four hallway
/🆑

Slightly redirects the deck four hallway around the hangar instead of threw it, re-adds flight control tower next to supply office.
Best of both worlds, regarding safe passage through deck 4 and an open, monitorable hangar.

Extra special thanks to gy1ta23 and Azlan

![image](https://user-images.githubusercontent.com/21371500/187811871-0cb15dd4-3f14-47ee-899d-420c6ec937f7.png)
