### PR TITLE
Lethal shots in to heart can now cause KO

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -226,3 +226,10 @@
 
 /obj/item/organ/internal/heart/get_mechanical_assisted_descriptor()
 	return "pacemaker-assisted [name]"
+
+/obj/item/organ/internal/heart/take_internal_damage(amount, silent)
+	..()
+	if ((damage >= min_broken_damage) && (amount >= 10))
+		if (owner)
+			owner.Paralyse(6)
+


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Imienny
tweak: Lethal hits in to heart now knocks you out.
/:cl:

As explained on discord,
this PR will make damaging heart for more than 10 dmg in single attack knock you out if that attack cause heart failure (more or equal than 22 heart damage)