### PR TITLE
remove as x from procs

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -120,7 +120,7 @@
 	var/turf/x2y2 = locate(((centre.x+rad)>world.maxx ? world.maxx : centre.x+rad),((centre.y+rad)>world.maxy ? world.maxy : centre.y+rad),centre.z)
 	return block(x1y1,x2y2)
 
-/proc/get_dist_euclidian(atom/Loc1 as turf|mob|obj,atom/Loc2 as turf|mob|obj)
+/proc/get_dist_euclidian(atom/Loc1,atom/Loc2)
 	var/dx = Loc1.x - Loc2.x
 	var/dy = Loc1.y - Loc2.y
 

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -881,7 +881,7 @@ arguments tx, ty, tz are target coordinates (requred), range defines render dist
 cap_mode is capturing mode (optional), user is capturing mob (requred only wehen cap_mode = CAPTURE_MODE_REGULAR),
 lighting determines lighting capturing (optional), suppress_errors suppreses errors and continues to capture (optional).
 */
-/proc/generate_image(tx as num, ty as num, tz as num, range as num, cap_mode = CAPTURE_MODE_PARTIAL, mob/living/user, lighting = 1, suppress_errors = 1)
+/proc/generate_image(tx, ty, tz, range, cap_mode = CAPTURE_MODE_PARTIAL, mob/living/user, lighting = 1, suppress_errors = 1)
 	var/list/turfstocapture = list()
 	//Lines below determine what tiles will be rendered
 	for(var/xoff = 0 to range)

--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -97,7 +97,7 @@ var/global/list/delta_index = list(
 	return list(mult,0,0, 0,mult,0, 0,0,mult, add,add,add)
 
 //Exxagerates or removes colors
-/proc/color_saturation(value as num)
+/proc/color_saturation(value)
 	if(value == 0)
 		return color_identity()
 	value = clamp(value, -100, 100)

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -14,7 +14,7 @@
  */
 
 // Run all strings to be used in an SQL query through this proc first to properly escape out injection attempts.
-/proc/sanitizeSQL(t as text)
+/proc/sanitizeSQL(t)
 	var/sqltext = dbcon.Quote(t);
 	return copytext(sqltext, 2, length(sqltext));//Quote() adds quotes around input, we already do that
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -904,7 +904,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	return TRUE
 
 
-/proc/is_hot(obj/item/W as obj)
+/proc/is_hot(obj/item/W)
 	switch(W.type)
 		if(/obj/item/weldingtool)
 			var/obj/item/weldingtool/WT = W
@@ -940,14 +940,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			return 0
 
 //Whether or not the given item counts as sharp in terms of dealing damage
-/proc/is_sharp(obj/O as obj)
+/proc/is_sharp(obj/O)
 	if (!O) return 0
 	if (O.sharp) return 1
 	if (O.edge) return 1
 	return 0
 
 //Whether or not the given item counts as cutting with an edge in terms of removing limbs
-/proc/has_edge(obj/O as obj)
+/proc/has_edge(obj/O)
 	if (!O) return 0
 	if (O.edge) return 1
 	return 0

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -92,7 +92,7 @@
  * **Parameters**:
  * - `user` - The mob clicking on the atom.
  */
-/atom/proc/attack_ai(mob/user as mob)
+/atom/proc/attack_ai(mob/user)
 	return
 
 /*

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -239,7 +239,7 @@
 
 // In case of use break glass
 /*
-/atom/proc/MiddleClick(mob/M as mob)
+/atom/proc/MiddleClick(mob/M)
 	return
 */
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -176,6 +176,6 @@
 	A.attack_robot(src)
 	return TRUE
 
-/atom/proc/attack_robot(mob/user as mob)
+/atom/proc/attack_robot(mob/user)
 	attack_ai(user)
 	return

--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -51,7 +51,7 @@
  * **Parameters**:
  * - `user` - The mob clicking on the atom.
  */
-/atom/proc/attack_ghost(mob/observer/ghost/user as mob)
+/atom/proc/attack_ghost(mob/observer/ghost/user)
 	if(!istype(user))
 		return
 	if(user.client && user.client.inquisitive_ghost)
@@ -59,6 +59,6 @@
 	return
 
 
-/obj/effect/portal/attack_ghost(mob/user as mob)
+/obj/effect/portal/attack_ghost(mob/user)
 	if(target)
 		user.forceMove(get_turf(target))

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -313,7 +313,7 @@ var/global/datum/controller/radio/radio_controller
 /datum/controller/radio
 	var/list/datum/radio_frequency/frequencies = list()
 
-/datum/controller/radio/proc/add_object(obj/device as obj, new_frequency as num, object_filter = null as text|null)
+/datum/controller/radio/proc/add_object(obj/device, new_frequency, object_filter = null)
 	var/f_text = num2text(new_frequency)
 	var/datum/radio_frequency/frequency = frequencies[f_text]
 
@@ -338,7 +338,7 @@ var/global/datum/controller/radio/radio_controller
 
 	return 1
 
-/datum/controller/radio/proc/return_frequency(new_frequency as num)
+/datum/controller/radio/proc/return_frequency(new_frequency)
 	var/f_text = num2text(new_frequency)
 	var/datum/radio_frequency/frequency = frequencies[f_text]
 
@@ -353,7 +353,7 @@ var/global/datum/controller/radio/radio_controller
 	var/frequency as num
 	var/list/list/obj/devices = list()
 
-/datum/radio_frequency/proc/post_signal(obj/source as obj|null, datum/signal/signal, radio_filter = null as text|null, range = null as num|null)
+/datum/radio_frequency/proc/post_signal(obj/source, datum/signal/signal, radio_filter = null, range = null)
 	var/turf/start_point
 	if(range)
 		start_point = get_turf(source)
@@ -387,7 +387,7 @@ var/global/datum/controller/radio/radio_controller
 
 		device.receive_signal(signal, TRANSMISSION_RADIO, frequency)
 
-/datum/radio_frequency/proc/add_listener(obj/device as obj, radio_filter as text|null)
+/datum/radio_frequency/proc/add_listener(obj/device, radio_filter)
 	if (!radio_filter)
 		radio_filter = RADIO_DEFAULT
 	var/list/obj/devices_line = devices[radio_filter]

--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -63,7 +63,7 @@
 	holstered = null
 	atom_holder.SetName(initial(atom_holder.name))
 
-/datum/extension/holster/proc/unholster(mob/user as mob, avoid_intent = FALSE)
+/datum/extension/holster/proc/unholster(mob/user, avoid_intent = FALSE)
 	if(!holstered)
 		return 0
 	if(user.get_active_hand() && user.get_inactive_hand())

--- a/code/datums/helper_datums/events.dm
+++ b/code/datums/helper_datums/events.dm
@@ -2,7 +2,7 @@
 	var/list/events = list()
 
 
-/datum/events/proc/addEventType(event_type as text)
+/datum/events/proc/addEventType(event_type)
 	if (!(event_type in events) || !islist(events[event_type]))
 		events[event_type] = list()
 		return TRUE
@@ -10,7 +10,7 @@
 
 // Arguments: event_type as text, proc_holder as datum, proc_name as text
 // Returns: New event, null on error.
-/datum/events/proc/addEvent(event_type as text, proc_holder, proc_name as text)
+/datum/events/proc/addEvent(event_type, proc_holder, proc_name)
 	if (!event_type || !proc_holder || !proc_name)
 		return
 	addEventType(event_type)

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -74,7 +74,7 @@
 					break
 	return .
 
-/datum/recipe/proc/check_items(obj/container as obj)
+/datum/recipe/proc/check_items(obj/container)
 	. = 1
 	if (items && items.len)
 		var/list/checklist = list()
@@ -96,7 +96,7 @@
 	return .
 
 //general version
-/datum/recipe/proc/make(obj/container as obj)
+/datum/recipe/proc/make(obj/container)
 	var/obj/result_obj = new result(container)
 	for (var/obj/O in (container.InsertedContents()-result_obj))
 		O.reagents.trans_to_obj(result_obj, O.reagents.total_volume)
@@ -105,7 +105,7 @@
 	return result_obj
 
 // food-related
-/datum/recipe/proc/make_food(obj/container as obj)
+/datum/recipe/proc/make_food(obj/container)
 	if(!result)
 		log_error("<span class='danger'>Recipe [type] is defined without a result, please bug this.</span>")
 		return

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -126,7 +126,7 @@
 		qdel(O)
 	return result_obj
 
-/proc/select_recipe(list/datum/recipe/avaiable_recipes, obj/obj as obj, exact)
+/proc/select_recipe(list/datum/recipe/avaiable_recipes, obj/obj, exact)
 	var/list/datum/recipe/possible_recipes = new
 	var/target = exact ? 0 : 1
 	for (var/datum/recipe/recipe in avaiable_recipes)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -99,7 +99,7 @@
 
 //return flags that should be added to the viewer's sight var.
 //Otherwise return a negative number to indicate that the view should be cancelled.
-/atom/proc/check_eye(user as mob)
+/atom/proc/check_eye(user)
 	if (istype(user, /mob/living/silicon/ai)) // WHYYYY
 		return 0
 	return -1
@@ -117,7 +117,7 @@
 /atom/proc/on_color_transfer_reagent_change()
 	return
 
-/atom/proc/Bumped(AM as mob|obj)
+/atom/proc/Bumped(AM)
 	return
 
 // Convenience proc to see if a container is open for chemistry handling
@@ -132,7 +132,7 @@
 
 // If you want to use this, the atom must have the PROXMOVE flag, and the moving
 // atom must also have the PROXMOVE flag currently to help with lag. ~ ComicIronic
-/atom/proc/HasProximity(atom/movable/AM as mob|obj)
+/atom/proc/HasProximity(atom/movable/AM)
 	return
 
 /atom/proc/emp_act(severity)
@@ -156,7 +156,7 @@
 	P.on_hit(src, 0, def_zone)
 	. = 0
 
-/atom/proc/in_contents_of(container)//can take class or object instance as argument
+/atom/proc/in_contents_of(container)//can take class or object instance
 	if(ispath(container))
 		if(istype(src.loc, container))
 			return 1
@@ -262,7 +262,7 @@
 		M.apply_damage(TT.speed * 5, DAMAGE_BRUTE)
 
 //returns 1 if made bloody, returns 0 otherwise
-/atom/proc/add_blood(mob/living/carbon/human/M as mob)
+/atom/proc/add_blood(mob/living/carbon/human/M)
 	if(atom_flags & ATOM_FLAG_NO_BLOOD)
 		return 0
 

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -667,7 +667,7 @@ var/global/list/datum/absorbed_dna/hivemind_bank = list()
 	//STINGS//	//They get a pretty header because there's just so fucking many of them ;_;
 	//////////
 
-/mob/proc/sting_can_reach(mob/M as mob, sting_range = 1)
+/mob/proc/sting_can_reach(mob/M, sting_range = 1)
 	if(M.loc == src.loc)
 		return 1 //target and source are in the same thing
 	if(!isturf(src.loc) || !isturf(M.loc))

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -40,7 +40,7 @@
 
 	return 1
 
-/obj/item/melee/cultblade/pickup(mob/living/user as mob)
+/obj/item/melee/cultblade/pickup(mob/living/user)
 	if(!iscultist(user))
 		to_chat(user, "<span class='warning'>An overwhelming feeling of dread comes over you as you pick up the cultist's sword. It would be wise to be rid of this blade quickly.</span>")
 		user.make_dizzy(120)

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -49,7 +49,7 @@
 
 
 //maybe this proc can even be used as an admin tool for teleporting players without ruining immulsions?
-/proc/create_wormhole(turf/enter as turf, turf/exit as turf)
+/proc/create_wormhole(turf/enter, turf/exit)
 	var/obj/effect/portal/P = new /obj/effect/portal(enter)
 	P.target = exit
 	P.creator = null

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -205,7 +205,7 @@ var/global/list/meteors_cataclysm = list(\
 /obj/effect/meteor/ex_act()
 	return
 
-/obj/effect/meteor/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/effect/meteor/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/pickaxe))
 		qdel(src)
 		return

--- a/code/game/gamemodes/wizard/servant_items/champion.dm
+++ b/code/game/gamemodes/wizard/servant_items/champion.dm
@@ -72,7 +72,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cleaved", "sundered")
 
-/obj/item/excalibur/pickup(mob/living/user as mob)
+/obj/item/excalibur/pickup(mob/living/user)
 	if(user.mind)
 		if(!GLOB.wizards.is_antagonist(user.mind) || user.mind.special_role != ANTAG_SERVANT)
 			START_PROCESSING(SSobj, src)

--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -26,7 +26,7 @@
 	user.visible_message("\The [user] [!on?"dea":"a"]ctivates \the [src].", "You switch [src] [on? "on" : "off"]")
 	return TRUE
 
-/obj/machinery/cablelayer/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/cablelayer/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/stack/cable_coil))
 
 		var/result = load_cable(O)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -132,7 +132,7 @@
 /obj/machinery/optable/Process()
 	check_victim()
 
-/obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)
+/obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user)
 	if (C == user)
 		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
 	else
@@ -167,7 +167,7 @@
 
 	take_victim(usr,usr)
 
-/obj/machinery/optable/proc/check_table(mob/living/carbon/patient as mob)
+/obj/machinery/optable/proc/check_table(mob/living/carbon/patient)
 	check_victim()
 	if(src.victim && get_turf(victim) == get_turf(src) && victim.lying)
 		to_chat(usr, "<span class='warning'>\The [src] is already occupied!</span>")

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -808,7 +808,7 @@
 			apply_mode()
 			return TOPIC_REFRESH
 
-/obj/machinery/alarm/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/alarm/attackby(obj/item/W, mob/user)
 	switch(buildstage)
 		if(2)
 			if(isScrewdriver(W))  // Opening that Air Alarm up.
@@ -988,7 +988,7 @@ FIRE ALARM
 		alarm(rand(30/severity, 60/severity))
 	..()
 
-/obj/machinery/firealarm/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/firealarm/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		update_icon()

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -225,7 +225,7 @@
 		healthcheck()
 	..()
 
-/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W, mob/user)
 	if(!isWrench(W) && !istype(W, /obj/item/tank) && !istype(W, /obj/item/device/scanner/gas) && !istype(W, /obj/item/modular_computer/pda))
 		visible_message("<span class='warning'>\The [user] hits \the [src] with \a [W]!</span>")
 		src.health -= W.force

--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -118,7 +118,7 @@
 
 	return 1
 
-/obj/machinery/clamp/MouseDrop(obj/over_object as obj)
+/obj/machinery/clamp/MouseDrop(obj/over_object)
 	if(!usr)
 		return
 
@@ -148,7 +148,7 @@
 	icon_state = "pclamp0"
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 4)
 
-/obj/item/clamp/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/clamp/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)
 		return
 

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -103,7 +103,7 @@
 	if (network)
 		network.update = 1
 
-/obj/machinery/portable_atmospherics/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user)
 	if ((istype(W, /obj/item/tank) && !( src.destroyed )))
 		if (src.holding)
 			return

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -190,7 +190,7 @@
 	else
 		icon_state = "scrubber:0"
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/attackby(obj/item/I, mob/user)
 	if(isWrench(I))
 		if(use_power == POWER_USE_ACTIVE)
 			to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
@@ -214,7 +214,7 @@
 	machine_name = "large stationary portable scrubber"
 	machine_desc = "This is simply a large portable scrubber that can't be moved once it's bolted into place, and is otherwise identical."
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/attackby(obj/item/I, mob/user)
 	if(isWrench(I))
 		to_chat(user, "<span class='warning'>The bolts are too tight for you to unscrew!</span>")
 		return

--- a/code/game/machinery/bodyscanner_display.dm
+++ b/code/game/machinery/bodyscanner_display.dm
@@ -23,7 +23,7 @@
 	bodyscans += list(scan.Copy())
 	updateUsrDialog()
 
-/obj/machinery/body_scan_display/OnTopic(mob/user as mob, href_list)
+/obj/machinery/body_scan_display/OnTopic(mob/user, href_list)
 	if(href_list["view"])
 		var/selection = text2num(href_list["view"])
 		if(is_valid_index(selection, bodyscans))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -25,7 +25,7 @@
 	. = ..()
 	update_icon()
 
-/obj/machinery/button/attackby(obj/item/W, mob/user as mob)
+/obj/machinery/button/attackby(obj/item/W, mob/user)
 	return attack_hand(user)
 
 /obj/machinery/button/interface_interact(user)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -148,7 +148,7 @@
 
 	..() //and give it the regular chance of being deleted outright
 
-/obj/machinery/camera/hitby(AM as mob|obj)
+/obj/machinery/camera/hitby(AM)
 	..()
 	if (istype(AM, /obj))
 		var/obj/O = AM
@@ -172,7 +172,7 @@
 		destroy()
 		return TRUE
 
-/obj/machinery/camera/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/machinery/camera/attackby(obj/item/W, mob/living/user)
 	update_coverage()
 	var/datum/wires/camera/camera_wires = wires
 	// DECONSTRUCTION
@@ -235,7 +235,7 @@
 	else
 		..()
 
-/obj/machinery/camera/proc/deactivate(user as mob, choice = 1)
+/obj/machinery/camera/proc/deactivate(user, choice = 1)
 	// The only way for AI to reactivate cameras are malf abilities, this gives them different messages.
 	if(istype(user, /mob/living/silicon/ai))
 		user = null

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -23,7 +23,7 @@
 				4 = Screwdriver panel closed and is fully built (you cannot attach upgrades)
 	*/
 
-/obj/item/camera_assembly/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/item/camera_assembly/attackby(obj/item/W, mob/living/user)
 
 	switch(state)
 
@@ -148,7 +148,7 @@
 	else
 		icon_state = "cameracase"
 
-/obj/item/camera_assembly/attack_hand(mob/user as mob)
+/obj/item/camera_assembly/attack_hand(mob/user)
 	if(!anchored)
 		..()
 

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -54,6 +54,6 @@
 	detectTime = -1
 	return 1
 
-/obj/machinery/camera/HasProximity(atom/movable/AM as mob|obj)
+/obj/machinery/camera/HasProximity(atom/movable/AM)
 	if(isliving(AM))
 		newTarget(AM)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -38,7 +38,7 @@
 
 	return
 
-/mob/living/silicon/ai/proc/ai_store_location(loc as text)
+/mob/living/silicon/ai/proc/ai_store_location(loc)
 	set category = "Silicon Commands"
 	set name = "Store Camera Location"
 	set desc = "Stores your current camera location by the given name."
@@ -180,7 +180,7 @@
 	view_core()
 
 
-/obj/machinery/camera/attack_ai(mob/living/silicon/ai/user as mob)
+/obj/machinery/camera/attack_ai(mob/living/silicon/ai/user)
 	if (!istype(user))
 		return
 	if (!src.can_use())
@@ -188,7 +188,7 @@
 	user.eyeobj.setLoc(get_turf(src))
 
 
-/mob/living/silicon/ai/attack_ai(mob/user as mob)
+/mob/living/silicon/ai/attack_ai(mob/user)
 	ai_camera_list()
 
 /proc/camera_sort(list/L)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -5,7 +5,7 @@
 /mob/living/silicon/ai/var/max_locations = 10
 /mob/living/silicon/ai/var/stored_locations[0]
 
-/proc/InvalidPlayerTurf(turf/T as turf)
+/proc/InvalidPlayerTurf(turf/T)
 	return !(T && (T.z in GLOB.using_map.player_levels))
 
 /mob/living/silicon/ai/proc/get_camera_list()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -19,7 +19,7 @@ var/global/list/empty_playable_ai_cores = list()
 		return 1
 	. = ..()
 
-/obj/structure/AIcore/attackby(obj/item/P as obj, mob/user as mob)
+/obj/structure/AIcore/attackby(obj/item/P, mob/user)
 	if(!authorized)
 		if(access_ai_upload in P.GetAccess())
 			to_chat(user, "<span class='notice'>You swipe [P] at [src] and authorize it to connect into the systems of [GLOB.using_map.full_name].</span>")

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -24,7 +24,7 @@
 	var/message = "<span class='notice'>System bootup complete. Please select an option.</span>"	// The message that shows on the main menu.
 	var/auth = 0 // Are they authenticated?
 
-/obj/machinery/computer/message_monitor/attackby(obj/item/O as obj, mob/living/user as mob)
+/obj/machinery/computer/message_monitor/attackby(obj/item/O, mob/living/user)
 	if(stat & (NOPOWER|BROKEN))
 		..()
 		return
@@ -193,7 +193,7 @@
 	popup.open()
 	return
 
-/obj/machinery/computer/message_monitor/proc/BruteForce(mob/user as mob)
+/obj/machinery/computer/message_monitor/proc/BruteForce(mob/user)
 	if(isnull(linkedServer))
 		to_chat(user, "<span class='warning'>Could not complete brute-force: Linked Server Disconnected!</span>")
 	else

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -17,10 +17,10 @@
 	var/screen = 0 // 0 - No Access Denied, 1 - Access allowed
 
 
-/obj/machinery/computer/prisoner/attack_ai(mob/user as mob)
+/obj/machinery/computer/prisoner/attack_ai(mob/user)
 	return src.attack_hand(user)
 
-/obj/machinery/computer/prisoner/attack_hand(mob/user as mob)
+/obj/machinery/computer/prisoner/attack_hand(mob/user)
 	if(..())
 		return
 	user.set_machine(src)

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -9,7 +9,7 @@
 	var/list/authorized = list(  )
 
 
-/obj/machinery/computer/shuttle/attackby(obj/item/card/W as obj, mob/user as mob)
+/obj/machinery/computer/shuttle/attackby(obj/item/card/W, mob/user)
 	if(stat & (BROKEN|NOPOWER))	return
 
 	var/datum/evacuation_controller/shuttle/evac_control = evacuation_controller

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -88,7 +88,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)
+/obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user)
 	// note that relaymove will also be called for mobs outside the cell with UI open
 	if(src.occupant == user && !user.stat)
 		go_out()
@@ -197,7 +197,7 @@
 	if(istype(new_state))
 		updateUsrDialog()
 
-/obj/machinery/atmospherics/unary/cryo_cell/attackby(obj/G, mob/user as mob)
+/obj/machinery/atmospherics/unary/cryo_cell/attackby(obj/G, mob/user)
 	if(component_attackby(G, user))
 		return TRUE
 	if(istype(G, /obj/item/reagent_containers/glass))
@@ -297,7 +297,7 @@
 		on = !on
 		update_icon()
 
-/obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M as mob)
+/obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M)
 	if (stat & (NOPOWER|BROKEN))
 		to_chat(usr, "<span class='warning'>The cryo cell is not functioning.</span>")
 		return
@@ -394,7 +394,7 @@
 /datum/data/function/proc/reset()
 	return
 
-/datum/data/function/proc/r_input(href, href_list, mob/user as mob)
+/datum/data/function/proc/r_input(href, href_list, mob/user)
 	return
 
 /datum/data/function/proc/display()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -473,7 +473,7 @@
 	user.visible_message("<span class='notice'>\The [user] begins placing \the [target] into \the [src].</span>", "<span class='notice'>You start placing \the [target] into \the [src].</span>")
 	attempt_enter(target, user)
 
-/obj/machinery/cryopod/attackby(obj/item/G as obj, mob/user as mob)
+/obj/machinery/cryopod/attackby(obj/item/G, mob/user)
 
 	if(istype(G, /obj/item/grab))
 		var/obj/item/grab/grab = G
@@ -604,7 +604,7 @@
 	else
 		to_chat(user, "<span class='notice'>The glass is already open.</span>")
 
-/obj/structure/broken_cryo/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/broken_cryo/attackby(obj/item/W, mob/user)
 	if (busy)
 		to_chat(user, "<span class='notice'>Someone else is attempting to open this.</span>")
 		return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -433,7 +433,7 @@ About the new airlock wires panel:
 *		one wire for controlling door speed.  When active, dor closes at normal rate.  When cut, door does not close manually.  When pulsed, door attempts to close every tick.
 */
 
-/obj/machinery/door/airlock/bumpopen(mob/living/user as mob) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
+/obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))
 		if(src.isElectrified())
 			if(!src.justzap)
@@ -455,7 +455,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/set_justzap(val)
 	justzap = val
 
-/obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user as mob)
+/obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user)
 	..(user)
 
 /obj/machinery/door/airlock/proc/isElectrified()
@@ -807,7 +807,7 @@ About the new airlock wires panel:
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/door/airlock/proc/hack(mob/user as mob)
+/obj/machinery/door/airlock/proc/hack(mob/user)
 	if(src.aiHacking==0)
 		src.aiHacking=1
 		spawn(20)
@@ -1205,7 +1205,7 @@ About the new airlock wires panel:
 	qdel(src)
 
 	return da
-/obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)
+/obj/machinery/door/airlock/phoron/attackby(C, mob/user)
 	if(C)
 		ignite(is_hot(C))
 	..()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -249,7 +249,7 @@
 	else
 		icon_state = "access_button_off"
 
-/obj/machinery/access_button/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/access_button/attackby(obj/item/I, mob/user)
 	//Swiping ID on the access button
 	if (istype(I, /obj/item/card/id) || istype(I, /obj/item/modular_computer))
 		attack_hand(user)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -139,7 +139,7 @@
 // Parameters: 2 (C - Item this object was clicked with, user - Mob which clicked this object)
 // Description: If we are clicked with crowbar or wielded fire axe, try to manually open the door.
 // This only works on broken doors or doors without power. Also allows repair with Plasteel.
-/obj/machinery/door/blast/attackby(obj/item/C as obj, mob/user as mob)
+/obj/machinery/door/blast/attackby(obj/item/C, mob/user)
 	add_fingerprint(user, 0, C)
 	if(isCrowbar(C) || (istype(C, /obj/item/material/twohanded/fireaxe) && C:wielded == 1))
 		if(((stat & NOPOWER) || (stat & BROKEN)) && !( operating ))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -163,7 +163,7 @@
 	return !density
 
 
-/obj/machinery/door/proc/bumpopen(mob/user as mob)
+/obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)	return
 	if(user.last_airflow > world.time - vsc.airflow_delay) //Fakkit
 		return
@@ -199,7 +199,7 @@
 
 
 
-/obj/machinery/door/hitby(AM as mob|obj, datum/thrownthing/TT)
+/obj/machinery/door/hitby(AM, datum/thrownthing/TT)
 
 	..()
 	visible_message("<span class='danger'>[src.name] was hit by [AM].</span>")
@@ -217,7 +217,7 @@
 	if(CanInteract(user, DefaultTopicState()))
 		return attackby(user = user)
 
-/obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/door/attackby(obj/item/I, mob/user)
 	src.add_fingerprint(user, 0, I)
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == src.get_material_name())

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -113,7 +113,7 @@
 	material.place_dismantled_product(get_turf(src))
 	qdel(src)
 
-/obj/machinery/door/unpowered/simple/attack_ai(mob/user as mob) //those aren't machinery, they're just big fucking slabs of a mineral
+/obj/machinery/door/unpowered/simple/attack_ai(mob/user) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isAI(user)) //so the AI can't open it
 		return
 	else if(isrobot(user)) //but cyborgs can
@@ -134,7 +134,7 @@
 				take_damage(150)
 
 
-/obj/machinery/door/unpowered/simple/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/door/unpowered/simple/attackby(obj/item/I, mob/user)
 	src.add_fingerprint(user, 0, I)
 	if(istype(I, /obj/item/key) && lock)
 		var/obj/item/key/K = I

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -9,7 +9,7 @@
 	..()
 	return
 
-/obj/machinery/door/unpowered/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/door/unpowered/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/melee/energy/blade))	return
 	if(src.locked)	return
 	..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -72,7 +72,7 @@
 	update_nearby_tiles()
 	return ..()
 
-/obj/machinery/door/window/Bumped(atom/movable/AM as mob|obj)
+/obj/machinery/door/window/Bumped(atom/movable/AM)
 	if (!( ismob(AM) ))
 		var/mob/living/bot/bot = AM
 		if(istype(bot))
@@ -102,7 +102,7 @@
 	else
 		return 1
 
-/obj/machinery/door/window/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/machinery/door/window/CheckExit(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
 		return 1
 	if(get_dir(loc, target) == dir)
@@ -189,7 +189,7 @@
 /obj/machinery/door/window/CanFluidPass(coming_from)
 	return !density || ((dir in GLOB.cardinal) && coming_from != dir)
 
-/obj/machinery/door/window/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/door/window/attackby(obj/item/I, mob/user)
 
 	//If it's in the process of opening/closing, ignore the click
 	if (src.operating == 1)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -33,7 +33,7 @@
 //		src.sd_SetLuminosity(0)
 
 //Don't want to render prison breaks impossible
-/obj/machinery/flasher/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/flasher/attackby(obj/item/W, mob/user)
 	if(isWirecutter(W))
 		add_fingerprint(user, 0, W)
 		src.disable = !src.disable
@@ -110,7 +110,7 @@
 	base_state = "pflash"
 	density = TRUE
 
-/obj/machinery/flasher/portable/HasProximity(atom/movable/AM as mob|obj)
+/obj/machinery/flasher/portable/HasProximity(atom/movable/AM)
 	if(!anchored || disable || last_flash && world.time < last_flash + 150)
 		return
 
@@ -122,7 +122,7 @@
 	if(isanimal(AM))
 		flash()
 
-/obj/machinery/flasher/portable/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/flasher/portable/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		add_fingerprint(user)
 		src.anchored = !src.anchored

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -34,7 +34,7 @@
 	user.visible_message("<span class='notice'>[user] has [!on?"de":""]activated \the [src].</span>", "<span class='notice'>You [!on?"de":""]activate \the [src].</span>")
 	return TRUE
 
-/obj/machinery/floorlayer/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/floorlayer/attackby(obj/item/W, mob/user)
 
 	if(isWrench(W))
 		var/m = input("Choose work mode", "Mode") as null|anything in mode

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -104,7 +104,7 @@
 		icon_state = "migniter-p"
 //		src.sd_SetLuminosity(0)
 
-/obj/machinery/sparker/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/sparker/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		add_fingerprint(user)
 		disable = !disable

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -46,7 +46,7 @@
 	else
 		src.overlays += image('icons/obj/kitchen.dmi', "gridle")
 
-/obj/machinery/gibber/relaymove(mob/user as mob)
+/obj/machinery/gibber/relaymove(mob/user)
 	src.go_out()
 	return
 
@@ -155,7 +155,7 @@
 	update_icon()
 	return
 
-/obj/machinery/gibber/proc/startgibbing(mob/user as mob)
+/obj/machinery/gibber/proc/startgibbing(mob/user)
 	if(src.operating)
 		return
 	if(!src.occupant)

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -74,7 +74,7 @@
 	interact(user)
 	return TRUE
 
-/obj/machinery/icecream_vat/interact(mob/user as mob)
+/obj/machinery/icecream_vat/interact(mob/user)
 	user.set_machine(src)
 	var/dat
 	dat += "<b>ICECREAM</b><br><div class='statusDisplay'>"
@@ -99,7 +99,7 @@
 	popup.set_content(dat)
 	popup.open()
 
-/obj/machinery/icecream_vat/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/icecream_vat/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/reagent_containers/food/snacks/icecream))
 		var/obj/item/reagent_containers/food/snacks/icecream/I = O
 		if(!I.ice_creamed)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -54,7 +54,7 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/microwave/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/microwave/attackby(obj/item/O, mob/user)
 	if(broken > 0)
 		// Start repairs by using a screwdriver
 		if(broken == 2 && isScrewdriver(O))
@@ -240,7 +240,7 @@
 /obj/machinery/microwave/InsertedContents()
 	return ingredients
 
-/obj/machinery/microwave/interact(mob/user as mob) // The microwave Menu
+/obj/machinery/microwave/interact(mob/user) // The microwave Menu
 	user.set_machine(src)
 	var/dat = list()
 	if(broken > 0)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -45,7 +45,7 @@
 		return list()
 	return ..()
 
-/obj/machinery/smartfridge/proc/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/proc/accept_check(obj/item/O)
 	if(istype(O,/obj/item/reagent_containers/food/snacks/grown) || istype(O,/obj/item/seeds))
 		return 1
 	return 0
@@ -54,7 +54,7 @@
 	name = "\improper MegaSeed Servitor"
 	desc = "When you need seeds fast!"
 
-/obj/machinery/smartfridge/seeds/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/seeds/accept_check(obj/item/O)
 	if(istype(O,/obj/item/seeds))
 		return 1
 	return 0
@@ -65,7 +65,7 @@
 	icon_contents = "slime"
 	req_access = list(access_research)
 
-/obj/machinery/smartfridge/secure/extract/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/secure/extract/accept_check(obj/item/O)
 	if(istype(O,/obj/item/slime_extract))
 		return 1
 	return 0
@@ -76,7 +76,7 @@
 	icon_contents = "chem"
 	req_access = list(list(access_medical,access_chemistry))
 
-/obj/machinery/smartfridge/secure/medbay/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/secure/medbay/accept_check(obj/item/O)
 	if(istype(O,/obj/item/reagent_containers/glass))
 		return 1
 	if(istype(O,/obj/item/storage/pill_bottle))
@@ -91,7 +91,7 @@
 	req_access = list(access_virology)
 	icon_contents = "chem"
 
-/obj/machinery/smartfridge/secure/virology/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/secure/virology/accept_check(obj/item/O)
 	if(istype(O,/obj/item/reagent_containers/glass/beaker/vial))
 		return 1
 	return 0
@@ -101,7 +101,7 @@
 	desc = "A refrigerated storage unit for medicine and chemical storage."
 	icon_contents = "chem"
 
-/obj/machinery/smartfridge/chemistry/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/chemistry/accept_check(obj/item/O)
 	if(istype(O,/obj/item/storage/pill_bottle) || istype(O,/obj/item/reagent_containers))
 		return 1
 	return 0
@@ -118,7 +118,7 @@
 	icon_base = "fridge_dark"
 	icon_contents = "drink"
 
-/obj/machinery/smartfridge/drinks/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/drinks/accept_check(obj/item/O)
 	if(istype(O,/obj/item/reagent_containers/glass) || istype(O,/obj/item/reagent_containers/food/drinks) || istype(O,/obj/item/reagent_containers/food/condiment))
 		return 1
 
@@ -129,7 +129,7 @@
 	icon_state = "fridge_food"
 	icon_contents = "food"
 
-/obj/machinery/smartfridge/foods/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/foods/accept_check(obj/item/O)
 	if(istype(O,/obj/item/reagent_containers/food/snacks) || istype(O,/obj/item/material/kitchen/utensil))
 		return 1
 
@@ -138,7 +138,7 @@
 	desc = "A machine for drying plants."
 	icon_state = "drying_rack"
 
-/obj/machinery/smartfridge/drying_rack/accept_check(obj/item/O as obj)
+/obj/machinery/smartfridge/drying_rack/accept_check(obj/item/O)
 	if(istype(O, /obj/item/reagent_containers/food/snacks))
 		var/obj/item/reagent_containers/food/snacks/S = O
 		return S.dried_type
@@ -258,7 +258,7 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/smartfridge/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/smartfridge/attackby(obj/item/O, mob/user)
 	if(isScrewdriver(O))
 		panel_open = !panel_open
 		user.visible_message("[user] [panel_open ? "opens" : "closes"] the maintenance panel of \the [src].", "You [panel_open ? "open" : "close"] the maintenance panel of \the [src].")

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -66,7 +66,7 @@
 		set_state(!on)
 		return TRUE
 
-/obj/machinery/light_switch/attackby(obj/item/tool as obj, mob/user as mob)
+/obj/machinery/light_switch/attackby(obj/item/tool, mob/user)
 	if(istype(tool, /obj/item/screwdriver))
 		new /obj/item/frame/light_switch(user.loc, 1)
 		qdel(src)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -756,7 +756,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 	is_synth = synth
 	photo = p
 
-/obj/machinery/newscaster/proc/AttachPhoto(mob/user as mob)
+/obj/machinery/newscaster/proc/AttachPhoto(mob/user)
 	if(photo_data)
 		qdel(photo_data)
 		photo_data = null
@@ -907,7 +907,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 			src.attack_self(src.loc)
 
 
-/obj/item/newspaper/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/newspaper/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/pen))
 		if(src.scribble_page == src.curr_page)
 			to_chat(user, "<FONT COLOR='blue'>There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?</FONT>")
@@ -927,7 +927,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 ////////////////////////////////////helper procs
 
 
-/obj/machinery/newscaster/proc/scan_user(mob/living/user as mob)
+/obj/machinery/newscaster/proc/scan_user(mob/living/user)
 	if(istype(user,/mob/living/carbon/human))                       //User is a human
 		var/mob/living/carbon/human/human_user = user
 		var/obj/item/card/id/id = human_user.GetIdCard()

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -46,7 +46,7 @@ var/global/bomb_set
 			addtimer(CALLBACK(src, .proc/explode), 0)
 		SSnano.update_uis(src)
 
-/obj/machinery/nuclearbomb/attackby(obj/item/O as obj, mob/user as mob, params)
+/obj/machinery/nuclearbomb/attackby(obj/item/O, mob/user, params)
 	if(isScrewdriver(O))
 		add_fingerprint(user)
 		if(auth)
@@ -159,7 +159,7 @@ var/global/bomb_set
 			flick("lock", src)
 			update_icon()
 
-/obj/machinery/nuclearbomb/interface_interact(mob/user as mob)
+/obj/machinery/nuclearbomb/interface_interact(mob/user)
 	if(extended && !panel_open)
 		ui_interact(user)
 		return TRUE
@@ -473,7 +473,7 @@ var/global/bomb_set
 	for(var/obj/machinery/self_destruct/ch in get_area(src))
 		inserters += ch
 
-/obj/machinery/nuclearbomb/station/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/nuclearbomb/station/attackby(obj/item/O, mob/user)
 	if(isWrench(O))
 		return
 

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -98,7 +98,7 @@
 	breather = null
 	update_use_power(POWER_USE_IDLE)
 
-/obj/machinery/oxygen_pump/proc/can_apply_to_target(mob/living/carbon/human/target, mob/user as mob)
+/obj/machinery/oxygen_pump/proc/can_apply_to_target(mob/living/carbon/human/target, mob/user)
 	if(!user)
 		user = target
 	// Check target validity
@@ -133,7 +133,7 @@
 		return
 	return 1
 
-/obj/machinery/oxygen_pump/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/oxygen_pump/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		stat ^= MAINT
 		user.visible_message("<span class='notice'>\The [user] [stat & MAINT ? "opens" : "closes"] \the [src].</span>", "<span class='notice'>You [stat & MAINT ? "open" : "close"] \the [src].</span>")

--- a/code/game/machinery/pager.dm
+++ b/code/game/machinery/pager.dm
@@ -16,7 +16,7 @@
 		var/area/A = get_area(src)
 		location = A.name
 
-/obj/machinery/pager/attackby(obj/item/W, mob/user as mob)
+/obj/machinery/pager/attackby(obj/item/W, mob/user)
 	return attack_hand(user)
 
 /obj/machinery/pager/interface_interact(mob/living/user)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -67,7 +67,7 @@ Buildable meters
 		if(PIPE_ROTATE_ONEDIR)
 			set_dir(2)
 
-/obj/item/pipe/attack_self(mob/user as mob)
+/obj/item/pipe/attack_self(mob/user)
 	return rotate(user)
 
 /obj/item/pipe/proc/build_unary(obj/machinery/atmospherics/unary/P, pipefailtext)
@@ -132,7 +132,7 @@ Buildable meters
 		P.node4.build_network()
 	return 0
 
-/obj/item/pipe/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/pipe/attackby(obj/item/W, mob/user)
 	if(!isWrench(W))
 		return ..()
 	if (!isturf(loc))

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -70,7 +70,7 @@
 	popup.set_content(get_console_data(GLOB.all_pipe_datums_by_category, TRUE))
 	popup.open()
 
-/obj/machinery/pipedispenser/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/pipedispenser/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/pipe) || istype(W, /obj/item/machine_chassis))
 		if(!user.unEquip(W))
 			return
@@ -116,7 +116,7 @@
 	machine_desc = "Similar to a normal pipe dispenser, but calibrated for the heavy, dense metal tubes used in disposals networks."
 
 //Allow you to drag-drop disposal pipes into it
-/obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe as obj, mob/user as mob)
+/obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe, mob/user)
 	if(!CanPhysicallyInteract(user))
 		return
 

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -37,7 +37,7 @@
 	user.visible_message("<span class='notice'>[user] has [!on?"de":""]activated \the [src].</span>", "<span class='notice'>You [!on?"de":""]activate \the [src].</span>")
 	return TRUE
 
-/obj/machinery/pipelayer/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/pipelayer/attackby(obj/item/W, mob/user)
 
 	if(isWrench(W))
 		P_type_t = input("Choose pipe type", "Pipe type") as null|anything in Pipes

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -15,7 +15,7 @@
 	var/icon_state_idle = "recharger0" //also when unpowered
 	var/portable = 1
 
-/obj/machinery/recharger/attackby(obj/item/G as obj, mob/user as mob)
+/obj/machinery/recharger/attackby(obj/item/G, mob/user)
 	var/allowed = 0
 	for (var/allowed_type in allowed_devices)
 		if (istype(G, allowed_type)) allowed = 1

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -95,7 +95,7 @@
 	else
 		to_chat(user, "The indicator shows that the cell is missing.")
 
-/obj/machinery/recharge_station/relaymove(mob/user as mob)
+/obj/machinery/recharge_station/relaymove(mob/user)
 	if(user.stat)
 		return
 	go_out()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -189,7 +189,7 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 		return TOPIC_REFRESH
 
 					//err... hacking code, which has no reason for existing... but anyway... it was once supposed to unlock priority 3 messanging on that console (EXTREME priority...), but the code for that was removed.
-/obj/machinery/requests_console/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/requests_console/attackby(obj/item/O, mob/user)
 	/*
 	if (istype(O, /obj/item/crowbar))
 		if(open)

--- a/code/game/machinery/robot_fabricator.dm
+++ b/code/game/machinery/robot_fabricator.dm
@@ -10,7 +10,7 @@
 	idle_power_usage = 40
 	active_power_usage = 10000
 
-/obj/machinery/robotic_fabricator/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/robotic_fabricator/attackby(obj/item/O, mob/user)
 	if (istype(O, /obj/item/stack/material) && O.get_material_name() == MATERIAL_STEEL)
 		var/obj/item/stack/M = O
 		if (src.metal_amount < 150000.0)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -9,7 +9,7 @@
 	var/armed = 0
 	var/damaged = 0
 
-/obj/machinery/self_destruct/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/self_destruct/attackby(obj/item/W, mob/user)
 	if(isWelder(W))
 		if(damaged)
 			user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -37,7 +37,7 @@ var/global/list/ai_status_emotions = list(
 
 	return emotions
 
-/proc/set_ai_status_displays(mob/user as mob)
+/proc/set_ai_status_displays(mob/user)
 	var/list/ai_emotions = get_ai_emotions(user.ckey)
 	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
 	for (var/obj/machinery/M in SSmachines.machinery) //change status

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -69,7 +69,7 @@ var/global/list/ai_status_emotions = list(
 
 	var/emotion = "Neutral"
 
-/obj/machinery/ai_status_display/attack_ai/(mob/user as mob)
+/obj/machinery/ai_status_display/attack_ai/(mob/user)
 	var/list/ai_emotions = get_ai_emotions(user.ckey)
 	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
 	src.emotion = emote

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -73,7 +73,7 @@
 	DROP_NULL(helmet)
 	return ..()
 
-/obj/machinery/suit_cycler/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/suit_cycler/attackby(obj/item/I, mob/user)
 
 	if(electrified != 0)
 		if(shock(user, 100))
@@ -358,7 +358,7 @@
 
 	eject_occupant(usr)
 
-/obj/machinery/suit_cycler/proc/eject_occupant(mob/user as mob)
+/obj/machinery/suit_cycler/proc/eject_occupant(mob/user)
 
 	if(locked || active)
 		to_chat(user, "<span class='warning'>The cycler is locked.</span>")

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -128,7 +128,7 @@
 	else
 		to_chat(user, "<span class='danger'>You need to screw the beacon to the floor first!</span>")
 
-/obj/machinery/power/singularity_beacon/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/singularity_beacon/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		if(active)
 			to_chat(user, "<span class='danger'>You need to deactivate the beacon first!</span>")

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -17,7 +17,7 @@
 	stat_immune = 0
 	maximum_component_parts = list(/obj/item/stock_parts = 15)
 
-/obj/machinery/telecomms/attackby(obj/item/P as obj, mob/user as mob)
+/obj/machinery/telecomms/attackby(obj/item/P, mob/user)
 
 	// Using a multitool lets you access the receiver's interface
 	if(isMultitool(P))
@@ -142,7 +142,7 @@
 
 // Returns a multitool from a user depending on their mobtype.
 
-/obj/machinery/telecomms/proc/get_multitool(mob/user as mob)
+/obj/machinery/telecomms/proc/get_multitool(mob/user)
 
 	var/obj/item/device/multitool/P = null
 	// Let's double check

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -21,7 +21,7 @@
 
 	var/temp = ""				// temporary feedback messages
 
-/obj/machinery/computer/telecomms/monitor/attack_hand(mob/user as mob)
+/obj/machinery/computer/telecomms/monitor/attack_hand(mob/user)
 	if(stat & (BROKEN|NOPOWER))
 		return
 	user.set_machine(src)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -147,7 +147,7 @@
 		to_chat(user, "You short out the product lock on \the [src]")
 		return 1
 
-/obj/machinery/vending/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/vending/attackby(obj/item/W, mob/user)
 
 	var/obj/item/card/id/I = W.GetIdCard()
 
@@ -202,12 +202,12 @@
 	. = ..()
 	SSnano.update_uis(src)
 
-/obj/machinery/vending/MouseDrop_T(obj/item/I as obj, mob/user as mob)
+/obj/machinery/vending/MouseDrop_T(obj/item/I, mob/user)
 	if(!CanMouseDrop(I, user) || (I.loc != user))
 		return
 	return attempt_to_stock(I, user)
 
-/obj/machinery/vending/proc/attempt_to_stock(obj/item/I as obj, mob/user as mob)
+/obj/machinery/vending/proc/attempt_to_stock(obj/item/I, mob/user)
 	for(var/datum/stored_items/vending_products/R in product_records)
 		if(I.type == R.item_path)
 			stock(I, R, user)
@@ -300,7 +300,7 @@
  *
  *  Called after the money has already been taken from the customer.
  */
-/obj/machinery/vending/proc/credit_purchase(target as text)
+/obj/machinery/vending/proc/credit_purchase(target)
 	vendor_account.deposit(currently_vending.price, "Purchase of [currently_vending.item_name]", target)
 
 /obj/machinery/vending/physical_attack_hand(mob/user)

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -9,7 +9,7 @@
 	var/refund_type = /obj/item/stack/material/steel
 	var/reverse = 0 //if resulting object faces opposite its dir (like light fixtures)
 
-/obj/item/frame/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/frame/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		new refund_type( get_turf(src.loc), refund_amt)
 		qdel(src)

--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -14,7 +14,7 @@
 	var/insisting = 0
 
 // Just override; we're special.
-/obj/machinery/wish_granter/attack_hand(mob/user as mob)
+/obj/machinery/wish_granter/attack_hand(mob/user)
 	usr.set_machine(src)
 
 	if(charges <= 0)

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -132,7 +132,7 @@
 	desc = "[initial(desc)] [design.desc]"
 	icon_state = design.icon_state
 
-/obj/structure/sign/poster/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/sign/poster/attackby(obj/item/W, mob/user)
 	if(isWirecutter(W))
 		playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		if(ruined)
@@ -144,7 +144,7 @@
 		return
 
 
-/obj/structure/sign/poster/attack_hand(mob/user as mob)
+/obj/structure/sign/poster/attack_hand(mob/user)
 
 	if(ruined)
 		return

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -30,12 +30,12 @@
 	desc = "They look like the remains of a small rodent."
 	icon_state = "lizard"
 
-/obj/item/remains/attack_hand(mob/user as mob)
+/obj/item/remains/attack_hand(mob/user)
 	to_chat(user, "<span class='notice'>[src] sinks together into a pile of ash.</span>")
 	var/turf/simulated/floor/F = get_turf(src)
 	if (istype(F))
 		new /obj/effect/decal/cleanable/ash(F)
 	qdel(src)
 
-/obj/item/remains/robot/attack_hand(mob/user as mob)
+/obj/item/remains/robot/attack_hand(mob/user)
 	return

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -187,7 +187,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	. = ..()
 	addtimer(CALLBACK(src, .proc/fade_out), time_to_live)
 
-/obj/effect/effect/smoke/Crossed(mob/living/carbon/M as mob )
+/obj/effect/effect/smoke/Crossed(mob/living/carbon/M)
 	..()
 	if(istype(M))
 		affect(M)
@@ -285,7 +285,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/mob/living/carbon/M in get_turf(src))
 		affect(M)
 
-/obj/effect/effect/smoke/sleepy/affect(mob/living/carbon/M as mob )
+/obj/effect/effect/smoke/sleepy/affect(mob/living/carbon/M)
 	if (!..())
 		return 0
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -15,10 +15,10 @@
 	icon_state = "uglyminearmed"
 
 
-/obj/effect/mine/Crossed(AM as mob|obj)
+/obj/effect/mine/Crossed(AM)
 	Bumped(AM)
 
-/obj/effect/mine/Bumped(mob/M as mob|obj)
+/obj/effect/mine/Bumped(mob/M)
 
 	if(triggered) return
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -11,19 +11,19 @@
 	var/dangerous = 0
 	var/failchance = 0
 
-/obj/effect/portal/Bumped(mob/M as mob|obj)
+/obj/effect/portal/Bumped(mob/M)
 	spawn(0)
 		src.teleport(M)
 		return
 	return
 
-/obj/effect/portal/Crossed(AM as mob|obj)
+/obj/effect/portal/Crossed(AM)
 	spawn(0)
 		src.teleport(AM)
 		return
 	return
 
-/obj/effect/portal/attack_hand(mob/user as mob)
+/obj/effect/portal/attack_hand(mob/user)
 	spawn(0)
 		src.teleport(user)
 		return
@@ -47,7 +47,7 @@
 	target = null
 	. = ..()
 
-/obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
+/obj/effect/portal/proc/teleport(atom/movable/M)
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
 	if (icon_state == "portal1")

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -9,7 +9,7 @@
 /obj/effect/step_trigger/proc/Trigger(atom/movable/A)
 	return 0
 
-/obj/effect/step_trigger/Crossed(H as mob|obj)
+/obj/effect/step_trigger/Crossed(H)
 	..()
 	if(!H)
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -201,7 +201,7 @@
 
 	return ..(user, distance, "", desc_comp)
 
-/obj/item/attack_hand(mob/user as mob)
+/obj/item/attack_hand(mob/user)
 	if (!user) return
 	if (anchored)
 		return ..()
@@ -251,7 +251,7 @@
 			pixel_x = 0
 			pixel_y = 0
 
-/obj/item/attack_ai(mob/user as mob)
+/obj/item/attack_ai(mob/user)
 	if (istype(src.loc, /obj/item/robot_module))
 		//If the item is part of a cyborg module, equip it
 		if(!isrobot(user))
@@ -278,15 +278,15 @@
 		return FALSE
 	return ..()
 
-/obj/item/proc/talk_into(mob/M as mob, text)
+/obj/item/proc/talk_into(mob/M, text)
 	return
 
-/obj/item/proc/moved(mob/user as mob, old_loc as turf)
+/obj/item/proc/moved(mob/user, old_loc)
 	return
 
 
 /// Called whenever an item is removed from a slot, container, or anything else.
-/obj/item/proc/dropped(mob/user as mob)
+/obj/item/proc/dropped(mob/user)
 	if(randpixel)
 		pixel_z = randpixel //an idea borrowed from some of the older pixel_y randomizations. Intended to make items appear to drop at a character
 	update_twohanding()
@@ -304,15 +304,15 @@
 	return
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
-/obj/item/proc/on_exit_storage(obj/item/storage/S as obj)
+/obj/item/proc/on_exit_storage(obj/item/storage/S)
 	return
 
 // called when this item is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
-/obj/item/proc/on_enter_storage(obj/item/storage/S as obj)
+/obj/item/proc/on_enter_storage(obj/item/storage/S)
 	return
 
 // called when "found" in pockets and storage items. Returns 1 if the search should end.
-/obj/item/proc/on_found(mob/finder as mob)
+/obj/item/proc/on_found(mob/finder)
 	return
 
 
@@ -364,7 +364,7 @@ var/global/list/slot_flags_enumeration = list(
 //Set disable_warning to 1 if you wish it to not give you outputs.
 //Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
 //set force to ignore blocking overwear and occupied slots
-/obj/item/proc/mob_can_equip(M as mob, slot, disable_warning = 0, force = 0)
+/obj/item/proc/mob_can_equip(M, slot, disable_warning = 0, force = 0)
 	if(!slot) return 0
 	if(!M) return 0
 
@@ -565,7 +565,7 @@ var/global/list/slot_flags_enumeration = list(
 		L = L.loc
 	return loc
 
-/obj/item/proc/eyestab(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/proc/eyestab(mob/living/carbon/M, mob/living/carbon/user)
 	if (user.a_intent == I_HELP)
 		return FALSE
 
@@ -642,7 +642,7 @@ var/global/list/slot_flags_enumeration = list(
 		blood_overlay.color = COLOR_LUMINOL
 		update_icon()
 
-/obj/item/add_blood(mob/living/carbon/human/M as mob)
+/obj/item/add_blood(mob/living/carbon/human/M)
 	if (!..())
 		return 0
 

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -7,7 +7,7 @@
 	icon_state = "apc_frame"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
-/obj/item/frame/apc/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/frame/apc/attackby(obj/item/W, mob/user)
 	..()
 	if(isWrench(W))
 		new /obj/item/stack/material/steel( get_turf(src.loc), 2 )

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -23,7 +23,7 @@
 	. = ..()
 	desc = "Blueprints of \the [station_name()]. There is a \"Classified\" stamp and several coffee stains on it."
 
-/obj/item/blueprints/attack_self(mob/M as mob)
+/obj/item/blueprints/attack_self(mob/M)
 	if (!istype(M,/mob/living/carbon/human))
 		to_chat(M, "This stack of blue paper means nothing to you.")//monkeys cannot into projecting
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -32,7 +32,7 @@
 	var/contains_body = 0
 	var/has_label = FALSE
 
-/obj/structure/closet/body_bag/attackby(obj/item/W, mob/user as mob)
+/obj/structure/closet/body_bag/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if (user.get_active_hand() != W)

--- a/code/game/objects/items/buttons.dm
+++ b/code/game/objects/items/buttons.dm
@@ -37,7 +37,7 @@ GLOBAL_LIST_INIT(possible_switch_offsets, list(
 			"Offset Upper" = list(-32,7))))
 
 
-/obj/item/frame/light_switch/proc/position_with_direction(obj/item/frame/light_switch/S as obj, mob/user as mob)
+/obj/item/frame/light_switch/proc/position_with_direction(obj/item/frame/light_switch/S, mob/user)
 	for(var/i = 5; i >= 0; i -= 1)
 		var/direction_choice = input(user, "In which direction?", "Select direction.") as null|anything in GLOB.possible_switch_offsets
 		if(!direction_choice || user.incapacitated() || !user.Adjacent(src))
@@ -58,7 +58,7 @@ GLOBAL_LIST_INIT(possible_switch_offsets, list(
 			break
 	return 1
 
-/obj/item/frame/light_switch/attackby(obj/item/tool as obj, mob/user as mob)	//construction
+/obj/item/frame/light_switch/attackby(obj/item/tool, mob/user)	//construction
 	if(isWrench(tool))
 		new /obj/item/stack/material/steel( get_turf(src.loc), 1 )
 		qdel(src)
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(possible_switch_offsets, list(
 			qdel(S)
 	else ..()
 
-/obj/item/frame/light_switch/windowtint/attackby(obj/item/tool as obj, mob/user as mob)
+/obj/item/frame/light_switch/windowtint/attackby(obj/item/tool, mob/user)
 	if(isWrench(tool))
 		new /obj/item/stack/material/steel( get_turf(src.loc), 1 )
 		qdel(src)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -62,7 +62,7 @@
 	uses = 0
 	crayon_reagent = /datum/reagent/crayon_dust/grey
 
-/obj/item/pen/crayon/mime/attack_self(mob/living/user as mob) //inversion
+/obj/item/pen/crayon/mime/attack_self(mob/living/user) //inversion
 	if(colour != "#ffffff" && shadeColour != "#000000")
 		colour = "#ffffff"
 		shadeColour = "#000000"
@@ -82,12 +82,12 @@
 	uses = 0
 	crayon_reagent = /datum/reagent/crayon_dust/brown
 
-/obj/item/pen/crayon/rainbow/attack_self(mob/living/user as mob)
+/obj/item/pen/crayon/rainbow/attack_self(mob/living/user)
 	colour = input(user, "Please select the main colour.", "Crayon colour") as color
 	shadeColour = input(user, "Please select the shade colour.", "Crayon colour") as color
 	return
 
-/obj/item/pen/crayon/afterattack(atom/target, mob/user as mob, proximity)
+/obj/item/pen/crayon/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return
 	if(istype(target,/turf/simulated/floor))
 		var/drawtype = input("Choose what you'd like to draw.", "Crayon scribbles") in list("graffiti","rune","letter","arrow", "defector graffiti")
@@ -115,7 +115,7 @@
 					qdel(src)
 	return
 
-/obj/item/pen/crayon/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/pen/crayon/attack(mob/living/carbon/M, mob/user)
 	if(istype(M) && M == user)
 		to_chat(M, "You take a bite of the crayon and swallow it.")
 		M.adjust_nutrition(1)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -147,7 +147,7 @@
 	return FALSE
 
 
-/obj/item/device/flash/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
+/obj/item/device/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user || !clown_check(user)) 	return 0
 
 	if(broken)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -64,7 +64,7 @@
 	else
 		set_light(0)
 
-/obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/device/flashlight/attack(mob/living/M, mob/living/user)
 	add_fingerprint(user)
 	if(on && user.zone_sel.selecting == BP_EYES)
 

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -36,7 +36,7 @@
 	. |= active.fields["access"]
 
 //hit yourself with it
-/obj/item/device/holowarrant/attack_self(mob/living/user as mob)
+/obj/item/device/holowarrant/attack_self(mob/living/user)
 	active = null
 	var/list/warrants = list()
 	for(var/datum/computer_file/data/warrant/W in GLOB.all_warrants)
@@ -70,7 +70,7 @@
 	..()
 
 //hit other people with it
-/obj/item/device/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/device/holowarrant/attack(mob/living/carbon/M, mob/living/carbon/user)
 	user.visible_message("<span class='notice'>[user] holds up a warrant projector and shows the contents to [M].</span>", \
 			"<span class='notice'>You show the warrant to [M].</span>")
 	M.examinate(src)

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -12,7 +12,7 @@
 	var/insults = 0
 	var/list/insultmsg = list("FUCK EVERYONE!", "I'M A TATER!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!")
 
-/obj/item/device/megaphone/attack_self(mob/living/user as mob)
+/obj/item/device/megaphone/attack_self(mob/living/user)
 	if (user.client)
 		if(user.client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -15,7 +15,7 @@
 		/obj/item/clothing/suit/space/void
 		)
 
-/obj/item/device/modkit/afterattack(obj/O, mob/user as mob, proximity)
+/obj/item/device/modkit/afterattack(obj/O, mob/user, proximity)
 	if(!proximity)
 		return
 

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -12,13 +12,13 @@
 
 	var/code = 2
 
-/obj/item/device/radio/electropack/attack_hand(mob/user as mob)
+/obj/item/device/radio/electropack/attack_hand(mob/user)
 	if(src == user.back)
 		to_chat(user, "<span class='notice'>You need help taking this off!</span>")
 		return
 	..()
 
-/obj/item/device/radio/electropack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/radio/electropack/attackby(obj/item/W, mob/user)
 	..()
 	if(istype(W, /obj/item/clothing/head/helmet))
 		if(!b_stat)
@@ -102,7 +102,7 @@
 		master.receive_signal()
 	return
 
-/obj/item/device/radio/electropack/attack_self(mob/user as mob, flag1)
+/obj/item/device/radio/electropack/attack_self(mob/user, flag1)
 
 	if(!istype(user, /mob/living/carbon/human))
 		return

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -12,7 +12,7 @@
 	var/syndie = 0
 	var/list/channels = list()
 
-/obj/item/device/encryptionkey/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/encryptionkey/attackby(obj/item/W, mob/user)
 
 /obj/item/device/encryptionkey/map_preset
 	var/preset_name

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -46,7 +46,7 @@
 	to_chat(user, "The following channels are available:")
 	to_chat(user, radio_desc)
 
-/obj/item/device/radio/headset/handle_message_mode(mob/living/M as mob, message, channel)
+/obj/item/device/radio/headset/handle_message_mode(mob/living/M, message, channel)
 	if (channel == "special")
 		if (translate_binary)
 			var/datum/language/binary = all_languages[LANGUAGE_ROBOT_GLOBAL]
@@ -330,7 +330,7 @@
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/specops
 
-/obj/item/device/radio/headset/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/radio/headset/attackby(obj/item/W, mob/user)
 //	..()
 	user.set_machine(src)
 	if (!( isScrewdriver(W) || (istype(W, /obj/item/device/encryptionkey/ ))))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -92,7 +92,7 @@
 		STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/device/radio/attack_self(mob/user as mob)
+/obj/item/device/radio/attack_self(mob/user)
 	user.set_machine(src)
 	interact(user)
 
@@ -297,7 +297,7 @@
 	qdel(A)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum
-/obj/item/device/radio/proc/handle_message_mode(mob/living/M as mob, message, message_mode)
+/obj/item/device/radio/proc/handle_message_mode(mob/living/M, message, message_mode)
 	// If a channel isn't specified, send to common.
 	if(!message_mode || message_mode == "headset")
 		return radio_connection
@@ -538,7 +538,7 @@
 					  "[connection.frequency]", channel_color_presets["Menacing Maroon"])
 
 
-/obj/item/device/radio/hear_talk(mob/M as mob, msg, verb = "says", datum/language/speaking = null)
+/obj/item/device/radio/hear_talk(mob/M, msg, verb = "says", datum/language/speaking = null)
 
 	if (broadcasting)
 		if(get_dist(src, M) <= canhear_range)
@@ -596,7 +596,7 @@
 		if (power_usage && cell)
 			to_chat(user, "<span class='notice'>\The [src] charge meter reads [round(cell.percent(), 0.1)]%.</span>")
 
-/obj/item/device/radio/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/radio/attackby(obj/item/W, mob/user)
 	..()
 	user.set_machine(src)
 	if(isScrewdriver(W))
@@ -677,7 +677,7 @@
 		var/datum/robot_component/C = R.components["radio"]
 		R.cell_use_power(C.active_usage)
 
-/obj/item/device/radio/borg/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/radio/borg/attackby(obj/item/W, mob/user)
 //	..()
 	user.set_machine(src)
 	if (!( isScrewdriver(W) || (istype(W, /obj/item/device/encryptionkey/ ))))
@@ -770,7 +770,7 @@
 	if(.)
 		SSnano.update_uis(src)
 
-/obj/item/device/radio/borg/interact(mob/user as mob)
+/obj/item/device/radio/borg/interact(mob/user)
 	if(!on)
 		return
 

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -40,7 +40,7 @@
 /obj/item/device/spy_bug/attack_self(mob/user)
 	radio.attack_self(user)
 
-/obj/item/device/spy_bug/attackby(obj/W as obj, mob/living/user as mob)
+/obj/item/device/spy_bug/attackby(obj/W, mob/living/user)
 	if(istype(W, /obj/item/device/spy_monitor))
 		var/obj/item/device/spy_monitor/SM = W
 		SM.pair(src, user)
@@ -87,7 +87,7 @@
 	radio.attack_self(user)
 	view_cameras(user)
 
-/obj/item/device/spy_monitor/attackby(obj/W as obj, mob/living/user as mob)
+/obj/item/device/spy_monitor/attackby(obj/W, mob/living/user)
 	if(istype(W, /obj/item/device/spy_bug))
 		pair(W, user)
 	else
@@ -154,7 +154,7 @@
 	name = "DV-136ZB #[random_id(/obj/machinery/camera/spy, 1000,9999)]"
 	c_tag = name
 
-/obj/machinery/camera/spy/check_eye(mob/user as mob)
+/obj/machinery/camera/spy/check_eye(mob/user)
 	return 0
 
 /obj/item/device/radio/spy

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -109,7 +109,7 @@
 		turn_on()
 	to_chat(user, "<span class='notice'>You switch \the [src] [on ? "on" : "off"].</span>")
 
-/obj/item/device/suit_cooling_unit/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/suit_cooling_unit/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		if(cover_open)
 			cover_open = 0

--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -44,7 +44,7 @@
 /obj/item/device/suit_sensor_jammer/get_cell()
 	return bcell
 
-/obj/item/device/suit_sensor_jammer/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/device/suit_sensor_jammer/attackby(obj/item/I, mob/user)
 	if(isCrowbar(I))
 		if(bcell)
 			to_chat(user, "<span class='notice'>You remove \the [bcell].</span>")

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -101,7 +101,7 @@
 	if(distance <= 1 && maintenance)
 		to_chat(user, "<span class='notice'>The wires are exposed.</span>")
 
-/obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, verb="says", datum/language/speaking=null)
+/obj/item/device/taperecorder/hear_talk(mob/living/M, msg, verb="says", datum/language/speaking=null)
 	if(mytape && recording)
 
 		if(speaking)
@@ -112,7 +112,7 @@
 			mytape.record_speech("[M.name] [verb], \"[msg]\"")
 
 
-/obj/item/device/taperecorder/see_emote(mob/M as mob, text, emote_type)
+/obj/item/device/taperecorder/see_emote(mob/M, text, emote_type)
 	if(emote_type != AUDIBLE_MESSAGE) //only hearable emotes
 		return
 	if(mytape && recording)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -30,7 +30,7 @@ effective or pretty fucking useless.
 	var/times_used = 0 //Number of times it's been used.
 	var/max_uses = 2
 
-/obj/item/device/batterer/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
+/obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user) 	return
 	if(times_used >= max_uses)
 		to_chat(user, "<span class='warning'>The mind batterer has been burnt out!</span>")

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -69,13 +69,13 @@
 	return
 
 
-/obj/item/device/transfer_valve/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/device/transfer_valve/HasProximity(atom/movable/AM)
 	if(!attached_device)	return
 	attached_device.HasProximity(AM)
 	return
 
 
-/obj/item/device/transfer_valve/attack_self(mob/user as mob)
+/obj/item/device/transfer_valve/attack_self(mob/user)
 	ui_interact(user)
 
 /obj/item/device/transfer_valve/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -92,7 +92,7 @@
 		H.update_inv_l_hand()
 
 /* Assembly by a roboticist */
-/obj/item/robot_parts/head/attackby(obj/item/device/assembly/S, mob/user as mob)
+/obj/item/robot_parts/head/attackby(obj/item/device/assembly/S, mob/user)
 	if ((!istype(S, /obj/item/device/assembly/infra)))
 		..()
 		return

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -97,7 +97,7 @@
 	active = !active
 
 // Directly trigger the uplink. Turn on if it isn't already.
-/obj/item/device/uplink/proc/trigger(mob/user as mob)
+/obj/item/device/uplink/proc/trigger(mob/user)
 	if(!active)
 		toggle()
 	interact(user)
@@ -105,7 +105,7 @@
 // Checks to see if the value meets the target. Like a frequency being a traitor_frequency, in order to unlock a headset.
 // If true, it accesses trigger() and returns 1. If it fails, it returns false. Use this to see if you need to close the
 // current item's menu.
-/obj/item/device/uplink/proc/check_trigger(mob/user as mob, value, target)
+/obj/item/device/uplink/proc/check_trigger(mob/user, value, target)
 	if(value == target)
 		trigger(user)
 		return 1
@@ -205,7 +205,7 @@
 // You place this in your uplinkable item to check if an uplink is active or not.
 // If it is, it will display the uplink menu and return 1, else it'll return false.
 // If it returns true, I recommend closing the item's normal menu with "close_browser(user, "window=name")"
-/obj/item/proc/active_uplink_check(mob/user as mob)
+/obj/item/proc/active_uplink_check(mob/user)
 	// Activates the uplink if it's active
 	if(src.hidden_uplink)
 		if(src.hidden_uplink.active)
@@ -224,7 +224,7 @@
 	hidden_uplink = new(src, owner, amount)
 	icon_state = "radio"
 
-/obj/item/device/radio/uplink/attack_self(mob/user as mob)
+/obj/item/device/radio/uplink/attack_self(mob/user)
 	if(hidden_uplink)
 		hidden_uplink.trigger(user)
 
@@ -232,7 +232,7 @@
 	..()
 	hidden_uplink = new(src, owner)
 
-/obj/item/device/multitool/uplink/attack_self(mob/user as mob)
+/obj/item/device/multitool/uplink/attack_self(mob/user)
 	if(hidden_uplink)
 		hidden_uplink.trigger(user)
 

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -28,7 +28,7 @@
 
 	to_chat(usr, "You configure the hailer to shout \"[use_message]\".")
 
-/obj/item/device/hailer/attack_self(mob/living/carbon/user as mob)
+/obj/item/device/hailer/attack_self(mob/living/carbon/user)
 	if (spamcheck)
 		return
 

--- a/code/game/objects/items/instruments.dm
+++ b/code/game/objects/items/instruments.dm
@@ -11,5 +11,5 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "guitar"
 
-/obj/item/instrument/guitar/attack_self(mob/user as mob)
+/obj/item/instrument/guitar/attack_self(mob/user)
 	user.visible_message("<span class='notice'><b>\The [user]</b> strums [src]!</span>","<span class='notice'>You strum [src]!</span>")

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -43,6 +43,6 @@
 		burst()
 	return
 
-/obj/item/latexballon/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/latexballon/attackby(obj/item/W, mob/user)
 	if (W.can_puncture())
 		burst()

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -21,7 +21,7 @@
 		fingerprint = "N/A"
 	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species()]\nGender: [gender2text(H.gender)]\nAge: [H.age]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
 
-/obj/item/passport/attack_self(mob/user as mob)
+/obj/item/passport/attack_self(mob/user)
 	user.visible_message(
 		SPAN_ITALIC("[user] opens and checks [src]."),
 		SPAN_ITALIC("You open [src] and check for some main information."),

--- a/code/game/objects/items/robot/robot_frame.dm
+++ b/code/game/objects/items/robot/robot_frame.dm
@@ -31,7 +31,7 @@
 			return FALSE
 	return TRUE
 
-/obj/item/robot_parts/robot_suit/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/robot_parts/robot_suit/attackby(obj/item/W, mob/user)
 
 	// Uninstall a robotic part.
 	if(isCrowbar(W))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -102,7 +102,7 @@
 		success = FALSE
 	return success && ..()
 
-/obj/item/robot_parts/chest/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/robot_parts/chest/attackby(obj/item/W, mob/user)
 	..()
 	if(istype(W, /obj/item/cell))
 		if(src.cell)
@@ -182,7 +182,7 @@
 			continue
 		. += N
 
-/obj/item/robot_parts/head/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/robot_parts/head/attackby(obj/item/W, mob/user)
 	..()
 	if(istype(W, /obj/item/device/flash))
 		if(istype(user,/mob/living/silicon/robot))
@@ -195,7 +195,7 @@
 		else
 			add_flashes(W,user)
 
-/obj/item/robot_parts/head/proc/add_flashes(obj/item/W as obj, mob/user as mob) //Made into a seperate proc to avoid copypasta
+/obj/item/robot_parts/head/proc/add_flashes(obj/item/W, mob/user) //Made into a seperate proc to avoid copypasta
 	if(src.flash1 && src.flash2)
 		to_chat(user, "<span class='notice'>You have already inserted the eyes!</span>")
 		return

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -63,7 +63,7 @@
 	icon_state = "cyborg_upgrade1"
 	var/heldname = "default name"
 
-/obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
+/obj/item/borg/upgrade/rename/attack_self(mob/user)
 	heldname = sanitizeSafe(input(user, "Enter new robot name", "Robot Reclassification", heldname), MAX_NAME_LEN)
 
 /obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -8,7 +8,7 @@
 	amount = 10
 
 
-/obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/stack/nanopaste/attack(mob/living/M, mob/user)
 	if (!istype(M) || !istype(user))
 		return 0
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -40,7 +40,7 @@
 	throwforce = round(0.25*material.get_edge_damage())
 	force = round(0.5*material.get_blunt_damage())
 
-/obj/item/stack/material/rods/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/stack/material/rods/attackby(obj/item/W, mob/user)
 	if(isWelder(W))
 		var/obj/item/weldingtool/WT = W
 
@@ -62,7 +62,7 @@
 		return
 	..()
 
-/obj/item/stack/material/rods/attack_self(mob/user as mob)
+/obj/item/stack/material/rods/attack_self(mob/user)
 	src.add_fingerprint(user)
 
 	if(!istype(user.loc,/turf)) return 0

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -69,7 +69,7 @@
 	var/drying_threshold_temperature = 500 //Kelvin to start drying
 
 //Step one - dehairing.
-/obj/item/stack/animalhide/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/stack/animalhide/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/material/knife) || isHatchet(W))
 
 		//visible message on mobs is defined as visible_message(var/message, var/self_message, var/blind_message)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -54,10 +54,10 @@
 		else
 			to_chat(user, "There is enough charge for [get_amount()].")
 
-/obj/item/stack/attack_self(mob/user as mob)
+/obj/item/stack/attack_self(mob/user)
 	list_recipes(user)
 
-/obj/item/stack/proc/list_recipes(mob/user as mob, recipes_sublist)
+/obj/item/stack/proc/list_recipes(mob/user, recipes_sublist)
 	if (!recipes)
 		return
 	if (!src || get_amount() <= 0)
@@ -312,7 +312,7 @@
 	if (amount < max_amount)
 		. = Ceil(. * amount / max_amount)
 
-/obj/item/stack/attack_hand(mob/user as mob)
+/obj/item/stack/attack_hand(mob/user)
 	if (user.get_inactive_hand() == src)
 		var/N = input("How many stacks of [src] would you like to split off?", "Split stacks", 1) as num|null
 		if(N)
@@ -328,7 +328,7 @@
 		..()
 	return
 
-/obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/stack/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
 		src.transfer_to(S)

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -9,7 +9,7 @@
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	origin_tech = list(TECH_MATERIAL = 6, TECH_BLUESPACE = 4)
 
-/obj/item/stack/telecrystal/afterattack(obj/item/I as obj, mob/user as mob, proximity)
+/obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
 	if(!proximity)
 		return
 	if(istype(I, /obj/item))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -44,10 +44,10 @@
 	create_reagents(10)
 	..()
 
-/obj/item/toy/water_balloon/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+/obj/item/toy/water_balloon/attack(mob/living/carbon/human/M, mob/user)
 	return
 
-/obj/item/toy/water_balloon/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
+/obj/item/toy/water_balloon/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
 	if (istype(A, /obj/structure/reagent_dispensers/watertank) && get_dist(src,A) <= 1)
 		A.reagents.trans_to_obj(src, 10)
@@ -56,7 +56,7 @@
 		src.update_icon()
 	return
 
-/obj/item/toy/water_balloon/attackby(obj/O as obj, mob/user as mob)
+/obj/item/toy/water_balloon/attackby(obj/O, mob/user)
 	if(istype(O, /obj/item/reagent_containers/glass))
 		if(O.reagents)
 			if(O.reagents.total_volume < 1)
@@ -152,7 +152,7 @@
 	attack_verb = list("attacked", "struck", "hit")
 	var/bullets = 5
 
-/obj/item/toy/crossbow/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/toy/crossbow/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/toy/ammo/crossbow))
 		if(bullets <= 4)
 			if(!user.unEquip(I))
@@ -164,7 +164,7 @@
 			to_chat(usr, "<span class='warning'>It's already fully loaded.</span>")
 
 
-/obj/item/toy/crossbow/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
+/obj/item/toy/crossbow/afterattack(atom/target, mob/user, flag)
 	if(!isturf(target.loc) || target == user) return
 	if(flag) return
 
@@ -212,7 +212,7 @@
 			O.show_message(text("<span class='warning'>\The [] realized they were out of ammo and starting scrounging for some!</span>", user), 1)
 
 
-/obj/item/toy/crossbow/attack(mob/M as mob, mob/user as mob)
+/obj/item/toy/crossbow/attack(mob/M, mob/user)
 	src.add_fingerprint(user)
 
 // ******* Check
@@ -268,7 +268,7 @@
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "struck", "hit")
 
-/obj/item/toy/sword/attack_self(mob/user as mob)
+/obj/item/toy/sword/attack_self(mob/user)
 	src.active = !( src.active )
 	if (src.active)
 		to_chat(user, "<span class='notice'>You extend the plastic blade with a quick flick of your wrist.</span>")
@@ -321,7 +321,7 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)
 	qdel(src)
 
-/obj/item/toy/snappop/Crossed(H as mob|obj)
+/obj/item/toy/snappop/Crossed(H)
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
 		if(!MOVING_DELIBERATELY(M))
@@ -348,7 +348,7 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 
-/obj/item/toy/bosunwhistle/attack_self(mob/user as mob)
+/obj/item/toy/bosunwhistle/attack_self(mob/user)
 	if(cooldown < world.time - 35)
 		to_chat(user, "<span class='notice'>You blow on [src], creating an ear-splitting noise!</span>")
 		playsound(user, 'sound/misc/boatswain.ogg', 20, 1)
@@ -364,13 +364,13 @@
 	w_class = ITEM_SIZE_TINY
 
 //all credit to skasi for toy mech fun ideas
-/obj/item/toy/prize/attack_self(mob/user as mob)
+/obj/item/toy/prize/attack_self(mob/user)
 	if(cooldown < world.time - 8)
 		to_chat(user, "<span class='notice'>You play with [src].</span>")
 		playsound(user, 'sound/mecha/mechstep01.ogg', 20, 1)
 		cooldown = world.time
 
-/obj/item/toy/prize/attack_hand(mob/user as mob)
+/obj/item/toy/prize/attack_hand(mob/user)
 	if(loc == user)
 		if(cooldown < world.time - 8)
 			to_chat(user, "<span class='notice'>You play with [src].</span>")
@@ -842,7 +842,7 @@
 	set_light(0.6, 0.5, 2, 2, "#ff0000")
 	return ..()
 
-/obj/item/marshalling_wand/attack_self(mob/living/user as mob)
+/obj/item/marshalling_wand/attack_self(mob/living/user)
 	playsound(src.loc, 'sound/effects/rustle1.ogg', 100, 1)
 	if (user.a_intent == I_HELP)
 		user.visible_message("<span class='notice'>[user] beckons with \the [src], signalling forward motion.</span>",
@@ -874,7 +874,7 @@
 	icon_state= "ringbell"
 	anchored = TRUE
 
-/obj/item/toy/ringbell/attack_hand(mob/user as mob)
+/obj/item/toy/ringbell/attack_hand(mob/user)
 	if (user.a_intent == I_HELP)
 		user.visible_message("<span class='notice'>[user] rings \the [src], signalling the beginning of the contest.</span>")
 		playsound(user.loc, 'sound/items/oneding.ogg', 60)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -113,7 +113,7 @@ AI MODULES
 	desc = "A 'one crew member' AI module: 'Only <name> is a crew member.'."
 	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6) //made with diamonds!
 
-/obj/item/aiModule/oneHuman/attack_self(mob/user as mob)
+/obj/item/aiModule/oneHuman/attack_self(mob/user)
 	..()
 	var/targName = sanitize(input("Please enter the name of the person who is the only crew member.", "Who?", user.real_name))
 	targetName = targName
@@ -330,7 +330,7 @@ AI MODULES
 	desc = "A 'freeform' Core AI module: '<freeform>'."
 	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
 
-/obj/item/aiModule/freeformcore/attack_self(mob/user as mob)
+/obj/item/aiModule/freeformcore/attack_self(mob/user)
 	..()
 	var/newlaw = ""
 	var/targName = sanitize(input("Please enter a new core law for the AI.", "Freeform Law Entry", newlaw))
@@ -354,7 +354,7 @@ AI MODULES
 	desc = "A hacked AI law module: '<freeform>'."
 	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6, TECH_ESOTERIC = 7)
 
-/obj/item/aiModule/syndicate/attack_self(mob/user as mob)
+/obj/item/aiModule/syndicate/attack_self(mob/user)
 	..()
 	var/newlaw = ""
 	var/targName = sanitize(input("Please enter a new law for the AI.", "Freeform Law Entry", newlaw))

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -21,7 +21,7 @@ RSF
 	if(distance <= 0)
 		to_chat(user, "It currently holds [stored_matter]/30 fabrication-units.")
 
-/obj/item/rsf/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/rsf/attackby(obj/item/W, mob/user)
 	..()
 	if (istype(W, /obj/item/rcd_ammo))
 
@@ -36,7 +36,7 @@ RSF
 		to_chat(user, "The RSF now holds [stored_matter]/30 fabrication-units.")
 		return
 
-/obj/item/rsf/attack_self(mob/user as mob)
+/obj/item/rsf/attack_self(mob/user)
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
 	if (mode == 1)
 		mode = 2
@@ -59,7 +59,7 @@ RSF
 		to_chat(user, "Changed dispensing mode to 'Cigarette'")
 		return
 
-/obj/item/rsf/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/rsf/afterattack(atom/A, mob/user, proximity)
 
 	if(!proximity) return
 

--- a/code/game/objects/items/weapons/beachball.dm
+++ b/code/game/objects/items/weapons/beachball.dm
@@ -12,6 +12,6 @@
 	throw_range = 20
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
-/obj/item/beach_ball/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+/obj/item/beach_ball/afterattack(atom/target, mob/user)
 	if(user.unequip_item())
 		src.throw_at(target, throw_range, throw_speed, user)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -37,7 +37,7 @@
 		if(lit)
 			overlays += overlay_image(icon, "[icon_state]_lit", flags=RESET_COLOR)
 
-/obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/flame/candle/attackby(obj/item/W, mob/user)
 	..()
 	if(isflamesource(W) || is_hot(W))
 		light(user)
@@ -69,7 +69,7 @@
 		var/turf/T = loc
 		T.hotspot_expose(700, 5)
 
-/obj/item/flame/candle/attack_self(mob/user as mob)
+/obj/item/flame/candle/attack_self(mob/user)
 	if(lit)
 		lit = 0
 		update_icon()

--- a/code/game/objects/items/weapons/candle/scented.dm
+++ b/code/game/objects/items/weapons/candle/scented.dm
@@ -14,7 +14,7 @@
 	. = ..()
 	get_scent()
 
-/obj/item/flame/candle/scented/attack_self(mob/user as mob)
+/obj/item/flame/candle/scented/attack_self(mob/user)
 	..()
 	if(!lit)
 		remove_extension(src, /datum/extension/scent)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -213,7 +213,7 @@ var/global/const/NO_EMAG_ACT = -50
 /obj/item/card/id/proc/prevent_tracking()
 	return 0
 
-/obj/item/card/id/proc/show(mob/user as mob)
+/obj/item/card/id/proc/show(mob/user)
 	if(front && side)
 		send_rsc(user, front, "front.png")
 		send_rsc(user, side, "side.png")
@@ -290,7 +290,7 @@ var/global/const/NO_EMAG_ACT = -50
 	dat += "</tr></table>"
 	return jointext(dat,null)
 
-/obj/item/card/id/attack_self(mob/user as mob)
+/obj/item/card/id/attack_self(mob/user)
 	user.visible_message("\The [user] shows you: [icon2html(src, viewers(get_turf(src)))] [src.name]. The assignment on the card: [src.assignment]",\
 		"You flash your ID card: [icon2html(src, viewers(get_turf(src)))] [src.name]. The assignment on the card: [src.assignment]")
 

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -6,7 +6,7 @@
 	color = COLOR_GRAY40
 	detail_color = COLOR_NT_RED
 
-/obj/item/card/id/syndicate/New(mob/user as mob)
+/obj/item/card/id/syndicate/New(mob/user)
 	..()
 	access = syndicate_access.Copy()
 
@@ -21,7 +21,7 @@
 /obj/item/card/id/syndicate/prevent_tracking()
 	return electronic_warfare
 
-/obj/item/card/id/syndicate/afterattack(obj/item/O as obj, mob/user as mob, proximity)
+/obj/item/card/id/syndicate/afterattack(obj/item/O, mob/user, proximity)
 	if(!proximity) return
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/I = O
@@ -29,7 +29,7 @@
 		if(player_is_antag(user.mind))
 			to_chat(user, "<span class='notice'>The microscanner activates as you pass it over the ID, copying its access.</span>")
 
-/obj/item/card/id/syndicate/attack_self(mob/user as mob)
+/obj/item/card/id/syndicate/attack_self(mob/user)
 	// We use the fact that registered_name is not unset should the owner be vaporized, to ensure the id doesn't magically become unlocked.
 	if(!registered_user && register_user(user))
 		to_chat(user, "<span class='notice'>The microscanner marks you as its owner, preventing others from accessing its internals.</span>")

--- a/code/game/objects/items/weapons/circuitboards/computer/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/research.dm
@@ -2,7 +2,7 @@
 	name = T_BOARD("R&D control console")
 	build_path = /obj/machinery/computer/rdconsole/core
 
-/obj/item/stock_parts/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/stock_parts/circuitboard/rdconsole/attackby(obj/item/I, mob/user)
 	if(isScrewdriver(I))
 		user.visible_message("<span class='notice'>\The [user] adjusts the jumper on \the [src]'s access protocol pins.</span>", "<span class='notice'>You adjust the jumper on the access protocol pins.</span>")
 		if(src.build_path == /obj/machinery/computer/rdconsole/core)

--- a/code/game/objects/items/weapons/clothingbag.dm
+++ b/code/game/objects/items/weapons/clothingbag.dm
@@ -7,7 +7,7 @@
 	var/icon_used = "trashbag0"
 	var/opened = 0
 
-/obj/item/clothingbag/attack_self(mob/user as mob)
+/obj/item/clothingbag/attack_self(mob/user)
 	if(!opened)
 		user.visible_message("<span class='notice'>\The [user] tears open \the [src.name]!</span>", "<span class='notice'>You tear open \the [src.name]!</span>")
 		opened = 1

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -7,7 +7,7 @@
 /*
  * Banana Peals
  */
-/obj/item/bananapeel/Crossed(AM as mob|obj)
+/obj/item/bananapeel/Crossed(AM)
 	if (istype(AM, /mob/living))
 		var/mob/living/M = AM
 		M.slip("the [src.name]",4)
@@ -28,7 +28,7 @@
 	var/spam_flag = 0
 	var/audio_files = list("sound/items/bikehorn.ogg")
 
-/obj/item/bikehorn/attack_self(mob/user as mob)
+/obj/item/bikehorn/attack_self(mob/user)
 	if (spam_flag == 0)
 		spam_flag = 1
 		playsound(src.loc, pick(src.audio_files), 50, 1)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -29,7 +29,7 @@
 	colour = pick("red","purple","jade","black")
 	name = "[colour] lipstick"
 
-/obj/item/lipstick/attack_self(mob/user as mob)
+/obj/item/lipstick/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You twist \the [src] [open ? "closed" : "open"].</span>")
 	open = !open
 	if(open)
@@ -37,7 +37,7 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/lipstick/attack(atom/A, mob/user as mob, target_zone)
+/obj/item/lipstick/attack(atom/A, mob/user, target_zone)
 	if(!open)	return
 
 	if(ishuman(A))

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -60,7 +60,7 @@
 		comment = "Ouch, bad luck."
 	return list(result, comment)
 
-/obj/item/dice/attack_self(mob/user as mob)
+/obj/item/dice/attack_self(mob/user)
 	var/list/roll_result = roll_die()
 	var/result = roll_result[1]
 	var/comment = roll_result[2]

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -148,7 +148,7 @@
 		M.update_inv_r_hand(1)
 
 
-/obj/item/clothing/mask/smokable/ecig/attackby(obj/item/I, mob/user as mob)
+/obj/item/clothing/mask/smokable/ecig/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/ecig_cartridge))
 		if (ec_cartridge)//can't add second one
 			to_chat(user, "<span class='notice'>A cartridge has already been installed.</span> ")
@@ -176,7 +176,7 @@
 			to_chat(user, "<span class='notice'>\The [src] already has a battery installed.</span>")
 
 
-/obj/item/clothing/mask/smokable/ecig/attack_self(mob/user as mob)
+/obj/item/clothing/mask/smokable/ecig/attack_self(mob/user)
 	if (active)
 		Deactivate()
 		to_chat(user, "<span class='notice'>You turn off \the [src].</span> ")
@@ -199,7 +199,7 @@
 		else
 			to_chat(user, "<span class='warning'>\The [src] does not have a battery installed.</span>")
 
-/obj/item/clothing/mask/smokable/ecig/attack_hand(mob/user as mob)//eject cartridge
+/obj/item/clothing/mask/smokable/ecig/attack_hand(mob/user)//eject cartridge
 	if(user.get_inactive_hand() == src)//if being hold
 		if (ec_cartridge)
 			active=0

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -33,7 +33,7 @@
 	else
 		..()
 
-/obj/item/plastique/attack_self(mob/user as mob)
+/obj/item/plastique/attack_self(mob/user)
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num
 	if(user.get_active_hand() == src)
 		newtime = clamp(newtime, 10, 60000)
@@ -98,5 +98,5 @@
 		T--
 	explode(get_turf(target))
 
-/obj/item/plastique/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/plastique/attack(mob/M, mob/user, def_zone)
 	return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -55,7 +55,7 @@
 	if(distance <= 0)
 		to_chat(user, text("[icon2html(src, viewers(get_turf(src)))] [] contains [] units of water left!", src, src.reagents.total_volume))
 
-/obj/item/extinguisher/attack_self(mob/user as mob)
+/obj/item/extinguisher/attack_self(mob/user)
 	safety = !safety
 	src.icon_state = "[sprite_name][!safety]"
 	src.desc = "The safety is [safety ? "on" : "off"]."

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -76,7 +76,7 @@
 	else
 		return ..()
 
-/obj/item/flamethrower/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/flamethrower/attackby(obj/item/W, mob/user)
 	if(user.stat || user.restrained() || user.lying)	return
 	if(isWrench(W) && !status && !complete)//Taking this apart
 		if(weldtool)
@@ -121,7 +121,7 @@
 	return
 
 
-/obj/item/flamethrower/attack_self(mob/user as mob)
+/obj/item/flamethrower/attack_self(mob/user)
 	toggle_igniter(user)
 
 /obj/item/flamethrower/proc/toggle_igniter(mob/user)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -27,12 +27,12 @@
 	qdel(src)
 	return
 
-/obj/effect/spresent/relaymove(mob/user as mob)
+/obj/effect/spresent/relaymove(mob/user)
 	if (user.stat)
 		return
 	to_chat(user, "<span class='warning'>You can't move.</span>")
 
-/obj/effect/spresent/attackby(obj/item/W as obj, mob/user as mob)
+/obj/effect/spresent/attackby(obj/item/W, mob/user)
 	..()
 
 	if(!isWirecutter(W))
@@ -49,7 +49,7 @@
 
 	qdel(src)
 
-/obj/item/a_gift/attack_self(mob/M as mob)
+/obj/item/a_gift/attack_self(mob/M)
 	var/gift_type = pick(
 		/obj/item/storage/wallet,
 		/obj/item/storage/photo_album,
@@ -133,7 +133,7 @@
 			if(4) icon_state = "gift2"
 			if(5) icon_state = "gift3"
 
-/obj/item/gift/attack_self(mob/user as mob)
+/obj/item/gift/attack_self(mob/user)
 	user.drop_item()
 	if(src.gift)
 		user.put_in_active_hand(gift)
@@ -150,7 +150,7 @@
 	icon_state = "wrap_paper"
 	var/amount = 2.5*BASE_STORAGE_COST(ITEM_SIZE_HUGE)
 
-/obj/item/wrapping_paper/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/wrapping_paper/attackby(obj/item/W, mob/user)
 	..()
 	if (!( locate(/obj/structure/table, src.loc) ))
 		to_chat(user, "<span class='warning'>You MUST put the paper on a table!</span>")
@@ -190,7 +190,7 @@
 	if(distance <= 1)
 		to_chat(user, text("There is about [] square units of paper left!", src.amount))
 
-/obj/item/wrapping_paper/attack(mob/target as mob, mob/user as mob)
+/obj/item/wrapping_paper/attack(mob/target, mob/user)
 	if (!istype(target, /mob/living/carbon/human)) return
 	var/mob/living/carbon/human/H = target
 

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -63,7 +63,7 @@
 	if(T)
 		T.hotspot_expose(700,125)
 
-/obj/item/grenade/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/grenade/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		switch(det_time)
 			if (1)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -42,7 +42,7 @@
 	else
 		..()
 
-/obj/item/implanter/attack(mob/M as mob, mob/user as mob)
+/obj/item/implanter/attack(mob/M, mob/user)
 	if (!istype(M, /mob/living/carbon))
 		return
 	if (user && src.imp)

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -49,7 +49,7 @@
 		icon_state = "cimplanter0"
 	return
 
-/obj/item/implanter/compressed/attack(mob/M as mob, mob/user as mob)
+/obj/item/implanter/compressed/attack(mob/M, mob/user)
 	var/obj/item/implant/compressed/c = imp
 	if (!c)	return
 	if (c.scanned == null)
@@ -57,7 +57,7 @@
 		return
 	..()
 
-/obj/item/implanter/compressed/afterattack(obj/item/A, mob/user as mob, proximity)
+/obj/item/implanter/compressed/afterattack(obj/item/A, mob/user, proximity)
 	if(!proximity)
 		return
 	if(istype(A) && imp)

--- a/code/game/objects/items/weapons/implants/implants/death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implants/death_alarm.dm
@@ -61,7 +61,7 @@
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 
-/obj/item/implant/death_alarm/implanted(mob/source as mob)
+/obj/item/implant/death_alarm/implanted(mob/source)
 	mobname = source.real_name
 	START_PROCESSING(SSobj, src)
 	return TRUE

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -91,7 +91,7 @@
 	frequency = new_frequency
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
 
-/obj/item/implant/explosive/hear_talk(mob/M as mob, msg)
+/obj/item/implant/explosive/hear_talk(mob/M, msg)
 	hear(msg)
 
 /obj/item/implant/explosive/hear(msg)

--- a/code/game/objects/items/weapons/implants/implants/freedom.dm
+++ b/code/game/objects/items/weapons/implants/implants/freedom.dm
@@ -30,7 +30,7 @@
 	..()
 	return
 
-/obj/item/implant/freedom/trigger(emote, mob/living/carbon/source as mob)
+/obj/item/implant/freedom/trigger(emote, mob/living/carbon/source)
 	if (emote == activation_emote)
 		activate()
 

--- a/code/game/objects/items/weapons/implants/implants/uplink.dm
+++ b/code/game/objects/items/weapons/implants/implants/uplink.dm
@@ -18,7 +18,7 @@
 	hidden_uplink.uplink_owner = source.mind
 	return TRUE
 
-/obj/item/implant/uplink/trigger(emote, mob/source as mob)
+/obj/item/implant/uplink/trigger(emote, mob/source)
 	if(hidden_uplink && usr == source && !malfunction) // Let's not have another people activate our uplink
 		hidden_uplink.check_trigger(source, emote, activation_emote)
 

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -26,7 +26,7 @@
 	else if (contents.len >= max_butts/2)
 		overlays |= image('icons/obj/objects.dmi',"ashtray_half")
 
-/obj/item/material/ashtray/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/material/ashtray/attackby(obj/item/W, mob/user)
 	if (health_dead)
 		return
 

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -25,7 +25,7 @@
 	create_reagents(5)
 	return
 
-/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M))
 		return ..()
 

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -47,7 +47,7 @@
 		color = "#ffffff"
 		alpha = 255
 
-/obj/item/material/shard/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/material/shard/attackby(obj/item/W, mob/user)
 	if(isWelder(W) && material.shard_can_repair)
 		var/obj/item/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
@@ -56,7 +56,7 @@
 			return
 	return ..()
 
-/obj/item/material/shard/Crossed(AM as mob|obj)
+/obj/item/material/shard/Crossed(AM)
 	..()
 	if(isliving(AM))
 		var/mob/M = AM

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -12,12 +12,12 @@
 	attack_verb = list("poked", "jabbed")
 
 
-/obj/item/material/stick/attack_self(mob/user as mob)
+/obj/item/material/stick/attack_self(mob/user)
 	user.visible_message("<span class='warning'>\The [user] snaps [src].</span>", "<span class='warning'>You snap [src].</span>")
 	shatter(0)
 
 
-/obj/item/material/stick/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/material/stick/attackby(obj/item/W, mob/user)
 	if(W.sharp && W.edge && !sharp)
 		user.visible_message("<span class='warning'>[user] sharpens [src] with [W].</span>", "<span class='warning'>You sharpen [src] using [W].</span>")
 		sharp = TRUE

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -85,7 +85,7 @@
 	worth_multiplier = 31
 	base_parry_chance = 15
 
-/obj/item/material/twohanded/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user as mob, proximity)
+/obj/item/material/twohanded/fireaxe/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
 	..()
 	if(A && wielded)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -60,7 +60,7 @@
 		to_chat(user, "<span class='notice'>\The [src] deactivates!</span>")
 	set_light(0)
 
-/obj/item/melee/energy/attack_self(mob/living/user as mob)
+/obj/item/melee/energy/attack_self(mob/living/user)
 	if(active)
 		if((MUTATION_CLUMSY in user.mutations) && prob(50))
 			user.visible_message("<span class='danger'>\The [user] accidentally cuts \himself with \the [src].</span>",\
@@ -233,7 +233,7 @@
 /obj/item/melee/energy/blade/get_storage_cost()
 	return ITEM_SIZE_NO_CONTAINER
 
-/obj/item/melee/energy/blade/attack_self(mob/user as mob)
+/obj/item/melee/energy/blade/attack_self(mob/user)
 	user.drop_from_inventory(src)
 
 /obj/item/melee/energy/blade/dropped()

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -171,7 +171,7 @@ var/global/list/tape_roll_applications = list()
 	update_icon()
 	return ..()
 
-/obj/item/taperoll/attack_self(mob/user as mob)
+/obj/item/taperoll/attack_self(mob/user)
 	if(!start)
 		start = get_turf(src)
 		to_chat(usr, "<span class='notice'>You place the first end of \the [src].</span>")
@@ -286,7 +286,7 @@ var/global/list/tape_roll_applications = list()
 		to_chat(usr, "<span class='notice'>You finish placing \the [src].</span>")
 		return
 
-/obj/item/taperoll/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/taperoll/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)
 		return
 
@@ -332,10 +332,10 @@ var/global/list/tape_roll_applications = list()
 			crumple()
 	return ..(mover)
 
-/obj/item/tape/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/tape/attackby(obj/item/W, mob/user)
 	breaktape(user)
 
-/obj/item/tape/attack_hand(mob/user as mob)
+/obj/item/tape/attack_hand(mob/user)
 	if (user.a_intent == I_HELP && src.allowed(user))
 		user.show_viewers("<span class='notice'>\The [user] lifts \the [src], allowing passage.</span>")
 		for(var/obj/item/tape/T in gettapeline())

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -10,7 +10,7 @@
 	throw_range = 20
 	origin_tech = list(TECH_BLUESPACE = 4)
 
-/obj/item/teleportation_scroll/attack_self(mob/user as mob)
+/obj/item/teleportation_scroll/attack_self(mob/user)
 	if((user.mind && !GLOB.wizards.is_antagonist(user.mind)))
 		to_chat(usr, "<span class='warning'>You stare at the scroll but cannot make sense of the markings!</span>")
 		return

--- a/code/game/objects/items/weapons/secrets_disk.dm
+++ b/code/game/objects/items/weapons/secrets_disk.dm
@@ -41,7 +41,7 @@
 	Your sequencer can't break the code.</span>")
 	return 0
 
-/obj/item/disk/secret_project/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/disk/secret_project/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/card/id))
 		var/obj/item/card/id/ID = W
 		if(check_access(ID))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -81,7 +81,7 @@
 			return 0
 	return base_block_chance
 
-/obj/item/shield/riot/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/shield/riot/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/melee/baton))
 		if(cooldown < world.time - 25)
 			user.visible_message("<span class='warning'>[user] bashes [src] with [W]!</span>")
@@ -171,7 +171,7 @@
 			return (base_block_chance - round(damage / 2.5)) //block bullets and beams using the old block chance
 	return base_block_chance
 
-/obj/item/shield/energy/attack_self(mob/living/user as mob)
+/obj/item/shield/energy/attack_self(mob/living/user)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, "<span class='warning'>You beat yourself in the head with [src].</span>")
 		user.take_organ_damage(5, 0)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -43,7 +43,7 @@
 			return
 		AM.slip("the [src.name]",3)
 
-/obj/item/soap/afterattack(atom/target, mob/user as mob, proximity)
+/obj/item/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return
 	//I couldn't feasibly  fix the overlay bugs caused by cleaning items we are wearing.
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -27,7 +27,7 @@
 	/// Can this backpack be opened while worn on the back?
 	var/worn_access = TRUE
 
-/obj/item/storage/backpack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/backpack/attackby(obj/item/W, mob/user)
 	if (src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 1, -5)
 	return ..()
@@ -73,7 +73,7 @@
 	..()
 	return
 
-/obj/item/storage/backpack/holding/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/backpack/holding/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/storage/backpack/holding) || istype(W, /obj/item/storage/bag/trash/bluespace))
 		to_chat(user, "<span class='warning'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
 		qdel(W)
@@ -81,7 +81,7 @@
 	return ..()
 
 	//Please don't clutter the parent storage item with stupid hacks.
-/obj/item/storage/backpack/holding/can_be_inserted(obj/item/W as obj, stop_messages = 0)
+/obj/item/storage/backpack/holding/can_be_inserted(obj/item/W, stop_messages = 0)
 	if(istype(W, /obj/item/storage/backpack/holding))
 		return 1
 	return ..()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -7,11 +7,11 @@
 	use_to_pickup = 1
 	slot_flags = SLOT_BELT
 
-/obj/item/storage/bag/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
+/obj/item/storage/bag/handle_item_insertion(obj/item/W, prevent_warning = 0)
 	. = ..()
 	if(.) update_w_class()
 
-/obj/item/storage/bag/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/bag/remove_from_storage(obj/item/W, atom/new_location)
 	. = ..()
 	if(.) update_w_class()
 
@@ -68,7 +68,7 @@
 	desc = "The latest and greatest in custodial convenience, a trashbag that is capable of holding vast quantities of garbage."
 	icon_state = "bluetrashbag"
 
-/obj/item/storage/bag/trash/bluespace/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/bag/trash/bluespace/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/storage/backpack/holding) || istype(W, /obj/item/storage/bag/trash/bluespace))
 		to_chat(user, "<span class='warning'>The Bluespace interfaces of the two devices conflict and malfunction.</span>")
 		qdel(W)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -64,14 +64,14 @@
 	. = ..()
 	set_extension(src, /datum/extension/holster, src, sound_in, sound_out, can_holster)
 
-/obj/item/storage/belt/holster/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/belt/holster/attackby(obj/item/W, mob/user)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.holster(W, user))
 		return
 	else
 		. = ..(W, user)
 
-/obj/item/storage/belt/holster/attack_hand(mob/user as mob)
+/obj/item/storage/belt/holster/attack_hand(mob/user)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.unholster(user))
 		return

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -77,7 +77,7 @@
 				to_chat(M, "Nothing happened.")
 		..()
 
-/obj/item/storage/bible/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/storage/bible/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
 	if(user.mind && istype(user.mind.assigned_job, /datum/job/chaplain))
 		if(A.reagents && A.reagents.has_reagent(/datum/reagent/water)) //blesses all the water in the holder
@@ -86,7 +86,7 @@
 			A.reagents.del_reagent(/datum/reagent/water)
 			A.reagents.add_reagent(/datum/reagent/water/holywater,water2holy)
 
-/obj/item/storage/bible/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/bible/attackby(obj/item/W, mob/user)
 	if (src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 1, -5)
 	return ..()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -47,7 +47,7 @@
 	startswith = list(/obj/item/card/union = 14)
 
 // BubbleWrap - A box can be folded up to make card
-/obj/item/storage/box/attack_self(mob/user as mob)
+/obj/item/storage/box/attack_self(mob/user)
 	if(..()) return
 
 	//try to fold it.
@@ -366,7 +366,7 @@
 	can_hold = list(/obj/item/flame/match)
 	startswith = list(/obj/item/flame/match = 10)
 
-/obj/item/storage/box/matches/attackby(obj/item/flame/match/W as obj, mob/user as mob)
+/obj/item/storage/box/matches/attackby(obj/item/flame/match/W, mob/user)
 	if(istype(W) && !W.lit && !W.burnt)
 		W.lit = 1
 		W.damtype = INJURY_TYPE_BURN

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -155,14 +155,14 @@
 	atom_flags |= ATOM_FLAG_NO_REACT|ATOM_FLAG_OPEN_CONTAINER
 	create_reagents(5 * max_storage_space)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 
-/obj/item/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/fancy/cigarettes/remove_from_storage(obj/item/W, atom/new_location)
 	// Don't try to transfer reagents to lighters
 	if(istype(W, /obj/item/clothing/mask/smokable/cigarette))
 		var/obj/item/clothing/mask/smokable/cigarette/C = W
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 	..()
 
-/obj/item/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/storage/fancy/cigarettes/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M, /mob))
 		return
 
@@ -304,7 +304,7 @@
 	atom_flags |= ATOM_FLAG_NO_REACT
 	create_reagents(10 * storage_slots)
 
-/obj/item/storage/fancy/cigar/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/fancy/cigar/remove_from_storage(obj/item/W, atom/new_location)
 	var/obj/item/clothing/mask/smokable/cigarette/cigar/C = W
 	if(!istype(C)) return
 	reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
@@ -360,6 +360,6 @@
 		overlays += image(icon, src, "ledb")
 	return
 
-/obj/item/storage/lockbox/vials/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/lockbox/vials/attackby(obj/item/W, mob/user)
 	. = ..()
 	update_icon()

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -28,7 +28,7 @@
 //items that use internal storage have the option of calling this to emulate default storage MouseDrop behaviour.
 //returns 1 if the master item's parent's MouseDrop() should be called, 0 otherwise. It's strange, but no other way of
 //doing it without the ability to call another proc's parent, really.
-/obj/item/storage/internal/proc/handle_mousedrop(mob/user as mob, obj/over_object as obj)
+/obj/item/storage/internal/proc/handle_mousedrop(mob/user, obj/over_object)
 	if (ishuman(user) || issmall(user)) //so monkeys can take off their backpacks -- Urist
 
 		if(over_object == user && Adjacent(user)) // this must come before the screen objects only block
@@ -59,7 +59,7 @@
 //items that use internal storage have the option of calling this to emulate default storage attack_hand behaviour.
 //returns 1 if the master item's parent's attack_hand() should be called, 0 otherwise.
 //It's strange, but no other way of doing it without the ability to call another proc's parent, really.
-/obj/item/storage/internal/proc/handle_attack_hand(mob/user as mob)
+/obj/item/storage/internal/proc/handle_attack_hand(mob/user)
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -21,7 +21,7 @@
 	var/linked
 
 
-/obj/item/storage/laundry_basket/attack_hand(mob/user as mob)
+/obj/item/storage/laundry_basket/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.get_organ(BP_R_HAND)
@@ -36,7 +36,7 @@
 		return
 	return ..()
 
-/obj/item/storage/laundry_basket/attack_self(mob/user as mob)
+/obj/item/storage/laundry_basket/attack_self(mob/user)
 	var/turf/T = get_turf(user)
 	to_chat(user, "<span class='notice'>You dump the [src]'s contents onto \the [T].</span>")
 	return ..()
@@ -58,20 +58,20 @@
 	return
 
 
-/obj/item/storage/laundry_basket/MouseDrop(obj/over_object as obj)
+/obj/item/storage/laundry_basket/MouseDrop(obj/over_object)
 	if(over_object == usr)
 		return
 	else
 		return ..()
 
-/obj/item/storage/laundry_basket/dropped(mob/user as mob)
+/obj/item/storage/laundry_basket/dropped(mob/user)
 	qdel(linked)
 	return ..()
 
-/obj/item/storage/laundry_basket/show_to(mob/user as mob)
+/obj/item/storage/laundry_basket/show_to(mob/user)
 	return
 
-/obj/item/storage/laundry_basket/open(mob/user as mob)
+/obj/item/storage/laundry_basket/open(mob/user)
 
 
 //Offhand
@@ -81,8 +81,7 @@
 	name = "second hand"
 	use_to_pickup = 0
 
-/obj/item/storage/laundry_basket/offhand/dropped(mob/user as mob)
+/obj/item/storage/laundry_basket/offhand/dropped(mob/user)
 	..()
 	user.drop_from_inventory(linked)
 	return
-

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -38,7 +38,7 @@
 	QDEL_NULL(storage_ui)
 	. = ..()
 
-/obj/item/storage/MouseDrop(obj/over_object as obj)
+/obj/item/storage/MouseDrop(obj/over_object)
 	if(!canremove)
 		return
 
@@ -87,15 +87,15 @@
 			L += G.gift:return_inv()
 	return L
 
-/obj/item/storage/proc/show_to(mob/user as mob)
+/obj/item/storage/proc/show_to(mob/user)
 	if(storage_ui)
 		storage_ui.show_to(user)
 
-/obj/item/storage/proc/hide_from(mob/user as mob)
+/obj/item/storage/proc/hide_from(mob/user)
 	if(storage_ui)
 		storage_ui.hide_from(user)
 
-/obj/item/storage/proc/open(mob/user as mob)
+/obj/item/storage/proc/open(mob/user)
 	if (virtual)
 		return
 	if(!opened)
@@ -116,7 +116,7 @@
 /obj/item/storage/proc/prepare_ui()
 	storage_ui.prepare_ui()
 
-/obj/item/storage/proc/close(mob/user as mob)
+/obj/item/storage/proc/close(mob/user)
 	hide_from(user)
 	if(storage_ui)
 		storage_ui.after_close(user)
@@ -235,7 +235,7 @@
 		storage_ui.on_post_remove(usr)
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
-/obj/item/storage/proc/remove_from_storage(obj/item/W as obj, atom/new_location, NoUpdate = 0)
+/obj/item/storage/proc/remove_from_storage(obj/item/W, atom/new_location, NoUpdate = 0)
 	if(!istype(W)) return 0
 	new_location = new_location || get_turf(src)
 
@@ -276,7 +276,7 @@
 	update_icon()
 
 //This proc is called when you want to place an item into the storage item.
-/obj/item/storage/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/attackby(obj/item/W, mob/user)
 	. = ..()
 	if (.) //if the item was used as a crafting component, just return
 		return
@@ -290,7 +290,7 @@
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)
 
-/obj/item/storage/attack_hand(mob/user as mob)
+/obj/item/storage/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.l_store == src && !H.get_active_hand())	//Prevents opening if it's in a pocket.
@@ -436,7 +436,7 @@
 			O.emp_act(severity)
 	..()
 
-/obj/item/storage/attack_self(mob/user as mob)
+/obj/item/storage/attack_self(mob/user)
 	//Clicking on itself will empty it, if it has the verb to do that.
 	if(user.get_active_hand() == src)
 		if(src.verbs.Find(/obj/item/storage/verb/quick_empty))

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -57,7 +57,7 @@
 		front_id = null
 	. = ..()
 
-/obj/item/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/wallet/remove_from_storage(obj/item/W, atom/new_location)
 	. = ..(W, new_location)
 	if(.)
 		if(W == front_id)
@@ -65,7 +65,7 @@
 			SetName(initial(name))
 			update_icon()
 
-/obj/item/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
+/obj/item/storage/wallet/handle_item_insertion(obj/item/W, prevent_warning = 0)
 	. = ..(W, prevent_warning)
 	if(.)
 		if(!front_id && istype(W, /obj/item/card/id))

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -17,7 +17,7 @@
 	slot_flags = SLOT_BELT
 	force = 10
 
-/obj/item/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/melee/classic_baton/attack(mob/M, mob/living/user)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, "<span class='warning'>You club yourself over the head.</span>")
 		user.Weaken(3 * force)
@@ -43,7 +43,7 @@
 	var/on = 0
 
 
-/obj/item/melee/telebaton/attack_self(mob/user as mob)
+/obj/item/melee/telebaton/attack_self(mob/user)
 	on = !on
 	if(on)
 		user.visible_message("<span class='warning'>With a flick of their wrist, [user] extends their telescopic baton.</span>",\
@@ -77,7 +77,7 @@
 		overlays.Cut()
 		overlays += blood_overlay
 
-/obj/item/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
+/obj/item/melee/telebaton/attack(mob/target, mob/living/user)
 	if(on)
 		if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 			to_chat(user, "<span class='warning'>You club yourself over the head.</span>")

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -100,7 +100,7 @@
 	name = "jetpack"
 	var/obj/item/rig/holder
 
-/obj/item/tank/jetpack/rig/allow_thrust(num, mob/living/user as mob)
+/obj/item/tank/jetpack/rig/allow_thrust(num, mob/living/user)
 
 	if(!(src.on))
 		return 0

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -229,7 +229,7 @@ var/global/list/tank_gauge_cache = list()
 			else
 				to_chat(user, "<span class='notice'>The emergency pressure relief valve has already been welded.</span>")
 
-/obj/item/tank/attack_self(mob/user as mob)
+/obj/item/tank/attack_self(mob/user)
 	add_fingerprint(user)
 	if (!air_contents)
 		return
@@ -624,7 +624,7 @@ var/global/list/tank_gauge_cache = list()
 /obj/item/device/tankassemblyproxy/on_update_icon()
 	tank.update_icon()
 
-/obj/item/device/tankassemblyproxy/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/device/tankassemblyproxy/HasProximity(atom/movable/AM)
 	if(assembly)
 		assembly.HasProximity(AM)
 

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -24,7 +24,7 @@
 	origin_tech = list(TECH_MAGNET = 1)
 	matter = list(MATERIAL_ALUMINIUM = 400)
 
-/obj/item/locator/attack_self(mob/user as mob)
+/obj/item/locator/attack_self(mob/user)
 	user.set_machine(src)
 	var/dat
 	if (src.temp)

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -29,7 +29,7 @@
 		src.pixel_y = rand(0, 16)
 	. = ..()
 
-/obj/item/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/screwdriver/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M) || user.a_intent == "help")
 		return ..()
 	if(user.zone_sel.selecting != BP_EYES && user.zone_sel.selecting != BP_HEAD)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -47,7 +47,7 @@
 	else
 		to_chat(user, (distance <= 1 ? "It has [get_fuel()] [welding_resource] remaining. " : "") + "[tank] is attached.")
 
-/obj/item/weldingtool/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/weldingtool/attackby(obj/item/W, mob/user)
 	if(welding)
 		to_chat(user, SPAN_DANGER("Stop welding first!"))
 		return
@@ -90,7 +90,7 @@
 	..()
 
 
-/obj/item/weldingtool/attack_hand(mob/user as mob)
+/obj/item/weldingtool/attack_hand(mob/user)
 	if (tank && user.get_inactive_hand() == src)
 		if (!welding)
 			user.visible_message("[user] removes \the [tank] from \the [src].", "You remove \the [tank] from \the [src].")
@@ -142,7 +142,7 @@
 			location.hotspot_expose(700, 50, 1)
 	return
 
-/obj/item/weldingtool/attack_self(mob/user as mob)
+/obj/item/weldingtool/attack_self(mob/user)
 	setWelding(!welding, usr)
 	return
 
@@ -317,7 +317,7 @@
 	reagents.add_reagent(/datum/reagent/fuel, max_fuel)
 	. = ..()
 
-/obj/item/welder_tank/afterattack(obj/O as obj, mob/user as mob, proximity)
+/obj/item/welder_tank/afterattack(obj/O, mob/user, proximity)
 	if (!proximity)
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src, O) <= 1)

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -29,7 +29,7 @@
 		overlays += overlay_image(icon, "[hardware_icon]", flags=RESET_COLOR)
 	. = ..()
 
-/obj/item/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
+/obj/item/wirecutters/attack(mob/living/carbon/C, mob/user)
 	if(istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -10,7 +10,7 @@
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "A soft cotton towel."
 
-/obj/item/towel/attack_self(mob/living/user as mob)
+/obj/item/towel/attack_self(mob/living/user)
 	user.visible_message("<span class='notice'>[user] uses [src] to towel themselves off.</span>")
 	playsound(user, 'sound/weapons/towelwipe.ogg', 25, 1)
 

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -17,7 +17,7 @@
 /obj/item/beartrap/proc/can_use(mob/user)
 	return (user.IsAdvancedToolUser() && !issilicon(user) && !user.stat && !user.restrained())
 
-/obj/item/beartrap/user_unbuckle_mob(mob/user as mob)
+/obj/item/beartrap/user_unbuckle_mob(mob/user)
 	if(buckled_mob && can_use(user))
 		user.visible_message(
 			"<span class='notice'>\The [user] begins freeing \the [buckled_mob] from \the [src].</span>",
@@ -29,7 +29,7 @@
 			unbuckle_mob()
 			anchored = FALSE
 
-/obj/item/beartrap/attack_self(mob/user as mob)
+/obj/item/beartrap/attack_self(mob/user)
 	..()
 	if(!deployed && can_use(user))
 		user.visible_message(
@@ -49,7 +49,7 @@
 			update_icon()
 			anchored = TRUE
 
-/obj/item/beartrap/attack_hand(mob/user as mob)
+/obj/item/beartrap/attack_hand(mob/user)
 	if(buckled_mob)
 		user_unbuckle_mob(user)
 	else if(deployed && can_use(user))
@@ -86,7 +86,7 @@
 	to_chat(L, "<span class='danger'>The steel jaws of \the [src] bite into you, trapping you in place!</span>")
 	deployed = 0
 
-/obj/item/beartrap/Crossed(AM as mob|obj)
+/obj/item/beartrap/Crossed(AM)
 	if(deployed && isliving(AM))
 		var/mob/living/L = AM
 		if(!MOVING_DELIBERATELY(L))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -14,7 +14,7 @@
 /obj/item/nullrod/disrupts_psionics()
 	return src
 
-/obj/item/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
+/obj/item/nullrod/attack(mob/M, mob/living/user) //Paste from old-code to decult with a null rod.
 	if (user.a_intent == I_HELP)
 		return FALSE
 
@@ -208,7 +208,7 @@
 	healthcheck()
 	return
 
-/obj/effect/energy_net/attackby(obj/item/W as obj, mob/user as mob)
+/obj/effect/energy_net/attackby(obj/item/W, mob/user)
 	health -= W.force
 	healthcheck()
 	..()
@@ -217,7 +217,7 @@
 	return escape_net(user)
 
 
-/obj/effect/energy_net/proc/escape_net(mob/user as mob)
+/obj/effect/energy_net/proc/escape_net(mob/user)
 	visible_message(
 		"<span class='warning'>\The [user] attempts to free themselves from \the [src]!</span>",
 		"<span class='warning'>You attempt to free yourself from \the [src]!</span>"

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -17,7 +17,7 @@
 
 	. = ..()
 
-/obj/item/storage/backpack/weldpack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/backpack/weldpack/attackby(obj/item/W, mob/user)
 	if(isWelder(W))
 		var/obj/item/weldingtool/T = W
 		if(T.welding & prob(50))
@@ -44,7 +44,7 @@
 		return
 	..()
 
-/obj/item/storage/backpack/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
+/obj/item/storage/backpack/weldpack/afterattack(obj/O, mob/user, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
 		return
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume < max_fuel)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -98,7 +98,7 @@
 /obj/proc/hides_under_flooring()
 	return level == 1
 
-/obj/proc/hear_talk(mob/M as mob, text, verb, datum/language/speaking)
+/obj/proc/hear_talk(mob/M, text, verb, datum/language/speaking)
 	if(talking_atom)
 		talking_atom.catchMessage(text, M)
 /*
@@ -109,7 +109,7 @@
 		*/
 	return
 
-/obj/proc/see_emote(mob/M as mob, text, emote_type)
+/obj/proc/see_emote(mob/M, text, emote_type)
 	return
 
 /obj/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -24,7 +24,7 @@
 /obj/structure/barricade/get_material()
 	return material
 
-/obj/structure/barricade/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/barricade/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/material/rods) && !spiky)
 		var/obj/item/stack/material/rods/R = W
 		if(R.get_amount() < 5)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -125,7 +125,7 @@ LINEN BINS
 		else				icon_state = "linenbin-full"
 
 
-/obj/structure/bedsheetbin/attackby(obj/item/I as obj, mob/user as mob)
+/obj/structure/bedsheetbin/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/bedsheet))
 		if(!user.unEquip(I, src))
 			return

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -74,7 +74,7 @@
 		new plated_tile.build_type(src.loc)
 	qdel(src)
 
-/obj/structure/catwalk/attackby(obj/item/C as obj, mob/user as mob)
+/obj/structure/catwalk/attackby(obj/item/C, mob/user)
 	if(isWelder(C))
 		var/obj/item/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -6,14 +6,14 @@
 	var/obj/item/clothing/suit/coat
 	var/list/allowed = list(/obj/item/clothing/suit/storage/toggle/labcoat, /obj/item/clothing/suit/storage/det_trench)
 
-/obj/structure/coatrack/attack_hand(mob/user as mob)
+/obj/structure/coatrack/attack_hand(mob/user)
 	user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src]")
 	if(!user.put_in_active_hand(coat))
 		coat.dropInto(user.loc)
 	coat = null
 	update_icon()
 
-/obj/structure/coatrack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/coatrack/attackby(obj/item/W, mob/user)
 	var/can_hang = 0
 	for (var/T in allowed)
 		if(istype(W,T))

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -214,7 +214,7 @@
 		return MOB_LARGE
 	return 0
 
-/obj/structure/closet/proc/toggle(mob/user as mob)
+/obj/structure/closet/proc/toggle(mob/user)
 	if(locked)
 		togglelock(user)
 	else if(!(src.opened ? src.close() : src.open()))
@@ -249,7 +249,7 @@
 				break
 	. = ..()
 
-/obj/structure/closet/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/closet/attackby(obj/item/W, mob/user)
 	if (user.a_intent == I_HURT)
 		..()
 		return
@@ -327,7 +327,7 @@
 						 "You hear welding.")
 	qdel(src)
 
-/obj/structure/closet/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/structure/closet/MouseDrop_T(atom/movable/O, mob/user)
 	if (!O)
 		return
 	if(istype(O, /obj/screen))	//fix for HUD elements making their way into the world	-Pete
@@ -356,14 +356,14 @@
 	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
 		attack_hand(user)
 
-/obj/structure/closet/relaymove(mob/user as mob)
+/obj/structure/closet/relaymove(mob/user)
 	if(user.stat || !isturf(src.loc))
 		return
 
 	if(!src.open())
 		to_chat(user, "<span class='notice'>It won't budge!</span>")
 
-/obj/structure/closet/attack_hand(mob/user as mob)
+/obj/structure/closet/attack_hand(mob/user)
 	src.add_fingerprint(user)
 	src.toggle(user)
 

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -27,7 +27,7 @@
 	else
 		..()
 
-/obj/structure/closet/coffin/toggle(mob/user as mob)
+/obj/structure/closet/coffin/toggle(mob/user)
 	if(!(opened ? close() : open()))
 		to_chat(user, SPAN_NOTICE("It won't budge!"))
 

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -103,7 +103,7 @@
 /obj/structure/closet/statue/on_update_icon()
 	return
 
-/obj/structure/closet/statue/proc/shatter(mob/user as mob)
+/obj/structure/closet/statue/proc/shatter(mob/user)
 	if (user)
 		user.dust()
 	dump_contents()

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -20,14 +20,14 @@
 	var/amount = 2 // spawns each items X times.
 	closet_appearance = /decl/closet_appearance/wall/emergency
 
-/obj/structure/closet/walllocker/emerglocker/toggle(mob/user as mob)
+/obj/structure/closet/walllocker/emerglocker/toggle(mob/user)
 	src.attack_hand(user)
 	return
 
-/obj/structure/closet/walllocker/emerglocker/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/closet/walllocker/emerglocker/attackby(obj/item/W, mob/user)
 	return
 
-/obj/structure/closet/walllocker/emerglocker/attack_hand(mob/user as mob)
+/obj/structure/closet/walllocker/emerglocker/attack_hand(mob/user)
 	if (istype(user, /mob/living/silicon/ai))	//Added by Strumpetplaya - AI shouldn't be able to
 		return									//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc)
 	if(!amount)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -30,7 +30,7 @@
 			devices += A
 		to_chat(user,"There are some wires attached to the lid, connected to [english_list(devices)].")
 
-/obj/structure/closet/crate/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/closet/crate/attackby(obj/item/W, mob/user)
 	if(opened)
 		return ..()
 	else if(istype(W, /obj/item/stack/package_wrap))

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -13,11 +13,11 @@
 			continue
 		I.forceMove(src)
 
-/obj/structure/largecrate/attack_hand(mob/user as mob)
+/obj/structure/largecrate/attack_hand(mob/user)
 	to_chat(user, "<span class='notice'>You need a crowbar to pry this open!</span>")
 	return
 
-/obj/structure/largecrate/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/largecrate/attackby(obj/item/W, mob/user)
 	if(isCrowbar(W))
 		new /obj/item/stack/material/wood(src)
 		var/turf/T = get_turf(src)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -64,7 +64,7 @@
 	for(var/atom/movable/AM in contents)
 		underlays += AM.appearance
 
-/obj/structure/displaycase/attack_hand(mob/user as mob)
+/obj/structure/displaycase/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(!health_dead)
 		to_chat(usr, text("<span class='warning'>You kick the display case.</span>"))

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -85,7 +85,7 @@
 
 
 
-/obj/structure/door_assembly/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/door_assembly/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/pen))
 		var/t = sanitizeSafe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
 		if(!t)	return

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -12,7 +12,7 @@
 	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)
 	return
 
-/obj/structure/bed/chair/e_chair/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bed/chair/e_chair/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		var/obj/structure/bed/chair/C = new /obj/structure/bed/chair(loc)
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -38,7 +38,7 @@
 	var/list/success_message = list("with great effort", "straining hard", "without any trouble", "with ease")
 	var/list/fail_message = list(", lifting them part of the way and then letting them drop", ", unable to even budge them")
 
-/obj/structure/fitness/weightlifter/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/fitness/weightlifter/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 75, 1)
 		weight = (weight % max_weight) + 1

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -16,7 +16,7 @@
 	light_color = get_random_colour(lower = 190)
 	set_light(0.6, 3, 5, 2, light_color)
 
-/obj/structure/fountain/attack_hand(mob/living/user as mob)
+/obj/structure/fountain/attack_hand(mob/living/user)
 	if(user.incapacitated())
 		return
 	if(!CanPhysicallyInteract(user))
@@ -34,7 +34,7 @@
 	else
 		visible_message("\The [user] retracts their hand suddenly.")
 
-/obj/structure/fountain/proc/time_dilation(mob/living/carbon/human/user as mob)
+/obj/structure/fountain/proc/time_dilation(mob/living/carbon/human/user)
 	for(var/mob/living/L in oviewers(7, src))
 		L.flash_eyes(3)
 		L.eye_blurry += 9

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -216,7 +216,7 @@
 	new /obj/item/stack/material/steel(get_turf(src))
 	qdel(src)
 
-/obj/structure/girder/attack_hand(mob/user as mob)
+/obj/structure/girder/attack_hand(mob/user)
 	if (MUTATION_HULK in user.mutations)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
 		dismantle()
@@ -232,7 +232,7 @@
 /obj/structure/girder/cult/dismantle()
 	qdel(src)
 
-/obj/structure/girder/cult/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/girder/cult/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now disassembling the girder...</span>")

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -84,7 +84,7 @@
 /obj/structure/grille/Bumped(atom/user)
 	if(ismob(user)) shock(user, 70)
 
-/obj/structure/grille/attack_hand(mob/user as mob)
+/obj/structure/grille/attack_hand(mob/user)
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
@@ -151,7 +151,7 @@
 
 	damage_health(damage, Proj.damage_type)
 
-/obj/structure/grille/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/grille/attackby(obj/item/W, mob/user)
 	if (user.a_intent == I_HURT)
 		if (!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
 			..()
@@ -209,7 +209,7 @@
 // shock user with probability prb (if all connections & power are working)
 // returns 1 if shocked, 0 otherwise
 
-/obj/structure/grille/proc/shock(mob/user as mob, prb)
+/obj/structure/grille/proc/shock(mob/user, prb)
 	if(!anchored || is_broken())		// anchored/destroyed grilles are never connected
 		return 0
 	if(material && !material.conductive)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -137,7 +137,7 @@
 		return
 	..()
 
-/obj/structure/inflatable/attack_hand(mob/user as mob)
+/obj/structure/inflatable/attack_hand(mob/user)
 	add_fingerprint(user)
 	return
 
@@ -219,14 +219,14 @@
 	var/state = 0 //closed, 1 == open
 	var/isSwitchingStates = 0
 
-/obj/structure/inflatable/door/attack_ai(mob/user as mob) //those aren't machinery, they're just big fucking slabs of a mineral
+/obj/structure/inflatable/door/attack_ai(mob/user) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isAI(user)) //so the AI can't open it
 		return
 	else if(isrobot(user)) //but cyborgs can
 		if(get_dist(user,src) <= 1) //not remotely though
 			return TryToSwitchState(user)
 
-/obj/structure/inflatable/door/attack_hand(mob/user as mob)
+/obj/structure/inflatable/door/attack_hand(mob/user)
 	return TryToSwitchState(user)
 
 /obj/structure/inflatable/door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -64,7 +64,7 @@
 	else if(ishuman(over_object))
 		hook_up(over_object, usr)
 
-/obj/structure/iv_drip/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/iv_drip/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/reagent_containers/ivbag))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
@@ -121,7 +121,7 @@
 		if(attached.take_blood(beaker,amount))
 			queue_icon_update()
 
-/obj/structure/iv_drip/attack_hand(mob/user as mob)
+/obj/structure/iv_drip/attack_hand(mob/user)
 	if(attached)
 		drip_detach(user)
 	else if(beaker)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -60,7 +60,7 @@
 			qdel(C)
 	qdel(src)
 
-/obj/structure/lattice/attackby(obj/item/C as obj, mob/user as mob)
+/obj/structure/lattice/attackby(obj/item/C, mob/user)
 
 	if (istype(C, /obj/item/stack/tile/floor))
 		var/turf/T = get_turf(src)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -60,7 +60,7 @@
 				return
 	return
 
-/obj/structure/morgue/attack_hand(mob/user as mob)
+/obj/structure/morgue/attack_hand(mob/user)
 	if (src.connected)
 		for(var/atom/movable/A as mob|obj in src.connected.loc)
 			if (!( A.anchored ))
@@ -92,7 +92,7 @@
 		return attack_hand(user)
 	else return ..()
 
-/obj/structure/morgue/attackby(P as obj, mob/user as mob)
+/obj/structure/morgue/attackby(P, mob/user)
 	if (istype(P, /obj/item/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if (user.get_active_hand() != P)
@@ -107,7 +107,7 @@
 	src.add_fingerprint(user)
 	return
 
-/obj/structure/morgue/relaymove(mob/user as mob)
+/obj/structure/morgue/relaymove(mob/user)
 	if (user.stat)
 		return
 	src.connected = new /obj/structure/m_tray( src.loc )
@@ -145,7 +145,7 @@
 	connected = null
 	return ..()
 
-/obj/structure/m_tray/attack_hand(mob/user as mob)
+/obj/structure/m_tray/attack_hand(mob/user)
 	if (src.connected)
 		for(var/atom/movable/A as mob|obj in src.loc)
 			if (!( A.anchored ))
@@ -158,7 +158,7 @@
 		return
 	return
 
-/obj/structure/m_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/structure/m_tray/MouseDrop_T(atom/movable/O, mob/user)
 	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
@@ -258,7 +258,7 @@
 	src.add_fingerprint(user)
 	update()
 
-/obj/structure/crematorium/attackby(P as obj, mob/user as mob)
+/obj/structure/crematorium/attackby(P, mob/user)
 	if(istype(P, /obj/item/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
 		if(user.get_active_hand() != P)
@@ -273,7 +273,7 @@
 	src.add_fingerprint(user)
 	return
 
-/obj/structure/crematorium/relaymove(mob/user as mob)
+/obj/structure/crematorium/relaymove(mob/user)
 	if (user.stat || locked)
 		return
 	src.connected = new /obj/structure/c_tray( src.loc )
@@ -289,7 +289,7 @@
 		src.connected = null
 	return
 
-/obj/structure/crematorium/proc/cremate(atom/A, mob/user as mob)
+/obj/structure/crematorium/proc/cremate(atom/A, mob/user)
 	if(cremating)
 		return //don't let you cremate something twice or w/e
 
@@ -394,7 +394,7 @@
 	connected = null
 	return ..()
 
-/obj/structure/c_tray/attack_hand(mob/user as mob)
+/obj/structure/c_tray/attack_hand(mob/user)
 	if (src.connected)
 		for(var/atom/movable/A as mob|obj in src.loc)
 			if (!( A.anchored ))
@@ -407,7 +407,7 @@
 		return
 	return
 
-/obj/structure/c_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/structure/c_tray/MouseDrop_T(atom/movable/O, mob/user)
 	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -35,7 +35,7 @@ FLOOR SAFES
 	tumbler_2_pos = rand(0, 72)
 	tumbler_2_open = rand(0, 72)
 
-/obj/structure/safe/proc/check_unlocked(mob/user as mob, canhear)
+/obj/structure/safe/proc/check_unlocked(mob/user, canhear)
 	if(user && canhear)
 		if(tumbler_1_pos == tumbler_1_open)
 			to_chat(user, "<span class='notice'>You hear a [pick("tonk", "krunk", "plunk")] from [src].</span>")
@@ -68,7 +68,7 @@ FLOOR SAFES
 		icon_state = initial(icon_state)
 
 
-/obj/structure/safe/attack_hand(mob/user as mob)
+/obj/structure/safe/attack_hand(mob/user)
 	user.set_machine(src)
 	var/dat = "<center>"
 	dat += "<a href='?src=\ref[src];open=1'>[open ? "Close" : "Open"] [src]</a> | <a href='?src=\ref[src];decrement=1'>-</a> [dial * 5] <a href='?src=\ref[src];increment=1'>+</a>"
@@ -138,7 +138,7 @@ FLOOR SAFES
 				updateUsrDialog()
 
 
-/obj/structure/safe/attackby(obj/item/I as obj, mob/user as mob)
+/obj/structure/safe/attackby(obj/item/I, mob/user)
 	if(open)
 		if(I.w_class + space <= maxspace)
 			if(!user.unEquip(I, src))

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -20,7 +20,7 @@
 		else
 	return
 
-/obj/structure/sign/attackby(obj/item/tool as obj, mob/user as mob)	//deconstruction
+/obj/structure/sign/attackby(obj/item/tool, mob/user)	//deconstruction
 	if(isScrewdriver(tool) && !istype(src, /obj/structure/sign/double))
 		to_chat(user, "You unfasten the sign with your [tool.name].")
 		var/obj/item/sign/S = new(src.loc)
@@ -38,7 +38,7 @@
 	w_class = ITEM_SIZE_NORMAL		//big
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
+/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
 	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel") return

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -87,7 +87,7 @@
 				qdel(src)
 				return
 
-/obj/structure/bed/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bed/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		dismantle()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -15,7 +15,7 @@
 		rotate(user)
 	return TRUE
 
-/obj/structure/bed/chair/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bed/chair/attackby(obj/item/W, mob/user)
 	..()
 	if(!padding_material && istype(W, /obj/item/assembly/shock_kit))
 		var/obj/item/assembly/shock_kit/SK = W
@@ -337,7 +337,7 @@
 	var/chair_material = MATERIAL_WOOD
 	buckle_movable = FALSE
 
-/obj/structure/bed/chair/wood/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bed/chair/wood/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/stack) || istype(W, /obj/item/wirecutters))
 		return
 	..()

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -117,7 +117,7 @@ var/global/list/stool_cache = list() //haha stool
 		padding_material.place_sheet(get_turf(src))
 	qdel(src)
 
-/obj/item/stool/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/stool/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		dismantle()

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -20,7 +20,7 @@
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
 
-/obj/structure/bed/chair/wheelchair/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bed/chair/wheelchair/attackby(obj/item/W, mob/user)
 	if(isWrench(W) || istype(W,/obj/item/stack) || isWirecutter(W))
 		return
 	..()
@@ -106,7 +106,7 @@
 			if (occupant && (src.loc != occupant.loc))
 				src.forceMove(occupant.loc) // Failsafe to make sure the wheelchair stays beneath the occupant after driving
 
-/obj/structure/bed/chair/wheelchair/attack_hand(mob/living/user as mob)
+/obj/structure/bed/chair/wheelchair/attack_hand(mob/living/user)
 	if (pulling)
 		MouseDrop(usr)
 	else
@@ -181,7 +181,7 @@
 		B.set_dir(newdir)
 	bloodiness--
 
-/obj/structure/bed/chair/wheelchair/buckle_mob(mob/M as mob, mob/user as mob)
+/obj/structure/bed/chair/wheelchair/buckle_mob(mob/M, mob/user)
 	if(M == pulling)
 		pulling = null
 		usr.pulledby = null

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -31,12 +31,12 @@
 		if(1 to 4)	overlays += "phoron-[phorontanks]"
 		if(5 to INFINITY) overlays += "phoron-5"
 
-/obj/structure/dispenser/attack_ai(mob/user as mob)
+/obj/structure/dispenser/attack_ai(mob/user)
 	if(user.Adjacent(src))
 		return attack_hand(user)
 	..()
 
-/obj/structure/dispenser/attack_hand(mob/user as mob)
+/obj/structure/dispenser/attack_hand(mob/user)
 	user.set_machine(src)
 	var/dat = "[src]<br><br>"
 	dat += "Oxygen tanks: [oxygentanks] - [oxygentanks ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>"
@@ -46,7 +46,7 @@
 	return
 
 
-/obj/structure/dispenser/attackby(obj/item/I as obj, mob/user as mob)
+/obj/structure/dispenser/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/tank/oxygen) || istype(I, /obj/item/tank/air) || istype(I, /obj/item/tank/anesthetic))
 		if(oxygentanks < 10)
 			if(!user.unEquip(I, src))

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -98,7 +98,7 @@
 
 
 
-/obj/structure/transit_tube/Bumped(mob/AM as mob|obj)
+/obj/structure/transit_tube/Bumped(mob/AM)
 	var/obj/structure/transit_tube/T = locate() in AM.loc
 	if(T)
 		to_chat(AM, "<span class='warning'>The tube's support pylons block your way.</span>")
@@ -110,7 +110,7 @@
 /obj/structure/transit_tube/station/New(loc)
 	..(loc)
 
-/obj/structure/transit_tube/station/Bumped(mob/AM as mob|obj)
+/obj/structure/transit_tube/station/Bumped(mob/AM)
 	if(!pod_moving && icon_state == "open" && istype(AM, /mob))
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(pod.contents.len)
@@ -119,7 +119,7 @@
 			else if(!pod.moving && (pod.dir in directions()))
 				AM.forceMove(pod)
 
-/obj/structure/transit_tube/station/attack_hand(mob/user as mob)
+/obj/structure/transit_tube/station/attack_hand(mob/user)
 	if(!pod_moving)
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(!pod.moving && (pod.dir in directions()))

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -150,7 +150,7 @@
 			paint_color = adjust_brightness(paint_color, bleach_factor)
 		update_icon()
 
-/obj/structure/wall_frame/hitby(AM as mob|obj, datum/thrownthing/TT)
+/obj/structure/wall_frame/hitby(AM, datum/thrownthing/TT)
 	..()
 	var/tforce = 0
 	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dm

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -132,7 +132,7 @@
 /obj/structure/hygiene/toilet/on_update_icon()
 	icon_state = "toilet[open][cistern]"
 
-/obj/structure/hygiene/toilet/attackby(obj/item/I as obj, mob/living/user)
+/obj/structure/hygiene/toilet/attackby(obj/item/I, mob/living/user)
 	if(isCrowbar(I))
 		to_chat(user, "<span class='notice'>You start to [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"].</span>")
 		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
@@ -238,7 +238,7 @@
 		for (var/atom/movable/G in src.loc)
 			G.clean_blood()
 
-/obj/structure/hygiene/shower/attackby(obj/item/I as obj, mob/user)
+/obj/structure/hygiene/shower/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/device/scanner/gas))
 		to_chat(user, "<span class='notice'>The water temperature seems to be [watertemp].</span>")
 		return
@@ -394,7 +394,7 @@
 		"<span class='notice'>You wash your hands using \the [src].</span>")
 
 
-/obj/structure/hygiene/sink/attackby(obj/item/O as obj, mob/living/user)
+/obj/structure/hygiene/sink/attackby(obj/item/O, mob/living/user)
 
 	if(isplunger(O) && clogged > 0)
 		return ..()
@@ -470,7 +470,7 @@
 	..()
 	icon_state = "puddle"
 
-/obj/structure/hygiene/sink/puddle/attackby(obj/item/O as obj, mob/user)
+/obj/structure/hygiene/sink/puddle/attackby(obj/item/O, mob/user)
 	icon_state = "puddle-splash"
 	..()
 	icon_state = "puddle"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -55,7 +55,7 @@
 	else
 		return 1
 
-/obj/structure/windoor_assembly/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/structure/windoor_assembly/CheckExit(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
 		return 1
 	if(get_dir(loc, target) == dir)
@@ -64,7 +64,7 @@
 		return 1
 
 
-/obj/structure/windoor_assembly/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/windoor_assembly/attackby(obj/item/W, mob/user)
 	//I really should have spread this out across more states but thin little windoors are hard to sprite.
 	switch(state)
 		if("01")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -207,7 +207,7 @@
 	else
 		return 1
 
-/obj/structure/window/CheckExit(atom/movable/O as mob|obj, target as turf)
+/obj/structure/window/CheckExit(atom/movable/O, target)
 	if(istype(O) && O.checkpass(PASS_FLAG_GLASS))
 		return 1
 	if(get_dir(O.loc, target) == dir)
@@ -229,7 +229,7 @@
 	damage_health(tforce, DAMAGE_BRUTE)
 	deanchor(AM)
 
-/obj/structure/window/attack_hand(mob/user as mob)
+/obj/structure/window/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(MUTATION_HULK in user.mutations)
 		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
@@ -282,7 +282,7 @@
 	playsound(loc, 'sound/effects/Glasshit.ogg', 50, 1)
 	return TRUE
 
-/obj/structure/window/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/window/attackby(obj/item/W, mob/user)
 	if(!istype(W)) return//I really wish I did not need this
 
 	if(W.item_flags & ITEM_FLAG_NO_BLUDGEON) return
@@ -715,7 +715,7 @@
 		/obj/item/stock_parts/power/apc
 	)
 
-/obj/machinery/button/windowtint/attackby(obj/item/device/W as obj, mob/user as mob)
+/obj/machinery/button/windowtint/attackby(obj/item/device/W, mob/user)
 	if(isMultitool(W))
 		var/t = sanitizeSafe(input(user, "Enter the ID for the button.", src.name, id), MAX_NAME_LEN)
 		if(user.incapacitated() && !user.Adjacent(src))

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(chop_sound,list('sound/weapons/chop1.ogg','sound/weapons/chop2.
 GLOBAL_LIST_INIT(glasscrack_sound,list('sound/effects/glass_crack1.ogg','sound/effects/glass_crack2.ogg','sound/effects/glass_crack3.ogg','sound/effects/glass_crack4.ogg'))
 GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'))
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, frequency, is_ambiance = 0)
+/proc/playsound(atom/source, soundin, vol, vary, extrarange, falloff, is_global, frequency, is_ambiance = 0)
 
 	soundin = get_sfx(soundin) // same sound for everyone
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/tr
 
 var/global/const/FALLOFF_SOUNDS = 0.5
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, extrarange)
+/mob/proc/playsound_local(turf/turf_source, soundin, vol, vary, frequency, falloff, is_global, extrarange)
 	if(!src.client || ear_deaf > 0)	return
 	var/sound/S = soundin
 	if(!istype(S))

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -136,7 +136,7 @@
 	step(src, dir)
 
 //returns 1 if made bloody, returns 0 otherwise
-/turf/simulated/add_blood(mob/living/carbon/human/M as mob)
+/turf/simulated/add_blood(mob/living/carbon/human/M)
 	if (!..())
 		return 0
 
@@ -152,7 +152,7 @@
 	return 0
 
 // Only adds blood on the floor -- Skie
-/turf/simulated/proc/add_blood_floor(mob/living/carbon/M as mob)
+/turf/simulated/proc/add_blood_floor(mob/living/carbon/M)
 	if( istype(M, /mob/living/carbon/alien ))
 		var/obj/effect/decal/cleanable/blood/xeno/this = new /obj/effect/decal/cleanable/blood/xeno(src)
 		this.blood_DNA["UNKNOWN BLOOD"] = "X*"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -106,7 +106,7 @@
 
 	..()
 
-/turf/simulated/wall/hitby(AM as mob|obj, datum/thrownthing/TT)
+/turf/simulated/wall/hitby(AM, datum/thrownthing/TT)
 	if(!ismob(AM))
 		var/obj/O = AM
 		var/tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
@@ -226,7 +226,7 @@
 		return 0
 	return 1
 
-/turf/simulated/wall/proc/thermitemelt(mob/user as mob)
+/turf/simulated/wall/proc/thermitemelt(mob/user)
 	if(!can_melt())
 		return
 	var/obj/effect/overlay/O = new/obj/effect/overlay( src )

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -61,7 +61,7 @@
 	else
 		set_light(0)
 
-/turf/space/attackby(obj/item/C as obj, mob/user as mob)
+/turf/space/attackby(obj/item/C, mob/user)
 
 	if (istype(C, /obj/item/stack/material/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
@@ -103,7 +103,7 @@
 
 // Ported from unstable r355
 
-/turf/space/Entered(atom/movable/A as mob|obj)
+/turf/space/Entered(atom/movable/A)
 	..()
 	if(A && A.loc == src)
 		if (A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE + 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE + 1))

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -2,7 +2,7 @@
 	var/pushdirection // push things that get caught in the transit tile this direction
 
 //Overwrite because we dont want people building rods in space.
-/turf/space/transit/attackby(obj/O as obj, mob/user as mob)
+/turf/space/transit/attackby(obj/O, mob/user)
 	return
 
 //generates a list used to randomize transit animations so they aren't in lockstep

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -127,14 +127,14 @@
 	if(Adjacent(user))
 		attack_hand(user)
 
-/turf/attackby(obj/item/W as obj, mob/user as mob)
+/turf/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
 		if(S.use_to_pickup && S.collection_mode)
 			S.gather_all(src, user)
 	return ..()
 
-/turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
+/turf/Enter(atom/movable/mover, atom/forget)
 
 	..()
 
@@ -305,7 +305,7 @@ var/global/const/enterloopsanity = 100
 		decals = null
 
 // Called when turf is hit by a thrown object
-/turf/hitby(atom/movable/AM as mob|obj, datum/thrownthing/TT)
+/turf/hitby(atom/movable/AM, datum/thrownthing/TT)
 	if(src.density)
 		if(isliving(AM))
 			var/mob/living/M = AM

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -1,4 +1,4 @@
-/proc/anim(atom/target, a_icon, a_icon_state, flick_anim, sleeptime = 0, direction as num)
+/proc/anim(atom/target, a_icon, a_icon_state, flick_anim, sleeptime = 0, direction)
 //This proc throws up either an icon or an animation for a specified amount of time.
 //The variables should be apparent enough.
 	var/atom/movable/overlay/animation = new /atom/movable/overlay(target)

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -254,7 +254,7 @@
 
 	return GM
 
-/turf/remove_air(amount as num)
+/turf/remove_air(amount)
 	var/datum/gas_mixture/GM = return_air()
 	return GM.remove(amount)
 

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 	var/active = 1
 
-/obj/machinery/acting/wardrobe/attack_hand(mob/user as mob)
+/obj/machinery/acting/wardrobe/attack_hand(mob/user)
 	user.show_message("You push a button and watch patiently as the machine begins to hum.")
 	if(active)
 		active = 0
@@ -24,7 +24,7 @@
 	anchored = TRUE
 	density = TRUE
 
-/obj/machinery/acting/changer/attack_hand(mob/user as mob)
+/obj/machinery/acting/changer/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.change_appearance(APPEARANCE_COMMON, TRUE, state = GLOB.z_state)

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -152,7 +152,7 @@ var/global/savefile/Banlist
 
 	return 1
 
-/proc/GetExp(minutes as num)
+/proc/GetExp(minutes)
 	UpdateTime()
 	var/exp = minutes - CMinutes
 	if (exp <= 0)

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -3,14 +3,14 @@
 	var/datum/mob_lite/last_attacked_ = null
 	var/mob/attack_logs_ = list()
 
-/proc/log_and_message_admins(message as text, mob/user = usr, turf/location)
+/proc/log_and_message_admins(message, mob/user = usr, turf/location)
 	var/turf/T = location ? get_turf(location) : (user ? get_turf(user) : null)
 	message = append_admin_tools(message, user, T)
 
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")
 	message_admins(user ? "[key_name_admin(user)] [message]" : "EVENT [message]")
 
-/proc/log_and_message_staff(message as text, mob/user = usr, turf/location)
+/proc/log_and_message_staff(message, mob/user = usr, turf/location)
 	var/turf/T = location ? location : (user ? get_turf(user) : null)
 	message = append_admin_tools(message, user, T)
 

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -74,7 +74,7 @@
 
 	del(info) // savefile, so NOT qdel
 
-/proc/show_player_info_irc(key as text)
+/proc/show_player_info_irc(key)
 	var/dat = "          Info on [key]\n"
 	var/target = ckey(key)
 	var/savefile/info = new("data/player_saves/[copytext_char(target, 1, 2)]/[target]/info.sav")

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -44,7 +44,7 @@
 /obj/item/device/assembly/proc/holder_movement()							//Called when the holder is moved
 	return
 
-/obj/item/device/assembly/interact(mob/user as mob)					//Called when attack_self is called
+/obj/item/device/assembly/interact(mob/user)					//Called when attack_self is called
 	return
 
 
@@ -96,7 +96,7 @@
 	return 0
 
 
-/obj/item/device/assembly/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/assembly/attackby(obj/item/W, mob/user)
 	if(isassembly(W))
 		var/obj/item/device/assembly/A = W
 		if((!A.secured) && (!secured))
@@ -125,13 +125,13 @@
 			to_chat(user, "\The [src] can be attached!")
 
 
-/obj/item/device/assembly/attack_self(mob/user as mob)
+/obj/item/device/assembly/attack_self(mob/user)
 	if(!user)	return 0
 	user.set_machine(src)
 	interact(user)
 	return 1
 
-/obj/item/device/assembly/interact(mob/user as mob)
+/obj/item/device/assembly/interact(mob/user)
 	return //HTML MENU FOR WIRES GOES HERE
 
 /obj/item/device/assembly/nano_host()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -67,7 +67,7 @@
 		master.update_icon()
 
 
-/obj/item/device/assembly_holder/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/device/assembly_holder/HasProximity(atom/movable/AM)
 	if(a_left)
 		a_left.HasProximity(AM)
 	if(a_right)
@@ -76,7 +76,7 @@
 		special_assembly.HasProximity(AM)
 
 
-/obj/item/device/assembly_holder/Crossed(atom/movable/AM as mob|obj)
+/obj/item/device/assembly_holder/Crossed(atom/movable/AM)
 	if(a_left)
 		a_left.Crossed(AM)
 	if(a_right)
@@ -85,7 +85,7 @@
 		special_assembly.Crossed(AM)
 
 
-/obj/item/device/assembly_holder/on_found(mob/finder as mob)
+/obj/item/device/assembly_holder/on_found(mob/finder)
 	if(a_left)
 		a_left.on_found(finder)
 	if(a_right)
@@ -112,7 +112,7 @@
 	return
 
 
-/obj/item/device/assembly_holder/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/device/assembly_holder/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		if(!a_left || !a_right)
 			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
@@ -129,7 +129,7 @@
 	..()
 
 
-/obj/item/device/assembly_holder/attack_self(mob/user as mob)
+/obj/item/device/assembly_holder/attack_self(mob/user)
 	add_fingerprint(user)
 	if(secured)
 		if(!a_left || !a_right)
@@ -183,7 +183,7 @@
 	return ..()
 
 
-/obj/item/device/assembly_holder/hear_talk(mob/living/M as mob, msg, verb, datum/language/speaking)
+/obj/item/device/assembly_holder/hear_talk(mob/living/M, msg, verb, datum/language/speaking)
 	if(a_right)
 		a_right.hear_talk(M,msg,verb,speaking)
 	if(a_left)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -31,7 +31,7 @@
 	return 1
 
 
-/obj/item/device/assembly/igniter/attack_self(mob/user as mob)
+/obj/item/device/assembly/igniter/attack_self(mob/user)
 	activate()
 	add_fingerprint(user)
 	return

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -57,7 +57,7 @@
 		holder.update_icon()
 	update_beams()
 
-/obj/item/device/assembly/infra/interact(mob/user as mob)//TODO: change this this to the wire control panel
+/obj/item/device/assembly/infra/interact(mob/user)//TODO: change this this to the wire control panel
 	if(!secured)
 		return
 	if(!CanInteract(user, GLOB.physical_state))

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -114,7 +114,7 @@
 	return
 
 
-/obj/item/device/assembly/prox_sensor/interact(mob/user as mob)//TODO: Change this to the wires thingy
+/obj/item/device/assembly/prox_sensor/interact(mob/user)//TODO: Change this to the wires thingy
 	if(!secured)
 		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
 		return 0

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -14,7 +14,7 @@
 	..()
 	return
 
-/obj/item/assembly/shock_kit/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/assembly/shock_kit/attackby(obj/item/W, mob/user)
 	if(isWrench(W) && !status)
 		part1.dropInto(loc)
 		part2.dropInto(loc)
@@ -30,7 +30,7 @@
 	add_fingerprint(user)
 	return
 
-/obj/item/assembly/shock_kit/attack_self(mob/user as mob)
+/obj/item/assembly/shock_kit/attack_self(mob/user)
 	part1.attack_self(user, status)
 	part2.attack_self(user, status)
 	add_fingerprint(user)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -39,7 +39,7 @@
 		holder.update_icon()
 	return
 
-/obj/item/device/assembly/signaler/interact(mob/user as mob, flag1)
+/obj/item/device/assembly/signaler/interact(mob/user, flag1)
 	var/t1 = "-------"
 	var/dat = {"
 		<TT>

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -68,7 +68,7 @@
 	return
 
 
-/obj/item/device/assembly/timer/interact(mob/user as mob)//TODO: Have this use the wires
+/obj/item/device/assembly/timer/interact(mob/user)//TODO: Have this use the wires
 	if(!secured)
 		user.show_message("<span class='warning'>\The [name] is unsecured!</span>")
 		return 0

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -15,7 +15,7 @@
 	GLOB.listening_objects -= src
 	return ..()
 
-/obj/item/device/assembly/voice/hear_talk(mob/living/M as mob, msg)
+/obj/item/device/assembly/voice/hear_talk(mob/living/M, msg)
 	if(listening)
 		recorded = msg
 		listening = 0

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -62,7 +62,7 @@ Pipelines + Other Objects -> Pipe network
 	else
 		reset_plane_and_layer()
 
-/obj/machinery/atmospherics/attackby(atom/A, mob/user as mob)
+/obj/machinery/atmospherics/attackby(atom/A, mob/user)
 	if(istype(A, /obj/item/device/scanner/gas))
 		return
 	..()

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -90,7 +90,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/binary/circulator/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/binary/circulator/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		anchored = !anchored

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -49,7 +49,7 @@
 	. = ..()
 	to_chat(user,"Its outlet port is to the [dir2text(dir)]")
 
-/obj/machinery/atmospherics/binary/oxyregenerator/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/atmospherics/binary/oxyregenerator/attackby(obj/item/O, mob/user)
 	if(component_attackby(O, user))
 		return TRUE
 	if(isWrench(O))

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -235,7 +235,7 @@
 	src.add_fingerprint(usr)
 	return
 
-/obj/machinery/atmospherics/binary/passive_gate/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/binary/passive_gate/attackby(obj/item/W, mob/user)
 	if(!isWrench(W))
 		return ..()
 	if (unlocked)

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -76,7 +76,7 @@
 		return 0
 	return 1
 
-/obj/machinery/atmospherics/omni/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/omni/attackby(obj/item/W, mob/user)
 	if(!isWrench(W))
 		return ..()
 

--- a/code/modules/atmospherics/components/pipesparker.dm
+++ b/code/modules/atmospherics/components/pipesparker.dm
@@ -75,7 +75,7 @@
 	)
 	ignite()
 
-/obj/machinery/atmospherics/pipe/cap/sparker/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/pipe/cap/sparker/attackby(obj/item/W, mob/user)
 	if (isScrewdriver(W) && !signaler)
 		add_fingerprint(user)
 		disabled = !disabled

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -130,7 +130,7 @@
 	return null
 
 
-/obj/machinery/atmospherics/portables_connector/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/portables_connector/attackby(obj/item/W, mob/user)
 	if(!isWrench(W))
 		return ..()
 	if (connected_device)

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -264,7 +264,7 @@
 
 	return null
 
-/obj/machinery/atmospherics/tvalve/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/tvalve/attackby(obj/item/W, mob/user)
 	if(!isWrench(W))
 		return ..()
 	var/datum/gas_mixture/int_air = return_air()

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -68,7 +68,7 @@
 	return 1
 
 
-/obj/machinery/atmospherics/unary/heat_exchanger/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/heat_exchanger/attackby(obj/item/W, mob/user)
 	if(!isWrench(W))
 		return ..()
 	var/turf/T = src.loc

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -203,7 +203,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/hide(i)
 	update_underlays()
 
-/obj/machinery/atmospherics/unary/outlet_injector/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/outlet_injector/attackby(obj/item/O, mob/user)
 	if(isMultitool(O))
 		var/datum/browser/popup = new (user, "Vent Configuration Utility", "[src] Configuration Panel", 600, 200)
 		popup.set_content(jointext(get_console_data(),"<br>"))

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -58,7 +58,7 @@
 /obj/machinery/atmospherics/unary/tank/return_air()
 	return air_contents
 
-/obj/machinery/atmospherics/unary/tank/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/tank/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		if (air_contents.return_pressure() > 2*ONE_ATMOSPHERE)
 			to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -309,7 +309,7 @@
 	if(welded)
 		to_chat(user, "It seems welded shut.")
 
-/obj/machinery/atmospherics/unary/vent_pump/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/vent_pump/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		if (!(stat & NOPOWER) && use_power)
 			to_chat(user, "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>")

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -203,7 +203,7 @@
 			return SPAN_WARNING("You cannot take this [src] apart, it too exerted due to internal pressure.")
 	return ..()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/vent_scrubber/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weldingtool))
 
 		var/obj/item/weldingtool/WT = W

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -215,7 +215,7 @@
 
 	return null
 
-/obj/machinery/atmospherics/valve/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/valve/attackby(obj/item/W, mob/user)
 	if (!istype(W, /obj/item/wrench))
 		return ..()
 	var/datum/gas_mixture/int_air = return_air()

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -106,7 +106,7 @@
 
 	. = ..()
 
-/obj/machinery/atmospherics/pipe/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/pipe/attackby(obj/item/W, mob/user)
 	if (istype(src, /obj/machinery/atmospherics/unary/tank))
 		return ..()
 	if (istype(src, /obj/machinery/atmospherics/pipe/vent))

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -68,7 +68,7 @@
 
 
 //BS12: Species-restricted clothing check.
-/obj/item/clothing/mob_can_equip(M as mob, slot, disable_warning = 0)
+/obj/item/clothing/mob_can_equip(M, slot, disable_warning = 0)
 
 	//if we can't equip the item anyway, don't bother with species_restricted (cuts down on spam)
 	if (!..())
@@ -939,7 +939,7 @@ BLIND     // can't see anything
 		if(SUIT_SENSOR_TRACKING)
 			to_chat(user, "Its vital tracker and tracking beacon appear to be enabled.")
 
-/obj/item/clothing/under/proc/set_sensors(mob/user as mob)
+/obj/item/clothing/under/proc/set_sensors(mob/user)
 	var/mob/M = user
 	if (isobserver(M)) return
 	if (user.incapacitated()) return

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -135,7 +135,7 @@
 	if (istype(location, /turf))
 		location.hotspot_expose(700, 1)
 
-/obj/item/clothing/head/cakehat/attack_self(mob/user as mob)
+/obj/item/clothing/head/cakehat/attack_self(mob/user)
 	src.onfire = !( src.onfire )
 	if (src.onfire)
 		src.force = 3
@@ -163,7 +163,7 @@
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 
-/obj/item/clothing/head/ushanka/attack_self(mob/user as mob)
+/obj/item/clothing/head/ushanka/attack_self(mob/user)
 	if(icon_state == initial(icon_state))
 		icon_state = icon_state_up
 		to_chat(user, "You raise the ear flaps on the ushanka.")

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -22,7 +22,7 @@
 	say_verbs = list("mumbles", "says")
 
 // Clumsy folks can't take the mask off themselves.
-/obj/item/clothing/mask/muzzle/attack_hand(mob/user as mob)
+/obj/item/clothing/mask/muzzle/attack_hand(mob/user)
 	if(user.wear_mask == src && !user.IsAdvancedToolUser())
 		return 0
 	..()

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -169,7 +169,7 @@
 	user.update_action_buttons()
 
 //In case they somehow come off while enabled.
-/obj/item/clothing/shoes/magboots/vox/dropped(mob/user as mob)
+/obj/item/clothing/shoes/magboots/vox/dropped(mob/user)
 	..()
 	if(src.magpulse)
 		user.visible_message("The [src] go limp as they are removed from [usr]'s feet.", "The [src] go limp as they are removed from your feet.")

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -182,7 +182,7 @@
 
 //Handles repairs (and also upgrades).
 
-/obj/item/clothing/suit/space/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/clothing/suit/space/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/stack/material))
 		var/repair_power = 0
 		switch(W.get_material_name())

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -66,7 +66,7 @@
 		if(2)
 			to_chat(user, "It is almost completely destroyed.")
 
-/obj/item/rig_module/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/rig_module/attackby(obj/item/W, mob/user)
 
 	if(istype(W,/obj/item/stack/nanopaste))
 

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -1,4 +1,4 @@
-/obj/item/rig/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/rig/attackby(obj/item/W, mob/user)
 
 	if(!istype(user,/mob/living)) return 0
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -230,7 +230,7 @@ else if(##equipment_var) {\
 	src.tank = null
 	playsound(loc, 'sound/effects/spray3.ogg', 50)
 
-/obj/item/clothing/suit/space/void/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/clothing/suit/space/void/attackby(obj/item/W, mob/user)
 
 	if(!istype(user,/mob/living)) return
 
@@ -308,7 +308,7 @@ else if(##equipment_var) {\
 
 	..()
 
-/obj/item/clothing/suit/space/void/attack_hand(mob/user as mob)
+/obj/item/clothing/suit/space/void/attack_hand(mob/user)
 	if (loc == user)
 		return
 	return ..()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -125,7 +125,7 @@
 		return PROJECTILE_FORCE_MISS
 	return 0
 
-/obj/item/clothing/suit/armor/reactive/attack_self(mob/user as mob)
+/obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
 	src.active = !( src.active )
 	if (src.active)
 		to_chat(user, "<span class='notice'>The reactive armor is now active.</span>")

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -11,11 +11,11 @@
 	QDEL_NULL(pockets)
 	. = ..()
 
-/obj/item/clothing/suit/storage/attack_hand(mob/user as mob)
+/obj/item/clothing/suit/storage/attack_hand(mob/user)
 	if (pockets.handle_attack_hand(user))
 		..(user)
 
-/obj/item/clothing/suit/storage/MouseDrop(obj/over_object as obj)
+/obj/item/clothing/suit/storage/MouseDrop(obj/over_object)
 	if (pockets.handle_mousedrop(usr, over_object))
 		..(over_object)
 

--- a/code/modules/clothing/under/accessories/_accessory.dm
+++ b/code/modules/clothing/under/accessories/_accessory.dm
@@ -113,7 +113,7 @@
 
 
 //default attack_hand behaviour
-/obj/item/clothing/accessory/attack_hand(mob/user as mob)
+/obj/item/clothing/accessory/attack_hand(mob/user)
 	if(parent)
 		return	//we aren't an object on the ground so don't call parent
 	..()
@@ -134,11 +134,11 @@
 	..()
 
 
-/obj/item/clothing/accessory/toggleable/on_attached(obj/item/clothing/under/S, mob/user as mob)
+/obj/item/clothing/accessory/toggleable/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
 	parent.verbs += /obj/item/clothing/accessory/toggleable/verb/toggle
 
-/obj/item/clothing/accessory/toggleable/on_removed(mob/user as mob)
+/obj/item/clothing/accessory/toggleable/on_removed(mob/user)
 	if(parent)
 		parent.verbs -= /obj/item/clothing/accessory/toggleable/verb/toggle
 	..()

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -16,7 +16,7 @@
 	set_extension(src, /datum/extension/holster, container, sound_in, sound_out, can_holster)
 
 
-/obj/item/clothing/accessory/storage/holster/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/clothing/accessory/storage/holster/attackby(obj/item/W, mob/user)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if (H.holster(W, user))
 		return
@@ -24,7 +24,7 @@
 		. = ..(W, user)
 
 
-/obj/item/clothing/accessory/storage/holster/attack_hand(mob/user as mob)
+/obj/item/clothing/accessory/storage/holster/attack_hand(mob/user)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if (H.unholster(user))
 		return
@@ -37,12 +37,12 @@
 	H.examine_holster(user)
 
 
-/obj/item/clothing/accessory/storage/holster/on_attached(obj/item/clothing/under/S, mob/user as mob)
+/obj/item/clothing/accessory/storage/holster/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
 	parent.verbs += /atom/proc/holster_verb
 
 
-/obj/item/clothing/accessory/storage/holster/on_removed(mob/user as mob)
+/obj/item/clothing/accessory/storage/holster/on_removed(mob/user)
 	if (parent)
 		var/remove_verb = TRUE
 		if (has_extension(parent, /datum/extension/holster))

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -15,7 +15,7 @@
 	var/last_process_worldtime = 0
 	var/report_num = 0
 
-/obj/machinery/dnaforensics/attackby(obj/item/W, mob/user as mob)
+/obj/machinery/dnaforensics/attackby(obj/item/W, mob/user)
 
 	if(bloodsamp)
 		to_chat(user, "<span class='warning'>There is already a sample in the machine.</span>")

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -38,7 +38,7 @@
 	STOP_PROCESSING(SSobj, src) //so we don't continue turning to ash while gc'd
 	. = ..()
 
-/obj/item/reagent_containers/glass/rag/attack_self(mob/user as mob)
+/obj/item/reagent_containers/glass/rag/attack_self(mob/user)
 	if(on_fire && user.unEquip(src))
 		user.visible_message("<span class='warning'>\The [user] stamps out [src].</span>", "<span class='warning'>You stamp out [src].</span>")
 		extinguish()
@@ -114,7 +114,7 @@
 			else
 				A.clean_blood()
 
-/obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
+/obj/item/reagent_containers/glass/rag/attack(atom/target, mob/user, flag)
 	if(isliving(target))
 		var/mob/living/M = target
 		if(on_fire)
@@ -182,7 +182,7 @@
 
 	return ..()
 
-/obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
+/obj/item/reagent_containers/glass/rag/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)
 		return
 

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -67,7 +67,7 @@
 		to_chat(user, "[icon2html(src, user)] <span class='warning'>[src] beeps: \"[response]\"</span>")
 		return 1
 
-/obj/machinery/atm/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/atm/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/card/id))
 		if(emagged > 0)
 			//prevent inserting id into an emagged ATM
@@ -423,14 +423,14 @@
 
 	interact(usr)
 
-/obj/machinery/atm/proc/scan_user(mob/living/carbon/human/human_user as mob)
+/obj/machinery/atm/proc/scan_user(mob/living/carbon/human/human_user)
 	if(!authenticated_account)
 		var/obj/item/card/id/I = human_user.GetIdCard()
 		if(istype(I))
 			return I
 
 // put the currently held id on the ground or in the hand of the user
-/obj/machinery/atm/proc/release_held_id(mob/living/carbon/human/human_user as mob)
+/obj/machinery/atm/proc/release_held_id(mob/living/carbon/human/human_user)
 	if(!held_card)
 		return
 
@@ -443,7 +443,7 @@
 	held_card = null
 
 
-/obj/machinery/atm/proc/spawn_ewallet(sum, loc, mob/living/carbon/human/human_user as mob)
+/obj/machinery/atm/proc/spawn_ewallet(sum, loc, mob/living/carbon/human/human_user)
 	var/obj/item/spacecash/ewallet/E = new /obj/item/spacecash/ewallet(loc)
 	if(ishuman(human_user) && !human_user.get_active_hand())
 		human_user.put_in_hands(E)

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -82,7 +82,7 @@
 	D.wrapped = R
 	D.SetName("small parcel - 'EFTPOS access code'")
 
-/obj/item/device/eftpos/attack_self(mob/user as mob)
+/obj/item/device/eftpos/attack_self(mob/user)
 	if(get_dist(src,user) <= 1)
 		var/dat = "<b>[eftpos_name]</b><br>"
 		dat += "<i>This terminal is</i> [machine_id]. <i>Report this code when contacting IT Support</i><br>"
@@ -110,7 +110,7 @@
 	else
 		show_browser(user, null,"window=eftpos")
 
-/obj/item/device/eftpos/attackby(obj/item/O as obj, user as mob)
+/obj/item/device/eftpos/attackby(obj/item/O, user)
 
 	var/obj/item/card/id/I = O.GetIdCard()
 

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -17,7 +17,7 @@
 	var/worth = 0
 	var/static/denominations = list(1000,500,200,100,50,20,10,1)
 
-/obj/item/spacecash/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/spacecash/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/spacecash))
 		if(istype(W, /obj/item/spacecash/ewallet)) return 0
 
@@ -94,7 +94,7 @@
 	else
 		w_class = ITEM_SIZE_SMALL
 
-/obj/item/spacecash/bundle/attack_hand(mob/user as mob)
+/obj/item/spacecash/bundle/attack_hand(mob/user)
 	if (user.get_inactive_hand() == src)
 		var/amount = input(usr, "How many [GLOB.using_map.local_currency_name] do you want to take? (0 to [src.worth])", "Take Money", 20) as num
 		amount = round(clamp(amount, 0, src.worth))

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -164,7 +164,7 @@
 	desc = "It's worth 1000 Thalers."
 	worth = 1000
 
-/proc/spawn_money(sum, spawnloc, mob/living/carbon/human/human_user as mob)
+/proc/spawn_money(sum, spawnloc, mob/living/carbon/human/human_user)
 	if(sum in list(1000,500,200,100,50,20,10,1))
 		var/cash_type = text2path("/obj/item/spacecash/bundle/c[sum]")
 		var/obj/cash = new cash_type (spawnloc)

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -16,17 +16,17 @@
 	else
 		..()
 
-/obj/item/board/attack_hand(mob/living/carbon/human/M as mob)
+/obj/item/board/attack_hand(mob/living/carbon/human/M)
 	if(M.machine == src)
 		return ..()
 	else
 		M.examinate(src)
 
-/obj/item/board/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/board/attackby(obj/item/I, mob/user)
 	if(!addPiece(I,user))
 		..()
 
-/obj/item/board/proc/addPiece(obj/item/I as obj, mob/user as mob, tile = 0)
+/obj/item/board/proc/addPiece(obj/item/I, mob/user, tile = 0)
 	if(I.w_class != ITEM_SIZE_TINY) //only small stuff
 		user.show_message("<span class='warning'>\The [I] is too big to be used as a board piece.</span>")
 		return 0
@@ -60,7 +60,7 @@
 	return 1
 
 
-/obj/item/board/interact(mob/user as mob)
+/obj/item/board/interact(mob/user)
 	if(user.is_physically_disabled() || (!isAI(user) && !user.Adjacent(src))) //can't see if you arent conscious. If you are not an AI you can't see it unless you are next to it, either.
 		close_browser(user, "window=boardgame")
 		user.unset_machine()

--- a/code/modules/games/tarot.dm
+++ b/code/modules/games/tarot.dm
@@ -28,7 +28,7 @@
 			P.desc = "A Rider-Waite tarot card."
 			cards += P
 
-/obj/item/deck/tarot/attack_self(mob/user as mob)
+/obj/item/deck/tarot/attack_self(mob/user)
 	var/list/newcards = list()
 	while(cards.len)
 		var/datum/playingcard/P = pick(cards)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -138,7 +138,7 @@
 	src.updateUsrDialog()
 	return
 
-/obj/machinery/computer/HolodeckControl/emag_act(remaining_charges, mob/user as mob)
+/obj/machinery/computer/HolodeckControl/emag_act(remaining_charges, mob/user)
 	playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 	last_to_emag = user //emag again to change the owner
 	if (!emagged)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -10,7 +10,7 @@
 /turf/simulated/floor/holofloor/get_lumcount(minlum = 0, maxlum = 1)
 	return 0.8
 
-/turf/simulated/floor/holofloor/attackby(obj/item/W as obj, mob/user as mob)
+/turf/simulated/floor/holofloor/attackby(obj/item/W, mob/user)
 	return
 	// HOLOFLOOR DOES NOT GIVE A FUCK
 
@@ -154,7 +154,7 @@
 /obj/structure/window/reinforced/holowindow/Destroy()
 	..()
 
-/obj/structure/window/reinforced/holowindow/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/window/reinforced/holowindow/attackby(obj/item/W, mob/user)
 
 	if(!istype(W) || W.item_flags & ITEM_FLAG_NO_BLUDGEON) return
 
@@ -181,7 +181,7 @@
 /obj/machinery/door/window/holowindoor/Destroy()
 	..()
 
-/obj/machinery/door/window/holowindoor/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/door/window/holowindoor/attackby(obj/item/I, mob/user)
 
 	if (src.operating == 1)
 		return
@@ -214,7 +214,7 @@
 /obj/structure/bed/chair/holochair/Destroy()
 	..()
 
-/obj/structure/bed/chair/holochair/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bed/chair/holochair/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/wrench))
 		to_chat(user, ("<span class='notice'>It's a holochair, you can't dismantle it!</span>"))
 	return
@@ -258,7 +258,7 @@
 /obj/item/holo/esword/New()
 	item_color = pick("red","blue","green","purple")
 
-/obj/item/holo/esword/attack_self(mob/living/user as mob)
+/obj/item/holo/esword/attack_self(mob/living/user)
 	active = !active
 	if (active)
 		force = 30
@@ -363,7 +363,7 @@
 	active_power_usage = 6
 	power_channel = ENVIRON
 
-/obj/machinery/readybutton/attack_ai(mob/user as mob)
+/obj/machinery/readybutton/attack_ai(mob/user)
 	to_chat(user, "The AI is not to interact with these devices!")
 	return
 
@@ -371,7 +371,7 @@
 	..()
 
 
-/obj/machinery/readybutton/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/readybutton/attackby(obj/item/W, mob/user)
 	to_chat(user, "The device is a solid button, there's nothing you can do with it!")
 
 /obj/machinery/readybutton/physical_attack_hand(mob/user)

--- a/code/modules/holomap/ship_holomap.dm
+++ b/code/modules/holomap/ship_holomap.dm
@@ -95,7 +95,7 @@
 // In order to actually get Bumped() we need to block movement.  We're (visually) on a wall, so people
 // couldn't really walk into us anyway.  But in reality we are on the turf in front of the wall, so bumping
 // against where we seem is actually trying to *exit* our real loc
-/obj/machinery/ship_map/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/machinery/ship_map/CheckExit(atom/movable/mover, turf/target)
 	if(get_dir(target, loc) == dir) // Opposite of "normal" since we are visually in the next turf over
 		return FALSE
 	else

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -240,7 +240,7 @@
 				to_chat(user, "<span class='danger'>\The [src] has fallen to bits.</span>")
 			qdel(src)
 
-/obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user as mob)
+/obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 
 	if(!seed)
 		return

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -8,7 +8,7 @@
 	var/list/genes = list()
 	var/genesource = "unknown"
 
-/obj/item/disk/botany/attack_self(mob/user as mob)
+/obj/item/disk/botany/attack_self(mob/user)
 	if(genes.len)
 		var/choice = alert(user, "Are you sure you want to wipe the disk?", "Xenobotany Data", "No", "Yes")
 		if(src && user && genes && choice && choice == "Yes" && user.Adjacent(get_turf(src)))
@@ -65,7 +65,7 @@
 			visible_message("[icon2html(src, viewers(get_turf(src)))] [src] beeps and spits out [loaded_disk].")
 			loaded_disk = null
 
-/obj/machinery/botany/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/botany/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/seeds))
 		if(seed)
 			to_chat(user, "There is already a seed loaded.")

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -143,7 +143,7 @@
 	interact(user)
 	return TRUE
 
-/obj/machinery/seed_storage/interact(mob/user as mob)
+/obj/machinery/seed_storage/interact(mob/user)
 	user.set_machine(src)
 
 	var/dat = "<center><h1>Seed storage contents</h1></center>"
@@ -283,7 +283,7 @@
 			break
 	updateUsrDialog()
 
-/obj/machinery/seed_storage/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/seed_storage/attackby(obj/item/O, mob/user)
 	if (istype(O, /obj/item/seeds))
 		add(O)
 		user.visible_message("[user] puts \the [O.name] into \the [src].", "You put \the [O] into \the [src].")

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -8,7 +8,7 @@
 	mechanical = 0
 	tray_light = 0
 
-/obj/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/O, mob/user)
 	if(istype(O,/obj/item/tank))
 		return
 	else

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -878,7 +878,7 @@
 	GLOB.listening_objects -= src
 	. = ..()
 
-/obj/item/integrated_circuit/input/microphone/hear_talk(mob/living/M as mob, text, verb, datum/language/speaking)
+/obj/item/integrated_circuit/input/microphone/hear_talk(mob/living/M, text, verb, datum/language/speaking)
 	var/translated = FALSE
 	if(M && text && speaking)
 		if(!(speaking.flags & invalid_flags))

--- a/code/modules/item_worth/item_worth.dm
+++ b/code/modules/item_worth/item_worth.dm
@@ -1,5 +1,5 @@
 GLOBAL_LIST_EMPTY(price_cache)
-/proc/get_value(atom/A) // A can be either type *or* instance; ie get_value(/obj) is valid, as is get_value(new /obj)
+/proc/get_value(atom/A) // A can be either type *or* instance; ie get_value(/obj) is valid,)
 	var/atom/t = ispath(A) ? A : A.type
 	while(!(t in worths)) // Find the first parent that is in the list
 		t = PARENT(t)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -26,7 +26,7 @@
 	update_icon()
 	. = ..()
 
-/obj/structure/bookcase/attackby(obj/O as obj, mob/user as mob)
+/obj/structure/bookcase/attackby(obj/O, mob/user)
 	if(istype(O, /obj/item/book))
 		if(!user.unEquip(O, src))
 			return
@@ -51,7 +51,7 @@
 		..()
 	return
 
-/obj/structure/bookcase/attack_hand(mob/user as mob)
+/obj/structure/bookcase/attack_hand(mob/user)
 	if(contents.len)
 		var/obj/item/book/choice = input("Which book would you like to remove from the shelf?") as null|obj in contents
 		if(choice)
@@ -149,7 +149,7 @@
 	var/carved = 0	 // Has the book been hollowed out for use as a secret storage item?
 	var/obj/item/store	//What's in the book?
 
-/obj/item/book/attack_self(mob/user as mob)
+/obj/item/book/attack_self(mob/user)
 	if(carved)
 		if(store)
 			to_chat(user, "<span class='notice'>[store] falls out of [title]!</span>")
@@ -166,7 +166,7 @@
 	else
 		to_chat(user, "This book is completely blank!")
 
-/obj/item/book/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/book/attackby(obj/item/W, mob/user)
 	if(carved == 1)
 		if(!store)
 			if(W.w_class < ITEM_SIZE_NORMAL)
@@ -221,7 +221,7 @@
 	else
 		..()
 
-/obj/item/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/book/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(user.zone_sel.selecting == BP_EYES)
 		user.visible_message("<span class='notice'>You open up the book and show it to [M]. </span>", \
 			"<span class='notice'> [user] opens up a book and shows it to [M]. </span>")

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -16,7 +16,7 @@
 	density = TRUE
 	var/obj/item/book/cache		// Last scanned book
 
-/obj/machinery/libraryscanner/attackby(obj/O as obj, mob/user as mob)
+/obj/machinery/libraryscanner/attackby(obj/O, mob/user)
 	if(istype(O, /obj/item/book))
 		if(!user.unEquip(O, src))
 			return
@@ -68,7 +68,7 @@
 	anchored = TRUE
 	density = TRUE
 
-/obj/machinery/bookbinder/attackby(obj/O as obj, mob/user as mob)
+/obj/machinery/bookbinder/attackby(obj/O, mob/user)
 	if(istype(O, /obj/item/paper))
 		if(!user.unEquip(O, src))
 			return

--- a/code/modules/maps/dmm_suite.dm
+++ b/code/modules/maps/dmm_suite.dm
@@ -293,7 +293,7 @@ GLOBAL_DATUM_INIT(maploader, /dmm_suite, new)
 		/obj/structure,
 	)
 
-/dmm_suite/proc/parse_grid(model as text, model_key as text, xcrd as num,ycrd as num,zcrd as num, no_changeturf as num, clear_contents as num, initialized_areas_by_type)
+/dmm_suite/proc/parse_grid(model, model_key, xcrd,ycrd,zcrd, no_changeturf, clear_contents, initialized_areas_by_type)
 	/*Method parse_grid()
 	- Accepts a text string containing a comma separated list of type paths of the
 		same construction as those contained in a .dmm file, and instantiates them.
@@ -483,7 +483,7 @@ GLOBAL_DATUM_INIT(maploader, /dmm_suite, new)
 
 //find the position of the next delimiter,skipping whatever is comprised between opening_escape and closing_escape
 //returns 0 if reached the last delimiter
-/dmm_suite/proc/find_next_delimiter_position(text as text,initial_position as num, delimiter=",",opening_escape="\"",closing_escape="\"")
+/dmm_suite/proc/find_next_delimiter_position(text,initial_position, delimiter=",",opening_escape="\"",closing_escape="\"")
 	var/position = initial_position
 	var/next_delimiter = findtext(text,delimiter,position,0)
 	var/next_opening = findtext(text,opening_escape,position,0)
@@ -495,7 +495,7 @@ GLOBAL_DATUM_INIT(maploader, /dmm_suite, new)
 
 	return next_delimiter
 
-/dmm_suite/proc/readlistitem(text as text)
+/dmm_suite/proc/readlistitem(text)
 	//Check for string
 	if(findtext(text,"\"",1,2))
 		. = copytext(text,2,findtext(text,"\"",3,0))
@@ -522,7 +522,7 @@ GLOBAL_DATUM_INIT(maploader, /dmm_suite, new)
 
 //build a list from variables in text form (e.g {var1="derp"; var2; var3=7} => list(var1="derp", var2, var3=7))
 //return the filled list
-/dmm_suite/proc/readlist(text as text, delimiter=",")
+/dmm_suite/proc/readlist(text, delimiter=",")
 	var/list/to_return = list()
 
 	var/position

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -10,7 +10,7 @@
 /obj/item/ore/get_material()
 	return material
 
-/obj/item/ore/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/ore/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/device/core_sampler))
 		var/obj/item/device/core_sampler/C = W
 		C.sample_item(src, user)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -574,7 +574,7 @@
 	if(owner && holding)
 		update_icon()
 
-/obj/item/mech_equipment/mounted_system/flamethrower/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/mech_equipment/mounted_system/flamethrower/attackby(obj/item/W, mob/user)
 	if(!CanPhysicallyInteract(user))	return
 
 	var/obj/item/flamethrower/full/mech/FM = holding

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -138,7 +138,7 @@
 		if(100)
 			new/obj/item/clothing/head/bearpelt(src)
 
-/obj/structure/closet/crate/secure/loot/togglelock(mob/user as mob)
+/obj/structure/closet/crate/secure/loot/togglelock(mob/user)
 	if(!locked)
 		return
 
@@ -179,7 +179,7 @@
 		if(guesschar != code[i])
 			. = 0
 
-/obj/structure/closet/crate/secure/loot/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/closet/crate/secure/loot/attackby(obj/item/W, mob/user)
 	if(locked)
 		if (istype(W, /obj/item/device/multitool)) // Greetings Urist McProfessor, how about a nice game of cows and bulls?
 			to_chat(user, "<span class='notice'>DECA-CODE LOCK ANALYSIS:</span>")

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -155,7 +155,7 @@
 /obj/machinery/mining/drill/components_are_accessible(path)
 	return !active && ..()
 
-/obj/machinery/mining/drill/physical_attack_hand(mob/user as mob)
+/obj/machinery/mining/drill/physical_attack_hand(mob/user)
 	check_supports()
 	if(need_player_check)
 		if(can_use_power_oneoff(10 KILOWATTS))
@@ -268,7 +268,7 @@
 		return SPAN_NOTICE("You can't work with the brace of a running drill!")
 	return ..()
 
-/obj/machinery/mining/brace/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/mining/brace/attackby(obj/item/W, mob/user)
 	if(connected && connected.active)
 		to_chat(user, "<span class='notice'>You can't work with the brace of a running drill!</span>")
 		return TRUE

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -151,7 +151,7 @@ var/global/list/mining_floors = list()
 	update_icon()
 
 //Not even going to touch this pile of spaghetti
-/turf/simulated/mineral/attackby(obj/item/W as obj, mob/user as mob)
+/turf/simulated/mineral/attackby(obj/item/W, mob/user)
 	if (!user.IsAdvancedToolUser())
 		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
@@ -455,7 +455,7 @@ var/global/list/mining_floors = list()
 /turf/simulated/floor/asteroid/is_plating()
 	return !density
 
-/turf/simulated/floor/asteroid/attackby(obj/item/W as obj, mob/user as mob)
+/turf/simulated/floor/asteroid/attackby(obj/item/W, mob/user)
 	if(!W || !user)
 		return 0
 
@@ -549,7 +549,7 @@ var/global/list/mining_floors = list()
 				A = get_step(src, direction)
 				A.updateMineralOverlays()
 
-/turf/simulated/floor/asteroid/Entered(atom/movable/M as mob|obj)
+/turf/simulated/floor/asteroid/Entered(atom/movable/M)
 	..()
 	if(istype(M,/mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = M

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -10,7 +10,7 @@
 	var/last_update = 0
 	var/list/stored_ore = list()
 
-/obj/structure/ore_box/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/ore_box/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/ore))
 		user.unEquip(W, src)
 	else if (istype(W, /obj/item/storage))

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -133,7 +133,7 @@ var/global/list/holder_mob_icon_cache = list()
 	origin_tech = list(TECH_BIO = 3, TECH_ENGINEERING = 4)
 	item_state = "poppy"
 
-/obj/item/holder/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/holder/attackby(obj/item/W, mob/user)
 	for(var/mob/M in src.contents)
 		M.attackby(W,user)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -190,7 +190,7 @@
 	As far as I can tell the proc exists so that mobs with different inventory slots can override
 	the search through all the slots, without having to duplicate the rest of the item dropping.
 */
-/mob/proc/u_equip(obj/W as obj)
+/mob/proc/u_equip(obj/W)
 	if (W == r_hand)
 		r_hand = null
 		update_inv_r_hand(0)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -27,11 +27,11 @@
 
 	..()
 
-/mob/living/carbon/alien/u_equip(obj/item/W as obj)
+/mob/living/carbon/alien/u_equip(obj/item/W)
 	return
 
 /mob/living/carbon/alien/restrained()
 	return 0
 
-/mob/living/carbon/alien/show_inv(mob/user as mob)
+/mob/living/carbon/alien/show_inv(mob/user)
 	return //Consider adding cuffs and hats to this, for the sake of fun.

--- a/code/modules/mob/living/carbon/alien/alien_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/alien_attacks.dm
@@ -2,7 +2,7 @@
 /mob/living/carbon/alien/attack_ui(slot_id)
 	return
 
-/mob/living/carbon/alien/attack_hand(mob/living/carbon/M as mob)
+/mob/living/carbon/alien/attack_hand(mob/living/carbon/M)
 
 	..()
 

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -44,7 +44,7 @@
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
 	var/obj/item/organ/internal/brain/brainobj = null	//The current brain organ.
 
-/obj/item/device/mmi/attackby(obj/item/O as obj, mob/user as mob)
+/obj/item/device/mmi/attackby(obj/item/O, mob/user)
 	if(istype(O,/obj/item/organ/internal/brain) && !brainmob) //Time to stick a brain in it --NEO
 
 		var/obj/item/organ/internal/brain/B = O
@@ -87,7 +87,7 @@
 	..()
 
 	//TODO: ORGAN REMOVAL UPDATE. Make the brain remain in the MMI so it doesn't lose organ data.
-/obj/item/device/mmi/attack_self(mob/user as mob)
+/obj/item/device/mmi/attack_self(mob/user)
 	if(!brainmob)
 		to_chat(user, "<span class='warning'>You upend the MMI, but there's nothing in it.</span>")
 	else if(locked)
@@ -110,7 +110,7 @@
 		update_icon()
 		SetName(initial(name))
 
-/obj/item/device/mmi/proc/transfer_identity(mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->robot people.
+/obj/item/device/mmi/proc/transfer_identity(mob/living/carbon/human/H)//Same deal
 	brainmob = new(src)
 	brainmob.SetName(H.real_name)
 	brainmob.real_name = H.real_name

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -86,7 +86,7 @@
 /mob/living/carbon/proc/clear_coughedtime()
 	coughedtime = 0
 
-/mob/living/carbon/attack_hand(mob/M as mob)
+/mob/living/carbon/attack_hand(mob/M)
 	if(!istype(M, /mob/living/carbon)) return
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -348,7 +348,7 @@
 		return 1
 	return
 
-/mob/living/carbon/u_equip(obj/item/W as obj)
+/mob/living/carbon/u_equip(obj/item/W)
 	if(!W)	return 0
 
 	else if (W == handcuffed)
@@ -412,7 +412,7 @@
 				break
 	return result
 
-/mob/living/carbon/show_inv(mob/user as mob)
+/mob/living/carbon/show_inv(mob/user)
 	user.set_machine(src)
 	var/dat = {"
 	<B><HR><FONT size=3>[name]</FONT></B>

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -342,7 +342,7 @@
 	to_chat(user, jointext(msg, null))
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
-/proc/hasHUD(mob/M as mob, hudtype)
+/proc/hasHUD(mob/M, hudtype)
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/clothing/glasses/G = H.glasses

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -168,7 +168,7 @@
 /mob/living/carbon/human/var/temperature_resistance = T0C+75
 
 
-/mob/living/carbon/human/show_inv(mob/user as mob)
+/mob/living/carbon/human/show_inv(mob/user)
 	if(user.incapacitated()  || !user.Adjacent(src) || !user.IsAdvancedToolUser())
 		return
 
@@ -935,7 +935,7 @@
 	if(L)
 		L.rupture()
 
-/mob/living/carbon/human/add_blood(mob/living/carbon/human/M as mob)
+/mob/living/carbon/human/add_blood(mob/living/carbon/human/M)
 	if (!..())
 		return 0
 	//if this blood isn't already in the list, add it

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -18,7 +18,7 @@
 			return u_attack
 	return null
 
-/mob/living/carbon/human/attack_hand(mob/living/carbon/M as mob)
+/mob/living/carbon/human/attack_hand(mob/living/carbon/M)
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -312,7 +312,7 @@ meteor_act
 	return 1
 
 //this proc handles being hit by a thrown atom
-/mob/living/carbon/human/hitby(atom/movable/AM as mob|obj, datum/thrownthing/TT)
+/mob/living/carbon/human/hitby(atom/movable/AM, datum/thrownthing/TT)
 
 	if(isobj(AM))
 		var/obj/O = AM

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -119,7 +119,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_tie)
 			return 1
 
-/mob/living/carbon/human/u_equip(obj/W as obj)
+/mob/living/carbon/human/u_equip(obj/W)
 	if(!W)	return 0
 
 	if (W == wear_suit)
@@ -226,7 +226,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 
 //This is an UNSAFE proc. Use mob_can_equip() before calling this one! Or rather use equip_to_slot_if_possible() or advanced_equip_to_slot_if_possible()
 //set redraw_mob to 0 if you don't wish the hud to be updated - if you're doing it manually in your own proc.
-/mob/living/carbon/human/equip_to_slot(obj/item/W as obj, slot, redraw_mob = 1)
+/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = 1)
 
 	if(!slot) return
 	if(!istype(W)) return

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -1,5 +1,5 @@
 //Lallander was here
-/mob/living/carbon/human/whisper(message as text)
+/mob/living/carbon/human/whisper(message)
 	message = sanitize(message, encode = 0)
 
 	if (src.client)

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -13,7 +13,7 @@
 	var/enhanced = 0 //has it been enhanced before?
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/slime_extract/attackby(obj/item/O as obj, mob/user as mob)
+/obj/item/slime_extract/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/slimesteroid2))
 		if(enhanced == 1)
 			to_chat(user, "<span class='warning'> This extract has already been enhanced!</span>")
@@ -132,7 +132,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
 
-/obj/item/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/slimepotion/attack(mob/living/carbon/slime/M, mob/user)
 	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 		to_chat(user, "<span class='warning'> The potion only works on baby slimes!</span>")
 		return ..()
@@ -166,7 +166,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
 
-/obj/item/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/slimepotion2/attack(mob/living/carbon/slime/M, mob/user)
 	if(!istype(M, /mob/living/carbon/slime))
 		to_chat(user, "<span class='warning'> The potion only works on slimes!</span>")
 		return ..()
@@ -198,7 +198,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle16"
 
-/obj/item/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/slimesteroid/attack(mob/living/carbon/slime/M, mob/user)
 	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 		to_chat(user, "<span class='warning'> The steroid only works on baby slimes!</span>")
 		return ..()
@@ -289,7 +289,7 @@
 	else
 		icon_state = "golem"
 
-/obj/effect/golemrune/attack_hand(mob/living/user as mob)
+/obj/effect/golemrune/attack_hand(mob/living/user)
 	var/mob/observer/ghost/ghost
 	for(var/mob/observer/ghost/O in src.loc)
 		if(!O.client)

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -115,7 +115,7 @@
 
 	return tally
 
-/mob/living/carbon/slime/Bump(atom/movable/AM as mob|obj, yes)
+/mob/living/carbon/slime/Bump(atom/movable/AM, yes)
 	if ((!(yes) || now_pushing))
 		return
 	now_pushing = 1
@@ -216,13 +216,13 @@
 	updatehealth()
 
 
-/mob/living/carbon/slime/u_equip(obj/item/W as obj)
+/mob/living/carbon/slime/u_equip(obj/item/W)
 	return
 
 /mob/living/carbon/slime/attack_ui(slot)
 	return
 
-/mob/living/carbon/slime/attack_hand(mob/living/carbon/human/M as mob)
+/mob/living/carbon/slime/attack_hand(mob/living/carbon/human/M)
 
 	..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -23,7 +23,7 @@
 	return
 
 //mob verbs are faster than object verbs. See above.
-/mob/living/pointed(atom/A as mob|obj|turf in view())
+/mob/living/pointed(atom/A))
 	if(incapacitated())
 		return 0
 	if(src.status_flags & FAKEDEATH)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -272,12 +272,12 @@ var/global/list/ai_verbs_default = list(
 			custom_icons += selected_sprite
 	update_icon()
 
-/mob/living/silicon/ai/pointed(atom/A as mob|obj|turf in view())
+/mob/living/silicon/ai/pointed(atom/A))
 	set popup_menu = 0
 	set src = usr.contents
 	return 0
 
-/mob/living/silicon/ai/fully_replace_character_name(pickedName as text)
+/mob/living/silicon/ai/fully_replace_character_name(pickedName)
 	..()
 	announcement.announcer = pickedName
 	if(eyeobj)
@@ -386,7 +386,7 @@ var/global/list/ai_verbs_default = list(
 		emergency_message_cooldown = 0
 
 
-/mob/living/silicon/ai/check_eye(mob/user as mob)
+/mob/living/silicon/ai/check_eye(mob/user)
 	if (!camera)
 		return -1
 	return 0
@@ -612,7 +612,7 @@ var/global/list/ai_verbs_default = list(
 		camera_light_on = world.timeofday + 1 * 20 // Update the light every 2 seconds.
 
 
-/mob/living/silicon/ai/attackby(obj/item/W as obj, mob/user as mob)
+/mob/living/silicon/ai/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/aicard))
 
 		var/obj/item/aicard/card = W

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 	if (client.statpanel == "Status")
 		show_silenced()
 
-/mob/living/silicon/pai/check_eye(mob/user as mob)
+/mob/living/silicon/pai/check_eye(mob/user)
 	if (!current)
 		return -1
 	return 0
@@ -280,7 +280,7 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 		if(stat != 2) fold()
 	return
 
-/mob/living/silicon/pai/attack_hand(mob/user as mob)
+/mob/living/silicon/pai/attack_hand(mob/user)
 	visible_message(SPAN_DANGER("[user] boops [src] on the head."))
 	fold()
 

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -6,7 +6,7 @@
 
 	var/obj/machinery/machine
 
-/obj/item/pai_cable/proc/plugin(obj/machinery/M as obj, mob/user as mob)
+/obj/item/pai_cable/proc/plugin(obj/machinery/M, mob/user)
 	if(istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
 		if(!user.unEquip(src, M))
 			return
@@ -15,5 +15,5 @@
 	else
 		user.visible_message("[user] dumbly fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")
 
-/obj/item/pai_cable/attack(obj/machinery/M as obj, mob/user as mob)
+/obj/item/pai_cable/attack(obj/machinery/M, mob/user)
 	src.plugin(M, user)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -116,7 +116,7 @@ var/global/datum/paiController/paiController			// Global handler for pAI candida
 
 		recruitWindow(usr, href_list["allow_submit"] != "0")
 
-/datum/paiController/proc/recruitWindow(mob/M as mob, allowSubmit = 1)
+/datum/paiController/proc/recruitWindow(mob/M, allowSubmit = 1)
 	var/datum/paiCandidate/candidate
 	for(var/datum/paiCandidate/c in pai_candidates)
 		if(!istype(c) || !istype(M))

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -152,7 +152,7 @@ var/global/list/mob_hat_cache = list()
 	playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 
 //Redefining some robot procs...
-/mob/living/silicon/robot/drone/fully_replace_character_name(pickedName as text)
+/mob/living/silicon/robot/drone/fully_replace_character_name(pickedName)
 	// Would prefer to call the grandparent proc but this isn't possible, so..
 	real_name = pickedName
 	SetName(real_name)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -161,7 +161,7 @@
 
 /obj/item/gripper/no_use //Used when you want to hold and put items in other things, but not able to 'use' the item
 
-/obj/item/gripper/no_use/attack_self(mob/user as mob)
+/obj/item/gripper/no_use/attack_self(mob/user)
 	return
 
 /obj/item/gripper/no_use/loader //This is used to disallow building with metal.
@@ -178,7 +178,7 @@
 	if(wrapped)
 		to_chat(user, "It is holding \a [wrapped].")
 
-/obj/item/gripper/attack_self(mob/user as mob)
+/obj/item/gripper/attack_self(mob/user)
 	if(wrapped)
 		return wrapped.attack_self(user)
 	return ..()
@@ -203,7 +203,7 @@
 	wrapped = null
 	//on_update_icon()
 
-/obj/item/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
 	// Don't fall through and smack people with gripper, instead just no-op
 	return 0
 
@@ -319,10 +319,10 @@
 	var/datum/matter_synth/wood = null
 	var/datum/matter_synth/plastic = null
 
-/obj/item/matter_decompiler/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/matter_decompiler/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return
 
-/obj/item/matter_decompiler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)
+/obj/item/matter_decompiler/afterattack(atom/target, mob/living/user, proximity, params)
 
 	if(!proximity) return //Not adjacent.
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -163,7 +163,7 @@
 
 	playsound(loc, spawn_sound, 75, pitch_toggle)
 
-/mob/living/silicon/robot/fully_replace_character_name(pickedName as text)
+/mob/living/silicon/robot/fully_replace_character_name(pickedName)
 	custom_name = pickedName
 	updatename()
 
@@ -288,7 +288,7 @@
 /mob/living/silicon/robot/get_cell()
 	return cell
 
-/mob/living/silicon/robot/proc/updatename(prefix as text)
+/mob/living/silicon/robot/proc/updatename(prefix)
 	if(prefix)
 		modtype = prefix
 
@@ -461,7 +461,7 @@
 	if(prob(75) && Proj.damage > 0) spark_system.start()
 	return 2
 
-/mob/living/silicon/robot/attackby(obj/item/W as obj, mob/user as mob)
+/mob/living/silicon/robot/attackby(obj/item/W, mob/user)
 
 	if(istype(W, /obj/item/inducer)) return // inducer.dm afterattack handles this
 	if (istype(W, /obj/item/handcuffs)) // fuck i don't even know why isrobot() in handcuff code isn't working so this will have to do

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -16,7 +16,7 @@
 	..()
 	files = new /datum/research/techonly(src) //Setup the research data holder.
 
-/obj/item/portable_destructive_analyzer/attack_self(user as mob)
+/obj/item/portable_destructive_analyzer/attack_self(user)
 	var/response = alert(user, 	"Analyzing the item inside will *DESTROY* the item for good.\n\
 							Syncing to the research server will send the data that is stored inside to research.\n\
 							Ejecting will place the loaded item onto the floor.",
@@ -209,7 +209,7 @@
 	name = "Printing Pen"
 	var/mode = 1
 
-/obj/item/pen/robopen/attack_self(mob/user as mob)
+/obj/item/pen/robopen/attack_self(mob/user)
 
 	var/choice = input("Would you like to change colour or mode?") as null|anything in list("Colour","Mode")
 	if(!choice) return
@@ -256,10 +256,10 @@
 	icon_state = "paper_bin1"
 	item_state = "sheet-metal"
 
-/obj/item/form_printer/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/form_printer/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return
 
-/obj/item/form_printer/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag, params)
+/obj/item/form_printer/afterattack(atom/target, mob/living/user, flag, params)
 
 	if(!target || !flag)
 		return
@@ -267,7 +267,7 @@
 	if(istype(target,/obj/structure/table))
 		deploy_paper(get_turf(target))
 
-/obj/item/form_printer/attack_self(mob/user as mob)
+/obj/item/form_printer/attack_self(mob/user)
 	deploy_paper(get_turf(src))
 
 /obj/item/form_printer/proc/deploy_paper(turf/T)

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -26,7 +26,7 @@
 
 	return FALSE
 
-/mob/living/simple_animal/attack_hand(mob/living/carbon/human/M as mob)
+/mob/living/simple_animal/attack_hand(mob/living/carbon/human/M)
 	..()
 
 	switch(M.a_intent)

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -96,7 +96,7 @@
 	name = "Corgi meat"
 	desc = "Tastes like... well you know..."
 
-/mob/living/simple_animal/passive/corgi/attackby(obj/item/O as obj, mob/user as mob)  //Marker -Agouri
+/mob/living/simple_animal/passive/corgi/attackby(obj/item/O, mob/user)  //Marker -Agouri
 	if(istype(O, /obj/item/newspaper))
 		if(!stat)
 			for(var/mob/M in viewers(user, null))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -77,7 +77,7 @@
 				var/step = get_step_to(src, food, 0)
 				Move(step)
 
-/mob/living/simple_animal/hostile/retaliate/goat/attackby(obj/item/O as obj, mob/user as mob)
+/mob/living/simple_animal/hostile/retaliate/goat/attackby(obj/item/O, mob/user)
 	var/obj/item/reagent_containers/glass/G = O
 	if(stat == CONSCIOUS && istype(G) && G.is_open_container())
 		user.visible_message("<span class='notice'>[user] milks [src] using \the [O].</span>")
@@ -120,7 +120,7 @@
 	udder = new(50, src)
 	..()
 
-/mob/living/simple_animal/passive/cow/attackby(obj/item/O as obj, mob/user as mob)
+/mob/living/simple_animal/passive/cow/attackby(obj/item/O, mob/user)
 	var/obj/item/reagent_containers/glass/G = O
 	if(stat == CONSCIOUS && istype(G) && G.is_open_container())
 		user.visible_message("<span class='notice'>[user] milks [src] using \the [O].</span>")
@@ -139,7 +139,7 @@
 	if(udder && prob(5))
 		udder.add_reagent(/datum/reagent/drink/milk, rand(5, 10))
 
-/mob/living/simple_animal/passive/cow/attack_hand(mob/living/carbon/M as mob)
+/mob/living/simple_animal/passive/cow/attack_hand(mob/living/carbon/M)
 	if(!stat && M.a_intent == I_DISARM && icon_state != icon_dead)
 		M.visible_message("<span class='warning'>[M] tips over [src].</span>","<span class='notice'>You tip over [src].</span>")
 		Weaken(30)
@@ -243,7 +243,7 @@ var/global/chicken_count = 0
 	..(gibbed, deathmessage, show_dead_message)
 	chicken_count -= 1
 
-/mob/living/simple_animal/passive/chicken/attackby(obj/item/O as obj, mob/user as mob)
+/mob/living/simple_animal/passive/chicken/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown)) //feedin' dem chickens
 		var/obj/item/reagent_containers/food/snacks/grown/G = O
 		if(G.seed && G.seed.kitchen_tag == "wheat")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -95,7 +95,7 @@
 	adjustBruteLoss(maxHealth)  // Enough damage to kill
 	src.death()
 
-/mob/living/simple_animal/passive/mouse/Crossed(AM as mob|obj)
+/mob/living/simple_animal/passive/mouse/Crossed(AM)
 	if( ishuman(AM) )
 		if(!stat)
 			var/mob/M = AM

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -28,7 +28,7 @@
 	if(.)
 		src.emote("roars in rage!")
 
-/mob/living/simple_animal/hostile/commanded/bear/attack_hand(mob/living/carbon/human/M as mob)
+/mob/living/simple_animal/hostile/commanded/bear/attack_hand(mob/living/carbon/human/M)
 	..()
 	if(M.a_intent == I_HURT)
 		src.emote("roars in rage!")

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -181,7 +181,7 @@
 			friends -= weakref(user)
 
 
-/mob/living/simple_animal/hostile/commanded/attack_hand(mob/living/carbon/human/M as mob)
+/mob/living/simple_animal/hostile/commanded/attack_hand(mob/living/carbon/human/M)
 	..()
 	if(M.a_intent == I_HURT && retribution) //assume he wants to hurt us.
 		target_mob = M

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -27,7 +27,7 @@
 	if (hunger > 500)
 		ai_holder.hostile = TRUE
 
-/mob/living/simple_animal/proc/name_species(newname as text)
+/mob/living/simple_animal/proc/name_species(newname)
 	set name = "Name Alien Species"
 	set category = "IC"
 	set src in view()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -136,7 +136,7 @@
 /*
  * Inventory
  */
-/mob/living/simple_animal/hostile/retaliate/parrot/show_inv(mob/user as mob)
+/mob/living/simple_animal/hostile/retaliate/parrot/show_inv(mob/user)
 	user.set_machine(src)
 	if(user.stat) return
 
@@ -228,7 +228,7 @@
  * Attack responces
  */
 //Humans, monkeys, aliens
-/mob/living/simple_animal/hostile/retaliate/parrot/attack_hand(mob/living/carbon/M as mob)
+/mob/living/simple_animal/hostile/retaliate/parrot/attack_hand(mob/living/carbon/M)
 	..()
 	if(client)
 		return
@@ -253,7 +253,7 @@
 	return
 
 //Mobs with objects
-/mob/living/simple_animal/hostile/retaliate/parrot/attackby(obj/item/O as obj, mob/user as mob)
+/mob/living/simple_animal/hostile/retaliate/parrot/attackby(obj/item/O, mob/user)
 	..()
 	if(!stat && !client && !istype(O, /obj/item/stack/medical))
 		if(O.force)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -45,7 +45,7 @@
 	weapon2 = /obj/item/shield/energy
 	status_flags = 0
 
-/mob/living/simple_animal/hostile/syndicate/melee/attackby(obj/item/O as obj, mob/user as mob)
+/mob/living/simple_animal/hostile/syndicate/melee/attackby(obj/item/O, mob/user)
 	if(O.force)
 		if(prob(80))
 			var/damage = O.force

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -303,7 +303,7 @@
 	return
 
 
-/mob/proc/show_inv(mob/user as mob)
+/mob/proc/show_inv(mob/user)
 	return
 
 
@@ -525,7 +525,7 @@
 			return 1
 	return 0
 
-/mob/MouseDrop(mob/M as mob)
+/mob/MouseDrop(mob/M)
 	..()
 	if(M != usr) return
 	if(usr == src) return

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -2,7 +2,7 @@
 //This proc is the most basic of the procs. All it does is make a new mob on the same tile and transfer over a few variables.
 //Returns the new mob
 //Note that this proc does NOT do MMI related stuff!
-/mob/proc/change_mob_type(new_type = null, turf/location = null, new_name = null as text, delete_old_mob = 0 as num, subspecies)
+/mob/proc/change_mob_type(new_type = null, turf/location = null, new_name = null, delete_old_mob = 0, subspecies)
 
 	if(istype(src,/mob/new_player))
 		to_chat(usr, "<span class='warning'>Cannot convert players who have not entered yet.</span>")

--- a/code/modules/mob/observer/freelook/ai/update_triggers.dm
+++ b/code/modules/mob/observer/freelook/ai/update_triggers.dm
@@ -2,7 +2,7 @@
 
 // An addition to deactivate which removes/adds the camera from the chunk list based on if it works or not.
 
-/obj/machinery/camera/deactivate(user as mob, choice = 1)
+/obj/machinery/camera/deactivate(user, choice = 1)
 	..(user, choice)
 	invalidateCameraCache()
 	if(!can_use())

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -144,7 +144,7 @@
 	qdel(src) // Queues us for a hard delete
 	return O
 
-/mob/living/carbon/human/proc/slimeize(adult as num, reproduce as num)
+/mob/living/carbon/human/proc/slimeize(adult, reproduce)
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
 		return
 	for(var/obj/item/W in src)

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -113,7 +113,7 @@
 	else if(!enabled && screen_on)
 		turn_on(user)
 
-/obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/modular_computer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/card/id)) // ID Card, try to insert it.
 		var/obj/item/card/id/I = W
 		if(!card_slot)

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -21,7 +21,7 @@
 	// Allows us to create "north bump" "south bump" etc. named objects, for more comfortable mapping.
 	name = "telescreen"
 
-/obj/item/modular_computer/telescreen/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/modular_computer/telescreen/attackby(obj/item/W, mob/user)
 	if(isCrowbar(W))
 		if(anchored)
 			shutdown_computer()

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -154,7 +154,7 @@
 			L.tracking_cancelled()
 	current_camera = null
 
-/datum/nano_module/camera_monitor/check_eye(mob/user as mob)
+/datum/nano_module/camera_monitor/check_eye(mob/user)
 	if(!current_camera)
 		return 0
 	var/viewflag = current_camera.check_eye(user)

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -26,7 +26,7 @@
 	/// Whether attackby will be passed on it even with a closed panel
 	var/external_slot
 
-/obj/item/stock_parts/computer/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/item/stock_parts/computer/attackby(obj/item/W, mob/living/user)
 	// Multitool. Runs diagnostics
 	if(isMultitool(W))
 		to_chat(user, "***** DIAGNOSTICS REPORT *****")

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -41,7 +41,7 @@
 		return FALSE
 	return TRUE
 
-/obj/item/stock_parts/computer/nano_printer/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/stock_parts/computer/nano_printer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper))
 		if(stored_paper >= max_paper)
 			to_chat(user, "You try to add \the [W] into \the [src], but its paper bin is full.")

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -269,7 +269,7 @@
 		ui.set_auto_update(1)
 
 
-/obj/machinery/lapvend/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/lapvend/attackby(obj/item/W, mob/user)
 	var/obj/item/card/id/I = W.GetIdCard()
 	// Awaiting payment state
 	if(state == 2)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -223,7 +223,7 @@
 			above.ChangeTurf(/turf/simulated/open)
 	. = ..()
 
-/obj/structure/stairs/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+/obj/structure/stairs/CheckExit(atom/movable/mover, turf/target)
 	if(get_dir(loc, target) == dir && upperStep(mover.loc))
 		return FALSE
 	return ..()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -197,10 +197,10 @@
 /atom/movable/openspace/turf_proxy/attackby(obj/item/W, mob/user)
 	loc.attackby(W, user)
 
-/atom/movable/openspace/turf_proxy/attack_hand(mob/user as mob)
+/atom/movable/openspace/turf_proxy/attack_hand(mob/user)
 	loc.attack_hand(user)
 
-/atom/movable/openspace/turf_proxy/attack_generic(mob/user as mob)
+/atom/movable/openspace/turf_proxy/attack_generic(mob/user)
 	loc.attack_generic(user)
 
 /atom/movable/openspace/turf_proxy/examine(mob/examiner)
@@ -224,10 +224,10 @@
 /atom/movable/openspace/turf_mimic/attackby(obj/item/W, mob/user)
 	loc.attackby(W, user)
 
-/atom/movable/openspace/turf_mimic/attack_hand(mob/user as mob)
+/atom/movable/openspace/turf_mimic/attack_hand(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/turf_mimic/attack_generic(mob/user as mob)
+/atom/movable/openspace/turf_mimic/attack_generic(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
 /atom/movable/openspace/turf_mimic/examine(mob/examiner)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -220,7 +220,7 @@
 	for(var/obj/item/organ/external/child in children)
 		child.show_decay_status(user)
 
-/obj/item/organ/external/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/organ/external/attackby(obj/item/W, mob/user)
 	switch(stage)
 		if(0)
 			if(W.sharp)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -208,7 +208,7 @@ var/global/list/organ_cache = list()
 						germ_level += rand(3,5)
 						owner.reagents.add_reagent(/datum/reagent/toxin, rand(1,2))
 
-/obj/item/organ/proc/receive_chem(chemical as obj)
+/obj/item/organ/proc/receive_chem(chemical)
 	return 0
 
 /obj/item/organ/proc/remove_rejuv()

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -126,7 +126,7 @@
 	. = ..()
 	new /obj/item/tank/hydrogen(src)
 
-/obj/structure/fuel_port/attack_hand(mob/user as mob)
+/obj/structure/fuel_port/attack_hand(mob/user)
 	if(!opened)
 		to_chat(user, "<spawn class='notice'>The door is secured tightly. You'll need a crowbar to open it.")
 		return
@@ -143,7 +143,7 @@
 	else
 		icon_state = icon_closed
 
-/obj/structure/fuel_port/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/fuel_port/attackby(obj/item/W, mob/user)
 	if(isCrowbar(W))
 		if(opened)
 			to_chat(user, "<spawn class='notice'>You tightly shut \the [src] door.")

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -22,7 +22,7 @@
 		desc = initial(desc)
 		desc += " It's made of [material.use_name]."
 
-/obj/item/material/clipboard/MouseDrop(obj/over_object as obj) //Quick clipboard fix. -Agouri
+/obj/item/material/clipboard/MouseDrop(obj/over_object) //Quick clipboard fix. -Agouri
 	if(ishuman(usr))
 		var/mob/M = usr
 		if(!(istype(over_object, /obj/screen) ))
@@ -50,7 +50,7 @@
 	overlays += overlay_image(icon, "clipboard_over", flags=RESET_COLOR)
 	return
 
-/obj/item/material/clipboard/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/material/clipboard/attackby(obj/item/W, mob/user)
 
 	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo))
 		if(!user.unEquip(W, src))
@@ -66,7 +66,7 @@
 
 	return
 
-/obj/item/material/clipboard/attack_self(mob/user as mob)
+/obj/item/material/clipboard/attack_self(mob/user)
 	var/dat = "<title>Clipboard</title>"
 	if(haspen)
 		dat += "<A href='?src=\ref[src];pen=1'>Remove Pen</A><BR><HR>"

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(admin_departments)
 	if (department && !(("[department]" in GLOB.alldepartments) || ("[department]" in GLOB.admin_departments)))
 		GLOB.alldepartments |= department
 
-/obj/machinery/photocopier/faxmachine/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/photocopier/faxmachine/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/paper))
 		var/obj/item/paper/P = O
 		if(!P.readable)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -46,7 +46,7 @@
 			I.forceMove(src)
 	. = ..()
 
-/obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
+/obj/structure/filingcabinet/attackby(obj/item/P, mob/user)
 	if(is_type_in_list(P, can_hold))
 		if(!user.unEquip(P, src))
 			return
@@ -57,7 +57,7 @@
 	else
 		..()
 
-/obj/structure/filingcabinet/attack_hand(mob/user as mob)
+/obj/structure/filingcabinet/attack_hand(mob/user)
 	if(contents.len <= 0)
 		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
 		return

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -31,7 +31,7 @@
 		overlays += "folder_paper"
 	return
 
-/obj/item/folder/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/folder/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo) || istype(W, /obj/item/paper_bundle))
 		if(!user.unEquip(W, src))
 			return
@@ -43,7 +43,7 @@
 			SetName("folder[(n_name ? text("- '[n_name]'") : null)]")
 	return
 
-/obj/item/folder/attack_self(mob/user as mob)
+/obj/item/folder/attack_self(mob/user)
 	var/dat = "<title>[name]</title>"
 	for(var/obj/item/paper/P in src)
 		dat += "<A href='?src=\ref[src];remove=\ref[P]'>Remove</A> <A href='?src=\ref[src];rename=\ref[P]'>Rename</A> - <A href='?src=\ref[src];read=\ref[P]'>[P.name]</A><BR>"
@@ -131,14 +131,14 @@
 		update_icon()
 		return 1
 
-/obj/item/folder/envelope/attack_self(mob/user as mob)
+/obj/item/folder/envelope/attack_self(mob/user)
 	if(sealed)
 		sealcheck(user)
 		return
 	else
 		..()
 
-/obj/item/folder/envelope/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/folder/envelope/attackby(obj/item/W, mob/user)
 	if(sealed)
 		sealcheck(user)
 		return

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -11,7 +11,7 @@
 /obj/item/hand_labeler/attack()
 	return
 
-/obj/item/hand_labeler/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/hand_labeler/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)
 		return
 	if(!mode)	//if it's off, give up.
@@ -50,7 +50,7 @@
 	var/datum/extension/labels/L = get_or_create_extension(src, /datum/extension/labels)
 	L.AttachLabel(user, label_text)
 
-/obj/item/hand_labeler/attack_self(mob/user as mob)
+/obj/item/hand_labeler/attack_self(mob/user)
 	mode = !mode
 	icon_state = "labeler[mode]"
 	if(mode)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -206,7 +206,7 @@
 	SetName(n_name)
 	add_fingerprint(usr)
 
-/obj/item/paper/attack_self(mob/living/user as mob)
+/obj/item/paper/attack_self(mob/living/user)
 	if(user.a_intent == I_HURT)
 		if(icon_state == "scrap")
 			user.show_message("<span class='warning'>\The [src] is already crumpled.</span>")
@@ -221,7 +221,7 @@
 /obj/item/paper/attack_ai(mob/living/silicon/ai/user)
 	show_content(user)
 
-/obj/item/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/paper/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(user.zone_sel.selecting == BP_EYES)
 		user.visible_message("<span class='notice'>You show the paper to [M]. </span>", \
 			"<span class='notice'> [user] holds up a paper and shows it to [M]. </span>")
@@ -296,7 +296,7 @@
 	updateinfolinks()
 	update_icon()
 
-/obj/item/paper/proc/get_signature(obj/item/pen/P, mob/user as mob)
+/obj/item/paper/proc/get_signature(obj/item/pen/P, mob/user)
 	if(P && istype(P, /obj/item/pen))
 		return P.get_signature(user)
 	return (user && user.real_name) ? user.real_name : "Anonymous"
@@ -444,7 +444,7 @@
 		update_icon()
 
 
-/obj/item/paper/attackby(obj/item/P as obj, mob/user as mob)
+/obj/item/paper/attackby(obj/item/P, mob/user)
 	..()
 	var/clown = 0
 	if(user.mind && (user.mind.assigned_role == "Clown"))

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -15,7 +15,7 @@
 	var/list/pages = list()  // Ordered list of pages as they are to be displayed. Can be different order than src.contents.
 
 
-/obj/item/paper_bundle/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/paper_bundle/attackby(obj/item/W, mob/user)
 	..()
 	if(!istype(W))
 		return
@@ -102,7 +102,7 @@
 	else
 		to_chat(user, "<span class='notice'>It is too far away.</span>")
 
-/obj/item/paper_bundle/proc/show_content(mob/user as mob)
+/obj/item/paper_bundle/proc/show_content(mob/user)
 	var/dat
 	var/obj/item/W = pages[page]
 
@@ -133,7 +133,7 @@
 		send_rsc(user, P.img, "tmp_photo.png")
 		show_browser(user, JOINTEXT(dat), "window=[name]")
 
-/obj/item/paper_bundle/attack_self(mob/user as mob)
+/obj/item/paper_bundle/attack_self(mob/user)
 	src.show_content(user)
 	add_fingerprint(user)
 	update_icon()

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -13,7 +13,7 @@
 	var/list/papers = new/list()	//List of papers put in the bin for reference.
 
 
-/obj/item/paper_bin/MouseDrop(mob/user as mob)
+/obj/item/paper_bin/MouseDrop(mob/user)
 	if((user == usr && (!( usr.restrained() ) && (!( usr.stat ) && (usr.contents.Find(src) || in_range(src, usr))))))
 		if(!istype(usr, /mob/living/carbon/slime) && !istype(usr, /mob/living/simple_animal))
 			if( !usr.get_active_hand() )		//if active hand is empty
@@ -31,7 +31,7 @@
 
 	return
 
-/obj/item/paper_bin/attack_hand(mob/user as mob)
+/obj/item/paper_bin/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.organs_by_name[BP_R_HAND]
@@ -69,7 +69,7 @@
 	return
 
 
-/obj/item/paper_bin/attackby(obj/item/i as obj, mob/user as mob)
+/obj/item/paper_bin/attackby(obj/item/i, mob/user)
 	if(istype(i, /obj/item/paper))
 		if(!user.unEquip(i, src))
 			return

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -107,7 +107,7 @@
 /obj/machinery/papershredder/on_update_icon()
 	icon_state = "papershredder[max(0,min(5,Floor(paperamount/2)))]"
 
-/obj/item/shreddedp/attackby(obj/item/W as obj, mob/user)
+/obj/item/shreddedp/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/flame/lighter))
 		burnpaper(W, user)
 	else

--- a/code/modules/paperwork/pen/chameleon_pen.dm
+++ b/code/modules/paperwork/pen/chameleon_pen.dm
@@ -1,7 +1,7 @@
 /obj/item/pen/chameleon
 	var/signature = ""
 
-/obj/item/pen/chameleon/attack_self(mob/user as mob)
+/obj/item/pen/chameleon/attack_self(mob/user)
 	/*
 	// Limit signatures to official crew members
 	var/personnel_list[] = list()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -104,7 +104,7 @@
 		to_chat(user, "<span class='notice'>You take \the [copyitem] out of \the [src].</span>")
 		copyitem = null
 
-/obj/machinery/photocopier/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/photocopier/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/paper) || istype(O, /obj/item/photo) || istype(O, /obj/item/paper_bundle))
 		if(!copyitem)
 			if(!user.unEquip(O, src))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -39,7 +39,7 @@ var/global/photo_count = 0
 /obj/item/photo/New()
 	id = photo_count++
 
-/obj/item/photo/attack_self(mob/user as mob)
+/obj/item/photo/attack_self(mob/user)
 	user.examinate(src)
 
 /obj/item/photo/on_update_icon()
@@ -57,7 +57,7 @@ var/global/photo_count = 0
 	tiny.pixel_x = -32*(photo_size-1)/2 - 3
 	tiny.pixel_y = -32*(photo_size-1)/2 + 3
 
-/obj/item/photo/attackby(obj/item/P as obj, mob/user as mob)
+/obj/item/photo/attackby(obj/item/P, mob/user)
 	if(istype(P, /obj/item/pen))
 		var/txt = sanitize(input(user, "What would you like to write on the back?", "Photo Writing", null)  as text, 128)
 		if(loc == user && user.stat == 0)
@@ -74,7 +74,7 @@ var/global/photo_count = 0
 	else
 		to_chat(user, "<span class='notice'>It is too far away.</span>")
 
-/obj/item/photo/proc/show(mob/user as mob)
+/obj/item/photo/proc/show(mob/user)
 	send_rsc(user, img, "tmp_photo_[id].png")
 	var/output = "<html><head><title>[name]</title></head>"
 	output += "<body style='overflow:hidden;margin:0;text-align:center'>"
@@ -111,7 +111,7 @@ var/global/photo_count = 0
 	storage_slots = DEFAULT_BOX_STORAGE //yes, that's storage_slots. Photos are w_class 1 so this has as many slots equal to the number of photos you could put in a box
 	can_hold = list(/obj/item/photo)
 
-/obj/item/storage/photo_album/MouseDrop(obj/over_object as obj)
+/obj/item/storage/photo_album/MouseDrop(obj/over_object)
 
 	if((istype(usr, /mob/living/carbon/human)))
 		var/mob/M = usr
@@ -173,16 +173,16 @@ var/global/photo_count = 0
 		size = nsize
 		to_chat(usr, "<span class='notice'>Camera will now take [size]x[size] photos.</span>")
 
-/obj/item/device/camera/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+/obj/item/device/camera/attack(mob/living/carbon/human/M, mob/user)
 	return
 
-/obj/item/device/camera/attack_self(mob/user as mob)
+/obj/item/device/camera/attack_self(mob/user)
 	on = !on
 	update_icon()
 	to_chat(user, "You switch the camera [on ? "on" : "off"].")
 	return
 
-/obj/item/device/camera/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/device/camera/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/device/camera_film))
 		if(pictures_left)
 			to_chat(user, "<span class='notice'>[src] still has some film in it!</span>")
@@ -194,7 +194,7 @@ var/global/photo_count = 0
 	..()
 
 
-/obj/item/device/camera/proc/get_mobs(turf/the_turf as turf)
+/obj/item/device/camera/proc/get_mobs(turf/the_turf)
 	var/mob_detail
 	for(var/mob/living/carbon/A in the_turf)
 		if(A.invisibility) continue
@@ -213,7 +213,7 @@ var/global/photo_count = 0
 			mob_detail += "You can also see [A] on the photo[(A.health / A.maxHealth)< 0.75 ? " - [A] looks hurt":""].[holding ? " [holding]":"."]."
 	return mob_detail
 
-/obj/item/device/camera/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
+/obj/item/device/camera/afterattack(atom/target, mob/user, flag)
 	if(!on || !pictures_left || ismob(target.loc)) return
 	captureimage(target, user, flag)
 

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -48,7 +48,7 @@
 	icon_state = "stamp-cargo"
 
 // Syndicate stamp to forge documents.
-/obj/item/stamp/chameleon/attack_self(mob/user as mob)
+/obj/item/stamp/chameleon/attack_self(mob/user)
 
 	var/list/stamp_types = typesof(/obj/item/stamp) - src.type // Get all stamp types except our own
 	var/list/stamps = list()

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -237,7 +237,7 @@
 		internal_cells -= C
 	return ..()
 
-/obj/machinery/power/smes/batteryrack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/smes/batteryrack/attackby(obj/item/W, mob/user)
 	if(..())
 		return TRUE
 	if(istype(W, /obj/item/cell)) // ID Card, try to insert it.

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -84,7 +84,7 @@
 	busy = 0
 	return TRUE
 
-/obj/machinery/power/breakerbox/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/breakerbox/attackby(obj/item/W, mob/user)
 	if(isMultitool(W))
 		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
 		if(newtag)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -154,7 +154,7 @@
 		update_icon()
 	add_avail(effective_gen)
 
-/obj/machinery/power/generator/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/generator/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		anchored = !anchored

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -290,7 +290,7 @@
 		return SPAN_WARNING("You cannot do this while \the [src] is running!")
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/power/port_gen/pacman/attackby(obj/item/O, mob/user)
 	if(istype(O, sheet_path))
 		var/obj/item/stack/addstack = O
 		var/amount = min((max_sheets - sheets), addstack.amount)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -251,7 +251,7 @@
 //power_source is a source of electricity, can be powercell, area, apc, cable, powernet or null
 //source is an object caused electrocuting (airlock, grille, etc)
 //No animations will be performed by this proc.
-/proc/electrocute_mob(mob/living/carbon/M as mob, power_source, obj/source, siemens_coeff = 1.0)
+/proc/electrocute_mob(mob/living/carbon/M, power_source, obj/source, siemens_coeff = 1.0)
 	var/area/source_area
 	if(istype(power_source,/area))
 		source_area = power_source

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -29,7 +29,7 @@
 /obj/machinery/containment_field/ex_act(severity)
 	return 0
 
-/obj/machinery/containment_field/HasProximity(atom/movable/AM as mob|obj)
+/obj/machinery/containment_field/HasProximity(atom/movable/AM)
 	if(istype(AM,/mob/living/silicon) && prob(40))
 		shock(AM)
 		return 1
@@ -40,7 +40,7 @@
 
 
 
-/obj/machinery/containment_field/shock(mob/living/user as mob)
+/obj/machinery/containment_field/shock(mob/living/user)
 	if(hasShocked)
 		return 0
 	if(!FG1 || !FG2)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -82,7 +82,7 @@
 	activate(user)
 	return TRUE
 
-/obj/machinery/power/emitter/proc/activate(mob/user as mob)
+/obj/machinery/power/emitter/proc/activate(mob/user)
 	if (!istype(user))
 		user = null // safety, as the proc is publicly available.
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -48,7 +48,7 @@
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/obj/singularity/attack_hand(mob/user as mob)
+/obj/singularity/attack_hand(mob/user)
 	consume(user)
 	return 1
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -237,7 +237,7 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/smes/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/smes/attackby(obj/item/W, mob/user)
 	if(component_attackby(W, user))
 		return TRUE
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -149,7 +149,7 @@
 // Proc: total_system_failure()
 // Parameters: 2 (intensity - how strong the failure is, user - person which caused the failure)
 // Description: Checks the sensors for alerts. If change (alerts cleared or detected) occurs, calls for icon update.
-/obj/machinery/power/smes/buildable/proc/total_system_failure(intensity = 0, mob/user as mob)
+/obj/machinery/power/smes/buildable/proc/total_system_failure(intensity = 0, mob/user)
 	// SMESs store very large amount of power. If someone screws up (ie: Disables safeties and attempts to modify the SMES) very bad things happen.
 	// Bad things are based on charge percentage.
 	// Possible effects:
@@ -333,7 +333,7 @@
 // Proc: attackby()
 // Parameters: 2 (W - object that was used on this machine, user - person which used the object)
 // Description: Handles tool interaction. Allows deconstruction/upgrading/fixing.
-/obj/machinery/power/smes/buildable/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/smes/buildable/attackby(obj/item/W, mob/user)
 	// No more disassembling of overloaded SMESs. You broke it, now enjoy the consequences.
 	if (failing)
 		to_chat(user, "<span class='warning'>\The [src]'s screen is flashing with alerts. It seems to be overloaded! Touching it now is probably not a good idea.</span>")

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -58,7 +58,7 @@
 	if(A)
 		LAZYDISTINCTADD(A.gunshot_residue, caliber)
 
-/obj/item/ammo_casing/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/ammo_casing/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		if(!BB)
 			to_chat(user, "<span class='notice'>There is no bullet in the casing to inscribe anything into.</span>")
@@ -136,7 +136,7 @@
 		SetName("[name] ([english_list(labels, and_text = ", ")])")
 	update_icon()
 
-/obj/item/ammo_magazine/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/ammo_magazine/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/C = W
 		if(C.caliber != caliber)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -279,7 +279,7 @@
 	return null
 
 //used by aiming code
-/obj/item/gun/proc/can_hit(atom/target as mob, mob/living/user as mob)
+/obj/item/gun/proc/can_hit(atom/target, mob/living/user)
 	if(!special_check(user))
 		return 2
 	//just assume we can shoot through glass and stuff. No big deal, the player can just choose to not target someone

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -64,7 +64,7 @@
 	projectile_type=/obj/item/projectile/beam/pulse/destroy
 	charge_cost= 40
 
-/obj/item/gun/energy/pulse_rifle/destroyer/attack_self(mob/living/user as mob)
+/obj/item/gun/energy/pulse_rifle/destroyer/attack_self(mob/living/user)
 	to_chat(user, "<span class='warning'>[src.name] has three settings, and they are all DESTROY.</span>")
 	
 /obj/item/gun/energy/pulse_rifle/skrell

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -12,7 +12,7 @@
 	fire_sound_text = "a launcher firing"
 
 //This normally uses a proc on projectiles and our ammo is not strictly speaking a projectile.
-/obj/item/gun/launcher/can_hit(mob/living/target as mob, mob/living/user as mob)
+/obj/item/gun/launcher/can_hit(mob/living/target, mob/living/user)
 	return 1
 
 //Override this to avoid a runtime with suicide handling.

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -81,7 +81,7 @@
 	update_icon()
 	..()
 
-/obj/item/gun/launcher/crossbow/attack_self(mob/living/user as mob)
+/obj/item/gun/launcher/crossbow/attack_self(mob/living/user)
 	if(tension)
 		if(bolt)
 			user.visible_message("[user] relaxes the tension on [src]'s string and removes [bolt].","You relax the tension on [src]'s string and remove [bolt].")
@@ -96,7 +96,7 @@
 	else
 		draw(user)
 
-/obj/item/gun/launcher/crossbow/proc/draw(mob/user as mob)
+/obj/item/gun/launcher/crossbow/proc/draw(mob/user)
 
 	if(!bolt)
 		to_chat(user, "You don't have anything nocked to [src].")
@@ -130,7 +130,7 @@
 
 		user.visible_message("[usr] draws back the string of [src]!","<span class='notice'>You continue drawing back the string of [src]!</span>")
 
-/obj/item/gun/launcher/crossbow/proc/increase_tension(mob/user as mob)
+/obj/item/gun/launcher/crossbow/proc/increase_tension(mob/user)
 
 	if(!bolt || !tension || current_user != user) //Arrow has been fired, bow has been relaxed or user has changed.
 		return
@@ -235,7 +235,7 @@
 		flick("[icon_state]-empty", src)
 
 
-/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/attack_self(mob/living/user as mob)
+/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/attack_self(mob/living/user)
 	if(tension)
 		user.visible_message("[user] relaxes the tension on [src]'s string.","You relax the tension on [src]'s string.")
 		tension = 0

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -27,7 +27,7 @@
 	matter = list(MATERIAL_STEEL = 2000)
 
 //revolves the magazine, allowing players to choose between multiple grenade types
-/obj/item/gun/launcher/grenade/proc/pump(mob/M as mob)
+/obj/item/gun/launcher/grenade/proc/pump(mob/M)
 	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
 
 	var/obj/item/grenade/next

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -113,7 +113,7 @@
 
 	return bling
 
-/obj/item/gun/launcher/money/attack_self(mob/user as mob)
+/obj/item/gun/launcher/money/attack_self(mob/user)
 	var/disp_amount = min(input(user, "How many [GLOB.using_map.local_currency_name_singular] do you want to dispense at a time? (0 to [src.receptacle_value])", "Money Cannon Settings", 20) as num, receptacle_value)
 
 	if (disp_amount < 1)
@@ -123,13 +123,13 @@
 	src.dispensing = disp_amount
 	to_chat(user, "<span class='notice'>You set [src] to dispense [dispensing] [GLOB.using_map.local_currency_name_singular] at a time.</span>")
 
-/obj/item/gun/launcher/money/attack_hand(mob/user as mob)
+/obj/item/gun/launcher/money/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)
 		unload_receptacle(user)
 	else
 		return ..()
 
-/obj/item/gun/launcher/money/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/gun/launcher/money/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/spacecash))
 		var/obj/item/spacecash/bling = W
 		if(bling.worth < 1)

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -59,13 +59,13 @@
 	else
 		to_chat(user, "There is nothing to remove in \the [src].")
 
-/obj/item/gun/launcher/pneumatic/attack_hand(mob/user as mob)
+/obj/item/gun/launcher/pneumatic/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)
 		unload_hopper(user)
 	else
 		return ..()
 
-/obj/item/gun/launcher/pneumatic/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/gun/launcher/pneumatic/attackby(obj/item/W, mob/user)
 	if(!tank && istype(W,/obj/item/tank) && user.unEquip(W, src))
 		tank = W
 		user.visible_message("[user] jams [W] into [src]'s valve and twists it closed.","You jam [W] into [src]'s valve and twist it closed.")
@@ -73,7 +73,7 @@
 	else if(istype(W) && item_storage.can_be_inserted(W, user))
 		item_storage.handle_item_insertion(W)
 
-/obj/item/gun/launcher/pneumatic/attack_self(mob/user as mob)
+/obj/item/gun/launcher/pneumatic/attack_self(mob/user)
 	eject_tank(user)
 
 /obj/item/gun/launcher/pneumatic/consume_next_projectile(mob/user=null)

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -23,7 +23,7 @@
 	if(distance <= 2)
 		to_chat(user, "<span class='notice'>[rockets.len] / [max_rockets] rockets.</span>")
 
-/obj/item/gun/launcher/rocket/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/gun/launcher/rocket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/ammo_casing/rocket))
 		if(rockets.len < max_rockets)
 			if(!user.unEquip(I, src))

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -93,7 +93,7 @@
 	darts -= next
 	next = null
 
-/obj/item/gun/launcher/syringe/attack_self(mob/living/user as mob)
+/obj/item/gun/launcher/syringe/attack_self(mob/living/user)
 	if(next)
 		user.visible_message("[user] unlatches and carefully relaxes the bolt on [src].", "<span class='warning'>You unlatch and carefully relax the bolt on [src], unloading the spring.</span>")
 		next = null
@@ -103,7 +103,7 @@
 		next = darts[1]
 	add_fingerprint(user)
 
-/obj/item/gun/launcher/syringe/attack_hand(mob/living/user as mob)
+/obj/item/gun/launcher/syringe/attack_hand(mob/living/user)
 	if(user.get_inactive_hand() == src)
 		if(!darts.len)
 			to_chat(user, "<span class='warning'>[src] is empty.</span>")
@@ -118,7 +118,7 @@
 	else
 		..()
 
-/obj/item/gun/launcher/syringe/attackby(obj/item/A as obj, mob/user as mob)
+/obj/item/gun/launcher/syringe/attackby(obj/item/A, mob/user)
 	if(istype(A, /obj/item/syringe_cartridge))
 		var/obj/item/syringe_cartridge/C = A
 		if(darts.len >= max_darts)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -251,17 +251,17 @@
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
 	update_icon()
 
-/obj/item/gun/projectile/attackby(obj/item/A as obj, mob/user as mob)
+/obj/item/gun/projectile/attackby(obj/item/A, mob/user)
 	if(!load_ammo(A, user))
 		return ..()
 
-/obj/item/gun/projectile/attack_self(mob/user as mob)
+/obj/item/gun/projectile/attack_self(mob/user)
 	if(firemodes.len > 1)
 		..()
 	else
 		unload_ammo(user)
 
-/obj/item/gun/projectile/attack_hand(mob/user as mob)
+/obj/item/gun/projectile/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)
 		unload_ammo(user, allow_dump=0)
 	else

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -289,13 +289,13 @@
 	to_chat(user, "<span class='notice'>You [cover_open ? "open" : "close"] [src]'s cover.</span>")
 	update_icon()
 
-/obj/item/gun/projectile/automatic/l6_saw/attack_self(mob/user as mob)
+/obj/item/gun/projectile/automatic/l6_saw/attack_self(mob/user)
 	if(cover_open)
 		toggle_cover(user) //close the cover
 	else
 		return ..() //once closed, behave like normal
 
-/obj/item/gun/projectile/automatic/l6_saw/attack_hand(mob/user as mob)
+/obj/item/gun/projectile/automatic/l6_saw/attack_hand(mob/user)
 	if(!cover_open && user.get_inactive_hand() == src)
 		toggle_cover(user) //open the cover
 	else

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -104,7 +104,7 @@
 				for(var/datum/reagent/R in B.reagents.reagent_list)
 					to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
 
-/obj/item/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/gun/projectile/dartgun/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/glass))
 		add_beaker(I, user)
 		return 1

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -32,12 +32,12 @@
 		return chambered.BB
 	return null
 
-/obj/item/gun/projectile/shotgun/pump/attack_self(mob/living/user as mob)
+/obj/item/gun/projectile/shotgun/pump/attack_self(mob/living/user)
 	if(world.time >= recentpump + 10)
 		pump(user)
 		recentpump = world.time
 
-/obj/item/gun/projectile/shotgun/pump/proc/pump(mob/M as mob)
+/obj/item/gun/projectile/shotgun/pump/proc/pump(mob/M)
 	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
 
 	if(chambered)//We have a shell in the chamber
@@ -112,7 +112,7 @@
 	..(user, allow_dump=1)
 
 //this is largely hacky and bad :(	-Pete
-/obj/item/gun/projectile/shotgun/doublebarrel/attackby(obj/item/A as obj, mob/user as mob)
+/obj/item/gun/projectile/shotgun/doublebarrel/attackby(obj/item/A, mob/user)
 	if(w_class > 3 && (istype(A, /obj/item/circular_saw) || istype(A, /obj/item/melee/energy) || istype(A, /obj/item/gun/energy/plasmacutter)))
 		if(istype(A, /obj/item/gun/energy/plasmacutter))
 			var/obj/item/gun/energy/plasmacutter/cutter = A

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -46,7 +46,7 @@
 		loaded -= chambered
 		chambered = null
 
-/obj/item/gun/projectile/heavysniper/attack_self(mob/user as mob)
+/obj/item/gun/projectile/heavysniper/attack_self(mob/user)
 	bolt_open = !bolt_open
 	if(bolt_open)
 		if(chambered)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -127,7 +127,7 @@
 /obj/item/projectile/proc/check_penetrate(atom/A)
 	return 1
 
-/obj/item/projectile/proc/check_fire(atom/target as mob, mob/living/user as mob)  //Checks if you can hit them or not.
+/obj/item/projectile/proc/check_fire(atom/target, mob/living/user)  //Checks if you can hit them or not.
 	check_trajectory(target, user, pass_flags, item_flags, obj_flags)
 
 //sets the click point of the projectile using mouse input params
@@ -270,7 +270,7 @@
 
 	return 1
 
-/obj/item/projectile/Bump(atom/A as mob|obj|turf|area, forced=0)
+/obj/item/projectile/Bump(atom/A, forced=0)
 	if(A == src)
 		return 0 //no
 
@@ -449,7 +449,7 @@
 	var/result = 0 //To pass the message back to the gun.
 	var/atom/hit_thing
 
-/obj/item/projectile/test/Bump(atom/A as mob|obj|turf|area, forced=0)
+/obj/item/projectile/test/Bump(atom/A, forced=0)
 	if(A == firer)
 		forceMove(A.loc)
 		return //cannot shoot yourself

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -499,7 +499,7 @@
 				return 1
 
 //Helper proc to check if you can hit them or not.
-/proc/check_trajectory(atom/target as mob|obj, atom/firer as mob|obj, pass_flags=PASS_FLAG_TABLE|PASS_FLAG_GLASS|PASS_FLAG_GRILLE, item_flags = null, obj_flags = null)
+/proc/check_trajectory(atom/target, atom/firer, pass_flags=PASS_FLAG_TABLE|PASS_FLAG_GLASS|PASS_FLAG_GRILLE, item_flags = null, obj_flags = null)
 	if(!istype(target) || !istype(firer))
 		return 0
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -40,7 +40,7 @@
 	damage_type = DAMAGE_BRUTE
 	nodamage = TRUE
 
-/obj/item/projectile/meteor/Bump(atom/A as mob|obj|turf|area, forced=0)
+/obj/item/projectile/meteor/Bump(atom/A, forced=0)
 	if(A == firer)
 		forceMove(A.loc)
 		return

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(secure_weapons, list())
 	if(distance <= 0 && is_secure_gun())
 		to_chat(user, "The registration screen shows, \"" + (registered_owner ? "[registered_owner]" : "unregistered") + "\"")
 
-/obj/item/gun/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/gun/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/card/id) && is_secure_gun())
 		user.visible_message("[user] swipes an ID through \the [src].", range = 3)
 		if(!registered_owner)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -56,7 +56,7 @@
 				qdel(src)
 				return
 
-/obj/machinery/chem_master/attackby(obj/item/B as obj, mob/user as mob)
+/obj/machinery/chem_master/attackby(obj/item/B, mob/user)
 
 	if(istype(B, /obj/item/reagent_containers/glass))
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -36,7 +36,7 @@
 	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/reagent_containers/verb/set_amount_per_transfer_from_this
 
-/obj/item/reagent_containers/attack_self(mob/user as mob)
+/obj/item/reagent_containers/attack_self(mob/user)
 	return
 
 /obj/item/reagent_containers/afterattack(obj/target, mob/user, flag)
@@ -47,7 +47,7 @@
 		return reagents.get_reagents()
 	return "No reagent holder"
 
-/obj/item/reagent_containers/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/pen) || istype(W, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
 		if(length(tmp_label) > 10)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -103,7 +103,7 @@
 				to_chat(user, SPAN_NOTICE("[transferred] units injected. [R.total_volume] units remaining in \the [container]."))
 	return
 
-/obj/item/reagent_containers/borghypo/attack_self(mob/user as mob)
+/obj/item/reagent_containers/borghypo/attack_self(mob/user)
 	ui_interact(user)
 
 /obj/item/reagent_containers/borghypo/examine(mob/user, distance)

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/food/drinks/glass2/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/reagent_containers/food/drinks/glass2/attackby(obj/item/I, mob/user)
 	if(extras.len >= 2) return ..() // max 2 extras, one on each side of the drink
 
 	if(istype(I, /obj/item/glass_extra))
@@ -26,7 +26,7 @@
 	else
 		return ..()
 
-/obj/item/reagent_containers/food/drinks/glass2/attack_hand(mob/user as mob)
+/obj/item/reagent_containers/food/drinks/glass2/attack_hand(mob/user)
 	if(src != user.get_inactive_hand())
 		return ..()
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -31,17 +31,17 @@
 		/datum/reagent/oliveoil = /obj/item/reagent_containers/food/condiment/small/oliveoil
 		)
 
-/obj/item/reagent_containers/food/condiment/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/condiment/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/pen) || istype(W, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
 		var/datum/extension/labels/L = get_or_create_extension(src, /datum/extension/labels)
 		L.AttachLabel(user, tmp_label)
 		return
 
-/obj/item/reagent_containers/food/condiment/attack_self(mob/user as mob)
+/obj/item/reagent_containers/food/condiment/attack_self(mob/user)
 	return
 
-/obj/item/reagent_containers/food/condiment/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/condiment/attack(mob/M, mob/user, def_zone)
 	if(standard_feed_mob(user, M))
 		return
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -20,7 +20,7 @@
 /obj/item/reagent_containers/food/drinks/on_color_transfer_reagent_change()
 	return
 
-/obj/item/reagent_containers/food/drinks/attack_self(mob/user as mob)
+/obj/item/reagent_containers/food/drinks/attack_self(mob/user)
 	if(!is_open_container())
 		open(user)
 
@@ -29,7 +29,7 @@
 	to_chat(user, "<span class='notice'>You open \the [src] with an audible pop!</span>")
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/drinks/attack(mob/M, mob/user, def_zone)
 	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
 		return ..()
 

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/food/snacks/slice/bread/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/slice/bread/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/material/shard) || istype(W,/obj/item/reagent_containers/food/snacks))
 		if (is_path_in_list(W.type, list(/obj/item/reagent_containers/food/snacks/custombowl, /obj/item/reagent_containers/food/snacks/csandwich)))
 			return
@@ -101,7 +101,7 @@
 	var/obj/item/O = pick(contents)
 	to_chat(user, SPAN_ITALIC("You think you can see [O.name] in there."))
 
-/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/M, mob/user, def_zone)
 
 	var/obj/item/shard
 	for(var/obj/item/O in contents)

--- a/code/modules/reagents/reagent_containers/food/shaker.dm
+++ b/code/modules/reagents/reagent_containers/food/shaker.dm
@@ -8,7 +8,7 @@
 	center_of_mass = "x=17;y=10"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_REACT
 
-/obj/item/reagent_containers/food/drinks/shaker/attack_self(mob/user as mob)
+/obj/item/reagent_containers/food/drinks/shaker/attack_self(mob/user)
 	if(user.skill_check(SKILL_COOKING, SKILL_PROF))
 		user.visible_message("<span class='rose'>\The [user] shakes \the [src] briskly in one hand, with supreme confidence and competence.</span>", "<span class='rose'>You shake \the [src] briskly with one hand.</span>")
 		mix()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -48,11 +48,11 @@
 	qdel(src)
 
 
-/obj/item/reagent_containers/food/snacks/attack_self(mob/user as mob)
+/obj/item/reagent_containers/food/snacks/attack_self(mob/user)
 	return
 
 
-/obj/item/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/snacks/attack(mob/M, mob/user, def_zone)
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='danger'>None of [src] left!</span>")
 		qdel(src)
@@ -134,7 +134,7 @@
 	else
 		to_chat(user, "<span class='notice'>\The [src] was bitten multiple times!</span>")
 
-/obj/item/reagent_containers/food/snacks/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/storage))
 		..()// -> item/attackby()
 		return
@@ -292,7 +292,7 @@
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein/egg, 3)
 
-/obj/item/reagent_containers/food/snacks/egg/afterattack(obj/O as obj, mob/user as mob, proximity)
+/obj/item/reagent_containers/food/snacks/egg/afterattack(obj/O, mob/user, proximity)
 	if(istype(O,/obj/machinery/microwave))
 		return ..()
 	if(!(proximity && O.is_open_container()))
@@ -310,7 +310,7 @@
 	..()
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/egg/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/egg/attackby(obj/item/W, mob/user)
 	if(istype( W, /obj/item/pen/crayon ))
 		var/obj/item/pen/crayon/C = W
 		var/clr = C.colourName
@@ -2719,7 +2719,7 @@
 
 	icon_state = "pizzabox[boxes.len+1]"
 
-/obj/item/pizzabox/attack_hand( mob/user as mob )
+/obj/item/pizzabox/attack_hand( mob/user)
 
 	if( open && pizza )
 		user.put_in_hands( pizza )
@@ -2744,7 +2744,7 @@
 		return
 	..()
 
-/obj/item/pizzabox/attack_self( mob/user as mob )
+/obj/item/pizzabox/attack_self( mob/user)
 
 	if( boxes.len > 0 )
 		return
@@ -2756,7 +2756,7 @@
 
 	update_icon()
 
-/obj/item/pizzabox/attackby( obj/item/I as obj, mob/user as mob )
+/obj/item/pizzabox/attackby( obj/item/I, mob/user)
 	if( istype(I, /obj/item/pizzabox) )
 		var/obj/item/pizzabox/box = I
 
@@ -2879,7 +2879,7 @@
 //	reagents.add_reagent(/datum/reagent/nutriment/protein, 1)
 
 // Dough + rolling pin = flat dough
-/obj/item/reagent_containers/food/snacks/dough/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/dough/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/material/kitchen/rollingpin))
 		new /obj/item/reagent_containers/food/snacks/sliceable/flatdough(src)
 		to_chat(user, "You flatten the dough.")
@@ -2927,7 +2927,7 @@
 
 //Items you can craft together. Like bomb making, but with food and less screwdrivers.
 
-/obj/item/reagent_containers/food/snacks/bun/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/bun/attackby(obj/item/W, mob/user)
 	// bun + meatball = burger
 	if(istype(W,/obj/item/reagent_containers/food/snacks/meatball))
 		new /obj/item/reagent_containers/food/snacks/plainburger(src)
@@ -2950,7 +2950,7 @@
 		qdel(src)
 
 // burger + cheese wedge = cheeseburger
-/obj/item/reagent_containers/food/snacks/plainburger/attackby(obj/item/reagent_containers/food/snacks/cheesewedge/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/plainburger/attackby(obj/item/reagent_containers/food/snacks/cheesewedge/W, mob/user)
 	if(istype(W))// && !istype(src,/obj/item/reagent_containers/food/snacks/cheesewedge))
 		new /obj/item/reagent_containers/food/snacks/cheeseburger(src)
 		to_chat(user, "You make a cheeseburger.")
@@ -2961,7 +2961,7 @@
 		..()
 
 // Hamburger + cheese wedge = cheeseburger
-/obj/item/reagent_containers/food/snacks/hamburger/attackby(obj/item/reagent_containers/food/snacks/cheesewedge/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/hamburger/attackby(obj/item/reagent_containers/food/snacks/cheesewedge/W, mob/user)
 	if(istype(W))// && !istype(src,/obj/item/reagent_containers/food/snacks/cheesewedge))
 		new /obj/item/reagent_containers/food/snacks/cheeseburger(src)
 		to_chat(user, "You make a cheeseburger.")
@@ -2972,7 +2972,7 @@
 		..()
 
 // Human burger + cheese wedge = cheeseburger
-/obj/item/reagent_containers/food/snacks/human/burger/attackby(obj/item/reagent_containers/food/snacks/cheesewedge/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/human/burger/attackby(obj/item/reagent_containers/food/snacks/cheesewedge/W, mob/user)
 	if(istype(W))
 		new /obj/item/reagent_containers/food/snacks/cheeseburger(src)
 		to_chat(user, "You make a cheeseburger.")
@@ -2983,7 +2983,7 @@
 		..()
 
 // Spaghetti + meatball = spaghetti with meatball(s)
-/obj/item/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/reagent_containers/food/snacks/meatball/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/reagent_containers/food/snacks/meatball/W, mob/user)
 	if(istype(W))
 		new /obj/item/reagent_containers/food/snacks/meatballspagetti(src)
 		to_chat(user, "You add some meatballs to the spaghetti.")
@@ -2994,7 +2994,7 @@
 		..()
 
 // Spaghetti with meatballs + meatball = spaghetti with more meatball(s)
-/obj/item/reagent_containers/food/snacks/meatballspagetti/attackby(obj/item/reagent_containers/food/snacks/meatball/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/meatballspagetti/attackby(obj/item/reagent_containers/food/snacks/meatball/W, mob/user)
 	if(istype(W))
 		new /obj/item/reagent_containers/food/snacks/spesslaw(src)
 		to_chat(user, "You add some more meatballs to the spaghetti.")
@@ -3139,7 +3139,7 @@
 	nutriment_amt = 3
 
 // potato + knife = raw sticks
-/obj/item/reagent_containers/food/snacks/grown/potato/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/grown/potato/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/material/knife))
 		new /obj/item/reagent_containers/food/snacks/rawsticks(src)
 		to_chat(user, "You cut the potato.")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -67,7 +67,7 @@
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	update_icon()
 
-/obj/item/reagent_containers/glass/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/glass/attack(mob/M, mob/user, def_zone)
 	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
 		return	..()
 	if(standard_feed_mob(user, M))
@@ -299,7 +299,7 @@
 	matter = list(MATERIAL_WOOD = 280)
 	volume = 200
 
-/obj/item/reagent_containers/glass/bucket/attackby(obj/D, mob/user as mob)
+/obj/item/reagent_containers/glass/bucket/attackby(obj/D, mob/user)
 	if(istype(D, /obj/item/mop))
 		if(reagents.total_volume < 1)
 			to_chat(user, "<span class='warning'>\The [src] is empty!</span>")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -181,7 +181,7 @@
 	update_icon()
 	return
 
-/obj/item/reagent_containers/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/hypospray/autoinjector/attack(mob/M, mob/user)
 	..()
 	update_icon()
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -18,7 +18,7 @@
 	if(!icon_state)
 		icon_state = "pill[rand(1, 5)]" //preset pills only use colour changing or unique icons
 
-/obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/pill/attack(mob/M, mob/user, def_zone)
 		//TODO: replace with standard_feed_mob() call.
 
 	if(M == user)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -23,7 +23,7 @@
 	..()
 	src.verbs -= /obj/item/reagent_containers/verb/set_amount_per_transfer_from_this
 
-/obj/item/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
+/obj/item/reagent_containers/spray/afterattack(atom/A, mob/user, proximity)
 	if(istype(A, /obj/item/storage) || istype(A, /obj/structure/table) || istype(A, /obj/structure/closet) || istype(A, /obj/item/reagent_containers) || istype(A, /obj/structure/hygiene/sink) || istype(A, /obj/structure/janitorialcart))
 		return
 
@@ -43,7 +43,7 @@
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 	return
 
-/obj/item/reagent_containers/spray/proc/Spray_at(atom/A as mob|obj, mob/user as mob, proximity)
+/obj/item/reagent_containers/spray/proc/Spray_at(atom/A, mob/user, proximity)
 	playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)
 	if (reagents.should_admin_log())
 		var/contained = reagents.get_reagents()
@@ -143,7 +143,7 @@
 	safety = !safety
 	to_chat(usr, "<span class = 'notice'>You switch the safety [safety ? "on" : "off"].</span>")
 
-/obj/item/reagent_containers/spray/pepper/Spray_at(atom/A as mob|obj)
+/obj/item/reagent_containers/spray/pepper/Spray_at(atom/A)
 	if(safety)
 		to_chat(usr, "<span class = 'warning'>The safety is on!</span>")
 		return
@@ -176,7 +176,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	step_delay = 8
 
-/obj/item/reagent_containers/spray/chemsprayer/Spray_at(atom/A as mob|obj)
+/obj/item/reagent_containers/spray/chemsprayer/Spray_at(atom/A)
 	var/direction = get_dir(src, A)
 	var/turf/T = get_turf(A)
 	var/turf/T1 = get_step(T,turn(direction, 90))
@@ -208,7 +208,7 @@
 	..()
 	reagents.add_reagent(/datum/reagent/toxin/plantbgone, 100)
 
-/obj/item/reagent_containers/spray/plantbgone/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
+/obj/item/reagent_containers/spray/plantbgone/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
 
 	if(istype(A, /obj/effect/blob)) // blob damage in blob code

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -39,7 +39,7 @@
 	..()
 	update_icon()
 
-/obj/item/reagent_containers/syringe/attack_self(mob/user as mob)
+/obj/item/reagent_containers/syringe/attack_self(mob/user)
 	switch(mode)
 		if(SYRINGE_DRAW)
 			mode = SYRINGE_INJECT
@@ -53,7 +53,7 @@
 	..()
 	update_icon()
 
-/obj/item/reagent_containers/syringe/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/reagent_containers/syringe/attackby(obj/item/I, mob/user)
 	return
 
 /obj/item/reagent_containers/syringe/afterattack(obj/target, mob/user, proximity)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -12,7 +12,7 @@
 	var/amount_per_transfer_from_this = 10
 	var/possible_transfer_amounts = "10;25;50;100;500"
 
-/obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/reagent_dispensers/attackby(obj/item/W, mob/user)
 	return
 
 /obj/structure/reagent_dispensers/New()
@@ -180,7 +180,7 @@
 			rig = null
 			overlays.Cut()
 
-/obj/structure/reagent_dispensers/fueltank/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/reagent_dispensers/fueltank/attackby(obj/item/W, mob/user)
 	src.add_fingerprint(user)
 	if (istype(W,/obj/item/wrench))
 		user.visible_message("\The [user] wrenches \the [src]'s faucet [modded ? "closed" : "open"].", \
@@ -301,7 +301,7 @@
 /obj/structure/reagent_dispensers/water_cooler/proc/RejectionMessage(mob/user)
 	return "The [src]'s cup dispenser is empty."
 
-/obj/structure/reagent_dispensers/water_cooler/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/reagent_dispensers/water_cooler/attackby(obj/item/W, mob/user)
 	if (istype(W,/obj/item/wrench))
 		src.add_fingerprint(user)
 		if(anchored)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	return
 
 // attempt to move while inside
-/obj/machinery/disposal/relaymove(mob/user as mob)
+/obj/machinery/disposal/relaymove(mob/user)
 	if (user.incapacitated() || src.flushing)
 		return
 	if (user.loc == src)

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -131,7 +131,7 @@
 		partialTag = new_tag
 
 // called when player tries to move while in a pipe
-/obj/structure/disposalholder/relaymove(mob/user as mob)
+/obj/structure/disposalholder/relaymove(mob/user)
 	if(!istype(user,/mob/living))
 		return
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -13,10 +13,10 @@
 	var/label_x
 	var/tag_x
 
-/obj/structure/bigDelivery/attack_robot(mob/user as mob)
+/obj/structure/bigDelivery/attack_robot(mob/user)
 	unwrap(user)
 
-/obj/structure/bigDelivery/attack_hand(mob/user as mob)
+/obj/structure/bigDelivery/attack_hand(mob/user)
 	unwrap(user)
 
 /obj/structure/bigDelivery/proc/unwrap(mob/user)
@@ -24,7 +24,7 @@
 		// Destroy will drop our wrapped object on the turf, so let it.
 		qdel(src)
 
-/obj/structure/bigDelivery/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/bigDelivery/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/device/destTagger))
 		var/obj/item/device/destTagger/O = W
 		if(O.currTag)
@@ -143,13 +143,13 @@
 
 	qdel(src)
 
-/obj/item/smallDelivery/attack_robot(mob/user as mob)
+/obj/item/smallDelivery/attack_robot(mob/user)
 	unwrap(user)
 
-/obj/item/smallDelivery/attack_self(mob/user as mob)
+/obj/item/smallDelivery/attack_self(mob/user)
 	unwrap(user)
 
-/obj/item/smallDelivery/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/smallDelivery/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/device/destTagger))
 		var/obj/item/device/destTagger/O = W
 		if(O.currTag)
@@ -254,7 +254,7 @@
 	throw_speed = 4
 	throw_range = 5
 
-/obj/item/stack/package_wrap/afterattack(obj/target as obj, mob/user as mob, proximity)
+/obj/item/stack/package_wrap/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return
 	if(!istype(target))	//this really shouldn't be necessary (but it is).	-Pete
 		return
@@ -345,7 +345,7 @@
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_STEEL = 100, MATERIAL_GLASS = 34)
 
-/obj/item/device/destTagger/proc/openwindow(mob/user as mob)
+/obj/item/device/destTagger/proc/openwindow(mob/user)
 	var/dat = "<tt><center><h1><b>TagMaster 2.3</b></h1></center>"
 
 	dat += "<table style='width:100%; padding:4px;'><tr>"
@@ -360,7 +360,7 @@
 	show_browser(user, dat, "window=destTagScreen;size=450x375")
 	onclose(user, "destTagScreen")
 
-/obj/item/device/destTagger/attack_self(mob/user as mob)
+/obj/item/device/destTagger/attack_self(mob/user)
 	openwindow(user)
 
 /obj/item/device/destTagger/OnTopic(user, href_list, state)

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -96,7 +96,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 	return ..()
 
-/obj/machinery/r_n_d/circuit_imprinter/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/r_n_d/circuit_imprinter/attackby(obj/item/O, mob/user)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy. Please wait for completion of previous operation.</span>")
 		return 1

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -51,7 +51,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		return SPAN_NOTICE("There is something already loaded into \the [src]. You must remove it first.")
 	return ..()
 
-/obj/machinery/r_n_d/destructive_analyzer/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/r_n_d/destructive_analyzer/attackby(obj/item/O, mob/user)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy right now.</span>")
 		return

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -117,7 +117,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	update_icon()
 	return TRUE
 
-/obj/machinery/message_server/attackby(obj/item/O as obj, mob/living/user as mob)
+/obj/machinery/message_server/attackby(obj/item/O, mob/living/user)
 	if (active && !(stat & (BROKEN|NOPOWER)) && (spamfilter_limit < MESSAGE_SERVER_DEFAULT_SPAM_LIMIT*2) && \
 		istype(O,/obj/item/stock_parts/circuitboard/message_monitor))
 		spamfilter_limit += round(MESSAGE_SERVER_DEFAULT_SPAM_LIMIT / 2)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -91,7 +91,7 @@
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 	return ..()
 
-/obj/machinery/r_n_d/protolathe/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/r_n_d/protolathe/attackby(obj/item/O, mob/user)
 	if(busy)
 		to_chat(user, "<span class='notice'>\The [src] is busy. Please wait for completion of previous operation.</span>")
 		return 1

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -131,7 +131,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	SyncRDevices()
 	. = ..()
 
-/obj/machinery/computer/rdconsole/attackby(obj/item/D as obj, mob/user as mob)
+/obj/machinery/computer/rdconsole/attackby(obj/item/D, mob/user)
 	//Loading a disk into it.
 	if(istype(D, /obj/item/disk))
 		if(t_disk || d_disk)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -19,11 +19,11 @@
 	active_power_usage = 6
 	power_channel = ENVIRON
 
-/obj/machinery/keycard_auth/attack_ai(mob/user as mob)
+/obj/machinery/keycard_auth/attack_ai(mob/user)
 	to_chat(user, "<span class='warning'>A firewall prevents you from interfacing with this device!</span>")
 	return
 
-/obj/machinery/keycard_auth/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/keycard_auth/attackby(obj/item/W, mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "This device is not powered.")
 		return

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -217,7 +217,7 @@
 
 
 // Attacks with hand tools. Blocked by Hyperkinetic flag.
-/obj/effect/shield/attackby(obj/item/I as obj, mob/user as mob)
+/obj/effect/shield/attackby(obj/item/I, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -210,7 +210,7 @@
 		return SPAN_NOTICE("Wait until \the [src] cools down from emergency shutdown first!")
 	return ..()
 
-/obj/machinery/power/shield_generator/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/power/shield_generator/attackby(obj/item/O, mob/user)
 	if(panel_open && (isMultitool(O) || isWirecutter(O)))
 		attack_hand(user)
 		return TRUE

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -42,7 +42,7 @@
 	if(!height || air_group) return 0
 	else return ..()
 
-/obj/machinery/shield/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/shield/attackby(obj/item/W, mob/user)
 	if(!istype(W)) return
 
 	//Calculate damage
@@ -90,7 +90,7 @@
 	..()
 
 
-/obj/machinery/shield/hitby(AM as mob|obj, datum/thrownthing/TT)
+/obj/machinery/shield/hitby(AM, datum/thrownthing/TT)
 	//Let everyone know we've been hit!
 	visible_message("<span class='notice'><B>\[src] was hit by [AM].</B></span>")
 
@@ -252,7 +252,7 @@
 	checkhp()
 	..()
 
-/obj/machinery/shieldgen/interface_interact(mob/user as mob)
+/obj/machinery/shieldgen/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
 	if(locked)
@@ -283,7 +283,7 @@
 		update_icon()
 		return 1
 
-/obj/machinery/shieldgen/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/shieldgen/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		if(is_open)

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -166,7 +166,7 @@
 		emagged = TRUE
 		return 1
 
-/obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/W, mob/user)
 	read_authorization(W)
 	..()
 

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -3,7 +3,7 @@
 	shuttle_tag = "Special Operations"
 	req_access = list(access_cent_specops)
 
-/obj/machinery/computer/shuttle_control/specops/attack_ai(user as mob)
+/obj/machinery/computer/shuttle_control/specops/attack_ai(user)
 	to_chat(user, "<span class='warning'>Access Denied.</span>")
 	return 1
 

--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -12,7 +12,7 @@
 	force = 10
 	hitsound = 'sound/magic/forcewall.ogg'
 
-/obj/item/scrying/attack_self(mob/user as mob)
+/obj/item/scrying/attack_self(mob/user)
 	if((user.mind && !GLOB.wizards.is_antagonist(user.mind)))
 		to_chat(user, "<span class='warning'>You stare into the orb and see nothing but your own reflection.</span>")
 		return

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -7,7 +7,7 @@
 	var/contract_master = null
 	var/list/contract_spells = list(/spell/contract/reward,/spell/contract/punish,/spell/contract/return_master)
 
-/obj/item/contract/attack_self(mob/user as mob)
+/obj/item/contract/attack_self(mob/user)
 	if(contract_master == null)
 		to_chat(user, "<span class='notice'>You bind the contract to your soul, making you the recipient of whatever poor fool's soul that decides to contract with you.</span>")
 		contract_master = user
@@ -32,7 +32,7 @@
 		log_and_message_admins("signed their soul over to \the [contract_master] using \the [src].", user)
 		qdel(src)
 
-/obj/item/contract/proc/contract_effect(mob/user as mob)
+/obj/item/contract/proc/contract_effect(mob/user)
 	to_chat(user, "<span class='warning'>You've signed your soul over to \the [contract_master] and with that your unbreakable vow of servitude begins.</span>")
 	return 1
 
@@ -41,7 +41,7 @@
 	desc = "a wizarding school contract for those who want to sign their soul for a piece of the magic pie."
 	color = "#993300"
 
-/obj/item/contract/apprentice/contract_effect(mob/user as mob)
+/obj/item/contract/apprentice/contract_effect(mob/user)
 	if(user.mind.special_role == ANTAG_APPRENTICE)
 		to_chat(user, "<span class='warning'>You are already a wizarding apprentice!</span>")
 		return 0
@@ -62,7 +62,7 @@
 	desc = "This contract is almost see-through..."
 	color = "#339900"
 
-/obj/item/contract/wizard/xray/contract_effect(mob/user as mob)
+/obj/item/contract/wizard/xray/contract_effect(mob/user)
 	..()
 	if (!(MUTATION_XRAY in user.mutations))
 		user.mutations.Add(MUTATION_XRAY)
@@ -78,7 +78,7 @@
 	desc = "The edges of the contract grow blurry when you look away from them. To be fair, actually reading it gives you a headache."
 	color = "#fcc605"
 
-/obj/item/contract/wizard/telepathy/contract_effect(mob/user as mob)
+/obj/item/contract/wizard/telepathy/contract_effect(mob/user)
 	..()
 	if (!ishuman(user))
 		return 0
@@ -108,7 +108,7 @@
 		item_name = initial(S.name)
 	name = "[item_name] contract"
 
-/obj/item/contract/boon/contract_effect(mob/user as mob)
+/obj/item/contract/boon/contract_effect(mob/user)
 	..()
 	if(user.mind.special_role == ANTAG_SERVANT)
 		to_chat(user, "<span class='warning'>As a servant you find yourself unable to use this contract.</span>")

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -42,7 +42,7 @@
 	startswith = list(/obj/item/spacecash/bundle/c1000 = 1)
 
 //HUMAN
-/obj/item/storage/bag/cash/infinite/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/bag/cash/infinite/remove_from_storage(obj/item/W, atom/new_location)
 	. = ..()
 	if(.)
 		if(istype(W,/obj/item/spacecash)) //only matters if its spacecash.
@@ -167,20 +167,20 @@
 	if(istype(owner,/mob))
 		contract_master = owner
 
-/obj/item/contract/apprentice/skrell/attack_self(mob/user as mob)
+/obj/item/contract/apprentice/skrell/attack_self(mob/user)
 	if(!linked)
 		to_chat(user, "<span class='warning'>This contract requires a link to a spellbook.</span>")
 		return
 	..()
 
-/obj/item/contract/apprentice/skrell/afterattack(atom/A, mob/user as mob, proximity)
+/obj/item/contract/apprentice/skrell/afterattack(atom/A, mob/user, proximity)
 	if(!linked && istype(A,/obj/item/spellbook))
 		linked = A
 		to_chat(user, "<span class='notice'>You've linked \the [A] to \the [src]</span>")
 		return
 	..()
 
-/obj/item/contract/apprentice/skrell/contract_effect(mob/user as mob)
+/obj/item/contract/apprentice/skrell/contract_effect(mob/user)
 	. = ..()
 	if(.)
 		linked.uses += 0.5

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -387,7 +387,7 @@ var/global/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 	return temp
 
-/spell/proc/spell_do_after(mob/user as mob, delay as num, numticks = 5)
+/spell/proc/spell_do_after(mob/user, delay, numticks = 5)
 	if(!user || isnull(user))
 		return 0
 

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -45,7 +45,7 @@ var/global/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		
 	name = spellbook.name
 	desc = spellbook.desc
 
-/obj/item/spellbook/attack_self(mob/user as mob)
+/obj/item/spellbook/attack_self(mob/user)
 	if(!user.mind)
 		return
 	if (user.mind.special_role != ANTAG_WIZARD)
@@ -59,7 +59,7 @@ var/global/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		
 		to_chat(user, "You notice the apprentice-proof lock is on. Luckily you are beyond such things.")
 	interact(user)
 
-/obj/item/spellbook/proc/make_sacrifice(obj/item/I as obj, mob/user as mob, reagent)
+/obj/item/spellbook/proc/make_sacrifice(obj/item/I, mob/user, reagent)
 	if(has_sacrificed)
 		to_chat(user, SPAN_WARNING("\The [src] is already sated! Wait for a return on your investment before you sacrifice more to it."))
 		return
@@ -78,7 +78,7 @@ var/global/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		
 	investing_time = max(investing_time - 6000,1) //subtract 10 minutes. Make sure it doesn't act funky at the beginning of the game.
 
 
-/obj/item/spellbook/attackby(obj/item/I as obj, mob/user as mob)
+/obj/item/spellbook/attackby(obj/item/I, mob/user)
 	if(investing_time)
 		var/list/objects = spellbook.sacrifice_objects
 		if(objects && objects.len)
@@ -96,7 +96,7 @@ var/global/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		
 						return 1
 	..()
 
-/obj/item/spellbook/interact(mob/user as mob)
+/obj/item/spellbook/interact(mob/user)
 	var/dat = null
 	if(temp)
 		dat = "[temp]<br><a href='byond://?src=\ref[src];temp=1'>Return</a>"

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -462,7 +462,7 @@
 		damage += proj_damage * config_bullet_energy
 	return 0
 
-/obj/machinery/power/supermatter/attack_robot(mob/user as mob)
+/obj/machinery/power/supermatter/attack_robot(mob/user)
 	if(Adjacent(user))
 		return attack_hand(user)
 	else
@@ -475,7 +475,7 @@
 /obj/machinery/power/supermatter/attack_ghost(mob/user)
 	ui_interact(user)
 
-/obj/machinery/power/supermatter/attack_hand(mob/user as mob)
+/obj/machinery/power/supermatter/attack_hand(mob/user)
 	user.visible_message(
 		SPAN_WARNING("\The [user] reaches out and touches \the [src], inducing a resonance. For a brief instant, \his body glows brilliantly, then flashes into ash."),
 		SPAN_DANGER(FONT_LARGE("You reach out and touch \the [src]. Instantly, you feel a curious sensation as your body turns into new and exciting forms of plasma. That was not a wise decision.")),
@@ -511,7 +511,7 @@
 		ui.set_auto_update(1)
 
 
-/obj/machinery/power/supermatter/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/machinery/power/supermatter/attackby(obj/item/W, mob/living/user)
 	if(istype(W, /obj/item/tape_roll))
 		to_chat(user, SPAN_NOTICE("You repair some of the damage to \the [src] with \the [W]."))
 		damage = max(damage - 10, 0)
@@ -529,7 +529,7 @@
 	user.apply_damage(150, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
 
 
-/obj/machinery/power/supermatter/Bumped(atom/AM as mob|obj)
+/obj/machinery/power/supermatter/Bumped(atom/AM)
 	if(istype(AM, /obj/effect))
 		return
 	if(istype(AM, /mob/living))

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -281,7 +281,7 @@
 	. = ..()
 
 
-/obj/item/device/synthesized_instrument/attack_self(mob/user as mob)
+/obj/item/device/synthesized_instrument/attack_self(mob/user)
 	src.interact(user)
 
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -47,7 +47,7 @@
 	if (health_dead)
 		return PROJECTILE_CONTINUE
 
-/obj/structure/table/CheckExit(atom/movable/O as mob|obj, target as turf)
+/obj/structure/table/CheckExit(atom/movable/O, target)
 	if(istype(O) && O.checkpass(PASS_FLAG_TABLE))
 		return 1
 	if (flipped==1)

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -123,7 +123,7 @@
 
 	show_browser(user, dat, "window=alien_replicator")
 
-/obj/machinery/replicator/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/machinery/replicator/attackby(obj/item/W, mob/living/user)
 	if(!user.unEquip(W, src))
 		return
 	stored_materials.Add(W)

--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -36,7 +36,7 @@
 		var/mob/living/M = src.loc
 		M.say(pick(heard_talk))
 
-/obj/item/clothing/mask/gas/poltergeist/hear_talk(mob/M as mob, text)
+/obj/item/clothing/mask/gas/poltergeist/hear_talk(mob/M, text)
 	..()
 	if(heard_talk.len > max_stored_messages)
 		heard_talk.Remove(pick(heard_talk))
@@ -129,7 +129,7 @@
 		else if(get_dist(W, src) > 10)
 			shadow_wights.Remove(wight_check_index)
 
-/obj/item/vampiric/hear_talk(mob/M as mob, text)
+/obj/item/vampiric/hear_talk(mob/M, text)
 	..()
 	if(world.time - last_bloodcall >= bloodcall_interval && (M in view(7, src)))
 		bloodcall(M)

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -33,7 +33,7 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 
-/obj/item/anodevice/attackby(obj/I as obj, mob/user as mob)
+/obj/item/anodevice/attackby(obj/I, mob/user)
 	if(istype(I, /obj/item/anobattery))
 		if(!inserted_battery)
 			if(!user.unEquip(I, src))
@@ -44,7 +44,7 @@
 	else
 		return ..()
 
-/obj/item/anodevice/attack_self(mob/user as mob)
+/obj/item/anodevice/attack_self(mob/user)
 	return src.interact(user)
 
 /obj/item/anodevice/interact(mob/user)
@@ -203,7 +203,7 @@
 	STOP_PROCESSING(SSobj, src)
 	..()
 
-/obj/item/anodevice/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
+/obj/item/anodevice/attack(mob/living/M, mob/living/user, def_zone)
 	if (!istype(M))
 		return
 

--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -19,7 +19,7 @@
 	if(!owned_scanner)
 		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
 
-/obj/machinery/artifact_harvester/attackby(obj/I as obj, mob/user as mob)
+/obj/machinery/artifact_harvester/attackby(obj/I, mob/user)
 	if(istype(I,/obj/item/anobattery))
 		if(!inserted_battery)
 			if(!user.unEquip(I, src))
@@ -32,11 +32,11 @@
 	else
 		return..()
 
-/obj/machinery/artifact_harvester/attack_hand(mob/user as mob)
+/obj/machinery/artifact_harvester/attack_hand(mob/user)
 	..()
 	interact(user)
 
-/obj/machinery/artifact_harvester/interact(mob/user as mob)
+/obj/machinery/artifact_harvester/interact(mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
 	user.set_machine(src)

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -63,7 +63,7 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/radiocarbon_spectrometer/attackby(obj/I as obj, mob/user as mob)
+/obj/machinery/radiocarbon_spectrometer/attackby(obj/I, mob/user)
 	if(scanning)
 		to_chat(user, "<span class='warning'>You can't do that while [src] is scanning!</span>")
 	else

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -158,7 +158,7 @@
 /obj/item/device/depth_scanner/attack_self(mob/living/user)
 	interact(user)
 
-/obj/item/device/depth_scanner/interact(mob/user as mob)
+/obj/item/device/depth_scanner/interact(mob/user)
 	user.set_machine(src)
 	var/dat = "<b>Coordinates with positive matches</b><br>"
 
@@ -240,7 +240,7 @@
 				cur_dist = check_dist
 				. = weakref(R)
 
-/obj/item/pinpointer/radio/attack_self(mob/user as mob)
+/obj/item/pinpointer/radio/attack_self(mob/user)
 	interact(user)
 
 /obj/item/pinpointer/radio/interact(mob/user)

--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -29,7 +29,7 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 	title = "[GLOB.using_map.boss_name] Update"
 	announcement_type = "[GLOB.using_map.boss_name] Update"
 
-/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, do_newscast = newscast, msg_sanitized = 0, zlevels = GLOB.using_map.contact_levels)
+/datum/announcement/proc/Announce(message, new_title = "", new_sound = null, do_newscast = newscast, msg_sanitized = 0, zlevels = GLOB.using_map.contact_levels)
 	if(!message)
 		return
 	var/message_title = new_title ? new_title : title
@@ -53,23 +53,23 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 		log_say("[key_name(usr)] has made \a [announcement_type]: [message_title] - [message] - [announcer]")
 		message_admins("[key_name_admin(usr)] has made \a [announcement_type].", 1)
 
-/datum/announcement/proc/FormMessage(message as text, message_title as text)
+/datum/announcement/proc/FormMessage(message, message_title)
 	. = "<h2 class='alert'>[message_title]</h2>"
 	. += "<br><span class='alert'>[message]</span>"
 	if (announcer)
 		. += "<br><span class='alert'> -[html_encode(announcer)]</span>"
 
-/datum/announcement/minor/FormMessage(message as text, message_title as text)
+/datum/announcement/minor/FormMessage(message, message_title)
 	. = "<b>[message]</b>"
 
-/datum/announcement/priority/FormMessage(message as text, message_title as text)
+/datum/announcement/priority/FormMessage(message, message_title)
 	. = "<h1 class='alert'>[message_title]</h1>"
 	. += "<br><span class='alert'>[message]</span>"
 	if(announcer)
 		. += "<br><span class='alert'> -[html_encode(announcer)]</span>"
 	. += "<br>"
 
-/datum/announcement/priority/command/FormMessage(message as text, message_title as text)
+/datum/announcement/priority/command/FormMessage(message, message_title)
 	. = "<h1 class='alert'>[GLOB.using_map.boss_name] Update</h1>"
 	if (message_title)
 		. += "<br><h2 class='alert'>[message_title]</h2>"
@@ -77,7 +77,7 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 	. += "<br><span class='alert'>[message]</span><br>"
 	. += "<br>"
 
-/datum/announcement/priority/security/FormMessage(message as text, message_title as text)
+/datum/announcement/priority/security/FormMessage(message, message_title)
 	. = "<font size=4 color='red'>[message_title]</font>"
 	. += "<br><font color='red'>[message]</font>"
 

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -185,7 +185,7 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/deity/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/deity/attackby(obj/item/W, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 50, 1)

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -93,7 +93,7 @@
 	anchored = TRUE
 	var/busy=0
 
-/obj/structure/casino/roulette/attack_hand(mob/user as mob)
+/obj/structure/casino/roulette/attack_hand(mob/user)
 	if (busy)
 		to_chat(user,"<span class='notice'>You cannot spin now! \The [src] is already spinning.</span> ")
 		return

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -46,7 +46,7 @@
 	else if (health < 90)
 		to_chat(user, "Few ribbons of \the [src] are cut away.")
 
-/obj/structure/net/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/net/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/material)) //sharp objects can cut thorugh
 		var/obj/item/material/SH = W
 		if (!(SH.sharp) || (SH.sharp && SH.force < 10))//is not sharp enough or at all

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -84,7 +84,7 @@
 	..()
 	to_chat(user, "<span class='notice'> You don't see how you could turn off \the [src]. You can try to stick something in rotating hands.</span>")
 
-/obj/structure/magshield/maggen/attackby(obj/item/W as obj, mob/user as mob)
+/obj/structure/magshield/maggen/attackby(obj/item/W, mob/user)
 	if (being_stopped)
 		to_chat(user, "<span class='notice'> Somebody is already interacting with \the [src].</span>")
 		return


### PR DESCRIPTION
Much like #32503 except targeting spurious `as X` in proc signatures.

Some procs are used as verbs, so this needs more scrutiny. I'll double check it after seeing what tests say.