### PR TITLE
Removes all no-smoking signs from every map

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -159,14 +159,6 @@
 	name = "\improper MOVING PARTS"
 	icon_state = "movingparts"
 
-/obj/structure/sign/warning/nosmoking_1
-	name = "\improper NO SMOKING"
-	icon_state = "nosmoking"
-
-/obj/structure/sign/warning/nosmoking_2
-	name = "\improper NO SMOKING"
-	icon_state = "nosmoking2"
-
 /obj/structure/sign/warning/nosmoking_burned
 	name = "\improper NO SMOKING"
 	icon_state = "nosmoking2_b"

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -434,10 +434,6 @@
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "bg" = (
-/obj/structure/sign/warning/nosmoking_1{
-	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
-	pixel_y = 32
-	},
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /turf/unsimulated/floor{
 	icon_state = "plating";

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -2584,9 +2584,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = -32
-	},
 /obj/structure/sign/goldenplaque/medical{
 	pixel_x = 32
 	},
@@ -4507,9 +4504,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = -32
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24;

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2559,7 +2559,6 @@
 /area/constructionsite/medical)
 "iD" = (
 /obj/structure/lattice,
-/obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall,
 /area/constructionsite/medical)
 "iE" = (

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -2553,9 +2553,6 @@
 	dir = 1;
 	icon_state = "corner_white"
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 23
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Zq" = (

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -3665,12 +3665,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/medical)
-"tv" = (
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/hall)
 "ty" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -7117,9 +7111,6 @@
 /obj/structure/table/standard,
 /obj/random/medical/lite,
 /obj/item/storage/belt/medical,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/medical)
 "Lp" = (
@@ -7305,15 +7296,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/mess)
-"Mp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/chem)
 "Mq" = (
 /obj/machinery/door/blast/regular{
 	icon_state = "pdoor0";
@@ -9981,7 +9963,7 @@ ew
 Ua
 zk
 eT
-Mp
+NY
 Pv
 NY
 NY
@@ -10445,7 +10427,7 @@ Qr
 yw
 Yo
 nx
-tv
+iH
 Pk
 iH
 eT

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -3065,10 +3065,6 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "hc" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -3116,10 +3112,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/fuel)
 "hf" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
@@ -3330,10 +3322,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "hP" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
@@ -8682,10 +8670,6 @@
 /area/rnd/canister)
 "sZ" = (
 /obj/machinery/portable_atmospherics/canister/empty,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -11740,10 +11724,6 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 1;
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -12530,10 +12510,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
 "Gl" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 1;
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1;
 	name = "CO2 to Hangar"
@@ -15553,10 +15529,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/toxins)
 "Sr" = (
@@ -16683,10 +16655,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/rnd)
 "Xd" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -8066,13 +8066,6 @@
 /obj/structure/curtain/black,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/chapel/main)
-"rG" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/disperser)
 "rH" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -41978,7 +41971,7 @@ HX
 DM
 DU
 IK
-rG
+Pp
 Pp
 QL
 Qq

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2614,10 +2614,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
 "fa" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
 /obj/random/powercell,
@@ -5605,10 +5601,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "mI" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 8
 	},
@@ -8004,10 +7996,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "tc" = (
@@ -9172,10 +9160,6 @@
 "wA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_bay)
 "wB" = (
@@ -9936,10 +9920,6 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
@@ -14885,10 +14865,6 @@
 	name = "plastic table frame"
 	},
 /obj/random/single/playing_cards,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/disposal)
 "NW" = (
@@ -17002,10 +16978,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/foreport)
-"UU" = (
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/r_wall/prepainted,
-/area/engineering/atmos)
 "UY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -17311,10 +17283,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18361,19 +18329,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage)
-"ZC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
 "ZF" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -33515,7 +33470,7 @@ rF
 qv
 xp
 yh
-ZC
+sv
 zK
 QX
 sv
@@ -41789,7 +41744,7 @@ qV
 IB
 qV
 qV
-UU
+sZ
 tM
 wQ
 DK

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -578,9 +578,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/chemistry)
 "abm" = (
@@ -2324,9 +2321,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -5628,14 +5622,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/auxpower)
-"alo" = (
-/obj/structure/closet/l3closet/general,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/medical/foyer/storeroom)
 "alp" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -6586,10 +6572,6 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/medpaperworkoffice)
@@ -7253,10 +7235,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -37
 	},
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine{
@@ -14241,9 +14219,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/equipstorage)
 "bmb" = (
@@ -15711,9 +15686,6 @@
 /area/hallway/primary/firstdeck/center)
 "dab" = (
 /obj/structure/table/standard,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
 "daB" = (
@@ -15756,10 +15728,6 @@
 	req_access = newlist()
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 8;
-	pixel_x = 32
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/medical)
 "ddP" = (
@@ -22640,10 +22608,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
-"mUm" = (
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/rnd/entry)
 "mVb" = (
 /obj/machinery/nuclearbomb/station{
 	name = "ship self-destruct terminal"
@@ -23843,9 +23807,6 @@
 /obj/structure/closet/secure_closet/medical_torchsenior,
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
 "owb" = (
@@ -25626,9 +25587,6 @@
 /obj/structure/iv_drip,
 /obj/machinery/light/spot{
 	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_y = 24
 	},
 /obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled/white,
@@ -27548,10 +27506,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "sGs" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -52187,7 +52141,7 @@ lkb
 nLb
 nLb
 odb
-mUm
+aBP
 jRb
 dxm
 qtb
@@ -53576,7 +53530,7 @@ acQ
 uXe
 adv
 kZb
-alo
+cXb
 xuW
 cEb
 fmb

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1366,11 +1366,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 1;
-	pixel_x = 2;
-	pixel_y = -34
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
@@ -2504,10 +2499,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 2;
-	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -7685,10 +7676,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
 "to" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -37
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
@@ -7755,10 +7742,6 @@
 	dir = 8
 	},
 /obj/random/drinkbottle,
-/obj/structure/sign/warning/nosmoking_1{
-	desc = "A warning sign which reads 'NO SMOKING'. Someone has scratched a variety of crude words in gutter across the entire sign.";
-	pixel_y = 26
-	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tz" = (
@@ -8266,10 +8249,6 @@
 /obj/item/reagent_containers/food/drinks/glass2/square,
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 8
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -37
 	},
 /obj/structure/sign/double/solgovflag/left{
 	pixel_y = 32
@@ -9888,10 +9867,6 @@
 /obj/random/coin,
 /obj/random/firstaid,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 2;
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "zF" = (
@@ -13171,10 +13146,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -37
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "NM" = (


### PR DESCRIPTION
Apparently, players and admins think these signs exist as a mechanism to arrest people for 20 minutes because they are smoking anywhere on the Torch. This was not the purpose of them being included on the map, they were put in to open RP, not arbitrarily arrest people.