### PR TITLE
Removes the zombie juice from data capsules

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -41,7 +41,7 @@
 /obj/item/reagent_containers/glass/beaker/vial/random_podchem/Initialize()
 	. = ..()
 	desc += "Label is smudged, and there's crusted blood fingerprints on it."
-	var/reagent_type = pick(/datum/reagent/random, /datum/reagent/zombie/science, /datum/reagent/rezadone, /datum/reagent/drugs/three_eye)
+	var/reagent_type = pick(/datum/reagent/random, /datum/reagent/rezadone, /datum/reagent/drugs/three_eye)
 	reagents.add_reagent(pick(reagent_type), 5)
 
 /obj/structure/backup_server


### PR DESCRIPTION
:cl: SierraKomodo
maptweak: Zombie juice is no longer a spawnable option from data capsules.
/:cl: