### PR TITLE
Let admins use APCs while ghosted, lower explosion size of bombard z level verb

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -976,9 +976,9 @@ Ccomp's first proc.
 	var/high_intensity
 	var/low_intensity
 	while(booms > 0)
-		range = rand(0, 2)
-		high_intensity = rand(5,8)
-		low_intensity = rand(7,10)
+		range = prob(45)
+		high_intensity = rand(2,5)
+		low_intensity = rand(6,8)
 		var/turf/T
 		if (connected == "Yes")
 			T = pick_area_turf_in_connected_z_levels(list(/proc/is_not_space_area), z_level = zlevel)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -731,7 +731,7 @@
 		"totalCharging" = round(lastused_charging),
 		"coverLocked" = coverlocked,
 		"failTime" = failure_timer * 2,
-		"siliconUser" = istype(user, /mob/living/silicon),
+		"siliconUser" = (istype(user, /mob/living/silicon) || (isghost(user) && isadmin(user))),
 		"powerChannels" = list(
 			list(
 				"title" = "Equipment",
@@ -838,7 +838,7 @@
 	if(..())
 		return 1
 
-	if(!istype(usr, /mob/living/silicon) && (locked && !emagged))
+	if(!istype(usr, /mob/living/silicon) && (locked && !emagged) && !(isghost(usr) && isadmin(usr)))
 		// Shouldn't happen, this is here to prevent href exploits
 		to_chat(usr, "You must unlock the panel to use this!")
 		return 1
@@ -887,7 +887,7 @@
 				locked = !locked
 				update_icon()
 
-	return 0
+	return STATUS_UPDATE
 
 /obj/machinery/power/apc/proc/force_update_channels()
 	autoflag = -1 // This clears state, forcing a full recalculation


### PR DESCRIPTION
:cl: Mucker
admin: Lowered the explosion sizes from the bombard z level verb.
admin: Ghosted admins can now use APC's as if they were unlocked.
/:cl: