### PR TITLE
Misc crafting fixes

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -361,6 +361,7 @@
 	if(material)
 		use_material = material.name
 		difficulty += material.construction_difficulty
+		difficulty = clamp(difficulty, MATERIAL_EASY_DIY, MATERIAL_VERY_HARD_DIY)
 	if(reinforce_material)
 		use_reinf_material = reinforce_material
 

--- a/code/modules/crafting/crafting_knives_misc.dm
+++ b/code/modules/crafting/crafting_knives_misc.dm
@@ -33,7 +33,7 @@
 	completion_trigger_type = /obj/item/stack/material/rods
 	product = /obj/item/material/sword/makeshift
 
-/singleton/crafting_stage/sword_handle/get_product(obj/item/work)
+/singleton/crafting_stage/material/sword_handle/get_product(obj/item/work)
 	var/obj/item/material/large_blade/blade = locate() in work
 	. = ispath(product, /obj/item/material) && new product(get_turf(work), blade?.material?.name)
 


### PR DESCRIPTION
- Fixes #32742
- Fixes #31207

:cl: SierraKomodo
bugfix: Titanium (And other materials with high crafting costs) can now have their crafting menus opened again.
bugfix: Claymores now use the correct material when they are crafted.
/:cl: