### PR TITLE
Bloodbags

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -79,11 +79,29 @@
 	cost = 10
 	containername = "blood pack crate"
 
-/decl/hierarchy/supply_pack/medical/blood
+/decl/hierarchy/supply_pack/medical/nanoblood
 	name = "Refills - Nanoblood"
 	contains = list(/obj/item/reagent_containers/ivbag/nanoblood = 4)
-	cost = 15
+	cost = 30
 	containername = "nanoblood crate"
+
+/decl/hierarchy/supply_pack/medical/humanblood
+	name = "Refills - Human O- Blood"
+	contains = list(/obj/item/reagent_containers/ivbag/blood/OMinus = 4)
+	cost = 15
+	containername = "human O- blood crate"
+
+/decl/hierarchy/supply_pack/medical/skrellblood
+	name = "Refills - Skrell O- Blood"
+	contains = list(/obj/item/reagent_containers/ivbag/blood/OMinus/skrell = 4)
+	cost = 20
+	containername = "skrell blood crate"
+
+/decl/hierarchy/supply_pack/medical/unathiblood
+	name = "Refills - Unathi O- Blood"
+	contains = list(/obj/item/reagent_containers/ivbag/blood/OMinus/unathi = 4)
+	cost = 20
+	containername = "unathi blood crate"
 
 /decl/hierarchy/supply_pack/medical/bodybag
 	name = "Equipment - Body bags"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -84,12 +84,21 @@
 /obj/item/reagent_containers/ivbag/blood
 	name = "blood pack"
 	var/blood_type = null
+	var/blood_species = SPECIES_HUMAN
 
 /obj/item/reagent_containers/ivbag/blood/New()
 	..()
 	if(blood_type)
-		name = "blood pack [blood_type]"
-		reagents.add_reagent(/datum/reagent/blood, volume, list("donor" = null, "blood_DNA" = null, "blood_type" = blood_type, "trace_chem" = null))
+		var/datum/species/species = all_species[blood_species]
+		name = "blood pack [blood_type] ([blood_species])"
+		reagents.add_reagent(/datum/reagent/blood, volume, list(
+			"donor" = null,
+			"blood_DNA" = null,
+			"blood_type" = blood_type,
+			"trace_chem" = null,
+			"blood_species" = blood_species,
+			"blood_colour" = species.blood_color
+		))
 
 /obj/item/reagent_containers/ivbag/blood/APlus
 	blood_type = "A+"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -117,3 +117,9 @@
 
 /obj/item/reagent_containers/ivbag/blood/OMinus
 	blood_type = "O-"
+
+/obj/item/reagent_containers/ivbag/blood/OMinus/skrell
+	blood_species = SPECIES_SKRELL
+
+/obj/item/reagent_containers/ivbag/blood/OMinus/unathi
+	blood_species = SPECIES_UNATHI

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2183,10 +2183,10 @@
 /obj/item/reagent_containers/ivbag/blood/OMinus,
 /obj/item/reagent_containers/ivbag/blood/OMinus,
 /obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus/skrell,
+/obj/item/reagent_containers/ivbag/blood/OMinus/skrell,
+/obj/item/reagent_containers/ivbag/blood/OMinus/unathi,
+/obj/item/reagent_containers/ivbag/blood/OMinus/unathi,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "IV Equipment Cabinet";
 	pixel_y = 32

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2179,10 +2179,14 @@
 	},
 /obj/item/reagent_containers/ivbag,
 /obj/item/reagent_containers/ivbag,
-/obj/item/reagent_containers/ivbag/nanoblood,
-/obj/item/reagent_containers/ivbag/nanoblood,
-/obj/item/reagent_containers/ivbag/nanoblood,
-/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "IV Equipment Cabinet";
 	pixel_y = 32
@@ -25351,8 +25355,10 @@
 /obj/machinery/light,
 /obj/structure/closet/crate/freezer,
 /obj/item/device/mmi,
-/obj/item/reagent_containers/ivbag/nanoblood,
-/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qqb" = (
@@ -28382,8 +28388,10 @@
 	},
 /obj/structure/closet/crate/freezer,
 /obj/item/device/mmi,
-/obj/item/reagent_containers/ivbag/nanoblood,
-/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "tCO" = (


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Bloodbags now spawn with the correct blood color based on their initial contents.
maptweak: Medbay's nanoblood supply has been replaced with O- human blood. The number of pre-filled blood bags has been doubled to counter the reduced efficiency compared to nanoblood bags. Two packs of skrellian and two packs of unathi blood has also been added to the blood locker.
rscadd: Human, unathi, and skrell O- blood packs are now available through supply. Costs of nanoblood and blood packs have been adjusted: Nanoblood is now 30 credits, skrell and unathi blood is 20 credits, and human blood is 15.
/:cl: