### PR TITLE
Adds rags to janitorial closets/belts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -329,6 +329,7 @@
 		/obj/item/device/flashlight,
 		/obj/item/reagent_containers/spray/cleaner,
 		/obj/item/soap,
+		/obj/item/reagent_containers/glass/rag,
 		/obj/item/holosign_creator,
 		/obj/item/clothing/gloves,
 		/obj/item/device/assembly/mousetrap,

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -67,6 +67,7 @@
 		/obj/item/storage/bag/trash,
 		/obj/item/clothing/shoes/galoshes,
 		/obj/item/soap,
+		/obj/item/reagent_containers/glass/rag,
 		/obj/item/storage/belt/janitor
 	)
 

--- a/maps/torch/structures/closets/services.dm
+++ b/maps/torch/structures/closets/services.dm
@@ -61,6 +61,7 @@
 		/obj/item/clothing/shoes/galoshes,
 		/obj/item/storage/box/detergent,
 		/obj/item/soap,
+		/obj/item/reagent_containers/glass/rag,
 		/obj/item/storage/belt/janitor,
 		/obj/item/clothing/glasses/hud/janitor
 	)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

🆑 gy1ta23
tweak: janitors rejoice; your closet has a rag, your belts will fit it
/🆑

As a certified sanitation technician, I run into the same problem shift after shift; I need to wipe things down, yet I am given naught but non-foaming cleaner and a mop. Truly a horrid state of affairs, begging for scraps of old rags to use to shine the bridge's windows from outside. If only there was a solution, I would think at night in bed, tossing and turning with the thought of having to go another day without a cloth. If only, I would think, ravaged by heartbreak.

And now, at last, I present it! There is a solution, because there is a god, and he is me, and he is kind and magnanimous. Janitorial closets? Rags. Belts? Rags. The rag economy has been fully revamped and revolutionized with the expertise of a long-time deck sweeper. RPC (rag per capita) has been increased by at least **3** times. No longer will the common working man be dragged down into the dark depths of darkened despair, as I once was. Now, we may walk into the light, changed men (and whatever else) with hope for the future once more rekindled within our hearts.