### PR TITLE
Fix spamming inflatables

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -26,7 +26,7 @@
 		SPAN_ITALIC("You can hear rushing air."),
 		range = 5
 	)
-	if (!do_after(user, 1 SECOND, target, DO_PUBLIC_PROGRESS))
+	if (!do_after(user, 1 SECOND, target, DO_PUBLIC_UNIQUE) || QDELETED(src))
 		return
 	obstruction = T.get_obstruction()
 	if (obstruction)


### PR DESCRIPTION
- Fixes #32740

:cl: SierraKomodo
bugfix: You can no longer create new inflatables by spam clicking them.
/:cl: