### PR TITLE
Fix potential double-references in `add_to_stacks` when checking hands

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -297,7 +297,7 @@
 		if(isstack(user.r_hand))
 			stacks += user.r_hand
 	for (var/obj/item/stack/item in user.loc)
-		stacks += item
+		stacks |= item
 	for (var/obj/item/stack/item in stacks)
 		if (item==src)
 			continue


### PR DESCRIPTION
A quick fix to a logic error noticed while updating old code for to use #32600

Might fix some runtimes or errors in the game, but might not have any user-facing effects. Nothing immediately stands out in the runtime lists as directly related.