### PR TITLE
Fix blood decals not reappearing with luminol

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -29,7 +29,8 @@ var/global/list/image/splatter_cache=list()
 	var/blood_size = BLOOD_SIZE_MEDIUM // A relative size; larger-sized blood will not override smaller-sized blood, except maybe at mapload.
 
 /obj/effect/decal/cleanable/blood/reveal_blood()
-	if(!fluorescent)
+	if(!fluorescent || invisibility == 100)
+		set_invisibility(0)
 		fluorescent = ATOM_FLOURESCENCE_INACTIVE
 		basecolor = COLOR_LUMINOL
 		update_icon()
@@ -41,7 +42,7 @@ var/global/list/image/splatter_cache=list()
 		amount = 0
 		STOP_PROCESSING(SSobj, src)
 		remove_extension(src, /datum/extension/scent)
-	..(ignore=1)
+		return TRUE
 
 /obj/effect/decal/cleanable/blood/hide()
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -77,7 +77,7 @@
 
 	changing_turf = FALSE
 
-	remove_cleanables()
+	remove_cleanables(FALSE)
 	fluid_update()
 	REMOVE_ACTIVE_FLUID_SOURCE(src)
 
@@ -291,9 +291,9 @@ var/global/const/enterloopsanity = 100
 		to_chat(user, SPAN_WARNING("\The [source] is too dry to wash that."))
 	source.reagents.trans_to_turf(src, 1, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
 
-/turf/proc/remove_cleanables()
+/turf/proc/remove_cleanables(skip_blood = TRUE)
 	for(var/obj/effect/O in src)
-		if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable))
+		if(istype(O,/obj/effect/rune) || (istype(O,/obj/effect/decal/cleanable) && (!skip_blood || !istype(O, /obj/effect/decal/cleanable/blood))))
 			qdel(O)
 
 /turf/proc/update_blood_overlays()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -855,14 +855,12 @@
 			var/turf/tile = loc
 			if(isturf(tile))
 				tile.clean_blood()
+				tile.remove_cleanables()
 				if (istype(tile, /turf/simulated))
 					var/turf/simulated/S = tile
 					S.dirt = 0
 				for(var/A in tile)
-					if(istype(A, /obj/effect))
-						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
-							qdel(A)
-					else if(istype(A, /obj/item))
+					if(istype(A, /obj/item))
 						var/obj/item/cleaned_item = A
 						cleaned_item.clean_blood()
 					else if(istype(A, /mob/living/carbon/human))


### PR DESCRIPTION
- Fixes #32778

:cl: SierraKomodo
bugfix: Luminol now properly reveals cleaned blood decals, unless they were cleaned with sterilizine.
/:cl: