### PR TITLE
Remove holding checks for silencer attachment

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -139,9 +139,6 @@
 
 /obj/item/gun/projectile/pistol/holdout/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/silencer))
-		if (!user.IsHolding())
-			to_chat(user, SPAN_WARNING("You'll need \the [src] in your hands to do that."))
-			return
 		if (silenced)
 			to_chat(user, SPAN_WARNING("\The [src] is already silenced."))
 			return


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Silencers can now be attached to pistols again.
tweak: You no longer need to hold the target gun in your hand to attach a silencer.
/:cl:

Who named these silencers. They're suppressors.

Alternative to #32733 since checking if `I` is held in an attackby call is redundant, and checking if the gun is in hand is not really necessary and inconsistent with related attachment actions.

closes #32733