### PR TITLE
Fixes issues with GAS climbing instead of flying sometimes

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -11,12 +11,12 @@
 	SelfMove(DOWN)
 
 /mob/proc/move_up()
-	SelfMove(UP)
+	return SelfMove(UP)
 
 /mob/living/carbon/human/move_up()
 	var/turf/old_loc = loc
-	..()
-	if(loc != old_loc)
+	. = ..()
+	if(. || loc != old_loc)
 		return
 
 	var/turf/simulated/open/O = GetAbove(src)


### PR DESCRIPTION
Apparently move up can fail to move up due to move delay then immediately try to climb. Small issue that confused some players