### PR TITLE
adrenaline takes 20% less volume to restart hearts

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -915,8 +915,8 @@
 	M.add_chemical_effect(CE_STIMULANT, 2)
 	if(M.chem_doses[type] > 10)
 		M.make_jittery(5)
-	if(volume >= 5 && M.is_asystole())
-		remove_self(5)
+	if(volume >= 4 && M.is_asystole())
+		remove_self(4)
 		if(M.resuscitate())
 			var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
 			heart.take_internal_damage(heart.max_damage * 0.075)


### PR DESCRIPTION
:cl:
tweak: Adrenaline takes 4u to restart hearts, down from 5.
bugfix: Adrenaline injectors can now actually restart hearts.
/:cl:
