### PR TITLE
Hand labeler fixes

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -3,33 +3,35 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/label = null
 	var/labels_left = 30
 	var/mode = 0	//off or on.
 	matter = list(MATERIAL_PLASTIC = 100)
 
-/obj/item/hand_labeler/attack()
-	return
+/obj/item/hand_labeler/get_mechanics_info()
+	. = ..()
+	. += {"
+		<p>The hand labeler can be used to attach labels to objects. To do this, first set a label by using the labeler in your hand and typing in the text to use. Then click on any object.</p>
+		<p>You can turn the labeler back off by using it in hand again.</p>
+		<p>If the labeler is turned on, this will bypass all other interactions - This means you can use the labeler on bags without also storing it, and other such interactions.</p>
+	"}
 
-/obj/item/hand_labeler/afterattack(atom/A, mob/user as mob, proximity)
-	if(!proximity)
-		return
-	if(!mode)	//if it's off, give up.
-		return
-	if(A == loc)	// if placing the labeller into something (e.g. backpack)
-		return		// don't set a label
-
-	if(!labels_left)
-		to_chat(user, SPAN_NOTICE("No labels left."))
-		return
-	if(!label || !length(label))
-		to_chat(user, SPAN_NOTICE("No label text set."))
-		return
-	if(has_extension(A, /datum/extension/labels))
-		var/datum/extension/labels/L = get_extension(A, /datum/extension/labels)
+/obj/item/hand_labeler/attack(atom/target, mob/living/user, target_zone, animate)
+	if (!mode)
+		return FALSE
+	if (!labels_left)
+		to_chat(user, SPAN_WARNING("\The [src] has no labels left."))
+		return TRUE
+	if (!label || !length(label))
+		to_chat(user, SPAN_WARNING("\The [src] does not have label text set."))
+		return TRUE
+	if(has_extension(target, /datum/extension/labels))
+		var/datum/extension/labels/L = get_extension(target, /datum/extension/labels)
 		if(!L.CanAttachLabel(user, label))
-			return
-	A.attach_label(user, src, label)
+			return TRUE
+	target.attach_label(user, src, label)
+	return TRUE
 
 
 /**

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -62,16 +62,21 @@
 	L.AttachLabel(user, label_text)
 
 /obj/item/hand_labeler/attack_self(mob/user as mob)
-	mode = !mode
-	icon_state = "labeler[mode]"
-	if(mode)
-		to_chat(user, SPAN_NOTICE("You turn on \the [src]."))
-		//Now let them chose the text.
+	if (!mode)
 		var/str = sanitizeSafe(input(user,"Label text?","Set label",""), MAX_LNAME_LEN)
-		if(!str || !length(str))
-			to_chat(user, SPAN_NOTICE("Invalid text."))
+		if (!str || !length(str))
+			to_chat(user, SPAN_WARNING("Invalid text."))
 			return
 		label = str
-		to_chat(user, SPAN_NOTICE("You set the text to '[str]'."))
+		mode = TRUE
+		update_icon()
+		to_chat(user, SPAN_NOTICE("You turn \the [src] on and set it's text to '[label]'."))
 	else
+		label = null
+		mode = FALSE
+		update_icon()
 		to_chat(user, SPAN_NOTICE("You turn off \the [src]."))
+
+
+/obj/item/hand_labeler/on_update_icon()
+	icon_state = "labeler[mode]"


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Hand labelers will now skip all other interactions except labeling while turned on. This means they won't toggle locker locks or any other weirdness while also attaching labels. While the labeler is turned off, it will go into containers and behave as usual.
bugfix: Hand labelers will no long turn on if you provide an invalid or empty string as the label text.
rscadd: Added codex mechanics to hand labelers.
/:cl: