### PR TITLE
Smoke alone no longer makes you drop things

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -261,7 +261,6 @@ would spawn and follow the beaker, even if it is carried or thrown.
 /obj/effect/effect/smoke/bad/affect(mob/living/carbon/M)
 	if (!..())
 		return 0
-	M.unequip_item()
 	M.adjustOxyLoss(1)
 	if (M.coughedtime != 1)
 		M.coughedtime = 1
@@ -289,7 +288,6 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	if (!..())
 		return 0
 
-	M.unequip_item()
 	M:sleeping += 1
 	if (M.coughedtime != 1)
 		M.coughedtime = 1


### PR DESCRIPTION
:cl: SierraKomodo
rscdel: Smoke effects no longer make mobs drop things solely from the smoke effect itself. Mobs may still drop things due to other effects such as sleepiness from sleep smoke or any chemical effects carried by the smoke.
/:cl:

Also resolves the issue of smoke making you drop things even if you should have been immune to smoke, i.e., gas mask.