### PR TITLE
Add cleaner spray to medical robots

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -29,7 +29,8 @@
 		/obj/item/stack/medical/splint,
 		/obj/item/robot_rack/roller,
 		/obj/item/gripper/auto_cpr,
-		/obj/item/gripper/ivbag
+		/obj/item/gripper/ivbag,
+		/obj/item/reagent_containers/spray/cleaner/drone
 	)
 	synths = list(/datum/matter_synth/medicine = 15000)
 	emag = /obj/item/reagent_containers/spray

--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -44,7 +44,9 @@
 		/obj/item/crowbar,
 		/obj/item/stack/nanopaste,
 		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/reagent_containers/dropper
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/spray/cleaner/drone,
+		/obj/item/reagent_containers/spray/sterilizine
 	)
 	synths = list(
 		/datum/matter_synth/medicine = 10000,
@@ -116,7 +118,8 @@
 		/obj/item/inflatable_dispenser/robot,
 		/obj/item/stack/medical/advanced/ointment,
 		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/stack/medical/splint
+		/obj/item/stack/medical/splint,
+		/obj/item/reagent_containers/spray/cleaner/drone
 	)
 	synths = list(
 		/datum/matter_synth/medicine = 15000

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -78,8 +78,13 @@
 
 /obj/item/reagent_containers/spray/examine(mob/user, distance)
 	. = ..()
-	if(distance == 0 && loc == user)
-		to_chat(user, "[round(reagents.total_volume)] unit\s left.")
+	if(distance > 0)
+		return
+
+	if(reagents?.reagent_list.len)
+		to_chat(user, SPAN_NOTICE("It contains [round(reagents.total_volume)] units of liquid."))
+	else
+		to_chat(user, SPAN_NOTICE("It is empty."))
 
 /obj/item/reagent_containers/spray/verb/empty()
 


### PR DESCRIPTION
It just seems weird that surgeon bot has no way of cleaning up their OR and the crisis bot is stuck with a filthy infirmary, while so many other modules get free space cleaner.

You're on your own for refilling the bottles, though. No one else gets free cleaner at recharge, and if janibot doesn't, why should medibots?

:cl: Ninetailed
rscadd: Surgeon, Crisis, and Emergency modules now have space cleaner
rscadd: Surgeon module now has sterilizine
tweak: Examining spray bottles now shows a message more like the ones beakers have.
/:cl: