### PR TITLE
atomic cracker unit and doppler array are now printable

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -143,3 +143,29 @@
 		/obj/item/stock_parts/power/battery/buildable/stock = 1,
 		/obj/item/cell/high = 1
 	)
+
+/obj/item/stock_parts/circuitboard/cracker
+	name = T_BOARD("molecular cracking unit")
+	build_path = /obj/machinery/portable_atmospherics/cracker
+	board_type = "machine"
+	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
+	req_components = list(
+							/obj/item/stock_parts/matter_bin = 3,
+							/obj/item/stock_parts/micro_laser = 3,
+							/obj/item/stock_parts/manipulator = 1)
+	additional_spawn_components = list(
+		/obj/item/stock_parts/power/apc/buildable = 1
+	)
+
+/obj/item/stock_parts/circuitboard/doppler_array
+	name = T_BOARD("doppler array")
+	build_path = /obj/machinery/doppler_array
+	board_type = "machine"
+	origin_tech = list(TECH_ENGINEERING = 7, TECH_MATERIAL = 4, TECH_DATA = 4, TECH_BLUESPACE = 3)
+	req_components = list(
+							/obj/item/stock_parts/scanning_module = 2,
+							/obj/item/stock_parts/computer/hard_drive/cluster = 2,
+							/obj/item/stock_parts/computer/processor_unit/photonic= 1)
+	additional_spawn_components = list(
+		/obj/item/stock_parts/power/apc/buildable = 1
+	)

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -437,39 +437,53 @@
 	build_path = /obj/item/stock_parts/circuitboard/oxyregenerator
 	sort_string = "JCAAC"
 
+/datum/design/circuit/cracker
+	name = "molecular cracking unit"
+	id = "cracer"
+	req_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
+	build_path = /obj/item/stock_parts/circuitboard/cracker
+	sort_string = "JCAAD"
+
 /datum/design/circuit/reagent_heater
 	name = "chemical heating system"
 	id = "chemheater"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/reagent_heater
-	sort_string = "JCAAD"
+	sort_string = "JCAAE"
 
 /datum/design/circuit/reagent_cooler
 	name = "chemical cooling system"
 	id = "chemcooler"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/reagent_heater/cooler
-	sort_string = "JCAAE"
+	sort_string = "JCAAF"
 
 /datum/design/circuit/atmos_control
 	name = "atmospherics control console"
 	id = "atmos_control"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/atmoscontrol
-	sort_string = "JCAAF"
+	sort_string = "JCAAG"
 
 /datum/design/circuit/pipe_dispenser
 	name = "pipe dispenser"
 	id = "pipe_dispenser"
 	req_tech = list(TECH_ENGINEERING = 6, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/pipedispensor
-	sort_string = "JCAAG"
+	sort_string = "JCAAH"
 
 /datum/design/circuit/pipe_dispenser/disposal
 	name = "disposal pipe dispenser"
 	id = "pipe_disposal"
 	build_path = /obj/item/stock_parts/circuitboard/pipedispensor/disposal
-	sort_string = "JCAAH"
+	sort_string = "JCAAI"
+
+/datum/design/circuit/dopplerarray
+	name = "doppler array"
+	id = "doppler"
+	req_tech = list(TECH_ENGINEERING = 7, TECH_MATERIAL = 4, TECH_DATA = 4, TECH_BLUESPACE = 3)
+	build_path = /obj/item/stock_parts/circuitboard/doppler_array
+	sort_string = "JCAAJ"
 
 /datum/design/circuit/secure_airlock
 	name = "secure airlock electronics"
@@ -831,7 +845,7 @@
 	id = "bluespacedrive"
 	req_tech = list(TECH_BLUESPACE = 12, TECH_POWER = 12, TECH_ENGINEERING = 12) // You are not supposed to get this
 	build_path = /obj/item/stock_parts/circuitboard/bluespacedrive
-	sort_string = "XAAAF"
+	sort_string = "XAAAG"
 
 /datum/design/circuit/shipmap
 	name = "ship holomap"


### PR DESCRIPTION
formerly part of #32727 

adds boards for the atom cracker and doppler array, adding them to the research screen: both machines are fully functional but never got added to the actual rotation, as with arc welders on the past.

:cl: SomeAngryMiner
rscadd: Atom cracker and doppler arrays are now printable.
/:cl: