### PR TITLE
Fixes Heavy Bullpup not being Orderable

### DIFF
--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -123,7 +123,7 @@
 	access = access_emergency_armory
 	security_level = SUPPLY_SECURITY_HIGH
 
-/singleton/hierarchy/supply_pack/security/bullpup
+/singleton/hierarchy/supply_pack/security/light_bullpup
 	name = "Weapons - Light ballistic rifles"
 	contains = list(/obj/item/gun/projectile/automatic/bullpup_rifle/light = 2)
 	cost = 80


### PR DESCRIPTION
Minor bug when I added the light bullpup. Both had the same supplypack path so only the light bullpup was showing up.

This fixes that.

:cl: PurplePineapple
bugfix: Heavy bullpup can now be ordered as before
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->