### PR TITLE
Revert "Convert 'user lacking prefs' message to runtime"

### DIFF
--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -88,7 +88,7 @@
 		else
 			return null
 	else
-		crash_with("Client is lacking preferences: [log_info_line(src)]")
+		log_error("Client is lacking preferences: [log_info_line(src)]")
 
 /client/proc/set_preference(preference, set_preference)
 	var/datum/client_preference/cp = get_client_preference(preference)


### PR DESCRIPTION
This reverts commit c574127d5a1e7ba986046c4d84137aad2cbaf8f5.

Spook was right. That was a bad idea.