### PR TITLE
Purge formal name suffixes and prefixes

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -293,7 +293,6 @@
 	var/datum/computer_file/report/crew_record/new_record = CreateModularRecord(user)
 	if(I)
 		new_record.set_name(I.registered_name)
-		new_record.set_formal_name("[I.formal_name_prefix][I.registered_name][I.formal_name_suffix]")
 		new_record.set_sex(I.sex)
 		new_record.set_age(I.age)
 		new_record.set_job(I.assignment)
@@ -304,7 +303,6 @@
 			new_record.set_branch(I.military_branch.name)
 			if(I.military_rank)
 				new_record.set_rank(I.military_rank.name)
-				new_record.set_formal_name("[I.registered_name][I.formal_name_suffix]") // Rank replaces formal name prefix in real manifest entries
 	if(random_record)
 		COPY_VALUE(faction)
 		COPY_VALUE(religion)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -165,9 +165,6 @@ var/global/const/NO_EMAG_ACT = -50
 	var/datum/mil_branch/military_branch = null //Vars for tracking branches and ranks on multi-crewtype maps
 	var/datum/mil_rank/military_rank = null
 
-	var/formal_name_prefix
-	var/formal_name_suffix
-
 	var/detail_color
 	var/extra_details
 
@@ -226,9 +223,7 @@ var/global/const/NO_EMAG_ACT = -50
 /obj/item/card/id/proc/get_display_name()
 	. = registered_name
 	if(military_rank && military_rank.name_short)
-		. ="[military_rank.name_short] [.][formal_name_suffix]"
-	else if(formal_name_prefix || formal_name_suffix)
-		. = "[formal_name_prefix][.][formal_name_suffix]"
+		. ="[military_rank.name_short] [.]"
 	if(assignment)
 		. += ", [assignment]"
 
@@ -238,16 +233,6 @@ var/global/const/NO_EMAG_ACT = -50
 
 /mob/proc/set_id_info(obj/item/card/id/id_card)
 	id_card.age = 0
-
-	id_card.formal_name_prefix = initial(id_card.formal_name_prefix)
-	id_card.formal_name_suffix = initial(id_card.formal_name_suffix)
-	if(client && client.prefs)
-		for(var/culturetag in client.prefs.cultural_info)
-			var/decl/cultural_info/culture = SSculture.get_culture(client.prefs.cultural_info[culturetag])
-			if(culture)
-				id_card.formal_name_prefix = "[culture.get_formal_name_prefix()][id_card.formal_name_prefix]"
-				id_card.formal_name_suffix = "[id_card.formal_name_suffix][culture.get_formal_name_suffix()]"
-
 	id_card.registered_name = real_name
 
 	var/gender_term = "Unset"
@@ -272,7 +257,7 @@ var/global/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/proc/dat()
 	var/list/dat = list("<table><tr><td>")
-	dat += text("Name: []</A><BR>", "[formal_name_prefix][registered_name][formal_name_suffix]")
+	dat += text("Name: []</A><BR>", registered_name)
 	dat += text("Sex: []</A><BR>\n", sex)
 	dat += text("Age: []</A><BR>\n", age)
 

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -46,8 +46,6 @@
 	var/data[0]
 	var/entries[0]
 	entries[++entries.len] = list("name" = "Age", 				"value" = age)
-	entries[++entries.len] = list("name" = "Prefix", 			"value" = formal_name_prefix)
-	entries[++entries.len] = list("name" = "Suffix", 			"value" = formal_name_suffix)
 	entries[++entries.len] = list("name" = "Appearance",		"value" = "Set")
 	entries[++entries.len] = list("name" = "Assignment",		"value" = assignment)
 	if(GLOB.using_map.flags & MAP_HAS_BRANCH)
@@ -108,18 +106,6 @@
 					else
 						age = new_age
 					to_chat(user, "<span class='notice'>Age has been set to '[age]'.</span>")
-					. = 1
-			if("Prefix")
-				var/new_prefix = sanitizeSafe(input(user,"What title prefix would you like to put on this card?","Agent Card Prefix", age) as text, MAX_NAME_LEN)
-				if(!isnull(new_prefix) && CanUseTopic(user, state))
-					formal_name_prefix = new_prefix
-					to_chat(user, "<span class='notice'>Title prefix has been set to '[formal_name_prefix]'.</span>")
-					. = 1
-			if("Suffix")
-				var/new_suffix = sanitizeSafe(input(user,"What title suffix would you like to put on this card?","Agent Card Suffix", age) as text, MAX_NAME_LEN)
-				if(!isnull(new_suffix) && CanUseTopic(user, state))
-					formal_name_suffix = new_suffix
-					to_chat(user, "<span class='notice'>Title suffix has been set to '[formal_name_suffix]'.</span>")
 					. = 1
 			if("Appearance")
 				var/datum/card_state/choice = input(user, "Select the appearance for this card.", "Agent Card Appearance") as null|anything in id_card_states()
@@ -190,8 +176,6 @@
 			if("Factory Reset")
 				if(alert("This will factory reset the card, including access and owner. Continue?", "Factory Reset", "No", "Yes") == "Yes" && CanUseTopic(user, state))
 					age = initial(age)
-					formal_name_prefix = initial(formal_name_prefix)
-					formal_name_suffix = initial(formal_name_suffix)
 					access = syndicate_access.Copy()
 					assignment = initial(assignment)
 					blood_type = initial(blood_type)

--- a/code/modules/culture_descriptor/_culture.dm
+++ b/code/modules/culture_descriptor/_culture.dm
@@ -94,12 +94,6 @@
 	if(default_language)          . |= default_language
 	if(LAZYLEN(additional_langs)) . |= additional_langs
 
-/decl/cultural_info/proc/get_formal_name_suffix()
-	return
-
-/decl/cultural_info/proc/get_formal_name_prefix()
-	return
-
 /decl/cultural_info/proc/get_qualifications()
 	return qualifications
 

--- a/code/modules/culture_descriptor/culture/cultures_serpentid.dm
+++ b/code/modules/culture_descriptor/culture/cultures_serpentid.dm
@@ -12,9 +12,6 @@
 	var/list/hidden_valid_jobs = list(/datum/job/ai, /datum/job/cyborg)
 	var/title_suffix
 
-/decl/cultural_info/culture/nabber/get_formal_name_suffix()
-	return title_suffix
-
 /decl/cultural_info/culture/nabber/New()
 	..()
 

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -38,7 +38,7 @@
 	"}
 	// sort mobs
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
-		var/name = CR.get_formal_name()
+		var/name = CR.get_name()
 		var/rank = CR.get_job()
 		mil_ranks[name] = ""
 

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -185,8 +185,6 @@
 					var/temp_name = sanitizeName(input("Enter name.", "Name", id_card.registered_name),allow_numbers=TRUE)
 					if(temp_name)
 						id_card.registered_name = temp_name
-						id_card.formal_name_suffix = initial(id_card.formal_name_suffix)
-						id_card.formal_name_prefix = initial(id_card.formal_name_prefix)
 					else
 						computer.show_error(usr, "Invalid name entered!")
 				else if(href_list["account"])

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -32,21 +32,8 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 		photo_side = getFlatIcon(dummy, WEST, always_use_defdir = 1)
 		qdel(dummy)
 
-	// Add honorifics, etc.
-	var/formal_name = "Unset"
-	if(H)
-		formal_name = H.real_name
-		if(H.client && H.client.prefs)
-			for(var/culturetag in H.client.prefs.cultural_info)
-				var/decl/cultural_info/culture = SSculture.get_culture(H.client.prefs.cultural_info[culturetag])
-				if(H.char_rank && H.char_rank.name_short)
-					formal_name = "[formal_name][culture.get_formal_name_suffix()]"
-				else
-					formal_name = "[culture.get_formal_name_prefix()][formal_name][culture.get_formal_name_suffix()]"
-
 	// Generic record
 	set_name(H ? H.real_name : "Unset")
-	set_formal_name(formal_name)
 	set_job(H ? GetAssignment(H) : "Unset")
 	var/gender_term = "Unset"
 	if(H)
@@ -195,7 +182,6 @@ KEY.set_access(ACCESS, ACCESS_EDIT || ACCESS || access_bridge)}
 
 // GENERIC RECORDS
 FIELD_SHORT("Name", name, null, access_change_ids)
-FIELD_SHORT("Formal Name", formal_name, null, access_change_ids)
 FIELD_SHORT("Job", job, null, access_change_ids)
 FIELD_LIST("Sex", sex, record_genders(), null, access_change_ids)
 FIELD_NUM("Age", age, null, access_change_ids)


### PR DESCRIPTION
:cl: SierraKomodo
rscdel: The 'Formal Name' fields from crew records and ID cards have been fully removed.
bugfix: Manifest entries no longer show the wrong name when a mob's name is changed by admins.
/:cl:

TODO:
- [X] Purge existing formal name prefix and suffix code
- [ ] Ensure GAS grades still appear on ID cards