### PR TITLE
Move aft hallway area boundaries to match physical separators

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -303,7 +303,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "bd" = (
 /turf/simulated/wall/r_wall/hull,
 /area/thruster/d3starboard)
@@ -324,7 +324,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "bg" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -870,7 +870,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "ch" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -1004,7 +1004,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "cx" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -3363,7 +3363,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "gV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -4633,7 +4633,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "jn" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -6904,7 +6904,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "oy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7848,7 +7848,7 @@
 /obj/machinery/door/airlock/glass/civilian,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "rb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7874,13 +7874,10 @@
 "re" = (
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "rf" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "rh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atm{
@@ -7890,7 +7887,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "ri" = (
 /obj/machinery/light{
 	dir = 1
@@ -7902,7 +7899,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "rk" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -7917,7 +7914,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "rm" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -7932,7 +7929,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "rr" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -8437,7 +8434,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "sv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8474,7 +8471,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "sx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8490,7 +8487,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "sy" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8507,27 +8504,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "sz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
-/obj/machinery/atmospherics/valve/shutoff/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/valve/shutoff/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/center)
 "sB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8545,7 +8528,7 @@
 	},
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "sC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9024,7 +9007,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "tT" = (
 /obj/structure/closet/medical_wall/filled{
 	pixel_x = -32
@@ -9577,7 +9560,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "vM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9723,13 +9706,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "wk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "wl" = (
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/thirddeck/aft)
@@ -10105,7 +10088,7 @@
 /area/maintenance/thirddeck/port)
 "xl" = (
 /turf/simulated/open,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "xm" = (
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
@@ -10350,7 +10333,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "xT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10553,7 +10536,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "yq" = (
 /obj/machinery/computer/modular/preset/civilian{
 	dir = 4;
@@ -12498,7 +12481,7 @@
 	},
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Ep" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200
@@ -14155,7 +14138,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "IW" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14244,7 +14227,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14262,7 +14245,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Jc" = (
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
@@ -14277,7 +14260,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Jg" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -14297,6 +14280,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
+"Ji" = (
+/obj/effect/floor_decal/corner/green/half,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/thirddeck/center)
 "Jk" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -15204,7 +15191,7 @@
 	name = "lightsout"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Lk" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -15341,7 +15328,7 @@
 	},
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Lz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15926,7 +15913,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Nj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
@@ -16475,7 +16462,7 @@
 	},
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "OX" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -16491,7 +16478,7 @@
 /obj/machinery/door/airlock/glass/civilian,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "OZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16601,7 +16588,7 @@
 	},
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Ps" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/bed/chair{
@@ -16920,7 +16907,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "Qu" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -17270,7 +17257,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "RE" = (
 /obj/machinery/alarm{
 	pixel_y = 16
@@ -18739,22 +18726,27 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "VF" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "VG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/thirddeck/center)
 "VI" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/corner/red/mono,
@@ -19534,7 +19526,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "XR" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
@@ -19827,7 +19819,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/primary/thirddeck/center)
 "YR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -40335,8 +40327,8 @@ RW
 Oc
 Jg
 Wb
-sW
-sv
+rf
+VG
 re
 uU
 uU
@@ -40540,7 +40532,7 @@ Zb
 cw
 su
 Ly
-VG
+uL
 wf
 wf
 wf
@@ -40739,10 +40731,10 @@ Vc
 hx
 WB
 Zb
-rf
+xE
 XP
 ov
-wl
+wD
 Ez
 Ts
 Ts
@@ -41146,11 +41138,11 @@ Wb
 rh
 sx
 tS
-wl
-wl
-wl
-wl
-wl
+wD
+wD
+wD
+wD
+wD
 AN
 zE
 Bz
@@ -41347,7 +41339,7 @@ eI
 eI
 ri
 sy
-ji
+Ji
 OW
 IV
 Pr
@@ -41749,13 +41741,13 @@ Yv
 Up
 MU
 fn
-rk
+sz
 Jb
-sW
+rf
 rp
 wk
 Lj
-sW
+rf
 jm
 PA
 AK
@@ -41953,12 +41945,12 @@ MU
 eI
 rl
 Jb
-sW
+rf
 rp
-sW
+rf
 yp
 yp
-sW
+rf
 MN
 AL
 BK
@@ -42154,7 +42146,7 @@ oo
 pm
 eI
 cg
-sz
+IY
 re
 Em
 vH
@@ -42358,11 +42350,11 @@ eI
 ra
 sB
 OY
-wl
-wl
-wl
-wl
-wl
+wD
+wD
+wD
+wD
+wD
 AN
 AN
 AN

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -7527,7 +7527,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "awV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7642,7 +7642,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "axy" = (
 /obj/structure/sign/directions/med{
 	pixel_y = 32
@@ -7651,7 +7651,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "axB" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -7995,7 +7995,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "ayy" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8013,7 +8013,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "ayz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14553,7 +14553,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "bFb" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "xenobio3_vent";
@@ -16065,7 +16065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "dEb" = (
 /obj/random/torchcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -16209,7 +16209,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "dNb" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/alarm{
@@ -16627,7 +16627,7 @@
 /obj/effect/floor_decal/corner/research/half,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "erb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -17044,7 +17044,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "fmb" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -17723,7 +17723,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "gyj" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
@@ -17795,7 +17795,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "gDb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -18039,13 +18039,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "hdb" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "heb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18081,7 +18081,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "hgb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18099,7 +18099,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "hgt" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -18149,7 +18149,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "hhB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
@@ -18837,7 +18837,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "hZb" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -18880,6 +18880,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
+"igp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/firstdeck/center)
 "igK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/wall/ocp_wall,
@@ -19459,7 +19476,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "iTP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -19486,7 +19503,7 @@
 "iUb" = (
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "iVb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -19499,7 +19516,7 @@
 /obj/effect/floor_decal/industrial/shutoff,
 /obj/machinery/atmospherics/valve/shutoff/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "iVM" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 1
@@ -19515,7 +19532,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "iZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -19525,7 +19542,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "jab" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -19538,7 +19555,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "jbk" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall/hull,
@@ -20158,6 +20175,22 @@
 /obj/structure/closet/l3closet/scientist/multi,
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"jHf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/center)
 "jIb" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -21796,6 +21829,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/hardstorage/aux)
+"lMD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/firstdeck/center)
 "lNb" = (
 /obj/structure/closet/crate/solar,
 /obj/machinery/light/small,
@@ -22113,7 +22153,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "mpy" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/aftstarboard)
@@ -23439,7 +23479,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "nWP" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -23748,7 +23788,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "ooN" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/dark,
@@ -23931,7 +23971,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "oAx" = (
 /obj/structure/sign/warning/pods/south{
 	dir = 1
@@ -26021,7 +26061,7 @@
 /area/rnd/xenobiology/xenoflora)
 "rcx" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "rdb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -26351,7 +26391,7 @@
 "rvY" = (
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "rwb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -26867,8 +26907,8 @@
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/vending/hydronutrients{
-	vendor_flags = 3;
-	dir = 1
+	dir = 1;
+	vendor_flags = 3
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
@@ -27298,7 +27338,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/primary/firstdeck/center)
 "stb" = (
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -28269,8 +28309,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/alarm/monitor{
 	alarm_id = "xenobio3_alarm";
-	req_access = list(list("ACCESS_RESEARCH","ACCESS_ATMOS","ACCESS_ENGINE_EQUIP"));
-	dir = 8
+	dir = 8;
+	req_access = list(list("ACCESS_RESEARCH","ACCESS_ATMOS","ACCESS_ENGINE_EQUIP"))
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/cell_3)
@@ -29892,6 +29932,24 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/firstdeck)
+"xmO" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/primary/firstdeck/center)
 "xoo" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -50580,7 +50638,7 @@ agj
 aGx
 agY
 fMr
-ivT
+ycz
 gxX
 dDc
 rsu
@@ -50984,7 +51042,7 @@ agH
 agx
 oLK
 iiy
-ivT
+ycz
 hgb
 flB
 hrb
@@ -51186,8 +51244,8 @@ siI
 aGx
 qrq
 ahc
-vHB
-ayB
+lMD
+jHf
 nWl
 hsb
 hDb
@@ -51591,7 +51649,7 @@ gzb
 ovb
 leb
 dMe
-hnN
+xmO
 mpq
 hqb
 ljb
@@ -51792,7 +51850,7 @@ orb
 orb
 owb
 gWb
-ivT
+ycz
 hhb
 iVb
 hub
@@ -52399,7 +52457,7 @@ gDb
 gDb
 gWb
 hdb
-jAM
+igp
 equ
 hwb
 hIb
@@ -52601,7 +52659,7 @@ gEb
 gEb
 nCb
 axy
-hib
+heb
 oAp
 haT
 hJb
@@ -52802,7 +52860,7 @@ ata
 aua
 avl
 gXb
-vHB
+lMD
 ayy
 iXb
 acG
@@ -53004,8 +53062,8 @@ atb
 xMy
 gRb
 gXb
-ivT
-hnN
+ycz
+xmO
 gAU
 hyb
 llb
@@ -53206,7 +53264,7 @@ iMW
 twz
 oZb
 gXb
-ivT
+ycz
 ayw
 iZb
 aAJ
@@ -53409,7 +53467,7 @@ twz
 avo
 nCb
 awM
-jAM
+igp
 jab
 aCf
 lnb


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: Area boundaries for deck 1 and deck 3 aft hallways have been pushed back to line up with the physical boundaries created by the doors and windows in the hallways.
/:cl:

![StrongDMM_7Q70LA7ME5](https://user-images.githubusercontent.com/11140088/205447329-329dfa85-143f-4b6a-bd59-41ce2a236311.png)

![StrongDMM_zkvG5jFV3K](https://user-images.githubusercontent.com/11140088/205447333-25454724-9f6f-4dd6-9d98-0fdaadd45b72.png)