### PR TITLE
Standardized Health Everything

### DIFF
--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -360,7 +360,6 @@
 
 
 /atom/attackby(obj/item/W, mob/user, click_params)
-	. = ..()
 	if (user.a_intent == I_HURT && get_max_health() && !(W.item_flags & ITEM_FLAG_NO_BLUDGEON))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
@@ -377,3 +376,5 @@
 			SPAN_DANGER("You hit \the [src] with \the [W]!")
 		)
 		damage_health(W.force, W.damtype, skip_can_damage_check = TRUE)
+		return TRUE
+	return ..()

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -340,7 +340,7 @@
 	. = ..()
 	if (get_max_health())
 		var/damage = P.damage
-		if (istype(src, /obj/structure) || istype(src, /turf/simulated/wall)) // TODO Better conditions for non-structures that want to use structure damage
+		if (istype(src, /obj/structure) || istype(src, /turf/simulated/wall) || istype(src, /obj/machinery)) // TODO Better conditions for non-structures that want to use structure damage
 			damage = P.get_structure_damage()
 		if (!can_damage_health(damage, P.damage_type))
 			return

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -123,6 +123,9 @@
 	..()
 
 /obj/machinery/ex_act(severity)
+	..()
+	if (health_max)
+		return
 	switch(severity)
 		if(EX_ACT_DEVASTATING)
 			qdel(src)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "yellow"
 	density = TRUE
-	var/health = 100.0
+	health_max = 100
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_GARGANTUAN
 	construct_state = null
@@ -146,30 +146,19 @@
 		overlays += "can-o3"
 
 /obj/machinery/portable_atmospherics/canister/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > temperature_resistance)
-		health -= 5
-		healthcheck()
+	if (exposed_temperature > temperature_resistance)
+		..()
 
-/obj/machinery/portable_atmospherics/canister/proc/healthcheck()
-	if(destroyed)
-		return 1
-
-	if (src.health <= 10)
-		var/atom/location = src.loc
-		location.assume_air(air_contents)
-
-		src.destroyed = 1
-		playsound(src.loc, 'sound/effects/spray.ogg', 10, 1, -3)
-		src.set_density(0)
-		update_icon()
-
-		if (src.holding)
-			src.holding.dropInto(loc)
-			src.holding = null
-
-		return 1
-	else
-		return 1
+/obj/machinery/portable_atmospherics/canister/on_death()
+	var/atom/location = loc
+	location.assume_air(air_contents)
+	destroyed = TRUE
+	playsound(src, 'sound/effects/spray.ogg', 10, TRUE, -3)
+	set_density(FALSE)
+	update_icon()
+	if (holding)
+		holding.dropInto(loc)
+		holding = null
 
 /obj/machinery/portable_atmospherics/canister/Process()
 	if (destroyed)
@@ -216,21 +205,7 @@
 		return GM.return_pressure()
 	return 0
 
-/obj/machinery/portable_atmospherics/canister/bullet_act(obj/item/projectile/Proj)
-	if (!(Proj.damage_type == DAMAGE_BRUTE || Proj.damage_type == DAMAGE_BURN))
-		return
-
-	if(Proj.damage)
-		src.health -= round(Proj.damage / 2)
-		healthcheck()
-	..()
-
 /obj/machinery/portable_atmospherics/canister/attackby(obj/item/W as obj, mob/user as mob)
-	if(!isWrench(W) && !istype(W, /obj/item/tank) && !istype(W, /obj/item/device/scanner/gas) && !istype(W, /obj/item/modular_computer/pda))
-		visible_message(SPAN_WARNING("\The [user] hits \the [src] with \a [W]!"))
-		src.health -= W.force
-		healthcheck()
-
 	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/tank/jetpack))
 		var/datum/gas_mixture/thejetpack = W:air_contents
 		var/env_pressure = thejetpack.return_pressure()
@@ -242,9 +217,9 @@
 			var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 			thejetpack.merge(removed)
 			to_chat(user, "You pulse-pressurize your jetpack from the tank.")
-		return
+		return TRUE
 
-	..()
+	. = ..()
 
 	SSnano.update_uis(src) // Update all NanoUIs attached to src
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -12,8 +12,10 @@
 	frame_type = /obj/machinery/constructable_frame/computerframe/deconstruct
 	var/processing = 0
 
-	var/max_health = 80
-	var/health
+	health_max = 80
+	health_resistances = DAMAGE_RESIST_ELECTRICAL
+	damage_hitsound = 'sound/weapons/smash.ogg'
+
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
 	var/light_max_bright_on = 0.2
@@ -29,57 +31,16 @@
 
 /obj/machinery/computer/Initialize()
 	. = ..()
-	health = max_health
 	update_icon()
 
-/obj/machinery/computer/emp_act(severity)
-	..()
-	if(prob(20/severity))
-		take_damage(max_health)
+/obj/machinery/computer/can_damage_health(damage, damage_type)
+	if (!can_use_tools)
+		return FALSE
+	. = ..()
 
-/obj/machinery/computer/ex_act(severity)
-	switch(severity)
-		if(EX_ACT_DEVASTATING)
-			qdel(src)
-			return
-		if(EX_ACT_HEAVY)
-			if (prob(25))
-				qdel(src)
-				return
-			if (prob(50))
-				for(var/x in verbs)
-					verbs -= x
-				take_damage(max_health)
-		if(EX_ACT_LIGHT)
-			if (prob(25))
-				for(var/x in verbs)
-					verbs -= x
-				take_damage(max_health)
-
-/obj/machinery/computer/bullet_act(obj/item/projectile/Proj)
-	take_damage(Proj.get_structure_damage())
-	..()
-
-/obj/machinery/computer/attackby(obj/item/I, mob/user)
-	if (isScrewdriver(I) || isWrench(I) || isCrowbar(I))
-		return ..() // handled by construction
-	if (user.a_intent != I_HURT)
-		return ..()
-
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(src)
-	playsound(src, 'sound/weapons/smash.ogg', 25, 1)
-	take_damage(I.force)
-	..()
-
-/obj/machinery/computer/proc/take_damage(damage)
-	if (health <= 0 || !can_use_tools)
-		return
-
-	health -= damage
-	if(health <= 0)
-		set_broken(TRUE)
-		visible_message(SPAN_WARNING("\The [src] breaks!"))
+/obj/machinery/computer/on_death()
+	set_broken(TRUE)
+	visible_message(SPAN_WARNING("\The [src] breaks!"))
 
 /obj/machinery/computer/on_update_icon()
 	overlays.Cut()

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -43,11 +43,6 @@
 /obj/structure/window/airlock_crush(crush_damage)
 	shatter(TRUE)
 
-/obj/machinery/portable_atmospherics/canister/airlock_crush(crush_damage)
-	. = ..()
-	health -= crush_damage
-	healthcheck()
-
 /obj/effect/energy_field/airlock_crush(crush_damage)
 	Stress(crush_damage)
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -18,10 +18,12 @@
 	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power
 	power_channel = EQUIP	//drains power from the EQUIPMENT channel
 
+	health_max = 80
+	health_resistances = DAMAGE_RESIST_ELECTRICAL
+	health_min_damage = 5
+
 	var/raised = 0			//if the turret cover is "open" and the turret is raised
 	var/raising= 0			//if the turret is currently opening or closing its cover
-	var/health = 80			//the turret's health
-	var/maxhealth = 80		//turrets maximal health.
 	var/auto_repair = 0		//if 1 the turret slowly repairs itself.
 	var/locked = 1			//if the turret's behaviour control access is locked
 	var/controllock = 0		//if the turret responds to control panels
@@ -82,7 +84,7 @@
 	ailock = 0
 	malf_upgraded = 1
 	to_chat(user, "\The [src] has been upgraded. It's damage and rate of fire has been increased. Auto-regeneration system has been enabled. Power usage has increased.")
-	maxhealth = round(initial(maxhealth) * 1.5)
+	set_max_health(round(initial(health_max) * 1.5), FALSE)
 	shot_delay = round(initial(shot_delay) / 2)
 	auto_repair = 1
 	change_power_consumption(round(initial(active_power_usage) * 5), POWER_USE_ACTIVE)
@@ -293,17 +295,18 @@ var/global/list/turret_icons
 				else
 					to_chat(user, SPAN_NOTICE("You remove the turret but did not manage to salvage anything."))
 				qdel(src) // qdel
+			return TRUE
 
 	else if(isWrench(I))
 		if(enabled || raised)
 			to_chat(user, SPAN_WARNING("You cannot unsecure an active turret!"))
-			return
+			return TRUE
 		if(wrenching)
 			to_chat(user, SPAN_WARNING("Someone is already [anchored ? "un" : ""]securing the turret!"))
-			return
+			return TRUE
 		if(!anchored && isinspace())
 			to_chat(user, SPAN_WARNING("Cannot secure turrets in space!"))
-			return
+			return TRUE
 
 		user.visible_message(
 			SPAN_WARNING("\The [user] begins [anchored ? "un" : ""]securing the turret."),
@@ -324,6 +327,7 @@ var/global/list/turret_icons
 				to_chat(user, SPAN_NOTICE("You unsecure the exterior bolts on the turret."))
 				update_icon()
 		wrenching = 0
+		return TRUE
 
 	else if(istype(I, /obj/item/card/id)||istype(I, /obj/item/modular_computer))
 		//Behavior lock/unlock mangement
@@ -333,18 +337,9 @@ var/global/list/turret_icons
 			updateUsrDialog()
 		else
 			to_chat(user, SPAN_NOTICE("Access denied."))
+		return TRUE
 
-	else
-		//if the turret was attacked with the intention of harming it:
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		take_damage(I.force * 0.5)
-		if(I.force * 0.5 > 1) //if the force of impact dealt at least 1 damage, the turret gets pissed off
-			if(!attacked && !emagged)
-				attacked = 1
-				spawn()
-					sleep(60)
-					attacked = 0
-		..()
+	return ..()
 
 /obj/machinery/porta_turret/emag_act(remaining_charges, mob/user)
 	if(!emagged)
@@ -360,17 +355,22 @@ var/global/list/turret_icons
 		enabled = 1 //turns it back on. The cover popUp() popDown() are automatically called in process(), no need to define it here
 		return 1
 
-/obj/machinery/porta_turret/proc/take_damage(force)
-	if(!raised && !raising)
-		force = force / 8
-		if(force < 5)
-			return
+/obj/machinery/porta_turret/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)
+	if (!raised && !raising)
+		damage = damage / 8
+	. = ..()
 
-	health -= force
-	if (force > 5 && prob(45))
-		spark_system.start()
-	if(health <= 0)
-		die()	//the death process :(
+/obj/machinery/porta_turret/post_health_change(health_mod, damage_type)
+	. = ..()
+	if (health_mod < 0)
+		if (!emagged && enabled)
+			attacked = TRUE
+			addtimer(CALLBACK(src, .proc/timer_attacked), 6 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		if (prob(45))
+			spark_system.start()
+
+/obj/machinery/porta_turret/proc/timer_attacked()
+	attacked = FALSE
 
 /obj/machinery/porta_turret/bullet_act(obj/item/projectile/Proj)
 	var/damage = Proj.get_structure_damage()
@@ -378,16 +378,7 @@ var/global/list/turret_icons
 	if(!damage)
 		return
 
-	if(enabled)
-		if(!attacked && !emagged)
-			attacked = 1
-			spawn()
-				sleep(60)
-				attacked = 0
-
-	..()
-
-	take_damage(damage)
+	. = ..()
 
 /obj/machinery/porta_turret/emp_act(severity)
 	if(enabled)
@@ -411,20 +402,7 @@ var/global/list/turret_icons
 	if(disabled)
 		disabled = 0
 
-/obj/machinery/porta_turret/ex_act(severity)
-	switch (severity)
-		if (EX_ACT_DEVASTATING)
-			qdel(src)
-		if (EX_ACT_HEAVY)
-			if (prob(25))
-				qdel(src)
-			else
-				take_damage(initial(health) * 8) //should instakill most turrets
-		if (EX_ACT_LIGHT)
-			take_damage(initial(health) * 8 / 3)
-
-/obj/machinery/porta_turret/proc/die()	//called when the turret dies, ie, health <= 0
-	health = 0
+/obj/machinery/porta_turret/on_death()
 	set_broken(TRUE)
 	spark_system.start()	//creates some sparks because they look cool
 	atom_flags |= ATOM_FLAG_CLIMBABLE // they're now climbable
@@ -450,9 +428,9 @@ var/global/list/turret_icons
 		if(!tryToShootAt(secondarytargets)) // if no valid targets, go for secondary targets
 			popDown() // no valid targets, close the cover
 
-	if(auto_repair && (health < maxhealth))
+	if(auto_repair && health_damaged())
 		use_power_oneoff(20000)
-		health = min(health+1, maxhealth) // 1HP for 20kJ
+		restore_health(1)
 
 /obj/machinery/porta_turret/proc/assess_and_assign(mob/living/L, list/targets, list/secondarytargets)
 	switch(assess_living(L))

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -5,57 +5,7 @@
 	icon = 'icons/effects/effects.dmi'
 	anchored = TRUE
 	density = FALSE
-	var/health = 15
-
-//similar to weeds, but only barfed out by nurses manually
-/obj/effect/spider/ex_act(severity)
-	switch(severity)
-		if(EX_ACT_DEVASTATING)
-			qdel(src)
-		if(EX_ACT_HEAVY)
-			if (prob(50))
-				qdel(src)
-		if(EX_ACT_LIGHT)
-			if (prob(5))
-				qdel(src)
-	return
-
-/obj/effect/spider/attackby(obj/item/W, mob/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-
-	if(W.attack_verb.len)
-		visible_message(SPAN_WARNING("\The [src] have been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]"))
-	else
-		visible_message(SPAN_WARNING("\The [src] have been attacked with \the [W][(user ? " by [user]." : ".")]"))
-
-	var/damage = W.force / 4.0
-
-	if(W.edge)
-		damage += 5
-
-	if(isWelder(W))
-		var/obj/item/weldingtool/WT = W
-
-		if(WT.remove_fuel(0, user))
-			damage = 15
-			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
-
-	health -= damage
-	healthcheck()
-
-/obj/effect/spider/bullet_act(obj/item/projectile/Proj)
-	..()
-	health -= Proj.get_structure_damage()
-	healthcheck()
-
-/obj/effect/spider/proc/healthcheck()
-	if(health <= 0)
-		qdel(src)
-
-/obj/effect/spider/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > 300 + T0C)
-		health -= 5
-		healthcheck()
+	health_max = 15
 
 /obj/effect/spider/stickyweb
 	icon_state = "stickyweb1"
@@ -128,7 +78,8 @@
 	icon_state = "green"
 	anchored = FALSE
 	layer = BELOW_OBJ_LAYER
-	health = 3
+	health_max = 3
+	health_resistances = DAMAGE_RESIST_BIOLOGICAL
 	var/mob/living/simple_animal/hostile/giant_spider/greater_form
 	var/last_itch = 0
 	var/amount_grown = -1
@@ -190,8 +141,8 @@
 	. = ..()
 
 /obj/effect/spider/spiderling/attackby(obj/item/W, mob/user)
-	..()
-	if(health > 0)
+	. = ..()
+	if (!health_dead)
 		disturbed()
 
 /obj/effect/spider/spiderling/Crossed(mob/living/L)
@@ -212,14 +163,10 @@
 	else
 		..()
 
-/obj/effect/spider/spiderling/proc/die()
-	visible_message(SPAN_CLASS("alert", "[src] dies!"))
+/obj/effect/spider/spiderling/on_death()
+	visible_message(SPAN_CLASS("alert", "\The [src] dies!"))
 	new /obj/effect/decal/cleanable/spiderling_remains(loc)
 	qdel(src)
-
-/obj/effect/spider/spiderling/healthcheck()
-	if(health <= 0)
-		die()
 
 /obj/effect/spider/spiderling/proc/check_vent(obj/machinery/atmospherics/unary/vent_pump/exit_vent)
 	if(QDELETED(exit_vent) || exit_vent.welded) // If it's qdeleted we probably were too, but in that case we won't be making this call due to timer cleanup.
@@ -247,7 +194,7 @@
 	if(loc)
 		var/datum/gas_mixture/environment = loc.return_air()
 		if(environment && environment.gas[GAS_METHYL_BROMIDE] > 0)
-			die()
+			kill_health()
 			return
 
 	if(travelling_in_vent)
@@ -335,7 +282,7 @@
 	name = "cocoon"
 	desc = "Something wrapped in silky spider web."
 	icon_state = "cocoon1"
-	health = 60
+	health_max = 60
 
 /obj/effect/spider/cocoon/Initialize()
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -152,6 +152,8 @@
 
 /obj/item/ex_act(severity)
 	..()
+	if (health_max)
+		return
 	switch(severity)
 		if(EX_ACT_DEVASTATING)
 			qdel(src)

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -96,7 +96,7 @@
 			qdel(A)
 		else if(istype(A,/obj/effect/vine))
 			var/obj/effect/vine/P = A
-			P.die_off()
+			P.kill_health()
 
 /obj/item/material/twohanded/fireaxe/IsHatchet()
 	return TRUE

--- a/code/modules/admin/buildmode/turret.dm
+++ b/code/modules/admin/buildmode/turret.dm
@@ -147,8 +147,7 @@
 		else
 			P = new /obj/machinery/porta_turret(T)
 
-		P.health = settings["health"]
-		P.maxhealth = settings["health"]
+		P.set_max_health(settings["health"])
 		P.auto_repair = settings["repair"]
 		P.installation = settings["weapon"]
 		P.check_weapons = settings["check_weapons"]

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -42,9 +42,7 @@
 	icon_state = ""
 	pass_flags = PASS_FLAG_TABLE
 	buckle_sound = null
-
-	var/health = 10
-	var/max_health = 100
+	health_max = 100
 	var/growth_threshold = 0
 	var/growth_type = 0
 	var/max_growth = 0
@@ -70,10 +68,9 @@
 	seed = newseed
 	if(start_matured)
 		mature_time = 0
-		health = max_health
 	..()
 
-/obj/effect/vine/Initialize()
+/obj/effect/vine/Initialize(mapload, datum/seed/newseed, obj/effect/vine/newparent, start_matured = 0)
 	. = ..()
 
 	if(!SSplants)
@@ -84,15 +81,18 @@
 	if(!seed)
 		return INITIALIZE_HINT_QDEL
 	name = seed.display_name
-	max_health = round(seed.get_trait(TRAIT_ENDURANCE)/2)
+	health_max = round(seed.get_trait(TRAIT_ENDURANCE)/2)
 	if(seed.get_trait(TRAIT_SPREAD) == 2)
 		mouse_opacity = 2
 		max_growth = VINE_GROWTH_STAGES
-		growth_threshold = max_health/VINE_GROWTH_STAGES
+		growth_threshold = health_max / VINE_GROWTH_STAGES
 		growth_type = seed.get_growth_type()
 	else
 		max_growth = seed.growth_stages
-		growth_threshold = max_growth && max_health/max_growth
+		growth_threshold = max_growth && health_max / max_growth
+
+	if (!start_matured)
+		health_current = 10
 
 	if(max_growth > 2 && prob(50))
 		max_growth-- //Ensure some variation in final sprite, makes the carpet of crap look less wonky.
@@ -112,7 +112,7 @@
 
 /obj/effect/vine/on_update_icon()
 	overlays.Cut()
-	var/growth = growth_threshold ? min(max_growth, round(health/growth_threshold)) : 1
+	var/growth = growth_threshold ? min(max_growth, round(get_current_health() / growth_threshold)) : 1
 	var/at_fringe = get_dist(src,parent)
 	if(spread_distance > 5)
 		if(at_fringe >= spread_distance-3)
@@ -196,23 +196,19 @@
 	if(W.edge && W.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
 		if(!is_mature())
 			to_chat(user, SPAN_WARNING("\The [src] is not mature enough to yield a sample yet."))
-			return
+			return TRUE
 		if(!seed)
 			to_chat(user, SPAN_WARNING("There is nothing to take a sample from."))
-			return
+			return TRUE
 		var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
 		if(prob(user.skill_fail_chance(SKILL_BOTANY, 90, needed_skill)))
 			to_chat(user, SPAN_WARNING("You failed to get a usable sample."))
 		else
 			seed.harvest(user,0,1)
-		health -= (rand(3,5)*5)
-	else
-		..()
-		var/damage = W.force
-		if(W.edge)
-			damage *= 2
-		adjust_health(-damage)
-		playsound(get_turf(src), W.hitsound, 100, 1)
+		damage_health(rand(15, 25), W.damtype)
+		return TRUE
+
+	return ..()
 
 /obj/effect/vine/AltClick(mob/user)
 	if(!CanPhysicallyInteract(user) || user.incapacitated())
@@ -221,13 +217,13 @@
 	if(istype(W) && W.edge && W.w_class >= ITEM_SIZE_NORMAL)
 		visible_message(SPAN_NOTICE("[user] starts chopping down \the [src]."))
 		playsound(, W.hitsound, 100, 1)
-		var/chop_time = (health/W.force) * 0.5 SECONDS
+		var/chop_time = (get_current_health() / W.force) * 0.5 SECONDS
 		if(user.skill_check(SKILL_BOTANY, SKILL_ADEPT))
 			chop_time *= 0.5
 		if (do_after(user, chop_time, src, DO_PUBLIC_UNIQUE))
 			visible_message(SPAN_NOTICE("[user] chops down \the [src]."))
 			playsound(get_turf(src), W.hitsound, 100, 1)
-			die_off()
+			kill_health()
 
 //handles being overrun by vines - note that attacker_parent may be null in some cases
 /obj/effect/vine/proc/vine_overrun(datum/seed/attacker_seed, obj/effect/vine/attacker_parent)
@@ -252,31 +248,20 @@
 	aggression -= resiliance
 
 	if(aggression > 0)
-		adjust_health(-aggression*5)
+		damage_health(aggression * 5)
 
-/obj/effect/vine/ex_act(severity)
-	switch(severity)
-		if(EX_ACT_DEVASTATING)
-			die_off()
-			return
-		if(EX_ACT_HEAVY)
-			if (prob(50))
-				die_off()
-				return
-		if(EX_ACT_LIGHT)
-			if (prob(5))
-				die_off()
-				return
-		else
-	return
+/obj/effect/vine/on_death()
+	if(plant)
+		plant.die()
+	wake_neighbors()
+	qdel(src)
 
-/obj/effect/vine/proc/adjust_health(value)
-	health = clamp(health + value, 0, max_health)
-	if(health <= 0)
-		die_off()
+/obj/effect/vine/post_health_change(health_mod, damage_type)
+	..()
+	queue_icon_update()
 
 /obj/effect/vine/proc/is_mature()
-	return (health >= (max_health/3) && world.time > mature_time)
+	return (get_damage_percentage() < 66 && world.time > mature_time)
 
 /obj/effect/vine/is_burnable()
 	return seed.get_trait(TRAIT_HEAT_TOLERANCE) < 1000

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -56,8 +56,8 @@
 		return
 
 	//Take damage from bad environment if any
-	adjust_health(-seed.handle_environment(T,T.return_air(),null,1))
-	if(health <= 0)
+	damage_health(seed.handle_environment(T, T.return_air(), null, 1))
+	if(health_dead)
 		return
 
 	//Vine fight!
@@ -66,9 +66,9 @@
 			other.vine_overrun(seed, src)
 
 	//Growing up
-	if(health < max_health)
-		adjust_health(1)
-		if(round(growth_threshold) && !(health % growth_threshold))
+	if(health_damaged())
+		restore_health(1)
+		if(round(growth_threshold) && !(get_current_health() % growth_threshold))
 			update_icon()
 
 	if(is_mature())
@@ -107,14 +107,14 @@
 
 /obj/effect/vine/proc/can_spawn_plant()
 	var/turf/simulated/T = get_turf(src)
-	return parent == src && health == max_health && !plant && istype(T) && !T.CanZPass(src, DOWN)
+	return parent == src && !health_damaged() && !plant && istype(T) && !T.CanZPass(src, DOWN)
 
 /obj/effect/vine/proc/should_sleep()
 	if(buckled_mob) //got a victim to fondle
 		return FALSE
 	if(length(get_neighbors())) //got places to spread to
 		return FALSE
-	if(health < max_health) //got some growth to do
+	if(health_damaged()) //got some growth to do
 		return FALSE
 	if(targets_in_range()) //got someone to grab
 		return FALSE
@@ -155,11 +155,5 @@
 				targets |= M
 	if(targets.len)
 		return targets
-
-/obj/effect/vine/proc/die_off()
-	// Kill off our plant.
-	if(plant) plant.die()
-	wake_neighbors()
-	qdel(src)
 
 #undef NEIGHBOR_REFRESH_TIME

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -62,7 +62,7 @@
 			var/obj/effect/vine/SV = locate() in loc
 			if(prob(60))
 				src.visible_message(SPAN_NOTICE("\The [src] eats the plants."))
-				SV.die_off(1)
+				SV.kill_health(1)
 				if(locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in loc)
 					var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in loc
 					qdel(SP)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -5,7 +5,7 @@
 
 	handle_power() // Handles all power interaction
 
-	if(damage > broken_damage)
+	if (get_damage_value() > broken_damage)
 		shutdown_computer()
 		return
 
@@ -96,7 +96,7 @@
 	if(tesla_link)
 		tesla_link.enabled = TRUE
 	var/issynth = issilicon(user) // Robots and AIs get different activation messages.
-	if(damage > broken_damage)
+	if (get_damage_value() > broken_damage)
 		if(issynth)
 			to_chat(user, "You send an activation signal to \the [src], but it responds with an error code. It must be damaged.")
 		else

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -1,9 +1,5 @@
-/obj/item/modular_computer/examine(mob/user)
-	. = ..()
-	if(damage > broken_damage)
-		to_chat(user, SPAN_DANGER("It is heavily damaged!"))
-	else if(damage)
-		to_chat(user, "It is damaged.")
+/obj/item/modular_computer/on_death()
+	break_apart()
 
 /obj/item/modular_computer/proc/break_apart()
 	visible_message("\The [src] breaks apart!")
@@ -16,44 +12,10 @@
 			H.damage_health(rand(10,30))
 	qdel(src)
 
-/obj/item/modular_computer/proc/take_damage(amount, component_probability, damage_casing = 1, randomize = 1)
-	if(!modifiable)
-		return
-
-	if(randomize)
-		// 75%-125%, rand() works with integers, apparently.
-		amount *= (rand(75, 125) / 100.0)
-	amount = round(amount)
-	if(damage_casing)
-		damage += amount
-		damage = clamp(damage, 0, max_damage)
-
-	if(component_probability)
-		for(var/obj/item/stock_parts/computer/H in get_all_components())
-			if(prob(component_probability))
-				H.damage_health(round(amount / 2))
-
-	if(damage >= max_damage)
-		break_apart()
-
-// Stronger explosions cause serious damage to internal components
-// Minor explosions are mostly mitigitated by casing.
-/obj/item/modular_computer/ex_act(severity)
-	take_damage(rand(100,200) / severity, 30 / severity)
-
-// EMPs are similar to explosions, but don't cause physical damage to the casing. Instead they screw up the components
-/obj/item/modular_computer/emp_act(severity)
-	take_damage(rand(100,200) / severity, 50 / severity, 0)
-	..()
-
-// "Stun" weapons can cause minor damage to components (short-circuits?)
-// "Burn" damage is equally strong against internal components and exterior casing
-// "Brute" damage mostly damages the casing.
-/obj/item/modular_computer/bullet_act(obj/item/projectile/Proj)
-	switch(Proj.damage_type)
-		if (DAMAGE_BRUTE)
-			take_damage(Proj.damage, Proj.damage / 2)
-		if (DAMAGE_PAIN)
-			take_damage(Proj.damage, Proj.damage / 3, 0)
-		if (DAMAGE_BURN)
-			take_damage(Proj.damage, Proj.damage / 1.5)
+/obj/item/modular_computer/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)
+	// Damage components first, so that they're still caught if the computer dies and ejects them all.
+	for (var/obj/item/stock_parts/computer/H in get_all_components())
+		if (prob(50))
+			var/component_damage = damage * (rand(75, 125) / 100)
+			H.damage_health(component_damage, damage_type, damage_flags, severity, skip_can_damage_check)
+	. = ..()

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -171,13 +171,14 @@
 			to_chat(user, "\The [W] is off.")
 			return
 
-		if(!damage)
+		if(!get_damage_value())
 			to_chat(user, "\The [src] does not require repairs.")
 			return
 
 		to_chat(user, "You begin repairing damage to \the [src]...")
-		if(WT.remove_fuel(round(damage/75)) && do_after(usr, damage/10, src, DO_REPAIR_CONSTRUCT))
-			damage = 0
+		var/damage = get_damage_value()
+		if(WT.remove_fuel(round(damage / 75)) && do_after(user, damage / 10, src, DO_REPAIR_CONSTRUCT))
+			revive_health()
 			to_chat(user, "You repair \the [src].")
 		return
 

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -28,10 +28,9 @@
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 	var/light_strength = 0									// Intensity of light this computer emits. Comparable to numbers light fixtures use.
 
-	// Damage of the chassis. If the chassis takes too much damage it will break apart.
-	var/damage = 0				// Current damage level
-	var/broken_damage = 50		// Damage level at which the computer ceases to operate
-	var/max_damage = 100		// Damage level at which the computer breaks apart.
+	health_max = 100
+	/// Integer. Damage level at which the computer ceased to operate.
+	var/broken_damage = 50
 	var/list/terminals          // List of open terminal datums.
 
 	// Important hardware (must be installed for computer to work)

--- a/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
@@ -11,7 +11,7 @@
 	base_active_power_usage = 200
 	max_hardware_size = 2
 	light_strength = 3
-	max_damage = 200
+	health_max = 200
 	broken_damage = 100
 	w_class = ITEM_SIZE_NORMAL
 	var/icon_state_closed = "laptop-closed"

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -12,7 +12,7 @@
 	max_hardware_size = 2
 	steel_sheet_cost = 10
 	light_strength = 4
-	max_damage = 300
+	health_max = 300
 	broken_damage = 150
 	w_class = ITEM_SIZE_HUGE
 

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -8,6 +8,7 @@
 	machine_name = "sensors console"
 	machine_desc = "Used to activate, monitor, and configure a spaceship's sensors. Higher range means higher temperature; dangerously high temperatures may fry the delicate equipment."
 	health_max = 100
+	health_resistances = DAMAGE_RESIST_ELECTRICAL
 	var/obj/machinery/shipsensors/sensors
 	var/list/last_scan
 	var/print_language = LANGUAGE_HUMAN_EURO
@@ -43,11 +44,11 @@
 	if(sensors)
 		data["on"] = sensors.use_power
 		data["range"] = sensors.range
-		data["health"] = sensors.health
-		data["max_health"] = sensors.max_health
+		data["health"] = sensors.get_current_health()
+		data["max_health"] = sensors.get_max_health()
 		data["heat"] = sensors.heat
 		data["critical_heat"] = sensors.critical_heat
-		if(sensors.health == 0)
+		if(sensors.health_dead)
 			data["status"] = "DESTROYED"
 		else if(!sensors.powered())
 			data["status"] = "NO POWER"
@@ -145,8 +146,7 @@
 	anchored = TRUE
 	density = TRUE
 	construct_state = /singleton/machine_construction/default/panel_closed
-	var/max_health = 200
-	var/health = 200
+	health_max = 200
 	var/critical_heat = 50 // sparks and takes damage when active & above this heat
 	var/heat_reduction = 1.5 // mitigates this much heat per tick
 	var/heat = 0
@@ -154,25 +154,26 @@
 	idle_power_usage = 5000
 
 /obj/machinery/shipsensors/attackby(obj/item/W, mob/user)
-	var/damage = max_health - health
-	if(damage && isWelder(W))
-
+	if (isWelder(W) && user.a_intent != I_HURT)
+		var/damage = get_damage_value()
 		var/obj/item/weldingtool/WT = W
+		if (!damage)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't need any repairs."))
+			return TRUE
+		if (!WT.isOn())
+			to_chat(user, SPAN_WARNING("\The [W] needs to be turned on first."))
+			return TRUE
+		if (!WT.remove_fuel(0,user))
+			to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
+			return TRUE
+		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		if(do_after(user, max(5, damage / 5), src, DO_REPAIR_CONSTRUCT) && WT?.isOn())
+			to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+			revive_health()
+		return TRUE
 
-		if(!WT.isOn())
-			return
-
-		if(WT.remove_fuel(0,user))
-			to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
-			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			if(do_after(user, max(5, damage / 5), src, DO_REPAIR_CONSTRUCT) && WT && WT.isOn())
-				to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
-				take_damage(-damage)
-		else
-			to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
-			return
-		return
-	..()
+	return ..()
 
 /obj/machinery/shipsensors/proc/in_vacuum()
 	var/turf/T=get_turf(src)
@@ -193,20 +194,6 @@
 	if(panel_open)
 		overlays += "sensors_panel"
 	. = ..()
-/obj/machinery/shipsensors/examine(mob/user)
-	. = ..()
-	if(health_dead)
-		to_chat(user, "\The [src] is wrecked.")
-	else if(health < max_health * 0.25)
-		to_chat(user, SPAN_DANGER("\The [src] looks like it's about to break!"))
-	else if(health < max_health * 0.5)
-		to_chat(user, SPAN_DANGER("\The [src] looks seriously damaged!"))
-	else if(health < max_health * 0.75)
-		to_chat(user, SPAN_NOTICE("\The [src] shows signs of damage!"))
-
-/obj/machinery/shipsensors/bullet_act(obj/item/projectile/Proj)
-	take_damage(Proj.get_structure_damage())
-	..()
 
 /obj/machinery/shipsensors/proc/toggle()
 	if(!use_power && (health_dead || !in_vacuum()))
@@ -226,7 +213,7 @@
 			s.set_up(3, 1, src)
 			s.start()
 
-			take_damage(rand(10,50))
+			damage_health(rand(10, 50), DAMAGE_BURN)
 			toggle()
 		heat += idle_power_usage/15000
 
@@ -243,14 +230,13 @@
 	change_power_consumption(1500 * (range**2), POWER_USE_IDLE) //Exponential increase, also affects speed of overheating
 
 /obj/machinery/shipsensors/emp_act(severity)
-	if(use_power)
-		take_damage(20/severity)
+	if (use_power)
 		toggle()
 	..()
 
-/obj/machinery/shipsensors/proc/take_damage(value)
-	health = min(max(health - value, 0),max_health)
-	if(use_power && health == 0)
+/obj/machinery/shipsensors/on_death()
+	. = ..()
+	if (use_power)
 		toggle()
 
 /obj/machinery/shipsensors/RefreshParts()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -11,8 +11,9 @@ var/global/solar_gen_rate = 1500
 	density = TRUE
 	idle_power_usage = 0
 	active_power_usage = 0
+	health_max = 10
+	health_resistances = DAMAGE_RESIST_ELECTRICAL
 	var/id = 0
-	var/health = 10
 	var/obscured = 0
 	var/sunfrac = 0
 	var/efficiency = 1
@@ -57,13 +58,12 @@ var/global/solar_gen_rate = 1500
 		S.anchored = TRUE
 	S.forceMove(src)
 	if(S.glass_type == /obj/item/stack/material/glass/reinforced) //if the panel is in reinforced glass
-		health *= 2 								 //this need to be placed here, because panels already on the map don't have an assembly linked to
+		set_max_health(health_max * 2)
 	update_icon()
 
 
 
 /obj/machinery/power/solar/attackby(obj/item/W, mob/user)
-
 	if(isCrowbar(W))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		user.visible_message(SPAN_NOTICE("[user] begins to take the glass off the solar panel."))
@@ -75,17 +75,9 @@ var/global/solar_gen_rate = 1500
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			user.visible_message(SPAN_NOTICE("[user] takes the glass off the solar panel."))
 			qdel(src)
-		return
-	else if (W)
-		src.add_fingerprint(user)
-		src.health -= W.force
-		src.healthcheck()
-	..()
+		return TRUE
 
-/obj/machinery/power/solar/proc/healthcheck()
-	if (src.health <= 0)
-		if(!MACHINE_IS_BROKEN(src))
-			set_broken(TRUE)
+	. = ..()
 
 /obj/machinery/power/solar/on_update_icon()
 	..()
@@ -131,13 +123,17 @@ var/global/solar_gen_rate = 1500
 
 /obj/machinery/power/solar/set_broken(new_state)
 	. = ..()
-	if(. && new_state)
-		health = 0
-		new /obj/item/material/shard(src.loc)
-		new /obj/item/material/shard(src.loc)
-		var/obj/item/solar_assembly/S = locate() in src
-		S.glass_type = null
-		unset_control()
+	if(. && new_state && !health_dead)
+		kill_health()
+
+/obj/machinery/power/solar/on_death()
+	. = ..()
+	set_broken(TRUE)
+	new /obj/item/material/shard(src.loc)
+	new /obj/item/material/shard(src.loc)
+	var/obj/item/solar_assembly/S = locate() in src
+	S.glass_type = null
+	unset_control()
 
 /obj/machinery/power/solar/ex_act(severity)
 	switch(severity)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -7,25 +7,19 @@
 	opacity = 0
 	anchored = TRUE
 	unacidable = TRUE
-	var/const/max_health = 200
-	var/health = max_health //The shield can only take so much beating (prevents perma-prisons)
+	health_max = 200
+	health_resistances = DAMAGE_RESIST_ELECTRICAL
+	damage_hitsound = 'sound/effects/EMPulse.ogg'
 	var/shield_generate_power = 7500	//how much power we use when regenerating
 	var/shield_idle_power = 1500		//how much power we use when just being sustained.
 
 /obj/machinery/shield/malfai
 	name = "emergency forcefield"
 	desc = "A weak forcefield which seems to be projected by the emergency atmosphere containment field."
-	health = max_health/2 // Half health, it's not suposed to resist much.
+	health_max = 100 // Half health, it's not suposed to resist much.
 
 /obj/machinery/shield/malfai/Process()
-	health -= 0.5 // Slowly lose integrity over time
-	check_failure()
-
-/obj/machinery/shield/proc/check_failure()
-	if (src.health <= 0)
-		visible_message(SPAN_NOTICE("\The [src] dissipates!"))
-		qdel(src)
-		return
+	damage_health(1) // Slowly lose integrity over time
 
 /obj/machinery/shield/New()
 	src.set_dir(pick(1,2,3,4))
@@ -42,53 +36,17 @@
 	if(!height || air_group) return 0
 	else return ..()
 
-/obj/machinery/shield/attackby(obj/item/W as obj, mob/user as mob)
-	if(!istype(W)) return
+/obj/machinery/shield/post_health_change(health_mod, damage_type)
+	. = ..()
+	if (health_dead)
+		return
+	if (health_mod < -1) // To prevent slow degradation proccing this constantly
+		set_opacity(TRUE)
+		addtimer(CALLBACK(src, /atom/proc/set_opacity, FALSE), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
-	//Calculate damage
-	var/aforce = W.force
-	if (W.damtype == DAMAGE_BRUTE || W.damtype == DAMAGE_BURN)
-		src.health -= aforce
-
-	//Play a fitting sound
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 75, 1)
-
-	check_failure()
-	set_opacity(1)
-	spawn(20) if(!QDELETED(src)) set_opacity(0)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-
-	..()
-
-/obj/machinery/shield/bullet_act(obj/item/projectile/Proj)
-	health -= Proj.get_structure_damage()
-	..()
-	check_failure()
-	set_opacity(1)
-	spawn(20) if(!QDELETED(src)) set_opacity(0)
-
-/obj/machinery/shield/ex_act(severity)
-	switch(severity)
-		if(EX_ACT_DEVASTATING)
-			if (prob(75))
-				qdel(src)
-		if(EX_ACT_HEAVY)
-			if (prob(50))
-				qdel(src)
-		if(EX_ACT_LIGHT)
-			if (prob(25))
-				qdel(src)
-	return
-
-/obj/machinery/shield/emp_act(severity)
-	switch(severity)
-		if(EMP_ACT_HEAVY)
-			qdel(src)
-		if(EMP_ACT_LIGHT)
-			if(prob(50))
-				qdel(src)
-	..()
-
+/obj/machinery/shield/on_death()
+	visible_message(SPAN_NOTICE("\The [src] dissipates!"))
+	qdel(src)
 
 /obj/machinery/shield/hitby(AM as mob|obj, datum/thrownthing/TT)
 	//Let everyone know we've been hit!
@@ -104,16 +62,7 @@
 		var/obj/O = AM
 		tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
 
-	src.health -= tforce
-
-	//This seemed to be the best sound for hitting a force field.
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 100, 1)
-
-	check_failure()
-
-	//The shield becomes dense to absorb the blow.. purely asthetic.
-	set_opacity(1)
-	spawn(20) if(!QDELETED(src)) set_opacity(0)
+	damage_health(tforce)
 
 	..()
 /obj/machinery/shieldgen
@@ -125,8 +74,7 @@
 	opacity = 0
 	anchored = FALSE
 	req_access = list(access_engine)
-	var/const/max_health = 100
-	var/health = max_health
+	health_max = 100
 	var/active = 0
 	var/malfunction = 0 //Malfunction causes parts of the shield to slowly dissapate
 	var/list/deployed_shields = list()
@@ -214,42 +162,25 @@
 		else
 			check_delay--
 
-/obj/machinery/shieldgen/proc/checkhp()
-	if(health <= 30)
-		src.malfunction = 1
-	if(health <= 0)
-		spawn(0)
-			explosion(get_turf(src.loc), 1, EX_ACT_LIGHT, 0, 0)
-		qdel(src)
-	update_icon()
-	return
+/obj/machinery/shieldgen/post_health_change(health_mod, damage_type)
+	. = ..()
+	queue_icon_update()
+	if (get_current_health() <= 30)
+		malfunction = TRUE
 
-/obj/machinery/shieldgen/ex_act(severity)
-	switch(severity)
-		if(EX_ACT_DEVASTATING)
-			src.health -= 75
-			src.checkhp()
-		if(EX_ACT_HEAVY)
-			src.health -= 30
-			if (prob(15))
-				src.malfunction = 1
-			src.checkhp()
-		if(EX_ACT_LIGHT)
-			src.health -= 10
-			src.checkhp()
-	return
+/obj/machinery/shieldgen/on_death()
+	. = ..()
+	explosion(get_turf(src), 1, EX_ACT_LIGHT, 0, 0)
+	qdel(src)
 
 /obj/machinery/shieldgen/emp_act(severity)
 	switch(severity)
 		if(EMP_ACT_HEAVY)
-			src.health /= 2 //cut health in half
 			malfunction = 1
 			locked = pick(0,1)
 		if(EMP_ACT_LIGHT)
 			if(prob(50))
-				src.health *= 0.3 //chop off a third of the health
 				malfunction = 1
-	checkhp()
 	..()
 
 /obj/machinery/shieldgen/interface_interact(mob/user as mob)
@@ -292,6 +223,7 @@
 		else
 			to_chat(user, SPAN_NOTICE("You open the panel and expose the wiring."))
 			is_open = 1
+		return TRUE
 
 	else if(isCoil(W) && malfunction && is_open)
 		var/obj/item/stack/cable_coil/coil = W
@@ -299,15 +231,15 @@
 		//if(do_after(user, min(60, round( ((maxhealth/health)*10)+(malfunction*10) ))) //Take longer to repair heavier damage
 		if(do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
 			if (coil.use(1))
-				health = max_health
+				revive_health()
 				malfunction = 0
 				to_chat(user, SPAN_NOTICE("You repair the [src]!"))
-				update_icon()
+		return TRUE
 
 	else if(istype(W, /obj/item/wrench))
 		if(locked)
 			to_chat(user, "The bolts are covered, unlocking this would retract the covers.")
-			return
+			return TRUE
 		if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			to_chat(user, SPAN_NOTICE("'You unsecure the [src] from the floor!"))
@@ -320,7 +252,7 @@
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			to_chat(user, SPAN_NOTICE("You secure the [src] to the floor!"))
 			anchored = TRUE
-
+		return TRUE
 
 	else if(istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer/pda))
 		if(src.allowed(user))
@@ -328,8 +260,9 @@
 			to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, SPAN_WARNING("Access denied."))
-	else
-		..()
+		return TRUE
+
+	return ..()
 
 
 /obj/machinery/shieldgen/on_update_icon()

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -24,7 +24,8 @@
 	icon_state = "net_f"
 	anchored = TRUE
 	layer = CATWALK_LAYER//probably? Should cover cables, pipes and the rest of objects that are secured on the floor
-	var/health = 100
+	health_max = 100
+	health_min_damage = 10
 
 /obj/structure/net/Initialize(mapload)
 	. = ..()
@@ -37,40 +38,31 @@
 					continue
 				N.update_connections()
 
-/obj/structure/net/examine(mob/user)
-	. = ..()
-	if (health < 20)
-		to_chat(user, "\The [src] is barely hanging on a few last threads.")
-	else if (health < 50)
-		to_chat(user, "Many ribbons of \the [src] are cut away.")
-	else if (health < 90)
-		to_chat(user, "Few ribbons of \the [src] are cut away.")
-
 /obj/structure/net/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/material)) //sharp objects can cut thorugh
+	if (user.a_intent == I_HURT && istype(W, /obj/item/material)) //sharp objects can cut thorugh
 		var/obj/item/material/SH = W
 		if (!(SH.sharp) || (SH.sharp && SH.force < 10))//is not sharp enough or at all
 			to_chat(user,SPAN_WARNING("You can't cut throught \the [src] with \the [W], it's too dull."))
-			return
+			return TRUE
 		visible_message(SPAN_WARNING("[user] starts to cut through \the [src] with \the [W]!"))
-		while (health > 0)
+		while (!health_dead)
 			if (!do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))
 				visible_message(SPAN_WARNING("[user] stops cutting through \the [src] with \the [W]!"))
-				return
-			health -= 20 * (1 + (SH.force-10)/10)//the sharper the faster, every point of force above 10 adds 10 % to damage
+				return TRUE
+			damage_health(20 * (1 + (SH.force-10) / 10), W.damtype, DAMAGE_FLAG_SHARP)
 		visible_message(SPAN_WARNING("[user] cuts through \the [src]!"))
 		new /obj/item/stack/net(src.loc)
 		qdel(src)
+		return TRUE
+
+	return ..()
 
 /obj/structure/net/bullet_act(obj/item/projectile/P)
 	. = PROJECTILE_CONTINUE //few cloth ribbons won't stop bullet or energy ray
 	if (P.damage_type != DAMAGE_BURN)//beams, lasers, fire. Bullets won't make a lot of damage to the few hanging belts.
 		return
 	visible_message(SPAN_WARNING("\The [P] hits \the [src] and tears it!"))
-	health -= P.damage
-	if (health < 0)
-		visible_message(SPAN_WARNING("\The [src] is torn apart!"))
-		qdel(src)
+	damage_health(P.damage, P.damage_type)
 
 /obj/structure/net/update_connections()//maybe this should also be called when any of the walls nearby is removed but no idea how I can make it happen
 	overlays.Cut()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 361 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 355 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
:cl: SierraKomodo
refactor: The following items now use standardized health: Energy nets, tablets, PDAs, computers, laptops, telescreens, gas canisters, turrets, spiderlings, spider coccoons, spider webs, ship sensors, solars, emergency shields, the errant pisces net, and vines. This means these items should now be properly affected by all possible damage sources.
tweak: Attacking energy nets with your bare hands or melee weapons now requires you to be on harm intent.
tweak: You can now damage doors that are open.
bugfix: Items and machinery that use standardize health will no longer delete themselves from explosions if the explosion didn't kill them.
/:cl:

Non-user facing fixes:
- Fixes standardized health not returning a valid call handled response during attackby()
- Updated atoms listed below now return valid attackby() responses

Applies standardized health to the following:
- Energy nets
- Modular and standard computers
- Gas canisters
- Doors/airlocks
- Turrets
- Spider effects (`/obj/effect/spider`)
- Vines
- Ship sensors
- Solars
- Emergency Shields
- Errant Pisces net

Intentionally skips the following subtypes:
- Organs (These are complex enough to warrant separate PRs)
- Doors (These are complex enough to warrant separate PRs)
- Mobs (These are complex enough to warrant separate PRs)
- Mech Components (These are complex enough to warrant separate PRs)
- Radiation Collectors (Health var here is solely for overheating checks; No other damage sources affect it)
- R&D Servers (Health var here is solely for overheating checks; No other damage sources affect it)
- Artifacts (This will require some tweaks to damage procs to include `DAMAGE_FLAG_*` checks and handlers)
- Portals (The health var here exists only as an expiration counter)