### PR TITLE
Adds a concealed shotgun cane

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -61,3 +61,9 @@
 	var/plushtype = pick(typesof(path))
 	var/obj/item/I = new plushtype(loc)
 	return I
+
+/datum/uplink_item/item/stealthy_weapons/guncane
+	name = "Concealed Cane Gun"
+	desc = "A cane used by true gentlemen, especially ones with a penchant for loud weaponry!"
+	item_cost = 25
+	path = /obj/item/gun/projectile/shotgun/cane

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -54,3 +54,54 @@
 		SetName("cane shaft")
 		icon_state = "cane_noknife"
 		item_state = "foldcane"
+
+/obj/item/gun/projectile/shotgun/cane
+	name = "cane"
+	desc = "A cane used by true gentlemen. Or a clown."
+	icon = 'icons/obj/weapons/melee_physical.dmi'
+	icon_state = "cane"
+	item_icons = list(
+		slot_r_hand_str = 'icons/mob/onmob/items/righthand.dmi',
+		slot_l_hand_str = 'icons/mob/onmob/items/lefthand.dmi'
+	)
+	item_state_slots = list(
+		slot_r_hand_str = "stick",
+		slot_l_hand_str = "stick"
+	)
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	force = 5.0
+	throwforce = 7.0
+	w_class = ITEM_SIZE_LARGE
+	matter = list(MATERIAL_ALUMINIUM = 50)
+	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
+	base_parry_chance = 30
+	load_method = SINGLE_CASING|SPEEDLOADER
+	handle_casings = CYCLE_CASINGS
+	max_shells = 1
+	ammo_type = /obj/item/ammo_casing/shotgun/pellet
+	caliber = CALIBER_SHOTGUN
+	one_hand_penalty = 5
+	accuracy = -3
+
+/obj/item/gun/projectile/shotgun/cane/examine(mob/user, distance)
+	. = ..()
+	if (distance <= 1 && !safety_state && user.skill_check(SKILL_WEAPONS, SKILL_BASIC))
+		to_chat(user, SPAN_NOTICE("You notice a small trigger sticking out from the bottom of \the [src]."))
+
+/obj/item/gun/projectile/shotgun/cane/on_update_icon()
+	return
+
+/obj/item/gun/projectile/shotgun/cane/Fire(atom/target, mob/living/user, clickparams, pointblank, reflex)
+	if (safety_state)
+		to_chat(user, SPAN_WARNING("You can't fire \the [src] without readying it!"))
+		return
+	..()
+
+/obj/item/gun/projectile/shotgun/cane/CtrlClick(mob/user)
+	if (src == user.get_active_hand() || src == user.get_inactive_hand())
+		to_chat(user, SPAN_NOTICE("You [safety_state ? "flick out a hidden trigger on \the [src] and shift your grip" : "flick back the hidden trigger and relax your grip"]."))
+		..()
+
+/obj/item/gun/projectile/shotgun/cane/get_antag_info()
+	. = ..()
+	. += "<p>This cane conceals a single-shot shotgun! Ctrl-click the weapon to toggle the concealed trigger, acting in place of a safety. Inaccurate, so you'll want to be close to your victim.</p>"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
rscadd: Adds a single-shot shotgun to the uplink, concealed within a cane. Beware the old man.
/:cl:
As above. The cane comes with a single buckshot round and is pretty inaccurate, can be adjusted if necessary.