### PR TITLE
gives deck crew helmets ear protection, allows helmets to have volume_multiplier

### DIFF
--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -14,6 +14,7 @@
 	var/visible_name = "Unknown"
 	var/ironed_state = WRINKLES_DEFAULT
 	var/smell_state = SMELL_DEFAULT
+	var/volume_multiplier = 1
 
 	var/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // if this item covers the feet, the footprints it should leave
 
@@ -202,7 +203,6 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 2
 	slot_flags = SLOT_EARS
-	var/volume_multiplier = 1
 
 /obj/item/clothing/ears/update_clothing_icon()
 	if (ismob(src.loc))

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -394,33 +394,29 @@
 	desc = "A helmet with ear protection and a visor, used in hangars on many ships."
 	icon_state = "deckcrew"
 	flags_inv = BLOCKHEADHAIR
+	volume_multiplier = 0.1
 
 /obj/item/clothing/head/deckcrew/green
 	name = "green deck crew helmet"
 	desc = "A helmet with ear protection and a visor, used by support staff in Fleet hangars."
 	icon_state = "deckcrew_g"
-	flags_inv = BLOCKHEADHAIR
 
 /obj/item/clothing/head/deckcrew/blue
 	name = "blue deck crew helmet"
 	desc = "A helmet with ear protection and a visor, used by tug operators in Fleet hangars."
 	icon_state = "deckcrew_b"
-	flags_inv = BLOCKHEADHAIR
 
 /obj/item/clothing/head/deckcrew/yellow
 	name = "yellow deck crew helmet"
 	desc = "A helmet with ear protection and a visor, used by traffic control in Fleet hangars."
 	icon_state = "deckcrew_y"
-	flags_inv = BLOCKHEADHAIR
 
 /obj/item/clothing/head/deckcrew/purple
 	name = "purple deck crew helmet"
 	desc = "A helmet with ear protection and a visor, used by fueling personnel in Fleet hangars."
 	icon_state = "deckcrew_p"
-	flags_inv = BLOCKHEADHAIR
 
 /obj/item/clothing/head/deckcrew/red
 	name = "red deck crew helmet"
 	desc = "A helmet with ear protection and a visor, used by munitions handlers in Fleet hangars."
 	icon_state = "deckcrew_r"
-	flags_inv = BLOCKHEADHAIR

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1816,7 +1816,7 @@
 
 /mob/living/carbon/human/get_sound_volume_multiplier()
 	. = ..()
-	for(var/obj/item/clothing/ears/C in list(l_ear, r_ear))
+	for(var/obj/item/clothing/C in list(head, l_ear, r_ear))
 		. = min(., C.volume_multiplier)
 
 /mob/living/carbon/human/handle_pull_damage(mob/living/puller)


### PR DESCRIPTION
🆑 Gy1ta23
rscadd: helmets can do volume multipliers, deck crew helmets now muffle sound
/🆑

All of this is done with the blessing of Joey, who didn't know that earmuffs actually muffled sound, nor that you could muffle sound via ear clothing at all. Love you, Joey 😘
Taza helped me do all the code for letting helmets use the volume multipliers. Very essential, thank you

Now, anyways:

**A SPECTRE HAUNTS THIS CODEBASE.**

THE SPECTRE OF SERVICE-INDUCED HEARING LOSS. Do you think the SCG VA cares that you have tinnitus from working the deck? Of course not! You're issued ear-pro as part of your job, aren't you? But that's just the thing! Joey advertised his crew helmet as sound-protecting, but just like 3M Combat Arms Earplugs from 2002-2015, that was a lie! Your ears aren't protected, not at all - in fact, the lie that they are protected is so dangerous to ear protection that it gives *negative* ear protection!

Now, fixing them required adding functionality for volume multipliers to be assigned to head items. This isn't done /perfectly/, but I've done a lot of testing and it certainly works fine. If one would want to add volume_multipliers to other headwear after this PR, or var-edit it, they could do so, and I'd imagine the use cases for that are pretty big.

Also, I removed like five duplicate flags, too, but that's not really important to defeating the SPECTRE OF SERVICE-INDUCED HEARING LOSS.