### PR TITLE
Adds an incredibly spooky new artefact effect

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3140,6 +3140,7 @@
 #include "code\modules\xenoarcheaology\effects\roboheal.dm"
 #include "code\modules\xenoarcheaology\effects\robohurt.dm"
 #include "code\modules\xenoarcheaology\effects\sleepy.dm"
+#include "code\modules\xenoarcheaology\effects\spooky.dm"
 #include "code\modules\xenoarcheaology\effects\stun.dm"
 #include "code\modules\xenoarcheaology\effects\teleport.dm"
 #include "code\modules\xenoarcheaology\effects\hellportal\hell_portal.dm"

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -105,4 +105,5 @@
 	for(var/obj/item/organ/external/E in organs)
 		E.status |= ORGAN_DISFIGURED
 	update_body(1)
+	playsound(src.loc, 'sound/effects/bonerattle.ogg', 50, 1)
 	return

--- a/code/modules/xenoarcheaology/effects/spooky.dm
+++ b/code/modules/xenoarcheaology/effects/spooky.dm
@@ -1,0 +1,59 @@
+/datum/artifact_effect/skeletonise
+	name = "skeletonise"
+	effect_type = EFFECT_ORGANIC
+
+/datum/artifact_effect/skeletonise/DoEffectTouch(mob/user)
+	if (user)
+		if (istype(user, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = user
+			if (MUTATION_SKELETON in H.mutations)
+				return
+			var/weakness = GetAnomalySusceptibility(H)
+			if (prob(weakness * 100))
+				if (!addtimer(CALLBACK(H, /mob/living/carbon/human/proc/ChangeToSkeleton), rand(30 SECONDS, 2 MINUTES), TIMER_UNIQUE | TIMER_NO_HASH_WAIT))
+					return
+				to_chat(H, SPAN_WARNING("You suddenly feel a deep chill in your bones..."))
+				var/datum/gas_mixture/env = H.loc.return_air()
+				if (env)
+					env.temperature -= 15
+
+/datum/artifact_effect/skeletonise/DoEffectAura(atom/holder)
+	if (holder)
+		var/turf/T = get_turf(holder)
+		for (var/mob/living/carbon/human/H in range(src.effectrange, T))
+			if (MUTATION_SKELETON in H.mutations)
+				return
+			var/weakness = GetAnomalySusceptibility(H)
+			if (prob(weakness * 100))
+				if (!addtimer(CALLBACK(H, /mob/living/carbon/human/proc/ChangeToSkeleton), rand(30 SECONDS, 2 MINUTES), TIMER_UNIQUE | TIMER_NO_HASH_WAIT))
+					return
+				to_chat(H, SPAN_WARNING("You suddenly feel a deep chill in your bones..."))
+				var/datum/gas_mixture/env = H.loc.return_air()
+				if (env)
+					env.temperature -= 15
+
+/datum/artifact_effect/skeletonise/DoEffectPulse(atom/holder)
+	if (holder)
+		var/turf/T = get_turf(holder)
+		for (var/mob/living/carbon/human/H in range(src.effectrange, T))
+			if (MUTATION_SKELETON in H.mutations)
+				return
+			var/weakness = GetAnomalySusceptibility(H)
+			if (prob(weakness * 100))
+				if (!addtimer(CALLBACK(H, /mob/living/carbon/human/proc/ChangeToSkeleton), rand(30 SECONDS, 2 MINUTES), TIMER_UNIQUE | TIMER_NO_HASH_WAIT))
+					return
+				to_chat(H, SPAN_WARNING("You suddenly feel a deep chill in your bones..."))
+				var/datum/gas_mixture/env = H.loc.return_air()
+				if (env)
+					env.temperature -= 15
+
+/datum/artifact_effect/skeletonise/destroyed_effect()
+	. = ..()
+
+	if (holder)
+		var/turf/T = get_turf(holder)
+		new /mob/living/simple_animal/hostile/skeleton(T)
+		for (var/mob/living/carbon/human/H in range(src.effectrange, T))
+			if (prob(50))
+				H.custom_pain(SPAN_DANGER("You feel a deep ache in your bones!"), 30)
+				H.Weaken(10)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
rscadd: Adds the skeletonise artefact effect. Now you can finally allow your inner skeleton to hatch!
tweak: Adds a rattling sound to the ChangeToSkeleton() proc.
/:cl:
All in the spirit of this most spooky of seasons. Now when you touch the funny rock, instead of regressing into a child or being zapped into the nether realm, you can enjoy life being poked and prodded by science as a rattling boneman