### PR TITLE
Sensor fixes

### DIFF
--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -258,14 +258,6 @@
 	..()
 	heat_reduction = clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator), heat_reduction_minimum, 5)
 
-/obj/machinery/shipsensors/weak
-	heat_reduction_minimum = 0.2
-	desc = "Miniturized gravity scanner with various other sensors, used to detect irregularities in surrounding space. Can only run in vacuum to protect delicate quantum BS elements."
-
-/obj/machinery/shipsensors/weak/RefreshParts()
-	..()
-	heat_reduction = clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator), heat_reduction_minimum, 5)
-
 /obj/item/stock_parts/circuitboard/shipsensors
 	name = T_BOARD("broad-band sensor suite")
 	board_type = "machine"
@@ -280,6 +272,3 @@
 	additional_spawn_components = list(
 		/obj/item/stock_parts/power/apc/buildable = 1
 	)
-
-/obj/item/stock_parts/circuitboard/shipsensors/weak
-	build_path = /obj/machinery/shipsensors/weak

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -102,7 +102,7 @@
 			if(!CanInteract(user,state))
 				return TOPIC_NOACTION
 			if (nrange)
-				sensors.set_range(clamp(nrange, 1, world.view))
+				sensors.set_range(clamp(round(nrange), 1, world.view))
 			return TOPIC_REFRESH
 		if (href_list["toggle"])
 			sensors.toggle()

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -149,7 +149,6 @@
 	var/health = 200
 	var/critical_heat = 50 // sparks and takes damage when active & above this heat
 	var/heat_reduction = 1.5 // mitigates this much heat per tick
-	var/heat_reduction_minimum = 1.5 //minimum amount of heat mitigation unupgraded
 	var/heat = 0
 	var/range = 1
 	idle_power_usage = 5000
@@ -256,7 +255,7 @@
 
 /obj/machinery/shipsensors/RefreshParts()
 	..()
-	heat_reduction = round(clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator) / 3), heat_reduction_minimum, 5)
+	heat_reduction = round(total_component_rating_of_type(/obj/item/stock_parts/manipulator) / 3)
 
 /obj/item/stock_parts/circuitboard/shipsensors
 	name = T_BOARD("broad-band sensor suite")

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -256,7 +256,7 @@
 
 /obj/machinery/shipsensors/RefreshParts()
 	..()
-	heat_reduction = clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator), heat_reduction_minimum, 5)
+	heat_reduction = round(clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator) / 3), heat_reduction_minimum, 5)
 
 /obj/item/stock_parts/circuitboard/shipsensors
 	name = T_BOARD("broad-band sensor suite")

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -847,18 +847,11 @@
 	build_path = /obj/item/stock_parts/circuitboard/bluespacedrive
 	sort_string = "XAAAG"
 
-/datum/design/circuit/shipsensoradv
-	name = "BS quantum sensor suite"
-	id = "shipsensoradv"
-	req_tech = list(TECH_BLUESPACE = 12) //You are not supposed to get these either
-	build_path = /obj/item/stock_parts/circuitboard/shipsensors
-	sort_string = "XAAAG"
-
 /datum/design/circuit/shipsensors
 	name = "Broad-band sensor suite"
 	id = "shipsensors"
 	req_tech = list(TECH_BLUESPACE = 2, TECH_POWER = 4, TECH_ENGINEERING = 4, TECH_DATA = 4)
-	build_path = /obj/item/stock_parts/circuitboard/shipsensors/weak
+	build_path = /obj/item/stock_parts/circuitboard/shipsensors
 	sort_string = "XAAAH"
 
 /datum/design/circuit/radio_beacon

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -2836,7 +2836,7 @@
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
 "XQ" = (
-/obj/machinery/shipsensors/weak{
+/obj/machinery/shipsensors{
 	use_power = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -526,7 +526,7 @@
 /turf/simulated/floor/airless,
 /area/scavver/gantry/up2)
 "ef" = (
-/obj/machinery/shipsensors/weak{
+/obj/machinery/shipsensors{
 	use_power = 0
 	},
 /turf/simulated/floor/airless,
@@ -2314,7 +2314,7 @@
 /turf/simulated/floor/tiled,
 /area/scavver/hab)
 "sp" = (
-/obj/machinery/shipsensors/weak{
+/obj/machinery/shipsensors{
 	use_power = 0
 	},
 /obj/structure/handrail{

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -12556,7 +12556,7 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
 "Gq" = (
-/obj/machinery/shipsensors/weak,
+/obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "Gr" = (


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Default ship sensor range overheat threshhold reduced to 3, bringing it back in line to previous values. This allows upgrading the sensors with better manipulators to become viable. Maximum possible upgraded range before overheating is 6.
tweak: Ship sensor range inputs now only accept whole numbers, and will round any decimal value entered.
rscdel: The weak variant of ship sensors has been removed. The GUP's sensors are now equivalent to all other sensors.
/:cl:

Rounding of input is to resolv a discovered bug in sensor range calculations where it would not properly update the view range when switching to a decimal value, but would update the heat generation and power use, allowing for longer range sensors for no power or heat tradeoff.