### PR TITLE
Re-do mapping of distress signals

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -144,11 +144,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "ax" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
@@ -2300,14 +2297,8 @@
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/merc_spawn)
 "Bh" = (
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "Bj" = (
 /obj/effect/floor_decal/industrial/outline/red,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -40,10 +40,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/scrap/command/bridge)
-"ae" = (
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
 "ag" = (
 /obj/machinery/computer/modular/preset/cardslot/command,
 /turf/simulated/floor/bluegrid/airless,
@@ -5655,6 +5651,10 @@
 /obj/machinery/power/port_gen/pacman/super,
 /turf/simulated/floor,
 /area/ship/scrap/hidden)
+"PZ" = (
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/bluegrid,
+/area/ship/scrap/comms)
 "Qd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12381,7 +12381,7 @@ Yv
 Yv
 ed
 ar
-ae
+PZ
 aO
 aX
 Yv

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -829,10 +829,6 @@
 	temperature = 233
 	},
 /area/bluespaceriver/ground)
-"cE" = (
-/obj/machinery/radio_beacon,
-/turf/simulated/wall/titanium,
-/area/bluespaceriver/ship)
 "hN" = (
 /obj/machinery/door/airlock/science,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3648,7 +3644,7 @@ aR
 Lk
 bi
 bx
-cE
+ay
 ay
 ay
 ay

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -96,14 +96,6 @@
 /obj/effect/shuttle_landmark/nav_casino/nav5,
 /turf/space,
 /area/space)
-"al" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled,
-/area/casino/casino_bridge)
 "am" = (
 /turf/simulated/wall/r_wall,
 /area/casino/casino_bridge)
@@ -328,6 +320,14 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/casino/casino_bridge)
+"ba" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_bridge)
@@ -4858,6 +4858,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_crew_cantina)
+"qB" = (
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/tiled,
+/area/casino/casino_bridge)
 "rb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
@@ -9560,7 +9564,7 @@ gb
 ax
 ax
 ax
-ap
+qB
 aV
 am
 bj
@@ -10071,7 +10075,7 @@ aA
 Kb
 aM
 ap
-al
+ba
 am
 bo
 Pb

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -614,10 +614,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/errant_pisces/enginering)
-"bK" = (
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/plating,
-/area/errant_pisces/enginering)
 "bL" = (
 /obj/structure/table/steel,
 /obj/random/tool,
@@ -6836,6 +6832,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/head_f)
+"si" = (
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/plating,
+/area/errant_pisces/enginering)
 "tb" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -28362,7 +28362,7 @@ at
 aA
 aP
 aZ
-bK
+si
 bn
 bn
 co

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -3,23 +3,6 @@
 /obj/effect/shuttle_landmark/scavver_gantry/generic/aquila,
 /turf/space,
 /area/space)
-"ab" = (
-/obj/machinery/alarm{
-	dir = 4;
-	locked = 0;
-	pixel_x = -25;
-	req_access = list()
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/light,
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled,
-/area/scavver/calypso)
 "ak" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor/airless,
@@ -1916,6 +1899,22 @@
 	},
 /turf/simulated/floor/airless,
 /area/scavver/yachtdown)
+"Gq" = (
+/obj/machinery/alarm{
+	dir = 4;
+	locked = 0;
+	pixel_x = -25;
+	req_access = list()
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/scavver/calypso)
 "Gr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /turf/simulated/floor/airless,
@@ -1924,6 +1923,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/radio_beacon,
 /turf/simulated/floor/airless,
 /area/scavver/calypso)
 "Gz" = (
@@ -16380,7 +16380,7 @@ UM
 gs
 sN
 vX
-ab
+Gq
 ry
 ry
 qQ

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -22,23 +22,6 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/tiled/skrell/orange,
 /area/ship/skrellscoutship/maintenance/atmos)
-"ae" = (
-/obj/machinery/power/apc/critical{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	req_access = list("ACCESS_SKRELLSCOUT")
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled/skrell/orange,
-/area/ship/skrellscoutship/maintenance/power)
 "ag" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
@@ -268,6 +251,22 @@
 	},
 /turf/simulated/floor/tiled/skrell,
 /area/ship/skrellscoutshuttle)
+"bh" = (
+/obj/machinery/power/apc/critical{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24;
+	req_access = list("ACCESS_SKRELLSCOUT")
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/skrell/orange,
+/area/ship/skrellscoutship/maintenance/power)
 "bi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable{
@@ -3760,6 +3759,11 @@
 /obj/machinery/door/firedoor/autoset,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/skrellscoutship/maintenance/power)
+"nw" = (
+/obj/machinery/light/skrell,
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/tiled/skrell/red,
+/area/ship/skrellscoutship/command/bridge)
 "nD" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -8490,7 +8494,7 @@ AU
 AU
 Eq
 ig
-QA
+nw
 CX
 CX
 CX
@@ -11853,7 +11857,7 @@ dl
 gy
 oj
 mI
-ae
+bh
 by
 Qr
 Lw

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -182,14 +182,6 @@
 "aB" = (
 /turf/simulated/wall/titanium,
 /area/yacht/living)
-"aC" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 6
-	},
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/plating,
-/area/yacht/engine)
 "aD" = (
 /obj/structure/hygiene/shower{
 	pixel_y = 20
@@ -1203,6 +1195,14 @@
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/yacht/engine)
+"dC" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 6
+	},
+/obj/machinery/radio_beacon,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "dD" = (
@@ -6833,7 +6833,7 @@ df
 dk
 dt
 dw
-aC
+dC
 dE
 aa
 aa

--- a/maps/event/iccgn_ship/icgnv_hound.dmm
+++ b/maps/event/iccgn_ship/icgnv_hound.dmm
@@ -931,6 +931,8 @@
 /obj/structure/table/rack,
 /obj/item/device/radio/headset/iccgn,
 /obj/item/device/radio/headset/iccgn,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/icgnv_hound)
 "Po" = (
@@ -1040,9 +1042,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/table/rack,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
+/obj/machinery/radio_beacon,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/icgnv_hound)
 "TO" = (

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -334,8 +334,8 @@
 /area/map_template/sfv_arbiter)
 "kU" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "sfv_arbiter_shuttle_pump_out_internal";
-	dir = 4
+	dir = 4;
+	id_tag = "sfv_arbiter_shuttle_pump_out_internal"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 4;
@@ -589,23 +589,24 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/radio_beacon,
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "sN" = (
 /obj/effect/floor_decal/corner/b_green/mono,
 /obj/structure/table/rack,
 /obj/machinery/door/window/eastleft{
-	req_access = list("ACCESS_SYNDICATE");
-	autoset_access = 0
+	autoset_access = 0;
+	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/item/rig/ert/fleet,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "sS" = (
 /obj/machinery/airlock_sensor{
-	pixel_y = 24;
+	frequency = 1380;
 	id_tag = s;
-	frequency = 1380
+	pixel_y = 24
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -680,9 +681,9 @@
 /area/map_template/sfv_arbiter)
 "uY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
 	icon_state = "map_vent_in";
-	pump_direction = 0;
-	dir = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
@@ -706,8 +707,8 @@
 /obj/effect/floor_decal/corner/b_green/mono,
 /obj/structure/table/rack,
 /obj/machinery/door/window/eastleft{
-	req_access = list("ACCESS_SYNDICATE");
-	autoset_access = 0
+	autoset_access = 0;
+	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/item/rig/ert/fleet,
 /turf/simulated/floor/tiled/dark,
@@ -886,8 +887,8 @@
 /obj/effect/floor_decal/corner/b_green/mono,
 /obj/structure/table/rack,
 /obj/machinery/door/window/eastleft{
-	req_access = list("ACCESS_SYNDICATE");
-	autoset_access = 0
+	autoset_access = 0;
+	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/item/rig/ert/fleet,
 /turf/simulated/floor/tiled/dark,
@@ -1115,9 +1116,9 @@
 	dir = 1
 	},
 /obj/machinery/airlock_sensor{
-	pixel_y = 24;
+	frequency = 1380;
 	id_tag = "sfv_arbiter_shuttle_sensor";
-	frequency = 1380
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/sfv_arbiter)
@@ -1904,8 +1905,8 @@
 /area/map_template/sfv_arbiter)
 "RA" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "sfv_arbiter_shuttle_pump_out_internal";
-	dir = 4
+	dir = 4;
+	id_tag = "sfv_arbiter_shuttle_pump_out_internal"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/sfv_arbiter)
@@ -2512,8 +2513,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -1,9 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
 "ab" = (
 /turf/simulated/wall/r_wall,
 /area/map_template/crashed_pod)
@@ -1022,6 +1017,11 @@
 /obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
+"pO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
 "vG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -1222,7 +1222,7 @@ gw
 gG
 ay
 hm
-aa
+pO
 lG
 "}
 (10,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -1,11 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled/monotile,
-/area/map_template/oldpod)
 "ab" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1
@@ -553,7 +546,7 @@ Kh
 (3,1,1) = {"
 MA
 MA
-aa
+am
 as
 az
 am

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1037,6 +1037,11 @@
 /obj/random/cash,
 /obj/random/cash,
 /obj/item/spacecash/bundle/c1000,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/tcomms)
 "ck" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
@@ -14,16 +14,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/map_template/colony2/engineering)
-"ac" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_steel_grid/diagonal{
-	dir = 4
-	},
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/tiled/techmaint,
-/area/map_template/colony2/ship)
 "an" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -680,6 +670,16 @@
 /obj/effect/paint/ocean,
 /turf/simulated/wall,
 /area/map_template/colony2/atmospherics)
+"lW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_steel_grid/diagonal{
+	dir = 4
+	},
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/tiled/techmaint,
+/area/map_template/colony2/ship)
 "lZ" = (
 /obj/machinery/atmospherics/omni/mixer{
 	tag_east = 1;
@@ -3227,7 +3227,7 @@ Og
 (11,1,1) = {"
 PU
 dj
-ac
+lW
 ci
 ZJ
 UN

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -76,17 +76,6 @@
 /obj/effect/paint/silver,
 /turf/simulated/wall/ocp_wall,
 /area/shuttle/petrov/toxins)
-"ak" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/radio_beacon,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/guppy_hangar/start)
 "al" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -106,23 +95,6 @@
 "an" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/fore)
-"ao" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/radio_beacon,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/exploration_shuttle/power)
 "ap" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -643,6 +615,15 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/expedition/storage)
+"br" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/guppy_hangar/start)
 "bs" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -2163,6 +2144,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"eK" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/radio_beacon,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/exploration_shuttle/power)
 "eM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
@@ -35362,7 +35359,7 @@ dv
 dJ
 ed
 eh
-ao
+eK
 fq
 fP
 gi
@@ -37169,7 +37166,7 @@ aJ
 aX
 ee
 aZ
-ak
+br
 bI
 cg
 Zn

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -489,10 +489,10 @@
 /area/hallway/primary/bridge/aft)
 "aY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/uniform_vendor,
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
-/obj/machinery/radio_beacon,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "aZ" = (
@@ -6759,6 +6759,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/radio_beacon,
 /turf/simulated/floor/plating,
 /area/aquila/power)
 "qE" = (
@@ -11528,7 +11529,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
-/obj/machinery/computer/modular/preset/cardslot/command,
+/obj/machinery/radio_beacon,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "GZ" = (


### PR DESCRIPTION
The placement of the signal beacons was not the best in several cases, and replaced items or machinery without moving those items to another location.

- Reverts mapping changes from #32727 and #32769.
- Closes #32767

:cl: SierraKomodo
maptweak: The locations of radio beacons have been tweaked to be less intrusive and resolve various issues of blocking access to other areas/items, or outright replacing them.
maptweak: The bridge uniform vendor has been restored.
maptweak: The SEV Aquila now has a radio beacon.
maptweak: The Casino's radio beacon has been moved to the bridge area.
maptweak: Radio beacons have been removed from the blueriver and oldpod maps.
maptweak: Salvage Gantry's radio beacon has been moved to the rear section of the cockpit area.
maptweak: Skrell ship's radio beacon has been moved to the bridge area.
maptweak: Radio beacon has been removed from the Guppy pending a planned update to use wall-mounted beacons and a decision on whether or not the pod should even have one.
maptweak: Added radio beacons to the mercenary ship, as well as the fleet and terran event ships.
/:cl: