### PR TITLE
Seed storage fixes

### DIFF
--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -108,13 +108,15 @@
 
 /obj/machinery/seed_storage/Initialize(mapload)
 	. = ..()
-	for(var/typepath in starting_seeds)
-		var/amount = starting_seeds[typepath]
-		if(isnull(amount))
-			amount = 1
-		for (var/i = 1 to amount)
-			var/O = new typepath
-			add(O)
+	if (LAZYLEN(starting_seeds))
+		for(var/typepath in starting_seeds)
+			var/amount = starting_seeds[typepath]
+			if(isnull(amount))
+				amount = 1
+			for (var/i = 1 to amount)
+				var/O = new typepath
+				add(O)
+		sort_piles()
 
 /obj/machinery/seed_storage/random // This is mostly for testing, but I guess admins could spawn it
 	name = "Random seed storage"
@@ -293,6 +295,7 @@
 /obj/machinery/seed_storage/attackby(obj/item/O as obj, mob/user as mob)
 	if (istype(O, /obj/item/seeds))
 		add(O)
+		sort_piles()
 		user.visible_message("[user] puts \the [O.name] into \the [src].", "You put \the [O] into \the [src].")
 		return
 	else if (istype(O, /obj/item/storage/plants))
@@ -304,6 +307,7 @@
 			add(G, 1)
 		P.finish_bulk_removal()
 		if (loaded)
+			sort_piles()
 			user.visible_message("[user] puts the seeds from \the [O.name] into \the [src].", "You put the seeds from \the [O.name] into \the [src].")
 		else
 			to_chat(user, "<span class='notice'>There are no seeds in \the [O.name].</span>")
@@ -337,3 +341,8 @@
 	piles += new /datum/seed_pile(O, newID)
 	flick("[initial(icon_state)]-vend", src)
 	return
+
+
+/// Handles sorting of the `piles` list.
+/obj/machinery/seed_storage/proc/sort_piles()
+	piles = sortAtom(piles)

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -141,7 +141,9 @@
 
 /obj/machinery/seed_storage/all/Initialize(mapload)
 	for (var/typepath in subtypesof(/obj/item/seeds))
-		starting_seeds += list(typepath = 5)
+		if (typepath == /obj/item/seeds/random || typepath == /obj/item/seeds/cutting)
+			continue
+		starting_seeds[typepath] = 5
 	. = ..()
 
 /obj/machinery/seed_storage/interface_interact(mob/user)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Seed storage UI now automatically sorts the list of seeds the machine contains.
/:cl:

NUFC:
- Fixes the runtime that occurs when spawning the debug variant of seed storage (`/obj/machinery/seed_storage/all`)