### PR TITLE
Fix SFV Arbiter access, add syndicate ids

### DIFF
--- a/maps/event/sfv_arbiter/sfv_arbiter.dm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dm
@@ -37,4 +37,4 @@
 	name = "\improper SFV Arbiter"
 	icon_state = "yellow"
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
-	req_access = list(access_cent_general)
+	req_access = list(access_syndicate)

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -287,6 +287,12 @@
 /obj/item/clothing/suit/storage/solgov/service/fleet/officer,
 /obj/item/clothing/suit/storage/solgov/service/fleet/snco,
 /obj/item/clothing/suit/storage/solgov/service/fleet/snco,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "kF" = (


### PR DESCRIPTION
:cl: Mucker
admin: The SFV Arbiter now uses access_syndicate instead of centcom.
admin: Added some agent IDs to the SFV Arbiter.
/:cl:

Syndicate IDs are easily edited so I figured it would be better for the shuttle to use them over centcom access.