### PR TITLE
Move psychologist to counselor alt titles

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -227,6 +227,7 @@
 	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/medical/counselor
 	alt_titles = list(
 		"Psychiatrist",
+		"Psychologist",
 		"Psionic Counselor",
 		"Mentalist"
 

--- a/maps/torch/job/misc_jobs.dm
+++ b/maps/torch/job/misc_jobs.dm
@@ -35,7 +35,6 @@ Civilian
 		"Historian",
 		"Botanist",
 		"Investor" = /singleton/hierarchy/outfit/job/torch/passenger/passenger/investor,
-		"Psychologist" = /singleton/hierarchy/outfit/job/torch/passenger/passenger/psychologist,
 		"Naturalist",
 		"Ecologist",
 		"Entertainer",

--- a/maps/torch/job/outfits/misc_outfits.dm
+++ b/maps/torch/job/outfits/misc_outfits.dm
@@ -6,11 +6,6 @@
 	pda_type = /obj/item/modular_computer/pda
 	id_types = list(/obj/item/card/id/torch/passenger)
 
-/singleton/hierarchy/outfit/job/torch/passenger/passenger/psychologist
-	name = OUTFIT_JOB_NAME("Passenger - Psychologist")
-	uniform = /obj/item/clothing/under/rank/psych/turtleneck
-	shoes = /obj/item/clothing/shoes/laceup
-
 /singleton/hierarchy/outfit/job/torch/passenger/passenger/journalist
 	name = OUTFIT_JOB_NAME("Journalist - Torch")
 	backpack_contents = list(/obj/item/device/camera/tvcamera = 1,


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Psychologist has been moved from Passenger to Counselor as an alt title. It does not confer any psionic abilities.
/:cl: