### PR TITLE
Fix inheritance issue for simple animal gibbing

### DIFF
--- a/code/modules/mob/living/simple_animal/life.dm
+++ b/code/modules/mob/living/simple_animal/life.dm
@@ -90,8 +90,8 @@
 	if(purge)
 		purge -= 1
 
-/mob/living/simple_animal/gib()
-	..(icon_gib,1)
+/mob/living/simple_animal/gib(anim = icon_gib, do_gibs = TRUE)
+	..()
 
 /mob/living/simple_animal/proc/visible_emote(act_desc)
 	custom_emote(1, act_desc)


### PR DESCRIPTION
NUFC

Fixes simple_animal gib procs overriding anything passed on by subtypes.