### PR TITLE
Fix racks having unused material definitions

### DIFF
--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -157,6 +157,7 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/rack
 	title = "rack"
 	result_type = /obj/structure/table/rack
+	send_material_data = FALSE
 
 /datum/stack_recipe/furniture/closet
 	title = "closet"

--- a/code/modules/tables/rack.dm
+++ b/code/modules/tables/rack.dm
@@ -7,8 +7,6 @@
 	can_reinforce = 0
 	flipped = -1
 
-	material = DEFAULT_FURNITURE_MATERIAL
-
 /obj/structure/table/rack/New()
 	..()
 	verbs -= /obj/structure/table/verb/do_flip


### PR DESCRIPTION
- Fixes #32771

:cl: SierraKomodo
bugfix: Disassembling racks no longer gives you free aluminum.
/:cl: