### PR TITLE
prepare gh-pages branch for wider usage

### DIFF
--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -31,12 +31,11 @@ jobs:
       - name: Generate documentation
         run: |
           ~/dmdoc
-          touch dmdoc/.nojekyll
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages-dmdoc
-          single-commit: true
+          branch: gh-pages
           folder: dmdoc
+          target-folder: docs/dmdoc
           clean: true


### PR DESCRIPTION
dmdoc is built to docs/dmdoc on :gh-pages
repo settings updated to serve :gh-pages/docs at github.baystation.xyz
dmdoc is therefore accessible at https://github.baystation.xyz/dmdoc
