### PR TITLE
Reduces BSD's power draw

### DIFF
--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 	pixel_y = -32
 	pixel_x = -32
-	idle_power_usage = 150 KILOWATTS
+	idle_power_usage = 15 KILOWATTS
 	construct_state = /decl/machine_construction/default/panel_closed
 	health_max = 1000
 	health_resistances = DAMAGE_RESIST_ELECTRICAL


### PR DESCRIPTION
:cl: Ryan180602
tweak: Reduces BSD power draw to 15kW
/:cl:

This will ensure solars can keep telecomms running for longer as it used to.