### PR TITLE
Increase guest pass time limit to 60 minutes

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -130,7 +130,7 @@
 	else if (href_list["duration"])
 		var/dur = input(user, "Duration (in minutes) during which pass is valid (up to 60 minutes).", "Duration") as num|null
 		if (dur && CanUseTopic(user, state))
-			if (dur > 0 && dur <= 30)
+			if (dur > 0 && dur <= 60)
 				duration = dur
 				. = TOPIC_REFRESH
 			else


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Guest pass terminals now allow guest passes to have a time limit of 60 minutes, up from 30 minutes.
/:cl:

~~Noticed this while taking a look at the video in #32775~~

Updated to increase the limit to 60 minutes instead, per staff request.