### PR TITLE
RIGs balance changes

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -171,7 +171,7 @@
 
 
 /obj/item/rcd/mounted/useResource(amount, mob/user)
-	var/cost = amount*35 // About 9 deconstructions of walls on a good cell, less if it involves airlocks.
+	var/cost = amount*20 // About 5 deconstructions of walls on a standard cell (1k), less if it involves airlocks.
 	var/obj/item/cell/cell
 	if(istype(loc,/obj/item/rig_module))
 		var/obj/item/rig_module/module = loc

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -159,6 +159,15 @@
 	suit_type = "medical command hardsuit"
 	desc = "A specialized hardsuit rig control module issued to ranking medical officers of the Expeditionary Corps and their peers."
 	icon_state = "command_med_rig"
+	armor = list(
+		melee = ARMOR_MELEE_KNIVES,
+		bullet = ARMOR_BALLISTIC_SMALL,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+		)
 
 	chest_type = /obj/item/clothing/suit/space/rig/command/medical
 	helm_type = /obj/item/clothing/head/helmet/space/rig/command/medical
@@ -205,7 +214,7 @@
 	icon_state = "command_sec_rig"
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_PISTOL,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
 		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED,


### PR DESCRIPTION
:cl: Sbotkin
tweak: COS' RIG now offers better protection against ballistics, as intended.
tweak: CMO's RIG now offers better protection against radiation, on par with the rescue RIG.
tweak: RIG mounted RCD now consumes 43% less energy!
/:cl:

COS' RIG's buffs have been requested several times and apparently it was intended to be more ballistic-resistant.
CMO can now perform their duty during rad storms.
RIG mounted RCD has been buffed because otherwise you can only use it 3 times (changed to 5) on a standard cell (1k). Since the rigs are now much more punishing in terms of usage (no retraction), I think this is appropriate. For comparison, the standard RCD with full ammo allows for 13 usages.