### PR TITLE
Add PDA notifications to fax machines

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -323,6 +323,16 @@
 	return found
 
 /**
+ * Recursively searches containers for a given path, and returns the first match.
+ */
+/atom/proc/get_container(container_type)
+	var/atom/A = src
+	while (!istype(A, /area))
+		if (istype(A.loc, container_type))
+			return A.loc
+		A = A.loc
+
+/**
  * Called when a user examines the atom. This proc and its overrides handle displaying the text that appears in chat
  * during examines.
  *

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -32,6 +32,25 @@
 	else
 		..()
 
+/obj/item/modular_computer/pda/proc/receive_notification(message = null)
+	if (!enabled || bsod)
+		return
+	var/display = "pings softly[message ? " and displays a message: '[message]'" : null]"
+	var/mob/found_mob = get_container(/mob)
+	if (found_mob)
+		found_mob.visible_message(
+			SPAN_NOTICE("\The [found_mob]'s [name] [display]."),
+			SPAN_NOTICE("Your [name] [display]."),
+			SPAN_NOTICE("You hear a soft ping."),
+			1
+		)
+		return
+	visible_message(
+		SPAN_NOTICE("\The [src] [display]."),
+		SPAN_NOTICE("You hear a soft ping."),
+		1
+	)
+
 // PDA box
 /obj/item/storage/box/PDAs
 	name = "box of spare PDAs"


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: You can now link PDAs to fax machines to receive notifications of received faxes from anywhere on the ship. You can do this by clicking the fax machine with your PDA.
/:cl:

- Also adds a `get_container()` proc which can be used to fetch the first instance of a given type in an atom's loc tree - I.e., to find the first mob holding an atom that might be in boxes and bags.