### PR TITLE
Counselor ID fix, operant card changes

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -44,6 +44,56 @@
 		return
 	..()
 
+/obj/item/card/operant_card
+	name = "operant registration card"
+	icon_state = "warrantcard_civ"
+	desc = "A registration card in a faux-leather case. It marks the named individual as a registered, law-abiding psionic."
+	w_class = ITEM_SIZE_SMALL
+	attack_verb = list("whipped")
+	hitsound = 'sound/weapons/towelwhip.ogg'
+	var/info
+	var/potential
+	var/use_rating
+
+
+/obj/item/card/operant_card/proc/set_info(mob/living/carbon/human/human)
+	if(!istype(human))
+		return
+	switch(human.psi?.rating)
+		if(0)
+			use_rating = "[human.psi.rating]-Lambda"
+		if(1)
+			use_rating = "[human.psi.rating]-Epsilon"
+		if(2)
+			use_rating = "[human.psi.rating]-Gamma"
+		if(3)
+			use_rating = "[human.psi.rating]-Delta"
+		if(4)
+			use_rating = "[human.psi.rating]-Beta"
+		if(5)
+			use_rating = "[human.psi.rating]-Alpha"
+		if (6 to INFINITY)
+			use_rating = "[human.psi.rating]-Omega"
+		else
+			use_rating = "Non-Psionic"
+
+	potential = "This individual has an overall psi rating of [use_rating]."
+	info = {"\
+		Name: [human.real_name]\n\
+		Species: [human.get_species()]\n\
+		Fingerprint: [human.dna?.uni_identity ? md5(human.dna.uni_identity) : "N/A"]\n\
+		Assessed Potential: [potential]\
+	"}
+
+
+/obj/item/card/operant_card/attack_self(mob/living/user)
+	user.visible_message(
+		SPAN_ITALIC("\The [user] examines \a [src]."),
+		SPAN_ITALIC("You examine \the [src]."),
+		3
+	)
+	to_chat(user, info || SPAN_WARNING("\The [src] is completely blank!"))
+
 /obj/item/card/data
 	name = "data card"
 	desc = "A plastic magstripe card for simple and speedy data storage and transfer. This one has a stripe running down the middle."

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -131,12 +131,19 @@
 	description = "A travel visa issued by the Sol Central Government for the purpose of recreation."
 	path = /obj/item/paper/travelvisa
 
+
 /datum/gear/passport
 	display_name = "passports selection"
 	description = "A selection of passports."
 	path = /obj/item/passport
 	flags = GEAR_HAS_SUBTYPE_SELECTION
 	custom_setup_proc = /obj/item/passport/proc/set_info
+
+/datum/gear/foundation_civilian
+	display_name = "operant registration card"
+	description = "A registration card in a faux-leather case. It marks the named individual as a registered, law-abiding psionic."
+	path = /obj/item/card/operant_card
+	custom_setup_proc = /obj/item/card/operant_card/proc/set_info
 
 /datum/gear/mirror
 	display_name = "handheld mirror"

--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -55,6 +55,9 @@
 	job_access_type = /datum/job/chemist
 	detail_color = COLOR_PALE_BLUE_GRAY
 
+/obj/item/card/id/torch/crew/medical/counselor
+	job_access_type = /datum/job/psychiatrist
+
 /obj/item/card/id/torch/contractor/medical/counselor
 	job_access_type = /datum/job/psychiatrist
 

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -227,8 +227,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/medical/counselor
 	alt_titles = list(
 		"Psychiatrist",
-		"Psionic Counselor" = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/mentalist,
-		"Mentalist" = /decl/hierarchy/outfit/job/torch/crew/medical/counselor/mentalist
+		"Psionic Counselor",
+		"Mentalist"
 
 	)
 

--- a/maps/torch/job/outfits/medical_outfits.dm
+++ b/maps/torch/job/outfits/medical_outfits.dm
@@ -83,21 +83,16 @@
 	name = OUTFIT_JOB_NAME("Counselor")
 	uniform = /obj/item/clothing/under/rank/psych/turtleneck
 	shoes = /obj/item/clothing/shoes/white
-	id_types = list(
-		/obj/item/card/id/torch/contractor/medical/counselor,
-		/obj/item/card/id/foundation_civilian)
+	id_types = list(/obj/item/card/id/torch/contractor/medical/counselor)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor/ec
 	name = OUTFIT_JOB_NAME("Counselor - Expeditionary Corps")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
+	id_types = list(/obj/item/card/id/torch/crew/medical/counselor)
 
 /decl/hierarchy/outfit/job/torch/crew/medical/counselor/fleet
 	name = OUTFIT_JOB_NAME("Counselor - Fleet")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/medical
 	shoes = /obj/item/clothing/shoes/dutyboots
-
-/decl/hierarchy/outfit/job/torch/crew/medical/counselor/mentalist
-	name = OUTFIT_JOB_NAME("Counselor - Mentalist")
-	suit = /obj/item/clothing/suit/storage/toggle/labcoat
-	shoes = /obj/item/clothing/shoes/laceup
+	id_types = list(/obj/item/card/id/torch/crew/medical/counselor)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -263,6 +263,9 @@
 /datum/gear/accessory/ftu_pin
 	allowed_branches = CIVILIAN_BRANCHES
 
+/datum/gear/foundation_civilian
+	allowed_roles = list(/datum/job/psychiatrist)
+
 /*********************
  tactical accessories
 *********************/


### PR DESCRIPTION
:cl: SingingSpock
bugfix: EC and Fleet counselors will no longer spawn with a contractor ID
tweak: Operant registration card is now normally a normal card rather than an ID card
tweak: Operant card no longer part of loadout for Counselor, instead it's a loadout item restricted to counselors
rscadd: Operant card now shows your basic level of psionic talent.
/:cl:

So I accidentally nuked my old PR (twice now) after making the requested fixes by being a dumdum. Just like before, this fixes up the counselor outfit, moves the operant card to a loadout item restricted to counselors, and reworks the whole card to a non-ID card that displays a (cryptic) description of the owner's level of psionic talent.