### PR TITLE
Add height to species and mobs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2919,6 +2919,7 @@
 #include "code\modules\species\species_attack.dm"
 #include "code\modules\species\species_getters.dm"
 #include "code\modules\species\species_grab.dm"
+#include "code\modules\species\species_height.dm"
 #include "code\modules\species\species_helpers.dm"
 #include "code\modules\species\species_hud.dm"
 #include "code\modules\species\species_random.dm"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -8,6 +8,16 @@
 		default_language = all_languages[species_language]
 	..()
 
+/mob/living/carbon/Initialize(mapload)
+	. = ..()
+
+	// Figure height if necessary
+	if (isnull(height))
+		if (!species)
+			height = 168 // ~5'5"
+		else
+			height = species.get_average_height()
+
 /mob/living/carbon/Destroy()
 	QDEL_NULL(touching)
 	bloodstr = null // We don't qdel(bloodstr) because it's the same as qdel(reagents)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -2,6 +2,9 @@
 	gender = MALE
 	var/datum/species/species //Contains icon generation and language information, set during New().
 
+	/// Integer. The mob's height in centimeters. Generally constrained by `species`. Autoset during `Initialize()` if not already defined.
+	var/height
+
 	var/life_tick = 0      // The amount of life ticks that have processed on this mob.
 	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
 	//Surgery info

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -62,6 +62,9 @@
 	maneuvers = list(/decl/maneuver/leap/grab)
 	standing_jump_range = 5
 
+	min_height = 130
+	max_height = 200
+
 	override_limb_types = list(
 		BP_GROIN = /obj/item/organ/external/groin/vox
 	)

--- a/code/modules/species/species_height.dm
+++ b/code/modules/species/species_height.dm
@@ -1,0 +1,46 @@
+/// Integer. The minimum height for the species in centimeters.
+/datum/species/var/min_height = 145 // ~4'9"
+
+/// Integer. The maximum height for the species in centimeters.
+/datum/species/var/max_height = 203 // ~6'8"
+
+
+/**
+ * Whether or not the given height value falls within the species' minimum and maximum height values.
+ *
+ * **Parameters**:
+ * - `height` (integer) - The height value to check in centimeters.
+ *
+ * Returns boolean.
+ */
+/datum/species/proc/height_is_valid(height)
+	return height >= min_height && height <= max_height
+
+
+/**
+ * Retrieves the average height for the species, as the number immediately between min and max.
+ *
+ * Returns integer.
+ */
+/datum/species/proc/get_average_height()
+	return round((max_height - min_height + 1) / 2)
+
+
+/**
+ * Returns a height descriptor for the given height, relative to the species min and max heights.
+ *
+ * **Parameters**:
+ * - `height` - The height value to check in centimeters.
+ *
+ * Returns string. A height descriptor as defined in `/datum/mob_descriptor/height`.
+ */
+/datum/species/proc/get_height_descriptor(height)
+	var/datum/mob_descriptor/height/descriptor = new()
+	var/descriptor_count = descriptor.standalone_value_descriptors.len
+
+	// Math magic to determine what heights apply to what descriptor based on min and max height
+	var/height_block = (max_height - min_height + 1) / descriptor_count
+	for (var/count = 1 to descriptor_count)
+		var/height_threshhold = round(height_block * count)
+		if (height <= height_threshhold)
+			return descriptor.standalone_value_descriptors[count]

--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -54,6 +54,9 @@
 	slowdown = -1
 	hud_type = /datum/hud_data/adherent
 
+	min_height = 200
+	max_height = 300
+
 	available_cultural_info = list(
 		TAG_CULTURE = list(
 			CULTURE_ADHERENT

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -98,6 +98,9 @@
 		/datum/mob_descriptor/build = 2
 		)
 
+	min_height = 168
+	max_height = 260
+
 	available_cultural_info = list(
 		TAG_CULTURE = list(
 			CULTURE_UNATHI_POLAR,

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -21,6 +21,9 @@
 		/obj/aura/regenerating/human/unathi/yeosa
 		)
 
+	min_height = 150
+	max_height = 275
+
 	additional_available_cultural_info = list(
 		TAG_CULTURE = list(
 			CULTURE_UNATHI_YEOSA_ABYSS,

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -48,6 +48,9 @@
 		/datum/mob_descriptor/build = -2
 	)
 
+	min_height = 55
+	max_height = 95
+
 	force_cultural_info = list(
 		TAG_CULTURE =   CULTURE_MONKEY,
 		TAG_HOMEWORLD = HOME_SYSTEM_STATELESS,

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -118,6 +118,9 @@
 		/datum/mob_descriptor/body_length = 0
 		)
 
+	min_height = 270
+	max_height = 300
+
 	available_cultural_info = list(
 		TAG_CULTURE = list(
 			CULTURE_NABBER_CMINUS,

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -184,6 +184,9 @@
 	)
 	speech_chance = 10
 
+	min_height = 152
+	max_height = 206
+
 	available_cultural_info = list(
 		TAG_CULTURE = list(
 			CULTURE_SKRELL_QERR,


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Character heights are now determined by entering actual height values in centimeters.
/:cl:

### TODO
- [X] Add height values to mobs
- [X] Add height limits to species
- [ ] Add numerical height field to character setup
- [ ] Update height scaling to fit numerical values