### PR TITLE
Gives the roboticist access to the AI Upload

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -207,7 +207,7 @@
 	skill_points = 20
 
 	access = list(
-		access_robotics, access_engine, access_solgov_crew, access_network, access_radio_eng
+		access_robotics, access_engine, access_solgov_crew, access_network, access_radio_eng, access_ai_upload
 	)
 
 /datum/job/roboticist/get_description_blurb()


### PR DESCRIPTION
:cl: Sbotkin
tweak: The roboticist is now allowed into the AI Upload.
/:cl:

Since the AI has been removed and the roboticist is responsible for working with the station-bound synthetics anyway, it doesn't make much sense that they don't have access to the Upload. At this point the roboticist must hack their way into the upload just to do their job.