### PR TITLE
SSV anomaly and science equipment

### DIFF
--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -98,11 +98,12 @@ var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
 
 /datum/job/submap/skrellscoutship_crew/equip(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	. = ..(H, alt_title, branch, grade)	//passing through arguments
-	//Limited to subcastes that make sense on the vessel. No need for ground-forces or R&D on such a ship.
+	//Limited to subcastes that make sense on the vessel. No need for ground-forces on such a ship.
 	var/skrellscoutcastes = list(
 		"Malish-Katish" = list(
 			"Mero'ta-Ketish",
-			"Toglo'i-Ketish"
+			"Toglo'i-Ketish",
+			"Keloa-Ketish"
 		),
 		"Kanin-Katish" = list(
 			"Xiqarr-Ketish",

--- a/maps/away/skrellscoutship/skrellscoutship_areas.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_areas.dm
@@ -6,7 +6,7 @@
 
 /area/ship/skrellscoutship/solars
 	name = "\improper Solar Area"
-	
+
 /area/ship/skrellscoutship/crew/hallway/d1
 	name = "\improper Hallway - Deck 1"
 
@@ -16,7 +16,7 @@
 /area/ship/skrellscoutship/crew/rec
 	name = "\improper Recreational Area"
 	icon_state = "green"
-	
+
 /area/ship/skrellscoutship/crew/fit
 	name = "\improper Exercise Area"
 	icon_state = "green"
@@ -32,7 +32,7 @@
 /area/ship/skrellscoutship/robotics
 	name = "\improper Maintenance"
 	icon_state = "green"
-	
+
 /area/ship/skrellscoutship/maintenance/power
 	name = "\improper Engineering"
 	icon_state = "engine_smes"
@@ -41,11 +41,11 @@
 /area/ship/skrellscoutship/command/bridge
 	name = "\improper SSV Helm"
 	icon_state = "bridge"
-	
+
 /area/ship/skrellscoutship/command/armory
 	name = "\improper Armory"
 	icon_state = "shuttlered"
-	
+
 /area/ship/skrellscoutshuttle
 	name = "\improper SSV Shuttle"
 	icon_state = "bridge"
@@ -95,9 +95,9 @@
 	name = "\improper Medical Bay"
 	icon_state = "medbay"
 
-/area/ship/skrellscoutship/crew/kitchen
-	name = "\improper Galley"
-	icon_state = "kitchen"
+/area/ship/skrellscoutship/crew/labs
+	name = "\improper Research Labs"
+	icon_state = "labwing"
 
 /area/ship/skrellscoutship/maintenance/power
 	name = "\improper Engineering"

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -489,6 +489,7 @@
 "bQ" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/command/bridge)
 "bR" = (
@@ -1658,8 +1659,8 @@
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
 "fy" = (
-/obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/stasis_cage,
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/robotics)
 "fA" = (
@@ -2064,9 +2065,6 @@
 /area/ship/skrellscoutship/crew/rec)
 "gA" = (
 /obj/structure/table/woodentable/walnut,
-/obj/machinery/light/skrell{
-	dir = 4
-	},
 /obj/item/reagent_containers/food/drinks/glass2/coffeecup{
 	pixel_x = -6
 	},
@@ -2116,6 +2114,10 @@
 /area/ship/skrellscoutship/crew/rec)
 "gI" = (
 /obj/machinery/vending/dinnerware,
+/obj/machinery/light/skrell{
+	dir = 1;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/rec)
 "gK" = (
@@ -2271,6 +2273,10 @@
 "hf" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/machinery/light/skrell{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/rec)
 "hi" = (
@@ -2338,65 +2344,99 @@
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/rec)
 "ho" = (
-/obj/machinery/seed_storage/garden,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/cooker/oven,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/rec)
 "hp" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/reagent_temperature,
+/obj/machinery/light/skrell,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hr" = (
-/obj/machinery/smartfridge,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/structure/table/rack,
+/obj/item/stock_parts/capacitor/super,
+/obj/item/stock_parts/capacitor/super,
+/obj/item/stock_parts/capacitor/super,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/manipulator/pico,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/matter_bin/super,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/micro_laser/ultra,
+/obj/item/stock_parts/micro_laser/ultra,
+/obj/item/stock_parts/micro_laser/ultra,
+/obj/item/stock_parts/computer/tesla_link,
+/obj/item/stock_parts/computer/tesla_link,
+/obj/item/stock_parts/computer/tesla_link,
+/obj/item/stock_parts/scanning_module/phasic,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/computer/hard_drive/advanced,
+/obj/item/stock_parts/computer/nano_printer,
+/obj/item/stock_parts/computer/processor_unit/photonic,
+/obj/item/anobattery{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/scanning_module,
+/obj/machinery/light/skrell{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hs" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/structure/anomaly_container,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "ht" = (
-/obj/machinery/cooker/grill,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/labs)
 "hu" = (
-/obj/structure/table/standard,
-/obj/machinery/microwave,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/radiocarbon_spectrometer,
+/obj/machinery/light/skrell{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/labs)
 "hv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/command/bridge)
 "hx" = (
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/labs)
 "hy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/suspension_gen,
+/turf/simulated/floor/tiled/skrell,
+/area/ship/skrellscoutshuttle)
 "hz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hB" = (
 /obj/structure/flora/pottedplant,
 /turf/simulated/floor/carpet/purple,
@@ -2434,28 +2474,34 @@
 /turf/simulated/floor/tiled/skrell/blue,
 /area/ship/skrellscoutship/crew/rec)
 "hO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/smartfridge,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/rec)
 "hP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
+/obj/structure/table/rack,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
+"hQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
-"hQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8;
-	level = 2
-	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/structure/table/rack,
+/obj/item/storage/belt/archaeology,
+/obj/item/storage/belt/archaeology,
+/obj/item/pickaxe/xeno/drill/plasma,
+/obj/item/clothing/glasses/hud/science,
+/obj/item/storage/excavation,
+/obj/item/device/scanner/xenobio,
+/obj/item/device/measuring_tape,
+/obj/item/storage/box/evidence,
+/obj/item/device/scanner/mining,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2464,8 +2510,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hS" = (
 /obj/machinery/alarm/skrell{
 	dir = 1;
@@ -2476,8 +2522,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "hT" = (
 /obj/machinery/power/apc/critical{
 	name = "south bump";
@@ -2489,14 +2536,19 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
-"hU" = (
 /obj/structure/table/standard,
-/obj/machinery/reagentgrinder/juicer,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/item/device/scanner/spectrometer/adv,
+/obj/item/device/scanner/reagent,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
+"hU" = (
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/closet/toolcloset/excavation,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/labs)
 "hX" = (
 /obj/machinery/alarm/skrell{
 	pixel_y = 14
@@ -2527,7 +2579,7 @@
 /area/ship/skrellscoutship/command/bridge)
 "hY" = (
 /obj/machinery/door/airlock{
-	name = "Hydroponics"
+	name = "Laboratory"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2538,7 +2590,7 @@
 	},
 /obj/machinery/door/firedoor/autoset,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ship/skrellscoutship/crew/kitchen)
+/area/ship/skrellscoutship/crew/labs)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2898,6 +2950,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/wings/port)
 "iR" = (
@@ -3657,8 +3710,12 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "ng" = (
 /obj/machinery/light/skrell{
 	dir = 1
@@ -3714,7 +3771,7 @@
 /obj/effect/paint/black,
 /obj/effect/wallframe_spawn/reinforced_phoron/hull,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/ship/skrellscoutship/crew/kitchen)
+/area/ship/skrellscoutship/crew/labs)
 "nK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3754,10 +3811,6 @@
 /obj/structure/table/woodentable/walnut,
 /obj/item/reagent_containers/food/condiment/psilocybin{
 	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/space_drugs{
-	pixel_x = -4;
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/condiment/mindbreaker,
@@ -3819,8 +3872,8 @@
 /area/ship/skrellscoutship/command/bridge)
 "py" = (
 /obj/machinery/light/skrell,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
 	dir = 1;
@@ -4212,13 +4265,8 @@
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/hangar)
 "wi" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/skrell{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "wk" = (
 /obj/machinery/door/airlock/multi_tile/glass/engineering{
 	name = "Storage"
@@ -4236,13 +4284,10 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/dock)
 "wu" = (
-/obj/machinery/vending/hydronutrients{
-	categories = 3;
-	dir = 1
-	},
 /obj/machinery/light/skrell,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/rec)
 "wy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -4304,6 +4349,11 @@
 	},
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/hangar)
+"xF" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/rec)
 "xI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4403,7 +4453,7 @@
 /obj/effect/wallframe_spawn/reinforced_phoron/hull,
 /obj/effect/paint/black,
 /turf/simulated/floor/plating,
-/area/ship/skrellscoutship/crew/kitchen)
+/area/ship/skrellscoutship/crew/labs)
 "zl" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/skrell/blue,
@@ -4422,7 +4472,7 @@
 "zK" = (
 /obj/effect/paint/black,
 /turf/simulated/wall/r_wall,
-/area/ship/skrellscoutship/crew/kitchen)
+/area/ship/skrellscoutship/crew/labs)
 "zO" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/accessory/storage/black_vest,
@@ -4541,6 +4591,11 @@
 /obj/effect/paint/black,
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutship/crew/rec)
+"BH" = (
+/obj/structure/table/standard,
+/obj/machinery/reagent_temperature/cooler,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "BK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/paint/black,
@@ -4604,10 +4659,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/skrellscoutship/robotics)
 "CA" = (
-/obj/machinery/light/skrell{
-	dir = 4;
-	icon_state = "tube1"
-	},
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_alc/full,
 /turf/simulated/floor/tiled/skrell/white,
@@ -5093,10 +5144,9 @@
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/hangar)
 "Lj" = (
-/obj/machinery/cooker/oven,
-/obj/machinery/light/skrell,
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/labs)
 "Lr" = (
 /obj/structure/flora/pottedplant/mysterious,
 /turf/simulated/floor/tiled/skrell,
@@ -5152,7 +5202,20 @@
 /area/ship/skrellscoutship/wings/starboard)
 "Mm" = (
 /obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/machinery/reagentgrinder/juicer,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/material/hatchet,
+/obj/item/material/minihoe,
+/obj/item/seeds/ximikoa,
+/obj/item/seeds/ximikoa,
+/obj/item/seeds/ximikoa,
+/obj/item/seeds/okrri,
+/obj/item/seeds/okrri,
+/obj/item/seeds/okrri,
+/obj/item/seeds/qokkloa,
+/obj/item/seeds/qokkloa,
+/obj/item/seeds/qokkloa,
+/obj/item/reagent_containers/glass/bottle/eznutrient,
 /turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/rec)
 "Mw" = (
@@ -5244,6 +5307,17 @@
 	},
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/maintenance/power)
+"NK" = (
+/obj/structure/hygiene/sink/kitchen{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/light/skrell{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/rec)
 "NR" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/ivbag/nanoblood{
@@ -5499,6 +5573,11 @@
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
 /area/ship/skrellscoutshuttle)
+"Ql" = (
+/obj/machinery/artifact_analyser,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "Qp" = (
 /obj/machinery/alarm/skrell{
 	dir = 8;
@@ -5662,16 +5741,9 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutshuttle)
 "SS" = (
-/obj/structure/table/glass,
-/obj/item/material/hatchet,
-/obj/item/material/minihoe,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light/skrell{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "SY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/atmospherics/portables_connector,
@@ -5734,6 +5806,16 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/skrellscoutshuttle)
+"TZ" = (
+/obj/machinery/cooker/grill,
+/turf/simulated/floor/tiled/skrell/white,
+/area/ship/skrellscoutship/crew/rec)
+"Uf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "Uh" = (
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 1
@@ -5752,13 +5834,10 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutship/wings/port)
 "Uu" = (
+/obj/machinery/artifact_harvester,
 /obj/structure/table/standard,
-/obj/machinery/light/skrell{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/skrell/blue,
-/area/ship/skrellscoutship/crew/kitchen)
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/crew/labs)
 "UD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -6004,11 +6083,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/skrellscoutship/crew/quarters)
 "WZ" = (
-/obj/machinery/door/airlock{
-	name = "Living Area"
-	},
-/obj/machinery/door/firedoor/autoset,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/skrell/white,
 /area/ship/skrellscoutship/crew/rec)
 "Xl" = (
 /obj/structure/bed/chair/comfy/red{
@@ -6087,10 +6163,6 @@
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutshuttle)
 "Zp" = (
-/obj/machinery/light/skrell{
-	dir = 1;
-	icon_state = "tube1"
-	},
 /obj/item/device/radio/intercom/map_preset/skrellscoutship{
 	dir = 8;
 	pixel_x = 24
@@ -9625,9 +9697,9 @@ Rb
 AU
 AU
 AU
-AU
+TZ
+TL
 WZ
-AU
 AU
 QR
 kt
@@ -9726,11 +9798,11 @@ bH
 Rb
 Gw
 Gw
-zK
+AU
 ho
-hx
+TL
 wu
-zK
+AU
 kq
 tl
 nR
@@ -9828,11 +9900,11 @@ Rb
 Rb
 Gw
 Gw
-yV
-hp
-hx
+AU
+xF
+NK
 hO
-zK
+AU
 kq
 kt
 nR
@@ -9930,11 +10002,11 @@ Rb
 Gw
 Gw
 Gw
-yV
-SS
-hy
-hP
-nJ
+AU
+AU
+AU
+AU
+AU
 kq
 kt
 uk
@@ -10032,9 +10104,9 @@ Rb
 Gw
 Gw
 Gw
-yV
+zK
 hr
-hz
+hP
 hQ
 zK
 kq
@@ -10134,8 +10206,8 @@ Gw
 Gw
 Gw
 Gw
-zK
-hs
+yV
+wi
 hz
 nc
 zK
@@ -10237,7 +10309,7 @@ Gw
 Gw
 Gw
 yV
-hs
+wi
 hz
 py
 zK
@@ -10442,7 +10514,7 @@ Gw
 Gw
 yV
 hs
-hx
+Uf
 hS
 zK
 kq
@@ -10542,9 +10614,9 @@ Gw
 Gw
 Gw
 Gw
-zK
-hs
-hx
+yV
+Ql
+wi
 hT
 zK
 kq
@@ -10645,9 +10717,9 @@ Gw
 Gw
 Gw
 yV
-hp
-hx
-hx
+SS
+wi
+BH
 nJ
 kq
 kt
@@ -10748,7 +10820,7 @@ Gw
 Gw
 yV
 Uu
-hx
+wi
 hp
 zK
 kq
@@ -13300,7 +13372,7 @@ Le
 aM
 dy
 gf
-aT
+hy
 Wf
 cf
 aY

--- a/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_shuttles.dm
@@ -44,7 +44,7 @@
 		/area/ship/skrellscoutship/command/bridge, /area/ship/skrellscoutship/wings/port, /area/ship/skrellscoutship/wings/starboard,
 		/area/ship/skrellscoutship/brig, /area/ship/skrellscoutship/portcheckpoint, /area/ship/skrellscoutship/forestorage,
 		/area/ship/skrellscoutship/externalwing/port, /area/ship/skrellscoutship/externalwing/starboard, /area/ship/skrellscoutship/corridor,
-		/area/ship/skrellscoutship/crew/quarters, /area/ship/skrellscoutship/crew/medbay, /area/ship/skrellscoutship/crew/kitchen,
+		/area/ship/skrellscoutship/crew/quarters, /area/ship/skrellscoutship/crew/medbay, /area/ship/skrellscoutship/crew/labs,
 		/area/ship/skrellscoutship/maintenance/power, /area/ship/skrellscoutship/hangar, /area/ship/skrellscoutship/command/armory,
 		/area/ship/skrellscoutship/dock, /area/ship/skrellscoutship/maintenance/atmos, /area/ship/skrellscoutship/robotics,
 		/area/ship/skrellscoutship/crew/rec


### PR DESCRIPTION
🆑 JoeyNosegay
rscadd: Adds anomaly and science equipment to the warbleship
/🆑

Replaces the warbleships massive garden and kitchen with a more reasonable food prep area and a small lab with basic science and xenoarchaeology equipment.

Also allows spawning as the 'Keloa-Ketish' subcaste on warbleship. 

Areas in question:
![image](https://user-images.githubusercontent.com/21371500/187826272-f2922d8f-f32f-4063-b7e5-60c209c41fac.png)
![image](https://user-images.githubusercontent.com/21371500/187826281-336d7434-b447-4d0a-b278-4cecaa78c791.png)

Took the ship and shuttle for a few test flights, everything checks out!