### PR TITLE
re-corrects codeql scope & config path

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        #config-file: ./.github/workflow-config/codeql-config.yml
+        config-file: ./.github/workflow-config/codeql.yml
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
I am a root vegetable

In #32572 I broke the codeql config path

In #32587 I disabled codeql scopes because of failing config

This corrects the config path and re-enables scopes
