### PR TITLE
Fix prebuilt mechs lacking valid cameras

### DIFF
--- a/code/modules/mechs/components/head.dm
+++ b/code/modules/mechs/components/head.dm
@@ -6,7 +6,7 @@
 	var/vision_flags = 0
 	var/see_invisible = 0
 	var/obj/item/robot_parts/robot_component/radio/radio
-	var/obj/item/robot_parts/robot_component/camera
+	var/obj/item/robot_parts/robot_component/camera/camera
 	var/obj/item/mech_component/control_module/software
 	has_hardpoints = list(HARDPOINT_HEAD)
 	var/active_sensors = 0


### PR DESCRIPTION
- Fixes #32753

:cl: SierraKomodo
bugfix: Prebuilt mechs, including the cargo powerloader, now have valid cameras in their sensors.
/:cl: