### PR TITLE
Fix runtime in grown.dm

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -50,6 +50,10 @@
 	// Fill the object up with the appropriate reagents.
 	for(var/rid in seed.chems)
 		var/list/reagent_data = seed.chems[rid]
+		if(reagent_data && !islist(reagent_data))
+			log_debug(append_admin_tools("A fill_reagents list was created as a non-list. Seed: [seed] ([seed.type]). Reagent: [rid] = [seed.chems[rid]].", location = get_turf(src)))
+			reagent_data = list(reagent_data)
+
 		if(reagent_data && reagent_data.len)
 			var/rtotal = reagent_data[1]
 			var/list/data = list()

--- a/code/modules/overmap/exoplanets/exoplanet_flora.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_flora.dm
@@ -33,7 +33,7 @@
 			if (color == "RANDOM")
 				color = get_random_colour(0,75,190)
 			S.set_trait(TRAIT_LEAVES_COLOUR,color)
-			S.chems[/datum/reagent/woodpulp] = 1
+			S.chems[/datum/reagent/woodpulp] = list(1)
 			big_flora_types += S
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/adapt_seed(datum/seed/S)


### PR DESCRIPTION
Addresses issue #18534 

reagent_data should be a 1- or 2-element list, but exoplanet_flora.dm sometimes gives it a bare integer.
The PR makes exoplanet_flora.dm wrap the integer in a 1-element list.
Also if a non-list is somehow still provided, it is wrapped in a 1-element list.

:cl: Sennalen
bugfix: Fixed a runtime that could cause an exoplanet flora to lack reagents.
/:cl: