### PR TITLE
fixes fusion injector interactions and organprinter feedback

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -159,6 +159,8 @@
 			if(sheets_to_take > 0)
 				add_matter = min(max_stored_matter - stored_matter, sheets_to_take*matter_amount_per_sheet)
 				S.use(sheets_to_take)
+		else
+			to_chat(user, SPAN_WARNING("\The [src] is too full."))
 
 	else if(istype(W,/obj/item/organ))
 		var/obj/item/organ/O = W
@@ -166,10 +168,13 @@
 			if(!BP_IS_ROBOTIC(O))
 				to_chat(user, SPAN_WARNING("\The [src] only accepts robotic organs."))
 				return
-			var/recycle_worth = Floor(products[O.organ_tag][2] * 0.5)
-			if((max_stored_matter-stored_matter) >= recycle_worth)
-				add_matter = recycle_worth
-				qdel(O)
+			if(max_stored_matter == stored_matter)
+				to_chat(user, SPAN_WARNING("\The [src] is too full."))
+			else
+				var/recycle_worth = Floor(products[O.organ_tag][2] * 0.5)
+				if((max_stored_matter-stored_matter) >= recycle_worth)
+					add_matter = recycle_worth
+					qdel(O)
 		else
 			to_chat(user, SPAN_WARNING("\The [src] does not know how to recycle \the [O]."))
 			return
@@ -178,9 +183,7 @@
 
 	if(add_matter)
 		to_chat(user, SPAN_INFO("\The [src] processes \the [object_name]. Levels of stored matter now: [stored_matter]"))
-	else
-		to_chat(user, SPAN_WARNING("\The [src] is too full."))
-
+		return
 	return ..()
 // END ROBOT ORGAN PRINTER
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -44,12 +44,11 @@
 /obj/machinery/fusion_fuel_injector/attackby(obj/item/W, mob/user)
 
 	if(isMultitool(W))
-		var/datum/extension/local_network_member/lanm = get_extension(src, /datum/extension/local_network_member)
-		lanm.set_tag(null, initial_id_tag)
+		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
+		fusion.get_new_tag(user)
 		return
 
 	if(istype(W, /obj/item/fuel_assembly))
-
 		if(injecting)
 			to_chat(user, "<span class='warning'>Shut \the [src] off before playing with the fuel rod!</span>")
 			return
@@ -65,12 +64,12 @@
 		cur_assembly = W
 		return
 
-	if(isWrench(W))
+	if(isWelder(W))
 		if(injecting)
 			to_chat(user, "<span class='warning'>Shut \the [src] off first!</span>")
 			return
 		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+		playsound(src.loc, 'sound/items/Welder.ogg', 75, 1)
 		if(anchored)
 			user.visible_message("\The [user] secures \the [src] to the floor.")
 		else


### PR DESCRIPTION
:cl: SomeAngryMiner
rscadd: RUST injectors can now have their parts removed and linked to the fusion network again. Anchoring and unanchoring now requires welding.
rscadd: mechanical organ printers will no longer display "The prosthetic organ printer is too full." at every interaction, and will only do it when its actually full.
/:cl: