### PR TITLE
User lacking preferences spam fix

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -123,24 +123,24 @@
 	var/bad_version = config.minimum_byond_version && byond_version < config.minimum_byond_version
 	var/bad_build = config.minimum_byond_build && byond_build < config.minimum_byond_build
 	if (bad_build || bad_version)
-		to_chat(src, "You are attempting to connect with a out of date version of BYOND. Please update to the latest version at http://www.byond.com/ before trying again.")
+		legacy_chat(src, "You are attempting to connect with a out of date version of BYOND. Please update to the latest version at http://www.byond.com/ before trying again.")
 		qdel(src)
 		return
 
 	if("[byond_version].[byond_build]" in config.forbidden_versions)
 		_DB_staffwarn_record(ckey, "Tried to connect with broken and possibly exploitable BYOND build.")
-		to_chat(src, "You are attempting to connect with a broken and possibly exploitable BYOND build. Please update to the latest version at http://www.byond.com/ before trying again.")
+		legacy_chat(src, "You are attempting to connect with a broken and possibly exploitable BYOND build. Please update to the latest version at http://www.byond.com/ before trying again.")
 		qdel(src)
 		return
 
 	if(!config.guests_allowed && IsGuestKey(key))
-		alert(src,"This server doesn't allow guest accounts to play. Please go to http://www.byond.com/ and register for a key.","Guest","OK")
+		legacy_chat(src, "This server doesn't allow guest accounts to play. Please go to http://www.byond.com/ and register for a key.")
 		qdel(src)
 		return
 
 	if(config.player_limit != 0)
 		if((GLOB.clients.len >= config.player_limit) && !(ckey in admin_datums))
-			alert(src,"This server is currently full and not accepting new connections.","Server Full","OK")
+			legacy_chat(src, "This server is currently full and not accepting new connections.")
 			log_admin("[ckey] tried to join and was turned away due to the server being full (player_limit=[config.player_limit])")
 			qdel(src)
 			return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -155,10 +155,6 @@
 		src.preload_rsc = pick(config.resource_urls)
 	else src.preload_rsc = 1 // If config.resource_urls is not set, preload like normal.
 
-	if(byond_version < DM_VERSION)
-		to_chat(src, "<span class='warning'>You are running an older version of BYOND than the server and may experience issues.</span>")
-		to_chat(src, "<span class='warning'>It is recommended that you update to at least [DM_VERSION] at http://www.byond.com/download/.</span>")
-	to_chat(src, "<span class='warning'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
 	GLOB.clients += src
 	GLOB.ckey_directory[ckey] = src
 
@@ -180,15 +176,8 @@
 
 	GLOB.using_map.map_info(src)
 
-	if (config.event)
-		to_chat(src, "<h1 class='alert'>Event</h1>")
-		to_chat(src, "<h2 class='alert'>An event is taking place. OOC Info:</h2>")
-		to_chat(src, "<span class='alert'>[config.event]</span>")
-		to_chat(src, "<br>")
-
 	if(holder)
 		add_admin_verbs()
-		admin_memo_show()
 
 	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
 	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)
@@ -201,15 +190,6 @@
 	log_client_to_db()
 
 	send_resources()
-
-	if (GLOB.changelog_hash && prefs.lastchangelog != GLOB.changelog_hash) //bolds the changelog button on the interface so we know there are updates.
-		to_chat(src, "<span class='info'>You have unread updates in the changelog.</span>")
-		winset(src, "rpane.changelog", "background-color=#eaeaea;font-style=bold")
-		if(config.aggressive_changelog)
-			src.changes()
-
-	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
-		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 
 	if(holder)
 		src.control_freak = 0 //Devs need 0 for profiler access

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -145,10 +145,16 @@
 			qdel(src)
 			return
 
+	var/join_notification = "has joined the game."
 	for (var/datum/ticket/T in tickets)
 		if (T.status == TICKET_OPEN && T.owner.ckey == ckey)
-			message_staff("[key_name_admin(src)] has joined the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]")
+			join_notification = "has joined the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]"
 			break
+	join_notification = "[key_name_admin(src)] [join_notification]"
+	join_notification = "<span class=\"log_message\"><span class=\"prefix\">JOIN LOG:</span> <span class=\"message\">[join_notification]</span></span>"
+	for (var/client/C as anything in GLOB.admins)
+		if (C && C.holder && C.get_preference_value(/datum/client_preference/staff/show_join_logs) == GLOB.PREF_SHOW)
+			to_chat(C, join_notification)
 
 	// Change the way they should download resources.
 	if(config.resource_urls && config.resource_urls.len)

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -88,7 +88,7 @@
 		else
 			return null
 	else
-		log_error("Client is lacking preferences: [log_info_line(src)]")
+		crash_with("Client is lacking preferences: [log_info_line(src)]")
 
 /client/proc/set_preference(preference, set_preference)
 	var/datum/client_preference/cp = get_client_preference(preference)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -322,6 +322,11 @@ var/global/list/_client_preferences_by_type
 	key = "CHAT_RLOOC"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/staff/show_join_logs
+	description = "Join Logs"
+	key = "CHAT_JOINLOGS"
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+
 /********************
 * Admin Preferences *
 ********************/

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -34,10 +34,33 @@
 		maybe_send_staffwarns("connected as new player")
 		if(client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
 			client.chatOutput.start()
+		if (client.byond_version < DM_VERSION)
+			to_chat(src, SPAN_DANGER("You are running an older version of BYOND than the server and may experience issues."))
+			to_chat(src, SPAN_DANGER("It is recommended that you update to at least [DM_VERSION] at http://www.byond.com/download/."))
+
+	to_chat(src, SPAN_WARNING("If the title screen is black, resources are still downloading. Please be patient until the title screen appears."))
+
+	if (config.event)
+		to_chat(src, "<h1 class='alert'>Event</h1>")
+		to_chat(src, "<h2 class='alert'>An event is taking place. OOC Info:</h2>")
+		to_chat(src, "<span class='alert'>[config.event]</span>")
+		to_chat(src, "<br>")
+
+	if (client.holder)
+		client.admin_memo_show()
 
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 	var/decl/security_level/SL = security_state.current_security_level
 	var/alert_desc = ""
 	if(SL.up_description)
 		alert_desc = SL.up_description
-	to_chat(src, "<span class='notice'>The alert level on the [station_name()] is currently: <font color=[SL.light_color_alarm]><B>[SL.name]</B></font>. [alert_desc]</span>")
+	to_chat(src, SPAN_NOTICE("The alert level on the [station_name()] is currently: <font color=[SL.light_color_alarm]><B>[SL.name]</B></font>. [alert_desc]"))
+
+	if (client && GLOB.changelog_hash && client.prefs.lastchangelog != GLOB.changelog_hash) //bolds the changelog button on the interface so we know there are updates.
+		to_chat(src, SPAN_INFO("You have unread updates in the changelog."))
+		winset(client, "rpane.changelog", "background-color=#eaeaea;font-style=bold")
+		if(config.aggressive_changelog)
+			client.changes()
+
+	if (!winexists(client, "asset_cache_browser")) // The client is using a custom skin, tell them.
+		to_chat(src, SPAN_WARNING("Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you."))


### PR DESCRIPTION
:cl: SierraKomodo
admin: Client join and disconnect logs can now appear to staff that enable the new Show Join Logs preference.
bugfix: Various on-connect messages now wait for goon chat to load, allowing users with goon chat enabled to see said on-connect messages.
/:cl:

NUFC:
- The client is lacking preferences debug log is now a runtime error so it comes with a stack trace. 
- Client init should no longer proc lacking preferences errors.
- Messages sent to clients as connection failures now all use legacy_chat to bypass goonchat pref checks, and because alert() doesn't work in client/New() in testing.