### PR TITLE
Round `skill_fail_chance()` result

### DIFF
--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -132,7 +132,7 @@
 	if(points >= no_more_fail)
 		return 0
 	else
-		return fail_chance * 2 ** (factor*(SKILL_MIN - points))
+		return round(fail_chance * 2 ** (factor*(SKILL_MIN - points)))
 
 // Simple prob using above
 /mob/proc/skill_fail_prob(skill_path, fail_chance, no_more_fail = SKILL_MAX, factor = 1)


### PR DESCRIPTION
NUFC

Because floats do unfun things and it's possible to receive a non-whole result.