### PR TITLE
Re-adds NanoBlood to medical.

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -2179,14 +2179,10 @@
 	},
 /obj/item/reagent_containers/ivbag,
 /obj/item/reagent_containers/ivbag,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus/skrell,
-/obj/item/reagent_containers/ivbag/blood/OMinus/skrell,
-/obj/item/reagent_containers/ivbag/blood/OMinus/unathi,
-/obj/item/reagent_containers/ivbag/blood/OMinus/unathi,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "IV Equipment Cabinet";
 	pixel_y = 32
@@ -25355,10 +25351,8 @@
 /obj/machinery/light,
 /obj/structure/closet/crate/freezer,
 /obj/item/device/mmi,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qqb" = (
@@ -28388,10 +28382,8 @@
 	},
 /obj/structure/closet/crate/freezer,
 /obj/item/device/mmi,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/nanoblood,
+/obj/item/reagent_containers/ivbag/nanoblood,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "tCO" = (


### PR DESCRIPTION
:cl: Rootoo807
maptweak: Replaces Medbay's supply of human/Skrell/Unathi O- blood with NanoBlood.
/:cl:

The nanoblood bags in medical got swapped with regular blood about a month ago, I think to try and shift us towards more realism and more difficult med play, but it's been causing some issues. Mainly:
- The default transfer rate on IV bags is 0.2/u per tic, regardless of contents. This works fine for nanoblood, but is pretty much lethal with normal blood. You can adjust the rates, but have to do so for every single bag, and this more or less just turns into a trap for players who don't realize the transfer rate is borked.
- The volume of regular blood is effectively quartered, meaning the eight total bags of human O- medical starts with is equivalent to two bags of nanoblood.

Together these have meant that either medical just rushes supply, or runs out of blood crazy fast whenever something happens (or, they forget to set the rates and kill people). I suppose it's increased the difficulty in a sense, but it's more just tedious than challenging in a fun way. A couple people have started taking a look into ways to make regular blood IVs more useable, but even if it's just in the interim, it would be nice to have workable blood.


