### PR TITLE
Makes voidsuit helmets and magboots de-link from voidsuit on dismemberment

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -321,3 +321,26 @@ else if(##equipment_var) {\
 	if(tank && slot == slot_back)
 		ret.overlays += tank.get_mob_overlay(user_mob, slot_back_str)
 	return ret
+
+/obj/item/clothing/suit/space/void/proc/forceDropEquipment(equipment)
+	var/mob/living/carbon/human/H
+	if(helmet && equipment == helmet)
+		H = helmet.loc
+		if(istype(H))
+			if(H.head == helmet)
+				helmet.canremove = TRUE
+				helmet.dropInto(loc)
+				helmet = null
+	if(boots && equipment == boots)
+		H = boots.loc
+		if(istype(H))
+			if(H.shoes == boots)
+				boots.canremove = TRUE
+				boots.dropInto(loc)
+				boots = null
+	if(tank && equipment == tank)
+		tank.canremove = TRUE
+		tank.dropInto(loc)
+		tank = null
+	else
+		return

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1192,10 +1192,16 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	switch(body_part)
 		if(FOOT_LEFT, FOOT_RIGHT)
+			if(istype(owner.wear_suit, /obj/item/clothing/suit/space/void))
+				var/obj/item/clothing/suit/space/void/voidsuit = owner.wear_suit
+				voidsuit.forceDropEquipment(voidsuit.boots)
 			owner.drop_from_inventory(owner.shoes)
 		if(HAND_LEFT, HAND_RIGHT)
 			owner.drop_from_inventory(owner.gloves)
 		if(HEAD)
+			if(istype(owner.wear_suit, /obj/item/clothing/suit/space/void))
+				var/obj/item/clothing/suit/space/void/voidsuit = owner.wear_suit
+				voidsuit.forceDropEquipment(voidsuit.helmet)
 			owner.drop_from_inventory(owner.glasses)
 			owner.drop_from_inventory(owner.head)
 			owner.drop_from_inventory(owner.l_ear)


### PR DESCRIPTION
:cl: Rootoo807
bugfix: Voidsuit helmets and magboots properly de-link from the suit when the wearer loses their head/feet, instead of dropping broken items. 
/:cl:

Fixes #32566. 