### PR TITLE
reduces laser armor of merc void from MAJOR to HANDGUNS

### DIFF
--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -7,7 +7,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_RESISTANT,
-		laser = ARMOR_LASER_MAJOR,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
@@ -40,7 +40,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_RESISTANT,
-		laser = ARMOR_LASER_MAJOR,
+		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,


### PR DESCRIPTION
tentative balance tweak.
Mercenary voidsuits as of currently were outperforming any kind of torch weapon due to the damage dropoff changes, and it has started to show: this is a tentative test to see if this alleviates said issue, by dropping the armor one bar.

If more tweaks are needed, they will be done separately after practice and experimentation ingame. Blind heavy chops are terrible.

:cl: SomeAngryMiner
rscadd: reduces mercenary voidsuit laser resistance from laser_major to laser_handguns.
/:cl: