### PR TITLE
Command backpacks for uniformed support

### DIFF
--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -114,6 +114,10 @@
 	id_types = list(/obj/item/card/id/torch/crew/sea)
 	pda_type = /obj/item/modular_computer/pda/heads
 
+/decl/hierarchy/outfit/job/torch/crew/command/sea/New()
+	..()
+	BACKPACK_OVERRIDE_COMMAND
+
 /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
 	name = OUTFIT_JOB_NAME("Bridge Officer")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command
@@ -121,6 +125,10 @@
 	id_types = list(/obj/item/card/id/torch/crew/bridgeofficer)
 	pda_type = /obj/item/modular_computer/pda/heads
 	l_ear = /obj/item/device/radio/headset/bridgeofficer
+
+/decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/New()
+	..()
+	BACKPACK_OVERRIDE_COMMAND
 
 /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet
 	name = OUTFIT_JOB_NAME("Bridge Officer - Fleet")


### PR DESCRIPTION
:cl: SingingSpock
tweak: SEA and bridge officers now have command backpack options
/:cl:

Gave the bridge officer and SEA the command backpacks rather than the boring grey generic ones. They work on the bridge and they're uniformed, they should have the nicer looking backpacks.