### PR TITLE
Whats cooking

### DIFF
--- a/code/game/machinery/kitchen/cookers.dm
+++ b/code/game/machinery/kitchen/cookers.dm
@@ -172,7 +172,7 @@
 			--index
 		QDEL_NULL_LIST(source)
 		audible_message(SPAN_ITALIC("\The [src] lets out a happy ding."))
-		playsound(src, 'sound/machines/ding.ogg', 0.5)
+		playsound(src, 'sound/machines/ding.ogg', 70, frequency = 0.75)
 		threshold = 1
 	if (!burn_time)
 		empty()
@@ -189,9 +189,14 @@
 			--index
 		QDEL_NULL_LIST(source)
 		threshold = 2
-	if (prob(10))
+	if (prob(15))
 		visible_message(SPAN_WARNING("\The [src] vomits a gout of rancid smoke!"))
 		smoke.start()
+	if (threshold < 3 && prob(10))
+		visible_message(SPAN_WARNING("\The [src] is on fire!"))
+		var/turf/adjacent = get_step(src, dir)
+		adjacent.IgniteTurf(20)
+		threshold = 3
 
 
 /obj/machinery/cooker/proc/cook_item(obj/item/reagent_containers/food/snacks/source)


### PR DESCRIPTION
🆑 CrimsonShrike
rscadd: Unattended cookers will now also create a small fire once per burned meal.
tweak: cooker ding is actually audible now.
/🆑

![](https://cdn.discordapp.com/attachments/492799900145418270/1021746787540799498/unknown.png)
![](https://cdn.discordapp.com/attachments/492799900145418270/1021746744209449021/unknown.png)