### PR TITLE
Fix extinguishers not working on airless tiles

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -116,9 +116,10 @@
 	var/hotspot = (locate(/obj/hotspot) in T)
 	if(hotspot && !istype(T, /turf/space))
 		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles)
-		lowertemp.temperature = max(min(lowertemp.temperature-2000, lowertemp.temperature / 2), 0)
-		lowertemp.react()
-		T.assume_air(lowertemp)
+		if (lowertemp)
+			lowertemp.temperature = max(min(lowertemp.temperature-2000, lowertemp.temperature / 2), 0)
+			lowertemp.react()
+			T.assume_air(lowertemp)
 		qdel(hotspot)
 
 	if (environment && environment.temperature > min_temperature) // Abstracted as steam or something


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Fire extinguishers now properly put out fires on tiles that have no atmosphere or no temperature.
/:cl:

This does not resolve the issue of fires continuing to exist on airless tiles when they shouldn't.

- Fixes #32626