### PR TITLE
fix beacon on/off toggle not working

### DIFF
--- a/code/modules/overmap/ships/beacon.dm
+++ b/code/modules/overmap/ships/beacon.dm
@@ -45,7 +45,7 @@
 	if(!O)
 		to_chat(user, SPAN_WARNING("You cannot deploy \the [src] here."))
 		return
-	var/toggle_prompt = alert(user, "Turn the beacon...", "[src] Options", "[signal ? "On" : "Off"]", "Distress", "Cancel")
+	var/toggle_prompt = alert(user, "Turn the beacon...", "[src] Options", "[signal ? "Off" : "On"]", "Distress", "Cancel")
 
 	if (toggle_prompt == "Cancel")
 		return


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed being unable to turn ship beacons on.
/:cl:

Forgot to include this in the initial review of the PR when I edited on my local, so I missed it and am fixing that here now.