### PR TITLE
Prevent multiple vision modules in rig suits

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -145,6 +145,38 @@
 	holder = new_holder
 	return
 
+/**
+ * Whether or not the module can be installed in the given rig.
+ *
+ * **Parameters**:
+ * - `new_holder` - The rig the module is attempting to be installed to.
+ * - `user` - The user attempting to install the module. Used for feedback messages. Omit for silent checks.
+ *
+ * Returns boolean.
+ */
+/obj/item/rig_module/proc/can_install(obj/item/rig/rig, mob/user = null)
+	if (is_type_in_list(src, rig.banned_modules))
+		if (user)
+			to_chat(user, SPAN_WARNING("\The [rig] cannot mount this type of module."))
+		return FALSE
+
+	if (LAZYLEN(rig.installed_modules))
+		for (var/obj/item/rig_module/installed_module as anything in rig.installed_modules)
+			if (!installed_module.redundant && installed_module.type == type)
+				if (user)
+					to_chat(user, SPAN_WARNING("\The [rig] already has \a [installed_module] installed."))
+				return FALSE
+			if (LAZYLEN(banned_modules) && is_type_in_list(installed_module, banned_modules))
+				if (user)
+					to_chat(user, SPAN_WARNING("\The [installed_module] already installed in \the [rig] is not compatible with \the [src]."))
+				return FALSE
+			if (LAZYLEN(installed_module.banned_modules) && is_type_in_list(src, installed_module.banned_modules))
+				if (user)
+					to_chat(user, SPAN_WARNING("\The [installed_module] already installed in \the [rig] is not compatible with \the [src]."))
+				return FALSE
+
+	return TRUE
+
 /obj/item/rig_module/proc/check(charge = 50)
 
 	if(damage >= 2)

--- a/code/modules/clothing/spacesuits/rig/modules/vision.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/vision.dm
@@ -56,6 +56,10 @@
 	activate_string = "Enable Visor"
 	deactivate_string = "Disable Visor"
 
+	banned_modules = list(
+		/obj/item/rig_module/vision
+	)
+
 	var/datum/rig_vision/vision
 	var/list/vision_modes = list(
 		/datum/rig_vision/nvg,

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -187,6 +187,10 @@
 	if(initial_modules && initial_modules.len)
 		for(var/path in initial_modules)
 			var/obj/item/rig_module/module = new path(src)
+			if (!module.can_install(src))
+				crash_with("\A [module] ([module.type]) failed to initialize within \a [src].")
+				qdel(module)
+				continue
 			installed_modules += module
 			module.installed(src)
 

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -73,40 +73,18 @@
 
 		// Check if this is a hardsuit upgrade or a modification.
 		else if(istype(W,/obj/item/rig_module))
-
-			if(istype(src.loc,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = src.loc
-				if(H.back == src)
-					to_chat(user, "<span class='danger'>You can't install a hardsuit module while the suit is being worn.</span>")
-					return 1
-
-			if(is_type_in_list(W,banned_modules))
-				to_chat(user, SPAN_DANGER("\The [src] cannot mount this type of module."))
-				return 1
-
 			var/obj/item/rig_module/mod = W
-
-			if(!installed_modules) installed_modules = list()
-			if(installed_modules.len)
-				for(var/obj/item/rig_module/installed_mod in installed_modules)
-					if(is_type_in_list(installed_mod,mod.banned_modules))
-						to_chat(user, SPAN_DANGER("\The [installed_mod] is incompatible with this module."))
-						return 1
-					if(installed_mod.banned_modules.len)
-						if(is_type_in_list(W,installed_mod.banned_modules))
-							to_chat(user, SPAN_DANGER("\The [installed_mod] is incompatible with this module."))
-							return 1
-					if(!installed_mod.redundant && installed_mod.type == W.type)
-						to_chat(user, "The hardsuit already has a module of that class installed.")
-						return 1
+			if (!mod.can_install(src, user))
+				return TRUE
 
 			to_chat(user, "You begin installing \the [mod] into \the [src].")
 			if(!do_after(user, 4 SECONDS, src, DO_PUBLIC_UNIQUE))
 				return
-			if(!user || !W)
+			if(!user || !W || !mod.can_install(src, user))
 				return
 			if(!user.unEquip(mod)) return
 			to_chat(user, "You install \the [mod] into \the [src].")
+			LAZYADD(installed_modules, mod)
 			installed_modules |= mod
 			mod.forceMove(src)
 			mod.installed(src)


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Hardsuit rigs no longer allow installing multiple types of vision modules at a time, resulting in a broken state with said modules.
/:cl:

- Closes #29288